### PR TITLE
Deprecate creating configurations in buildscript block

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/IsolateTransformParametersCodec.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/IsolateTransformParametersCodec.kt
@@ -21,7 +21,7 @@ import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.artifacts.transform.DefaultTransform
 import org.gradle.api.internal.artifacts.transform.TransformParameterScheme
 import org.gradle.api.internal.file.FileCollectionFactory
-import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext
 import org.gradle.configurationcache.extensions.uncheckedCast
 import org.gradle.configurationcache.serialization.Codec
 import org.gradle.configurationcache.serialization.ReadContext
@@ -54,7 +54,7 @@ class IsolateTransformParametersCodec(
             parameterObject,
             implementationClass,
             cacheable,
-            RootScriptDomainObjectContext.INSTANCE,
+            StandaloneDomainObjectContext.ANONYMOUS,
             parameterScheme.inspectionScheme.propertyWalker,
             isolatableFactory,
             buildOperationExecutor,

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/Documentation.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/Documentation.java
@@ -38,7 +38,7 @@ public abstract class Documentation implements DocLink {
         return new UserGuide(id, null);
     }
 
-    static Documentation upgradeGuide(int majorVersion, String upgradeGuideSection) {
+    public static Documentation upgradeGuide(int majorVersion, String upgradeGuideSection) {
         return new UpgradeGuide(majorVersion, upgradeGuideSection);
     }
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -185,6 +185,56 @@ tasks.register("resolveReplacement") {
 ======
 =====
 
+[[creating_new_buildscript_configurations]]
+==== Deprecated creating new buildscript configurations
+
+Starting in Gradle 9.0, creating new configurations in a script's link:{javadocPath}/org/gradle/api/Script.html#buildscript-groovy.lang.Closure-[buildscript] block will result in an error.
+This applies to project, settings, init, and standalone scripts.
+
+The buildscript configurations block is only intended to be used to declare dependencies for the buildscript classpath.
+
+Consider the following script that creates a new buildscript configuration in a Settings script and resolves it:
+
+=====
+[.multi-language-sample]
+======
+.settings.gradle.kts
+[source,kotlin]
+----
+buildscript {
+    configurations {
+        create("myConfig")
+    }
+    dependencies {
+        "myConfig"("org:foo:1.0")
+    }
+}
+
+val files = buildscript.configurations["myConfig"].files
+----
+======
+=====
+
+This pattern is sometimes used to resolve dependencies in Settings, where there is no other way to obtain a Configuration.
+Resolving dependencies in this context is not recommended, however using a detached configuration will still work for the time being.
+
+Consider the following replacement to the above example, which uses a detached configuration instead:
+
+=====
+[.multi-language-sample]
+======
+.settings.gradle.kts
+[source,kotlin]
+----
+val myConfig = buildscript.configurations.detachedConfiguration(
+    buildscript.dependencies.create("org:foo:1.0")
+)
+
+val files = myConfig.files
+----
+======
+=====
+
 [[changes_8.6]]
 == Upgrading from 8.5 and earlier
 

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/internal/PluginUsePluginServiceRegistry.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/internal/PluginUsePluginServiceRegistry.java
@@ -24,7 +24,7 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.artifacts.dsl.dependencies.UnknownProjectFinder;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
-import org.gradle.api.internal.initialization.RootScriptDomainObjectContext;
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext;
 import org.gradle.api.internal.plugins.PluginInspector;
 import org.gradle.initialization.ClassLoaderScopeRegistry;
 import org.gradle.internal.Factory;
@@ -127,7 +127,7 @@ public class PluginUsePluginServiceRegistry extends AbstractPluginServiceRegistr
             return new Factory<DependencyResolutionServices>() {
                 @Override
                 public DependencyResolutionServices create() {
-                    return dependencyManagementServices.create(fileResolver, fileCollectionFactory, dependencyMetaDataProvider, makeUnknownProjectFinder(), RootScriptDomainObjectContext.PLUGINS);
+                    return dependencyManagementServices.create(fileResolver, fileCollectionFactory, dependencyMetaDataProvider, makeUnknownProjectFinder(), StandaloneDomainObjectContext.PLUGINS);
                 }
             };
         }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/BuildscriptResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/BuildscriptResolutionIntegrationTest.groovy
@@ -1,0 +1,786 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.dsl.GradleDsl
+
+/**
+ * Tests edge cases of buildscript configuration resolution.
+ *
+ * <p>Tests should cover cases of initscript, settings, standalone, and project buildscript configurations.</p>
+ */
+class BuildscriptResolutionIntegrationTest extends AbstractIntegrationSpec {
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'root'
+        """
+    }
+
+    // This is not desired behavior. A project dependency should refer to the actual
+    // project, not its buildscript component. This is a bug.
+    def "project buildscript configuration can select itself"() {
+        buildFile << """
+            buildscript {
+                configurations {
+                    conf {
+                        outgoing {
+                            artifact file('foo.txt')
+                        }
+                        attributes {
+                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "foo"))
+                        }
+                    }
+                }
+
+                dependencies {
+                    conf project(":")
+                }
+            }
+
+            task resolve {
+                def files = buildscript.configurations.conf.incoming.files
+                doLast {
+                    assert files.files*.name == ["foo.txt"]
+                }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("While resolving configuration 'conf', it was also selected as a variant. Configurations should not act as both a resolution root and a variant simultaneously. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false or use the 'resolvable(String)' configuration factory method to create them. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration")
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        succeeds("resolve")
+    }
+
+    // This is not desired behavior. A project dependency should refer to the actual
+    // project, not its buildscript component. This is a bug.
+    def "project buildscript classpath configuration can select itself"() {
+        buildFile << """
+            buildscript {
+                configurations {
+                    classpath {
+                        outgoing {
+                            artifact file('foo.txt')
+                        }
+                    }
+                }
+
+                dependencies {
+                    classpath project(":")
+                }
+            }
+
+            task resolve {
+                def files = buildscript.configurations.classpath.incoming.files
+                doLast {
+                    assert files.files*.name == ["foo.txt"]
+                }
+            }
+        """
+
+        expect:
+        2.times {
+            // Once when resolving the classpath normally, once when re-resolving in `resolve`
+            executer.expectDocumentedDeprecationWarning("The classpath configuration has been deprecated for consumption. This will fail with an error in Gradle 9.0. For more information, please refer to https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.")
+            executer.expectDocumentedDeprecationWarning("While resolving configuration 'classpath', it was also selected as a variant. Configurations should not act as both a resolution root and a variant simultaneously. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false or use the 'resolvable(String)' configuration factory method to create them. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration")
+        }
+        succeeds("resolve")
+    }
+
+    def "project buildscript configuration can select another project"() {
+        buildFile << """
+            buildscript {
+                configurations {
+                    conf {
+                        attributes {
+                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "foo"))
+                        }
+                    }
+                }
+
+                dependencies {
+                    conf project(":other")
+                }
+            }
+
+            task resolve {
+                def files = buildscript.configurations.conf.incoming.files
+                doLast {
+                    assert files.files*.name == ["bar.txt"]
+                }
+            }
+        """
+        settingsFile << """
+            include "other"
+        """
+        file("other/build.gradle") << """
+            configurations {
+                consumable("conf") {
+                    outgoing {
+                        artifact file('bar.txt')
+                    }
+                    attributes {
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "foo"))
+                    }
+                }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        succeeds(":resolve")
+    }
+
+    def "project buildscript classpath configuration can select another project"() {
+        settingsFile << """
+            include "first"
+            include "other"
+        """
+        file("first/build.gradle") << """
+            buildscript {
+                dependencies {
+                    classpath project(":other")
+                }
+            }
+        """
+        file("other/build.gradle") << """
+            configurations {
+                other {
+                    outgoing {
+                        artifact file('bar.txt')
+                    }
+                    attributes {
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "library"))
+                    }
+                }
+            }
+        """
+
+        expect:
+        succeeds("help")
+    }
+
+    def "project buildscript classpath configuration cannot select another project when the selected artifact is built by a task"() {
+        settingsFile << """
+            include "first"
+            include "other"
+        """
+        file("first/build.gradle") << """
+            buildscript {
+                dependencies {
+                    classpath project(":other")
+                }
+            }
+        """
+        file("other/build.gradle") << """
+            task myTask { }
+            configurations {
+                other {
+                    outgoing {
+                        artifact(file('bar.txt')) {
+                            builtBy tasks.myTask
+                        }
+                    }
+                    attributes {
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "library"))
+                    }
+                }
+            }
+        """
+
+        expect:
+        fails("help")
+        failure.assertHasCause("Script classpath dependencies must reside in a separate build from the script itself.")
+    }
+
+    // This is not desired behavior. A project dependency should refer to the actual
+    // project, not its buildscript component. This is a bug.
+    def "project buildscript configuration can select other buildscript configurations"() {
+        buildFile << """
+            buildscript {
+                configurations {
+                    conf {
+                        canBeConsumed = false
+                        attributes {
+                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "other"))
+                        }
+                    }
+                    other {
+                        outgoing {
+                            artifact file('bar.txt')
+                        }
+                        attributes {
+                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "other"))
+                        }
+                    }
+                }
+
+                dependencies {
+                    conf project(":")
+                }
+            }
+
+            task resolve {
+                def files = buildscript.configurations.conf.incoming.files
+                doLast {
+                    assert files*.name == ["bar.txt"]
+                }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        succeeds("resolve")
+    }
+
+    // This is not desired behavior. A project dependency should refer to the actual
+    // project, not its buildscript component. This is a bug.
+    def "project buildscript classpath configuration can select other buildscript configurations"() {
+        buildFile << """
+            buildscript {
+                configurations {
+                    classpath {
+                        // To ensure it doesn't select itself over `other`
+                        canBeConsumed = false
+                    }
+                    other {
+                        outgoing {
+                            artifact file('bar.txt')
+                        }
+                        attributes {
+                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "library"))
+                        }
+                    }
+                }
+
+                dependencies {
+                    classpath project(":")
+                }
+            }
+
+            task resolve {
+                def files = buildscript.configurations.classpath.incoming.files
+                doLast {
+                    assert files*.name == ["bar.txt"]
+                }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Allowed usage is changing for configuration ':classpath', consumable was true and is now false. Ideally, usage should be fixed upon creation. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Usage should be fixed upon creation. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        succeeds("resolve")
+    }
+
+    // This is not desired behavior. A project dependency should refer to the actual
+    // project, not its buildscript component. This is a bug.
+    def "project buildscript resolvable configuration and consumable configuration from same project live in same resolved component"() {
+        buildFile << """
+            buildscript {
+                configurations {
+                    conf {
+                        canBeConsumed = false
+                        attributes {
+                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "foo"))
+                        }
+                    }
+                    other {
+                        outgoing {
+                            artifact file("foo.txt")
+                        }
+                        attributes {
+                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "foo"))
+                        }
+                    }
+                }
+
+                dependencies {
+                    conf project(":")
+                }
+            }
+
+            task resolve {
+                def rootComponent = buildscript.configurations.conf.incoming.resolutionResult.rootComponent
+                doLast {
+                    def root = rootComponent.get()
+                    assert root.id.projectName == 'root'
+                    assert root.variants.size() == 2
+                    def conf = root.variants.find { it.displayName == 'conf' }
+                    def other = root.variants.find { it.displayName == 'other' }
+                    assert conf != null
+                    assert other != null
+                }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        succeeds("resolve")
+    }
+
+    // This is not necessarily desired behavior, or important behavior at all -- who cares about the identity of the buildscript classpath resolution?
+    // The buildscript is _not_ the project. It should not claim to be the project.
+    // Ideally, this configuration would have an unspecified identity, similar to init, settings, and standalone scripts.
+    def "project buildscript classpath configuration is identified by the root project's identity"() {
+        buildFile << """
+            version = "1.0"
+            group = "foo"
+
+            task resolve {
+                def rootComponent = buildscript.configurations.classpath.incoming.resolutionResult.rootComponent
+                doLast {
+                    def root = rootComponent.get()
+                    assert root.moduleVersion.group == "foo"
+                    assert root.moduleVersion.name == "root"
+                    assert root.moduleVersion.version == "1.0"
+                    assert root.id instanceof ProjectComponentIdentifier
+                    assert root.id.projectName == "root"
+                    assert root.id.build.buildPath == ":"
+                    assert root.id.projectPath == ":"
+                    assert root.id.buildTreePath == ":"
+                    assert root.id.projectName == "root"
+                }
+            }
+        """
+
+        expect:
+        succeeds("resolve")
+    }
+
+    def "settings buildscript classpath configuration has unspecified identity"() {
+        settingsFile << """
+            def rootComponent = buildscript.configurations.classpath.incoming.resolutionResult.rootComponent
+            def root = rootComponent.get()
+            assert root.moduleVersion.group == "unspecified"
+            assert root.moduleVersion.name == "unspecified"
+            assert root.moduleVersion.version == "unspecified"
+            assert root.id instanceof ModuleComponentIdentifier
+            assert root.id.module == "unspecified"
+            assert root.id.group == "unspecified"
+            assert root.id.version == "unspecified"
+        """
+
+        expect:
+        succeeds("help")
+    }
+
+    def "init buildscript classpath configuration has unspecified identity"() {
+        initScriptFile << """
+            def rootComponent = buildscript.configurations.classpath.incoming.resolutionResult.rootComponent
+            def root = rootComponent.get()
+            assert root.moduleVersion.group == "unspecified"
+            assert root.moduleVersion.name == "unspecified"
+            assert root.moduleVersion.version == "unspecified"
+            assert root.id instanceof ModuleComponentIdentifier
+            assert root.id.module == "unspecified"
+            assert root.id.group == "unspecified"
+            assert root.id.version == "unspecified"
+        """
+
+        when:
+        executer.usingInitScript(initScriptFile)
+
+        then:
+        succeeds("help")
+    }
+
+    def "standalone buildscript classpath configuration has unspecified identity"() {
+        file("foo.gradle") << """
+            def rootComponent = buildscript.configurations.classpath.incoming.resolutionResult.rootComponent
+            def root = rootComponent.get()
+            assert root.moduleVersion.group == "unspecified"
+            assert root.moduleVersion.name == "unspecified"
+            assert root.moduleVersion.version == "unspecified"
+            assert root.id instanceof ModuleComponentIdentifier
+            assert root.id.module == "unspecified"
+            assert root.id.group == "unspecified"
+            assert root.id.version == "unspecified"
+        """
+
+        buildFile << """
+            apply from: "foo.gradle"
+        """
+
+        expect:
+        succeeds("help")
+    }
+
+    def "Adding configuration to project buildscript is deprecated"() {
+        buildFile << """
+            buildscript {
+                configurations {
+                    newconf
+                }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        succeeds("help")
+    }
+
+    def "Adding configuration to settings buildscript is deprecated"() {
+        settingsFile << """
+            buildscript {
+                configurations {
+                    newconf
+                }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for settings file 'settings.gradle' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        succeeds("help")
+    }
+
+    def "Adding configuration to init buildscript is deprecated"() {
+        initScriptFile << """
+            buildscript {
+                configurations {
+                    newconf
+                }
+            }
+        """
+
+        when:
+        executer.usingInitScript(initScriptFile)
+
+        then:
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for initialization script 'init.gradle' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        succeeds("help")
+    }
+
+    def "Adding configuration to standalone buildscript is deprecated"() {
+        file("foo.gradle") << """
+            buildscript {
+                configurations {
+                    newconf
+                }
+            }
+        """
+
+        buildFile << """
+            apply from: "foo.gradle"
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for script 'foo.gradle' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        succeeds("help")
+    }
+
+    def "project buildscripts support detached configurations for resolving external dependencies"() {
+        mavenRepo.module("org", "foo").publish()
+        buildFile << """
+            buildscript {
+                ${mavenTestRepository()}
+            }
+            task resolve {
+                def files = buildscript.configurations.detachedConfiguration(
+                    buildscript.dependencies.create("org:foo:1.0")
+                ).incoming.files
+                doLast {
+                    assert files.files*.name == ["foo-1.0.jar"]
+                }
+            }
+        """
+
+        expect:
+        succeeds("resolve")
+    }
+
+    def "settings buildscripts support detached configurations for resolving external dependencies"() {
+        mavenRepo.module("org", "foo").publish()
+        settingsFile << """
+            buildscript {
+                ${mavenTestRepository()}
+            }
+            def files = buildscript.configurations.detachedConfiguration(
+                buildscript.dependencies.create("org:foo:1.0")
+            ).incoming.files
+            assert files.files*.name == ["foo-1.0.jar"]
+        """
+
+        expect:
+        succeeds("help")
+    }
+
+    def "init buildscripts support detached configurations for resolving external dependencies"() {
+        mavenRepo.module("org", "foo").publish()
+        initScriptFile << """
+            buildscript {
+                ${mavenTestRepository()}
+            }
+            def files = buildscript.configurations.detachedConfiguration(
+                buildscript.dependencies.create("org:foo:1.0")
+            ).incoming.files
+            assert files.files*.name == ["foo-1.0.jar"]
+        """
+
+        when:
+        executer.usingInitScript(initScriptFile)
+
+        then:
+        succeeds("help")
+    }
+
+    def "standalone buildscripts support detached configurations for resolving external dependencies"() {
+        mavenRepo.module("org", "foo").publish()
+        file("foo.gradle") << """
+            buildscript {
+                ${mavenTestRepository()}
+            }
+            def files = buildscript.configurations.detachedConfiguration(
+                buildscript.dependencies.create("org:foo:1.0")
+            ).incoming.files
+            assert files.files*.name == ["foo-1.0.jar"]
+        """
+
+        buildFile << """
+            apply from: "foo.gradle"
+        """
+
+        expect:
+        succeeds("help")
+    }
+
+    // This is not necessarily desired behavior, or important behavior at all.
+    // The detached configuration is _not_ the project. It should not claim to be the project.
+    // Ideally, this configuration would have an unspecified identity, similar to init, settings, and standalone scripts.
+    def "project buildscripts detached configurations are identified by the root project's identity"() {
+        mavenRepo.module("org", "foo").publish()
+        buildFile << """
+            buildscript {
+                ${mavenTestRepository()}
+            }
+
+            version = "1.0"
+            group = "foo"
+
+            task resolve {
+                def rootComponent = buildscript.configurations.detachedConfiguration(
+                    buildscript.dependencies.create("org:foo:1.0")
+                ).incoming.resolutionResult.rootComponent
+                doLast {
+                    def root = rootComponent.get()
+                    assert root.moduleVersion.group == "foo"
+                    assert root.moduleVersion.name == "root"
+                    assert root.moduleVersion.version == "1.0"
+                    assert root.id instanceof ProjectComponentIdentifier
+                    assert root.id.projectName == "root"
+                    assert root.id.build.buildPath == ":"
+                    assert root.id.projectPath == ":"
+                    assert root.id.buildTreePath == ":"
+                    assert root.id.projectName == "root"
+                }
+            }
+        """
+
+        expect:
+        succeeds("resolve")
+    }
+
+    def "settings buildscripts support detached configurations have unspecified identity"() {
+        mavenRepo.module("org", "foo").publish()
+        settingsFile << """
+            buildscript {
+                ${mavenTestRepository()}
+            }
+            def rootComponent = buildscript.configurations.detachedConfiguration(
+                buildscript.dependencies.create("org:foo:1.0")
+            ).incoming.resolutionResult.rootComponent
+            def root = rootComponent.get()
+            assert root.moduleVersion.group == "unspecified"
+            assert root.moduleVersion.name == "unspecified"
+            assert root.moduleVersion.version == "unspecified"
+            assert root.id instanceof ModuleComponentIdentifier
+            assert root.id.module == "unspecified"
+            assert root.id.group == "unspecified"
+            assert root.id.version == "unspecified"
+        """
+
+        expect:
+        succeeds("help")
+    }
+
+    def "init buildscripts support detached configurations have unspecified identity"() {
+        mavenRepo.module("org", "foo").publish()
+        initScriptFile << """
+            buildscript {
+                ${mavenTestRepository()}
+            }
+            def rootComponent = buildscript.configurations.detachedConfiguration(
+                buildscript.dependencies.create("org:foo:1.0")
+            ).incoming.resolutionResult.rootComponent
+            def root = rootComponent.get()
+            assert root.moduleVersion.group == "unspecified"
+            assert root.moduleVersion.name == "unspecified"
+            assert root.moduleVersion.version == "unspecified"
+            assert root.id instanceof ModuleComponentIdentifier
+            assert root.id.module == "unspecified"
+            assert root.id.group == "unspecified"
+            assert root.id.version == "unspecified"
+        """
+
+        when:
+        executer.usingInitScript(initScriptFile)
+
+        then:
+        succeeds("help")
+    }
+
+    def "standalone buildscripts support detached configurations have unspecified identity"() {
+        mavenRepo.module("org", "foo").publish()
+        file("foo.gradle") << """
+            buildscript {
+                ${mavenTestRepository()}
+            }
+            def rootComponent = buildscript.configurations.detachedConfiguration(
+                buildscript.dependencies.create("org:foo:1.0")
+            ).incoming.resolutionResult.rootComponent
+            def root = rootComponent.get()
+            assert root.moduleVersion.group == "unspecified"
+            assert root.moduleVersion.name == "unspecified"
+            assert root.moduleVersion.version == "unspecified"
+            assert root.id instanceof ModuleComponentIdentifier
+            assert root.id.module == "unspecified"
+            assert root.id.group == "unspecified"
+            assert root.id.version == "unspecified"
+        """
+
+        buildFile << """
+            apply from: "foo.gradle"
+        """
+
+        expect:
+        succeeds("help")
+    }
+
+    def "project buildscripts support detached configurations for resolving local dependencies"() {
+        buildFile << """
+            task resolve {
+                def conf = buildscript.configurations.detachedConfiguration(
+                    buildscript.dependencies.create(project(":other"))
+                )
+                conf.attributes {
+                    attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "foo"))
+                }
+                def files = conf.incoming.files
+                doLast {
+                    assert files.files*.name == ["foo.txt"]
+                }
+            }
+        """
+        settingsFile << """
+            include "other"
+        """
+        file("other/build.gradle") << """
+            configurations {
+                consumable("foo") {
+                    outgoing {
+                        artifact file("foo.txt")
+                    }
+                    attributes {
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "foo"))
+                    }
+                }
+            }
+        """
+
+        expect:
+        succeeds(":resolve")
+    }
+
+    def "standalone buildscripts support detached configurations for resolving local dependencies"() {
+        mavenRepo.module("org", "foo").publish()
+        file("foo.gradle") << """
+            buildscript {
+                ${mavenTestRepository()}
+            }
+            def files = buildscript.configurations.detachedConfiguration(
+                buildscript.dependencies.create(project(":other"))
+            ).incoming.files
+            assert files.files*.name == ["foo.txt"]
+        """
+        settingsFile << """
+            include "other"
+        """
+        file("other/build.gradle") << """
+            configurations {
+                consumable("foo") {
+                    outgoing {
+                        artifact file("foo.txt")
+                    }
+                    attributes {
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "foo"))
+                    }
+                }
+            }
+        """
+
+        buildFile << """
+            apply from: "foo.gradle"
+        """
+
+        expect:
+        succeeds("help")
+    }
+
+    def "creating a settings buildscript configuration is deprecated in Kotlin"() {
+        mavenRepo.module("org", "foo").publish()
+        settingsFile.delete()
+        settingsKotlinFile << """
+            buildscript {
+                ${mavenTestRepository(GradleDsl.KOTLIN)}
+                configurations {
+                    create("myConfig")
+                }
+                dependencies {
+                    "myConfig"("org:foo:1.0")
+                }
+            }
+
+            val files = buildscript.configurations["myConfig"].files
+            assert(files.map { it.name } == listOf("foo-1.0.jar"))
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for settings file 'settings.gradle.kts' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        succeeds("help")
+    }
+
+    def "creating a detached settings buildscript configuration works in Kotlin"() {
+        mavenRepo.module("org", "foo").publish()
+        settingsFile.delete()
+        settingsKotlinFile << """
+            buildscript {
+                ${mavenTestRepository(GradleDsl.KOTLIN)}
+            }
+
+            val myConfig = buildscript.configurations.detachedConfiguration(
+                buildscript.dependencies.create("org:foo:1.0")
+            )
+
+            val files = myConfig.files
+            assert(files.map { it.name } == listOf("foo-1.0.jar"))
+        """
+
+        expect:
+        succeeds("help")
+    }
+}

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RootComponentResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RootComponentResolutionIntegrationTest.groovy
@@ -28,76 +28,6 @@ class RootComponentResolutionIntegrationTest extends AbstractIntegrationSpec {
         settingsFile << "rootProject.name = 'root'"
     }
 
-    def "buildscript configuration can select itself"() {
-        buildFile << """
-            buildscript {
-                configurations {
-                    conf {
-                        outgoing {
-                            artifact file('foo.txt')
-                        }
-                        attributes {
-                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "foo"))
-                        }
-                    }
-                }
-
-                dependencies {
-                    conf project(":")
-                }
-            }
-
-            task resolve {
-                def files = buildscript.configurations.conf.incoming.files
-                doLast {
-                    assert files.files*.name == ["foo.txt"]
-                }
-            }
-        """
-
-        executer.expectDocumentedDeprecationWarning("While resolving configuration 'conf', it was also selected as a variant. Configurations should not act as both a resolution root and a variant simultaneously. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false or use the 'resolvable(String)' configuration factory method to create them. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration")
-
-        expect:
-        succeeds("resolve")
-    }
-
-    def "buildscript configuration can select other buildscript configurations"() {
-        buildFile << """
-            buildscript {
-                configurations {
-                    conf {
-                        canBeConsumed = false
-                        attributes {
-                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "other"))
-                        }
-                    }
-                    other {
-                        outgoing {
-                            artifact file('bar.txt')
-                        }
-                        attributes {
-                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "other"))
-                        }
-                    }
-                }
-
-                dependencies {
-                    conf project(":")
-                }
-            }
-
-            task resolve {
-                def files = buildscript.configurations.conf.incoming.files
-                doLast {
-                    assert files*.name == ["bar.txt"]
-                }
-            }
-        """
-
-        expect:
-        succeeds("resolve")
-    }
-
     def "resolvable configuration does not contribute artifacts"() {
         mavenRepo.module("org", "foo").publish()
         buildFile << """
@@ -247,47 +177,6 @@ class RootComponentResolutionIntegrationTest extends AbstractIntegrationSpec {
         succeeds("resolve")
     }
 
-    def "buildscript resolvable configuration and consumable configuration from same project live in same resolved component"() {
-        buildFile << """
-            buildscript {
-                configurations {
-                    conf {
-                        canBeConsumed = false
-                        attributes {
-                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "foo"))
-                        }
-                    }
-                    other {
-                        outgoing {
-                            artifact file("foo.txt")
-                        }
-                        attributes {
-                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "foo"))
-                        }
-                    }
-                }
-
-                dependencies {
-                    conf project(":")
-                }
-            }
-
-            task resolve {
-                def result = buildscript.configurations.conf.incoming.resolutionResult
-                def root = result.root
-                assert root.id.projectName == 'root'
-                assert root.variants.size() == 2
-                def conf = root.variants.find { it.displayName == 'conf' }
-                def other = root.variants.find { it.displayName == 'other' }
-                assert conf != null
-                assert other != null
-            }
-        """
-
-        expect:
-        succeeds("resolve")
-    }
-
     def "resolvable configuration and consumable configuration from same project live in same resolved component"() {
         buildFile << """
             configurations {
@@ -320,6 +209,40 @@ class RootComponentResolutionIntegrationTest extends AbstractIntegrationSpec {
                 def other = root.variants.find { it.displayName == 'other' }
                 assert conf != null
                 assert other != null
+            }
+        """
+
+        expect:
+        succeeds("resolve")
+    }
+
+    // This is not necessarily desired behavior, or important behavior at all.
+    // The detached configuration is _not_ the project. It should not claim to be the project.
+    // Ideally, this configuration would have an unspecified identity, similar to init, settings, and standalone scripts.
+    def "project detached configurations are identified by the root project's identity"() {
+        mavenRepo.module("org", "foo").publish()
+        buildFile << """
+            ${mavenTestRepository()}
+
+            version = "1.0"
+            group = "foo"
+
+            task resolve {
+                def rootComponent = configurations.detachedConfiguration(
+                    dependencies.create("org:foo:1.0")
+                ).incoming.resolutionResult.rootComponent
+                doLast {
+                    def root = rootComponent.get()
+                    assert root.moduleVersion.group == "foo"
+                    assert root.moduleVersion.name == "root"
+                    assert root.moduleVersion.version == "1.0"
+                    assert root.id instanceof ProjectComponentIdentifier
+                    assert root.id.projectName == "root"
+                    assert root.id.build.buildPath == ":"
+                    assert root.id.projectPath == ":"
+                    assert root.id.buildTreePath == ":"
+                    assert root.id.projectName == "root"
+                }
             }
         """
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -370,6 +370,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         ConfigurationContainerInternal createConfigurationContainer(
             Instantiator instantiator,
             CollectionCallbackActionDecorator callbackDecorator,
+            DomainObjectContext domainObjectContext,
             DefaultRootComponentMetadataBuilder.Factory rootComponentMetadataBuilderFactory,
             DefaultConfigurationFactory defaultConfigurationFactory,
             ResolutionStrategyFactory resolutionStrategyFactory
@@ -377,6 +378,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             return instantiator.newInstance(DefaultConfigurationContainer.class,
                 instantiator,
                 callbackDecorator,
+                domainObjectContext,
                 rootComponentMetadataBuilderFactory,
                 defaultConfigurationFactory,
                 resolutionStrategyFactory

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -30,10 +30,12 @@ import org.gradle.api.artifacts.ResolvableConfiguration;
 import org.gradle.api.artifacts.UnknownConfigurationException;
 import org.gradle.api.internal.AbstractValidatingNamedDomainObjectContainer;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultRootComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder;
 import org.gradle.internal.Actions;
 import org.gradle.internal.Cast;
+import org.gradle.internal.Describables;
 import org.gradle.internal.Factory;
 import org.gradle.internal.artifacts.configurations.AbstractRoleBasedConfigurationCreationRequest;
 import org.gradle.internal.artifacts.configurations.NoContextRoleBasedConfigurationCreationRequest;
@@ -58,19 +60,23 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
     private static final Set<ConfigurationRole> VALID_MAYBE_CREATE_ROLES = new HashSet<>(Arrays.asList(ConfigurationRoles.CONSUMABLE, ConfigurationRoles.RESOLVABLE, ConfigurationRoles.DEPENDENCY_SCOPE, ConfigurationRoles.RESOLVABLE_DEPENDENCY_SCOPE));
 
     private final AtomicInteger detachedConfigurationDefaultNameCounter = new AtomicInteger(1);
-    private final Factory<ResolutionStrategyInternal> resolutionStrategyFactory;
+
+    private final DomainObjectContext domainObjectContext;
     private final RootComponentMetadataBuilder rootComponentMetadataBuilder;
     private final DefaultConfigurationFactory defaultConfigurationFactory;
+    private final Factory<ResolutionStrategyInternal> resolutionStrategyFactory;
 
     public DefaultConfigurationContainer(
         Instantiator instantiator,
         CollectionCallbackActionDecorator callbackDecorator,
+        DomainObjectContext domainObjectContext,
         DefaultRootComponentMetadataBuilder.Factory rootComponentMetadataBuilderFactory,
         DefaultConfigurationFactory defaultConfigurationFactory,
         ResolutionStrategyFactory resolutionStrategyFactory
     ) {
         super(Configuration.class, instantiator, new Configuration.Namer(), callbackDecorator);
 
+        this.domainObjectContext = domainObjectContext;
         this.rootComponentMetadataBuilder = rootComponentMetadataBuilderFactory.create(this);
         this.defaultConfigurationFactory = defaultConfigurationFactory;
         this.resolutionStrategyFactory = resolutionStrategyFactory;
@@ -385,5 +391,10 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
         protected I createDomainObject() {
             return factory.apply(getName());
         }
+    }
+
+    @Override
+    public String getDisplayName() {
+        return Describables.of("configuration container for", domainObjectContext).getDisplayName();
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
@@ -28,7 +28,7 @@ import org.gradle.api.internal.artifacts.configurations.MutationValidator;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.LocalConfigurationMetadataBuilder;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.EmptySchema;
-import org.gradle.api.internal.initialization.RootScriptDomainObjectContext;
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext;
 import org.gradle.api.internal.project.HoldsProjectState;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectState;
@@ -136,7 +136,7 @@ public class DefaultRootComponentMetadataBuilder implements RootComponentMetadat
                 return state;
             });
         } else {
-            return createRootComponentMetadata(module, componentIdentifier, EmptySchema.INSTANCE, RootScriptDomainObjectContext.INSTANCE);
+            return createRootComponentMetadata(module, componentIdentifier, EmptySchema.INSTANCE, StandaloneDomainObjectContext.ANONYMOUS);
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/management/DefaultDependencyResolutionManagement.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/management/DefaultDependencyResolutionManagement.java
@@ -41,7 +41,7 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.artifacts.dsl.dependencies.UnknownProjectFinder;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
-import org.gradle.api.internal.initialization.RootScriptDomainObjectContext;
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -84,7 +84,7 @@ public class DefaultDependencyResolutionManagement implements DependencyResoluti
         this.context = context;
         this.repositoryMode = objects.property(RepositoriesMode.class).convention(RepositoriesMode.PREFER_PROJECT);
         this.rulesMode = objects.property(RulesMode.class).convention(RulesMode.PREFER_PROJECT);
-        this.dependencyResolutionServices = Lazy.locking().of(() -> dependencyManagementServices.create(fileResolver, fileCollectionFactory, dependencyMetaDataProvider, makeUnknownProjectFinder(), RootScriptDomainObjectContext.INSTANCE));
+        this.dependencyResolutionServices = Lazy.locking().of(() -> dependencyManagementServices.create(fileResolver, fileCollectionFactory, dependencyMetaDataProvider, makeUnknownProjectFinder(), StandaloneDomainObjectContext.ANONYMOUS));
         this.librariesExtensionName = objects.property(String.class).convention("libs");
         this.projectsExtensionName = objects.property(String.class).convention("projects");
         this.versionCatalogs = objects.newInstance(DefaultVersionCatalogBuilderContainer.class, collectionCallbackActionDecorator, objects, context, dependencyResolutionServices);

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -28,7 +28,7 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvi
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultRootComponentMetadataBuilder
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext
 import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.api.specs.Spec
 import org.gradle.internal.code.UserCodeApplicationContext
@@ -103,7 +103,7 @@ class DefaultConfigurationContainerSpec extends Specification {
     def "adds and gets"() {
         1 * domainObjectContext.identityPath("compile") >> Path.path(":build:compile")
         1 * domainObjectContext.projectPath("compile") >> Path.path(":compile")
-        1 * domainObjectContext.model >> RootScriptDomainObjectContext.INSTANCE
+        1 * domainObjectContext.model >> StandaloneDomainObjectContext.ANONYMOUS
 
         when:
         def compile = configurationContainer.create("compile")
@@ -134,7 +134,7 @@ class DefaultConfigurationContainerSpec extends Specification {
     def "configures and finds"() {
         1 * domainObjectContext.identityPath("compile") >> Path.path(":build:compile")
         1 * domainObjectContext.projectPath("compile") >> Path.path(":compile")
-        1 * domainObjectContext.model >> RootScriptDomainObjectContext.INSTANCE
+        1 * domainObjectContext.model >> StandaloneDomainObjectContext.ANONYMOUS
 
         when:
         def compile = configurationContainer.create("compile") {
@@ -150,7 +150,7 @@ class DefaultConfigurationContainerSpec extends Specification {
     def "creates detached"() {
         given:
         1 * domainObjectContext.projectPath("detachedConfiguration1") >> Path.path(":detachedConfiguration1")
-        1 * domainObjectContext.model >> RootScriptDomainObjectContext.INSTANCE
+        1 * domainObjectContext.model >> StandaloneDomainObjectContext.ANONYMOUS
 
         def dependency1 = new DefaultExternalModuleDependency("group", "name", "version")
         def dependency2 = new DefaultExternalModuleDependency("group", "name2", "version")

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
@@ -35,7 +35,7 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvi
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultRootComponentMetadataBuilder
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext
 import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.internal.artifacts.configurations.NoContextRoleBasedConfigurationCreationRequest
 import org.gradle.internal.code.UserCodeApplicationContext
@@ -64,7 +64,7 @@ class DefaultConfigurationContainerTest extends Specification {
     private CalculatedValueContainerFactory calculatedValueContainerFactory = Mock()
     private Instantiator instantiator = TestUtil.instantiatorFactory().decorateLenient()
     private ImmutableAttributesFactory immutableAttributesFactory = AttributeTestUtil.attributesFactory()
-    private DomainObjectContext domainObjectContext = new RootScriptDomainObjectContext()
+    private DomainObjectContext domainObjectContext = StandaloneDomainObjectContext.ANONYMOUS
     private DefaultRootComponentMetadataBuilder metadataBuilder = Mock(DefaultRootComponentMetadataBuilder) {
         getValidator() >> Mock(MutationValidator)
     }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -59,7 +59,7 @@ import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact
 import org.gradle.api.internal.artifacts.result.DefaultMinimalResolutionResult
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext
 import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.specs.Spec
@@ -1821,7 +1821,7 @@ All Artifacts:
         _ * domainObjectContext.identityPath(_) >> { String p -> build.append(Path.path(projectPath)).child(p) }
         _ * domainObjectContext.projectPath(_) >> { String p -> Path.path(projectPath).child(p) }
         _ * domainObjectContext.buildPath >> Path.path(buildPath)
-        _ * domainObjectContext.model >> RootScriptDomainObjectContext.INSTANCE
+        _ * domainObjectContext.model >> StandaloneDomainObjectContext.ANONYMOUS
 
         def publishArtifactNotationParser = new PublishArtifactNotationParserFactory(
             instantiator,

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilderTest.groovy
@@ -27,7 +27,7 @@ import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
 import org.gradle.api.internal.artifacts.configurations.DetachedConfigurationsProvider
 import org.gradle.api.internal.attributes.AttributeContainerInternal
-import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext
 import org.gradle.internal.component.local.model.LocalComponentMetadata
 import org.gradle.internal.component.model.Exclude
 import org.gradle.internal.component.model.ExcludeMetadata
@@ -167,6 +167,6 @@ class DefaultLocalConfigurationMetadataBuilderTest extends Specification {
     }
 
     def create() {
-        return converter.create(configuration, configurationsProvider, component, cache, RootScriptDomainObjectContext.INSTANCE, TestUtil.calculatedValueContainerFactory())
+        return converter.create(configuration, configurationsProvider, component, cache, StandaloneDomainObjectContext.ANONYMOUS, TestUtil.calculatedValueContainerFactory())
     }
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
@@ -29,7 +29,7 @@ import org.gradle.api.internal.DomainObjectContext
 import org.gradle.api.internal.DynamicObjectAware
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileLookup
-import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext
 import org.gradle.api.internal.tasks.properties.InspectionScheme
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.internal.execution.InputFingerprinter
@@ -63,7 +63,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
         getPropertyWalker() >> propertyWalker
     }
     def domainObjectContext = Mock(DomainObjectContext) {
-        getModel() >> RootScriptDomainObjectContext.INSTANCE
+        getModel() >> StandaloneDomainObjectContext.ANONYMOUS
     }
 
     def isolatableFactory = new TestIsolatableFactory()

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetadataTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetadataTest.groovy
@@ -43,7 +43,7 @@ import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext
 import org.gradle.api.internal.tasks.TaskDependencyFactory
 import org.gradle.internal.Describables
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
@@ -81,7 +81,7 @@ class DefaultLocalComponentMetadataTest extends Specification {
     }
 
     def configurationsFactory = new DefaultLocalComponentMetadata.ConfigurationsProviderMetadataFactory(
-        configurationsProvider, metadataBuilder, RootScriptDomainObjectContext.INSTANCE, TestUtil.calculatedValueContainerFactory())
+        configurationsProvider, metadataBuilder, StandaloneDomainObjectContext.ANONYMOUS, TestUtil.calculatedValueContainerFactory())
 
     def metadata = new DefaultLocalComponentMetadata(
         id, componentIdentifier, "status", Mock(AttributesSchemaInternal),

--- a/platforms/software/reporting/src/main/java/org/gradle/api/reporting/internal/DefaultReportContainer.java
+++ b/platforms/software/reporting/src/main/java/org/gradle/api/reporting/internal/DefaultReportContainer.java
@@ -37,6 +37,7 @@ public class DefaultReportContainer<T extends Report> extends DefaultNamedDomain
 
     public DefaultReportContainer(Class<? extends T> type, Instantiator instantiator, CollectionCallbackActionDecorator callbackActionDecorator) {
         super(type, instantiator, Report.NAMER, callbackActionDecorator);
+        getMutationGuard().forbidMutation(ImmutableViolationException::new);
 
         enabled = matching(new Spec<T>() {
             @Override
@@ -44,11 +45,6 @@ public class DefaultReportContainer<T extends Report> extends DefaultNamedDomain
                 return element.getRequired().get();
             }
         });
-    }
-
-    @Override
-    protected void assertMutableCollectionContents() {
-        throw new ImmutableViolationException();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DomainObjectContext.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal;
 
+import org.gradle.api.Describable;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.model.ModelContainer;
 import org.gradle.util.Path;
@@ -24,7 +25,7 @@ import javax.annotation.Nullable;
 /**
  * Represents a node in the tree of builds/projects.
  */
-public interface DomainObjectContext {
+public interface DomainObjectContext extends Describable {
 
     /**
      * Creates a path from the root of the build tree to the current context + name.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/MutationGuard.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/MutationGuard.java
@@ -17,9 +17,14 @@
 package org.gradle.api.internal;
 
 import org.gradle.api.Action;
+import org.gradle.api.problems.internal.DocLink;
+import org.gradle.internal.Factory;
 
 /**
- * A guard object for the mutability of an object. All mutable method of the object needs to be guarded by calling {@code #assertMutationAllowed(String)}. If you want to allow ad-hoc code to pass over the mutation guard of the object, the object will need to implement {@code WithMutationGuard}. You can then use {@code MutationGuards#of(Object)} to acquire the guard and enable/disable the mutation as you see fit.
+ * A guard object for the mutability of an object.
+ * All mutable method of the object needs to be guarded by calling {@code #assertMutationAllowed(String)}.
+ * If you want to allow ad-hoc code to pass over the mutation guard of the object, the object will need to implement {@code WithMutationGuard}.
+ * You can then use {@code MutationGuards#of(Object)} to acquire the guard and enable/disable the mutation as you see fit.
  */
 public interface MutationGuard {
     /**
@@ -54,4 +59,26 @@ public interface MutationGuard {
     void assertMutationAllowed(String methodName, Object target);
 
     <T> void assertMutationAllowed(String methodName, T target, Class<T> targetType);
+
+    /**
+     * Unconditionally deprecate subsequent mutations of the object guarded by this guard.
+     *
+     * Even {@link #withMutationDisabled} and {@link #withMutationEnabled} cannot override
+     * this deprecation.
+     *
+     * In a future version of Gradle, the deprecation will become an error.
+     *
+     * @param documentationUrl The URL to the documentation explaining the deprecation.
+     */
+    void deprecateMutation(DocLink documentationUrl);
+
+    /**
+     * Unconditionally forbid subsequent mutations of the object guarded by this guard.
+     *
+     * Even {@link #withMutationDisabled} and {@link #withMutationEnabled} cannot override
+     * this prohibition.
+     *
+     * @param exceptionFactory A factory for the exception to throw when a mutation is attempted.
+     */
+    void forbidMutation(Factory<RuntimeException> exceptionFactory);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/MutationGuards.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/MutationGuards.java
@@ -17,6 +17,8 @@
 package org.gradle.api.internal;
 
 import org.gradle.api.Action;
+import org.gradle.api.problems.internal.DocLink;
+import org.gradle.internal.Factory;
 
 public class MutationGuards {
     private static final MutationGuard IDENTITY_MUTATION_GUARD = new MutationGuard() {
@@ -44,6 +46,16 @@ public class MutationGuards {
         public <T> void assertMutationAllowed(String methodName, T target, Class<T> targetType) {
             // do nothing
         }
+
+        @Override
+        public void deprecateMutation(DocLink documentationUrl) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void forbidMutation(Factory<RuntimeException> exceptionFactory) {
+            throw new UnsupportedOperationException();
+        }
     };
 
     /**
@@ -54,13 +66,13 @@ public class MutationGuards {
     }
 
     /**
-     * Retrieves the {@code MutationGuard} of the target if it implements {@code WithMutationGuard}, else returns an identity mutation guard performing no guard operations.
+     * Retrieves the {@code MutationGuard} of the target if it implements {@code WithMutationGuard}, otherwise throws an exception.
      */
     public static MutationGuard of(Object target) {
         if (target instanceof WithMutationGuard) {
             return ((WithMutationGuard) target).getMutationGuard();
         } else {
-            return IDENTITY_MUTATION_GUARD;
+            throw new IllegalArgumentException("The target object does not implement WithMutationGuard: " + target);
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DependencyResolutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DependencyResolutionServices.java
@@ -23,16 +23,12 @@ import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.model.ObjectFactory;
 
-/**
- * Provides access to services required for dependency resolution.
- * <p>
- * Note that changes to this type, even seemingly safe ones such as narrowing the return types, can
- * cause problems for IDEs (the IDE tests should fail upon such changes, alerting us to
- * this problem).  Thus, this internal API should be treated as semi-public.
- */
 public interface DependencyResolutionServices {
     RepositoryHandler getResolveRepositoryHandler();
 
+    // This  method is currently referenced by IDEA, here:
+    // https://github.com/JetBrains/intellij-community/blob/819a54af52161355ac894671f861384e626b2784/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/builder/VersionCatalogsModelBuilder.java#L50
+    // Therefore, we cannot change its signature.
     ConfigurationContainer getConfigurationContainer();
 
     DependencyHandler getDependencyHandler();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultBuildLogicBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultBuildLogicBuilder.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.initialization;
 
+import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
@@ -69,7 +70,9 @@ public class DefaultBuildLogicBuilder implements BuildLogicBuilder {
         List<TaskIdentifier.TaskBasedTaskIdentifier> tasksToBuild = new ArrayList<>();
         for (Task task : getDependenciesForInternalUse(classpath)) {
             BuildState targetBuild = owningBuildOf(task);
-            assert targetBuild != currentBuild;
+            if (targetBuild == currentBuild) {
+                throw new InvalidUserDataException("Script classpath dependencies must reside in a separate build from the script itself.");
+            }
             tasksToBuild.add(TaskIdentifier.of(targetBuild.getBuildIdentifier(), (TaskInternal) task));
         }
         return tasksToBuild;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.dsl.DependencyLockingHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.initialization.dsl.ScriptHandler;
+import org.gradle.api.internal.MutationGuards;
 import org.gradle.api.internal.artifacts.DependencyResolutionServices;
 import org.gradle.api.internal.artifacts.JavaEcosystemSupport;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationRolesForMigration;
@@ -35,6 +36,7 @@ import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.internal.Factory;
 import org.gradle.internal.classloader.ClasspathUtil;
 import org.gradle.internal.classpath.ClassPath;
+import org.gradle.internal.deprecation.Documentation;
 import org.gradle.internal.resource.ResourceLocation;
 import org.gradle.util.internal.ConfigureUtil;
 
@@ -157,6 +159,7 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
         }
         if (classpathConfiguration == null) {
             classpathConfiguration = configContainer.migratingUnlocked(CLASSPATH_CONFIGURATION, ConfigurationRolesForMigration.LEGACY_TO_RESOLVABLE_DEPENDENCY_SCOPE);
+            MutationGuards.of(configContainer).deprecateMutation(Documentation.upgradeGuide(8, "creating_new_buildscript_configurations"));
             buildLogicBuilder.prepareClassPath(classpathConfiguration, dependencyHandler);
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandlerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandlerFactory.java
@@ -50,7 +50,7 @@ public class DefaultScriptHandlerFactory implements ScriptHandlerFactory {
 
     @Override
     public ScriptHandlerInternal create(ScriptSource scriptSource, ClassLoaderScope classLoaderScope) {
-        return create(scriptSource, classLoaderScope, RootScriptDomainObjectContext.INSTANCE);
+        return create(scriptSource, classLoaderScope, StandaloneDomainObjectContext.forScript(scriptSource));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/StandaloneDomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/StandaloneDomainObjectContext.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.initialization;
 
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.internal.model.CalculatedModelValue;
 import org.gradle.internal.model.ModelContainer;
 import org.gradle.util.Path;
@@ -26,18 +27,38 @@ import javax.annotation.Nullable;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public class RootScriptDomainObjectContext implements DomainObjectContext, ModelContainer<Object> {
+public abstract class StandaloneDomainObjectContext implements DomainObjectContext, ModelContainer<Object> {
     private static final Object MODEL = new Object();
-    public static final RootScriptDomainObjectContext INSTANCE = new RootScriptDomainObjectContext();
 
-    public static final RootScriptDomainObjectContext PLUGINS = new RootScriptDomainObjectContext() {
+    public static final StandaloneDomainObjectContext ANONYMOUS = new StandaloneDomainObjectContext() {
+        @Override
+        public String getDisplayName() {
+            return "anonymous";
+        }
+    };
+
+    public static final StandaloneDomainObjectContext PLUGINS = new StandaloneDomainObjectContext() {
         @Override
         public boolean isPluginContext() {
             return true;
         }
+
+        @Override
+        public String getDisplayName() {
+            return "plugins";
+        }
     };
 
-    private RootScriptDomainObjectContext() {
+    public static StandaloneDomainObjectContext forScript(ScriptSource source) {
+        return new StandaloneDomainObjectContext() {
+            @Override
+            public String getDisplayName() {
+                return source.getShortDisplayName().getDisplayName();
+            }
+        };
+    }
+
+    private StandaloneDomainObjectContext() {
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -1610,5 +1610,10 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
         public boolean isDetachedState() {
             return true;
         }
+
+        @Override
+        public String getDisplayName() {
+            return delegate.getDisplayName();
+        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/model/CalculatedValueContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/model/CalculatedValueContainer.java
@@ -17,7 +17,7 @@
 package org.gradle.internal.model;
 
 import org.gradle.api.Project;
-import org.gradle.api.internal.initialization.RootScriptDomainObjectContext;
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext;
 import org.gradle.api.internal.tasks.NodeExecutionContext;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.internal.tasks.WorkNodeAction;
@@ -149,7 +149,7 @@ public class CalculatedValueContainer<T, S extends ValueCalculator<? extends T>>
         if (calculationState != null && calculationState.supplier.usesMutableProjectState()) {
             return calculationState.supplier.getOwningProject().getOwner();
         } else {
-            return RootScriptDomainObjectContext.INSTANCE.getModel();
+            return StandaloneDomainObjectContext.ANONYMOUS.getModel();
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -294,6 +294,11 @@ public class ProjectScopeServices extends ScopedServiceRegistry {
         public boolean isPluginContext() {
             return false;
         }
+
+        @Override
+        public String getDisplayName() {
+            return "buildscript of " + delegate.getDisplayName();
+        }
     }
 
     protected DependencyMetaDataProvider createDependencyMetaDataProvider() {


### PR DESCRIPTION
The intention of the buildscript block is to contain the `classpath` configuration and allow dependencies to be declared on the configuration. This commit deprecates using the block for other questionable purposes, by deprecating the creation of new configurations in the block.

This closes some odd corner cases where a buildscript configuration can resolve other buildscript configurations, a behavior that we never intended to support. There are some questionable use cases for using the buildscript block to perform ad-hoc resolutions, for example in settings scripts where there is no other way to obtain a configuration. For this reason, creating detached configurations is still permitted in buildscript blocks.

We add a bunch of tests in `BuildscriptResolutionIntegrationTest`, which tests corner cases for buildscript configuration resolution.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
