### PR TITLE
Do not completely ignore some files when trying to generate @since in…

### DIFF
--- a/build-logic/kotlin-dsl-shared-runtime/src/main/kotlin/org/gradle/kotlin/dsl/internal/sharedruntime/codegen/ApiTypeProvider.kt
+++ b/build-logic/kotlin-dsl-shared-runtime/src/main/kotlin/org/gradle/kotlin/dsl/internal/sharedruntime/codegen/ApiTypeProvider.kt
@@ -164,6 +164,10 @@ class ApiType internal constructor(
     private val context: ApiTypeProvider.Context
 ) {
 
+    override fun toString(): String {
+        return binaryName
+    }
+
     internal
     val binaryName: String
         get() = binaryNameOfInternalName(delegate.name)


### PR DESCRIPTION
…formation

Previously, this would completely skip parsing Provider. This was OK as long as we never generated extension methods for this type.

We skipped parsing Provider and a few other classes due to bugs in qdox.

If we did generate an extension for a type that was skipped, FunctionSinceRepository.since(...) would fail with an unhelpful error and prevent you from running any tests.

Instead of completing ignoring files, we remove the annotation that causes the qdox bug in a hacky way. In the end, we only needed to skip Transformer and Provider and not any of the other types.

ApiTypeProvider was changed to have slightly better toString for ApiType, so you can find things in the map in the debugger.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
