### PR TITLE
Incremental Compilation - prefer project compiled sources (#21255)

### DIFF
--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/AbstractRecompilationSpecProvider.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/AbstractRecompilationSpecProvider.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.compile.incremental.recomp;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.file.FileTree;
@@ -30,7 +31,6 @@ import org.gradle.internal.file.Deleter;
 import org.gradle.work.FileChange;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -119,7 +119,7 @@ abstract class AbstractRecompilationSpecProvider implements RecompilationSpecPro
         }
     }
 
-    private String rebuildClauseForChangedNonSourceFile(FileChange fileChange) {
+    private static String rebuildClauseForChangedNonSourceFile(FileChange fileChange) {
         return String.format("%s '%s' has been %s", "resource", fileChange.getFile().getName(), fileChange.getChangeType().name().toLowerCase(Locale.US));
     }
 
@@ -265,10 +265,12 @@ abstract class AbstractRecompilationSpecProvider implements RecompilationSpecPro
     }
 
     private static void includePreviousCompilationOutputOnClasspath(JavaCompileSpec spec) {
-        List<File> classpath = new ArrayList<>(spec.getCompileClasspath());
+        List<File> originalClasspath = spec.getCompileClasspath();
         File destinationDir = spec.getDestinationDir();
-        classpath.add(destinationDir);
-        spec.setCompileClasspath(classpath);
+        spec.setCompileClasspath(ImmutableList.<File>builderWithExpectedSize(originalClasspath.size() + 1)
+            .add(destinationDir)
+            .addAll(originalClasspath)
+            .build());
     }
 
     @Override


### PR DESCRIPTION
 This stops a situation where if versions of the same class are in both your sources and your dependencies, the version in your dependencies would be used over the one in your sources. This would lead to compile errors in incremental builds in instances where a consumer class in your sources depends on the specifics of your sources' version that differs from the version in the dependencies.

<!--- The issue this PR addresses -->
Fixes #21255 

### Context
Although generally discouraged, projects may contain class files that conflict with their dependencies.
During a full build the compiler will deal with this and prefer resolution to classes being compiled however in incremental building mode we need to consider the order of the classpath to indicate preference of where to source classes from.

This has been seen in the wild in issues such as PaperMC/paperweight#199

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [X] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [N/A] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
