### PR TITLE
Change javadoc to avoid commitment to specific details

### DIFF
--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/ProblemAggregation.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/ProblemAggregation.java
@@ -25,8 +25,6 @@ import java.util.List;
  * Represents a list of aggregated problems. These are sent at the end of the build.
  * All Problems that occurred more than once during the build are aggregated and sent as a {@link ProblemAggregation}.
  * They won't be sent in between the build only the first one.
- * The aggregation happens based on the {@link ProblemCategory} and {@link Label}.
- * Therefore, the {@link ProblemCategory} and {@link Label} are the same for all aggregated problems and are also present in the this aggregation interface.
  *
  * @since 8.6
  */

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/ProblemAggregationDescriptor.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/ProblemAggregationDescriptor.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 /**
  * Describes the problem aggregations sent at the end of the build.
- * Note: They can also be sent during the build if the total number of problems exceeds 10,000.
  *
  * @since 8.6
  */


### PR DESCRIPTION
Fixes 
 - gradle/gradle-private#4110

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
