### PR TITLE
Lazily evaluate git commit id

### DIFF
--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildEnvironment.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildEnvironment.kt
@@ -66,7 +66,7 @@ fun Project.currentGitCommitViaFileSystemQuery(): Provider<String> = getBuildEnv
 
 
 @Suppress("UnstableApiUsage")
-fun Project.git(vararg args: String): String {
+fun Project.git(vararg args: String): Provider<String> {
     val projectDir = layout.projectDirectory.asFile
     val execOutput = providers.exec {
         workingDir = projectDir
@@ -76,8 +76,10 @@ fun Project.git(vararg args: String): String {
             commandLine = listOf("cmd", "/c") + commandLine
         }
     }
-    return if (execOutput.result.get().exitValue == 0) execOutput.standardOutput.asText.get().trim()
-    else "<unknown>" // It's a source distribution, we don't know.
+    return execOutput.result.zip(execOutput.standardOutput.asText) { result, outputText ->
+        if (result.exitValue == 0) outputText.trim()
+        else "<unknown>" // It's a source distribution, we don't know.
+    }
 }
 
 


### PR DESCRIPTION
So it isn't a configuration input anymore.

I tried it locally and doing a commit did not invalidate the configuration cache state any more.