### PR TITLE
Implement the "-Werror" compiler flag handling when emitting compiler diagnostics as problems

### DIFF
--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
@@ -29,7 +29,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * A {@link DiagnosticListener} that consumes {@link Diagnostic} messages, and reports them as Gradle {@link Problems}.
@@ -41,7 +41,7 @@ public class DiagnosticToProblemListener implements DiagnosticListener<JavaFileO
     private final ProblemReporter problemReporter;
 
     /** A collection of filters that will serve as a predicate to determine if a diagnostic should be reported or not.*/
-    private final Collection<Function<Diagnostic<? extends JavaFileObject>, Boolean>> diagnosticFilters = new ArrayList<>();
+    private final Collection<Predicate<Diagnostic<? extends JavaFileObject>>> diagnosticFilters = new ArrayList<>();
 
     /**
      * A map of explicit overrides between {@link Diagnostic.Kind} and {@link Severity}.
@@ -55,7 +55,7 @@ public class DiagnosticToProblemListener implements DiagnosticListener<JavaFileO
         this.problemReporter = problemReporter;
     }
 
-    public void addDiagnosticFilter(Function<Diagnostic<? extends JavaFileObject>, Boolean> diagnosticFilter) {
+    public void addDiagnosticFilter(Predicate<Diagnostic<? extends JavaFileObject>> diagnosticFilter) {
         diagnosticFilters.add(diagnosticFilter);
     }
 
@@ -66,7 +66,7 @@ public class DiagnosticToProblemListener implements DiagnosticListener<JavaFileO
     @Override
     public void report(Diagnostic<? extends JavaFileObject> diagnostic) {
         // If any of the filters return true, we should not report the diagnostic
-        if (diagnosticFilters.stream().anyMatch(filter -> filter.apply(diagnostic))) {
+        if (diagnosticFilters.stream().anyMatch(filter -> filter.test(diagnostic))) {
             return;
         }
 

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
@@ -132,7 +132,6 @@ public class DiagnosticToProblemListener implements DiagnosticListener<JavaFileO
     }
 
     private static Severity mapKindToSeverity(Diagnostic.Kind kind) {
-        // Map the kind to a severity
         switch (kind) {
             case ERROR:
                 return Severity.ERROR;

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
@@ -39,15 +39,7 @@ import java.util.function.Predicate;
 public class DiagnosticToProblemListener implements DiagnosticListener<JavaFileObject> {
 
     private final ProblemReporter problemReporter;
-
-    /** A collection of filters that will serve as a predicate to determine if a diagnostic should be reported or not.*/
     private final Collection<Predicate<Diagnostic<? extends JavaFileObject>>> diagnosticFilters = new ArrayList<>();
-
-    /**
-     * A map of explicit overrides between {@link Diagnostic.Kind} and {@link Severity}.
-     * <p>
-     * This will take precedence over the default mapping defined in {@link #mapKindToSeverity(Diagnostic.Kind)}.
-     */
     private final Map<Diagnostic.Kind, Diagnostic.Kind> severityOverrides = new HashMap<>();
 
 
@@ -55,10 +47,20 @@ public class DiagnosticToProblemListener implements DiagnosticListener<JavaFileO
         this.problemReporter = problemReporter;
     }
 
+    /**
+     * Adds a filter, which will serve as a predicate if a diagnostic should be reported or not.
+     * <p>
+     * Multiple filters can be added, and if any of them return {@code true}, the diagnostic will not be reported.
+     */
     public void addDiagnosticFilter(Predicate<Diagnostic<? extends JavaFileObject>> diagnosticFilter) {
         diagnosticFilters.add(diagnosticFilter);
     }
 
+    /**
+     * Adds an explicit override for a given {@link Diagnostic.Kind}
+     * <p>
+     * When reporting a diagnostic, the override will replace the {@link #mapKindToSeverity(Diagnostic.Kind)} of the original diagnostic.
+     */
     public void addSeverityOverride(Diagnostic.Kind fromKind, Diagnostic.Kind toKind) {
         severityOverrides.put(fromKind, toKind);
     }

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.tasks.compile;
 
+import com.sun.tools.javac.resources.CompilerProperties;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDeclaration;
 import org.gradle.api.internal.tasks.compile.reflect.GradleStandardJavaFileManager;
@@ -37,7 +38,6 @@ import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 
 public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable {
@@ -101,7 +101,7 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
         if (spec.getCompileOptions().getCompilerArgs().contains("-Werror")) {
             // ... we filter out the warning that is emitted when -Werror is used, as it's not a real problem...
             diagnosticToProblemListener.addDiagnosticFilter(
-                diagnostic -> "warnings found and -Werror specified".equals(diagnostic.getMessage(Locale.getDefault()))
+                diagnostic -> CompilerProperties.Errors.WarningsAndWerror.key().equals(diagnostic.getCode())
             );
             // ... and instead we override the severity of all the warnings to be an error
             diagnosticToProblemListener.addSeverityOverride(Diagnostic.Kind.WARNING, Diagnostic.Kind.ERROR);


### PR DESCRIPTION
Closes [#27948](https://github.com/gradle/gradle/issues/27948) by solving the transforming/filtering of diagnostics.