### PR TITLE
Consolidate gitstream author checks with custom filter function

### DIFF
--- a/.cm/code_experts.cm
+++ b/.cm/code_experts.cm
@@ -44,31 +44,4 @@ is:
   requested: {{ (pr.comments | match(attr='content', term='@bot-gitstream check all') | some) or (pr.comments | match(attr='content', term='@bot-gitstream check experts') | some) }}
 
 author:
-  using_gitstream: {{ (pr.author | match(list=teams.build_scan.members) | some) or (pr.author | match(list=teams.configuration.members) | some) or (pr.author | match(list=teams.dev_prod.members) | some) or (pr.author | match(list=teams.execution.members) | some) or (pr.author | match(list=teams.ide.members) | some) or (pr.author | match(list=teams.jvm.members) | some) }}
-
-teams:
-  build_scan:
-    members:
-      - 'wolfs'
-  configuration:
-    members:
-      - 'alllex'
-  dev_prod:
-    members:
-      - 'blindpirate'
-  execution:
-    members:
-      - 'asodja-DISABLED'
-      - 'lptr-DISABLED'
-  ide:
-    members:
-      - 'hegyibalint'
-      - 'donat'
-      - 'reinsch82'
-  jvm:
-    members:
-      - 'big-guy'
-      - 'ghale'
-      - 'jvandort-DISABLED'
-      - 'octylFractal'
-      - 'tresat'
+  using_gitstream: {{ (pr.author | isEnabledUser ) }}

--- a/.cm/complex_changes.cm
+++ b/.cm/complex_changes.cm
@@ -35,31 +35,4 @@ automations:
 includes_src_changes: {{ files | match(regex=r/.*\/src\//) | some }}
 
 author:
-  using_gitstream: {{ (pr.author | match(list=teams.build_scan.members) | some) or (pr.author | match(list=teams.configuration.members) | some) or (pr.author | match(list=teams.dev_prod.members) | some) or (pr.author | match(list=teams.execution.members) | some) or (pr.author | match(list=teams.ide.members) | some) or (pr.author | match(list=teams.jvm.members) | some) }}
-
-teams:
-  build_scan:
-    members:
-      - 'wolfs'
-  configuration:
-    members:
-      - 'alllex'
-  dev_prod:
-    members:
-      - 'blindpirate'
-  execution:
-    members:
-      - 'asodja-DISABLED'
-      - 'lptr-DISABLED'
-  ide:
-    members:
-      - 'hegyibalint'
-      - 'donat'
-      - 'reinsch82'
-  jvm:
-    members:
-      - 'big-guy'
-      - 'ghale'
-      - 'jvandort'
-      - 'octylFractal'
-      - 'tresat'
+  using_gitstream: {{ (pr.author | isEnabledUser ) }}

--- a/.cm/estimated_time_to_review.cm
+++ b/.cm/estimated_time_to_review.cm
@@ -40,31 +40,4 @@ is:
   requested: {{ (pr.comments | match(attr='content', term='@bot-gitstream check all') | some) or (pr.comments | match(attr='content', term='@bot-gitstream check all') | some) }}
 
 author:
-  using_gitstream: {{ (pr.author | match(list=teams.build_scan.members) | some) or (pr.author | match(list=teams.configuration.members) | some) or (pr.author | match(list=teams.dev_prod.members) | some) or (pr.author | match(list=teams.execution.members) | some) or (pr.author | match(list=teams.ide.members) | some) or (pr.author | match(list=teams.jvm.members) | some) }}
-
-teams:
-  build_scan:
-    members:
-      - 'wolfs'
-  configuration:
-    members:
-      - 'alllex'
-  dev_prod:
-    members:
-      - 'blindpirate'
-  execution:
-    members:
-      - 'asodja-DISABLED'
-      - 'lptr-DISABLED'
-  ide:
-    members:
-      - 'hegyibalint'
-      - 'donat'
-      - 'reinsch82'
-  jvm:
-    members:
-      - 'big-guy'
-      - 'ghale'
-      - 'jvandort'
-      - 'octylFractal'
-      - 'tresat'
+  using_gitstream: {{ (pr.author | isEnabledUser ) }}

--- a/.cm/includes_todos.cm
+++ b/.cm/includes_todos.cm
@@ -42,31 +42,4 @@ is:
   requested: {{ (pr.comments | match(attr='content', term='@bot-gitstream check all') | some) or (pr.comments | match(attr='content', term='@bot-gitstream check todos') | some) }}
 
 author:
-  using_gitstream: {{ (pr.author | match(list=teams.build_scan.members) | some) or (pr.author | match(list=teams.configuration.members) | some) or (pr.author | match(list=teams.dev_prod.members) | some) or (pr.author | match(list=teams.execution.members) | some) or (pr.author | match(list=teams.ide.members) | some) or (pr.author | match(list=teams.jvm.members) | some) }}
-
-teams:
-  build_scan:
-    members:
-      - 'wolfs'
-  configuration:
-    members:
-      - 'alllex'
-  dev_prod:
-    members:
-      - 'blindpirate'
-  execution:
-    members:
-      - 'asodja-DISABLED'
-      - 'lptr-DISABLED'
-  ide:
-    members:
-      - 'hegyibalint'
-      - 'donat'
-      - 'reinsch82'
-  jvm:
-    members:
-      - 'big-guy'
-      - 'ghale'
-      - 'jvandort-DISABLED'
-      - 'octylFractal'
-      - 'tresat'
+  using_gitstream: {{ (pr.author | isEnabledUser ) }}

--- a/.cm/javadoc_on_new_files.cm
+++ b/.cm/javadoc_on_new_files.cm
@@ -42,31 +42,4 @@ colors:
   yellow: 'ffb300'
 
 author:
-  using_gitstream: {{ (pr.author | match(list=teams.build_scan.members) | some) or (pr.author | match(list=teams.configuration.members) | some) or (pr.author | match(list=teams.dev_prod.members) | some) or (pr.author | match(list=teams.execution.members) | some) or (pr.author | match(list=teams.ide.members) | some) or (pr.author | match(list=teams.jvm.members) | some) }}
-
-teams:
-  build_scan:
-    members:
-      - 'wolfs'
-  configuration:
-    members:
-      - 'alllex'
-  dev_prod:
-    members:
-      - 'blindpirate'
-  execution:
-    members:
-      - 'asodja-DISABLED'
-      - 'lptr-DISABLED'
-  ide:
-    members:
-      - 'hegyibalint'
-      - 'donat'
-      - 'reinsch82'
-  jvm:
-    members:
-      - 'big-guy'
-      - 'ghale'
-      - 'jvandort-DISABLED'
-      - 'octylFractal'
-      - 'tresat'
+  using_gitstream: {{ (pr.author | isEnabledUser ) }}

--- a/.cm/lacks_tests.cm
+++ b/.cm/lacks_tests.cm
@@ -51,31 +51,4 @@ is:
   requested: {{ (pr.comments | match(attr='content', term='@bot-gitstream check all') | some) or (pr.comments | match(attr='content', term='@bot-gitstream check tests') | some) }}
 
 author:
-  using_gitstream: {{ (pr.author | match(list=teams.build_scan.members) | some) or (pr.author | match(list=teams.configuration.members) | some) or (pr.author | match(list=teams.dev_prod.members) | some) or (pr.author | match(list=teams.execution.members) | some) or (pr.author | match(list=teams.ide.members) | some) or (pr.author | match(list=teams.jvm.members) | some) }}
-
-teams:
-  build_scan:
-    members:
-      - 'wolfs'
-  configuration:
-    members:
-      - 'alllex'
-  dev_prod:
-    members:
-      - 'blindpirate'
-  execution:
-    members:
-      - 'asodja-DISABLED'
-      - 'lptr-DISABLED'
-  ide:
-    members:
-      - 'hegyibalint'
-      - 'donat'
-      - 'reinsch82'
-  jvm:
-    members:
-      - 'big-guy'
-      - 'ghale'
-      - 'jvandort'
-      - 'octylFractal'
-      - 'tresat'
+  using_gitstream: {{ (pr.author | isEnabledUser ) }}

--- a/.cm/platform_labels.cm
+++ b/.cm/platform_labels.cm
@@ -172,31 +172,4 @@ platforms:
       - 'platforms/software/'
 
 author:
-  using_gitstream: {{ (pr.author | match(list=teams.build_scan.members) | some) or (pr.author | match(list=teams.configuration.members) | some) or (pr.author | match(list=teams.dev_prod.members) | some) or (pr.author | match(list=teams.execution.members) | some) or (pr.author | match(list=teams.ide.members) | some) or (pr.author | match(list=teams.jvm.members) | some) }}
-
-teams:
-  build_scan:
-    members:
-      - 'wolfs'
-  configuration:
-    members:
-      - 'alllex'
-  dev_prod:
-    members:
-      - 'blindpirate'
-  execution:
-    members:
-      - 'asodja-DISABLED'
-      - 'lptr-DISABLED'
-  ide:
-    members:
-      - 'hegyibalint'
-      - 'donat'
-      - 'reinsch82'
-  jvm:
-    members:
-      - 'big-guy'
-      - 'ghale'
-      - 'jvandort'
-      - 'octylFractal'
-      - 'tresat'
+  using_gitstream: {{ (pr.author | isEnabledUser ) }}

--- a/.cm/plugins/filters/isEnabledUser/index.js
+++ b/.cm/plugins/filters/isEnabledUser/index.js
@@ -1,0 +1,19 @@
+const buildScan = ["wolfs"];
+const configuration = ["alllex"];
+const devProd = ["blindpirate"];
+const execution = [];
+const ide = ["hegyibalint", "donat", "reinsch82"];
+const jvm = ["big-guy", "ghale", "jvandort", "octylFractal", "tresat"];
+
+/**
+ * @module isEnabledUser
+ * @description Returns true if the username that is passed to this function is a member of the Gradle BT Team who has opted into gitStream automations.
+ * @param {string} Input - The GitHub username to check.
+ * @returns {boolean} Returns true if the user is specified in any of the lists of Gradle BT team members above, otherwise false.
+ * @example {{ pr.author | isEnabledUser }}
+ */
+function isEnabledUser(username) {
+    return (buildScan.includes(username) || configuration.includes(username) || devProd.includes(username) || execution.includes(username) || ide.includes(username) || jvm.includes(username));
+};
+
+module.exports = isEnabledUser;

--- a/.cm/summary_table.cm
+++ b/.cm/summary_table.cm
@@ -63,34 +63,7 @@ is:
   requested: {{ (pr.comments | match(attr='content', term='@bot-gitstream check all') | some) or (pr.comments | match(attr='content', term='@bot-gitstream check summary') | some) }}
 
 author:
-  using_gitstream: {{ (pr.author | match(list=teams.build_scan.members) | some) or (pr.author | match(list=teams.configuration.members) | some) or (pr.author | match(list=teams.dev_prod.members) | some) or (pr.author | match(list=teams.execution.members) | some) or (pr.author | match(list=teams.ide.members) | some) or (pr.author | match(list=teams.jvm.members) | some) }}
-
-teams:
-  build_scan:
-    members:
-      - 'wolfs'
-  configuration:
-    members:
-      - 'alllex-DISABLED'
-  dev_prod:
-    members:
-      - 'blindpirate'
-  execution:
-    members:
-      - 'asodja-DISABLED'
-      - 'lptr-DISABLED'
-  ide:
-    members:
-      - 'hegyibalint'
-      - 'donat'
-      - 'reinsch82'
-  jvm:
-    members:
-      - 'big-guy'
-      - 'ghale'
-      - 'jvandort-DISABLED'
-      - 'octylFractal'
-      - 'tresat'
+  using_gitstream: {{ (pr.author | isEnabledUser ) }}
 
 # Perhaps a task could generate this list from the CODEOWNERS, or both this and CODEOWNERS could be generated from different single source of truth?
 # Keys like `- build_infrastructure:` do not mean anything, they just need to be unique


### PR DESCRIPTION
gitStream now supports [custom filter functions](https://docs.gitstream.cm/filter-function-plugins/).  This PR consolidates all our `isAuthor` checks into a single filter function.