### PR TITLE
Remove non-working printout of the diagnostic

### DIFF
--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
@@ -74,9 +74,6 @@ public class DiagnosticToProblemListener implements DiagnosticListener<JavaFileO
                 spec.lineInFileLocation(resourceName, line, column, length);
             }
         });
-
-        // We need to print the message to stderr as well, as it was the default behavior of the compiler
-        System.err.println(message);
     }
 
     private static String getPath(JavaFileObject fileObject) {


### PR DESCRIPTION
Accidentally left in the code this naïve implementation.