### PR TITLE
(Re)introduce Property.replace

### DIFF
--- a/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/generator/codegen/FunctionSinceRepository.kt
+++ b/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/generator/codegen/FunctionSinceRepository.kt
@@ -37,6 +37,10 @@ class FunctionSinceRepository(classPath: Set<File>, sourcePath: Set<File>) : Aut
     val filesWithUnsupportedAnnotations = listOf(
         "Transformer.java",
         "Provider.java",
+        "ListProperty.java",
+        "MapProperty.java",
+        "Property.java",
+        "SetProperty.java",
     )
 
     private

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -464,7 +464,7 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
     }
 
     @Override
-    public void update(Transformer<? extends @org.jetbrains.annotations.Nullable FileCollection, ? super FileCollection> transform) {
+    public void replace(Transformer<? extends @org.jetbrains.annotations.Nullable FileCollection, ? super FileCollection> transform) {
         FileCollection newValue = transform.transform(shallowCopy());
         if (newValue != null) {
             setFrom(newValue);

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -463,6 +463,7 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         return result;
     }
 
+    @Override
     public void update(Transformer<? extends @org.jetbrains.annotations.Nullable FileCollection, ? super FileCollection> transform) {
         FileCollection newValue = transform.transform(shallowCopy());
         if (newValue != null) {

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -464,8 +464,8 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
     }
 
     @Override
-    public void replace(Transformer<? extends @org.jetbrains.annotations.Nullable FileCollection, ? super FileCollection> transform) {
-        FileCollection newValue = transform.transform(shallowCopy());
+    public void replace(Transformer<? extends @org.jetbrains.annotations.Nullable FileCollection, ? super FileCollection> transformation) {
+        FileCollection newValue = transformation.transform(shallowCopy());
         if (newValue != null) {
             setFrom(newValue);
         } else {

--- a/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
+++ b/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
@@ -1803,20 +1803,20 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         copy.files == [new File("a"), new File("b")] as Set<File>
     }
 
-    def "update can modify contents of the collection"() {
+    def "replace can modify contents of the collection"() {
         given:
         def a = new File("a.txt")
         def b = new File("b.md")
         collection.from(containing(a, b))
 
         when:
-        collection.update { it.filter { f -> !f.name.endsWith(".txt") } }
+        collection.replace { it.filter { f -> !f.name.endsWith(".txt") } }
 
         then:
         collection.files == [b] as Set<File>
     }
 
-    def "update is not applied to later collection modifications"() {
+    def "replace is not applied to later collection modifications"() {
         given:
         def a = new File("a.txt")
         def b = new File("b.md")
@@ -1824,14 +1824,14 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         collection.from(containing(a, b))
 
         when:
-        collection.update { it.filter { f -> !f.name.endsWith(".txt") } }
+        collection.replace { it.filter { f -> !f.name.endsWith(".txt") } }
         collection.from(containing(c))
 
         then:
         collection.files == [b, c] as Set<File>
     }
 
-    def "update argument is live"() {
+    def "replace argument is live"() {
         given:
         def a = new File("a.txt")
         def b = new File("b.md")
@@ -1841,43 +1841,43 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         def upstream = new DefaultConfigurableFileCollection("<display>", fileResolver, taskDependencyFactory, patternSetFactory, host).from(containing(a, b))
         collection.from(upstream)
         when:
-        collection.update { it.filter { f -> !f.name.endsWith(".txt") } }
+        collection.replace { it.filter { f -> !f.name.endsWith(".txt") } }
         upstream.from(containing(c, d))
 
         then:
         collection.files == [b, d] as Set<File>
     }
 
-    def "returning null from update clears collection"() {
+    def "returning null from replace clears collection"() {
         given:
         collection.from(containing(new File("a.txt")))
 
         when:
-        collection.update { null }
+        collection.replace { null }
 
         then:
         collection.isEmpty()
     }
 
-    def "update transformation runs eagerly"() {
+    def "replace transformation runs eagerly"() {
         given:
         Transformer<FileCollection, FileCollection> transform = Mock()
         collection.from(containing(new File("a.txt")))
 
         when:
-        collection.update(transform)
+        collection.replace(transform)
 
         then:
         1 * transform.transform(_)
     }
 
-    def "update transformation result is evaluated lazily"() {
+    def "replace transformation result is evaluated lazily"() {
         given:
         Spec<File> filterSpec = Mock()
         collection.from(containing(new File("a.txt")))
 
         when:
-        collection.update { it.filter(filterSpec) }
+        collection.replace { it.filter(filterSpec) }
 
         then:
         0 * filterSpec._

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -739,8 +739,8 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         }
     }
 
-    public void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Iterable<? extends T>>, ? super Provider<C>> transform) {
-        Provider<? extends Iterable<? extends T>> newValue = transform.transform(shallowCopy());
+    public void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Iterable<? extends T>>, ? super Provider<C>> transformation) {
+        Provider<? extends Iterable<? extends T>> newValue = transformation.transform(shallowCopy());
         if (newValue != null) {
             set(newValue);
         } else {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -739,7 +739,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         }
     }
 
-    public void update(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Iterable<? extends T>>, ? super Provider<C>> transform) {
+    public void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Iterable<? extends T>>, ? super Provider<C>> transform) {
         Provider<? extends Iterable<? extends T>> newValue = transform.transform(shallowCopy());
         if (newValue != null) {
             set(newValue);

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -313,7 +313,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
     }
 
     @Override
-    public void update(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Map<? extends K, ? extends V>>, ? super Provider<Map<K, V>>> transform) {
+    public void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Map<? extends K, ? extends V>>, ? super Provider<Map<K, V>>> transform) {
         Provider<? extends Map<? extends K, ? extends V>> newValue = transform.transform(shallowCopy());
         if (newValue != null) {
             set(newValue);

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -312,6 +312,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         return new KeySetProvider();
     }
 
+    @Override
     public void update(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Map<? extends K, ? extends V>>, ? super Provider<Map<K, V>>> transform) {
         Provider<? extends Map<? extends K, ? extends V>> newValue = transform.transform(shallowCopy());
         if (newValue != null) {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -313,8 +313,8 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
     }
 
     @Override
-    public void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Map<? extends K, ? extends V>>, ? super Provider<Map<K, V>>> transform) {
-        Provider<? extends Map<? extends K, ? extends V>> newValue = transform.transform(shallowCopy());
+    public void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Map<? extends K, ? extends V>>, ? super Provider<Map<K, V>>> transformation) {
+        Provider<? extends Map<? extends K, ? extends V>> newValue = transformation.transform(shallowCopy());
         if (newValue != null) {
             set(newValue);
         } else {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -173,6 +173,7 @@ public class DefaultProperty<T> extends AbstractProperty<T, ProviderInternal<? e
         return String.format("property(%s, %s)", type.getName(), describeValue());
     }
 
+    @Override
     public void update(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends T>, ? super Provider<T>> transform) {
         Provider<? extends T> newValue = transform.transform(shallowCopy());
         if (newValue != null) {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -174,7 +174,7 @@ public class DefaultProperty<T> extends AbstractProperty<T, ProviderInternal<? e
     }
 
     @Override
-    public void update(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends T>, ? super Provider<T>> transform) {
+    public void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends T>, ? super Provider<T>> transform) {
         Provider<? extends T> newValue = transform.transform(shallowCopy());
         if (newValue != null) {
             set(newValue);

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -174,8 +174,8 @@ public class DefaultProperty<T> extends AbstractProperty<T, ProviderInternal<? e
     }
 
     @Override
-    public void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends T>, ? super Provider<T>> transform) {
-        Provider<? extends T> newValue = transform.transform(shallowCopy());
+    public void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends T>, ? super Provider<T>> transformation) {
+        Provider<? extends T> newValue = transformation.transform(shallowCopy());
         if (newValue != null) {
             set(newValue);
         } else {

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
@@ -1079,82 +1079,82 @@ The value of this property is derived from: <source>""")
         0 * _
     }
 
-    def "update can modify property"() {
+    def "replace can modify property"() {
         given:
         property.set(someValue())
 
         when:
-        property.update { it.map { someOtherValue() } }
+        property.replace { it.map { someOtherValue() } }
 
         then:
         property.get() == someOtherValue()
     }
 
-    def "update can modify property with convention"() {
+    def "replace can modify property with convention"() {
         given:
         property.convention(someValue())
 
         when:
-        property.update { it.map { someOtherValue() } }
+        property.replace { it.map { someOtherValue() } }
 
         then:
         property.get() == someOtherValue()
     }
 
-    def "update is not applied to later property modifications"() {
+    def "replace is not applied to later property modifications"() {
         given:
         property.set(someValue())
 
         when:
-        property.update { it.map { v -> v.collect { s -> s.reverse() } } }
+        property.replace { it.map { v -> v.collect { s -> s.reverse() } } }
         property.set(someOtherValue())
 
         then:
         property.get() == someOtherValue()
     }
 
-    def "update argument is live"() {
+    def "replace argument is live"() {
         given:
         def upstream = property().value(someValue()) as AbstractCollectionProperty<String, C>
         property.set(upstream)
 
         when:
-        property.update { it.map { v -> v.collect { s -> s.reverse() } } }
+        property.replace { it.map { v -> v.collect { s -> s.reverse() } } }
         upstream.set(someOtherValue())
 
         then:
         property.get() as Set<String> == someOtherValue().collect { it.reverse() } as Set<String>
     }
 
-    def "returning null from update unsets the property"() {
+    def "returning null from replace unsets the property"() {
         given:
         property.set(someValue())
 
         when:
-        property.update { null }
+        property.replace { null }
 
         then:
         !property.isPresent()
     }
 
-    def "returning null from update unsets the property falling back to convention"() {
+    def "returning null from replace unsets the property falling back to convention"() {
         given:
         property.value(someValue()).convention(someOtherValue())
 
         when:
-        property.update { null }
+        property.replace { null }
 
         then:
         property.get() == someOtherValue()
     }
 
-    def "update transformation runs eagerly"() {
+    def "replace transformation runs eagerly"() {
         given:
         Transformer<Provider<String>, Provider<String>> transform = Mock()
         property.set(someValue())
 
         when:
-        property.update(transform)
+        property.replace(transform)
 
         then:
         1 * transform.transform(_)

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyTest.groovy
@@ -363,82 +363,82 @@ class DefaultPropertyTest extends AbstractPropertySpec<String> {
         !provider.isPresent()
     }
 
-    def "update can modify property"() {
+    def "replace can modify property"() {
         given:
         def property = property().value(someValue())
 
         when:
-        property.update { it.map { someOtherValue() } }
+        property.replace { it.map { someOtherValue() } }
 
         then:
         property.get() == someOtherValue()
     }
 
-    def "update can modify property with convention"() {
+    def "replace can modify property with convention"() {
         given:
         def property = property().convention(someValue())
 
         when:
-        property.update { it.map { someOtherValue() } }
+        property.replace { it.map { someOtherValue() } }
 
         then:
         property.get() == someOtherValue()
     }
 
-    def "update is not applied to later property modifications"() {
+    def "replace is not applied to later property modifications"() {
         given:
         def property = property().value(someValue())
 
         when:
-        property.update { it.map { v -> v.reverse() } }
+        property.replace { it.map { v -> v.reverse() } }
         property.set(someOtherValue())
 
         then:
         property.get() == someOtherValue()
     }
 
-    def "update argument is live"() {
+    def "replace argument is live"() {
         given:
         def upstream = property().value(someValue())
         def property = property().value(upstream)
 
         when:
-        property.update { it.map { v -> v.reverse() }}
+        property.replace { it.map { v -> v.reverse() }}
         upstream.set(someOtherValue())
 
         then:
         property.get() == someOtherValue().reverse()
     }
 
-    def "returning null from update unsets the property"() {
+    def "returning null from replace unsets the property"() {
         given:
         def property = property().value(someValue())
 
         when:
-        property.update { null }
+        property.replace { null }
 
         then:
         !property.isPresent()
     }
 
-    def "returning null from update unsets the property falling back to convention"() {
+    def "returning null from replace unsets the property falling back to convention"() {
         given:
         def property = property().value(someValue()).convention(someOtherValue())
 
         when:
-        property.update { null }
+        property.replace { null }
 
         then:
         property.get() == someOtherValue()
     }
 
-    def "update transformation runs eagerly"() {
+    def "replace transformation runs eagerly"() {
         given:
         Transformer<Provider<String>, Provider<String>> transform = Mock()
         def property = property().value(someValue())
 
         when:
-        property.update(transform)
+        property.replace(transform)
 
         then:
         1 * transform.transform(_)

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
@@ -1675,82 +1675,82 @@ The value of this property is derived from: <source>""")
         }
     }
 
-    def "update can modify property"() {
+    def "replace can modify property"() {
         given:
         property.set(someValue())
 
         when:
-        property.update { it.map { someOtherValue() } }
+        property.replace { it.map { someOtherValue() } }
 
         then:
         property.get() == someOtherValue()
     }
 
-    def "update can modify property with convention"() {
+    def "replace can modify property with convention"() {
         given:
         property.convention(someValue())
 
         when:
-        property.update { it.map { someOtherValue() } }
+        property.replace { it.map { someOtherValue() } }
 
         then:
         property.get() == someOtherValue()
     }
 
-    def "update is not applied to later property modifications"() {
+    def "replace is not applied to later property modifications"() {
         given:
         property.set(someValue())
 
         when:
-        property.update { it.map { m -> m.collectEntries { k, v -> [v, k] } } }
+        property.replace { it.map { m -> m.collectEntries { k, v -> [v, k] } } }
         property.set(someOtherValue())
 
         then:
         property.get() == someOtherValue()
     }
 
-    def "update argument is live"() {
+    def "replace argument is live"() {
         given:
         def upstream = property().value(someValue())
         property.set(upstream)
 
         when:
-        property.update { it.map { m -> m.collectEntries { k, v -> [v, k] } } }
+        property.replace { it.map { m -> m.collectEntries { k, v -> [v, k] } } }
         upstream.set(someOtherValue())
 
         then:
         property.get() == someOtherValue().collectEntries { k, v -> [v, k] }
     }
 
-    def "returning null from update unsets the property"() {
+    def "returning null from replace unsets the property"() {
         given:
         property.set(someValue())
 
         when:
-        property.update { null }
+        property.replace { null }
 
         then:
         !property.isPresent()
     }
 
-    def "returning null from update unsets the property falling back to convention"() {
+    def "returning null from replace unsets the property falling back to convention"() {
         given:
         property.value(someValue()).convention(someOtherValue())
 
         when:
-        property.update { null }
+        property.replace { null }
 
         then:
         property.get() == someOtherValue()
     }
 
-    def "update transformation runs eagerly"() {
+    def "replace transformation runs eagerly"() {
         given:
         Transformer<Provider<String>, Provider<String>> transform = Mock()
         property.set(someValue())
 
         when:
-        property.update(transform)
+        property.replace(transform)
 
         then:
         1 * transform.transform(_)

--- a/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
@@ -2912,14 +2912,14 @@ The value of this provider is derived from:
         "value" | "getOrElse"
     }
 
-    def "update to itself does not trigger cycles"() {
+    def "replace to itself does not trigger cycles"() {
         def property = providerWithNoValue()
 
         given:
         property.set(someValue())
 
         when:
-        property.update { it }
+        property.replace { it }
 
         then:
         property.get() == someValue()

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -84,34 +84,33 @@ println(files.elements.get()) // [.../dir2]
 This feature caters to plugin developers.
 It is analogous to the [`convention(...)`](javadoc/org/gradle/api/provider/Property.html#convention-T-) methods that have been available on lazy properties since Gradle 5.1.
 
-<a name="update-api"></a>
-#### New `update()` API allows safe self-referencing lazy properties
+<a name="replace-method"></a>
+#### Updating lazy property based on its current value with `replace()`
 
 [Lazy configuration](userguide/lazy_configuration.html) delays calculating a property’s value until it is required for the build.
-This can lead to accidental recursions when assigning property values of an object to itself:
+Sometimes it is necessary to modify the property based on its current value, for example, by appending something to it.
+Previously, the only way to do that was to obtain the current value explicitly by calling `Property.get()`:
+```
+val property = objects.property<String>()
+property.set("some value")
+property.set("${property.get()} and more" })
+
+println(property.get()) // "some value and more""
+```
+This could lead to performance issues like configuration cache misses.
+Trying to build the value in a lazy manner, for example, by using `property.set(property.map { "$it and more" })`, causes build failure because of a circular reference evaluation.
+
+[`Property`](javadoc/org/gradle/api/provider/Property.html#replace-org.gradle.api.Transformer-) and [`ConfigurableFileCollection`](javadoc/org/gradle/api/file/ConfigurableFileCollection.html#replace-org.gradle.api.Transformer-) now provide their respective `replace(Transformer<...>)` methods that allow lazily building the new value based on the current one:
 
 ```
-var property = objects.property<String>()
+val property = objects.property<String>()
 property.set("some value")
-property.set(property.map { "$it and more" })
+property.replace { it.map { "$it and more" } }
 
-// Circular evaluation detected (or StackOverflowError, before 8.6)
 println(property.get()) // "some value and more"
 ```
 
-Previously, Gradle did not support circular references when evaluating lazy properties.
-
-[`Property`](javadoc/org/gradle/api/provider/Property.html#update-org.gradle.api.Transformer-) and [`ConfigurableFileCollection`](javadoc/org/gradle/api/file/ConfigurableFileCollection.html#update-org.gradle.api.Transformer-) now provide their respective `update(Transformer<...>)` methods which allow self-referencing updates safely:
-
-```
-var property = objects.property<String>()
-property.set("some value")
-property.update { it.map { "$it and more" } }
-
-println(property.get()) // "some value and more"
-```
-
-Refer to the javadoc for [`Property.update(Transformer<>)`](javadoc/org/gradle/api/provider/Property.html#update-org.gradle.api.Transformer-) and [`ConfigurableFileCollection.update(Transformer<>)`](javadoc/org/gradle/api/file/ConfigurableFileCollection.html#update-org.gradle.api.Transformer-) for more details, including limitations.
+Refer to the javadoc for [`Property.replace(Transformer<>)`](javadoc/org/gradle/api/provider/Property.html#replace-org.gradle.api.Transformer-) and [`ConfigurableFileCollection.replace(Transformer<>)`](javadoc/org/gradle/api/file/ConfigurableFileCollection.html#replace-org.gradle.api.Transformer-) for more details, including limitations.
 
 #### Improved error handling for toolchain resolvers
 

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -90,6 +90,7 @@ It is analogous to the [`convention(...)`](javadoc/org/gradle/api/provider/Prope
 [Lazy configuration](userguide/lazy_configuration.html) delays calculating a property’s value until it is required for the build.
 Sometimes it is necessary to modify the property based on its current value, for example, by appending something to it.
 Previously, the only way to do that was to obtain the current value explicitly by calling `Property.get()`:
+
 ```
 val property = objects.property<String>()
 property.set("some value")
@@ -97,8 +98,9 @@ property.set("${property.get()} and more" })
 
 println(property.get()) // "some value and more""
 ```
+
 This could lead to performance issues like configuration cache misses.
-Trying to build the value in a lazy manner, for example, by using `property.set(property.map { "$it and more" })`, causes build failure because of a circular reference evaluation.
+Trying to build the value lazily, for example, by using `property.set(property.map { "$it and more" })`, causes build failure because of a circular reference evaluation.
 
 [`Property`](javadoc/org/gradle/api/provider/Property.html#replace-org.gradle.api.Transformer-) and [`ConfigurableFileCollection`](javadoc/org/gradle/api/file/ConfigurableFileCollection.html#replace-org.gradle.api.Transformer-) now provide their respective `replace(Transformer<...>)` methods that allow lazily building the new value based on the current one:
 
@@ -110,7 +112,7 @@ property.replace { it.map { "$it and more" } }
 println(property.get()) // "some value and more"
 ```
 
-Refer to the javadoc for [`Property.replace(Transformer<>)`](javadoc/org/gradle/api/provider/Property.html#replace-org.gradle.api.Transformer-) and [`ConfigurableFileCollection.replace(Transformer<>)`](javadoc/org/gradle/api/file/ConfigurableFileCollection.html#replace-org.gradle.api.Transformer-) for more details, including limitations.
+Refer to the Javadoc for [`Property.replace(Transformer<>)`](javadoc/org/gradle/api/provider/Property.html#replace-org.gradle.api.Transformer-) and [`ConfigurableFileCollection.replace(Transformer<>)`](javadoc/org/gradle/api/file/ConfigurableFileCollection.html#replace-org.gradle.api.Transformer-) for more details, including limitations.
 
 #### Improved error handling for toolchain resolvers
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
@@ -116,10 +116,10 @@ public interface ConfigurableFileCollection extends FileCollection, HasConfigura
     ConfigurableFileCollection builtBy(Object... tasks);
 
     /**
-     * Replaces the current contents of this file collection with a one computed by the provided transform.
-     * The provided transformer is applied to the file collection representing the current contents, and the returned collection is used as a new content.
+     * Replaces the current contents of this file collection with a one computed by the provided transformation.
+     * The transformation is applied to the file collection representing the current contents, and the returned collection is used as a new content.
      * The current contents collection can be used to derive the new value, but doesn't have to.
-     * Returning null from the transformer empties this collection.
+     * Returning null from the transformation empties this collection.
      * For example, it is possible to filter out all text files from the collection:
      * <pre class='autoTested'>
      *     def collection = files("a.txt", "b.md")
@@ -132,7 +132,7 @@ public interface ConfigurableFileCollection extends FileCollection, HasConfigura
      * <b>Further changes to this file collection, such as calls to {@link #setFrom(Object...)} or {@link #from(Object...)}, are not transformed, and override the replacement instead</b>.
      * Because of this, this method inherently depends on the order of changes, and therefore must be used sparingly.
      * <p>
-     * If this file collection consists of other mutable sources, then the current contents collection tracks the changes to these sources.
+     * If this file collection consists of other mutable sources, then the current contents collection tracks changes to these sources.
      * For example, changes to the upstream collection are visible:
      * <pre class='autoTested'>
      *     def upstream = files("a.txt", "b.md")
@@ -148,9 +148,9 @@ public interface ConfigurableFileCollection extends FileCollection, HasConfigura
      * <p>
      * The current contents collection inherits dependencies of this collection specified by {@link #builtBy(Object...)}.
      *
-     * @param transform the transformation to apply to the current value. May return null, which empties this collection.
+     * @param transformation the transformation to apply to the current value. May return null, which empties this collection.
      * @since 8.8
      */
     @Incubating
-    void replace(Transformer<? extends @org.jetbrains.annotations.Nullable FileCollection, ? super FileCollection> transform);
+    void replace(Transformer<? extends @org.jetbrains.annotations.Nullable FileCollection, ? super FileCollection> transformation);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
@@ -17,6 +17,7 @@ package org.gradle.api.file;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.SupportsKotlinAssignmentOverloading;
+import org.gradle.api.Transformer;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.HasConfigurableValue;
 import org.gradle.api.provider.SupportsConvention;
@@ -113,4 +114,43 @@ public interface ConfigurableFileCollection extends FileCollection, HasConfigura
      * @return this
      */
     ConfigurableFileCollection builtBy(Object... tasks);
+
+    /**
+     * Applies an eager transformation to the current contents of this file collection, without explicitly resolving it.
+     * The provided transformer is applied to the file collection representing the current contents, and the returned collection is used as a new content.
+     * The current contents collection can be used to derive the new value, but doesn't have to.
+     * Returning null from the transformer empties this collection.
+     * For example, it is possible to filter out all text files from the collection:
+     * <pre class='autoTested'>
+     *     def collection = files("a.txt", "b.md")
+     *
+     *     collection.update { it.filter { f -&gt; !f.name.endsWith(".txt") } }
+     *
+     *     println(collection.files) // ["b.md"]
+     * </pre>
+     * <p>
+     * <b>Further changes to this file collection, such as calls to {@link #setFrom(Object...)} or {@link #from(Object...)}, are not transformed, and override the update instead</b>.
+     * Because of this, this method inherently depends on the order of changes, and therefore must be used sparingly.
+     * <p>
+     * If this file collection consists of other mutable sources, then the current contents collection tracks the changes to these sources.
+     * For example, changes to the upstream collection are visible:
+     * <pre class='autoTested'>
+     *     def upstream = files("a.txt", "b.md")
+     *     def collection = files(upstream)
+     *
+     *     collection.update { it.filter { f -&gt; !f.name.endsWith(".txt") } }
+     *     upstream.from("c.md", "d.txt")
+     *
+     *     println(collection.files) // ["b.md", "c.md"]
+     * </pre>
+     * The provided transformation runs <b>eagerly</b>, so it can capture any objects without introducing memory leaks and without breaking configuration caching.
+     * However, transformations applied to the current contents collection (like {@link FileCollection#filter(Closure)}) are subject to the usual constraints.
+     * <p>
+     * The current contents collection inherits dependencies of this collection specified by {@link #builtBy(Object...)}.
+     *
+     * @param transform the transformation to apply to the current value. May return null, which empties this collection.
+     * @since 8.6
+     */
+    @Incubating
+    void update(Transformer<? extends @org.jetbrains.annotations.Nullable FileCollection, ? super FileCollection> transform);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
@@ -116,7 +116,7 @@ public interface ConfigurableFileCollection extends FileCollection, HasConfigura
     ConfigurableFileCollection builtBy(Object... tasks);
 
     /**
-     * Applies an eager transformation to the current contents of this file collection, without explicitly resolving it.
+     * Replaces the current contents of this file collection with a one computed by the provided transform.
      * The provided transformer is applied to the file collection representing the current contents, and the returned collection is used as a new content.
      * The current contents collection can be used to derive the new value, but doesn't have to.
      * Returning null from the transformer empties this collection.
@@ -124,12 +124,12 @@ public interface ConfigurableFileCollection extends FileCollection, HasConfigura
      * <pre class='autoTested'>
      *     def collection = files("a.txt", "b.md")
      *
-     *     collection.update { it.filter { f -&gt; !f.name.endsWith(".txt") } }
+     *     collection.replace { it.filter { f -&gt; !f.name.endsWith(".txt") } }
      *
      *     println(collection.files) // ["b.md"]
      * </pre>
      * <p>
-     * <b>Further changes to this file collection, such as calls to {@link #setFrom(Object...)} or {@link #from(Object...)}, are not transformed, and override the update instead</b>.
+     * <b>Further changes to this file collection, such as calls to {@link #setFrom(Object...)} or {@link #from(Object...)}, are not transformed, and override the replacement instead</b>.
      * Because of this, this method inherently depends on the order of changes, and therefore must be used sparingly.
      * <p>
      * If this file collection consists of other mutable sources, then the current contents collection tracks the changes to these sources.
@@ -138,7 +138,7 @@ public interface ConfigurableFileCollection extends FileCollection, HasConfigura
      *     def upstream = files("a.txt", "b.md")
      *     def collection = files(upstream)
      *
-     *     collection.update { it.filter { f -&gt; !f.name.endsWith(".txt") } }
+     *     collection.replace { it.filter { f -&gt; !f.name.endsWith(".txt") } }
      *     upstream.from("c.md", "d.txt")
      *
      *     println(collection.files) // ["b.md", "c.md"]
@@ -149,8 +149,8 @@ public interface ConfigurableFileCollection extends FileCollection, HasConfigura
      * The current contents collection inherits dependencies of this collection specified by {@link #builtBy(Object...)}.
      *
      * @param transform the transformation to apply to the current value. May return null, which empties this collection.
-     * @since 8.6
+     * @since 8.8
      */
     @Incubating
-    void update(Transformer<? extends @org.jetbrains.annotations.Nullable FileCollection, ? super FileCollection> transform);
+    void replace(Transformer<? extends @org.jetbrains.annotations.Nullable FileCollection, ? super FileCollection> transform);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
@@ -16,6 +16,9 @@
 
 package org.gradle.api.provider;
 
+import org.gradle.api.Incubating;
+import org.gradle.api.Transformer;
+
 import javax.annotation.Nullable;
 import java.util.List;
 
@@ -81,4 +84,47 @@ public interface ListProperty<T> extends Provider<List<T>>, HasMultipleValues<T>
      */
     @Override
     ListProperty<T> unsetConvention();
+
+    /**
+     * Applies an eager transformation to the current value of the property "in place", without explicitly obtaining it.
+     * The provided transformer is applied to the provider of the current value, and the returned provider is used as a new value.
+     * The provider of the value can be used to derive the new value, but doesn't have to.
+     * Returning null from the transformer unsets the property.
+     * For example, the current value of a string list property can be reversed:
+     * <pre class='autoTested'>
+     *     def property = objects.listProperty(String).value(["a", "b"])
+     *
+     *     property.update { it.map { value -&gt; value.reverse() } }
+     *
+     *     println(property.get()) // ["b", "a"]
+     * </pre>
+     * Note that simply writing {@code property.set(property.map { ... } } doesn't work and will cause an exception because of a circular reference evaluation at runtime.
+     * <p>
+     * <b>Further changes to the value of the property, such as calls to {@link #set(Iterable)}, are not transformed, and override the update instead</b>.
+     * Because of this, this method inherently depends on the order of property changes, and therefore must be used sparingly.
+     * <p>
+     * If the value of the property is specified via a provider, then the current value provider tracks that provider.
+     * For example, changes to the upstream property are visible:
+     * <pre class='autoTested'>
+     *     def upstream = objects.listProperty(String).value(["a", "b"])
+     *     def property = objects.listProperty(String).value(upstream)
+     *
+     *     property.update { it.map { value -&gt; value.reverse() } }
+     *     upstream.set(["c", "d"])
+     *
+     *     println(property.get()) // ["d", "c"]
+     * </pre>
+     * The provided transformation runs <b>eagerly</b>, so it can capture any objects without introducing memory leaks and without breaking configuration caching.
+     * However, transformations applied to the current value provider (like {@link Provider#map(Transformer)}) are subject to the usual constraints.
+     * <p>
+     * If the property has no explicit value set, then the current value comes from the convention.
+     * Changes to convention of this property do not affect the current value provider in this case, though upstream changes are still visible if the convention was set to a provider.
+     * If there is no convention too, then the current value is a provider without a value.
+     * The updated value becomes the explicit value of the property.
+     *
+     * @param transform the transformation to apply to the current value. May return null, which unsets the property.
+     * @since 8.6
+     */
+    @Incubating
+    void update(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Iterable<? extends T>>, ? super Provider<List<T>>> transform);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
@@ -86,7 +86,7 @@ public interface ListProperty<T> extends Provider<List<T>>, HasMultipleValues<T>
     ListProperty<T> unsetConvention();
 
     /**
-     * Applies an eager transformation to the current value of the property "in place", without explicitly obtaining it.
+     * Replaces the current value of this property with a one computed by the provided transform.
      * The provided transformer is applied to the provider of the current value, and the returned provider is used as a new value.
      * The provider of the value can be used to derive the new value, but doesn't have to.
      * Returning null from the transformer unsets the property.
@@ -94,13 +94,13 @@ public interface ListProperty<T> extends Provider<List<T>>, HasMultipleValues<T>
      * <pre class='autoTested'>
      *     def property = objects.listProperty(String).value(["a", "b"])
      *
-     *     property.update { it.map { value -&gt; value.reverse() } }
+     *     property.replace { it.map { value -&gt; value.reverse() } }
      *
      *     println(property.get()) // ["b", "a"]
      * </pre>
      * Note that simply writing {@code property.set(property.map { ... } } doesn't work and will cause an exception because of a circular reference evaluation at runtime.
      * <p>
-     * <b>Further changes to the value of the property, such as calls to {@link #set(Iterable)}, are not transformed, and override the update instead</b>.
+     * <b>Further changes to the value of the property, such as calls to {@link #set(Iterable)}, are not transformed, and override the replacement instead</b>.
      * Because of this, this method inherently depends on the order of property changes, and therefore must be used sparingly.
      * <p>
      * If the value of the property is specified via a provider, then the current value provider tracks that provider.
@@ -109,7 +109,7 @@ public interface ListProperty<T> extends Provider<List<T>>, HasMultipleValues<T>
      *     def upstream = objects.listProperty(String).value(["a", "b"])
      *     def property = objects.listProperty(String).value(upstream)
      *
-     *     property.update { it.map { value -&gt; value.reverse() } }
+     *     property.replace { it.map { value -&gt; value.reverse() } }
      *     upstream.set(["c", "d"])
      *
      *     println(property.get()) // ["d", "c"]
@@ -120,11 +120,11 @@ public interface ListProperty<T> extends Provider<List<T>>, HasMultipleValues<T>
      * If the property has no explicit value set, then the current value comes from the convention.
      * Changes to convention of this property do not affect the current value provider in this case, though upstream changes are still visible if the convention was set to a provider.
      * If there is no convention too, then the current value is a provider without a value.
-     * The updated value becomes the explicit value of the property.
+     * The replacement value becomes the explicit value of the property.
      *
      * @param transform the transformation to apply to the current value. May return null, which unsets the property.
-     * @since 8.6
+     * @since 8.8
      */
     @Incubating
-    void update(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Iterable<? extends T>>, ? super Provider<List<T>>> transform);
+    void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Iterable<? extends T>>, ? super Provider<List<T>>> transform);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
@@ -86,10 +86,10 @@ public interface ListProperty<T> extends Provider<List<T>>, HasMultipleValues<T>
     ListProperty<T> unsetConvention();
 
     /**
-     * Replaces the current value of this property with a one computed by the provided transform.
-     * The provided transformer is applied to the provider of the current value, and the returned provider is used as a new value.
+     * Replaces the current value of this property with a one computed by the provided transformation.
+     * The transformation is applied to the provider of the current value, and the returned provider is used as a new value.
      * The provider of the value can be used to derive the new value, but doesn't have to.
-     * Returning null from the transformer unsets the property.
+     * Returning null from the transformation unsets the property.
      * For example, the current value of a string list property can be reversed:
      * <pre class='autoTested'>
      *     def property = objects.listProperty(String).value(["a", "b"])
@@ -122,9 +122,9 @@ public interface ListProperty<T> extends Provider<List<T>>, HasMultipleValues<T>
      * If there is no convention too, then the current value is a provider without a value.
      * The replacement value becomes the explicit value of the property.
      *
-     * @param transform the transformation to apply to the current value. May return null, which unsets the property.
+     * @param transformation the transformation to apply to the current value. May return null, which unsets the property.
      * @since 8.8
      */
     @Incubating
-    void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Iterable<? extends T>>, ? super Provider<List<T>>> transform);
+    void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Iterable<? extends T>>, ? super Provider<List<T>>> transformation);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
@@ -18,6 +18,7 @@ package org.gradle.api.provider;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.SupportsKotlinAssignmentOverloading;
+import org.gradle.api.Transformer;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -288,6 +289,49 @@ public interface MapProperty<K, V> extends Provider<Map<K, V>>, HasConfigurableV
     @Incubating
     @Override
     MapProperty<K, V> unsetConvention();
+
+    /**
+     * Applies an eager transformation to the current value of the property "in place", without explicitly obtaining it.
+     * The provided transformer is applied to the provider of the current value, and the returned provider is used as a new value.
+     * The provider of the value can be used to derive the new value, but doesn't have to.
+     * Returning null from the transformer unsets the property.
+     * For example, the current value of a string map property can be filtered to retain only vowel keys:
+     * <pre class='autoTested'>
+     *     def property = objects.mapProperty(String, String).value(a: "a", b: "b")
+     *
+     *     property.update { it.map { value -&gt; value.subMap("a", "e", "i", "o", "u") } }
+     *
+     *     println(property.get()) // [a: "a"]
+     * </pre>
+     * Note that simply writing {@code property.set(property.map { ... } } doesn't work and will cause an exception because of a circular reference evaluation at runtime.
+     * <p>
+     * <b>Further changes to the value of the property, such as calls to {@link #set(Map)}, are not transformed, and override the update instead</b>.
+     * Because of this, this method inherently depends on the order of property changes, and therefore must be used sparingly.
+     * <p>
+     * If the value of the property is specified via a provider, then the current value provider tracks that provider.
+     * For example, changes to the upstream property are visible:
+     * <pre class='autoTested'>
+     *     def upstream = objects.mapProperty(String, String).value(a: "a", b: "b")
+     *     def property = objects.mapProperty(String, String).value(upstream)
+     *
+     *     property.update { it.map { value -&gt; value.subMap("a", "e", "i", "o", "u") } }
+     *     upstream.value(e: "e", f: "f")
+     *
+     *     println(property.get()) // [e: "e"]
+     * </pre>
+     * The provided transformation runs <b>eagerly</b>, so it can capture any objects without introducing memory leaks and without breaking configuration caching.
+     * However, transformations applied to the current value provider (like {@link Provider#map(Transformer)}) are subject to the usual constraints.
+     * <p>
+     * If the property has no explicit value set, then the current value comes from the convention.
+     * Changes to convention of this property do not affect the current value provider in this case, though upstream changes are still visible if the convention was set to a provider.
+     * If there is no convention too, then the current value is a provider without a value.
+     * The updated value becomes the explicit value of the property.
+
+     * @param transform the transformation to apply to the current value. May return null, which unsets the property.
+     * @since 8.6
+     */
+    @Incubating
+    void update(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Map<? extends K, ? extends V>>, ? super Provider<Map<K, V>>> transform);
 
     /**
      * Disallows further changes to the value of this property. Calls to methods that change the value of this property, such as {@link #set(Map)} or {@link #put(Object, Object)} will fail.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
@@ -291,7 +291,7 @@ public interface MapProperty<K, V> extends Provider<Map<K, V>>, HasConfigurableV
     MapProperty<K, V> unsetConvention();
 
     /**
-     * Applies an eager transformation to the current value of the property "in place", without explicitly obtaining it.
+     * Replaces the current value of this property with a one computed by the provided transform.
      * The provided transformer is applied to the provider of the current value, and the returned provider is used as a new value.
      * The provider of the value can be used to derive the new value, but doesn't have to.
      * Returning null from the transformer unsets the property.
@@ -299,13 +299,13 @@ public interface MapProperty<K, V> extends Provider<Map<K, V>>, HasConfigurableV
      * <pre class='autoTested'>
      *     def property = objects.mapProperty(String, String).value(a: "a", b: "b")
      *
-     *     property.update { it.map { value -&gt; value.subMap("a", "e", "i", "o", "u") } }
+     *     property.replace { it.map { value -&gt; value.subMap("a", "e", "i", "o", "u") } }
      *
      *     println(property.get()) // [a: "a"]
      * </pre>
      * Note that simply writing {@code property.set(property.map { ... } } doesn't work and will cause an exception because of a circular reference evaluation at runtime.
      * <p>
-     * <b>Further changes to the value of the property, such as calls to {@link #set(Map)}, are not transformed, and override the update instead</b>.
+     * <b>Further changes to the value of the property, such as calls to {@link #set(Map)}, are not transformed, and override the replacement instead</b>.
      * Because of this, this method inherently depends on the order of property changes, and therefore must be used sparingly.
      * <p>
      * If the value of the property is specified via a provider, then the current value provider tracks that provider.
@@ -314,7 +314,7 @@ public interface MapProperty<K, V> extends Provider<Map<K, V>>, HasConfigurableV
      *     def upstream = objects.mapProperty(String, String).value(a: "a", b: "b")
      *     def property = objects.mapProperty(String, String).value(upstream)
      *
-     *     property.update { it.map { value -&gt; value.subMap("a", "e", "i", "o", "u") } }
+     *     property.replace { it.map { value -&gt; value.subMap("a", "e", "i", "o", "u") } }
      *     upstream.value(e: "e", f: "f")
      *
      *     println(property.get()) // [e: "e"]
@@ -325,13 +325,13 @@ public interface MapProperty<K, V> extends Provider<Map<K, V>>, HasConfigurableV
      * If the property has no explicit value set, then the current value comes from the convention.
      * Changes to convention of this property do not affect the current value provider in this case, though upstream changes are still visible if the convention was set to a provider.
      * If there is no convention too, then the current value is a provider without a value.
-     * The updated value becomes the explicit value of the property.
+     * The replacement value becomes the explicit value of the property.
 
      * @param transform the transformation to apply to the current value. May return null, which unsets the property.
-     * @since 8.6
+     * @since 8.8
      */
     @Incubating
-    void update(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Map<? extends K, ? extends V>>, ? super Provider<Map<K, V>>> transform);
+    void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Map<? extends K, ? extends V>>, ? super Provider<Map<K, V>>> transform);
 
     /**
      * Disallows further changes to the value of this property. Calls to methods that change the value of this property, such as {@link #set(Map)} or {@link #put(Object, Object)} will fail.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
@@ -291,10 +291,10 @@ public interface MapProperty<K, V> extends Provider<Map<K, V>>, HasConfigurableV
     MapProperty<K, V> unsetConvention();
 
     /**
-     * Replaces the current value of this property with a one computed by the provided transform.
-     * The provided transformer is applied to the provider of the current value, and the returned provider is used as a new value.
+     * Replaces the current value of this property with a one computed by the provided transformation.
+     * The transformation is applied to the provider of the current value, and the returned provider is used as a new value.
      * The provider of the value can be used to derive the new value, but doesn't have to.
-     * Returning null from the transformer unsets the property.
+     * Returning null from the transformation unsets the property.
      * For example, the current value of a string map property can be filtered to retain only vowel keys:
      * <pre class='autoTested'>
      *     def property = objects.mapProperty(String, String).value(a: "a", b: "b")
@@ -327,11 +327,11 @@ public interface MapProperty<K, V> extends Provider<Map<K, V>>, HasConfigurableV
      * If there is no convention too, then the current value is a provider without a value.
      * The replacement value becomes the explicit value of the property.
 
-     * @param transform the transformation to apply to the current value. May return null, which unsets the property.
+     * @param transformation the transformation to apply to the current value. May return null, which unsets the property.
      * @since 8.8
      */
     @Incubating
-    void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Map<? extends K, ? extends V>>, ? super Provider<Map<K, V>>> transform);
+    void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Map<? extends K, ? extends V>>, ? super Provider<Map<K, V>>> transformation);
 
     /**
      * Disallows further changes to the value of this property. Calls to methods that change the value of this property, such as {@link #set(Map)} or {@link #put(Object, Object)} will fail.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
@@ -201,7 +201,7 @@ public interface Property<T> extends Provider<T>, HasConfigurableValue, Supports
     void finalizeValue();
 
     /**
-     * Applies an eager transformation to the current value of the property "in place", without explicitly obtaining it.
+     * Replaces the current value of this property with a one computed by the provided transform.
      * The provided transformer is applied to the provider of the current value, and the returned provider is used as a new value.
      * The provider of the value can be used to derive the new value, but doesn't have to.
      * Returning null from the transformer unsets the property.
@@ -209,13 +209,13 @@ public interface Property<T> extends Provider<T>, HasConfigurableValue, Supports
      * <pre class='autoTested'>
      *     def property = objects.property(String).value("value")
      *
-     *     property.update { it.map { value -&gt; value.reverse() } }
+     *     property.replace { it.map { value -&gt; value.reverse() } }
      *
      *     println(property.get()) // "eulav"
      * </pre>
      * Note that simply writing {@code property.set(property.map { ... } } doesn't work and will cause an exception because of a circular reference evaluation at runtime.
      * <p>
-     * <b>Further changes to the value of the property, such as calls to {@link #set(Object)}, are not transformed, and override the update instead</b>.
+     * <b>Further changes to the value of the property, such as calls to {@link #set(Object)}, are not transformed, and override the replacement instead</b>.
      * Because of this, this method inherently depends on the order of property changes, and therefore must be used sparingly.
      * <p>
      * If the value of the property is specified via a provider, then the current value provider tracks that provider.
@@ -224,7 +224,7 @@ public interface Property<T> extends Provider<T>, HasConfigurableValue, Supports
      *     def upstream = objects.property(String).value("value")
      *     def property = objects.property(String).value(upstream)
      *
-     *     property.update { it.map { value -&gt; value.reverse() } }
+     *     property.replace { it.map { value -&gt; value.reverse() } }
      *     upstream.set("other")
      *
      *     println(property.get()) // "rehto"
@@ -235,11 +235,11 @@ public interface Property<T> extends Provider<T>, HasConfigurableValue, Supports
      * If the property has no explicit value set, then the current value comes from the convention.
      * Changes to convention of this property do not affect the current value provider in this case, though upstream changes are still visible if the convention was set to a provider.
      * If there is no convention too, then the current value is a provider without a value.
-     * The updated value becomes the explicit value of the property.
+     * The replacement value becomes the explicit value of the property.
      *
      * @param transform the transformation to apply to the current value. May return null, which unsets the property.
-     * @since 8.6
+     * @since 8.8
      */
     @Incubating
-    void update(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends T>, ? super Provider<T>> transform);
+    void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends T>, ? super Provider<T>> transform);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
@@ -16,7 +16,9 @@
 
 package org.gradle.api.provider;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.SupportsKotlinAssignmentOverloading;
+import org.gradle.api.Transformer;
 import org.gradle.api.model.ObjectFactory;
 
 import javax.annotation.Nullable;
@@ -197,4 +199,47 @@ public interface Property<T> extends Provider<T>, HasConfigurableValue, Supports
      */
     @Override
     void finalizeValue();
+
+    /**
+     * Applies an eager transformation to the current value of the property "in place", without explicitly obtaining it.
+     * The provided transformer is applied to the provider of the current value, and the returned provider is used as a new value.
+     * The provider of the value can be used to derive the new value, but doesn't have to.
+     * Returning null from the transformer unsets the property.
+     * For example, the current value of a string property can be reversed:
+     * <pre class='autoTested'>
+     *     def property = objects.property(String).value("value")
+     *
+     *     property.update { it.map { value -&gt; value.reverse() } }
+     *
+     *     println(property.get()) // "eulav"
+     * </pre>
+     * Note that simply writing {@code property.set(property.map { ... } } doesn't work and will cause an exception because of a circular reference evaluation at runtime.
+     * <p>
+     * <b>Further changes to the value of the property, such as calls to {@link #set(Object)}, are not transformed, and override the update instead</b>.
+     * Because of this, this method inherently depends on the order of property changes, and therefore must be used sparingly.
+     * <p>
+     * If the value of the property is specified via a provider, then the current value provider tracks that provider.
+     * For example, changes to the upstream property are visible:
+     * <pre class='autoTested'>
+     *     def upstream = objects.property(String).value("value")
+     *     def property = objects.property(String).value(upstream)
+     *
+     *     property.update { it.map { value -&gt; value.reverse() } }
+     *     upstream.set("other")
+     *
+     *     println(property.get()) // "rehto"
+     * </pre>
+     * The provided transformation runs <b>eagerly</b>, so it can capture any objects without introducing memory leaks and without breaking configuration caching.
+     * However, transformations applied to the current value provider (like {@link Provider#map(Transformer)}) are subject to the usual constraints.
+     * <p>
+     * If the property has no explicit value set, then the current value comes from the convention.
+     * Changes to convention of this property do not affect the current value provider in this case, though upstream changes are still visible if the convention was set to a provider.
+     * If there is no convention too, then the current value is a provider without a value.
+     * The updated value becomes the explicit value of the property.
+     *
+     * @param transform the transformation to apply to the current value. May return null, which unsets the property.
+     * @since 8.6
+     */
+    @Incubating
+    void update(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends T>, ? super Provider<T>> transform);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
@@ -201,10 +201,10 @@ public interface Property<T> extends Provider<T>, HasConfigurableValue, Supports
     void finalizeValue();
 
     /**
-     * Replaces the current value of this property with a one computed by the provided transform.
-     * The provided transformer is applied to the provider of the current value, and the returned provider is used as a new value.
+     * Replaces the current value of this property with a one computed by the provided transformation.
+     * The transformation is applied to the provider of the current value, and the returned provider is used as a new value.
      * The provider of the value can be used to derive the new value, but doesn't have to.
-     * Returning null from the transformer unsets the property.
+     * Returning null from the transformation unsets the property.
      * For example, the current value of a string property can be reversed:
      * <pre class='autoTested'>
      *     def property = objects.property(String).value("value")
@@ -237,9 +237,9 @@ public interface Property<T> extends Provider<T>, HasConfigurableValue, Supports
      * If there is no convention too, then the current value is a provider without a value.
      * The replacement value becomes the explicit value of the property.
      *
-     * @param transform the transformation to apply to the current value. May return null, which unsets the property.
+     * @param transformation the transformation to apply to the current value. May return null, which unsets the property.
      * @since 8.8
      */
     @Incubating
-    void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends T>, ? super Provider<T>> transform);
+    void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends T>, ? super Provider<T>> transformation);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
@@ -85,10 +85,10 @@ public interface SetProperty<T> extends Provider<Set<T>>, HasMultipleValues<T> {
     SetProperty<T> unsetConvention();
 
     /**
-     * Replaces the current value of this property with a one computed by the provided transform.
-     * The provided transformer is applied to the provider of the current value, and the returned provider is used as a new value.
+     * Replaces the current value of this property with a one computed by the provided transformation.
+     * The transformation is applied to the provider of the current value, and the returned provider is used as a new value.
      * The provider of the value can be used to derive the new value, but doesn't have to.
-     * Returning null from the transformer unsets the property.
+     * Returning null from the transformation unsets the property.
      * For example, the current value of a string set property can be filtered to exclude vowels:
      * <pre class='autoTested'>
      *     def property = objects.setProperty(String).value(["a", "b"])
@@ -122,9 +122,9 @@ public interface SetProperty<T> extends Provider<Set<T>>, HasMultipleValues<T> {
      * If there is no convention too, then the current value is a provider without a value.
      * The replacement value becomes the explicit value of the property.
 
-     * @param transform the transformation to apply to the current value. May return null, which unsets the property.
+     * @param transformation the transformation to apply to the current value. May return null, which unsets the property.
      * @since 8.8
      */
     @Incubating
-    void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Iterable<? extends T>>, ? super Provider<Set<T>>> transform);
+    void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Iterable<? extends T>>, ? super Provider<Set<T>>> transformation);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
@@ -85,7 +85,7 @@ public interface SetProperty<T> extends Provider<Set<T>>, HasMultipleValues<T> {
     SetProperty<T> unsetConvention();
 
     /**
-     * Applies an eager transformation to the current value of the property "in place", without explicitly obtaining it.
+     * Replaces the current value of this property with a one computed by the provided transform.
      * The provided transformer is applied to the provider of the current value, and the returned provider is used as a new value.
      * The provider of the value can be used to derive the new value, but doesn't have to.
      * Returning null from the transformer unsets the property.
@@ -93,14 +93,14 @@ public interface SetProperty<T> extends Provider<Set<T>>, HasMultipleValues<T> {
      * <pre class='autoTested'>
      *     def property = objects.setProperty(String).value(["a", "b"])
      *
-     *     property.update { it.map { value -&gt; value - ["a", "e", "i", "o", "u"] } }
+     *     property.replace { it.map { value -&gt; value - ["a", "e", "i", "o", "u"] } }
      *
      *     println(property.get()) // ["b"]
      * </pre>
      * <p>
      * Note that simply writing {@code property.set(property.map { ... } } doesn't work and will cause an exception because of a circular reference evaluation at runtime.
      * <p>
-     * <b>Further changes to the value of the property, such as calls to {@link #set(Iterable)}, are not transformed, and override the update instead</b>.
+     * <b>Further changes to the value of the property, such as calls to {@link #set(Iterable)}, are not transformed, and override the replacement instead</b>.
      * Because of this, this method inherently depends on the order of property changes, and therefore must be used sparingly.
      * <p>
      * If the value of the property is specified via a provider, then the current value provider tracks that provider.
@@ -109,7 +109,7 @@ public interface SetProperty<T> extends Provider<Set<T>>, HasMultipleValues<T> {
      *     def upstream = objects.setProperty(String).value(["a", "b"])
      *     def property = objects.setProperty(String).value(upstream)
      *
-     *     property.update { it.map { value -&gt; value - ["a", "e", "i", "o", "u"] } }
+     *     property.replace { it.map { value -&gt; value - ["a", "e", "i", "o", "u"] } }
      *     upstream.set(["e", "f"])
      *
      *     println(property.get()) // ["f"]
@@ -120,11 +120,11 @@ public interface SetProperty<T> extends Provider<Set<T>>, HasMultipleValues<T> {
      * If the property has no explicit value set, then the current value comes from the convention.
      * Changes to convention of this property do not affect the current value provider in this case, though upstream changes are still visible if the convention was set to a provider.
      * If there is no convention too, then the current value is a provider without a value.
-     * The updated value becomes the explicit value of the property.
+     * The replacement value becomes the explicit value of the property.
 
      * @param transform the transformation to apply to the current value. May return null, which unsets the property.
-     * @since 8.6
+     * @since 8.8
      */
     @Incubating
-    void update(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Iterable<? extends T>>, ? super Provider<Set<T>>> transform);
+    void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Iterable<? extends T>>, ? super Provider<Set<T>>> transform);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
@@ -16,6 +16,9 @@
 
 package org.gradle.api.provider;
 
+import org.gradle.api.Incubating;
+import org.gradle.api.Transformer;
+
 import javax.annotation.Nullable;
 import java.util.Set;
 
@@ -80,4 +83,48 @@ public interface SetProperty<T> extends Provider<Set<T>>, HasMultipleValues<T> {
      */
     @Override
     SetProperty<T> unsetConvention();
+
+    /**
+     * Applies an eager transformation to the current value of the property "in place", without explicitly obtaining it.
+     * The provided transformer is applied to the provider of the current value, and the returned provider is used as a new value.
+     * The provider of the value can be used to derive the new value, but doesn't have to.
+     * Returning null from the transformer unsets the property.
+     * For example, the current value of a string set property can be filtered to exclude vowels:
+     * <pre class='autoTested'>
+     *     def property = objects.setProperty(String).value(["a", "b"])
+     *
+     *     property.update { it.map { value -&gt; value - ["a", "e", "i", "o", "u"] } }
+     *
+     *     println(property.get()) // ["b"]
+     * </pre>
+     * <p>
+     * Note that simply writing {@code property.set(property.map { ... } } doesn't work and will cause an exception because of a circular reference evaluation at runtime.
+     * <p>
+     * <b>Further changes to the value of the property, such as calls to {@link #set(Iterable)}, are not transformed, and override the update instead</b>.
+     * Because of this, this method inherently depends on the order of property changes, and therefore must be used sparingly.
+     * <p>
+     * If the value of the property is specified via a provider, then the current value provider tracks that provider.
+     * For example, changes to the upstream property are visible:
+     * <pre class='autoTested'>
+     *     def upstream = objects.setProperty(String).value(["a", "b"])
+     *     def property = objects.setProperty(String).value(upstream)
+     *
+     *     property.update { it.map { value -&gt; value - ["a", "e", "i", "o", "u"] } }
+     *     upstream.set(["e", "f"])
+     *
+     *     println(property.get()) // ["f"]
+     * </pre>
+     * The provided transformation runs <b>eagerly</b>, so it can capture any objects without introducing memory leaks and without breaking configuration caching.
+     * However, transformations applied to the current value provider (like {@link Provider#map(Transformer)}) are subject to the usual constraints.
+     * <p>
+     * If the property has no explicit value set, then the current value comes from the convention.
+     * Changes to convention of this property do not affect the current value provider in this case, though upstream changes are still visible if the convention was set to a provider.
+     * If there is no convention too, then the current value is a provider without a value.
+     * The updated value becomes the explicit value of the property.
+
+     * @param transform the transformation to apply to the current value. May return null, which unsets the property.
+     * @since 8.6
+     */
+    @Incubating
+    void update(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Iterable<? extends T>>, ? super Provider<Set<T>>> transform);
 }


### PR DESCRIPTION
Fixes #27227

This PR reintroduces `update()` method pulled from 8.6 release under a new name.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
