### PR TITLE
Delete left over from jdk-toolchains

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -2035,7 +2035,7 @@ To avoid this warning, please apply the plugin to your project:
 [source,kotlin]
 ----
 plugins {
-    id("jdk-toolchains")
+    id("jvm-toolchains")
 }
 ----
 =====
@@ -2045,13 +2045,14 @@ plugins {
 [source,groovy]
 ----
 plugins {
-    id 'jdk-toolchains'
+    id 'jvm-toolchains'
 }
 ----
 =====
 ====
 
-The Java Toolchains plugin is applied automatically by the link:java_plugin.html[Java plugin], so you can also apply it to your project and it will fix the warning.
+The Java Toolchains plugin is applied automatically by the <<java_library_plugin#java_library_plugin,Java library plugin>> or other JVM plugins.
+So you can apply any of them to your project and it will fix the warning.
 
 [[org_gradle_util_reports_deprecations]]
 ==== Deprecated members of the `org.gradle.util` package now report their deprecation

--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -117,6 +117,14 @@
             ]
         },
         {
+            "type": "org.gradle.kotlin.dsl.BuiltinPluginIdExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.BuiltinPluginIdExtensionsKt.getJdk-toolchains(org.gradle.plugin.use.PluginDependenciesSpec)",
+            "acceptation": "Accessor for non existing plugin class, usage would fail the build",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
             "type": "org.gradle.kotlin.dsl.GradleApiKotlinDslExtensions_4xzlmchnjfhf5wwk67zexqao1Kt",
             "member": "Method org.gradle.kotlin.dsl.GradleApiKotlinDslExtensions_4xzlmchnjfhf5wwk67zexqao1Kt.registerIfAbsent(org.gradle.api.services.BuildServiceRegistry,java.lang.String,kotlin.reflect.KClass)",
             "acceptation": "Add new default method without action",

--- a/subprojects/plugins/src/main/resources/META-INF/gradle-plugins/org.gradle.jdk-toolchains.properties
+++ b/subprojects/plugins/src/main/resources/META-INF/gradle-plugins/org.gradle.jdk-toolchains.properties
@@ -1,1 +1,0 @@
-implementation-class=org.gradle.api.plugins.JdkToolchainsPlugin


### PR DESCRIPTION
* Was replaced by jvm-toolchains but the properties file was left around
* Update the upgrade guide entry which contained invalid information

Fixes #27802