### PR TITLE
Convert `int` location types to `long`

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/validation/DelegatingProblemBuilder.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/validation/DelegatingProblemBuilder.java
@@ -17,10 +17,10 @@
 package org.gradle.internal.reflect.validation;
 
 import org.gradle.api.NonNullApi;
-import org.gradle.api.problems.internal.DocLink;
-import org.gradle.api.problems.internal.Problem;
 import org.gradle.api.problems.Severity;
+import org.gradle.api.problems.internal.DocLink;
 import org.gradle.api.problems.internal.InternalProblemBuilder;
+import org.gradle.api.problems.internal.Problem;
 
 import javax.annotation.Nullable;
 
@@ -59,22 +59,22 @@ class DelegatingProblemBuilder implements InternalProblemBuilder {
     }
 
     @Override
-    public InternalProblemBuilder lineInFileLocation(String path, int line) {
+    public InternalProblemBuilder lineInFileLocation(String path, long line) {
         return validateDelegate(delegate.lineInFileLocation(path, line));
     }
 
     @Override
-    public InternalProblemBuilder lineInFileLocation(String path, int line, int column) {
+    public InternalProblemBuilder lineInFileLocation(String path, long line, long column) {
         return validateDelegate(delegate.offsetInFileLocation(path, line, column));
     }
 
     @Override
-    public InternalProblemBuilder lineInFileLocation(String path, int line, int column, int length) {
+    public InternalProblemBuilder lineInFileLocation(String path, long line, long column, long length) {
         return validateDelegate(delegate.lineInFileLocation(path, line, column, length));
     }
 
     @Override
-    public InternalProblemBuilder offsetInFileLocation(String path, int offset, int length) {
+    public InternalProblemBuilder offsetInFileLocation(String path, long offset, long length) {
         return validateDelegate(delegate.offsetInFileLocation(path, offset, length));
     }
 

--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerialization.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerialization.java
@@ -25,13 +25,6 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
-import org.gradle.api.problems.internal.DocLink;
-import org.gradle.api.problems.internal.FileLocation;
-import org.gradle.api.problems.internal.LineInFileLocation;
-import org.gradle.api.problems.internal.OffsetInFileLocation;
-import org.gradle.api.problems.internal.Problem;
-import org.gradle.api.problems.internal.ProblemCategory;
-import org.gradle.api.problems.internal.ProblemLocation;
 import org.gradle.api.problems.internal.DefaultFileLocation;
 import org.gradle.api.problems.internal.DefaultLineInFileLocation;
 import org.gradle.api.problems.internal.DefaultOffsetInFileLocation;
@@ -39,6 +32,13 @@ import org.gradle.api.problems.internal.DefaultPluginIdLocation;
 import org.gradle.api.problems.internal.DefaultProblem;
 import org.gradle.api.problems.internal.DefaultProblemCategory;
 import org.gradle.api.problems.internal.DefaultTaskPathLocation;
+import org.gradle.api.problems.internal.DocLink;
+import org.gradle.api.problems.internal.FileLocation;
+import org.gradle.api.problems.internal.LineInFileLocation;
+import org.gradle.api.problems.internal.OffsetInFileLocation;
+import org.gradle.api.problems.internal.Problem;
+import org.gradle.api.problems.internal.ProblemCategory;
+import org.gradle.api.problems.internal.ProblemLocation;
 import org.gradle.internal.reflect.validation.TypeValidationProblemRenderer;
 
 import javax.annotation.Nonnull;
@@ -243,10 +243,10 @@ public class ValidationProblemSerialization {
         private static FileLocation readObject(JsonReader in) throws IOException {
             String subtype = null;
             String path = null;
-            Integer offset = null;
-            Integer line = null;
-            Integer column = null;
-            Integer length = null;
+            Long offset = null;
+            Long line = null;
+            Long column = null;
+            Long length = null;
             while (in.hasNext()) {
                 String name = in.nextName();
                 switch (name) {
@@ -259,19 +259,19 @@ public class ValidationProblemSerialization {
                         break;
                     }
                     case "offset": {
-                        offset = in.nextInt();
+                        offset = in.nextLong();
                         break;
                     }
                     case "line": {
-                        line = in.nextInt();
+                        line = in.nextLong();
                         break;
                     }
                     case "column": {
-                        column = in.nextInt();
+                        column = in.nextLong();
                         break;
                     }
                     case "length": {
-                        length = in.nextInt();
+                        length = in.nextLong();
                         break;
                     }
                     default:

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/ProblemSpec.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/ProblemSpec.java
@@ -109,9 +109,9 @@ public interface ProblemSpec {
      * @param path the file location
      * @param line the one-indexed line number
      * @return this
-     * @since 8.6
+     * @since 8.7
      */
-    ProblemSpec lineInFileLocation(String path, int line);
+    ProblemSpec lineInFileLocation(String path, long line);
 
     /**
      * Declares that this problem is in a file with on a line at a certain position.
@@ -121,9 +121,9 @@ public interface ProblemSpec {
      * @param line the one-indexed line number
      * @param column the one-indexed column
      * @return this
-     * @since 8.6
+     * @since 8.7
      */
-    ProblemSpec lineInFileLocation(String path, int line, int column);
+    ProblemSpec lineInFileLocation(String path, long line, long column);
 
     /**
      * Declares that this problem is in a file with on a line at a certain position.
@@ -133,9 +133,9 @@ public interface ProblemSpec {
      * @param column the one-indexed column
      * @param length the length of the text
      * @return this
-     * @since 8.6
+     * @since 8.7
      */
-    ProblemSpec lineInFileLocation(String path, int line, int column, int length);
+    ProblemSpec lineInFileLocation(String path, long line, long column, long length);
 
     /**
      * Declares that this problem is in a file at a certain global position with a given length.
@@ -144,9 +144,9 @@ public interface ProblemSpec {
      * @param offset the zero-indexed global offset from the beginning of the file
      * @param length the length of the text
      * @return this
-     * @since 8.6
+     * @since 8.7
      */
-    ProblemSpec offsetInFileLocation(String path, int offset, int length);
+    ProblemSpec offsetInFileLocation(String path, long offset, long length);
 
     /**
      * Declares that this problem is emitted while applying a plugin.

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultLineInFileLocation.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultLineInFileLocation.java
@@ -18,11 +18,11 @@ package org.gradle.api.problems.internal;
 
 public class DefaultLineInFileLocation extends DefaultFileLocation implements LineInFileLocation {
 
-    private final int line;
-    private final int column;
-    private final int length;
+    private final long line;
+    private final long column;
+    private final long length;
 
-    private DefaultLineInFileLocation(String path, int line, int column, int length) {
+    private DefaultLineInFileLocation(String path, long line, long column, long length) {
         super(path);
         this.line = line;
         this.column = column;
@@ -30,29 +30,29 @@ public class DefaultLineInFileLocation extends DefaultFileLocation implements Li
     }
 
     @Override
-    public int getLine() {
+    public long getLine() {
         return line;
     }
 
     @Override
-    public int getColumn() {
+    public long getColumn() {
         return column;
     }
 
     @Override
-    public int getLength() {
+    public long getLength() {
         return length;
     }
 
-    public static FileLocation from(String path, Integer line) {
+    public static FileLocation from(String path, Long line) {
         return new DefaultLineInFileLocation(path, line, -1, -1);
     }
 
-    public static FileLocation from(String path, Integer line, Integer column) {
+    public static FileLocation from(String path, Long line, Long column) {
         return new DefaultLineInFileLocation(path, line, column, -1);
     }
 
-    public static FileLocation from(String path, Integer line, Integer column, Integer length) {
+    public static FileLocation from(String path, Long line, Long column, Long length) {
         return new DefaultLineInFileLocation(path, line, column, length);
     }
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultOffsetInFileLocation.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultOffsetInFileLocation.java
@@ -18,27 +18,27 @@ package org.gradle.api.problems.internal;
 
 public class DefaultOffsetInFileLocation extends DefaultFileLocation implements OffsetInFileLocation {
 
-    private final int offset;
-    private final int length;
+    private final long offset;
+    private final long length;
 
-    private DefaultOffsetInFileLocation(String path, int offset, int length) {
+    private DefaultOffsetInFileLocation(String path, long offset, long length) {
         super(path);
         this.offset = offset;
         this.length = length;
     }
 
-    public static FileLocation from(String path, int offset, int length) {
+    public static FileLocation from(String path, long offset, long length) {
         return new DefaultOffsetInFileLocation(path, offset, length);
     }
 
 
     @Override
-    public int getOffset() {
+    public long getOffset() {
         return offset;
     }
 
     @Override
-    public int getLength() {
+    public long getLength() {
         return length;
     }
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemBuilder.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemBuilder.java
@@ -129,25 +129,25 @@ public class DefaultProblemBuilder implements InternalProblemBuilder {
     }
 
     @Override
-    public InternalProblemBuilder lineInFileLocation(String path, int line) {
+    public InternalProblemBuilder lineInFileLocation(String path, long line) {
         this.addLocation(DefaultLineInFileLocation.from(path, line));
         return this;
     }
 
     @Override
-    public InternalProblemBuilder lineInFileLocation(String path, int line, int column) {
+    public InternalProblemBuilder lineInFileLocation(String path, long line, long column) {
         this.addLocation(DefaultLineInFileLocation.from(path, line, column));
         return this;
     }
 
     @Override
-    public InternalProblemBuilder offsetInFileLocation(String path, int offset, int length) {
+    public InternalProblemBuilder offsetInFileLocation(String path, long offset, long length) {
         this.addLocation(DefaultOffsetInFileLocation.from(path, offset, length));
         return this;
     }
 
     @Override
-    public InternalProblemBuilder lineInFileLocation(String path, int line, int column, int length) {
+    public InternalProblemBuilder lineInFileLocation(String path, long line, long column, long length) {
         this.addLocation(DefaultLineInFileLocation.from(path, line, column, length));
         return this;
     }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblemBuilder.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblemBuilder.java
@@ -46,13 +46,13 @@ public interface InternalProblemBuilder extends InternalProblemSpec {
     InternalProblemBuilder fileLocation(String path);
 
     @Override
-    InternalProblemBuilder lineInFileLocation(String path, int line);
+    InternalProblemBuilder lineInFileLocation(String path, long line);
 
     @Override
-    InternalProblemBuilder lineInFileLocation(String path, int line, int column, int length);
+    InternalProblemBuilder lineInFileLocation(String path, long line, long column, long length);
 
     @Override
-    InternalProblemBuilder offsetInFileLocation(String path, int offset, int length);
+    InternalProblemBuilder offsetInFileLocation(String path, long offset, long length);
 
     @Override
     InternalProblemBuilder pluginLocation(String pluginId);

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblemSpec.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblemSpec.java
@@ -60,16 +60,16 @@ public interface InternalProblemSpec extends ProblemSpec {
     InternalProblemSpec fileLocation(String path);
 
     @Override
-    InternalProblemSpec lineInFileLocation(String path, int line);
+    InternalProblemSpec lineInFileLocation(String path, long line);
 
     @Override
-    InternalProblemSpec lineInFileLocation(String path, int line, int column);
+    InternalProblemSpec lineInFileLocation(String path, long line, long column);
 
     @Override
-    InternalProblemSpec lineInFileLocation(String path, int line, int column, int length);
+    InternalProblemSpec lineInFileLocation(String path, long line, long column, long length);
 
     @Override
-    InternalProblemSpec offsetInFileLocation(String path, int offset, int length);
+    InternalProblemSpec offsetInFileLocation(String path, long offset, long length);
 
     @Override
     InternalProblemSpec pluginLocation(String pluginId);

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/LineInFileLocation.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/LineInFileLocation.java
@@ -31,7 +31,7 @@ public interface LineInFileLocation extends FileLocation {
      *
      * @return the line number
      */
-    int getLine();
+    long getLine();
 
     /**
      * The starting column on the selected line.
@@ -41,7 +41,7 @@ public interface LineInFileLocation extends FileLocation {
      *
      * @return the column
      */
-    int getColumn();
+    long getColumn();
 
     /**
      * The length of the selected content starting from specified column.
@@ -49,5 +49,5 @@ public interface LineInFileLocation extends FileLocation {
      *
      * @return the length
      */
-    int getLength();
+    long getLength();
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/OffsetInFileLocation.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/OffsetInFileLocation.java
@@ -28,12 +28,12 @@ public interface OffsetInFileLocation extends FileLocation {
      *
      * @return the zero-indexed the offset
      */
-    int getOffset();
+    long getOffset();
 
     /**
      * The content of the content starting from {@link #getOffset()}.
      *
      * @return the length
      */
-    int getLength();
+    long getLength();
 }

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/LineInFileLocation.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/LineInFileLocation.java
@@ -36,7 +36,7 @@ public interface LineInFileLocation extends FileLocation {
      * @return the line number
      * @since 8.6
      */
-    int getLine();
+    long getLine();
 
     /**
      * The starting column on the selected line.
@@ -47,7 +47,7 @@ public interface LineInFileLocation extends FileLocation {
      * @return the column
      * @since 8.6
      */
-    int getColumn();
+    long getColumn();
 
     /**
      * The length of the selected content starting from specified column.
@@ -56,5 +56,5 @@ public interface LineInFileLocation extends FileLocation {
      * @return the length
      * @since 8.6
      */
-    int getLength();
+    long getLength();
 }

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/OffsetInFileLocation.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/OffsetInFileLocation.java
@@ -34,7 +34,7 @@ public interface OffsetInFileLocation extends FileLocation {
      * @return the zero-indexed offset
      * @since 8.6
      */
-    int getOffset();
+    long getOffset();
 
     /**
      * The length of the content starting from {@link #getOffset()}.
@@ -42,5 +42,5 @@ public interface OffsetInFileLocation extends FileLocation {
      * @return the length
      * @since 8.6
      */
-    int getLength();
+    long getLength();
 }

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/internal/DefaultLineInFileLocation.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/internal/DefaultLineInFileLocation.java
@@ -19,11 +19,11 @@ package org.gradle.tooling.events.problems.internal;
 import org.gradle.tooling.events.problems.LineInFileLocation;
 
 public class DefaultLineInFileLocation extends DefaultFileLocation implements LineInFileLocation {
-    private final int line;
-    private final int column;
-    private final int length;
+    private final long line;
+    private final long column;
+    private final long length;
 
-    public DefaultLineInFileLocation(String path, int line, int column, int length) {
+    public DefaultLineInFileLocation(String path, long line, long column, long length) {
         super(path);
         this.line = line;
         this.column = column;
@@ -31,17 +31,17 @@ public class DefaultLineInFileLocation extends DefaultFileLocation implements Li
     }
 
     @Override
-    public int getLine() {
+    public long getLine() {
         return line;
     }
 
     @Override
-    public int getColumn() {
+    public long getColumn() {
         return column;
     }
 
     @Override
-    public int getLength() {
+    public long getLength() {
         return length;
     }
 }

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/internal/DefaultOffsetInFileLocation.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/internal/DefaultOffsetInFileLocation.java
@@ -19,22 +19,22 @@ package org.gradle.tooling.events.problems.internal;
 import org.gradle.tooling.events.problems.OffsetInFileLocation;
 
 public class DefaultOffsetInFileLocation extends DefaultFileLocation implements OffsetInFileLocation {
-    private final int offset;
-    private final int length;
+    private final long offset;
+    private final long length;
 
-    public DefaultOffsetInFileLocation(String path, int offset, int length) {
+    public DefaultOffsetInFileLocation(String path, long offset, long length) {
         super(path);
         this.offset = offset;
         this.length = length;
     }
 
     @Override
-    public int getOffset() {
+    public long getOffset() {
         return offset;
     }
 
     @Override
-    public int getLength() {
+    public long getLength() {
         return length;
     }
 }

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/problem/InternalLineInFileLocation.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/problem/InternalLineInFileLocation.java
@@ -18,9 +18,9 @@ package org.gradle.tooling.internal.protocol.problem;
 
 public interface InternalLineInFileLocation extends InternalFileLocation {
 
-    int getLine();
+    long getLine();
 
-    int getColumn();
+    long getColumn();
 
-    int getLength();
+    long getLength();
 }

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/problem/InternalOffsetInFileLocation.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/problem/InternalOffsetInFileLocation.java
@@ -18,7 +18,7 @@ package org.gradle.tooling.internal.protocol.problem;
 
 public interface InternalOffsetInFileLocation extends InternalFileLocation {
 
-    int getOffset();
+    long getOffset();
 
-    int getLength();
+    long getLength();
 }

--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/types/DefaultLineInFileLocation.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/types/DefaultLineInFileLocation.java
@@ -24,11 +24,11 @@ import java.io.Serializable;
 @NonNullApi
 public class DefaultLineInFileLocation extends DefaultFileLocation implements InternalLineInFileLocation, Serializable {
 
-    private final int line;
-    private final int column;
-    private final int length;
+    private final long line;
+    private final long column;
+    private final long length;
 
-    public DefaultLineInFileLocation(String path, int line, int column, int length) {
+    public DefaultLineInFileLocation(String path, long line, long column, long length) {
         super(path);
         this.line = line;
         this.column = column;
@@ -36,17 +36,17 @@ public class DefaultLineInFileLocation extends DefaultFileLocation implements In
     }
 
     @Override
-    public int getLine() {
+    public long getLine() {
         return line;
     }
 
     @Override
-    public int getColumn() {
+    public long getColumn() {
         return column;
     }
 
     @Override
-    public int getLength() {
+    public long getLength() {
         return length;
     }
 }

--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/types/DefaultOffsetInFileLocation.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/types/DefaultOffsetInFileLocation.java
@@ -23,22 +23,22 @@ import java.io.Serializable;
 
 @NonNullApi
 public class DefaultOffsetInFileLocation extends DefaultFileLocation implements InternalOffsetInFileLocation, Serializable {
-    private final int offset;
-    private final int length;
+    private final long offset;
+    private final long length;
 
-    public DefaultOffsetInFileLocation(String path, int offset, int length) {
+    public DefaultOffsetInFileLocation(String path, long offset, long length) {
         super(path);
         this.offset = offset;
         this.length = length;
     }
 
     @Override
-    public int getOffset() {
+    public long getOffset() {
         return offset;
     }
 
     @Override
-    public int getLength() {
+    public long getLength() {
         return length;
     }
 }


### PR DESCRIPTION
> [!WARNING]
> Sorry, made this non-draft when created, this is not RfR yet

## Make all size `long` instead of `int`. 

Currently, we are using `int` to represent line, column, or any positional index.
It's not hard to imagine when, e.g., using `(file, line)` tuple, some use-cases would overflow the $2^{31}-1 := 2,147,483,647$ limit expressable by an `int`.

2B lines in a CSV file, for example, are by no means unique. If we take a CSV linter use-case here, it would start to fail to locate lines above this limit.

We've agreed that the best solution would be to proactively bump all indices to `long`, as the extra 4 bytes well worth the possible headaches caused later.