### PR TITLE
Fix UserInputHandler.askYesNoQuestion

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/userinput/UserInputHandlingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/userinput/UserInputHandlingIntegrationTest.groovy
@@ -437,6 +437,31 @@ class UserInputHandlingIntegrationTest extends AbstractUserInputHandlerIntegrati
         result.assertTaskSkipped(":generate")
     }
 
+    def "can use askYesNoQuestion"() {
+        buildFile << """
+        task askYesNoQuestion {
+                def result = handler.askYesNoQuestion("thing?")
+                doLast {
+                    println "result = " + result
+                }
+            }
+        """
+
+        when:
+        runWithInput("askYesNoQuestion", input)
+
+        then:
+        result.output.count(YES_NO_PROMPT) == 1
+        outputContains("result = $booleanValue")
+
+        where:
+        input  | booleanValue
+        YES    | true
+        NO     | false
+        "What" | null
+        ""     | null
+    }
+
     void runWithInput(String task, String input) {
         interactiveExecution()
         def gradleHandle = executer.withTasks(task).start()

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/userinput/UserInputHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/userinput/UserInputHandler.java
@@ -35,7 +35,7 @@ public interface UserInputHandler {
     @Nullable
     @UsedByScanPlugin
     default Boolean askYesNoQuestion(String question) {
-        return askUser(interaction -> interaction.askYesNoQuestion(question)).get();
+        return askUser(interaction -> interaction.askYesNoQuestion(question)).getOrNull();
     }
 
     /**


### PR DESCRIPTION
When answering something else than `yes`/`no` the method should return null.

Currently, it fails with `Cannot query the value of this provider because it has no value available.`. This was changed in https://github.com/gradle/gradle/pull/27943.