### PR TITLE
Fix Javadoc for BuildCacheService

### DIFF
--- a/platforms/core-execution/build-cache-spi/src/main/java/org/gradle/caching/BuildCacheService.java
+++ b/platforms/core-execution/build-cache-spi/src/main/java/org/gradle/caching/BuildCacheService.java
@@ -33,7 +33,7 @@ import java.io.IOException;
  *     Fatal failures could include failing to read or write cache entries due to file permissions, authentication or corruption errors.
  * </p>
  * <p>
- *     Every build cache implementation should define a {@link org.gradle.caching.configuration.BuildCache} configuration and {@link BuildCacheServiceFactory} factory.
+ *     Every build cache implementation should define a {@code org.gradle.caching.configuration.BuildCache} configuration and {@code BuildCacheServiceFactory} factory.
  * </p>
  *
  * @since 3.5


### PR DESCRIPTION
By moving the class around, it can't access things in the Javadoc - that is needed for the promotion build.
