### PR TITLE
Improve test display names

### DIFF
--- a/platforms/core-runtime/messaging/src/integTest/groovy/org/gradle/internal/serialize/ExceptionPlaceholderIntegrationTest.groovy
+++ b/platforms/core-runtime/messaging/src/integTest/groovy/org/gradle/internal/serialize/ExceptionPlaceholderIntegrationTest.groovy
@@ -67,7 +67,7 @@ class ExceptionPlaceholderIntegrationTest extends AbstractIntegrationSpec {
         fails 'test'
 
         then:
-        outputContains "example.Issue1618Test > thisTestShouldBeMarkedAsFailed FAILED"
+        outputContains "Issue1618Test > thisTestShouldBeMarkedAsFailed FAILED"
     }
 
     @Issue("https://github.com/gradle/gradle/issues/9487")

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -97,6 +97,20 @@ In such a case, Gradle should retry the auto-provisioning process with other con
 This was also not the case before the fix.
 
 
+<a name="other"></a>
+### Other improvements
+
+#### Tests metadata improvements in tooling API
+
+IDEs and other tools can use tooling API to get information about tests Gradle runs.
+Each test event sent by tooling API contains a test descriptor that contains test metadata: human-readable name, class name, method name, etc.
+
+For JUnit5 and Spock, we updated the test descriptor for dynamic and parametrized tests to include the data about the class name and method name containing the test.
+We also improved the display names, so they are passed transparently from the frameworks and can be used by IDEs without transformations.
+
+These changes would allow IDEs to provide better navigation and reporting for dynamic and parametrized tests.
+
+
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ADD RELEASE FEATURES ABOVE
 ==========================================================

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -105,9 +105,12 @@ This was also not the case before the fix.
 IDEs and other tools leverage the tooling API to access information about tests executed by Gradle.
 Each test event sent via the tooling API includes a test descriptor containing metadata such as a human-readable name, class name, and method name.
 
-For JUnit5 and Spock, we updated the test descriptor for dynamic and parameterized tests to include information about the class name and method name containing the test.
-Additionally, we improved the display names so that they are transparently passed from the frameworks, enabling IDEs to use them without requiring transformations.
+We introduced a new method to the `TestOperationDescriptor` interface to provide the test display name – `getTestDisplayName`.
+It returns the display name of the test that can be used by IDEs to present the test in a human-readable format.
+It is transparently passed from the frameworks, enabling IDEs to use them without requiring transformations.
+Previously, the display name could be obtained only by parsing the operation display name, which was not always reliable.
 
+Additionally, for JUnit5 and Spock, we updated the test descriptor for dynamic and parameterized tests to include information about the class name and method name containing the test.
 These enhancements enable IDEs to offer improved navigation and reporting capabilities for dynamic and parameterized tests.
 
 

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -102,13 +102,13 @@ This was also not the case before the fix.
 
 #### Tests metadata improvements in tooling API
 
-IDEs and other tools can use tooling API to get information about tests Gradle runs.
-Each test event sent by tooling API contains a test descriptor that contains test metadata: human-readable name, class name, method name, etc.
+IDEs and other tools leverage the tooling API to access information about tests executed by Gradle.
+Each test event sent via the tooling API includes a test descriptor containing metadata such as a human-readable name, class name, and method name.
 
-For JUnit5 and Spock, we updated the test descriptor for dynamic and parametrized tests to include the data about the class name and method name containing the test.
-We also improved the display names, so they are passed transparently from the frameworks and can be used by IDEs without transformations.
+For JUnit5 and Spock, we updated the test descriptor for dynamic and parameterized tests to include information about the class name and method name containing the test.
+Additionally, we improved the display names so that they are transparently passed from the frameworks, enabling IDEs to use them without requiring transformations.
 
-These changes would allow IDEs to provide better navigation and reporting for dynamic and parametrized tests.
+These enhancements enable IDEs to offer improved navigation and reporting capabilities for dynamic and parameterized tests.
 
 
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionResultEvaluator.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionResultEvaluator.java
@@ -123,7 +123,7 @@ class TestExecutionResultEvaluator implements BuildOperationListener {
     private String formatInternalTestExecutionRequest() {
         StringBuilder requestDetails = new StringBuilder(INDENT).append("Requested tests:");
         for (InternalTestDescriptor internalTestDescriptor : internalTestExecutionRequest.getTestExecutionDescriptors()) {
-            requestDetails.append("\n").append(Strings.repeat(INDENT, 2)).append(internalTestDescriptor.getDisplayName());
+            requestDetails.append("\n").append(Strings.repeat(INDENT, 2)).append(internalTestDescriptor.toString());
             requestDetails.append(" (Task: '").append(((DefaultTestDescriptor) internalTestDescriptor).getTaskPath()).append("')");
         }
         final Collection<InternalJvmTestRequest> internalJvmTestRequests = internalTestExecutionRequest.getInternalJvmTestRequests();

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionResultEvaluator.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionResultEvaluator.java
@@ -123,7 +123,7 @@ class TestExecutionResultEvaluator implements BuildOperationListener {
     private String formatInternalTestExecutionRequest() {
         StringBuilder requestDetails = new StringBuilder(INDENT).append("Requested tests:");
         for (InternalTestDescriptor internalTestDescriptor : internalTestExecutionRequest.getTestExecutionDescriptors()) {
-            requestDetails.append("\n").append(Strings.repeat(INDENT, 2)).append(internalTestDescriptor.toString());
+            requestDetails.append("\n").append(Strings.repeat(INDENT, 2)).append(internalTestDescriptor.getDisplayName());
             requestDetails.append(" (Task: '").append(((DefaultTestDescriptor) internalTestDescriptor).getTaskPath()).append("')");
         }
         final Collection<InternalJvmTestRequest> internalJvmTestRequests = internalTestExecutionRequest.getInternalJvmTestRequests();

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestOperationMapper.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestOperationMapper.java
@@ -85,7 +85,7 @@ class TestOperationMapper implements BuildOperationMapper<ExecuteTestBuildOperat
     }
 
     private DefaultTestDescriptor toTestDescriptorForSuite(OperationIdentifier buildOperationId, OperationIdentifier parentId, TestDescriptorInternal suite) {
-        return new DefaultTestDescriptor(buildOperationId, suite.getName(), suite.getDisplayName(), InternalJvmTestDescriptor.KIND_SUITE, suite.getName(), suite.getClassName(), null, parentId, taskTracker.getTaskPath(buildOperationId));
+        return new DefaultTestDescriptor(buildOperationId, suite.getName(), suite.getDisplayName(), InternalJvmTestDescriptor.KIND_SUITE, suite.getName(), suite.getClassName(), suite.getMethodName(), parentId, taskTracker.getTaskPath(buildOperationId));
     }
 
     private DefaultTestDescriptor toTestDescriptorForTest(OperationIdentifier buildOperationId, OperationIdentifier parentId, TestDescriptorInternal test) {

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestOperationMapper.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestOperationMapper.java
@@ -85,11 +85,11 @@ class TestOperationMapper implements BuildOperationMapper<ExecuteTestBuildOperat
     }
 
     private DefaultTestDescriptor toTestDescriptorForSuite(OperationIdentifier buildOperationId, OperationIdentifier parentId, TestDescriptorInternal suite) {
-        return new DefaultTestDescriptor(buildOperationId, suite.getName(), suite.getDisplayName(), InternalJvmTestDescriptor.KIND_SUITE, suite.getName(), suite.getClassName(), suite.getMethodName(), parentId, taskTracker.getTaskPath(buildOperationId));
+        return new DefaultTestDescriptor(buildOperationId, suite.getName(), suite.toString(), suite.getDisplayName(), InternalJvmTestDescriptor.KIND_SUITE, suite.getName(), suite.getClassName(), suite.getMethodName(), parentId, taskTracker.getTaskPath(buildOperationId));
     }
 
     private DefaultTestDescriptor toTestDescriptorForTest(OperationIdentifier buildOperationId, OperationIdentifier parentId, TestDescriptorInternal test) {
-        return new DefaultTestDescriptor(buildOperationId, test.getName(), test.getDisplayName(), InternalJvmTestDescriptor.KIND_ATOMIC, null, test.getClassName(), test.getName(), parentId, taskTracker.getTaskPath(buildOperationId));
+        return new DefaultTestDescriptor(buildOperationId, test.getName(), test.toString(), test.getDisplayName(), InternalJvmTestDescriptor.KIND_ATOMIC, null, test.getClassName(), test.getName(), parentId, taskTracker.getTaskPath(buildOperationId));
     }
 
     private static AbstractTestResult adapt(TestResult result) {

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestOperationMapper.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestOperationMapper.java
@@ -85,37 +85,11 @@ class TestOperationMapper implements BuildOperationMapper<ExecuteTestBuildOperat
     }
 
     private DefaultTestDescriptor toTestDescriptorForSuite(OperationIdentifier buildOperationId, OperationIdentifier parentId, TestDescriptorInternal suite) {
-        String name = suite.getName();
-        String displayName = backwardsCompatibleDisplayNameOf(suite);
-        String testKind = InternalJvmTestDescriptor.KIND_SUITE;
-        String className = suite.getClassName();
-        String methodName = null;
-        String testTaskPath = taskTracker.getTaskPath(buildOperationId);
-        return new DefaultTestDescriptor(buildOperationId, name, displayName, testKind, suite.getName(), className, methodName, parentId, testTaskPath);
+        return new DefaultTestDescriptor(buildOperationId, suite.getName(), suite.getDisplayName(), InternalJvmTestDescriptor.KIND_SUITE, suite.getName(), suite.getClassName(), null, parentId, taskTracker.getTaskPath(buildOperationId));
     }
 
     private DefaultTestDescriptor toTestDescriptorForTest(OperationIdentifier buildOperationId, OperationIdentifier parentId, TestDescriptorInternal test) {
-        String name = test.getName();
-        String displayName = backwardsCompatibleDisplayNameOf(test);
-        String testKind = InternalJvmTestDescriptor.KIND_ATOMIC;
-        String className = test.getClassName();
-        String methodName = test.getName();
-        String taskPath = taskTracker.getTaskPath(buildOperationId);
-        return new DefaultTestDescriptor(buildOperationId, name, displayName, testKind, null, className, methodName, parentId, taskPath);
-    }
-
-    /**
-     * This method returns a display name which is "compatible with" what previous
-     * Gradle versions did.
-     */
-    private static String backwardsCompatibleDisplayNameOf(TestDescriptorInternal descriptor) {
-        String className = descriptor.getClassName();
-        String methodName = descriptor.getName();
-        String displayName = descriptor.getDisplayName();
-        if (methodName != null && methodName.equals(displayName) || className != null && className.equals(displayName)) {
-            return descriptor.toString();
-        }
-        return displayName;
+        return new DefaultTestDescriptor(buildOperationId, test.getName(), test.getDisplayName(), InternalJvmTestDescriptor.KIND_ATOMIC, null, test.getClassName(), test.getName(), parentId, taskTracker.getTaskPath(buildOperationId));
     }
 
     private static AbstractTestResult adapt(TestResult result) {

--- a/platforms/ide/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionBuildTaskSchedulerTest.groovy
+++ b/platforms/ide/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionBuildTaskSchedulerTest.groovy
@@ -158,7 +158,7 @@ class TestExecutionBuildTaskSchedulerTest extends Specification {
     }
 
     private DefaultTestDescriptor testDescriptor() {
-        new DefaultTestDescriptor(Stub(OperationIdentifier), "test1", "test 1", "ATOMIC", "test suite", TEST_CLASS_NAME, TEST_METHOD_NAME, null, TEST_TASK_NAME)
+        new DefaultTestDescriptor(Stub(OperationIdentifier), "test1", "Test $TEST_METHOD_NAME($TEST_CLASS_NAME)", "test 1", "ATOMIC", "test suite", TEST_CLASS_NAME, TEST_METHOD_NAME, null, TEST_TASK_NAME)
     }
 
 }

--- a/platforms/ide/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionResultEvaluatorTest.groovy
+++ b/platforms/ide/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionResultEvaluatorTest.groovy
@@ -46,7 +46,7 @@ class TestExecutionResultEvaluatorTest extends Specification {
 
         def testDescriptorInternal = Mock(TestDescriptorInternal)
         def defaultTestDescriptor = Mock(DefaultTestDescriptor)
-        1 * defaultTestDescriptor.toString() >> "Some Test Descriptor"
+        1 * defaultTestDescriptor.getDisplayName() >> "Some Test Descriptor"
         1 * defaultTestDescriptor.getTaskPath() >> ":someTestTask"
 
         def testResult = Mock(TestResult)

--- a/platforms/ide/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionResultEvaluatorTest.groovy
+++ b/platforms/ide/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionResultEvaluatorTest.groovy
@@ -46,7 +46,7 @@ class TestExecutionResultEvaluatorTest extends Specification {
 
         def testDescriptorInternal = Mock(TestDescriptorInternal)
         def defaultTestDescriptor = Mock(DefaultTestDescriptor)
-        1 * defaultTestDescriptor.getDisplayName() >> "Some Test Descriptor"
+        1 * defaultTestDescriptor.toString() >> "Some Test Descriptor"
         1 * defaultTestDescriptor.getTaskPath() >> ":someTestTask"
 
         def testResult = Mock(TestResult)

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/TestLauncherSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/TestLauncherSpec.groovy
@@ -318,7 +318,7 @@ abstract class TestLauncherSpec extends ToolingApiSpecification implements WithO
     }
 
     interface TestEventSpec {
-        void displayName(String displayName)
+        void testDisplayName(String displayName)
 
         void suite(String name, @DelegatesTo(value = TestEventSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> spec)
 
@@ -352,7 +352,7 @@ abstract class TestLauncherSpec extends ToolingApiSpecification implements WithO
         private final List<JvmTestOperationDescriptor> testEvents
         private final Set<OperationDescriptor> verifiedEvents
         private final OperationDescriptor parent
-        private String displayName
+        private String testDisplayName
 
         static void assertSpec(OperationDescriptor descriptor, List<JvmTestOperationDescriptor> testEvents, Set<OperationDescriptor> verifiedEvents, @DelegatesTo(value = TestEventSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
             verifiedEvents.add(descriptor)
@@ -370,8 +370,8 @@ abstract class TestLauncherSpec extends ToolingApiSpecification implements WithO
         }
 
         @Override
-        void displayName(String displayName) {
-            this.displayName = displayName
+        void testDisplayName(String displayName) {
+            this.testDisplayName = displayName
         }
 
         private static String normalizeExecutor(String name) {
@@ -394,6 +394,11 @@ abstract class TestLauncherSpec extends ToolingApiSpecification implements WithO
             if (child == null) {
                 failWith("test suite", name)
             }
+            if (name.startsWith("Gradle Test")) {
+                assert normalizeExecutor(child.displayName) == name
+            } else {
+                assert child.displayName == "Test suite '$name'"
+            }
             assertSpec(child, testEvents, verifiedEvents, spec)
         }
 
@@ -410,6 +415,7 @@ abstract class TestLauncherSpec extends ToolingApiSpecification implements WithO
             if (child == null) {
                 failWith("test class", name)
             }
+            assert child.displayName == "Test class $name"
             assertSpec(child, testEvents, verifiedEvents, spec)
         }
 
@@ -428,6 +434,7 @@ abstract class TestLauncherSpec extends ToolingApiSpecification implements WithO
             if (child == null) {
                 failWith("test", name)
             }
+            assert child.displayName == "Test $name($expectedClassName)"
             assertSpec(child, testEvents, verifiedEvents, spec)
         }
 
@@ -446,6 +453,7 @@ abstract class TestLauncherSpec extends ToolingApiSpecification implements WithO
             if (child == null) {
                 failWith("test method suite", name)
             }
+            assert child.displayName == "Test method $name"
             assertSpec(child, testEvents, verifiedEvents, spec)
         }
 
@@ -464,8 +472,8 @@ abstract class TestLauncherSpec extends ToolingApiSpecification implements WithO
         }
 
         void validate() {
-            if (displayName != null) {
-                assert displayName == parent.displayName
+            if (testDisplayName != null && parent.respondsTo("getTestDisplayName")) {
+                assert testDisplayName == ((TestOperationDescriptor) parent).testDisplayName
             }
         }
     }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/TestLauncherSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/TestLauncherSpec.groovy
@@ -327,8 +327,6 @@ abstract class TestLauncherSpec extends ToolingApiSpecification implements WithO
         void test(String name, @DelegatesTo(value = TestEventSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> spec)
 
         void testMethodSuite(String name, @DelegatesTo(value = TestEventSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> spec)
-
-        void generatedTest(String name, @DelegatesTo(value = TestEventSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> spec)
     }
 
     class DefaultTestEventsSpec implements TestEventsSpec {
@@ -417,11 +415,13 @@ abstract class TestLauncherSpec extends ToolingApiSpecification implements WithO
 
         @Override
         void test(String name, @DelegatesTo(value = TestEventSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
+            def expectedClassName = ((JvmTestOperationDescriptor) parent).className
+            assert expectedClassName != null
             def child = testEvents.find {
                 it.parent == parent &&
                     it.jvmTestKind == JvmTestKind.ATOMIC &&
                     it.suiteName == null &&
-                    it.className == parent.name &&
+                    it.className == expectedClassName &&
                     it.methodName == name &&
                     it.name == name
             }
@@ -434,6 +434,7 @@ abstract class TestLauncherSpec extends ToolingApiSpecification implements WithO
         @Override
         void testMethodSuite(String name, @DelegatesTo(value = TestEventSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
             def expectedClassName = ((JvmTestOperationDescriptor) parent).className
+            assert expectedClassName != null
             def child = testEvents.find {
                 it.parent == parent &&
                     it.jvmTestKind == JvmTestKind.SUITE &&
@@ -444,23 +445,6 @@ abstract class TestLauncherSpec extends ToolingApiSpecification implements WithO
             }
             if (child == null) {
                 failWith("test method suite", name)
-            }
-            assertSpec(child, testEvents, verifiedEvents, spec)
-        }
-
-        @Override
-        void generatedTest(String name, @DelegatesTo(value = TestEventSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
-            def expectedClassName = ((JvmTestOperationDescriptor) parent).className
-            def child = testEvents.find {
-                it.parent == parent &&
-                    it.jvmTestKind == JvmTestKind.ATOMIC &&
-                    it.suiteName == null &&
-                    it.className == expectedClassName &&
-                    it.methodName == name &&
-                    it.name == name
-            }
-            if (child == null) {
-                failWith("generated test", name)
             }
             assertSpec(child, testEvents, verifiedEvents, spec)
         }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TestProgressCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TestProgressCrossVersionSpec.groovy
@@ -17,9 +17,7 @@
 
 package org.gradle.integtests.tooling.r25
 
-
 import org.gradle.integtests.tooling.fixture.ProgressEvents
-import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.WithOldConfigurationsSupport
 import org.gradle.test.fixtures.file.TestFile
@@ -116,7 +114,6 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification implements Wi
         assertHasBuildSuccessfulLogging()
     }
 
-    @TargetGradleVersion(">8.6")
     def "receive test progress events for successful test run"() {
         given:
         buildFile << """
@@ -165,26 +162,29 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification implements Wi
         workerSuite.descriptor.methodName == null
         workerSuite.descriptor.parent == rootSuite.descriptor
 
-        def testClass = events.operation("MyTest")
+        def classDisplayName = targetDist.hasLegacyTestDisplayNames ? 'Test class example.MyTest' : 'MyTest'
+
+        def testClass = events.operation(classDisplayName)
         testClass.descriptor.jvmTestKind == JvmTestKind.SUITE
         testClass.descriptor.name == 'example.MyTest'
-        testClass.descriptor.displayName == 'MyTest'
+        testClass.descriptor.displayName == classDisplayName
         testClass.descriptor.suiteName == 'example.MyTest'
         testClass.descriptor.className == 'example.MyTest'
         testClass.descriptor.methodName == null
         testClass.descriptor.parent == workerSuite.descriptor
 
-        def testMethod = events.operation("foo")
+        def testDisplayName = targetDist.hasLegacyTestDisplayNames ? 'Test foo(example.MyTest)' : 'foo'
+
+        def testMethod = events.operation(testDisplayName)
         testMethod.descriptor.jvmTestKind == JvmTestKind.ATOMIC
         testMethod.descriptor.name == 'foo'
-        testMethod.descriptor.displayName == 'foo'
+        testMethod.descriptor.displayName == testDisplayName
         testMethod.descriptor.suiteName == null
         testMethod.descriptor.className == 'example.MyTest'
         testMethod.descriptor.methodName == 'foo'
         testMethod.descriptor.parent == testClass.descriptor
     }
 
-    @TargetGradleVersion(">8.6")
     def "receive test progress events for failed test run"() {
         given:
         buildFile << """
@@ -237,10 +237,12 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification implements Wi
         workerSuite.result instanceof TestFailureResult
         workerSuite.result.failures.size() == 0
 
-        def testClass = events.operation("MyTest")
+        def classDisplayName = targetDist.hasLegacyTestDisplayNames ? 'Test class example.MyTest' : 'MyTest'
+
+        def testClass = events.operation(classDisplayName)
         testClass.descriptor.jvmTestKind == JvmTestKind.SUITE
         testClass.descriptor.name == 'example.MyTest'
-        testClass.descriptor.displayName == 'MyTest'
+        testClass.descriptor.displayName == classDisplayName
         testClass.descriptor.suiteName == 'example.MyTest'
         testClass.descriptor.className == 'example.MyTest'
         testClass.descriptor.methodName == null
@@ -248,10 +250,12 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification implements Wi
         testClass.result instanceof TestFailureResult
         testClass.result.failures.size() == 0
 
-        def testMethod = events.operation("foo")
+        def testDisplayName = targetDist.hasLegacyTestDisplayNames ? 'Test foo(example.MyTest)' : 'foo'
+
+        def testMethod = events.operation(testDisplayName)
         testMethod.descriptor.jvmTestKind == JvmTestKind.ATOMIC
         testMethod.descriptor.name == 'foo'
-        testMethod.descriptor.displayName == 'foo'
+        testMethod.descriptor.displayName == testDisplayName
         testMethod.descriptor.suiteName == null
         testMethod.descriptor.className == 'example.MyTest'
         testMethod.descriptor.methodName == 'foo'
@@ -266,7 +270,6 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification implements Wi
         testMethod.result.failures[0].causes[0].causes.empty
     }
 
-    @TargetGradleVersion(">8.6")
     def "receive test progress events for skipped test run"() {
         given:
         buildFile << """
@@ -295,7 +298,8 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification implements Wi
 
         then:
         events.tests.size() == 4
-        def testMethod = events.operation("foo")
+        def testDisplayName = targetDist.hasLegacyTestDisplayNames ? 'Test foo(example.MyTest)' : 'foo'
+        def testMethod = events.operation(testDisplayName)
         testMethod.result instanceof TestSkippedResult
     }
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TestProgressCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TestProgressCrossVersionSpec.groovy
@@ -19,6 +19,7 @@ package org.gradle.integtests.tooling.r25
 
 
 import org.gradle.integtests.tooling.fixture.ProgressEvents
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.WithOldConfigurationsSupport
 import org.gradle.test.fixtures.file.TestFile
@@ -115,6 +116,7 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification implements Wi
         assertHasBuildSuccessfulLogging()
     }
 
+    @TargetGradleVersion(">8.6")
     def "receive test progress events for successful test run"() {
         given:
         buildFile << """
@@ -163,25 +165,26 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification implements Wi
         workerSuite.descriptor.methodName == null
         workerSuite.descriptor.parent == rootSuite.descriptor
 
-        def testClass = events.operation("Test class example.MyTest")
+        def testClass = events.operation("MyTest")
         testClass.descriptor.jvmTestKind == JvmTestKind.SUITE
         testClass.descriptor.name == 'example.MyTest'
-        testClass.descriptor.displayName == 'Test class example.MyTest'
+        testClass.descriptor.displayName == 'MyTest'
         testClass.descriptor.suiteName == 'example.MyTest'
         testClass.descriptor.className == 'example.MyTest'
         testClass.descriptor.methodName == null
         testClass.descriptor.parent == workerSuite.descriptor
 
-        def testMethod = events.operation("Test foo(example.MyTest)")
+        def testMethod = events.operation("foo")
         testMethod.descriptor.jvmTestKind == JvmTestKind.ATOMIC
         testMethod.descriptor.name == 'foo'
-        testMethod.descriptor.displayName == 'Test foo(example.MyTest)'
+        testMethod.descriptor.displayName == 'foo'
         testMethod.descriptor.suiteName == null
         testMethod.descriptor.className == 'example.MyTest'
         testMethod.descriptor.methodName == 'foo'
         testMethod.descriptor.parent == testClass.descriptor
     }
 
+    @TargetGradleVersion(">8.6")
     def "receive test progress events for failed test run"() {
         given:
         buildFile << """
@@ -234,10 +237,10 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification implements Wi
         workerSuite.result instanceof TestFailureResult
         workerSuite.result.failures.size() == 0
 
-        def testClass = events.operation("Test class example.MyTest")
+        def testClass = events.operation("MyTest")
         testClass.descriptor.jvmTestKind == JvmTestKind.SUITE
         testClass.descriptor.name == 'example.MyTest'
-        testClass.descriptor.displayName == 'Test class example.MyTest'
+        testClass.descriptor.displayName == 'MyTest'
         testClass.descriptor.suiteName == 'example.MyTest'
         testClass.descriptor.className == 'example.MyTest'
         testClass.descriptor.methodName == null
@@ -245,10 +248,10 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification implements Wi
         testClass.result instanceof TestFailureResult
         testClass.result.failures.size() == 0
 
-        def testMethod = events.operation("Test foo(example.MyTest)")
+        def testMethod = events.operation("foo")
         testMethod.descriptor.jvmTestKind == JvmTestKind.ATOMIC
         testMethod.descriptor.name == 'foo'
-        testMethod.descriptor.displayName == 'Test foo(example.MyTest)'
+        testMethod.descriptor.displayName == 'foo'
         testMethod.descriptor.suiteName == null
         testMethod.descriptor.className == 'example.MyTest'
         testMethod.descriptor.methodName == 'foo'
@@ -263,6 +266,7 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification implements Wi
         testMethod.result.failures[0].causes[0].causes.empty
     }
 
+    @TargetGradleVersion(">8.6")
     def "receive test progress events for skipped test run"() {
         given:
         buildFile << """
@@ -291,7 +295,7 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification implements Wi
 
         then:
         events.tests.size() == 4
-        def testMethod = events.operation("Test foo(example.MyTest)")
+        def testMethod = events.operation("foo")
         testMethod.result instanceof TestSkippedResult
     }
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TestProgressCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TestProgressCrossVersionSpec.groovy
@@ -162,23 +162,19 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification implements Wi
         workerSuite.descriptor.methodName == null
         workerSuite.descriptor.parent == rootSuite.descriptor
 
-        def classDisplayName = targetDist.hasLegacyTestDisplayNames ? 'Test class example.MyTest' : 'MyTest'
-
-        def testClass = events.operation(classDisplayName)
+        def testClass = events.operation("Test class example.MyTest")
         testClass.descriptor.jvmTestKind == JvmTestKind.SUITE
         testClass.descriptor.name == 'example.MyTest'
-        testClass.descriptor.displayName == classDisplayName
+        testClass.descriptor.displayName == 'Test class example.MyTest'
         testClass.descriptor.suiteName == 'example.MyTest'
         testClass.descriptor.className == 'example.MyTest'
         testClass.descriptor.methodName == null
         testClass.descriptor.parent == workerSuite.descriptor
 
-        def testDisplayName = targetDist.hasLegacyTestDisplayNames ? 'Test foo(example.MyTest)' : 'foo'
-
-        def testMethod = events.operation(testDisplayName)
+        def testMethod = events.operation("Test foo(example.MyTest)")
         testMethod.descriptor.jvmTestKind == JvmTestKind.ATOMIC
         testMethod.descriptor.name == 'foo'
-        testMethod.descriptor.displayName == testDisplayName
+        testMethod.descriptor.displayName == 'Test foo(example.MyTest)'
         testMethod.descriptor.suiteName == null
         testMethod.descriptor.className == 'example.MyTest'
         testMethod.descriptor.methodName == 'foo'
@@ -237,12 +233,10 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification implements Wi
         workerSuite.result instanceof TestFailureResult
         workerSuite.result.failures.size() == 0
 
-        def classDisplayName = targetDist.hasLegacyTestDisplayNames ? 'Test class example.MyTest' : 'MyTest'
-
-        def testClass = events.operation(classDisplayName)
+        def testClass = events.operation("Test class example.MyTest")
         testClass.descriptor.jvmTestKind == JvmTestKind.SUITE
         testClass.descriptor.name == 'example.MyTest'
-        testClass.descriptor.displayName == classDisplayName
+        testClass.descriptor.displayName == 'Test class example.MyTest'
         testClass.descriptor.suiteName == 'example.MyTest'
         testClass.descriptor.className == 'example.MyTest'
         testClass.descriptor.methodName == null
@@ -250,15 +244,10 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification implements Wi
         testClass.result instanceof TestFailureResult
         testClass.result.failures.size() == 0
 
-        def testDisplayName = targetDist.hasLegacyTestDisplayNames ? 'Test foo(example.MyTest)' : 'foo'
-
-        def testMethod = events.operation(testDisplayName)
+        def testMethod = events.operation("Test foo(example.MyTest)")
         testMethod.descriptor.jvmTestKind == JvmTestKind.ATOMIC
         testMethod.descriptor.name == 'foo'
-        testMethod.descriptor.displayName == testDisplayName
-        testMethod.descriptor.suiteName == null
-        testMethod.descriptor.className == 'example.MyTest'
-        testMethod.descriptor.methodName == 'foo'
+        testMethod.descriptor.displayName == 'Test foo(example.MyTest)'
         testMethod.descriptor.parent == testClass.descriptor
         testMethod.result instanceof TestFailureResult
         testMethod.result.failures.size() == 1
@@ -298,8 +287,7 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification implements Wi
 
         then:
         events.tests.size() == 4
-        def testDisplayName = targetDist.hasLegacyTestDisplayNames ? 'Test foo(example.MyTest)' : 'foo'
-        def testMethod = events.operation(testDisplayName)
+        def testMethod = events.operation("Test foo(example.MyTest)")
         testMethod.result instanceof TestSkippedResult
     }
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r26/TestLauncherCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r26/TestLauncherCrossVersionSpec.groovy
@@ -43,6 +43,7 @@ import spock.lang.Timeout
 class TestLauncherCrossVersionSpec extends TestLauncherSpec {
     public static final GradleVersion GRADLE_VERSION_34 = GradleVersion.version("3.4")
 
+    @TargetGradleVersion(">8.6")
     def "test launcher api fires progress events"() {
         given:
         collectDescriptorsFromBuild()
@@ -66,13 +67,13 @@ class TestLauncherCrossVersionSpec extends TestLauncherSpec {
         def testExecutorEvents = events.operations.findAll { it.descriptor.displayName.matches "Gradle Test Executor \\d+" }
         testExecutorEvents.size() == 2
         testExecutorEvents.every { it.successful }
-        events.tests.findAll { it.descriptor.displayName == "Test class example.MyTest" }.size() == 2
-        events.tests.findAll { it.descriptor.displayName == "Test foo(example.MyTest)" }.size() == 2
-        events.tests.findAll { it.descriptor.displayName == "Test foo2(example.MyTest)" }.size() == 2
+        events.tests.findAll { it.descriptor.displayName == "MyTest" }.size() == 2
+        events.tests.findAll { it.descriptor.displayName == "foo" }.size() == 2
+        events.tests.findAll { it.descriptor.displayName == "foo2" }.size() == 2
         if (supportsEfficientClassFiltering()) {
             events.tests.size() == 10
         } else {
-            events.tests.findAll { it.descriptor.displayName == "Test class example2.MyOtherTest" }.size() == 2
+            events.tests.findAll { it.descriptor.displayName == "MyOtherTest" }.size() == 2
             events.tests.size() == 12
         }
     }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r26/TestLauncherCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r26/TestLauncherCrossVersionSpec.groovy
@@ -66,26 +66,14 @@ class TestLauncherCrossVersionSpec extends TestLauncherSpec {
         def testExecutorEvents = events.operations.findAll { it.descriptor.displayName.matches "Gradle Test Executor \\d+" }
         testExecutorEvents.size() == 2
         testExecutorEvents.every { it.successful }
-        if (targetDist.hasLegacyTestDisplayNames) {
-            assert events.tests.findAll { it.descriptor.displayName == "Test class example.MyTest" }.size() == 2
-            assert events.tests.findAll { it.descriptor.displayName == "Test foo(example.MyTest)" }.size() == 2
-            assert events.tests.findAll { it.descriptor.displayName == "Test foo2(example.MyTest)" }.size() == 2
-            if (supportsEfficientClassFiltering()) {
-                assert events.tests.size() == 10
-            } else {
-                assert events.tests.findAll { it.descriptor.displayName == "Test class example2.MyOtherTest" }.size() == 2
-                assert events.tests.size() == 12
-            }
+        events.tests.findAll { it.descriptor.displayName == "Test class example.MyTest" }.size() == 2
+        events.tests.findAll { it.descriptor.displayName == "Test foo(example.MyTest)" }.size() == 2
+        events.tests.findAll { it.descriptor.displayName == "Test foo2(example.MyTest)" }.size() == 2
+        if (supportsEfficientClassFiltering()) {
+            assert events.tests.size() == 10
         } else {
-            assert events.tests.findAll { it.descriptor.displayName == "MyTest" }.size() == 2
-            assert events.tests.findAll { it.descriptor.displayName == "foo" }.size() == 2
-            assert events.tests.findAll { it.descriptor.displayName == "foo2" }.size() == 2
-            if (supportsEfficientClassFiltering()) {
-                assert events.tests.size() == 10
-            } else {
-                assert events.tests.findAll { it.descriptor.displayName == "MyOtherTest" }.size() == 2
-                assert events.tests.size() == 12
-            }
+            assert events.tests.findAll { it.descriptor.displayName == "Test class example2.MyOtherTest" }.size() == 2
+            assert events.tests.size() == 12
         }
     }
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/BasicProjectConfigurationProgressCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/BasicProjectConfigurationProgressCrossVersionSpec.groovy
@@ -193,13 +193,11 @@ class BasicProjectConfigurationProgressCrossVersionSpec extends ToolingApiSpecif
 
         then:
         events.tests.size() == events.operations.size()
-        def aTestDisplayName = targetDist.hasLegacyTestDisplayNames ? "Test ok(ATest)" : "ok"
         if (targetDist.runsBuildSrcTests) {
-            def event = events.operation("Gradle Test Run :buildSrc:a:test").descendant(aTestDisplayName)
+            def event = events.operation("Gradle Test Run :buildSrc:a:test").descendant("Test ok(ATest)")
             event.parent.descriptor.name == "ATest"
         }
-        def thingTestDisplayName = targetDist.hasLegacyTestDisplayNames ? "Test ok(ThingTest)" : "ok"
-        def event = events.operation("Gradle Test Run :test").descendant(thingTestDisplayName)
+        def event = events.operation("Gradle Test Run :test").descendant("Test ok(ThingTest)")
         event.parent.descriptor.name == "ThingTest"
     }
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/BasicProjectConfigurationProgressCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/BasicProjectConfigurationProgressCrossVersionSpec.groovy
@@ -124,7 +124,6 @@ class BasicProjectConfigurationProgressCrossVersionSpec extends ToolingApiSpecif
         configureA.failures[0].message == "A problem occurred configuring project ':a'."
     }
 
-    @TargetGradleVersion(">8.6")
     def "generates events for buildSrc builds"() {
         given:
         buildSrc()
@@ -194,10 +193,14 @@ class BasicProjectConfigurationProgressCrossVersionSpec extends ToolingApiSpecif
 
         then:
         events.tests.size() == events.operations.size()
+        def aTestDisplayName = targetDist.hasLegacyTestDisplayNames ? "Test ok(ATest)" : "ok"
         if (targetDist.runsBuildSrcTests) {
-            events.operation("Gradle Test Run :buildSrc:a:test").descendant("ok")
+            def event = events.operation("Gradle Test Run :buildSrc:a:test").descendant(aTestDisplayName)
+            event.parent.descriptor.name == "ATest"
         }
-        events.operation("Gradle Test Run :test").descendant("ok")
+        def thingTestDisplayName = targetDist.hasLegacyTestDisplayNames ? "Test ok(ThingTest)" : "ok"
+        def event = events.operation("Gradle Test Run :test").descendant(thingTestDisplayName)
+        event.parent.descriptor.name == "ThingTest"
     }
 
     def javaProjectWithTests() {

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/BasicProjectConfigurationProgressCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/BasicProjectConfigurationProgressCrossVersionSpec.groovy
@@ -124,6 +124,7 @@ class BasicProjectConfigurationProgressCrossVersionSpec extends ToolingApiSpecif
         configureA.failures[0].message == "A problem occurred configuring project ':a'."
     }
 
+    @TargetGradleVersion(">8.6")
     def "generates events for buildSrc builds"() {
         given:
         buildSrc()
@@ -194,9 +195,9 @@ class BasicProjectConfigurationProgressCrossVersionSpec extends ToolingApiSpecif
         then:
         events.tests.size() == events.operations.size()
         if (targetDist.runsBuildSrcTests) {
-            events.operation("Gradle Test Run :buildSrc:a:test").descendant("Test ok(ATest)")
+            events.operation("Gradle Test Run :buildSrc:a:test").descendant("ok")
         }
-        events.operation("Gradle Test Run :test").descendant("Test ok(ThingTest)")
+        events.operation("Gradle Test Run :test").descendant("ok")
     }
 
     def javaProjectWithTests() {

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r70/TestDisplayNameJUnit5CrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r70/TestDisplayNameJUnit5CrossVersionSpec.groovy
@@ -24,7 +24,7 @@ import spock.lang.Timeout
 
 @Timeout(120)
 @ToolingApiVersion('>=6.1')
-@TargetGradleVersion(">=7.0")
+@TargetGradleVersion(">=8.8")
 /**
  * @see org.gradle.integtests.tooling.r87.TestDisplayNameJUnit4CrossVersionSpec and
  * @see org.gradle.integtests.tooling.r87.TestDisplayNameSpockCrossVersionSpec
@@ -262,7 +262,8 @@ public class ParameterizedTests {
                 suite("Gradle Test Run :test") {
                     suite("Gradle Test Executor") {
                         testClass("org.example.ParameterizedTests") {
-                            suite("test1(String)") {
+                            displayName "Parameterized test"
+                            testMethodSuite("test1(String)") {
                                 displayName "1st test"
                                 generatedTest("test1(String)[1]") {
                                     displayName "[1] foo"
@@ -271,7 +272,7 @@ public class ParameterizedTests {
                                     displayName "[2] bar"
                                 }
                             }
-                            suite("test2(String)") {
+                            testMethodSuite("test2(String)") {
                                 displayName "2nd test"
                                 generatedTest("test2(String)[1]") {
                                     displayName "1 ==> the test for 'foo'"
@@ -287,7 +288,7 @@ public class ParameterizedTests {
         }
     }
 
-    @TargetGradleVersion(">8.6")
+    @TargetGradleVersion(">=8.8")
     def "reports display names for dynamic tests"() {
         file("src/test/java/org/example/DynamicTests.java") << """package org.example;
 
@@ -339,24 +340,25 @@ public class DynamicTests {
                 suite("Gradle Test Run :test") {
                     suite("Gradle Test Executor") {
                         testClass("org.example.DynamicTests") {
-                            suite("testFactory()") {
+                            displayName "DynamicTests"
+                            testMethodSuite("testFactory()") {
                                 displayName "testFactory()"
-                                suite("testFactory()[1]") {
+                                testMethodSuite("testFactory()[1]") {
                                     displayName "some container"
-                                    suite("testFactory()[1][1]") {
+                                    testMethodSuite("testFactory()[1][1]") {
                                         displayName "some nested container"
-                                        generatedTest("testFactory()[1][1][1]", "org.example.DynamicTests") {
+                                        generatedTest("testFactory()[1][1][1]") {
                                             displayName "foo"
                                         }
-                                        generatedTest("testFactory()[1][1][2]", "org.example.DynamicTests") {
+                                        generatedTest("testFactory()[1][1][2]") {
                                             displayName "bar"
                                         }
                                     }
                                 }
                             }
-                            suite("anotherTestFactory()") {
+                            testMethodSuite("anotherTestFactory()") {
                                 displayName "another test factory"
-                                generatedTest("anotherTestFactory()[1]", "org.example.DynamicTests") {
+                                generatedTest("anotherTestFactory()[1]") {
                                     displayName "foo"
                                 }
                             }
@@ -429,7 +431,7 @@ public class ComplexTests {
                             test("ugly_test()") {
                                 displayName "pretty pretty_test"
                             }
-                            suite("parametrized_test(int, String)") {
+                            testMethodSuite("parametrized_test(int, String)") {
                                 displayName "parametrized test (int, String)"
                                 generatedTest("parametrized_test(int, String)[1]") {
                                     displayName "[1] 10, first"
@@ -438,7 +440,7 @@ public class ComplexTests {
                                     displayName "[2] 20, second"
                                 }
                             }
-                            suite("ugly_parametrized_test(int, String)") {
+                            testMethodSuite("ugly_parametrized_test(int, String)") {
                                 displayName "pretty parametrized test"
                                 generatedTest("ugly_parametrized_test(int, String)[1]") {
                                     displayName "[1] 30, third"

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r70/TestDisplayNameJUnit5CrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r70/TestDisplayNameJUnit5CrossVersionSpec.groovy
@@ -266,19 +266,19 @@ public class ParameterizedTests {
                             displayName "Parameterized test"
                             testMethodSuite("test1(String)") {
                                 displayName "1st test"
-                                generatedTest("test1(String)[1]") {
+                                test("test1(String)[1]") {
                                     displayName "[1] foo"
                                 }
-                                generatedTest("test1(String)[2]") {
+                                test("test1(String)[2]") {
                                     displayName "[2] bar"
                                 }
                             }
                             testMethodSuite("test2(String)") {
                                 displayName "2nd test"
-                                generatedTest("test2(String)[1]") {
+                                test("test2(String)[1]") {
                                     displayName "1 ==> the test for 'foo'"
                                 }
-                                generatedTest("test2(String)[2]") {
+                                test("test2(String)[2]") {
                                     displayName "2 ==> the test for 'bar'"
                                 }
                             }
@@ -348,10 +348,10 @@ public class DynamicTests {
                                     displayName "some container"
                                     testMethodSuite("testFactory()[1][1]") {
                                         displayName "some nested container"
-                                        generatedTest("testFactory()[1][1][1]") {
+                                        test("testFactory()[1][1][1]") {
                                             displayName "foo"
                                         }
-                                        generatedTest("testFactory()[1][1][2]") {
+                                        test("testFactory()[1][1][2]") {
                                             displayName "bar"
                                         }
                                     }
@@ -359,7 +359,7 @@ public class DynamicTests {
                             }
                             testMethodSuite("anotherTestFactory()") {
                                 displayName "another test factory"
-                                generatedTest("anotherTestFactory()[1]") {
+                                test("anotherTestFactory()[1]") {
                                     displayName "foo"
                                 }
                             }
@@ -434,19 +434,19 @@ public class ComplexTests {
                             }
                             testMethodSuite("parametrized_test(int, String)") {
                                 displayName "parametrized test (int, String)"
-                                generatedTest("parametrized_test(int, String)[1]") {
+                                test("parametrized_test(int, String)[1]") {
                                     displayName "[1] 10, first"
                                 }
-                                generatedTest("parametrized_test(int, String)[2]") {
+                                test("parametrized_test(int, String)[2]") {
                                     displayName "[2] 20, second"
                                 }
                             }
                             testMethodSuite("ugly_parametrized_test(int, String)") {
                                 displayName "pretty parametrized test"
-                                generatedTest("ugly_parametrized_test(int, String)[1]") {
+                                test("ugly_parametrized_test(int, String)[1]") {
                                     displayName "[1] 30, third"
                                 }
-                                generatedTest("ugly_parametrized_test(int, String)[2]") {
+                                test("ugly_parametrized_test(int, String)[2]") {
                                     displayName "[2] 40, fourth"
                                 }
                             }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r70/TestDisplayNameJUnit5CrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r70/TestDisplayNameJUnit5CrossVersionSpec.groovy
@@ -26,8 +26,8 @@ import spock.lang.Timeout
 @ToolingApiVersion('>=6.1')
 @TargetGradleVersion(">=7.0")
 /**
- * @see org.gradle.integtests.tooling.r87.TestDisplayNameJUnit4CrossVersionSpec and
- * @see org.gradle.integtests.tooling.r87.TestDisplayNameSpockCrossVersionSpec
+ * @see org.gradle.integtests.tooling.r88.TestDisplayNameJUnit4CrossVersionSpec and
+ * @see org.gradle.integtests.tooling.r88.TestDisplayNameSpockCrossVersionSpec
  */
 class TestDisplayNameJUnit5CrossVersionSpec extends TestLauncherSpec {
     @Override
@@ -51,6 +51,7 @@ class TestDisplayNameJUnit5CrossVersionSpec extends TestLauncherSpec {
         """
     }
 
+    @TargetGradleVersion(">=8.8")
     def "reports display names of class and method"() {
         file("src/test/java/org/example/SimpleTests.java") << """package org.example;
 
@@ -77,9 +78,9 @@ public class SimpleTests {
                 suite("Gradle Test Run :test") {
                     suite("Gradle Test Executor") {
                         testClass("org.example.SimpleTests") {
-                            displayName "a class display name"
+                            testDisplayName "a class display name"
                             test("test()") {
-                                displayName "and a test display name"
+                                testDisplayName "and a test display name"
                             }
                         }
                     }
@@ -88,6 +89,7 @@ public class SimpleTests {
         }
     }
 
+    @TargetGradleVersion(">=8.8")
     def "reports display names of nested test classes"() {
         file("src/test/java/org/example/TestingAStackDemo.java") << """package org.example;
 
@@ -189,30 +191,30 @@ class TestingAStackDemo {
                 suite("Gradle Test Run :test") {
                     suite("Gradle Test Executor") {
                         testClass("org.example.TestingAStackDemo") {
-                            displayName "A stack"
+                            testDisplayName "A stack"
                             test("isInstantiatedWithNew()") {
-                                displayName "is instantiated with new Stack()"
+                                testDisplayName "is instantiated with new Stack()"
                             }
                             testClass("org.example.TestingAStackDemo\$WhenNew") {
-                                displayName "when new"
+                                testDisplayName "when new"
                                 test("isEmpty()") {
-                                    displayName "is empty"
+                                    testDisplayName "is empty"
                                 }
                                 test("throwsExceptionWhenPeeked()") {
-                                    displayName "throws EmptyStackException when peeked"
+                                    testDisplayName "throws EmptyStackException when peeked"
                                 }
                                 test("throwsExceptionWhenPopped()") {
-                                    displayName "throws EmptyStackException when popped"
+                                    testDisplayName "throws EmptyStackException when popped"
                                 }
                                 testClass("org.example.TestingAStackDemo\$WhenNew\$AfterPushing") {
                                     test("isNotEmpty()") {
-                                        displayName "it is no longer empty"
+                                        testDisplayName "it is no longer empty"
                                     }
                                     test("returnElementWhenPeeked()") {
-                                        displayName "returns the element when peeked but remains not empty"
+                                        testDisplayName "returns the element when peeked but remains not empty"
                                     }
                                     test("returnElementWhenPopped()") {
-                                        displayName "returns the element when popped and is empty"
+                                        testDisplayName "returns the element when popped and is empty"
                                     }
                                 }
                             }
@@ -263,23 +265,23 @@ public class ParameterizedTests {
                 suite("Gradle Test Run :test") {
                     suite("Gradle Test Executor") {
                         testClass("org.example.ParameterizedTests") {
-                            displayName "Parameterized test"
+                            testDisplayName "Parameterized test"
                             testMethodSuite("test1(String)") {
-                                displayName "1st test"
+                                testDisplayName "1st test"
                                 test("test1(String)[1]") {
-                                    displayName "[1] foo"
+                                    testDisplayName "[1] foo"
                                 }
                                 test("test1(String)[2]") {
-                                    displayName "[2] bar"
+                                    testDisplayName "[2] bar"
                                 }
                             }
                             testMethodSuite("test2(String)") {
-                                displayName "2nd test"
+                                testDisplayName "2nd test"
                                 test("test2(String)[1]") {
-                                    displayName "1 ==> the test for 'foo'"
+                                    testDisplayName "1 ==> the test for 'foo'"
                                 }
                                 test("test2(String)[2]") {
-                                    displayName "2 ==> the test for 'bar'"
+                                    testDisplayName "2 ==> the test for 'bar'"
                                 }
                             }
                         }
@@ -341,26 +343,26 @@ public class DynamicTests {
                 suite("Gradle Test Run :test") {
                     suite("Gradle Test Executor") {
                         testClass("org.example.DynamicTests") {
-                            displayName "DynamicTests"
+                            testDisplayName "DynamicTests"
                             testMethodSuite("testFactory()") {
-                                displayName "testFactory()"
+                                testDisplayName "testFactory()"
                                 testMethodSuite("testFactory()[1]") {
-                                    displayName "some container"
+                                    testDisplayName "some container"
                                     testMethodSuite("testFactory()[1][1]") {
-                                        displayName "some nested container"
+                                        testDisplayName "some nested container"
                                         test("testFactory()[1][1][1]") {
-                                            displayName "foo"
+                                            testDisplayName "foo"
                                         }
                                         test("testFactory()[1][1][2]") {
-                                            displayName "bar"
+                                            testDisplayName "bar"
                                         }
                                     }
                                 }
                             }
                             testMethodSuite("anotherTestFactory()") {
-                                displayName "another test factory"
+                                testDisplayName "another test factory"
                                 test("anotherTestFactory()[1]") {
-                                    displayName "foo"
+                                    testDisplayName "foo"
                                 }
                             }
                         }
@@ -421,33 +423,33 @@ public class ComplexTests {
                 suite("Gradle Test Run :test") {
                     suite("Gradle Test Executor") {
                         testClass("org.example.ComplexTests") {
-                            displayName "some_name for_tests"
+                            testDisplayName "some_name for_tests"
 
                             test("test()") {
-                                displayName "test"
+                                testDisplayName "test"
                             }
                             test("simple_test()") {
-                                displayName "simple test"
+                                testDisplayName "simple test"
                             }
                             test("ugly_test()") {
-                                displayName "pretty pretty_test"
+                                testDisplayName "pretty pretty_test"
                             }
                             testMethodSuite("parametrized_test(int, String)") {
-                                displayName "parametrized test (int, String)"
+                                testDisplayName "parametrized test (int, String)"
                                 test("parametrized_test(int, String)[1]") {
-                                    displayName "[1] 10, first"
+                                    testDisplayName "[1] 10, first"
                                 }
                                 test("parametrized_test(int, String)[2]") {
-                                    displayName "[2] 20, second"
+                                    testDisplayName "[2] 20, second"
                                 }
                             }
                             testMethodSuite("ugly_parametrized_test(int, String)") {
-                                displayName "pretty parametrized test"
+                                testDisplayName "pretty parametrized test"
                                 test("ugly_parametrized_test(int, String)[1]") {
-                                    displayName "[1] 30, third"
+                                    testDisplayName "[1] 30, third"
                                 }
                                 test("ugly_parametrized_test(int, String)[2]") {
-                                    displayName "[2] 40, fourth"
+                                    testDisplayName "[2] 40, fourth"
                                 }
                             }
                         }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r70/TestDisplayNameJUnit5CrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r70/TestDisplayNameJUnit5CrossVersionSpec.groovy
@@ -24,7 +24,7 @@ import spock.lang.Timeout
 
 @Timeout(120)
 @ToolingApiVersion('>=6.1')
-@TargetGradleVersion(">=8.8")
+@TargetGradleVersion(">=7.0")
 /**
  * @see org.gradle.integtests.tooling.r87.TestDisplayNameJUnit4CrossVersionSpec and
  * @see org.gradle.integtests.tooling.r87.TestDisplayNameSpockCrossVersionSpec
@@ -223,6 +223,7 @@ class TestingAStackDemo {
         }
     }
 
+    @TargetGradleVersion(">=8.8")
     def "reports display names of parameterized tests"() {
         file("src/test/java/org/example/ParameterizedTests.java") << """package org.example;
 
@@ -369,7 +370,7 @@ public class DynamicTests {
         }
     }
 
-
+    @TargetGradleVersion(">=8.8")
     def "reports transformed display names with DisplayNameGeneration"() {
         file("src/test/java/org/example/ComplexTests.java") << """package org.example;
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r75/CustomTestTaskProgressEventCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r75/CustomTestTaskProgressEventCrossVersionTest.groovy
@@ -47,14 +47,18 @@ class CustomTestTaskProgressEventCrossVersionTest extends ToolingApiSpecificatio
 
         @Override
         void statusChanged(ProgressEvent event) {
-            if (event.descriptor.name == "MyCustomTestRoot") {
+            if (event.descriptor.displayName == "Test suite 'MyCustomTestRoot'") {
                 suiteEvent = event
-            } else if (event.descriptor.displayName == 'org.my.MyClass descriptor') {
+            } else if (targetDist.hasTestDisplayNames && event.descriptor.displayName == 'Test MyCustomTest(org.my.MyClass)') {
+                testEvent = event
+            } else if (!targetDist.hasTestDisplayNames && event.descriptor.displayName == 'org.my.MyClass descriptor') {
                 testEvent = event
             }
         }
-        boolean receivedCustomTestTaskProgressEvents() {
-            suiteEvent != null && testEvent != null
+
+        void receivedCustomTestTaskProgressEvents() {
+            assert suiteEvent != null
+            assert testEvent != null
         }
     }
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r75/CustomTestTaskProgressEventCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r75/CustomTestTaskProgressEventCrossVersionTest.groovy
@@ -47,7 +47,7 @@ class CustomTestTaskProgressEventCrossVersionTest extends ToolingApiSpecificatio
 
         @Override
         void statusChanged(ProgressEvent event) {
-            if (event.descriptor.displayName == "Test suite 'MyCustomTestRoot'") {
+            if (event.descriptor.name == "MyCustomTestRoot") {
                 suiteEvent = event
             } else if (event.descriptor.displayName == 'org.my.MyClass descriptor') {
                 testEvent = event

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r87/TestDisplayNameJUnit4CrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r87/TestDisplayNameJUnit4CrossVersionSpec.groovy
@@ -26,7 +26,7 @@ import spock.lang.Timeout
 
 @Timeout(120)
 @ToolingApiVersion('>=6.1')
-@TargetGradleVersion(">8.6")
+@TargetGradleVersion(">=8.8")
 @Requires(UnitTestPreconditions.Jdk17OrEarlier)
 /**
  * @see org.gradle.integtests.tooling.r70.TestDisplayNameJUnit5CrossVersionSpec and

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r87/TestDisplayNameJUnit4CrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r87/TestDisplayNameJUnit4CrossVersionSpec.groovy
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r87
+
+import org.gradle.integtests.tooling.TestLauncherSpec
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.UnitTestPreconditions
+import org.gradle.tooling.TestLauncher
+import spock.lang.Timeout
+
+@Timeout(120)
+@ToolingApiVersion('>=6.1')
+@TargetGradleVersion(">8.6")
+@Requires(UnitTestPreconditions.Jdk17OrEarlier)
+/**
+ * @see org.gradle.integtests.tooling.r70.TestDisplayNameJUnit5CrossVersionSpec and
+ * @see org.gradle.integtests.tooling.r87.TestDisplayNameSpockCrossVersionSpec
+ */
+class TestDisplayNameJUnit4CrossVersionSpec extends TestLauncherSpec {
+    @Override
+    void addDefaultTests() {
+    }
+
+    @Override
+    String simpleJavaProject() {
+        """
+        allprojects{
+            apply plugin: 'java'
+            ${mavenCentralRepository()}
+            dependencies {
+                testImplementation("junit:junit:4.13.2")
+            }
+        }
+        """
+    }
+
+    def "reports display names of class and method"() {
+        file("src/test/java/org/example/SimpleTests.java") << """package org.example;
+
+import org.junit.Test;
+
+public class SimpleTests {
+
+    @Test
+    public void test() {
+    }
+}
+"""
+        when:
+        launchTests { TestLauncher launcher ->
+            launcher.withTaskAndTestClasses(':test', ['org.example.SimpleTests'])
+        }
+
+        then:
+        jvmTestEvents {
+            task(":test") {
+                suite("Gradle Test Run :test") {
+                    suite("Gradle Test Executor") {
+                        testClass("org.example.SimpleTests") {
+                            displayName "SimpleTests"
+                            test("test") {
+                                displayName "test"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    def "reports display names of parameterized tests"() {
+        file("src/test/java/org/example/ParameterizedTests.java") << """package org.example;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class ParameterizedTests {
+
+    private final int value;
+    private final String name;
+
+    public ParameterizedTests(int value, String name) {
+        this.value = value;
+        this.name = name;
+    }
+
+    @Test
+    public void parametrized_test() {
+        System.out.println(name + " " + value);
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {1, "first"},
+                {2, "second"}
+        });
+    }
+}
+"""
+
+        when:
+        launchTests { TestLauncher launcher ->
+            launcher.withTaskAndTestClasses(':test', ['org.example.ParameterizedTest*'])
+        }
+
+        then:
+        jvmTestEvents {
+            task(":test") {
+                suite("Gradle Test Run :test") {
+                    suite("Gradle Test Executor") {
+                        testClass("org.example.ParameterizedTests") {
+                            displayName "ParameterizedTests"
+                            generatedTest("parametrized_test[0]") {
+                                displayName "parametrized_test[0]" // JUnit4 does not provide detailed information for parameterized tests
+                            }
+                            generatedTest("parametrized_test[1]") {
+                                displayName "parametrized_test[1]"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r87/TestDisplayNameJUnit4CrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r87/TestDisplayNameJUnit4CrossVersionSpec.groovy
@@ -25,7 +25,7 @@ import org.gradle.tooling.TestLauncher
 import spock.lang.Timeout
 
 @Timeout(120)
-@ToolingApiVersion('>=6.1')
+@ToolingApiVersion('>=8.8')
 @TargetGradleVersion(">=8.8")
 @Requires(UnitTestPreconditions.Jdk17OrEarlier)
 /**

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r87/TestDisplayNameJUnit4CrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r87/TestDisplayNameJUnit4CrossVersionSpec.groovy
@@ -132,10 +132,10 @@ public class ParameterizedTests {
                     suite("Gradle Test Executor") {
                         testClass("org.example.ParameterizedTests") {
                             displayName "ParameterizedTests"
-                            generatedTest("parametrized_test[0]") {
+                            test("parametrized_test[0]") {
                                 displayName "parametrized_test[0]" // JUnit4 does not provide detailed information for parameterized tests
                             }
-                            generatedTest("parametrized_test[1]") {
+                            test("parametrized_test[1]") {
                                 displayName "parametrized_test[1]"
                             }
                         }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r87/TestDisplayNameSpockCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r87/TestDisplayNameSpockCrossVersionSpec.groovy
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r87
+
+import org.gradle.integtests.tooling.TestLauncherSpec
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.UnitTestPreconditions
+import org.gradle.tooling.TestLauncher
+import spock.lang.Timeout
+
+@Timeout(120)
+@ToolingApiVersion('>=6.1')
+@TargetGradleVersion(">8.6")
+@Requires(UnitTestPreconditions.Jdk17OrEarlier)
+/**
+ * @see org.gradle.integtests.tooling.r70.TestDisplayNameJUnit5CrossVersionSpec and
+ * @see org.gradle.integtests.tooling.r87.TestDisplayNameJUnit4CrossVersionSpec
+ */
+class TestDisplayNameSpockCrossVersionSpec extends TestLauncherSpec {
+    @Override
+    void addDefaultTests() {
+    }
+
+    @Override
+    String simpleJavaProject() {
+        """
+        allprojects{
+            apply plugin: 'groovy'
+            ${mavenCentralRepository()}
+            dependencies {
+                implementation 'org.codehaus.groovy:groovy-all:3.0.0'
+                testImplementation platform("org.spockframework:spock-bom:2.1-groovy-3.0")
+                testImplementation "org.spockframework:spock-core:2.1-groovy-3.0"
+            }
+
+            test {
+                useJUnitPlatform()
+            }
+        }
+        """
+    }
+
+    def "reports display names of class and method"() {
+        file("src/test/groovy/org/example/SimpleTests.groovy") << """package org.example
+
+import spock.lang.Specification
+
+class SimpleTests extends Specification {
+
+    def "success test"() {
+        expect:
+        true
+    }
+}
+
+"""
+        when:
+        launchTests { TestLauncher launcher ->
+            launcher.withTaskAndTestClasses(':test', ['org.example.SimpleTests'])
+        }
+
+        then:
+        jvmTestEvents {
+            task(":test") {
+                suite("Gradle Test Run :test") {
+                    suite("Gradle Test Executor") {
+                        testClass("org.example.SimpleTests") {
+                            displayName "SimpleTests"
+                            test("success test") {
+                                displayName "success test"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    def "reports display names of parameterized tests"() {
+        file("src/test/groovy/org/example/ParameterizedTests.groovy") << """package org.example
+
+import spock.lang.Specification
+
+class ParameterizedTests extends Specification {
+
+    def "length of #name is #length"() {
+        expect:
+        name.size() == length
+
+        where:
+        name    | length
+        "Spock" | 5
+        "junit5" | 6
+    }
+}
+
+"""
+
+        when:
+        launchTests { TestLauncher launcher ->
+            launcher.withTaskAndTestClasses(':test', ['org.example.ParameterizedTest*'])
+        }
+
+        then:
+        jvmTestEvents {
+            task(":test") {
+                suite("Gradle Test Run :test") {
+                    suite("Gradle Test Executor") {
+                        testClass("org.example.ParameterizedTests") {
+                            displayName "ParameterizedTests"
+                            suite("length of #name is #length") {
+                                displayName "length of #name is #length"
+                                generatedTest("length of Spock is 5") {
+                                    displayName "length of Spock is 5"
+                                }
+                                generatedTest("length of junit5 is 6") {
+                                    displayName "length of junit5 is 6"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r87/TestDisplayNameSpockCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r87/TestDisplayNameSpockCrossVersionSpec.groovy
@@ -26,7 +26,7 @@ import spock.lang.Timeout
 
 @Timeout(120)
 @ToolingApiVersion('>=6.1')
-@TargetGradleVersion(">8.6")
+@TargetGradleVersion(">=8.8")
 @Requires(UnitTestPreconditions.Jdk17OrEarlier)
 /**
  * @see org.gradle.integtests.tooling.r70.TestDisplayNameJUnit5CrossVersionSpec and
@@ -124,7 +124,7 @@ class ParameterizedTests extends Specification {
                     suite("Gradle Test Executor") {
                         testClass("org.example.ParameterizedTests") {
                             displayName "ParameterizedTests"
-                            suite("length of #name is #length") {
+                            testMethodSuite("length of #name is #length") {
                                 displayName "length of #name is #length"
                                 generatedTest("length of Spock is 5") {
                                     displayName "length of Spock is 5"

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r87/TestDisplayNameSpockCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r87/TestDisplayNameSpockCrossVersionSpec.groovy
@@ -126,10 +126,10 @@ class ParameterizedTests extends Specification {
                             displayName "ParameterizedTests"
                             testMethodSuite("length of #name is #length") {
                                 displayName "length of #name is #length"
-                                generatedTest("length of Spock is 5") {
+                                test("length of Spock is 5") {
                                     displayName "length of Spock is 5"
                                 }
-                                generatedTest("length of junit5 is 6") {
+                                test("length of junit5 is 6") {
                                     displayName "length of junit5 is 6"
                                 }
                             }

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/test/TestOperationDescriptor.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/test/TestOperationDescriptor.java
@@ -16,6 +16,7 @@
 
 package org.gradle.tooling.events.test;
 
+import org.gradle.api.Incubating;
 import org.gradle.tooling.events.OperationDescriptor;
 
 /**
@@ -24,4 +25,13 @@ import org.gradle.tooling.events.OperationDescriptor;
  * @since 2.4
  */
 public interface TestOperationDescriptor extends OperationDescriptor {
+    /**
+     * Returns the display name of the test.
+     * Not to be confused with {@link #getDisplayName()} which is the display name of the operation.
+     *
+     * @return the display name of the test.
+     * @since 8.8
+     */
+    @Incubating
+    String getTestDisplayName();
 }

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/test/internal/DefaultJvmTestOperationDescriptor.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/test/internal/DefaultJvmTestOperationDescriptor.java
@@ -32,7 +32,14 @@ public final class DefaultJvmTestOperationDescriptor extends DefaultTestOperatio
     private final String className;
     private final String methodName;
 
-    public DefaultJvmTestOperationDescriptor(InternalJvmTestDescriptor internalJvmTestDescriptor, OperationDescriptor parent, JvmTestKind jvmTestKind, String suiteName, String className, String methodName) {
+    public DefaultJvmTestOperationDescriptor(
+        InternalJvmTestDescriptor internalJvmTestDescriptor,
+        OperationDescriptor parent,
+        JvmTestKind jvmTestKind,
+        String suiteName,
+        String className,
+        String methodName
+    ) {
         super(internalJvmTestDescriptor, parent);
         this.jvmTestKind = jvmTestKind;
         this.suiteName = suiteName;

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/test/internal/DefaultTestOperationDescriptor.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/test/internal/DefaultTestOperationDescriptor.java
@@ -38,4 +38,9 @@ public class DefaultTestOperationDescriptor extends DefaultOperationDescriptor i
     public InternalOperationDescriptor getInternalOperationDescriptor() {
         return internalTestDescriptor;
     }
+
+    @Override
+    public String getTestDisplayName() {
+        return internalTestDescriptor.getTestDisplayName();
+    }
 }

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/events/InternalTestDescriptor.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/events/InternalTestDescriptor.java
@@ -22,4 +22,11 @@ package org.gradle.tooling.internal.protocol.events;
  * @since 2.4
  */
 public interface InternalTestDescriptor extends InternalOperationDescriptor {
+    /**
+     * Returns the display name of the test.
+     *
+     * @return The display name of the test
+     * @since 8.8
+     */
+    String getTestDisplayName();
 }

--- a/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junit/TestClassExecutionEventGenerator.java
+++ b/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junit/TestClassExecutionEventGenerator.java
@@ -46,7 +46,7 @@ public class TestClassExecutionEventGenerator implements TestResultProcessor, Te
 
     @Override
     public void testClassStarted(String testClassName) {
-        currentTestClass = new DefaultTestClassDescriptor(idGenerator.generateId(), testClassName);
+        currentTestClass = new DefaultTestClassDescriptor(idGenerator.generateId(), testClassName, classDisplayName(testClassName));
         resultProcessor.started(currentTestClass, new TestStartEvent(clock.getCurrentTime()));
     }
 
@@ -97,5 +97,15 @@ public class TestClassExecutionEventGenerator implements TestResultProcessor, Te
     @Override
     public void failure(Object testId, TestFailure result) {
         resultProcessor.failure(testId, result);
+    }
+
+    //Extract class name from the fully qualified class name
+    private static String classDisplayName(String className) {
+        int lastDot = className.lastIndexOf('.');
+        if (lastDot > 0) {
+            return className.substring(lastDot + 1);
+        } else {
+            return className;
+        }
     }
 }

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/AbstractJUnitConsoleLoggingIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/AbstractJUnitConsoleLoggingIntegrationTest.groovy
@@ -25,7 +25,6 @@ import static org.hamcrest.CoreMatchers.equalTo
 
 abstract class AbstractJUnitConsoleLoggingIntegrationTest extends AbstractTestingMultiVersionIntegrationTest {
     TestFile testFile = file('src/test/java/org/gradle/SomeTest.java')
-    abstract String getMaybePackagePrefix()
 
     def setup() {
         executer.noExtraLogging()
@@ -91,7 +90,7 @@ abstract class AbstractJUnitConsoleLoggingIntegrationTest extends AbstractTestin
 
         then:
         outputContains("""
-            ${maybePackagePrefix}SomeTest > ${maybeParentheses('badTest')} FAILED
+            SomeTest > ${maybeParentheses('badTest')} FAILED
                 java.lang.RuntimeException at SomeTest.java:${lineNumberOf('RuntimeException("bad")')}
         """.stripIndent())
     }
@@ -112,7 +111,7 @@ abstract class AbstractJUnitConsoleLoggingIntegrationTest extends AbstractTestin
 
         outputContains("${maybeParentheses('ignoredTest')} SKIPPED")
 
-        outputContains("${maybePackagePrefix}SomeTest FAILED")
+        outputContains("SomeTest FAILED")
     }
 
     def "standard output logging"() {

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/JUnit4ConsoleLoggingIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/JUnit4ConsoleLoggingIntegrationTest.groovy
@@ -23,8 +23,4 @@ import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_4
 
 @TargetCoverage({ JUNIT_4 })
 class JUnit4ConsoleLoggingIntegrationTest extends AbstractJUnitConsoleLoggingIntegrationTest implements JUnit4MultiVersionTest {
-    @Override
-    String getMaybePackagePrefix() {
-        return 'org.gradle.'
-    }
 }

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/jupiter/JUnitJupiterConsoleLoggingIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/jupiter/JUnitJupiterConsoleLoggingIntegrationTest.groovy
@@ -25,10 +25,6 @@ import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_JUPITER
 
 @TargetCoverage({ JUNIT_JUPITER })
 class JUnitJupiterConsoleLoggingIntegrationTest extends AbstractJUnitConsoleLoggingIntegrationTest implements JUnitJupiterMultiVersionTest {
-    @Override
-    String getMaybePackagePrefix() {
-        return ''
-    }
 
     def "failure during JUnit platform initialization is written to console when granularity is set"() {
         Assume.assumeTrue("Non-existent test engine is only an error after 5.9.0", VersionNumber.parse(version) >= VersionNumber.parse("5.9.0"))

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/vintage/JUnitVintageConsoleLoggingIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/vintage/JUnitVintageConsoleLoggingIntegrationTest.groovy
@@ -23,8 +23,4 @@ import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_VINTAGE
 
 @TargetCoverage({ JUNIT_VINTAGE })
 class JUnitVintageConsoleLoggingIntegrationTest extends AbstractJUnitConsoleLoggingIntegrationTest implements JUnitVintageMultiVersionTest {
-    @Override
-    String getMaybePackagePrefix() {
-        return ''
-    }
 }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/AbstractTestDescriptor.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/AbstractTestDescriptor.java
@@ -44,6 +44,11 @@ public abstract class AbstractTestDescriptor implements TestDescriptorInternal {
     }
 
     @Override
+    public String getMethodName() {
+        return null;
+    }
+
+    @Override
     public TestDescriptorInternal getParent() {
         return null;
     }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DecoratingTestDescriptor.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DecoratingTestDescriptor.java
@@ -60,6 +60,11 @@ public class DecoratingTestDescriptor implements TestDescriptorInternal {
     }
 
     @Override
+    public String getMethodName() {
+        return descriptor.getMethodName();
+    }
+
+    @Override
     public String getName() {
         return descriptor.getName();
     }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultParameterizedTestDescriptor.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultParameterizedTestDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,37 +16,27 @@
 
 package org.gradle.api.internal.tasks.testing;
 
-import org.gradle.internal.scan.UsedByScanPlugin;
+import org.gradle.api.NonNullApi;
+import org.gradle.internal.id.CompositeIdGenerator;
 
 import javax.annotation.Nullable;
 
-@UsedByScanPlugin("test-distribution")
-public class DefaultTestDescriptor extends AbstractTestDescriptor {
-    private final String displayName;
+@NonNullApi
+public class DefaultParameterizedTestDescriptor extends DefaultTestSuiteDescriptor {
+
+    private final CompositeIdGenerator.CompositeId parentId;
     private final String className;
-    private final String classDisplayName;
+    private final String displayName;
 
-    @UsedByScanPlugin("test-distribution")
-    public DefaultTestDescriptor(Object id, String className, String name) {
-        this(id, className, name, null, name);
-    }
-
-    @UsedByScanPlugin("test-distribution")
-    public DefaultTestDescriptor(Object id, String className, String name, @Nullable String classDisplayName, String displayName) {
-        super(id, name);
+    public DefaultParameterizedTestDescriptor(Object id, String methodName, @Nullable String className, String displayName, CompositeIdGenerator.CompositeId parentId) {
+        super(id, methodName);
         this.className = className;
-        this.classDisplayName = classDisplayName == null ? className : classDisplayName;
         this.displayName = displayName;
+        this.parentId = parentId;
     }
 
-    @Override
-    public String toString() {
-        return "Test " + getName() + "(" + className + ")";
-    }
-
-    @Override
-    public boolean isComposite() {
-        return false;
+    public CompositeIdGenerator.CompositeId getParentId() {
+        return parentId;
     }
 
     @Override
@@ -65,7 +55,7 @@ public class DefaultTestDescriptor extends AbstractTestDescriptor {
     }
 
     @Override
-    public String getClassDisplayName() {
-        return classDisplayName;
+    public String toString() {
+        return "Test method " + getMethodName();
     }
 }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/UnknownTestDescriptor.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/UnknownTestDescriptor.java
@@ -35,6 +35,11 @@ public class UnknownTestDescriptor implements TestDescriptorInternal {
     }
 
     @Override
+    public String getMethodName() {
+        return null;
+    }
+
+    @Override
     public boolean isComposite() {
         return false;
     }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/TestDescriptor.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/TestDescriptor.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.tasks.testing;
 
+import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
@@ -50,6 +51,16 @@ public interface TestDescriptor {
     @Nullable
     @UsedByScanPlugin("test-retry")
     String getClassName();
+
+    /**
+     * Returns the method name for this test, if any.
+     *
+     * @return The method name. May return null.
+     * @since 8.8
+     */
+    @Incubating
+    @Nullable
+    String getMethodName();
 
     /**
      * Is this test a composite test?

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/SimpleTestDescriptor.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/SimpleTestDescriptor.groovy
@@ -21,6 +21,7 @@ class SimpleTestDescriptor implements TestDescriptorInternal {
     String name = "testName"
     String displayName = "testName"
     String className = "ClassName"
+    String methodName = null
     String classDisplayName = "ClassName"
     boolean composite = false
     TestDescriptorInternal parent = null

--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/types/DefaultTestDescriptor.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/types/DefaultTestDescriptor.java
@@ -25,19 +25,32 @@ import java.io.Serializable;
 public class DefaultTestDescriptor implements Serializable, InternalJvmTestDescriptor, InternalOperationDescriptor {
 
     private final OperationIdentifier id;
-    private final String name;
-    private final String displayName;
+    private final String operationName;
+    private final String operationDisplayName;
     private final String testKind;
     private final String suiteName;
     private final String className;
     private final String methodName;
     private final OperationIdentifier parentId;
     private final String taskPath;
+    private final String testDisplayName;
 
-    public DefaultTestDescriptor(OperationIdentifier id, String name, String displayName, String testKind, String suiteName, String className, String methodName, OperationIdentifier parentId, String taskPath) {
+    public DefaultTestDescriptor(
+        OperationIdentifier id,
+        String operationName,
+        String operationDisplayName,
+        String displayName,
+        String testKind,
+        String suiteName,
+        String className,
+        String methodName,
+        OperationIdentifier parentId,
+        String taskPath
+    ) {
         this.id = id;
-        this.name = name;
-        this.displayName = displayName;
+        this.operationName = operationName;
+        this.operationDisplayName = operationDisplayName;
+        this.testDisplayName = displayName;
         this.testKind = testKind;
         this.suiteName = suiteName;
         this.className = className;
@@ -53,12 +66,17 @@ public class DefaultTestDescriptor implements Serializable, InternalJvmTestDescr
 
     @Override
     public String getName() {
-        return name;
+        return operationName;
     }
 
     @Override
     public String getDisplayName() {
-        return displayName;
+        return operationDisplayName;
+    }
+
+    @Override
+    public String getTestDisplayName() {
+        return testDisplayName;
     }
 
     @Override
@@ -88,19 +106,5 @@ public class DefaultTestDescriptor implements Serializable, InternalJvmTestDescr
 
     public String getTaskPath() {
         return taskPath;
-    }
-
-    // for backward compatibility
-    @Override
-    public String toString() {
-        if (methodName != null) {
-            return "Test method " + getName() + "(" + getClassName() + ")";
-        } else if (className != null) {
-            return "Test class " + getClassName();
-        } else if (suiteName != null) {
-            return "Test suite '" + getName() + "'";
-        } else {
-            return displayName;
-        }
     }
 }

--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/types/DefaultTestDescriptor.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/types/DefaultTestDescriptor.java
@@ -89,4 +89,18 @@ public class DefaultTestDescriptor implements Serializable, InternalJvmTestDescr
     public String getTaskPath() {
         return taskPath;
     }
+
+    // for backward compatibility
+    @Override
+    public String toString() {
+        if (methodName != null) {
+            return "Test method " + getName() + "(" + getClassName() + ")";
+        } else if (className != null) {
+            return "Test class " + getClassName();
+        } else if (suiteName != null) {
+            return "Test suite '" + getName() + "'";
+        } else {
+            return displayName;
+        }
+    }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.groovy
@@ -337,8 +337,8 @@ class DefaultGradleDistribution implements GradleDistribution {
     }
 
     @Override
-    boolean isHasLegacyTestDisplayNames() {
-        return !isSameOrNewer("8.8")
+    boolean isHasTestDisplayNames() {
+        return isSameOrNewer("8.8")
     }
 
     protected boolean isSameOrNewer(String otherVersion) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.groovy
@@ -336,6 +336,11 @@ class DefaultGradleDistribution implements GradleDistribution {
         return isSameOrNewer("4.10.3"); // see compatibility matrix https://docs.gradle.org/8.0/userguide/compatibility.html
     }
 
+    @Override
+    boolean isHasLegacyTestDisplayNames() {
+        return !isSameOrNewer("8.8")
+    }
+
     protected boolean isSameOrNewer(String otherVersion) {
         return isVersion(otherVersion) || version.compareTo(GradleVersion.version(otherVersion)) > 0;
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleDistribution.java
@@ -182,7 +182,7 @@ public interface GradleDistribution {
     boolean isSupportsKotlinScript();
 
     /**
-     * Returns true if this version wraps tests display names with 'test method(Class)' instead of 'method'
+     * Returns true if this version has a method for tests display names
      */
-    boolean isHasLegacyTestDisplayNames();
+    boolean isHasTestDisplayNames();
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleDistribution.java
@@ -180,4 +180,9 @@ public interface GradleDistribution {
      * Returns true if it as a Gradle version that supports Kotlin scripts
      */
     boolean isSupportsKotlinScript();
+
+    /**
+     * Returns true if this version wraps tests display names with 'test method(Class)' instead of 'method'
+     */
+    boolean isHasLegacyTestDisplayNames();
 }


### PR DESCRIPTION
Fixes #24538

>  - Display name of method, parametrised method, suite, class events are quoted and has prefixes. E.g. `Test name()`, `Test name()(org.example.TestCase)` and `Test suite 'name(org.example.TestCase)'` should be `name`;
>  - Display name for JUnit 5 method event by default has information about method arguments. E.g. `test()`, `test(int, String)`, etc should be `test`;

Display names are now passed transparently from Junit5, without transformations

>  - Display name for JUnit 4 class event has class with package prefix. E.g. `org.example.TestCase` should be `TestCase`;

fixed

>  - Display name for parametrised intermediate method event (which class are annotated by `@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)`) has trailing space in name. E.g. `pretty name (int)[1]` should be `pretty name`;

This is expected, added a test to cover that. Resulting display name is passed from Junit5 directly and doesn't have a trailing space.

>  - Class and method names are absent for JUnit 5 parametrised and Spock intermediate method events;

Those can be acquired via `OperationDescriptor.getParent()` and `JvmTestOperationDescriptor`

 > - Method name for JUnit 5 parametrised method event has suffix with parameter number.  E.g. `test(int)[1]`, `test(int)[2]`, `test(int)[3]`, etc should be `test`;
>  - Method name has unparsed signature of test method. I prefer to see here only method name. E.g. `test()`, `test(int)`, `test(int)[1]`, etc should be `test`;

fixed

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
