### PR TITLE
Do not load native services with org.gradle.native=false

### DIFF
--- a/platforms/core-execution/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/ChmodBenchmark.java
+++ b/platforms/core-execution/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/ChmodBenchmark.java
@@ -48,6 +48,7 @@ import static java.nio.file.attribute.PosixFilePermission.OTHERS_WRITE;
 import static java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE;
 import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
 import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
+import static org.gradle.internal.nativeintegration.services.NativeServices.NativeIntegrationCondition.RESOLVE_FROM_SYSTEM_PROPERTY;
 
 @Fork(1)
 @Warmup(iterations = 10)
@@ -74,7 +75,7 @@ public class ChmodBenchmark {
     @Setup(Level.Trial)
     public void setupTrial() throws IOException {
         this.tempRootDir = Files.createTempDirectory("chmod-benchmark");
-        NativeServices.initializeOnDaemon(tempRootDir.toFile());
+        NativeServices.initializeOnDaemon(tempRootDir.toFile(), RESOLVE_FROM_SYSTEM_PROPERTY);
         this.fileSystem = FileSystems.getDefault();
     }
 

--- a/platforms/core-execution/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/ChmodBenchmark.java
+++ b/platforms/core-execution/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/ChmodBenchmark.java
@@ -20,6 +20,7 @@ import org.apache.commons.io.FileUtils;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.nativeintegration.services.FileSystems;
 import org.gradle.internal.nativeintegration.services.NativeServices;
+import org.gradle.internal.nativeintegration.services.NativeServices.NativeIntegrationEnabled;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
@@ -48,7 +49,6 @@ import static java.nio.file.attribute.PosixFilePermission.OTHERS_WRITE;
 import static java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE;
 import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
 import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
-import static org.gradle.internal.nativeintegration.services.NativeServices.NativeIntegrationCondition.RESOLVE_FROM_SYSTEM_PROPERTY;
 
 @Fork(1)
 @Warmup(iterations = 10)
@@ -75,7 +75,7 @@ public class ChmodBenchmark {
     @Setup(Level.Trial)
     public void setupTrial() throws IOException {
         this.tempRootDir = Files.createTempDirectory("chmod-benchmark");
-        NativeServices.initializeOnDaemon(tempRootDir.toFile(), RESOLVE_FROM_SYSTEM_PROPERTY);
+        NativeServices.initializeOnDaemon(tempRootDir.toFile(), NativeIntegrationEnabled.fromSystemProperties());
         this.fileSystem = FileSystems.getDefault();
     }
 

--- a/platforms/core-execution/persistent-cache/src/integTest/groovy/org/gradle/cache/internal/DefaultFileLockManagerContentionIntegrationTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/integTest/groovy/org/gradle/cache/internal/DefaultFileLockManagerContentionIntegrationTest.groovy
@@ -232,6 +232,7 @@ class DefaultFileLockManagerContentionIntegrationTest extends AbstractIntegratio
             import org.gradle.cache.FileLockManager
             import org.gradle.internal.logging.events.OutputEventListener
             import org.gradle.internal.nativeintegration.services.NativeServices
+            import org.gradle.internal.nativeintegration.services.NativeServices.NativeIntegrationEnabled
             import org.gradle.internal.service.DefaultServiceRegistry
             import org.gradle.internal.service.scopes.GlobalScopeServices
             import org.gradle.internal.service.ServiceRegistryBuilder
@@ -291,7 +292,7 @@ class DefaultFileLockManagerContentionIntegrationTest extends AbstractIntegratio
 
                  static def getInstance(File gradleUserHome) {
                     if (instance == null) {
-                        NativeServices.initializeOnWorker(gradleUserHome)
+                        NativeServices.initializeOnWorker(gradleUserHome, NativeIntegrationEnabled.ENABLED)
                         def global = new ZincCompilerServices(gradleUserHome)
                         ServiceRegistryBuilder builder = ServiceRegistryBuilder.builder()
                         builder.parent(global)

--- a/platforms/core-execution/worker-processes/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
+++ b/platforms/core-execution/worker-processes/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
@@ -26,6 +26,7 @@ import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
 import org.gradle.internal.nativeintegration.services.NativeServices;
+import org.gradle.internal.nativeintegration.services.NativeServices.NativeIntegrationEnabled;
 import org.gradle.internal.remote.MessagingClient;
 import org.gradle.internal.remote.ObjectConnection;
 import org.gradle.internal.remote.services.MessagingServices;
@@ -85,7 +86,7 @@ public class SystemApplicationClassLoaderWorker implements Callable<Void> {
 
         // Configure services
         File gradleUserHomeDir = new File(config.getGradleUserHomeDirPath());
-        NativeServices.initializeOnWorker(gradleUserHomeDir);
+        NativeServices.initializeOnWorker(gradleUserHomeDir, NativeIntegrationEnabled.from(config.useNativeServices()));
         DefaultServiceRegistry basicWorkerServices = new DefaultServiceRegistry(NativeServices.getInstance(), loggingServiceRegistry);
         basicWorkerServices.add(ExecutorFactory.class, new DefaultExecutorFactory());
         basicWorkerServices.addProvider(new MessagingServices());

--- a/platforms/core-execution/worker-processes/src/main/java/org/gradle/process/internal/worker/messaging/WorkerConfig.java
+++ b/platforms/core-execution/worker-processes/src/main/java/org/gradle/process/internal/worker/messaging/WorkerConfig.java
@@ -34,8 +34,9 @@ public class WorkerConfig {
     private final long workerId;
     private final String displayName;
     private final Action<? super WorkerProcessContext> workerAction;
+    private final boolean useNativeServices;
 
-    public WorkerConfig(LogLevel logLevel, boolean publishJvmMemoryInfo, String gradleUserHomeDirPath, MultiChoiceAddress serverAddress, long workerId, String displayName, Action<? super WorkerProcessContext> workerAction) {
+    public WorkerConfig(LogLevel logLevel, boolean publishJvmMemoryInfo, String gradleUserHomeDirPath, MultiChoiceAddress serverAddress, long workerId, String displayName, Action<? super WorkerProcessContext> workerAction, boolean useNativeServices) {
         this.logLevel = logLevel;
         this.publishJvmMemoryInfo = publishJvmMemoryInfo;
         this.gradleUserHomeDirPath = gradleUserHomeDirPath;
@@ -43,6 +44,7 @@ public class WorkerConfig {
         this.workerId = workerId;
         this.displayName = displayName;
         this.workerAction = workerAction;
+        this.useNativeServices = useNativeServices;
 
         assert workerAction instanceof Serializable;
     }
@@ -75,6 +77,10 @@ public class WorkerConfig {
 
     public String getDisplayName() {
         return displayName;
+    }
+
+    public boolean useNativeServices() {
+        return useNativeServices;
     }
 
     public Action<? super WorkerProcessContext> getWorkerAction() {

--- a/platforms/core-execution/worker-processes/src/main/java/org/gradle/process/internal/worker/messaging/WorkerConfigSerializer.java
+++ b/platforms/core-execution/worker-processes/src/main/java/org/gradle/process/internal/worker/messaging/WorkerConfigSerializer.java
@@ -48,19 +48,21 @@ public class WorkerConfigSerializer implements Serializer<WorkerConfig> {
     public WorkerConfig read(Decoder decoder) throws IOException {
         LogLevel logLevel = LogLevel.values()[decoder.readSmallInt()];
         boolean shouldPublishJvmMemoryInfo = decoder.readBoolean();
+        boolean useNativeServices = decoder.readBoolean();
         String gradleUserHomeDirPath = decoder.readString();
         MultiChoiceAddress serverAddress = new MultiChoiceAddressSerializer().read(decoder);
         final long workerId = decoder.readSmallLong();
         final String displayName = decoder.readString();
         Action<? super WorkerProcessContext> workerAction = deserializeWorker(decoder.readBinary(), getClass().getClassLoader());
 
-        return new WorkerConfig(logLevel, shouldPublishJvmMemoryInfo, gradleUserHomeDirPath, serverAddress, workerId, displayName, workerAction);
+        return new WorkerConfig(logLevel, shouldPublishJvmMemoryInfo, gradleUserHomeDirPath, serverAddress, workerId, displayName, workerAction, useNativeServices);
     }
 
     @Override
     public void write(Encoder encoder, WorkerConfig config) throws IOException {
         encoder.writeSmallInt(config.getLogLevel().ordinal());
         encoder.writeBoolean(config.shouldPublishJvmMemoryInfo());
+        encoder.writeBoolean(config.useNativeServices());
         encoder.writeString(config.getGradleUserHomeDirPath());
         new MultiChoiceAddressSerializer().write(encoder, config.getServerAddress());
         encoder.writeSmallLong(config.getWorkerId());

--- a/platforms/core-execution/worker-processes/src/test/groovy/org/gradle/process/internal/worker/messaging/WorkerConfigSerializerTest.groovy
+++ b/platforms/core-execution/worker-processes/src/test/groovy/org/gradle/process/internal/worker/messaging/WorkerConfigSerializerTest.groovy
@@ -30,13 +30,14 @@ class WorkerConfigSerializerTest extends Specification {
 
         given:
         WorkerConfig original = new WorkerConfig(
-            LogLevel.ERROR,
-            true,
-            "/path/to/user/home",
-            new MultiChoiceAddress(new UUID(123, 456), 789, [InetAddress.getByName("example.com")]),
-            987,
-            "name",
-            new TestAction("value")
+                LogLevel.ERROR,
+                true,
+                "/path/to/user/home",
+                new MultiChoiceAddress(new UUID(123, 456), 789, [InetAddress.getByName("example.com")]),
+                987,
+                "name",
+                new TestAction("value"),
+                true
         )
 
         when:

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/BuildActionsFactory.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/BuildActionsFactory.java
@@ -102,7 +102,7 @@ class BuildActionsFactory implements CommandLineActionCreator {
             DaemonParameters daemonParameters = parameters.getDaemonParameters();
             ForegroundDaemonConfiguration conf = new ForegroundDaemonConfiguration(
                 UUID.randomUUID().toString(), daemonParameters.getBaseDir(), daemonParameters.getIdleTimeout(), daemonParameters.getPeriodicCheckInterval(), fileCollectionFactory,
-                daemonParameters.shouldApplyInstrumentationAgent());
+                daemonParameters.shouldApplyInstrumentationAgent(), daemonParameters.useNativeServices());
             return Actions.toAction(new ForegroundDaemonAction(loggingServices, conf));
         }
         if (parameters.getDaemonParameters().isEnabled()) {

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/DefaultCommandLineActionFactory.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/DefaultCommandLineActionFactory.java
@@ -52,7 +52,9 @@ import org.gradle.util.internal.DefaultGradleVersion;
 import javax.annotation.Nullable;
 import java.io.PrintStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * <p>Responsible for converting a set of command-line arguments into a {@link Runnable} action.</p>
@@ -329,6 +331,7 @@ public class DefaultCommandLineActionFactory implements CommandLineActionFactory
             parser.allowMixedSubcommandsAndOptions();
 
             WelcomeMessageConfiguration welcomeMessageConfiguration = new WelcomeMessageConfiguration(WelcomeMessageDisplayMode.ONCE);
+            Map<String, String> allProperties = Collections.emptyMap();
 
             try {
                 ParsedCommandLine parsedCommandLine = parser.parse(args);
@@ -339,6 +342,7 @@ public class DefaultCommandLineActionFactory implements CommandLineActionFactory
 
                 // Read *.properties files
                 AllProperties properties = layoutToPropertiesConverter.convert(initialProperties, buildLayout);
+                allProperties = properties.getProperties();
 
                 // Calculate the logging configuration
                 loggingBuildOptions.convert(parsedCommandLine, properties, loggingConfiguration);
@@ -355,7 +359,7 @@ public class DefaultCommandLineActionFactory implements CommandLineActionFactory
             try {
                 Action<ExecutionListener> exceptionReportingAction =
                     new ExceptionReportingAction(reporter, loggingManager,
-                        new NativeServicesInitializingAction(buildLayout, loggingConfiguration, loggingManager,
+                        new NativeServicesInitializingAction(buildLayout, loggingConfiguration, loggingManager, allProperties,
                             new WelcomeMessageAction(buildLayout, welcomeMessageConfiguration,
                                 new DebugLoggerWarningAction(loggingConfiguration, action))));
                 exceptionReportingAction.execute(executionListener);

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/NativeServicesInitializingAction.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/NativeServicesInitializingAction.java
@@ -20,13 +20,11 @@ import org.gradle.api.Action;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.nativeintegration.services.NativeServices;
-import org.gradle.internal.nativeintegration.services.NativeServices.NativeIntegrationCondition;
+import org.gradle.internal.nativeintegration.services.NativeServices.NativeIntegrationEnabled;
 import org.gradle.launcher.bootstrap.ExecutionListener;
 import org.gradle.launcher.configuration.BuildLayoutResult;
 
 import java.util.Map;
-
-import static org.gradle.launcher.daemon.configuration.DaemonBuildOptions.NativeServicesOption.GRADLE_PROPERTY;
 
 public class NativeServicesInitializingAction implements Action<ExecutionListener> {
 
@@ -52,8 +50,7 @@ public class NativeServicesInitializingAction implements Action<ExecutionListene
 
     @Override
     public void execute(ExecutionListener executionListener) {
-        NativeIntegrationCondition nativeIntegration = NativeIntegrationCondition.resolveFrom(allProperties.get(GRADLE_PROPERTY));
-        NativeServices.initializeOnClient(buildLayout.getGradleUserHomeDir(), nativeIntegration);
+        NativeServices.initializeOnClient(buildLayout.getGradleUserHomeDir(), NativeIntegrationEnabled.fromProperties(allProperties));
         loggingManager.attachProcessConsole(loggingConfiguration.getConsoleOutput());
         action.execute(executionListener);
     }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonMain.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonMain.java
@@ -27,7 +27,7 @@ import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
 import org.gradle.internal.nativeintegration.ProcessEnvironment;
 import org.gradle.internal.nativeintegration.services.NativeServices;
-import org.gradle.internal.nativeintegration.services.NativeServices.NativeIntegrationCondition;
+import org.gradle.internal.nativeintegration.services.NativeServices.NativeIntegrationEnabled;
 import org.gradle.internal.remote.Address;
 import org.gradle.internal.serialize.kryo.KryoBackedDecoder;
 import org.gradle.internal.service.scopes.GradleUserHomeScopeServiceRegistry;
@@ -79,7 +79,7 @@ public class DaemonMain extends EntryPoint {
         int idleTimeoutMs;
         int periodicCheckIntervalMs;
         boolean singleUse;
-        String nativeEnabledPropertyValue;
+        boolean useNativeServices;
         String daemonUid;
         DaemonParameters.Priority priority;
         List<File> additionalClassPath;
@@ -91,7 +91,7 @@ public class DaemonMain extends EntryPoint {
             idleTimeoutMs = decoder.readSmallInt();
             periodicCheckIntervalMs = decoder.readSmallInt();
             singleUse = decoder.readBoolean();
-            nativeEnabledPropertyValue = decoder.readString();
+            useNativeServices = decoder.readBoolean();
             daemonUid = decoder.readString();
             priority = DaemonParameters.Priority.values()[decoder.readSmallInt()];
             int argCount = decoder.readSmallInt();
@@ -109,9 +109,8 @@ public class DaemonMain extends EntryPoint {
         }
 
         // Native services are set before the daemon is initialized
-        NativeIntegrationCondition nativeEnabled = NativeIntegrationCondition.resolveFrom(nativeEnabledPropertyValue);
-        NativeServices.initializeOnDaemon(gradleHomeDir, nativeEnabled);
-        DaemonServerConfiguration parameters = new DefaultDaemonServerConfiguration(daemonUid, daemonBaseDir, idleTimeoutMs, periodicCheckIntervalMs, singleUse, priority, startupOpts, nativeEnabled.isNativeIntegrationsEnabled());
+        NativeServices.initializeOnDaemon(gradleHomeDir, NativeIntegrationEnabled.from(useNativeServices));
+        DaemonServerConfiguration parameters = new DefaultDaemonServerConfiguration(daemonUid, daemonBaseDir, idleTimeoutMs, periodicCheckIntervalMs, singleUse, priority, startupOpts, useNativeServices);
         LoggingServiceRegistry loggingRegistry = LoggingServiceRegistry.newCommandLineProcessLogging();
         LoggingManagerInternal loggingManager = loggingRegistry.newInstance(LoggingManagerInternal.class);
 

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonMain.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonMain.java
@@ -108,7 +108,6 @@ public class DaemonMain extends EntryPoint {
             throw new UncheckedIOException(e);
         }
 
-        // Native services are set before the daemon is initialized
         NativeServices.initializeOnDaemon(gradleHomeDir, NativeIntegrationEnabled.from(useNativeServices));
         DaemonServerConfiguration parameters = new DefaultDaemonServerConfiguration(daemonUid, daemonBaseDir, idleTimeoutMs, periodicCheckIntervalMs, singleUse, priority, startupOpts, useNativeServices);
         LoggingServiceRegistry loggingRegistry = LoggingServiceRegistry.newCommandLineProcessLogging();

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/client/DefaultDaemonStarter.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/client/DefaultDaemonStarter.java
@@ -36,6 +36,7 @@ import org.gradle.internal.time.Timer;
 import org.gradle.launcher.daemon.DaemonExecHandleBuilder;
 import org.gradle.launcher.daemon.bootstrap.DaemonOutputConsumer;
 import org.gradle.launcher.daemon.bootstrap.GradleDaemon;
+import org.gradle.launcher.daemon.configuration.DaemonBuildOptions.NativeServicesOption;
 import org.gradle.launcher.daemon.configuration.DaemonParameters;
 import org.gradle.launcher.daemon.diagnostics.DaemonStartupInfo;
 import org.gradle.launcher.daemon.registry.DaemonDir;
@@ -106,6 +107,9 @@ public class DefaultDaemonStarter implements DaemonStarter {
         if (Boolean.getBoolean("org.gradle.daemon.debug")) {
             daemonArgs.add(JvmOptions.getDebugArgument(true, true, "5005"));
         }
+
+        // Native services are initialized before any system property is set by Gradle process, so we pass option directly to the process
+        daemonArgs.add("-D" + NativeServicesOption.GRADLE_PROPERTY + "=" + daemonParameters.isUseNativeServices());
 
         ClassPath agentClasspath = registry.getModule(AgentUtils.AGENT_MODULE_NAME).getImplementationClasspath();
         if (daemonParameters.shouldApplyInstrumentationAgent()) {

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/client/DefaultDaemonStarter.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/client/DefaultDaemonStarter.java
@@ -36,7 +36,6 @@ import org.gradle.internal.time.Timer;
 import org.gradle.launcher.daemon.DaemonExecHandleBuilder;
 import org.gradle.launcher.daemon.bootstrap.DaemonOutputConsumer;
 import org.gradle.launcher.daemon.bootstrap.GradleDaemon;
-import org.gradle.launcher.daemon.configuration.DaemonBuildOptions.NativeServicesOption;
 import org.gradle.launcher.daemon.configuration.DaemonParameters;
 import org.gradle.launcher.daemon.diagnostics.DaemonStartupInfo;
 import org.gradle.launcher.daemon.registry.DaemonDir;
@@ -108,9 +107,6 @@ public class DefaultDaemonStarter implements DaemonStarter {
             daemonArgs.add(JvmOptions.getDebugArgument(true, true, "5005"));
         }
 
-        // Native services are initialized before any system property is set by Gradle process, so we pass option directly to the process
-        daemonArgs.add("-D" + NativeServicesOption.GRADLE_PROPERTY + "=" + daemonParameters.isUseNativeServices());
-
         ClassPath agentClasspath = registry.getModule(AgentUtils.AGENT_MODULE_NAME).getImplementationClasspath();
         if (daemonParameters.shouldApplyInstrumentationAgent()) {
             if (agentClasspath.isEmpty()) {
@@ -136,6 +132,7 @@ public class DefaultDaemonStarter implements DaemonStarter {
             encoder.writeSmallInt(daemonParameters.getIdleTimeout());
             encoder.writeSmallInt(daemonParameters.getPeriodicCheckInterval());
             encoder.writeBoolean(singleUse);
+            encoder.writeBoolean(daemonParameters.useNativeServices());
             encoder.writeString(daemonUid);
             encoder.writeSmallInt(daemonParameters.getPriority().ordinal());
             encoder.writeSmallInt(daemonOpts.size());

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonBuildOptions.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonBuildOptions.java
@@ -35,6 +35,8 @@ import java.io.File;
 import java.util.List;
 import java.util.Locale;
 
+import static org.gradle.internal.nativeintegration.services.NativeServices.NATIVE_SERVICES_OPTION;
+
 public class DaemonBuildOptions extends BuildOptionSet<DaemonParameters> {
 
     private static List<BuildOption<DaemonParameters>> options = ImmutableList.of(
@@ -243,10 +245,8 @@ public class DaemonBuildOptions extends BuildOptionSet<DaemonParameters> {
 
     @NonNullApi
     public static class NativeServicesOption extends BooleanBuildOption<DaemonParameters> {
-        public static final String GRADLE_PROPERTY = "org.gradle.native";
-
         public NativeServicesOption() {
-            super(GRADLE_PROPERTY);
+            super(NATIVE_SERVICES_OPTION);
         }
 
         @Override

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonBuildOptions.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonBuildOptions.java
@@ -17,6 +17,7 @@
 package org.gradle.launcher.daemon.configuration;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.NonNullApi;
 import org.gradle.internal.buildoption.BooleanBuildOption;
 import org.gradle.internal.buildoption.BooleanCommandLineOptionConfiguration;
 import org.gradle.internal.buildoption.BuildOption;
@@ -240,6 +241,7 @@ public class DaemonBuildOptions extends BuildOptionSet<DaemonParameters> {
         }
     }
 
+    @NonNullApi
     public static class NativeServicesOption extends BooleanBuildOption<DaemonParameters> {
         public static final String GRADLE_PROPERTY = "org.gradle.native";
 

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonBuildOptions.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonBuildOptions.java
@@ -52,7 +52,9 @@ public class DaemonBuildOptions extends BuildOptionSet<DaemonParameters> {
         new ForegroundOption(),
         new StopOption(),
         new StatusOption(),
-        new PriorityOption());
+        new PriorityOption(),
+        new NativeServicesOption()
+    );
 
     public static List<BuildOption<DaemonParameters>> get() {
         return options;
@@ -235,6 +237,19 @@ public class DaemonBuildOptions extends BuildOptionSet<DaemonParameters> {
         @Override
         public void applyTo(boolean value, DaemonParameters settings, Origin origin) {
             settings.setApplyInstrumentationAgent(value);
+        }
+    }
+
+    public static class NativeServicesOption extends BooleanBuildOption<DaemonParameters> {
+        public static final String GRADLE_PROPERTY = "org.gradle.native";
+
+        public NativeServicesOption() {
+            super(GRADLE_PROPERTY);
+        }
+
+        @Override
+        public void applyTo(boolean value, DaemonParameters settings, Origin origin) {
+            settings.setUseNativeServices(value);
         }
     }
 

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonBuildOptions.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonBuildOptions.java
@@ -29,6 +29,7 @@ import org.gradle.internal.buildoption.StringBuildOption;
 import org.gradle.internal.jvm.JavaHomeException;
 import org.gradle.internal.jvm.JavaInfo;
 import org.gradle.internal.jvm.Jvm;
+import org.gradle.internal.nativeintegration.services.NativeServices.NativeIntegrationEnabled;
 import org.gradle.process.internal.JvmOptions;
 
 import java.io.File;
@@ -244,14 +245,14 @@ public class DaemonBuildOptions extends BuildOptionSet<DaemonParameters> {
     }
 
     @NonNullApi
-    public static class NativeServicesOption extends BooleanBuildOption<DaemonParameters> {
+    public static class NativeServicesOption extends StringBuildOption<DaemonParameters> {
         public NativeServicesOption() {
             super(NATIVE_SERVICES_OPTION);
         }
 
         @Override
-        public void applyTo(boolean value, DaemonParameters settings, Origin origin) {
-            settings.setUseNativeServices(value);
+        public void applyTo(String value, DaemonParameters settings, Origin origin) {
+            settings.setUseNativeServices(NativeIntegrationEnabled.fromString(value).isEnabled());
         }
     }
 

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
@@ -219,7 +219,7 @@ public class DaemonParameters {
         return this;
     }
 
-    public boolean isUseNativeServices() {
+    public boolean useNativeServices() {
         return useNativeServices;
     }
 

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
@@ -49,6 +49,7 @@ public class DaemonParameters {
     private int periodicCheckInterval = DEFAULT_PERIODIC_CHECK_INTERVAL_MILLIS;
     private final DaemonJvmOptions jvmOptions;
     private boolean applyInstrumentationAgent = true;
+    private boolean useNativeServices = true;
     private Map<String, String> envVariables;
     private boolean enabled = true;
     private boolean hasJvmArgs;
@@ -215,6 +216,15 @@ public class DaemonParameters {
 
     public DaemonParameters setApplyInstrumentationAgent(boolean applyInstrumentationAgent) {
         this.applyInstrumentationAgent = applyInstrumentationAgent;
+        return this;
+    }
+
+    public boolean isUseNativeServices() {
+        return useNativeServices;
+    }
+
+    public DaemonParameters setUseNativeServices(boolean useNativeServices) {
+        this.useNativeServices = useNativeServices;
         return this;
     }
 

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonServerConfiguration.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonServerConfiguration.java
@@ -36,4 +36,6 @@ public interface DaemonServerConfiguration {
     boolean isSingleUse();
 
     boolean isInstrumentationAgentAllowed();
+
+    boolean useNativeServices();
 }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DefaultDaemonServerConfiguration.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DefaultDaemonServerConfiguration.java
@@ -29,18 +29,19 @@ public class DefaultDaemonServerConfiguration implements DaemonServerConfigurati
     private final DaemonParameters.Priority priority;
     private final List<String> jvmOptions;
     private final boolean instrumentationAgentAllowed;
+    private final boolean useNativeServices;
 
     /**
      * Creates the DefaultDaemonConfiguration that allows the use of the instrumentation agent if the latter is applied.
      */
-    public DefaultDaemonServerConfiguration(String daemonUid, File daemonBaseDir, int idleTimeoutMs, int periodicCheckIntervalMs, boolean singleUse, DaemonParameters.Priority priority, List<String> jvmOptions) {
+    public DefaultDaemonServerConfiguration(String daemonUid, File daemonBaseDir, int idleTimeoutMs, int periodicCheckIntervalMs, boolean singleUse, DaemonParameters.Priority priority, List<String> jvmOptions, boolean useNativeServices) {
         // Using the available agent is correct for the forked daemon processes, because the forking
         // code takes the desired agent status into account when configuring the daemon command line.
         // The daemon that shouldn't use the agent won't have the agent applied.
-        this(daemonUid, daemonBaseDir, idleTimeoutMs, periodicCheckIntervalMs, singleUse, priority, jvmOptions, true);
+        this(daemonUid, daemonBaseDir, idleTimeoutMs, periodicCheckIntervalMs, singleUse, priority, jvmOptions, true, useNativeServices);
     }
 
-    public DefaultDaemonServerConfiguration(String daemonUid, File daemonBaseDir, int idleTimeoutMs, int periodicCheckIntervalMs, boolean singleUse, DaemonParameters.Priority priority, List<String> jvmOptions, boolean instrumentationAgentAllowed) {
+    public DefaultDaemonServerConfiguration(String daemonUid, File daemonBaseDir, int idleTimeoutMs, int periodicCheckIntervalMs, boolean singleUse, DaemonParameters.Priority priority, List<String> jvmOptions, boolean instrumentationAgentAllowed, boolean useNativeServices) {
         // There is at least one case when the daemon shouldn't use the available agent: if the foreground
         // daemon is started with feature flag disabled.
         // The start script cannot look into the feature flags, so the agent is always applied to the foreground daemon.
@@ -53,6 +54,7 @@ public class DefaultDaemonServerConfiguration implements DaemonServerConfigurati
         this.priority = priority;
         this.jvmOptions = jvmOptions;
         this.instrumentationAgentAllowed = instrumentationAgentAllowed;
+        this.useNativeServices = useNativeServices;
     }
 
     @Override
@@ -93,5 +95,10 @@ public class DefaultDaemonServerConfiguration implements DaemonServerConfigurati
     @Override
     public boolean isInstrumentationAgentAllowed() {
         return instrumentationAgentAllowed;
+    }
+
+    @Override
+    public boolean useNativeServices() {
+        return useNativeServices;
     }
 }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/configuration/ForegroundDaemonConfiguration.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/configuration/ForegroundDaemonConfiguration.java
@@ -23,8 +23,8 @@ import java.io.File;
 
 public class ForegroundDaemonConfiguration extends DefaultDaemonServerConfiguration {
 
-    public ForegroundDaemonConfiguration(String daemonUid, File daemonBaseDir, int idleTimeoutMs, int periodicCheckIntervalMs, FileCollectionFactory fileCollectionFactory, boolean instrumentationAgentAllowed) {
+    public ForegroundDaemonConfiguration(String daemonUid, File daemonBaseDir, int idleTimeoutMs, int periodicCheckIntervalMs, FileCollectionFactory fileCollectionFactory, boolean instrumentationAgentAllowed, boolean useNativeServices) {
         // Foreground daemon cannot be 'told' what's his startup options as the client sits in the same process so we will infer the jvm opts from the inputArguments()
-        super(daemonUid, daemonBaseDir, idleTimeoutMs, periodicCheckIntervalMs, false, DaemonParameters.Priority.NORMAL, new CurrentProcess(fileCollectionFactory).getJvmOptions().getAllImmutableJvmArgs(), instrumentationAgentAllowed);
+        super(daemonUid, daemonBaseDir, idleTimeoutMs, periodicCheckIntervalMs, false, DaemonParameters.Priority.NORMAL, new CurrentProcess(fileCollectionFactory).getJvmOptions().getAllImmutableJvmArgs(), instrumentationAgentAllowed, useNativeServices);
     }
 }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/context/DaemonCompatibilitySpec.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/context/DaemonCompatibilitySpec.java
@@ -45,6 +45,8 @@ public class DaemonCompatibilitySpec implements ExplainingSpec<DaemonContext> {
             return "Process priority is different.\n" + description(context);
         } else if (!agentStatusMatches(context)) {
             return "Agent status is different.\n" + description(context);
+        } else if (!useNativeServicesMatches(context)) {
+            return "Use native services flag is different.\n" + description(context);
         }
         return null;
     }
@@ -79,6 +81,10 @@ public class DaemonCompatibilitySpec implements ExplainingSpec<DaemonContext> {
 
     private boolean agentStatusMatches(DaemonContext context) {
         return desiredContext.shouldApplyInstrumentationAgent() == context.shouldApplyInstrumentationAgent();
+    }
+
+    private boolean useNativeServicesMatches(DaemonContext context) {
+        return desiredContext.useNativeServices() == context.useNativeServices();
     }
 
     @Override

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/context/DaemonContext.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/context/DaemonContext.java
@@ -75,5 +75,12 @@ public interface DaemonContext extends Serializable {
      */
     boolean shouldApplyInstrumentationAgent();
 
+    /**
+     * Returns whether the daemon should use native services.
+     *
+     * @return {@code true} if the native services should be used.
+     */
+    boolean useNativeServices();
+
     DaemonParameters.Priority getPriority();
 }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/context/DaemonContextBuilder.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/context/DaemonContextBuilder.java
@@ -43,6 +43,7 @@ public class DaemonContextBuilder implements Factory<DaemonContext> {
     private Locale locale = Locale.getDefault();
     private List<String> daemonOpts = new ArrayList<>();
     private boolean applyInstrumentationAgent;
+    private boolean useNativeServices;
     private DaemonParameters.Priority priority;
 
     public DaemonContextBuilder(ProcessEnvironment processEnvironment) {
@@ -110,6 +111,10 @@ public class DaemonContextBuilder implements Factory<DaemonContext> {
         this.applyInstrumentationAgent = applyInstrumentationAgent;
     }
 
+    public void setUseNativeServices(boolean useNativeServices) {
+        this.useNativeServices = useNativeServices;
+    }
+
     public void setPriority(DaemonParameters.Priority priority) {
         this.priority = priority;
     }
@@ -118,6 +123,7 @@ public class DaemonContextBuilder implements Factory<DaemonContext> {
         setJavaHome(daemonParameters.getEffectiveJvm().getJavaHome());
         setDaemonOpts(daemonParameters.getEffectiveJvmArgs());
         setApplyInstrumentationAgent(daemonParameters.shouldApplyInstrumentationAgent());
+        setUseNativeServices(daemonParameters.useNativeServices());
         setPriority(daemonParameters.getPriority());
     }
 
@@ -129,6 +135,6 @@ public class DaemonContextBuilder implements Factory<DaemonContext> {
         if (daemonRegistryDir == null) {
             throw new IllegalStateException("Registry dir must be specified.");
         }
-        return new DefaultDaemonContext(uid, javaHome, daemonRegistryDir, pid, idleTimeout, daemonOpts, applyInstrumentationAgent, priority);
+        return new DefaultDaemonContext(uid, javaHome, daemonRegistryDir, pid, idleTimeout, daemonOpts, applyInstrumentationAgent, useNativeServices, priority);
     }
 }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/context/DefaultDaemonContext.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/context/DefaultDaemonContext.java
@@ -41,6 +41,7 @@ public class DefaultDaemonContext implements DaemonContext {
     private final List<String> daemonOpts;
     private final boolean applyInstrumentationAgent;
     private final DaemonParameters.Priority priority;
+    private final boolean useNativeServices;
 
     public DefaultDaemonContext(
         String uid,
@@ -50,6 +51,7 @@ public class DefaultDaemonContext implements DaemonContext {
         Integer idleTimeout,
         List<String> daemonOpts,
         boolean applyInstrumentationAgent,
+        boolean useNativeServices,
         DaemonParameters.Priority priority
     ) {
         this.uid = uid;
@@ -60,6 +62,7 @@ public class DefaultDaemonContext implements DaemonContext {
         this.daemonOpts = daemonOpts;
         this.applyInstrumentationAgent = applyInstrumentationAgent;
         this.priority = priority;
+        this.useNativeServices = useNativeServices;
     }
 
     @Override
@@ -104,6 +107,11 @@ public class DefaultDaemonContext implements DaemonContext {
     }
 
     @Override
+    public boolean useNativeServices() {
+        return useNativeServices;
+    }
+
+    @Override
     public DaemonParameters.Priority getPriority() {
         return priority;
     }
@@ -124,8 +132,9 @@ public class DefaultDaemonContext implements DaemonContext {
                 daemonOpts.add(decoder.readString());
             }
             boolean applyInstrumentationAgent = decoder.readBoolean();
+            boolean useNativeServices = decoder.readBoolean();
             DaemonParameters.Priority priority = decoder.readBoolean() ? DaemonParameters.Priority.values()[decoder.readInt()] : null;
-            return new DefaultDaemonContext(uid, javaHome, registryDir, pid, idle, daemonOpts, applyInstrumentationAgent, priority);
+            return new DefaultDaemonContext(uid, javaHome, registryDir, pid, idle, daemonOpts, applyInstrumentationAgent, useNativeServices, priority);
         }
 
         @Override
@@ -146,6 +155,7 @@ public class DefaultDaemonContext implements DaemonContext {
                 encoder.writeString(daemonOpt);
             }
             encoder.writeBoolean(context.applyInstrumentationAgent);
+            encoder.writeBoolean(context.useNativeServices);
             encoder.writeBoolean(context.priority != null);
             if (context.priority != null) {
                 encoder.writeInt(context.priority.ordinal());

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/DaemonServices.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/DaemonServices.java
@@ -98,6 +98,7 @@ public class DaemonServices extends DefaultServiceRegistry {
 
         builder.setDaemonOpts(configuration.getJvmOptions());
         builder.setApplyInstrumentationAgent(agentStatus.isAgentInstrumentationEnabled());
+        builder.setUseNativeServices(configuration.useNativeServices());
 
         return builder.create();
     }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/DefaultConnection.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/DefaultConnection.java
@@ -24,6 +24,7 @@ import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.jvm.UnsupportedJavaRuntimeException;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
 import org.gradle.internal.nativeintegration.services.NativeServices;
+import org.gradle.internal.nativeintegration.services.NativeServices.NativeIntegrationEnabled;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.ServiceRegistryBuilder;
 import org.gradle.tooling.UnsupportedVersionException;
@@ -63,8 +64,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.util.List;
-
-import static org.gradle.internal.nativeintegration.services.NativeServices.NativeIntegrationCondition.RESOLVE_FROM_SYSTEM_PROPERTY;
 
 @SuppressWarnings("deprecation")
 public class DefaultConnection implements ConnectionVersion4,
@@ -113,7 +112,7 @@ public class DefaultConnection implements ConnectionVersion4,
     }
 
     private void initializeServices(File gradleUserHomeDir) {
-        NativeServices.initializeOnClient(gradleUserHomeDir, RESOLVE_FROM_SYSTEM_PROPERTY);
+        NativeServices.initializeOnClient(gradleUserHomeDir, NativeIntegrationEnabled.fromSystemProperties());
         LoggingServiceRegistry loggingServices = LoggingServiceRegistry.newEmbeddableLogging();
         services = ServiceRegistryBuilder.builder()
             .displayName("Connection services")

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/DefaultConnection.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/DefaultConnection.java
@@ -64,6 +64,8 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.util.List;
 
+import static org.gradle.internal.nativeintegration.services.NativeServices.NativeIntegrationCondition.RESOLVE_FROM_SYSTEM_PROPERTY;
+
 @SuppressWarnings("deprecation")
 public class DefaultConnection implements ConnectionVersion4,
     ConfigurableConnection, InternalCancellableConnection, InternalParameterAcceptingConnection,
@@ -111,7 +113,7 @@ public class DefaultConnection implements ConnectionVersion4,
     }
 
     private void initializeServices(File gradleUserHomeDir) {
-        NativeServices.initializeOnClient(gradleUserHomeDir);
+        NativeServices.initializeOnClient(gradleUserHomeDir, RESOLVE_FROM_SYSTEM_PROPERTY);
         LoggingServiceRegistry loggingServices = LoggingServiceRegistry.newEmbeddableLogging();
         services = ServiceRegistryBuilder.builder()
             .displayName("Connection services")

--- a/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/daemon/client/DefaultDaemonConnectorTest.groovy
+++ b/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/daemon/client/DefaultDaemonConnectorTest.groovy
@@ -72,7 +72,7 @@ class DefaultDaemonConnectorTest extends Specification {
 
     def startBusyDaemon() {
         def daemonNum = daemonCounter++
-        DaemonContext context = new DefaultDaemonContext(daemonNum.toString(), javaHome, javaHome, daemonNum, 1000, [], false, DaemonParameters.Priority.NORMAL)
+        DaemonContext context = new DefaultDaemonContext(daemonNum.toString(), javaHome, javaHome, daemonNum, 1000, [], false, true, DaemonParameters.Priority.NORMAL)
         def address = createAddress(daemonNum)
         registry.store(new DaemonInfo(address, context, "password".bytes, Busy))
         return new DaemonStartupInfo(daemonNum.toString(), null, null);
@@ -80,7 +80,7 @@ class DefaultDaemonConnectorTest extends Specification {
 
     def startIdleDaemon() {
         def daemonNum = daemonCounter++
-        DaemonContext context = new DefaultDaemonContext(daemonNum.toString(), javaHome, javaHome, daemonNum, 1000, [], false, DaemonParameters.Priority.NORMAL)
+        DaemonContext context = new DefaultDaemonContext(daemonNum.toString(), javaHome, javaHome, daemonNum, 1000, [], false, true, DaemonParameters.Priority.NORMAL)
         def address = createAddress(daemonNum)
         registry.store(new DaemonInfo(address, context, "password".bytes, Idle))
     }

--- a/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/daemon/protocol/DaemonStatusAndErrorReportingTest.groovy
+++ b/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/daemon/protocol/DaemonStatusAndErrorReportingTest.groovy
@@ -26,7 +26,7 @@ class DaemonStatusAndErrorReportingTest extends Specification {
 
     def "PID can be null"() {
         given:
-        def daemonContext = new DefaultDaemonContext(null, null, null, null, null, null, false, null)
+        def daemonContext = new DefaultDaemonContext(null, null, null, null, null, null, false, true, null)
 
         when:
         def pid = daemonContext.pid;

--- a/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/daemon/registry/DaemonRegistryServicesTest.groovy
+++ b/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/daemon/registry/DaemonRegistryServicesTest.groovy
@@ -59,7 +59,7 @@ class DaemonRegistryServicesTest extends Specification {
         def registry = registry("someDir").get(DaemonRegistry)
         5.times { idx ->
             concurrent.start {
-                def context = new DefaultDaemonContext("$idx", new File("$idx"), new File("$idx"), idx, 5000, [], false, DaemonParameters.Priority.NORMAL)
+                def context = new DefaultDaemonContext("$idx", new File("$idx"), new File("$idx"), idx, 5000, [], false, true, DaemonParameters.Priority.NORMAL)
                 registry.store(new DaemonInfo(
                     new SocketInetAddress(localhost, (int)(8888 + idx)), context, "foo-$idx".bytes, Idle))
             }

--- a/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/daemon/server/DaemonRegistryUnavailableExpirationStrategyTest.groovy
+++ b/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/daemon/server/DaemonRegistryUnavailableExpirationStrategyTest.groovy
@@ -42,7 +42,7 @@ class DaemonRegistryUnavailableExpirationStrategyTest extends Specification {
     def "daemon should expire when registry file is unreachable"() {
         given:
         DaemonRegistryUnavailableExpirationStrategy expirationStrategy = new DaemonRegistryUnavailableExpirationStrategy(daemon)
-        DaemonContext daemonContext = new DefaultDaemonContext("user", null, tempDir.file("BOGUS"), 51234L, 10000, [] as List<String>, false, DaemonParameters.Priority.NORMAL)
+        DaemonContext daemonContext = new DefaultDaemonContext("user", null, tempDir.file("BOGUS"), 51234L, 10000, [] as List<String>, false, true, DaemonParameters.Priority.NORMAL)
 
         when:
         1 * daemon.getDaemonContext() >> { daemonContext }
@@ -60,7 +60,7 @@ class DaemonRegistryUnavailableExpirationStrategyTest extends Specification {
                 return "DAEMON_ADDRESS"
             }
         }
-        DaemonContext daemonContext = new DefaultDaemonContext("user", null, daemonDir, 51234L, 10000, [] as List<String>, false, DaemonParameters.Priority.NORMAL)
+        DaemonContext daemonContext = new DefaultDaemonContext("user", null, daemonDir, 51234L, 10000, [] as List<String>, false, true, DaemonParameters.Priority.NORMAL)
         DaemonDir daemonDir = new DaemonDir(daemonDir)
         DaemonRegistry registry = new EmbeddedDaemonRegistry()
         daemonDir.getRegistry().createNewFile()

--- a/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/daemon/server/DaemonServicesTest.groovy
+++ b/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/daemon/server/DaemonServicesTest.groovy
@@ -35,10 +35,10 @@ class DaemonServicesTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider(getClass())
 
-    final DaemonServices services = new DaemonServices(new DefaultDaemonServerConfiguration("uid", tmp.testDirectory, 100, 50, false, DaemonParameters.Priority.NORMAL, asList()),
+    final DaemonServices services = new DaemonServices(new DefaultDaemonServerConfiguration("uid", tmp.testDirectory, 100, 50, false, DaemonParameters.Priority.NORMAL, asList(), true),
         LoggingServiceRegistry.newEmbeddableLogging(), Mock(LoggingManagerInternal), Stub(ClassPath))
 
-    final DaemonServices singleRunServices = new DaemonServices(new DefaultDaemonServerConfiguration("uid", tmp.testDirectory, 200, 50, true, DaemonParameters.Priority.NORMAL, asList()),
+    final DaemonServices singleRunServices = new DaemonServices(new DefaultDaemonServerConfiguration("uid", tmp.testDirectory, 200, 50, true, DaemonParameters.Priority.NORMAL, asList(), true),
         LoggingServiceRegistry.newEmbeddableLogging(), Mock(LoggingManagerInternal), Stub(ClassPath))
 
 

--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
@@ -171,7 +171,6 @@ public class NativeServices extends DefaultServiceRegistry implements ServiceReg
      * Initializes all the services needed for the CLI or the Tooling API.
      */
     public static void initializeOnWorker(File userHomeDir, NativeIntegrationEnabled condition) {
-        // Native integration is disabled since we don't initialize any native feature
         INSTANCE.initialize(userHomeDir, EnumSet.noneOf(NativeFeatures.class), condition);
     }
 

--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
@@ -133,14 +133,14 @@ public class NativeServices extends DefaultServiceRegistry implements ServiceReg
         }
 
         public static NativeIntegrationEnabled fromSystemProperties() {
-            return fromValue(System.getProperty(NATIVE_SERVICES_OPTION));
+            return fromString(System.getProperty(NATIVE_SERVICES_OPTION));
         }
 
         public static NativeIntegrationEnabled fromProperties(Map<String, String> properties) {
-            return fromValue(properties.get(NATIVE_SERVICES_OPTION));
+            return fromString(properties.get(NATIVE_SERVICES_OPTION));
         }
 
-        private static NativeIntegrationEnabled fromValue(@Nullable String value) {
+        public static NativeIntegrationEnabled fromString(@Nullable String value) {
             // Default to enabled, make it disabled only if explicitly set to "false"
             value = (value == null ? "true" : value).trim();
             return from(!"false".equalsIgnoreCase(value));
@@ -170,9 +170,9 @@ public class NativeServices extends DefaultServiceRegistry implements ServiceReg
      *
      * Initializes all the services needed for the CLI or the Tooling API.
      */
-    public static void initializeOnWorker(File userHomeDir) {
+    public static void initializeOnWorker(File userHomeDir, NativeIntegrationEnabled condition) {
         // Native integration is disabled since we don't initialize any native feature
-        INSTANCE.initialize(userHomeDir, EnumSet.noneOf(NativeFeatures.class), NativeIntegrationEnabled.DISABLED);
+        INSTANCE.initialize(userHomeDir, EnumSet.noneOf(NativeFeatures.class), condition);
     }
 
     public static void logFileSystemWatchingUnavailable(NativeIntegrationUnavailableException ex) {
@@ -429,7 +429,7 @@ public class NativeServices extends DefaultServiceRegistry implements ServiceReg
         return new FallbackFileMetadataAccessor();
     }
 
-    protected NativeCapabilities createNativeCapabilities() {
+    public NativeCapabilities createNativeCapabilities() {
         return new NativeCapabilities() {
             @Override
             public boolean useNativeIntegrations() {

--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
@@ -79,6 +79,7 @@ public class NativeServices extends DefaultServiceRegistry implements ServiceReg
     private static final Logger LOGGER = LoggerFactory.getLogger(NativeServices.class);
     private static final NativeServices INSTANCE = new NativeServices();
 
+    public static final String NATIVE_SERVICES_OPTION = "org.gradle.native";
     public static final String NATIVE_DIR_OVERRIDE = "org.gradle.native.dir";
 
     private boolean initialized;
@@ -132,15 +133,16 @@ public class NativeServices extends DefaultServiceRegistry implements ServiceReg
         }
 
         public static NativeIntegrationEnabled fromSystemProperties() {
-            return fromValue(System.getProperty("org.gradle.native", "true"));
+            return fromValue(System.getProperty(NATIVE_SERVICES_OPTION));
         }
 
         public static NativeIntegrationEnabled fromProperties(Map<String, String> properties) {
-            return fromValue(properties.get("org.gradle.native"));
+            return fromValue(properties.get(NATIVE_SERVICES_OPTION));
         }
 
-        private static NativeIntegrationEnabled fromValue(String value) {
-            // Default to enabled, make it false only if explicitly set to "false"
+        private static NativeIntegrationEnabled fromValue(@Nullable String value) {
+            // Default to enabled, make it disabled only if explicitly set to "false"
+            value = (value == null ? "true" : value).trim();
             return from(!"false".equalsIgnoreCase(value));
         }
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/NativeServicesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/NativeServicesIntegrationTest.groovy
@@ -50,6 +50,26 @@ class NativeServicesIntegrationTest extends AbstractIntegrationSpec {
         nativeDir.directory
     }
 
+    def "native services are #description with systemProperties == #systemProperties"() {
+        given:
+        executer.requireOwnGradleUserHomeDir().withNoExplicitNativeServicesDir()
+        nativeDir = new File(executer.gradleUserHomeDir, 'native')
+        executer.withArguments(systemProperties)
+
+        when:
+        succeeds("help")
+
+        then:
+        nativeDir.exists() == initialized
+
+        where:
+        description       | systemProperties              | initialized
+        "initialized"     | ["-Dorg.gradle.native=true"]  | true
+        "not initialized" | ["-Dorg.gradle.native=false"] | false
+        "initialized"     | ["-Dorg.gradle.native=''"]    | true
+        "initialized"     | []                            | true
+    }
+
     @Issue("GRADLE-3573")
     def "jansi library is unpacked to gradle user home dir and isn't overwritten if existing"() {
         String tmpDirJvmOpt = "-Djava.io.tmpdir=$tmpDir.testDirectory.absolutePath"

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/ApplicationClassesInSystemClassLoaderWorkerImplementationFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/ApplicationClassesInSystemClassLoaderWorkerImplementationFactory.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.file.temp.TemporaryFileProvider;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.internal.io.StreamByteBuffer;
+import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.internal.process.ArgWriter;
 import org.gradle.internal.remote.Address;
 import org.gradle.internal.remote.internal.inet.MultiChoiceAddress;
@@ -148,9 +149,19 @@ public class ApplicationClassesInSystemClassLoaderWorkerImplementationFactory {
                 }
             }
 
+            boolean useNativeServices = NativeServices.getInstance()
+                .createNativeCapabilities()
+                .useNativeIntegrations();
             WorkerConfig config = new WorkerConfig(
-                logLevel, publishProcessInfo, gradleUserHomeDir.getAbsolutePath(),
-                (MultiChoiceAddress) serverAddress, workerId, displayName, processBuilder.getWorker());
+                logLevel,
+                publishProcessInfo,
+                gradleUserHomeDir.getAbsolutePath(),
+                (MultiChoiceAddress) serverAddress,
+                workerId,
+                displayName,
+                processBuilder.getWorker(),
+                useNativeServices
+            );
 
             // Serialize the worker config, this is consumed by SystemApplicationClassLoaderWorker
             OutputStreamBackedEncoder encoder = new OutputStreamBackedEncoder(outstr);

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
@@ -56,6 +56,7 @@ import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.id.UniqueId;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
 import org.gradle.internal.nativeintegration.services.NativeServices;
+import org.gradle.internal.nativeintegration.services.NativeServices.NativeIntegrationEnabled;
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
 import org.gradle.internal.scopeids.id.BuildInvocationScopeId;
@@ -78,7 +79,6 @@ import java.util.Set;
 import java.util.function.Function;
 
 import static org.gradle.internal.concurrent.CompositeStoppable.stoppable;
-import static org.gradle.internal.nativeintegration.services.NativeServices.NativeIntegrationCondition.RESOLVE_FROM_SYSTEM_PROPERTY;
 
 public class ProjectBuilderImpl {
     private static ServiceRegistry globalServices;
@@ -109,7 +109,7 @@ public class ProjectBuilderImpl {
         File userHomeDir = gradleUserHomeDir == null ? new File(projectDir, "userHome") : FileUtils.canonicalize(gradleUserHomeDir);
         StartParameterInternal startParameter = new StartParameterInternal();
         startParameter.setGradleUserHomeDir(userHomeDir);
-        NativeServices.initializeOnDaemon(userHomeDir, RESOLVE_FROM_SYSTEM_PROPERTY);
+        NativeServices.initializeOnDaemon(userHomeDir, NativeIntegrationEnabled.fromSystemProperties());
 
         final ServiceRegistry globalServices = getGlobalServices();
 

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
@@ -78,6 +78,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 import static org.gradle.internal.concurrent.CompositeStoppable.stoppable;
+import static org.gradle.internal.nativeintegration.services.NativeServices.NativeIntegrationCondition.RESOLVE_FROM_SYSTEM_PROPERTY;
 
 public class ProjectBuilderImpl {
     private static ServiceRegistry globalServices;
@@ -108,7 +109,7 @@ public class ProjectBuilderImpl {
         File userHomeDir = gradleUserHomeDir == null ? new File(projectDir, "userHome") : FileUtils.canonicalize(gradleUserHomeDir);
         StartParameterInternal startParameter = new StartParameterInternal();
         startParameter.setGradleUserHomeDir(userHomeDir);
-        NativeServices.initializeOnDaemon(userHomeDir);
+        NativeServices.initializeOnDaemon(userHomeDir, RESOLVE_FROM_SYSTEM_PROPERTY);
 
         final ServiceRegistry globalServices = getGlobalServices();
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/DaemonContextParser.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/DaemonContextParser.java
@@ -55,7 +55,7 @@ public class DaemonContextParser {
     }
 
     private static DaemonContext parseFrom(String source) {
-        Pattern pattern = Pattern.compile("^.*DefaultDaemonContext\\[(uid=[^\\n,]+)?,?javaHome=([^\\n]+),daemonRegistryDir=([^\\n]+),pid=([^\\n]+),idleTimeout=(.+?)(,priority=[^\\n,]+)?(?:,applyInstrumentationAgent=([^\\n,]+))?,daemonOpts=([^\\n]+)].*",
+        Pattern pattern = Pattern.compile("^.*DefaultDaemonContext\\[(uid=[^\\n,]+)?,?javaHome=([^\\n]+),daemonRegistryDir=([^\\n]+),pid=([^\\n]+),idleTimeout=(.+?)(,priority=[^\\n,]+)?(?:,applyInstrumentationAgent=([^\\n,]+))?(?:,useNativeServices=([^\\n,]+))?,daemonOpts=([^\\n]+)].*",
                 Pattern.MULTILINE + Pattern.DOTALL);
         Matcher matcher = pattern.matcher(source);
 
@@ -68,8 +68,9 @@ public class DaemonContextParser {
             Integer idleTimeout = Integer.decode(matcher.group(5));
             DaemonParameters.Priority priority = matcher.group(6) == null ? DaemonParameters.Priority.NORMAL : DaemonParameters.Priority.valueOf(matcher.group(6).substring(",priority=".length()));
             boolean applyInstrumentationAgent = Boolean.parseBoolean(matcher.group(7));
-            List<String> jvmOpts = Lists.newArrayList(Splitter.on(',').split(matcher.group(8)));
-            return new DefaultDaemonContext(uid, new File(javaHome), new File(daemonRegistryDir), pid, idleTimeout, jvmOpts, applyInstrumentationAgent, priority);
+            boolean useNativeServices = Boolean.parseBoolean(matcher.group(8));
+            List<String> jvmOpts = Lists.newArrayList(Splitter.on(',').split(matcher.group(9)));
+            return new DefaultDaemonContext(uid, new File(javaHome), new File(daemonRegistryDir), pid, idleTimeout, jvmOpts, applyInstrumentationAgent, useNativeServices, priority);
         } else {
             return null;
         }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/testfixtures/internal/NativeServicesTestFixture.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/testfixtures/internal/NativeServicesTestFixture.java
@@ -17,11 +17,10 @@
 package org.gradle.testfixtures.internal;
 
 import org.gradle.internal.nativeintegration.services.NativeServices;
+import org.gradle.internal.nativeintegration.services.NativeServices.NativeIntegrationEnabled;
 import org.gradle.test.fixtures.file.TestFile;
 
 import java.io.File;
-
-import static org.gradle.internal.nativeintegration.services.NativeServices.NativeIntegrationCondition.RESOLVE_FROM_SYSTEM_PROPERTY;
 
 public class NativeServicesTestFixture {
     // Collect this early, as the process' current directory can change during embedded test execution
@@ -33,7 +32,7 @@ public class NativeServicesTestFixture {
         if (!initialized) {
             System.setProperty("org.gradle.native", "true");
             File nativeDir = getNativeServicesDir();
-            NativeServices.initializeOnDaemon(nativeDir, RESOLVE_FROM_SYSTEM_PROPERTY);
+            NativeServices.initializeOnDaemon(nativeDir, NativeIntegrationEnabled.fromSystemProperties());
             initialized = true;
         }
     }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/testfixtures/internal/NativeServicesTestFixture.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/testfixtures/internal/NativeServicesTestFixture.java
@@ -21,6 +21,8 @@ import org.gradle.test.fixtures.file.TestFile;
 
 import java.io.File;
 
+import static org.gradle.internal.nativeintegration.services.NativeServices.NativeIntegrationCondition.RESOLVE_FROM_SYSTEM_PROPERTY;
+
 public class NativeServicesTestFixture {
     // Collect this early, as the process' current directory can change during embedded test execution
     private static final TestFile TEST_DIR = new TestFile(new File(".").toURI());
@@ -31,7 +33,7 @@ public class NativeServicesTestFixture {
         if (!initialized) {
             System.setProperty("org.gradle.native", "true");
             File nativeDir = getNativeServicesDir();
-            NativeServices.initializeOnDaemon(nativeDir);
+            NativeServices.initializeOnDaemon(nativeDir, RESOLVE_FROM_SYSTEM_PROPERTY);
             initialized = true;
         }
     }


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/28203

Relates to https://github.com/gradle/gradle/issues/24875

The problem is, that we try to read `org.gradle.native=false ` via `System.getProperty()` in `NativeServices`, but that system property might not be set at that moment, see current master [NativeServices#213](https://github.com/gradle/gradle/blob/f6dd2cd8b0e1b877ad5f3e3fc156deb72dabf50c/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java#L213). 

The solution is to figure out if  `org.gradle.native=false` is set before initialization and to explicitly pass a flag to `NativeServices.initialize*()` call method.

The only thing I am not sure is, how to pass value directly to the `DefaultConnection` for tooling API:
https://github.com/gradle/gradle/blob/071cfacc05e873aa4bb878ffa45af6ef58d9ab84/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/DefaultConnection.java#L115

But I think we can read a value from system properties there as we did before, any thoughts?