### PR TITLE
Fix Teamcity parallel test setup for Smoke tests

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
@@ -4,7 +4,6 @@ import com.alibaba.fastjson.JSONObject
 import com.alibaba.fastjson.annotation.JSONField
 import common.functionalTestExtraParameters
 import jetbrains.buildServer.configs.kotlin.BuildSteps
-import jetbrains.buildServer.configs.kotlin.buildFeatures.parallelTests
 import jetbrains.buildServer.configs.kotlin.buildFeatures.perfmon
 import model.CIBuildModel
 import model.Stage
@@ -66,15 +65,8 @@ class FunctionalTest(
         parallelizationMethod.extraBuildParameters
     ).filter { it.isNotBlank() }.joinToString(separator = " ")
 
-    if (parallelizationMethod is ParallelizationMethod.TeamCityParallelTests && parallelizationMethod.numberOfBatches > 1) {
-        params {
-            param("env.TEAMCITY_PARALLEL_TESTS_ENABLED", "1")
-        }
-        features {
-            parallelTests {
-                this.numberOfBatches = parallelizationMethod.numberOfBatches
-            }
-        }
+    if (parallelizationMethod is ParallelizationMethod.TeamCityParallelTests) {
+        tcParallelTests(parallelizationMethod.numberOfBatches)
     }
 
     features {

--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -27,6 +27,7 @@ import jetbrains.buildServer.configs.kotlin.ProjectFeatures
 import jetbrains.buildServer.configs.kotlin.RelativeId
 import jetbrains.buildServer.configs.kotlin.buildFeatures.PullRequests
 import jetbrains.buildServer.configs.kotlin.buildFeatures.commitStatusPublisher
+import jetbrains.buildServer.configs.kotlin.buildFeatures.parallelTests
 import jetbrains.buildServer.configs.kotlin.buildFeatures.pullRequests
 import model.CIBuildModel
 import model.StageName
@@ -68,6 +69,19 @@ fun BuildFeatures.enablePullRequestFeature() {
             }
             filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
             filterTargetBranch = "+:refs/heads/${VersionedSettingsBranch.fromDslContext().branchName}"
+        }
+    }
+}
+
+fun BaseGradleBuildType.tcParallelTests(numberOfBatches: Int) {
+    if (numberOfBatches > 1) {
+        params {
+            param("env.TEAMCITY_PARALLEL_TESTS_ENABLED", "1")
+        }
+        features {
+            parallelTests {
+                this.numberOfBatches = numberOfBatches
+            }
         }
     }
 }

--- a/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
+++ b/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
@@ -3,7 +3,6 @@ package configurations
 import common.JvmCategory
 import common.requiresNotEc2Agent
 import common.toCapitalized
-import jetbrains.buildServer.configs.kotlin.buildFeatures.parallelTests
 import model.CIBuildModel
 import model.Stage
 
@@ -14,12 +13,9 @@ class SmokeTests(model: CIBuildModel, stage: Stage, testJava: JvmCategory, id: S
 
     features {
         publishBuildStatusToGithub(model)
-        if (splitNumber > 1) {
-            parallelTests {
-                numberOfBatches = splitNumber
-            }
-        }
     }
+
+    tcParallelTests(splitNumber)
 
     requirements {
         // Smoke tests is usually heavy and the build time is twice on EC2 agents


### PR DESCRIPTION
We only do test replay when setting the env var, that was missing from the smoke tests.