### PR TITLE
Disable toolchain discovery on CI

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -264,7 +264,8 @@ fun functionalTestParameters(os: Os): List<String> {
     return listOf(
         "-PteamCityBuildId=%teamcity.build.id%",
         os.javaInstallationLocations(),
-        "-Porg.gradle.java.installations.auto-download=false"
+        "-Porg.gradle.java.installations.auto-download=false",
+        "-Porg.gradle.java.installations.auto-detect=false",
     )
 }
 


### PR DESCRIPTION
We only want to use the toolchains we pass to the build on the command line, nothing else.

If you don't do this, tests might pick up different JVMs with different tools.jar, like seen in [this Build Scan comparison](https://ge.gradle.org/c/fqepahmjls5qm/dd6r3hpwurugu/task-inputs?expanded=WyJ4a3Z0bHNwb3dyb3J3LXJlbGVhc2Vub3RlcyIsInR5enN0cnpzb2U0ZHUtc3RhYmxlY2xhc3NwYXRoIiwibXR6YW13ajJtcDRuZy1zdGFibGVjbGFzc3BhdGgiLCJuZWd6NW9hNXgydm8yLXN0YWJsZWNsYXNzcGF0aCJd), causing cache misses. 