### PR TITLE
Respect TEAMCITY_PARALLEL_TESTS_ENABLED

### DIFF
--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildEnvironment.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildEnvironment.kt
@@ -91,7 +91,13 @@ fun toMergeQueueBaseBranch(actualBranch: String): String = when {
     else -> actualBranch
 }
 
-
+/**
+ * The build environment.
+ *
+ * WARNING: Every val in here must not change for they same daemon. If it does, changes will go undetected,
+ *          since this whole object is kept in the classloader between builds.
+ *          Anything that changes must be in a val with a get() method that recomputes the value each time.
+ */
 object BuildEnvironment {
 
     /**
@@ -115,7 +121,8 @@ object BuildEnvironment {
     val isTravis = "TRAVIS" in System.getenv()
     val isGhActions = "GITHUB_ACTIONS" in System.getenv()
     val isTeamCity = "TEAMCITY_VERSION" in System.getenv()
-    val isTeamCityParallelTestsEnabled = "TEAMCITY_PARALLEL_TESTS_ENABLED" in System.getenv()
+    val isTeamCityParallelTestsEnabled
+        get() = "TEAMCITY_PARALLEL_TESTS_ENABLED" in System.getenv()
     val isCodeQl: Boolean by lazy {
         // This logic is kept here instead of `codeql-analysis.init.gradle` because that file will hopefully be removed in the future.
         // Removing that file is waiting on the GitHub team fixing an issue in Autobuilder logic.


### PR DESCRIPTION
Changing the `TEAMCITY_PARALLEL_TESTS_ENABLED` did go unnoticed, since BuildEnvironment was created once and kept in memory between builds on the same daemon.

We fix this by reading the env var every time when someone queries the val.

Follow up for #28024.