### PR TITLE
Removing excludes from DirectoryScanner works in configuration cache #27225

### DIFF
--- a/platforms/core-execution/snapshots/src/integTest/groovy/org/gradle/internal/vfs/DefaultExcludesIntegrationTest.groovy
+++ b/platforms/core-execution/snapshots/src/integTest/groovy/org/gradle/internal/vfs/DefaultExcludesIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.vfs
 
 import org.apache.tools.ant.DirectoryScanner
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
 
 class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
 
@@ -142,9 +143,25 @@ class DefaultExcludesIntegrationTest extends AbstractIntegrationSpec{
         failure.assertHasCause "Cannot change default excludes during the build. They were changed from ${defaultExcludesFromSettings} to ${defaultExcludesInTask}. Configure default excludes in the settings script instead."
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/27225")
+    def "default excludes are remove properly"() {
+        settingsFile << removeDefaultExclude()
+
+        when:
+        run "copyTask"
+        then:
+        executedAndNotSkipped(":copyTask")
+    }
+
     private static String addDefaultExclude(String excludedFileName = EXCLUDED_FILE_NAME) {
         """
             ${DirectoryScanner.name}.addDefaultExclude('**/${ excludedFileName}')
+        """
+    }
+
+    private static String removeDefaultExclude() {
+        """
+            ${DirectoryScanner.name}.removeDefaultExclude('**/.gitignore')
         """
     }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/util/internal/PatternSpecFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/util/internal/PatternSpecFactory.java
@@ -93,6 +93,8 @@ public class PatternSpecFactory implements FileSystemDefaultExcludesListener {
         Set<String> defaultExcludes = new HashSet<String>(Arrays.asList(DirectoryScanner.getDefaultExcludes()));
         if (defaultExcludeSpecCache.isEmpty()) {
             updateDefaultExcludeSpecCache(defaultExcludes);
+        } else if(previousDefaultExcludes.size() < defaultExcludes.size()) {
+            updateDefaultExcludeSpecCache(previousDefaultExcludes);
         } else if (invalidChangeOfExcludes(defaultExcludes)) {
             failOnChangedDefaultExcludes(previousDefaultExcludes, defaultExcludes);
         }


### PR DESCRIPTION
Fix Issue https://github.com/gradle/gradle/issues/27225

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

The cause of this issue was identified as the removeDefaultExcludes() method being called during the build, causing a change in DefaultExcludes(), and subsequently triggering an additional initialization. 

Therefore, it was determined that if the size of previousDefaultExcludes is smaller than DefaultExcludes, the DefaultExcludesCache should be built using previousDefaultExcludes to prevent redundant initialization.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things