### PR TITLE
Respect OS for performance test history and flakiness handling

### DIFF
--- a/.teamcity/performance-test-durations.json
+++ b/.teamcity/performance-test-durations.json
@@ -4,51 +4,51 @@
     "testProject" : "nowInAndroidBuild",
     "linux" : 266,
     "windows" : 392,
-    "macOs" : 204
+    "macOs" : 209
   }, {
     "testProject" : "santaTrackerAndroidBuild",
     "linux" : 630,
-    "windows" : 873,
-    "macOs" : 422
+    "windows" : 988,
+    "macOs" : 462
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.android.AndroidIncrementalExecutionPerformanceTest.abi change with configuration caching",
   "durations" : [ {
     "testProject" : "nowInAndroidBuild",
-    "linux" : 271,
-    "windows" : 403,
-    "macOs" : 207
+    "linux" : 272,
+    "windows" : 396,
+    "macOs" : 215
   }, {
     "testProject" : "santaTrackerAndroidBuild",
     "linux" : 672,
-    "windows" : 903,
-    "macOs" : 488
+    "windows" : 799,
+    "macOs" : 480
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.android.AndroidIncrementalExecutionPerformanceTest.non-abi change",
   "durations" : [ {
     "testProject" : "nowInAndroidBuild",
     "linux" : 298,
-    "windows" : 437,
-    "macOs" : 228
+    "windows" : 400,
+    "macOs" : 205
   }, {
     "testProject" : "santaTrackerAndroidBuild",
     "linux" : 463,
-    "windows" : 667,
-    "macOs" : 329
+    "windows" : 885,
+    "macOs" : 392
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.android.AndroidIncrementalExecutionPerformanceTest.non-abi change with configuration caching",
   "durations" : [ {
     "testProject" : "nowInAndroidBuild",
     "linux" : 283,
-    "windows" : 413,
-    "macOs" : 218
+    "windows" : 392,
+    "macOs" : 214
   }, {
     "testProject" : "santaTrackerAndroidBuild",
     "linux" : 451,
-    "windows" : 631,
-    "macOs" : 348
+    "windows" : 698,
+    "macOs" : 454
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.calculate task graph with test finalizer",
@@ -258,7 +258,7 @@
   "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph (parallel = true, locking = false)",
   "durations" : [ {
     "testProject" : "excludeRuleMergingBuild",
-    "linux" : 201
+    "linux" : 202
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.corefeature.LargeDependencyGraphPerformanceTest.resolve large dependency graph (parallel = true, locking = true)",
@@ -447,7 +447,7 @@
   "scenario" : "org.gradle.performance.regression.java.JavaIDEModelPerformanceTest.get IDE model for Eclipse",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 760
+    "linux" : 762
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.java.JavaIDEModelPerformanceTest.get IDE model for IDEA",
@@ -463,7 +463,7 @@
   }, {
     "testProject" : "largeJavaMultiProject",
     "linux" : 411,
-    "windows" : 916,
+    "windows" : 914,
     "macOs" : 284
   }, {
     "testProject" : "largeMonolithicGroovyProject",
@@ -477,8 +477,8 @@
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
     "linux" : 295,
-    "windows" : 836,
-    "macOs" : 275
+    "windows" : 745,
+    "macOs" : 232
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.assemble for non-abi change",
@@ -487,7 +487,7 @@
     "linux" : 537
   }, {
     "testProject" : "largeJavaMultiProject",
-    "linux" : 396,
+    "linux" : 397,
     "windows" : 897,
     "macOs" : 275
   }, {
@@ -495,15 +495,15 @@
     "linux" : 1805
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 1061
+    "linux" : 1063
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.assemble for non-abi change with configuration caching",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
     "linux" : 245,
-    "windows" : 710,
-    "macOs" : 235
+    "windows" : 672,
+    "macOs" : 231
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.test for non-abi change",
@@ -524,14 +524,14 @@
     "linux" : 508
   }, {
     "testProject" : "largeMonolithicJavaProject",
-    "linux" : 208
+    "linux" : 209
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.up-to-date assemble (parallel true)",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
     "linux" : 405,
-    "windows" : 888
+    "windows" : 872
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.up-to-date assemble with local build cache enabled (parallel false)",
@@ -672,7 +672,7 @@
   "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with build file change",
   "durations" : [ {
     "testProject" : "smallNativeMonolithic",
-    "linux" : 475
+    "linux" : 476
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.nativeplatform.RealWorldNativePluginPerformanceTest.build with header file change",

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -190,9 +190,23 @@ class PerformanceTestPlugin : Plugin<Project> {
             databaseParameters = project.propertiesForPerformanceDb
             branchName = buildBranch
             channel.convention(branchName.map { "commits-$it" })
-            channelPatterns.add(logicalBranch)
-            channelPatterns.add(logicalBranch.map { "commits-pre-test/$it/%" })
-            channelPatterns.add(logicalBranch.map { "commits-gh-readonly-queue/$it/%" })
+            val prefix = channel.map { channelName ->
+                val osIndependentPrefix = if (channelName.startsWith("flakiness-detection")) {
+                    "flakiness-detection"
+                } else {
+                    channelName.substringBefore('-')
+                }
+                if (channelName.startsWith("$osIndependentPrefix-macos")) {
+                    "$osIndependentPrefix-macos"
+                } else if (channelName.startsWith("$osIndependentPrefix-windows")) {
+                    "$osIndependentPrefix-windows"
+                } else {
+                    osIndependentPrefix
+                }
+            }
+            channelPatterns.add(prefix.zip(logicalBranch) { prefixString, branch -> "$prefixString-$branch" })
+            channelPatterns.add(prefix.zip(logicalBranch) { prefixString, branch -> "$prefixString-pre-test/$branch/%" })
+            channelPatterns.add(prefix.zip(logicalBranch) { prefixString, branch -> "$prefixString-gh-readonly-queue/$branch/%" })
             commitId = buildCommitId
             projectName = project.name
         }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/DefaultPerformanceFlakinessDataProvider.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/DefaultPerformanceFlakinessDataProvider.java
@@ -27,9 +27,9 @@ public class DefaultPerformanceFlakinessDataProvider implements PerformanceFlaki
     private final Map<PerformanceExperiment, BigDecimal> flakinessRates;
     private final Map<PerformanceExperiment, BigDecimal> failureThresholds;
 
-    public DefaultPerformanceFlakinessDataProvider(CrossVersionResultsStore crossVersionResultsStore) {
-        flakinessRates = crossVersionResultsStore.getFlakinessRates();
-        failureThresholds = crossVersionResultsStore.getFailureThresholds();
+    public DefaultPerformanceFlakinessDataProvider(CrossVersionResultsStore crossVersionResultsStore, OperatingSystem os) {
+        flakinessRates = crossVersionResultsStore.getFlakinessRates(os);
+        failureThresholds = crossVersionResultsStore.getFailureThresholds(os);
     }
 
     @Override

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceTestRuntimesGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceTestRuntimesGenerator.java
@@ -25,10 +25,13 @@ import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toMap;
 
 public class PerformanceTestRuntimesGenerator {
 
@@ -37,50 +40,61 @@ public class PerformanceTestRuntimesGenerator {
     }
 
     public void generate(File runtimesFile) throws IOException {
-        AllResultsStore resultsStore = new AllResultsStore();
-        PerformanceFlakinessDataProvider flakinessDataProvider = new DefaultPerformanceFlakinessDataProvider(new CrossVersionResultsStore());
-        Map<PerformanceExperimentOnOs, Long> estimatedExperimentDurations = resultsStore.getEstimatedExperimentDurationsInMillis();
-        Map<PerformanceScenario, List<Map.Entry<PerformanceExperimentOnOs, Long>>> performanceScenarioMap =
-            estimatedExperimentDurations.entrySet().stream()
-                .collect(Collectors.groupingBy(
-                    it -> it.getKey().getPerformanceExperiment().getScenario(),
-                    LinkedHashMap::new,
-                    Collectors.toList())
-                );
-        List<PerformanceScenarioDurations> json = performanceScenarioMap.entrySet().stream()
-            .map(entry -> {
-                PerformanceScenario scenario = entry.getKey();
-                Map<String, Map<OperatingSystem, Long>> perTestProject = entry.getValue().stream()
+        try (AllResultsStore resultsStore = new AllResultsStore()) {
+            Map<OperatingSystem, PerformanceFlakinessDataProvider> flakinessDataProviders = Arrays.stream(OperatingSystem.values())
+                .collect(toMap(
+                    os -> os,
+                    os -> new DefaultPerformanceFlakinessDataProvider(new CrossVersionResultsStore(), os)));
+            Map<PerformanceExperimentOnOs, Long> estimatedExperimentDurations = resultsStore.getEstimatedExperimentDurationsInMillis();
+            Map<PerformanceScenario, List<Map.Entry<PerformanceExperimentOnOs, Long>>> performanceScenarioMap =
+                estimatedExperimentDurations.entrySet().stream()
                     .collect(Collectors.groupingBy(
-                        it -> it.getKey().getPerformanceExperiment().getTestProject(),
+                        it -> it.getKey().getPerformanceExperiment().getScenario(),
                         LinkedHashMap::new,
-                        Collectors.toMap(it -> it.getKey().getOperatingSystem(), Map.Entry::getValue)
-                    ));
-                return new PerformanceScenarioDurations(
-                    scenario.getClassName() + "." + scenario.getTestName(),
-                    perTestProject.entrySet().stream()
-                        .map(experimentEntry -> {
-                            BigDecimal flakinessRate = flakinessDataProvider.getFlakinessRate(new PerformanceExperiment(experimentEntry.getKey(), scenario));
-                            Map<OperatingSystem, Long> perOs = experimentEntry.getValue();
-                                return new TestProjectDuration(
-                                    experimentEntry.getKey(),
-                                    increaseByFlakinessRate(perOs.get(OperatingSystem.LINUX), flakinessRate),
-                                    increaseByFlakinessRate(perOs.get(OperatingSystem.WINDOWS), flakinessRate),
-                                    increaseByFlakinessRate(perOs.get(OperatingSystem.MAC_OS), flakinessRate)
-                                );
-                            }
-                        )
-                        .collect(Collectors.toList())
-                );
-            })
-            .collect(Collectors.toList());
+                        Collectors.toList())
+                    );
+            List<PerformanceScenarioDurations> json = performanceScenarioMap.entrySet().stream()
+                .map(entry -> {
+                    PerformanceScenario scenario = entry.getKey();
+                    Map<String, Map<OperatingSystem, Long>> perTestProject = entry.getValue().stream()
+                        .collect(Collectors.groupingBy(
+                            it -> it.getKey().getPerformanceExperiment().getTestProject(),
+                            LinkedHashMap::new,
+                            toMap(it -> it.getKey().getOperatingSystem(), Map.Entry::getValue)
+                        ));
+                    return new PerformanceScenarioDurations(
+                        scenario.getClassName() + "." + scenario.getTestName(),
+                        perTestProject.entrySet().stream()
+                            .map(experimentEntry -> {
+                                    PerformanceExperiment experiment = new PerformanceExperiment(experimentEntry.getKey(), scenario);
+                                    Map<OperatingSystem, Long> perOs = experimentEntry.getValue();
+                                    return new TestProjectDuration(
+                                        experimentEntry.getKey(),
+                                        estimatedTimeForOs(experiment, OperatingSystem.LINUX, perOs, flakinessDataProviders),
+                                        estimatedTimeForOs(experiment, OperatingSystem.WINDOWS, perOs, flakinessDataProviders),
+                                        estimatedTimeForOs(experiment, OperatingSystem.MAC_OS, perOs, flakinessDataProviders)
+                                    );
+                                }
+                            )
+                            .collect(Collectors.toList())
+                    );
+                })
+                .collect(Collectors.toList());
 
-        new ObjectMapper().writerWithDefaultPrettyPrinter()
-            .writeValue(runtimesFile, json);
-        Files.write(runtimesFile.toPath(), "\n".getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+            new ObjectMapper().writerWithDefaultPrettyPrinter()
+                .writeValue(runtimesFile, json);
+            Files.write(runtimesFile.toPath(), "\n".getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+        }
     }
 
-    Long increaseByFlakinessRate(Long baseDuration, @Nullable BigDecimal flakinessRate) {
+    private static Long estimatedTimeForOs(PerformanceExperiment experiment, OperatingSystem os, Map<OperatingSystem, Long> perOs, Map<OperatingSystem, PerformanceFlakinessDataProvider> flakinessDataProviders) {
+        Long baseDuration = perOs.get(os);
+        PerformanceFlakinessDataProvider performanceFlakinessDataProvider = flakinessDataProviders.get(os);
+        BigDecimal flakinessRate = performanceFlakinessDataProvider.getFlakinessRate(experiment);
+        return increaseByFlakinessRate(baseDuration, flakinessRate);
+    }
+
+    private static Long increaseByFlakinessRate(Long baseDuration, @Nullable BigDecimal flakinessRate) {
         if (flakinessRate == null || baseDuration == null) {
             return baseDuration;
         }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ResultsStoreHelper.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ResultsStoreHelper.java
@@ -79,6 +79,26 @@ public class ResultsStoreHelper {
         return System.getProperty(SYSPROP_PERFORMANCE_TEST_CHANNEL, "commits");
     }
 
+    public static OperatingSystem determineOsFromChannel() {
+        String channel = determineChannel();
+        int firstDashIndex = channel.indexOf('-');
+        if (firstDashIndex == -1) {
+            return OperatingSystem.LINUX;
+        }
+        String prefix = channel.startsWith("flakiness-detection")
+            ? "flakiness-detection"
+            : channel.substring(0, firstDashIndex);
+        String channelWithoutPrefix = channel.substring(prefix.length());
+        if (channelWithoutPrefix.startsWith(OperatingSystem.MAC_OS.getChannelSuffix())) {
+            return OperatingSystem.MAC_OS;
+        } else if (channelWithoutPrefix.startsWith(OperatingSystem.WINDOWS.getChannelSuffix())) {
+            return OperatingSystem.WINDOWS;
+        } else {
+            return OperatingSystem.LINUX;
+        }
+
+    }
+
     public static List<String> determineChannelPatterns() {
         List<String> patterns = new ArrayList<>();
         patterns.add(ResultsStoreHelper.determineChannel());

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/DefaultReportGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/DefaultReportGenerator.java
@@ -21,6 +21,7 @@ import org.gradle.performance.results.CrossVersionResultsStore;
 import org.gradle.performance.results.DefaultPerformanceFlakinessDataProvider;
 import org.gradle.performance.results.PerformanceDatabase;
 import org.gradle.performance.results.PerformanceFlakinessDataProvider;
+import org.gradle.performance.results.ResultsStoreHelper;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -38,7 +39,7 @@ public class DefaultReportGenerator extends AbstractReportGenerator<AllResultsSt
     protected PerformanceFlakinessDataProvider getFlakinessDataProvider() {
         if (PerformanceDatabase.isAvailable()) {
             try (CrossVersionResultsStore resultsStore = new CrossVersionResultsStore()) {
-                return new DefaultPerformanceFlakinessDataProvider(resultsStore);
+                return new DefaultPerformanceFlakinessDataProvider(resultsStore, ResultsStoreHelper.determineOsFromChannel());
             }
         } else {
             return super.getFlakinessDataProvider();


### PR DESCRIPTION
Since we now have operating system specific channels for the performance history and flakiness detection, we should use them when querying as well.