### PR TITLE
Lock on project when calculating configuration metadata dependencies

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilder.java
@@ -53,7 +53,6 @@ import org.gradle.internal.model.ModelContainer;
 
 import javax.annotation.Nullable;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -222,71 +221,44 @@ public class DefaultLocalConfigurationMetadataBuilder implements LocalConfigurat
         }
     }
 
+    /**
+     * Lazily collect all dependencies and excludes of all configurations in the provided {@code hierarchy}.
+     */
     private CalculatedValue<DefaultLocalConfigurationMetadata.ConfigurationDependencyMetadata> getConfigurationDependencyState(
         ConfigurationsProvider configurationsProvider,
         DependencyCache dependencyCache,
         ModelContainer<?> model,
         CalculatedValueContainerFactory calculatedValueContainerFactory,
         String description,
-        ImmutableSet<String> unsortedHierarchy,
+        ImmutableSet<String> hierarchy,
         ImmutableAttributes attributes
     ) {
-        List<String> sortedHierarchy = getSortedHierarchyForDependencies(configurationsProvider, unsortedHierarchy);
-        return calculatedValueContainerFactory.create(Describables.of("Dependency state for", description), context -> {
-
-            boolean needsProjectLock = false;
-            List<DependencyState> states = new ArrayList<>(sortedHierarchy.size());
-            for (String config : sortedHierarchy) {
-                DependencyState state = dependencyCache.get(config);
-                states.add(state);
-                needsProjectLock |= state == null;
-            }
-
-            if (needsProjectLock) {
-                // Some configurations do not have cached dependency state.
-                // We need to lock the project to calculate the dependency state for these configurations.
-                model.applyToMutableState(p -> {
-                    for (int i = 0; i < sortedHierarchy.size(); i++) {
-                        if (states.get(i) == null) {
-                            String config = sortedHierarchy.get(i);
-                            ConfigurationInternal configuration = configurationsProvider.findByName(config);
-                            states.set(i, dependencyCache.computeIfAbsent(configuration, this::doGetDefinedState));
-                        }
-                    }
-                });
-            }
-
+        return calculatedValueContainerFactory.create(Describables.of("Dependency state for", description), context -> model.fromMutableState(p -> {
             ImmutableList.Builder<LocalOriginDependencyMetadata> dependencies = ImmutableList.builder();
             ImmutableSet.Builder<LocalFileDependencyMetadata> files = ImmutableSet.builder();
             ImmutableList.Builder<ExcludeMetadata> excludes = ImmutableList.builder();
 
-            for (DependencyState state : states) {
-                dependencies.addAll(state.dependencies);
-                files.addAll(state.files);
-                excludes.addAll(state.excludes);
-            }
+            configurationsProvider.visitAll(config -> {
+                if (hierarchy.contains(config.getName())) {
+                    DependencyState defined = getDefinedState(config, dependencyCache);
+                    dependencies.addAll(defined.dependencies);
+                    files.addAll(defined.files);
+                    excludes.addAll(defined.excludes);
+                }
+            });
 
             DependencyState state = new DependencyState(dependencies.build(), files.build(), excludes.build());
-
             return new DefaultLocalConfigurationMetadata.ConfigurationDependencyMetadata(
                 maybeForceDependencies(state.dependencies, attributes), state.files, state.excludes
             );
-        });
+        }));
     }
 
     /**
-     * Sorts the configuration's hierarchy in an arbitrary order.
-     * This order influences the order that dependencies are resolved and can therefore affect the resolved graph and artifacts.
-     * There is no reason to use this ordering other than for historical consistency.
+     * Get the defined dependencies and excludes for {@code configuration}, while also caching the result.
      */
-    private static List<String> getSortedHierarchyForDependencies(ConfigurationsProvider configurationsProvider, ImmutableSet<String> hierarchy) {
-        List<String> sortedHierarchy = new ArrayList<>(hierarchy.size());
-        configurationsProvider.visitAll(config -> {
-            if (hierarchy.contains(config.getName())) {
-                sortedHierarchy.add(config.getName());
-            }
-        });
-        return sortedHierarchy;
+    private DependencyState getDefinedState(ConfigurationInternal configuration, DependencyCache cache) {
+        return cache.computeIfAbsent(configuration, this::doGetDefinedState);
     }
 
     /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/LocalConfigurationMetadataBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/LocalConfigurationMetadataBuilder.java
@@ -27,9 +27,8 @@ import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.model.ModelContainer;
 
-import javax.annotation.Nullable;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 /**
@@ -58,12 +57,7 @@ public interface LocalConfigurationMetadataBuilder {
      * (resolvable and consumable), these conversions do not need to be executed multiple times.
      */
     class DependencyCache {
-        private final Map<String, DefaultLocalConfigurationMetadataBuilder.DependencyState> cache = new ConcurrentHashMap<>();
-
-        @Nullable
-        public DefaultLocalConfigurationMetadataBuilder.DependencyState get(String configurationName) {
-            return cache.get(configurationName);
-        }
+        private final Map<String, DefaultLocalConfigurationMetadataBuilder.DependencyState> cache = new HashMap<>();
 
         public DefaultLocalConfigurationMetadataBuilder.DependencyState computeIfAbsent(
             ConfigurationInternal configuration,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/LocalConfigurationMetadataBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/LocalConfigurationMetadataBuilder.java
@@ -27,8 +27,9 @@ import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.model.ModelContainer;
 
-import java.util.HashMap;
+import javax.annotation.Nullable;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 /**
@@ -57,7 +58,12 @@ public interface LocalConfigurationMetadataBuilder {
      * (resolvable and consumable), these conversions do not need to be executed multiple times.
      */
     class DependencyCache {
-        private final Map<String, DefaultLocalConfigurationMetadataBuilder.DependencyState> cache = new HashMap<>();
+        private final Map<String, DefaultLocalConfigurationMetadataBuilder.DependencyState> cache = new ConcurrentHashMap<>();
+
+        @Nullable
+        public DefaultLocalConfigurationMetadataBuilder.DependencyState get(String configurationName) {
+            return cache.get(configurationName);
+        }
 
         public DefaultLocalConfigurationMetadataBuilder.DependencyState computeIfAbsent(
             ConfigurationInternal configuration,


### PR DESCRIPTION
Calculating configuration dependencies requires iterating over the configuration container Iterating over this container can realize lazy elements, causing CMEs.

We guard access to this container while accessing it. An effort was made to avoid acquiring the project lock if all configuration dependency state has already been cached.

May fix: https://github.com/gradle/gradle/issues/28028

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
