### PR TITLE
Allow for returning DependencyCollector from DSL methods

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyCollector.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyCollector.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.artifacts.dsl;
 
+import com.h0tk3y.kotlin.staticObjectNotation.Restricted;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.NonExtensible;
@@ -48,6 +49,7 @@ import java.util.Set;
  *
  * @since 8.6
  */
+@Restricted
 @Incubating
 @NonExtensible
 @SuppressWarnings("JavadocReference")

--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/AllDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/AllDistributionIntegrationSpec.groovy
@@ -36,7 +36,7 @@ class AllDistributionIntegrationSpec extends DistributionIntegrationSpec {
 
     @Override
     int getMaxDistributionSizeBytes() {
-        return 217 * 1024 * 1024
+        return 218 * 1024 * 1024
     }
 
     @Requires(UnitTestPreconditions.StableGroovy) // cannot link to public javadocs of Groovy snapshots like https://docs.groovy-lang.org/docs/groovy-4.0.5-SNAPSHOT/html/gapi/

--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
@@ -38,7 +38,7 @@ class SrcDistributionIntegrationSpec extends DistributionIntegrationSpec {
 
     @Override
     int getMaxDistributionSizeBytes() {
-        return 60 * 1024 * 1024
+        return 61 * 1024 * 1024
     }
 
     @Override


### PR DESCRIPTION
Having this type annotated would be helpful for our declarative experiments on the JVM team.  Could we add this to your development branch?

Update: Looks like we can merge this into master now.  
Update: Maybe not?  