### PR TITLE
Eagerly calculate size for local store

### DIFF
--- a/platforms/core-execution/build-cache/src/main/java/org/gradle/caching/internal/controller/service/OpFiringLocalBuildCacheServiceHandle.java
+++ b/platforms/core-execution/build-cache/src/main/java/org/gradle/caching/internal/controller/service/OpFiringLocalBuildCacheServiceHandle.java
@@ -121,11 +121,11 @@ public class OpFiringLocalBuildCacheServiceHandle extends BaseLocalBuildCacheSer
 
     private static class LocalStoreDetails implements BuildCacheLocalStoreBuildOperationType.Details {
         private final BuildCacheKey key;
-        private final File file;
+        private final long archiveSize;
 
         public LocalStoreDetails(BuildCacheKey key, File file) {
             this.key = key;
-            this.file = file;
+            this.archiveSize = file.length();
         }
 
         @Override
@@ -135,7 +135,7 @@ public class OpFiringLocalBuildCacheServiceHandle extends BaseLocalBuildCacheSer
 
         @Override
         public long getArchiveSize() {
-            return file.length();
+            return archiveSize;
         }
     }
 }

--- a/platforms/core-execution/build-cache/src/main/java/org/gradle/caching/internal/controller/service/OpFiringLocalBuildCacheServiceHandle.java
+++ b/platforms/core-execution/build-cache/src/main/java/org/gradle/caching/internal/controller/service/OpFiringLocalBuildCacheServiceHandle.java
@@ -125,6 +125,8 @@ public class OpFiringLocalBuildCacheServiceHandle extends BaseLocalBuildCacheSer
 
         public LocalStoreDetails(BuildCacheKey key, File file) {
             this.key = key;
+            // We need to calculate the size eagerly here, since the file will already be gone
+            // (aka in the local cache), when the DV plugin queries the value.
             this.archiveSize = file.length();
         }
 


### PR DESCRIPTION
Since the temporary file will be moved away and we can't lazily access its size.