### PR TITLE
Run precondition tester on Intel macs

### DIFF
--- a/.teamcity/src/main/kotlin/model/FunctionalTestBucketGenerator.kt
+++ b/.teamcity/src/main/kotlin/model/FunctionalTestBucketGenerator.kt
@@ -191,7 +191,8 @@ fun onlyNativeSubprojectsForIntelMacs(
 ): Boolean {
     return if (testCoverage.os == Os.MACOS && testCoverage.arch == Arch.AMD64) {
         subprojectName.contains("native") ||
-            subprojectName in listOf("file-watching", "snapshots", "workers", "logging")
+            // Include precondition-tester here so we understand that tests do run on macOS intel as well
+            subprojectName in listOf("file-watching", "snapshots", "workers", "logging", "precondition-tester")
     } else {
         true
     }


### PR DESCRIPTION
Since we also run tests there. We should probably have a different check that only the subprojects here can use the condition.

A quick check for `HasXCode` and `NotMacOsM1` shows that `HasXCode` seems to be fine, though there are some tests in `build-init` and `integTest` that don't run on M1 macs. 
<img width="672" alt="image" src="https://github.com/gradle/gradle/assets/423186/3f427846-2b57-4528-8fda-38dbc263625a">
