### PR TITLE
Move more Develocity services to BuildTree scope

### DIFF
--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginBackgroundJobExecutors.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginBackgroundJobExecutors.java
@@ -16,12 +16,16 @@
 
 package org.gradle.internal.enterprise;
 
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
+
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 
 /**
  * Provides executors to run jobs in the background workers. The implementation is provided by Gradle.
  */
+@ServiceScope(Scopes.BuildTree.class)
 public interface GradleEnterprisePluginBackgroundJobExecutors {
     /**
      * Returns the executor to run user-provided background jobs in the background workers.

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginBuildState.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginBuildState.java
@@ -17,6 +17,8 @@
 package org.gradle.internal.enterprise;
 
 import org.gradle.StartParameter;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.launcher.daemon.server.scaninfo.DaemonScanInfo;
 
 import javax.annotation.Nullable;
@@ -24,6 +26,7 @@ import javax.annotation.Nullable;
 /**
  * Information about the current build invocation or build invocation environment required by the plugin.
  */
+@ServiceScope(Scopes.BuildTree.class)
 public interface GradleEnterprisePluginBuildState {
 
     long getBuildStartedTime();

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInService.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInService.java
@@ -16,11 +16,15 @@
 
 package org.gradle.internal.enterprise;
 
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
+
 /**
  * The plugin uses this to announce its presence and provide its service.
  *
  * It is obtained via the settings object's service registry for the root build only.
  */
+@ServiceScope(Scopes.Gradle.class)
 public interface GradleEnterprisePluginCheckInService {
 
     /**

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginConfig.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginConfig.java
@@ -16,9 +16,13 @@
 
 package org.gradle.internal.enterprise;
 
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
+
 /**
  * Information eagerly conveyed about the plugin from Gradle to the plugin.
  */
+@ServiceScope(Scopes.Gradle.class)
 public interface GradleEnterprisePluginConfig {
 
     enum BuildScanRequest {

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginConfig.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginConfig.java
@@ -22,7 +22,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
 /**
  * Information eagerly conveyed about the plugin from Gradle to the plugin.
  */
-@ServiceScope(Scopes.Gradle.class)
+@ServiceScope(Scopes.BuildTree.class)
 public interface GradleEnterprisePluginConfig {
 
     enum BuildScanRequest {

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginRequiredServices.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginRequiredServices.java
@@ -18,10 +18,13 @@ package org.gradle.internal.enterprise;
 
 import org.gradle.api.internal.tasks.userinput.UserInputHandler;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 /**
  * Infrastructure like services used by the plugin.
  */
+@ServiceScope(Scopes.Gradle.class)
 public interface GradleEnterprisePluginRequiredServices {
 
     UserInputHandler getUserInputHandler();

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginServiceRef.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginServiceRef.java
@@ -16,12 +16,16 @@
 
 package org.gradle.internal.enterprise;
 
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
+
 /**
  * A service that provides the plugin service for the current build invocation.
  *
  * The plugin uses this to encapsulate its service in user facing code that may be cached.
  * This allows such cached code to use the plugin service for the current build when used from-cache.
  */
+@ServiceScope(Scopes.BuildTree.class)
 public interface GradleEnterprisePluginServiceRef {
 
     GradleEnterprisePluginService get();

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginBackgroundJobExecutors.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginBackgroundJobExecutors.java
@@ -33,7 +33,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-@ServiceScope(Scopes.Gradle.class)
+@ServiceScope(Scopes.BuildTree.class)
 public class DefaultGradleEnterprisePluginBackgroundJobExecutors implements GradleEnterprisePluginBackgroundJobExecutors {
     private final ManagedExecutor executorService = createExecutor();
     private final InputTrackingState inputTrackingState;

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginBackgroundJobExecutors.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginBackgroundJobExecutors.java
@@ -21,8 +21,6 @@ import org.gradle.internal.concurrent.ExecutorPolicy;
 import org.gradle.internal.concurrent.ManagedExecutor;
 import org.gradle.internal.concurrent.ManagedExecutorImpl;
 import org.gradle.internal.enterprise.GradleEnterprisePluginBackgroundJobExecutors;
-import org.gradle.internal.service.scopes.Scopes;
-import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
@@ -33,7 +31,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-@ServiceScope(Scopes.BuildTree.class)
 public class DefaultGradleEnterprisePluginBackgroundJobExecutors implements GradleEnterprisePluginBackgroundJobExecutors {
     private final ManagedExecutor executorService = createExecutor();
     private final InputTrackingState inputTrackingState;

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginBuildState.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginBuildState.java
@@ -28,7 +28,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.time.Clock;
 import org.gradle.launcher.daemon.server.scaninfo.DaemonScanInfo;
 
-@ServiceScope(Scopes.Gradle.class)
+@ServiceScope(Scopes.BuildTree.class)
 public class DefaultGradleEnterprisePluginBuildState implements GradleEnterprisePluginBuildState {
 
     private final Clock clock;

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginBuildState.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginBuildState.java
@@ -23,12 +23,9 @@ import org.gradle.internal.enterprise.GradleEnterprisePluginBuildState;
 import org.gradle.internal.scopeids.id.BuildInvocationScopeId;
 import org.gradle.internal.scopeids.id.UserScopeId;
 import org.gradle.internal.scopeids.id.WorkspaceScopeId;
-import org.gradle.internal.service.scopes.Scopes;
-import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.time.Clock;
 import org.gradle.launcher.daemon.server.scaninfo.DaemonScanInfo;
 
-@ServiceScope(Scopes.BuildTree.class)
 public class DefaultGradleEnterprisePluginBuildState implements GradleEnterprisePluginBuildState {
 
     private final Clock clock;

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginBuildState.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginBuildState.java
@@ -17,12 +17,12 @@
 package org.gradle.internal.enterprise.impl;
 
 import org.gradle.StartParameter;
-import org.gradle.api.internal.GradleInternal;
 import org.gradle.internal.buildevents.BuildStartedTime;
 import org.gradle.internal.enterprise.GradleEnterprisePluginBuildState;
 import org.gradle.internal.scopeids.id.BuildInvocationScopeId;
 import org.gradle.internal.scopeids.id.UserScopeId;
 import org.gradle.internal.scopeids.id.WorkspaceScopeId;
+import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.time.Clock;
 import org.gradle.launcher.daemon.server.scaninfo.DaemonScanInfo;
 
@@ -33,7 +33,8 @@ public class DefaultGradleEnterprisePluginBuildState implements GradleEnterprise
     private final BuildInvocationScopeId buildInvocationId;
     private final WorkspaceScopeId workspaceId;
     private final UserScopeId userId;
-    private final GradleInternal gradle;
+    private final StartParameter startParameter;
+    private final ServiceRegistry serviceRegistry;
 
     public DefaultGradleEnterprisePluginBuildState(
         Clock clock,
@@ -41,14 +42,16 @@ public class DefaultGradleEnterprisePluginBuildState implements GradleEnterprise
         BuildInvocationScopeId buildInvocationId,
         WorkspaceScopeId workspaceId,
         UserScopeId userId,
-        GradleInternal gradle
+        StartParameter startParameter,
+        ServiceRegistry serviceRegistry
     ) {
         this.clock = clock;
         this.buildStartedTime = buildStartedTime;
         this.buildInvocationId = buildInvocationId;
         this.workspaceId = workspaceId;
         this.userId = userId;
-        this.gradle = gradle;
+        this.startParameter = startParameter;
+        this.serviceRegistry = serviceRegistry;
     }
 
     @Override
@@ -78,11 +81,11 @@ public class DefaultGradleEnterprisePluginBuildState implements GradleEnterprise
 
     @Override
     public DaemonScanInfo getDaemonScanInfo() {
-        return (DaemonScanInfo) gradle.getServices().find(DaemonScanInfo.class);
+        return (DaemonScanInfo) serviceRegistry.find(DaemonScanInfo.class);
     }
 
     @Override
     public StartParameter getStartParameter() {
-        return gradle.getStartParameter();
+        return startParameter;
     }
 }

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginCheckInService.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginCheckInService.java
@@ -24,13 +24,10 @@ import org.gradle.internal.enterprise.GradleEnterprisePluginMetadata;
 import org.gradle.internal.enterprise.GradleEnterprisePluginServiceFactory;
 import org.gradle.internal.enterprise.GradleEnterprisePluginServiceRef;
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
-import org.gradle.internal.service.scopes.Scopes;
-import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.util.internal.VersionNumber;
 
 import java.util.function.Supplier;
 
-@ServiceScope(Scopes.Gradle.class)
 public class DefaultGradleEnterprisePluginCheckInService implements GradleEnterprisePluginCheckInService {
 
     private final GradleEnterprisePluginManager manager;

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginConfig.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginConfig.java
@@ -20,10 +20,7 @@ import org.gradle.StartParameter;
 import org.gradle.api.internal.BuildType;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.internal.enterprise.GradleEnterprisePluginConfig;
-import org.gradle.internal.service.scopes.Scopes;
-import org.gradle.internal.service.scopes.ServiceScope;
 
-@ServiceScope(Scopes.Gradle.class)
 public class DefaultGradleEnterprisePluginConfig implements GradleEnterprisePluginConfig {
 
     private final BuildScanRequest buildScanRequest;

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginConfig.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginConfig.java
@@ -18,7 +18,6 @@ package org.gradle.internal.enterprise.impl;
 
 import org.gradle.StartParameter;
 import org.gradle.api.internal.BuildType;
-import org.gradle.api.internal.GradleInternal;
 import org.gradle.internal.enterprise.GradleEnterprisePluginConfig;
 
 public class DefaultGradleEnterprisePluginConfig implements GradleEnterprisePluginConfig {
@@ -27,8 +26,8 @@ public class DefaultGradleEnterprisePluginConfig implements GradleEnterprisePlug
     private final boolean taskExecutingBuild;
     private final boolean autoApplied;
 
-    public DefaultGradleEnterprisePluginConfig(GradleInternal gradle, BuildType buildType, GradleEnterprisePluginAutoAppliedStatus autoAppliedStatus) {
-        this.buildScanRequest = buildScanRequest(gradle.getStartParameter());
+    public DefaultGradleEnterprisePluginConfig(StartParameter startParameter, BuildType buildType, GradleEnterprisePluginAutoAppliedStatus autoAppliedStatus) {
+        this.buildScanRequest = buildScanRequest(startParameter);
         this.taskExecutingBuild = buildType == BuildType.TASKS;
         this.autoApplied = autoAppliedStatus.isAutoApplied();
     }

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginRequiredServices.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginRequiredServices.java
@@ -19,10 +19,7 @@ package org.gradle.internal.enterprise.impl;
 import org.gradle.api.internal.tasks.userinput.UserInputHandler;
 import org.gradle.internal.enterprise.GradleEnterprisePluginRequiredServices;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
-import org.gradle.internal.service.scopes.Scopes;
-import org.gradle.internal.service.scopes.ServiceScope;
 
-@ServiceScope(Scopes.Gradle.class)
 public class DefaultGradleEnterprisePluginRequiredServices implements GradleEnterprisePluginRequiredServices {
 
     private final UserInputHandler userInputHandler;

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginServiceRef.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginServiceRef.java
@@ -18,10 +18,7 @@ package org.gradle.internal.enterprise.impl;
 
 import org.gradle.internal.enterprise.GradleEnterprisePluginService;
 import org.gradle.internal.enterprise.GradleEnterprisePluginServiceRef;
-import org.gradle.internal.service.scopes.Scopes;
-import org.gradle.internal.service.scopes.ServiceScope;
 
-@ServiceScope(Scopes.BuildTree.class)
 public class DefaultGradleEnterprisePluginServiceRef implements GradleEnterprisePluginServiceRef {
 
     private GradleEnterprisePluginService service;

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/GradleEnterprisePluginServices.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/GradleEnterprisePluginServices.java
@@ -30,6 +30,9 @@ public class GradleEnterprisePluginServices extends AbstractPluginServiceRegistr
         registration.add(GradleEnterpriseAutoAppliedPluginRegistry.class);
         registration.add(GradleEnterprisePluginAutoAppliedStatus.class);
         registration.add(DefaultGradleEnterprisePluginServiceRef.class);
+        registration.add(DefaultGradleEnterprisePluginBuildState.class);
+        registration.add(DefaultGradleEnterprisePluginConfig.class);
+        registration.add(DefaultGradleEnterprisePluginBackgroundJobExecutors.class);
 
         // legacy
         registration.add(DefaultBuildScanClock.class);
@@ -44,9 +47,6 @@ public class GradleEnterprisePluginServices extends AbstractPluginServiceRegistr
     @Override
     public void registerGradleServices(ServiceRegistration registration) {
         registration.add(DefaultGradleEnterprisePluginAdapterFactory.class);
-        registration.add(DefaultGradleEnterprisePluginBackgroundJobExecutors.class);
-        registration.add(DefaultGradleEnterprisePluginBuildState.class);
-        registration.add(DefaultGradleEnterprisePluginConfig.class);
         registration.add(DefaultGradleEnterprisePluginCheckInService.class);
         registration.add(DefaultGradleEnterprisePluginRequiredServices.class);
 

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/legacy/DefaultBuildScanBuildStartedTime.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/legacy/DefaultBuildScanBuildStartedTime.java
@@ -18,12 +18,9 @@ package org.gradle.internal.enterprise.impl.legacy;
 
 import org.gradle.internal.buildevents.BuildStartedTime;
 import org.gradle.internal.scan.time.BuildScanBuildStartedTime;
-import org.gradle.internal.service.scopes.Scopes;
-import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.inject.Inject;
 
-@ServiceScope(Scopes.BuildTree.class)
 public class DefaultBuildScanBuildStartedTime implements BuildScanBuildStartedTime {
 
     private final BuildStartedTime buildStartedTime;

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/legacy/DefaultBuildScanClock.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/legacy/DefaultBuildScanClock.java
@@ -17,13 +17,10 @@
 package org.gradle.internal.enterprise.impl.legacy;
 
 import org.gradle.internal.scan.time.BuildScanClock;
-import org.gradle.internal.service.scopes.Scopes;
-import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.time.Clock;
 
 import javax.inject.Inject;
 
-@ServiceScope(Scopes.BuildTree.class)
 public class DefaultBuildScanClock implements BuildScanClock {
 
     private final Clock clock;

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/legacy/DefaultBuildScanScopeIds.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/legacy/DefaultBuildScanScopeIds.java
@@ -20,10 +20,7 @@ import org.gradle.internal.scan.scopeids.BuildScanScopeIds;
 import org.gradle.internal.scopeids.id.BuildInvocationScopeId;
 import org.gradle.internal.scopeids.id.UserScopeId;
 import org.gradle.internal.scopeids.id.WorkspaceScopeId;
-import org.gradle.internal.service.scopes.Scopes;
-import org.gradle.internal.service.scopes.ServiceScope;
 
-@ServiceScope(Scopes.Gradle.class)
 public class DefaultBuildScanScopeIds implements BuildScanScopeIds {
 
     private final BuildInvocationScopeId buildInvocationId;

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/scan/scopeids/BuildScanScopeIds.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/scan/scopeids/BuildScanScopeIds.java
@@ -17,11 +17,14 @@
 package org.gradle.internal.scan.scopeids;
 
 import org.gradle.internal.scopeids.id.BuildInvocationScopeId;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 /**
  * Obtained from the Gradle object services.
  * Exists to remove linkage against types such as {@link BuildInvocationScopeId} and friends.
  */
+@ServiceScope(Scopes.Gradle.class)
 public interface BuildScanScopeIds {
 
     String getBuildInvocationId();

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/scan/time/BuildScanBuildStartedTime.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/scan/time/BuildScanBuildStartedTime.java
@@ -17,6 +17,8 @@
 package org.gradle.internal.scan.time;
 
 import org.gradle.internal.buildevents.BuildStartedTime;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 /**
  * Used to determine when the build was started.
@@ -24,6 +26,7 @@ import org.gradle.internal.buildevents.BuildStartedTime;
  * This is effectively a build scan specific view of {@link BuildStartedTime}.
  * @since 4.2
  */
+@ServiceScope(Scopes.BuildTree.class)
 public interface BuildScanBuildStartedTime {
 
     long getBuildStartedTime();

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/scan/time/BuildScanClock.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/scan/time/BuildScanClock.java
@@ -16,6 +16,9 @@
 
 package org.gradle.internal.scan.time;
 
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
+
 /**
  * A view of the Gradle runtime's clock used by build scans.
  *
@@ -23,6 +26,7 @@ package org.gradle.internal.scan.time;
  *
  * @since 4.2
  */
+@ServiceScope(Scopes.BuildTree.class)
 public interface BuildScanClock {
 
     /**


### PR DESCRIPTION
The PR moves the `@ServiceScope` annotations to the interface where possible.

Follow-up for https://github.com/gradle/gradle/pull/27766/files#r1461467535.