### PR TITLE
Withdraw `ConfigurableFileCollection.convention(...)` from API

### DIFF
--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -231,14 +231,32 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         setExplicitCollector(newExplicitValue(path));
     }
 
-    @Override
+    /**
+     * Specifies the value to use as the convention (default value) to be used when resolving this file collection,
+     * if no source paths are explicitly defined.
+     *
+     * If, at the time this method is invoked, the set of source paths for this collection is empty, the convention will be used
+     * to resolve this file collection.
+     *
+     * @param paths The paths.
+     * @return this collection
+     */
     public ConfigurableFileCollection convention(Iterable<?> paths) {
         assertMutable();
         setConventionCollector(newConventionValue(paths));
         return this;
     }
 
-    @Override
+    /**
+     * Specifies the value to use as the convention (default value) to be used when resolving this file collection,
+     * if no source paths are explicitly defined.
+     *
+     * If, at the time this method is invoked, the set of source paths for this collection is empty, the convention will be used
+     * to resolve this file collection.
+     *
+     * @param paths The paths.
+     * @return this collection
+     */
     public ConfigurableFileCollection convention(Object... paths) {
         assertMutable();
         setConventionCollector(newConventionValue(paths));
@@ -264,7 +282,7 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
      * If the property has no convention set at the time this method is invoked,
      * the effect of invoking it is similar to invoking {@link #unset()}.
      */
-    protected SupportsConvention setToConvention() {
+    protected ConfigurableFileCollection setToConvention() {
         assertMutable();
         value = valueState.setToConvention();
         return this;
@@ -278,14 +296,18 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         value = valueState.explicitValue(valueCollector);
     }
 
-    @Override
+    /**
+     * @see SupportsConvention#unsetConvention()
+     */
     public ConfigurableFileCollection unsetConvention() {
         assertMutable();
         setConventionCollector(EMPTY_COLLECTOR);
         return this;
     }
 
-    @Override
+    /**
+     * @see SupportsConvention#unset()
+     */
     public ConfigurableFileCollection unset() {
         assertMutable();
         value = valueState.implicitValue();

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/FileCollectionConventionMappingIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/FileCollectionConventionMappingIntegrationTest.groovy
@@ -17,8 +17,11 @@
 package org.gradle.api.provider
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Ignore
 
 class FileCollectionConventionMappingIntegrationTest extends AbstractIntegrationSpec {
+    //TODO-RC re-enable for 8.8
+    @Ignore("https://github.com/gradle/gradle/pull/28135")
     def "convention mapping can be used with Configurable File Collection and an actual value"() {
         buildFile << """
             abstract class MyTask extends DefaultTask {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/extensibility/ConventionAwareHelper.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/extensibility/ConventionAwareHelper.java
@@ -19,7 +19,6 @@ package org.gradle.internal.extensibility;
 import groovy.lang.Closure;
 import groovy.lang.MissingPropertyException;
 import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.internal.provider.DefaultProvider;
@@ -108,9 +107,6 @@ public class ConventionAwareHelper implements ConventionMapping, org.gradle.api.
         } else if (target instanceof HasMultipleValues) {
             HasMultipleValues<Object> asCollectionProperty = Cast.uncheckedNonnullCast(target);
             asCollectionProperty.convention(new DefaultProvider<>(() -> Cast.uncheckedNonnullCast(mapping.getValue(_convention, _source))));
-        } else if (target instanceof ConfigurableFileCollection) {
-            ConfigurableFileCollection asFileCollection = Cast.uncheckedNonnullCast(target);
-            asFileCollection.convention((Callable) () -> mapping.getValue(_convention, _source));
         } else {
             return false;
         }

--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -1,14 +1,6 @@
 {
     "acceptedApiChanges": [
         {
-            "type": "org.gradle.api.file.ConfigurableFileCollection",
-            "member": "Class org.gradle.api.file.ConfigurableFileCollection",
-            "acceptation": "Introduce SupportsConvention",
-            "changes": [
-                "org.gradle.api.provider.SupportsConvention"
-            ]
-        },
-        {
             "type": "org.gradle.api.provider.HasMultipleValues",
             "member": "Class org.gradle.api.provider.HasMultipleValues",
             "acceptation": "Introduce SupportsConvention",

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
@@ -15,11 +15,9 @@
  */
 package org.gradle.api.file;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.SupportsKotlinAssignmentOverloading;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.HasConfigurableValue;
-import org.gradle.api.provider.SupportsConvention;
 
 import java.util.Set;
 
@@ -31,7 +29,7 @@ import java.util.Set;
  * <p><b>Note:</b> This interface is not intended for implementation by build script or plugin authors.</p>
  */
 @SupportsKotlinAssignmentOverloading
-public interface ConfigurableFileCollection extends FileCollection, HasConfigurableValue, SupportsConvention {
+public interface ConfigurableFileCollection extends FileCollection, HasConfigurableValue {
     /**
      * Returns the set of source paths for this collection. The paths are evaluated as per {@link org.gradle.api.Project#files(Object...)}.
      *
@@ -52,36 +50,6 @@ public interface ConfigurableFileCollection extends FileCollection, HasConfigura
      * @param paths The paths.
      */
     void setFrom(Object... paths);
-
-    /**
-     * Specifies the value to use as the convention (default value) to be used when resolving this file collection,
-     * if no source paths are explicitly defined.
-     *
-     * If, at the time this method is invoked, the set of source paths for this collection is empty, the convention will be used
-     * to resolve this file collection.
-     *
-     * @param paths The paths.
-     * @return this collection
-     *
-     * @since 8.7
-     */
-    @Incubating
-    ConfigurableFileCollection convention(Iterable<?> paths);
-
-    /**
-     * Specifies the value to use as the convention (default value) to be used when resolving this file collection,
-     * if no source paths are explicitly defined.
-     *
-     * If, at the time this method is invoked, the set of source paths for this collection is empty, the convention will be used
-     * to resolve this file collection.
-     *
-     * @param paths The paths.
-     * @return this collection
-     *
-     * @since 8.7
-     */
-    @Incubating
-    ConfigurableFileCollection convention(Object... paths);
 
     /**
      * Adds a set of source paths to this collection. The given paths are evaluated as per {@link org.gradle.api.Project#files(Object...)}.


### PR DESCRIPTION
We realized `ConfigurableFileCollection.convention()` needed more work after #28020. Since we are in RC phase, we decided to postpone releasing it in 8.8 only.