### PR TITLE
Remove unused properties from cache artifact metadata

### DIFF
--- a/platforms/core-execution/build-cache-base/src/main/java/org/gradle/caching/internal/origin/OriginMetadataFactory.java
+++ b/platforms/core-execution/build-cache-base/src/main/java/org/gradle/caching/internal/origin/OriginMetadataFactory.java
@@ -29,28 +29,16 @@ public class OriginMetadataFactory {
     private static final String CACHE_KEY = "buildCacheKey";
     private static final String CREATION_TIME_KEY = "creationTime";
     private static final String EXECUTION_TIME_KEY = "executionTime";
-    private static final String OPERATING_SYSTEM_KEY = "operatingSystem";
-    private static final String HOST_NAME_KEY = "hostName";
-    private static final String USER_NAME_KEY = "userName";
 
-    private final String userName;
-    private final String operatingSystem;
     private final String currentBuildInvocationId;
     private final PropertiesConfigurator additionalProperties;
-    private final HostnameLookup hostnameLookup;
 
     public OriginMetadataFactory(
-        String userName,
-        String operatingSystem,
         String currentBuildInvocationId,
-        PropertiesConfigurator additionalProperties,
-        HostnameLookup hostnameLookup
+        PropertiesConfigurator additionalProperties
     ) {
-        this.userName = userName;
-        this.operatingSystem = operatingSystem;
         this.additionalProperties = additionalProperties;
         this.currentBuildInvocationId = currentBuildInvocationId;
-        this.hostnameLookup = hostnameLookup;
     }
 
     public OriginWriter createWriter(String identity, Class<?> workType, HashCode buildCacheKey, Duration elapsedTime) {
@@ -62,9 +50,6 @@ public class OriginMetadataFactory {
             properties.setProperty(CACHE_KEY, buildCacheKey.toString());
             properties.setProperty(CREATION_TIME_KEY, Long.toString(System.currentTimeMillis()));
             properties.setProperty(EXECUTION_TIME_KEY, Long.toString(elapsedTime.toMillis()));
-            properties.setProperty(OPERATING_SYSTEM_KEY, operatingSystem);
-            properties.setProperty(HOST_NAME_KEY, hostnameLookup.getHostname());
-            properties.setProperty(USER_NAME_KEY, userName);
             additionalProperties.configure(properties);
             properties.store(outputStream, "Generated origin information");
         };
@@ -93,9 +78,5 @@ public class OriginMetadataFactory {
 
     public interface PropertiesConfigurator {
         void configure(Properties properties);
-    }
-
-    public interface HostnameLookup {
-        String getHostname();
     }
 }

--- a/platforms/core-execution/build-cache-base/src/test/groovy/org/gradle/caching/internal/origin/OriginMetadataFactoryTest.groovy
+++ b/platforms/core-execution/build-cache-base/src/test/groovy/org/gradle/caching/internal/origin/OriginMetadataFactoryTest.groovy
@@ -25,11 +25,8 @@ import java.time.Duration
 class OriginMetadataFactoryTest extends Specification {
     def buildInvocationId = UUID.randomUUID().toString()
     def factory = new OriginMetadataFactory(
-        "user",
-        "os",
         buildInvocationId,
-        { it.gradleVersion = "3.0" },
-        { "my-host" }
+        { it.gradleVersion = "3.0" }
     )
     def buildCacheKey = TestHashCodes.hashCodeFrom(1234)
 
@@ -51,9 +48,6 @@ class OriginMetadataFactoryTest extends Specification {
         origin.gradleVersion == "3.0"
         origin.creationTime != null
         origin.executionTime == "10"
-        origin.operatingSystem == "os"
-        origin.hostName == "my-host"
-        origin.userName == "user"
         origin.buildInvocationId == buildInvocationId
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CacheTaskOutputIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CacheTaskOutputIntegrationTest.groovy
@@ -56,12 +56,9 @@ class CacheTaskOutputIntegrationTest extends AbstractIntegrationSpec {
             "buildInvocationId",
             "creationTime",
             "executionTime",
-            "hostName",
         )
         metadata.identity == ":compileJava"
         metadata.type == TaskExecution.name.replaceAll(/\$/, ".")
-        metadata.userName == System.getProperty("user.name")
-        metadata.operatingSystem == System.getProperty("os.name")
         metadata.gradleVersion == GradleVersion.current().version
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskIntegrationTest.groovy
@@ -51,9 +51,6 @@ class CachedTaskIntegrationTest extends AbstractIntegrationSpec implements Direc
         metadata.contains("gradleVersion=")
         metadata.contains("creationTime=")
         metadata.contains("executionTime=")
-        metadata.contains("operatingSystem=")
-        metadata.contains("hostName=")
-        metadata.contains("userName=")
     }
 
     def "storing in the cache can be disabled"() {

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/BuildCacheServices.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/BuildCacheServices.java
@@ -38,7 +38,6 @@ import org.gradle.caching.internal.services.DefaultBuildCacheControllerFactory;
 import org.gradle.caching.local.DirectoryBuildCache;
 import org.gradle.caching.local.internal.DirectoryBuildCacheFileStoreFactory;
 import org.gradle.caching.local.internal.DirectoryBuildCacheServiceFactory;
-import org.gradle.internal.SystemProperties;
 import org.gradle.internal.file.BufferProvider;
 import org.gradle.internal.file.Deleter;
 import org.gradle.internal.file.FileException;
@@ -47,10 +46,8 @@ import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.hash.StreamHasher;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
-import org.gradle.internal.nativeintegration.network.HostnameLookup;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
-import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resource.local.DefaultPathKeyFileStore;
 import org.gradle.internal.resource.local.PathKeyFileStore;
@@ -87,15 +84,11 @@ public final class BuildCacheServices extends AbstractPluginServiceRegistry {
             }
 
             OriginMetadataFactory createOriginMetadataFactory(
-                BuildInvocationScopeId buildInvocationScopeId,
-                HostnameLookup hostnameLookup
+                BuildInvocationScopeId buildInvocationScopeId
             ) {
                 return new OriginMetadataFactory(
-                    SystemProperties.getInstance().getUserName(),
-                    OperatingSystem.current().getName(),
                     buildInvocationScopeId.getId().asString(),
-                    properties -> properties.setProperty(GRADLE_VERSION_KEY, GradleVersion.current().getVersion()),
-                    hostnameLookup::getHostname
+                    properties -> properties.setProperty(GRADLE_VERSION_KEY, GradleVersion.current().getVersion())
                 );
             }
         });


### PR DESCRIPTION
We have no use for the following entries in the `METADATA` properties file carried in every cache artifact:

- `operatingSystem`
- `hostName`
- `userName`

These values are captured in build scans via build operations, and are not otherwise consumed by anyone from the metadata file. Removing them decreases artifact size and also makes the OriginMetadataFactory carry fewer dependencies.
