### PR TITLE
Add incubating note to JVM Test Suite Plugin docs

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
@@ -19,7 +19,7 @@ The JVM Test Suite plugin (plugin id: `jvm-test-suite`) provides a DSL and API t
 
 For instance, this plugin can be used to define a group of Integration Tests, which might run much longer than unit tests and have different environmental requirements.
 
-NOTE: The JVM Test Suite plugin is an <<feature_lifecycle.adoc#sec:incubating_state,incubating>> API and is subject to changing in a future release.
+NOTE: The JVM Test Suite plugin is an <<feature_lifecycle.adoc#sec:incubating_state,incubating>> API and is subject to change in a future release.
 
 [[sec:jvm_test_suite_usage]]
 == Usage

--- a/platforms/documentation/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
@@ -18,6 +18,9 @@
 The JVM Test Suite plugin (plugin id: `jvm-test-suite`) provides a DSL and API to model multiple groups of automated tests into test suites in JVM-based projects.  Tests suites are intended to grouped by their purpose and can have separate dependencies and use different testing frameworks.
 
 For instance, this plugin can be used to define a group of Integration Tests, which might run much longer than unit tests and have different environmental requirements.
+
+NOTE: The JVM Test Suite plugin is an <<feature_lifecycle.adoc#sec:incubating_state,incubating>> API and is subject to changing in a future release.
+
 [[sec:jvm_test_suite_usage]]
 == Usage
 


### PR DESCRIPTION
Fixes #28141 

This does need to block 8.7 RC1, but as it is a pure-docs change I targeted it to release.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
