### PR TITLE
Fix the architecture docs diagram in dark mode

### DIFF
--- a/architecture/README.md
+++ b/architecture/README.md
@@ -13,48 +13,48 @@ The diagram below shows the main components of the Gradle architecture. See [ADR
     subgraph core["core platform"]
 
         core_runtime["core-runtime module"]
-        style core_runtime stroke:#1abc9c,fill:#b1f4e7,stroke-width:2px;
+        style core_runtime stroke:#1abc9c,fill:#b1f4e7,stroke-width:2px,color:#000;
 
         core_configuration["core-configuration module"]
-        style core_configuration stroke:#1abc9c,fill:#b1f4e7,stroke-width:2px;
+        style core_configuration stroke:#1abc9c,fill:#b1f4e7,stroke-width:2px,color:#000;
 
         core_execution["core-execution module"]
-        style core_execution stroke:#1abc9c,fill:#b1f4e7,stroke-width:2px;
+        style core_execution stroke:#1abc9c,fill:#b1f4e7,stroke-width:2px,color:#000;
     end
-    style core fill:#c2e0f4,stroke:#3498db,stroke-width:2px;
+    style core fill:#c2e0f4,stroke:#3498db,stroke-width:2px,color:#000;
 
     documentation["documentation module"]
-    style documentation stroke:#1abc9c,fill:#b1f4e7,stroke-width:2px;
+    style documentation stroke:#1abc9c,fill:#b1f4e7,stroke-width:2px,color:#000;
 
     ide["ide module"]
-    style ide stroke:#1abc9c,fill:#b1f4e7,stroke-width:2px;
+    style ide stroke:#1abc9c,fill:#b1f4e7,stroke-width:2px,color:#000;
 
     subgraph software["software platform"]
     end
-    style software fill:#c2e0f4,stroke:#3498db,stroke-width:2px;
+    style software fill:#c2e0f4,stroke:#3498db,stroke-width:2px,color:#000;
     software --> core
 
     subgraph jvm["jvm platform"]
     end
-    style jvm fill:#c2e0f4,stroke:#3498db,stroke-width:2px;
+    style jvm fill:#c2e0f4,stroke:#3498db,stroke-width:2px,color:#000;
     jvm --> core
     jvm --> software
 
     subgraph extensibility["extensibility platform"]
     end
-    style extensibility fill:#c2e0f4,stroke:#3498db,stroke-width:2px;
+    style extensibility fill:#c2e0f4,stroke:#3498db,stroke-width:2px,color:#000;
     extensibility --> core
     extensibility --> jvm
 
     subgraph native["native platform"]
     end
-    style native fill:#c2e0f4,stroke:#3498db,stroke-width:2px;
+    style native fill:#c2e0f4,stroke:#3498db,stroke-width:2px,color:#000;
     native --> core
     native --> software
 
     enterprise["enterprise module"]
-    style enterprise stroke:#1abc9c,fill:#b1f4e7,stroke-width:2px;
+    style enterprise stroke:#1abc9c,fill:#b1f4e7,stroke-width:2px,color:#000;
 
     build_infrastructure["build-infrastructure module"]
-    style build_infrastructure stroke:#1abc9c,fill:#b1f4e7,stroke-width:2px;
+    style build_infrastructure stroke:#1abc9c,fill:#b1f4e7,stroke-width:2px,color:#000;
 ```

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -357,7 +357,7 @@ abstract class GeneratorTask : DefaultTask() {
             }
         }
         node("end")
-        node("style ${platform.id} fill:#c2e0f4,stroke:#3498db,stroke-width:2px;")
+        node("style ${platform.id} fill:#c2e0f4,stroke:#3498db,stroke-width:2px,color:#000;")
         for (dep in platform.uses) {
             node("${platform.id} --> $dep")
         }
@@ -366,7 +366,7 @@ abstract class GeneratorTask : DefaultTask() {
     private fun NodeWriter.element(element: ArchitectureElement) {
         println()
         node("${element.id}[\"${element.name} module\"]")
-        node("style ${element.id} stroke:#1abc9c,fill:#b1f4e7,stroke-width:2px;")
+        node("style ${element.id} stroke:#1abc9c,fill:#b1f4e7,stroke-width:2px,color:#000;")
     }
 
     private class NodeWriter(private val writer: PrintWriter, private val indent: String) {


### PR DESCRIPTION
What it looked like before:
<img width="1021" alt="Screenshot 2024-02-21 at 5 17 20 PM" src="https://github.com/gradle/gradle/assets/2093023/1b0a5e86-6b1b-4f43-82e9-e002f71b3d52">
What it looks like now:
<img width="1043" alt="Screenshot 2024-02-21 at 5 33 56 PM" src="https://github.com/gradle/gradle/assets/2093023/2c9415f6-74b7-4364-a675-b2caf2ec9ca4">


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
