### PR TITLE
Adjust redundant configuration usage change warning

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -1701,13 +1701,6 @@ tasks.withType(HtmlDependencyReportTask) {
 =====
 ====
 
-[[redundant_configuration_usage_activation]]
-==== Redundant configuration usage activation
-
-Calling `setCanBeConsumed(boolean)` or `setCanBeResolved(boolean)` on a configuration that already allows that usage is deprecated.
-
-This deprecation is intended to help users identify unnecessary configuration usage modifications.
-
 [[deprecated_configuration_get_all]]
 ==== `link:{javadocPath}/org/gradle/api/artifacts/Configuration.html[Configuration]` method deprecations
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
@@ -631,37 +631,70 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
         given:
         buildFile << """
             def detached = project.configurations.detachedConfiguration()
+
+            assert detached.canBeConsumed
             assert detached.canBeResolved
+            assert detached.canBeDeclared
+
             detached.canBeResolved = false
+            detached.canBeConsumed = false
+            detached.canBeDeclared = false
         """
 
         expect:
         run "help"
     }
 
-    def "redundantly calling #setMethod on a configuration that is already #isSetMethod warns when #desc"() {
+    def "changing usage on detached configurations warns when flag is set"() {
         given:
         buildFile << """
-            import org.gradle.api.internal.artifacts.configurations.ConfigurationRole
-            import org.gradle.api.internal.artifacts.configurations.ConfigurationRoles
+            def detached = project.configurations.detachedConfiguration()
 
-            configurations.$confCreationCode
-
-            configurations.test {
-                assert $isSetMethod
-                $setMethod
-            }
+            detached.canBeResolved = false
+            detached.canBeConsumed = false
+            detached.canBeDeclared = false
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("The $usage usage is already allowed on configuration ':test'. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Remove the call to $setMethod, it has no effect. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#redundant_configuration_usage_activation")
-        succeeds 'help'
+        expectConsumableChanging(":detachedConfiguration1", false)
+        expectResolvableChanging(":detachedConfiguration1", false)
+        expectDeclarableChanging(":detachedConfiguration1", false)
+        succeeds('help', "-Dorg.gradle.internal.deprecation.preliminary.Configuration.redundantUsageChangeWarning.enabled=true")
+    }
 
-        where:
-        desc                                              | confCreationCode         | usage                | isSetMethod                   | setMethod
-        "using consumable to make a configuration"        | "consumable('test')"     | "consumable"         | "isCanBeConsumed()"           | "setCanBeConsumed(true)"
-        "using resolvable to make a configuration"        | "resolvable('test')"     | "resolvable"         | "isCanBeResolved()"           | "setCanBeResolved(true)"
-        "using dependencyScope to make a configuration"   | "dependencyScope('test')"   | "declarable"         | "isCanBeDeclared()"           | "setCanBeDeclared(true)"
+    def "redundantly changing usage on a role-locked configuration warns when flag is set"() {
+        given:
+        buildFile << """
+            configurations {
+                consumable('cons')
+                resolvable('res')
+                dependencyScope('dep')
+            }
+
+            configurations.cons.canBeConsumed = true
+            configurations.cons.canBeResolved = false
+            configurations.cons.canBeDeclared = false
+
+            configurations.res.canBeConsumed = false
+            configurations.res.canBeResolved = true
+            configurations.res.canBeDeclared = false
+
+            configurations.dep.canBeConsumed = false
+            configurations.dep.canBeResolved = false
+            configurations.dep.canBeDeclared = true
+        """
+
+        expect:
+        expectConsumableChanging(":cons", true)
+        expectResolvableChanging(":cons", false)
+        expectDeclarableChanging(":cons", false)
+        expectConsumableChanging(":res", false)
+        expectResolvableChanging(":res", true)
+        expectDeclarableChanging(":res", false)
+        expectConsumableChanging(":dep", false)
+        expectResolvableChanging(":dep", false)
+        expectDeclarableChanging(":dep", true)
+        succeeds('help', "-Dorg.gradle.internal.deprecation.preliminary.Configuration.redundantUsageChangeWarning.enabled=true")
     }
 
     def "redundantly calling #setMethod on a configuration that is already #isSetMethod does not warn when #desc"() {
@@ -673,7 +706,7 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
         """
 
         expect:
-        succeeds 'help'
+        succeeds('help', "-Dorg.gradle.internal.deprecation.preliminary.Configuration.redundantUsageChangeWarning.enabled=true")
 
         where:
         desc                                                        | confCreationCode              | usage                | isSetMethod            | setMethod

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
@@ -697,21 +697,17 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
         succeeds('help', "-Dorg.gradle.internal.deprecation.preliminary.Configuration.redundantUsageChangeWarning.enabled=true")
     }
 
-    def "redundantly calling #setMethod on a configuration that is already #isSetMethod does not warn when #desc"() {
+    def "redundantly changing usage on a legacy configuration does not warn"() {
         given:
         buildFile << """
-            def test = configurations.$confCreationCode
-            assert test.$isSetMethod
-            test.$setMethod
+            def test = configurations.create('test')
+            test.setCanBeConsumed(true)
+            test.setCanBeResolved(true)
+            test.setCanBeDeclared(true)
         """
 
         expect:
         succeeds('help', "-Dorg.gradle.internal.deprecation.preliminary.Configuration.redundantUsageChangeWarning.enabled=true")
-
-        where:
-        desc                                                        | confCreationCode              | usage                | isSetMethod            | setMethod
-        "using create to make an implicitly LEGACY configuration"   | "create('test')"              | "consumable"         | "isCanBeConsumed()"    | "setCanBeConsumed(true)"
-        "creating a detachedConfiguration"                          | "detachedConfiguration()"     | "consumable"         | "isCanBeConsumed()"    | "setCanBeConsumed(true)"
     }
     // endregion Warnings
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1649,6 +1649,11 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
             return;
         }
 
+        // Error will be thrown later. Don't emit a duplicate warning.
+        if (!usageCanBeMutated && (current != newValue)) {
+            return;
+        }
+
         // KGP continues to set the already-set value for a given usage even though it is already set
         boolean redundantChange = current == newValue;
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ConfigurationUsageChangingFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ConfigurationUsageChangingFixture.groovy
@@ -36,6 +36,6 @@ trait ConfigurationUsageChangingFixture {
     }
 
     void expectChangingUsage(String configurationPath, String method, boolean value) {
-        executer.expectDocumentedDeprecationWarning("Calling $method($value) on configuration '$configurationPath' has been deprecated. This will fail with an error in Gradle 9.0. This configuration's role was set upon creation should not be changed. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
+        executer.expectDocumentedDeprecationWarning("Calling $method($value) on configuration '$configurationPath' has been deprecated. This will fail with an error in Gradle 9.0. This configuration's role was set upon creation and its usage should not be changed. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ConfigurationUsageChangingFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ConfigurationUsageChangingFixture.groovy
@@ -23,19 +23,19 @@ import groovy.transform.SelfType
  */
 @SelfType(AbstractIntegrationSpec)
 trait ConfigurationUsageChangingFixture {
-    void expectConsumableChanging(String configurationPath, boolean current) {
-        expectChangingUsage(configurationPath, "consumable", current)
+    void expectConsumableChanging(String configurationPath, boolean value) {
+        expectChangingUsage(configurationPath, "setCanBeConsumed", value)
     }
 
-    void expectResolvableChanging(String configurationPath, boolean current) {
-        expectChangingUsage(configurationPath, "resolvable", current)
+    void expectResolvableChanging(String configurationPath, boolean value) {
+        expectChangingUsage(configurationPath, "setCanBeResolved", value)
     }
 
-    void expectDeclarableChanging(String configurationPath, boolean current) {
-        expectChangingUsage(configurationPath, "declarable", current)
+    void expectDeclarableChanging(String configurationPath, boolean value) {
+        expectChangingUsage(configurationPath, "setCanBeDeclared", value)
     }
 
-    void expectChangingUsage(String configurationPath, String usage, boolean current) {
-        executer.expectDocumentedDeprecationWarning("Allowed usage is changing for configuration '$configurationPath', $usage was ${!current} and is now $current. Ideally, usage should be fixed upon creation. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Usage should be fixed upon creation. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
+    void expectChangingUsage(String configurationPath, String method, boolean value) {
+        executer.expectDocumentedDeprecationWarning("Calling $method($value) on configuration '$configurationPath' has been deprecated. This will fail with an error in Gradle 9.0. This configuration's role was set upon creation should not be changed. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ResultAssertion.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ResultAssertion.java
@@ -149,7 +149,7 @@ public class ResultAssertion implements Action<ExecutionResult> {
             } else if (removeFirstExpectedDeprecationWarning(lines, i)) {
                 i += lastMatchedDeprecationWarning.getNumLines();
                 i = skipStackTrace(lines, i);
-            } else if (line.matches(".*\\s+deprecated.*") && !isConfigurationAllowedUsageChangingInfoLogMessage(line)) {
+            } else if (line.matches(".*\\s+deprecated.*")) {
                 if (checkDeprecations && expectedGenericDeprecationWarnings <= 0) {
                     throw new AssertionError(String.format("%s line %d contains a deprecation warning: %s%n=====%n%s%n=====%n", displayName, i + 1, line, output));
                 }
@@ -184,23 +184,6 @@ public class ResultAssertion implements Action<ExecutionResult> {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
-    }
-
-    /**
-     * Changes to a configuration's allowed usage contain the string "deprecated" and thus will trigger
-     * false positive identification as Deprecation warnings by the logic in {@link #validate(String, String)};
-     * this method is used to filter out those false positives.
-     * <p>
-     * The check for the "this behavior..." string ensures that deprecation warnings in this regard, as opposed
-     * to log messages, are not filtered out.
-     *
-     * @param line the output line to check
-     * @return {@code true} if the line is a configuration allowed usage changing info log message; {@code false} otherwise
-     */
-    private static boolean isConfigurationAllowedUsageChangingInfoLogMessage(String line) {
-        String msgPrefix = "Allowed usage is changing for configuration";
-        return (line.startsWith(msgPrefix) || line.contains("[org.gradle.api.internal.artifacts.configurations.DefaultConfiguration] " + msgPrefix))
-            && !line.contains("This behavior has been deprecated.");
     }
 
     /**

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithKotlinDeprecations.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithKotlinDeprecations.groovy
@@ -210,7 +210,7 @@ trait WithKotlinDeprecations extends WithReportDeprecations {
                 versionNumber < VersionNumber.parse("1.9.20"),
                 "Calling setCanBeConsumed(false) on configuration '$it' has been deprecated. " +
                     "This will fail with an error in Gradle 9.0. " +
-                    "This configuration's role was set upon creation should not be changed. " +
+                    "This configuration's role was set upon creation and its usage should not be changed. " +
                     "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#configurations_allowed_usage"
             )
         }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithKotlinDeprecations.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithKotlinDeprecations.groovy
@@ -208,9 +208,9 @@ trait WithKotlinDeprecations extends WithReportDeprecations {
         [':other:apiElements', ':other:runtimeElements'].each {
             runner.expectLegacyDeprecationWarningIf(
                 versionNumber < VersionNumber.parse("1.9.20"),
-                "Allowed usage is changing for configuration '$it', consumable was true and is now false. " +
-                    "Ideally, usage should be fixed upon creation. This behavior has been deprecated. " +
-                    "This behavior is scheduled to be removed in Gradle 9.0. Usage should be fixed upon creation. " +
+                "Calling setCanBeConsumed(false) on configuration '$it' has been deprecated. " +
+                    "This will fail with an error in Gradle 9.0. " +
+                    "This configuration's role was set upon creation should not be changed. " +
                     "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#configurations_allowed_usage"
             )
         }


### PR DESCRIPTION
Previously, we emitted a deprecation warning in some cases when a usage for a configuration was set to a value it already had. This was only emitted in certain cases -- for non-legacy, non-detached configurations, and when the value-being-set was to enable the usage.

The goal of this warning is to push users to not try to set roles for configurations that already have their roles set upon creation. However, the previous implementation is not ideal for the two following reasons

1. The warning message was worded in a way to dissuade users from redundantly changing a configuration's usage, making it seem this was a sort of correctness deprecation All other cases of non-redundant changes to roles were handled with a different deprecation warning
2. We only warned about this redundant change in very narrow circumstances -- when the usage's value was being set to true and for configurations with certain names This effectively defeats the purpose of this deprecation. The name matching avoided our own smoke tests from emitting this warning, but there are scenarios that users were hitting where this name matching did not cover.

Really, the goal here is for build logic to not call setCanBeX methods on configurations where the role is already set upon creation. For this reason, we update redundant calls to setCanBeX to emit the same warning as calling these methods non-redundantly. However, since KMP still redundantly calls setCanBeX, we hide the emitting of this deprecation behind a system property. We plan to file an issue with KMP to stop calling setCanBeX on all configurations that already exist -- or those that are managed by Gradle / created via source sets -- and tell them to verify their changes by enabling this system property. Until then, we will not warn for redundant usage changes.

Fixes: https://github.com/gradle/gradle/issues/25609

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
