### PR TITLE
Let declarative DSL performance tests declare minimum base Gradle version

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/declarativedsl/DeclarativeDslFirstUsePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/declarativedsl/DeclarativeDslFirstUsePerformanceTest.groovy
@@ -37,11 +37,14 @@ class DeclarativeDslFirstUsePerformanceTest extends AbstractCrossVersionPerforma
 
     private static final int MEASUREMENT_RUNS = 10
 
+    private static final String MINIMUM_BASE_VERSION = "8.8" // Declarative DSL not present in earlier versions
+
     def "first use"() {
         given:
         runner.tasksToRun = ['tasks']
         runner.warmUpRuns = WARMUP_RUNS
         runner.runs = MEASUREMENT_RUNS
+        runner.minimumBaseVersion = MINIMUM_BASE_VERSION
         runner.useDaemon = false
         runner.addBuildMutator { invocationSettings ->
             new ClearGradleUserHomeMutator(invocationSettings.gradleUserHome, AbstractCleanupMutator.CleanupSchedule.BUILD)
@@ -62,6 +65,7 @@ class DeclarativeDslFirstUsePerformanceTest extends AbstractCrossVersionPerforma
         runner.tasksToRun = ['tasks']
         runner.warmUpRuns = WARMUP_RUNS
         runner.runs = MEASUREMENT_RUNS
+        runner.minimumBaseVersion = MINIMUM_BASE_VERSION
         runner.useDaemon = false
         runner.addBuildMutator { invocationSettings ->
             new ClearProjectCacheMutator(invocationSettings.projectDir, AbstractCleanupMutator.CleanupSchedule.BUILD)
@@ -79,6 +83,7 @@ class DeclarativeDslFirstUsePerformanceTest extends AbstractCrossVersionPerforma
         runner.tasksToRun = ['tasks']
         runner.warmUpRuns = WARMUP_RUNS
         runner.runs = MEASUREMENT_RUNS
+        runner.minimumBaseVersion = MINIMUM_BASE_VERSION
         runner.useDaemon = false
 
         when:


### PR DESCRIPTION
A performance test for Declarative DSL was introduced in https://github.com/gradle/gradle/pull/28098, and it broke performance test because the baseline version doesn't support Declarative DSL. Reset the baseline to commit 03c5536d04b927da43318918ab0824a6b457206f