### PR TITLE
More performance test buckets for Windows

### DIFF
--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -42,7 +42,7 @@ enum class StageName(val stageName: String, val description: String, val uuid: S
 
 private val performanceRegressionTestCoverages = listOf(
     PerformanceTestCoverage(1, PerformanceTestType.per_commit, Os.LINUX, numberOfBuckets = 40, oldUuid = "PerformanceTestTestLinux"),
-    PerformanceTestCoverage(6, PerformanceTestType.per_commit, Os.WINDOWS, numberOfBuckets = 5, failsStage = false),
+    PerformanceTestCoverage(6, PerformanceTestType.per_commit, Os.WINDOWS, numberOfBuckets = 10, failsStage = false),
     PerformanceTestCoverage(7, PerformanceTestType.per_commit, Os.MACOS, numberOfBuckets = 5, failsStage = false)
 )
 


### PR DESCRIPTION
The biggest Windows performance bucket sometimes takes ~1h. Let's split Windows performance tests into more buckets: https://gradle.slack.com/archives/CBSJ2GUTV/p1708529446757299