### PR TITLE
Upgrade gradle-enterprise-conventions-plugin to 0.9.0

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -155,7 +155,7 @@ fun javaHome(jvm: Jvm, os: Os, arch: Arch = Arch.AMD64) = "%${os.name.lowercase(
 fun BuildType.paramsForBuildToolBuild(buildJvm: Jvm = BuildToolBuildJvm, os: Os, arch: Arch = Arch.AMD64) {
     params {
         param("env.BOT_TEAMCITY_GITHUB_TOKEN", "%github.bot-teamcity.token%")
-        param("env.GRADLE_CACHE_REMOTE_URL", "%gradle.cache.remote.server%")
+        param("env.GRADLE_CACHE_REMOTE_SERVER", "%gradle.cache.remote.server%")
 
         param("env.JAVA_HOME", javaHome(buildJvm, os, arch))
         param("env.GRADLE_OPTS", "-Xmx1536m")

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -871,9 +871,9 @@
             <pgp value="7186BBF993566D8C2F4F7ED7D945E643368FEF62"/>
          </artifact>
       </component>
-      <component group="io.github.gradle" name="gradle-enterprise-conventions-plugin" version="0.8.0">
-         <artifact name="gradle-enterprise-conventions-plugin-0.8.0.jar">
-            <sha256 value="9fb7ce8df50492a462b34f4f009a115932780aaa80658eb6209569827f141042" origin="Verified" reason="Artifact is not signed"/>
+      <component group="io.github.gradle" name="gradle-enterprise-conventions-plugin" version="0.9.0">
+         <artifact name="gradle-enterprise-conventions-plugin-0.9.0.jar">
+            <sha256 value="8987bf4627725ba89942f8871c86585b781576d5af6c49e3789028805636788b" origin="Verified" reason="Artifact is not signed"/>
          </artifact>
       </component>
       <component group="io.github.java-diff-utils" name="java-diff-utils" version="4.12">

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,7 +27,7 @@ pluginManagement {
 
 plugins {
     id("com.gradle.enterprise").version("3.16.2") // Sync with `build-logic-commons/build-platform/build.gradle.kts`
-    id("io.github.gradle.gradle-enterprise-conventions-plugin").version("0.8.0")
+    id("io.github.gradle.gradle-enterprise-conventions-plugin").version("0.9.0")
     id("org.gradle.toolchains.foojay-resolver-convention") version ("0.8.0")
 //    id("net.ltgt.errorprone").version("3.1.0")
 }


### PR DESCRIPTION
In the past, `gradle-enterprise-conventions-plugins` read env variable `GRADLE_CACHE_REMOTE_URL`, expecting the value with format `https://domain.com/cache/`.

In https://github.com/gradle/gradle/pull/28132, we upgraded the plugin and changed the value of `GRADLE_CACHE_REMOTE_URL` to format `https://domain.com/`. However, this broken the promotion build because Relese pipeline still passes the old value `GRADLE_CACHE_REMOTE_URL=https://domain.com/cache/`

Now we have renamed the property name in https://github.com/gradle/gradle-org-conventions-plugin/pull/25 so the old value in Release pipeline won't break the build.