### PR TITLE
Update supported CentOS version for file-system watching

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/file_system_watching.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/file_system_watching.adoc
@@ -49,7 +49,7 @@ Gradle supports file system watching on the following operating systems:
 * Windows 10, version 1709 and later
 * Linux, tested on the following distributions:
 ** Ubuntu 16.04 or later
-** CentOS 8 or later
+** CentOS Stream 8 or later
 ** Red Hat Enterprise Linux (RHEL) 8 or later
 ** Amazon Linux 2 or later
 * macOS 10.14 (Mojave) or later on Intel and ARM architectures


### PR DESCRIPTION
In a weird migration story CentOS 8 (which we did support) has already been deprecated, while CentOS 7 is still supported (but we did _not_ support FSW on it). Now there's CentOS _Stream_ 8 (which we _do_ support, and have tests for it), though it's going to reach end-of-life at the end of May 2024. After that there will only be CentOS Stream 9.

Details: https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/
