### PR TITLE
Fix user prompting when used with `--no-daemon`

### DIFF
--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/BuildActionsFactory.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/BuildActionsFactory.java
@@ -21,6 +21,7 @@ import org.gradle.StartParameter;
 import org.gradle.api.Action;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.internal.tasks.userinput.UserInputReader;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
 import org.gradle.configuration.GradleLauncherMetaData;
@@ -34,6 +35,7 @@ import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
+import org.gradle.internal.logging.console.GlobalUserInputReceiver;
 import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.ServiceRegistryBuilder;
@@ -153,8 +155,13 @@ class BuildActionsFactory implements CommandLineActionCreator {
 
         globalServices.get(AgentInitializer.class).maybeConfigureInstrumentationAgent();
 
+        BuildActionExecuter<BuildActionParameters, BuildRequestContext> executer = new InProcessUserInputHandlingExecutor(
+            globalServices.get(GlobalUserInputReceiver.class),
+            globalServices.get(UserInputReader.class),
+            globalServices.get(BuildExecuter.class));
+
         // Force the user home services to be stopped first, the dependencies between the user home services and the global services are not preserved currently
-        return runBuildAndCloseServices(startParameter, daemonParameters, globalServices.get(BuildExecuter.class), globalServices, globalServices.get(GradleUserHomeScopeServiceRegistry.class));
+        return runBuildAndCloseServices(startParameter, daemonParameters, executer, globalServices, globalServices.get(GradleUserHomeScopeServiceRegistry.class));
     }
 
     private Runnable runBuildInSingleUseDaemon(StartParameterInternal startParameter, DaemonParameters daemonParameters) {

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/InProcessUserInputHandlingExecutor.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/InProcessUserInputHandlingExecutor.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.launcher.cli;
+
+import org.gradle.api.internal.tasks.userinput.UserInputReader;
+import org.gradle.initialization.BuildRequestContext;
+import org.gradle.internal.invocation.BuildAction;
+import org.gradle.internal.logging.console.GlobalUserInputReceiver;
+import org.gradle.launcher.exec.BuildActionExecuter;
+import org.gradle.launcher.exec.BuildActionParameters;
+import org.gradle.launcher.exec.BuildActionResult;
+import org.gradle.launcher.exec.BuildExecuter;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/**
+ * A {@link BuildActionExecuter} implementation that takes care of connecting the {@link GlobalUserInputReceiver} and {@link UserInputReader} together when the build is run in-process.
+ */
+class InProcessUserInputHandlingExecutor implements BuildActionExecuter<BuildActionParameters, BuildRequestContext> {
+    private final GlobalUserInputReceiver userInputReceiver;
+    private final UserInputReader userInputReader;
+    private final BuildExecuter delegate;
+
+    public InProcessUserInputHandlingExecutor(GlobalUserInputReceiver userInputReceiver, UserInputReader userInputReader, BuildExecuter delegate) {
+        this.userInputReceiver = userInputReceiver;
+        this.userInputReader = userInputReader;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public BuildActionResult execute(BuildAction action, BuildActionParameters actionParameters, BuildRequestContext buildRequestContext) {
+        userInputReceiver.dispatchTo(() -> {
+            // Read a single line of text from stdin and forward to the UserInputReader
+            String line;
+            try {
+                line = new BufferedReader(new InputStreamReader(System.in)).readLine();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            if (line != null) {
+                userInputReader.putInput(new UserInputReader.TextResponse(line));
+            } else {
+                userInputReader.putInput(UserInputReader.END_OF_INPUT);
+            }
+        });
+        try {
+            return delegate.execute(action, actionParameters, buildRequestContext);
+        } finally {
+            userInputReceiver.stopDispatching();
+        }
+    }
+}

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/RunBuildAction.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/RunBuildAction.java
@@ -64,9 +64,7 @@ public class RunBuildAction implements Runnable {
                 throw new ReportedException();
             }
         } finally {
-            if (stoppable != null) {
-                stoppable.stop();
-            }
+            stoppable.stop();
         }
     }
 }

--- a/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionsFactoryTest.groovy
+++ b/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionsFactoryTest.groovy
@@ -31,7 +31,6 @@ import org.gradle.launcher.daemon.client.SingleUseDaemonClient
 import org.gradle.launcher.daemon.configuration.DaemonParameters
 import org.gradle.launcher.exec.BuildActionExecuter
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
-import org.gradle.tooling.internal.provider.SetupLoggingActionExecuter
 import org.gradle.util.SetSystemProperties
 import org.gradle.util.UsesNativeServices
 import org.junit.Rule
@@ -151,7 +150,7 @@ class BuildActionsFactoryTest extends Specification {
     void isInProcess(def action) {
         def runnable = unwrapAction(action)
         def executor = unwrapExecutor(runnable)
-        assert executor instanceof SetupLoggingActionExecuter
+        assert executor instanceof InProcessUserInputHandlingExecutor
     }
 
     void isSingleUseDaemon(def action) {


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context

This PR fixes a couple of issues with recent changes to move user prompting from the daemon to the client:

- Fix the `--no-daemon` case.
- Fix a flaky unit test.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
