### PR TITLE
Ignore flaky tests in Gradleception

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/Gradleception.kt
+++ b/.teamcity/src/main/kotlin/configurations/Gradleception.kt
@@ -130,7 +130,7 @@ class Gradleception(
 
             localGradle {
                 name = "QUICKCHECK_WITH_GRADLE_BUILT_BY_GRADLE"
-                tasks = "clean sanityCheck test " + if (bundleGroovy4) "--dry-run" else ""
+                tasks = "clean sanityCheck test -PflakyTests=exclude " + if (bundleGroovy4) "--dry-run" else ""
                 gradleHome = "%teamcity.build.checkoutDir%/dogfood-second"
                 gradleParams = defaultParameters
             }


### PR DESCRIPTION
Today I found a flaky test that should be ignored (marked as `@Flaky`) failing in Gradleception build. It turns out that Gradleception doesn't specify the flaky test strategy.