### PR TITLE
Make short group:name notation in version catalog more visible

### DIFF
--- a/platforms/documentation/docs/src/snippets/dependencyManagement/catalogs-toml/groovy/gradle/test-libs.versions.toml
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/catalogs-toml/groovy/gradle/test-libs.versions.toml
@@ -3,6 +3,7 @@ common = "1.4"
 
 [libraries]
 my-lib = "com.mycompany:mylib:1.4"
+my-lib-no-version.module = "com.mycompany:mylib"
 my-other-lib = { module = "com.mycompany:other", version = "1.4" }
 my-other-lib2 = { group = "com.mycompany", name = "alternate", version = "1.4" }
 mylib-full-format = { group = "com.mycompany", name = "alternate", version = { require = "1.4" } }

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/catalogs-toml/kotlin/gradle/test-libs.versions.toml
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/catalogs-toml/kotlin/gradle/test-libs.versions.toml
@@ -3,6 +3,7 @@ common = "1.4"
 
 [libraries]
 my-lib = "com.mycompany:mylib:1.4"
+my-lib-no-version.module = "com.mycompany:mylib"
 my-other-lib = { module = "com.mycompany:other", version = "1.4" }
 my-other-lib2 = { group = "com.mycompany", name = "alternate", version = "1.4" }
 mylib-full-format = { group = "com.mycompany", name = "alternate", version = { require = "1.4" } }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/catalog/parser/TomlCatalogFileParser.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/catalog/parser/TomlCatalogFileParser.java
@@ -322,10 +322,14 @@ public class TomlCatalogFileParser {
         if (gav instanceof String) {
             List<String> split = SPLITTER.splitToList((String) gav);
             if (split.size() != 3) {
-                throw throwVersionCatalogProblemException(builder ->
+                throw throwVersionCatalogProblemException(builder -> {
                     configureVersionCatalogError(builder, getInVersionCatalog(versionCatalogBuilder.getName()) + ", on alias '" + alias + "' notation '" + gav + "' is not a valid dependency notation.", INVALID_DEPENDENCY_NOTATION)
                         .details("When using a string to declare library coordinates, you must use a valid dependency notation")
-                        .solution("Make sure that the coordinates consist of 3 parts separated by colons, eg: my.group:artifact:1.2"));
+                        .solution("Make sure that the coordinates consist of 3 parts separated by colons, e.g.: my.group:artifact:1.2");
+                    if (split.size() == 2) {
+                        builder.solution("To declare without a version, use '" + alias + ".module' instead, i.e.: " + alias + ".module = \"" + gav + "\"");
+                    }
+                });
             }
             String group = notEmpty(split.get(0), "group", alias);
             String name = notEmpty(split.get(1), "name", alias);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownCategories.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownCategories.groovy
@@ -46,6 +46,7 @@ class KnownCategories {
         [namespace: "org.gradle", category: "dependency-version-catalog", subcategories: ["too-many-import-files"]],
         [namespace: "org.gradle", category: "dependency-version-catalog", subcategories: ["too-many-import-invocation"]],
         [namespace: "org.gradle", category: "dependency-version-catalog", subcategories: ["no-import-files"]],
+        [namespace: "org.gradle", category: "dependency-version-catalog", subcategories: ["invalid-dependency-notation"]],
         [namespace: "org.gradle", category: "deprecation", subcategories: ["build-invocation"]],
         [namespace: "org.gradle", category: "deprecation", subcategories: ["user-code-direct"]],
         [namespace: "org.gradle", category: "deprecation", subcategories: ["user-code-indirect"]],


### PR DESCRIPTION
Fixes #24169 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
