### PR TITLE
Implement diagnostic to problem conversion using internal compiler APIs

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -22,9 +22,9 @@ import gradlebuild.basics.FlakyTestStrategy
 import gradlebuild.basics.accessors.kotlinMainSourceSet
 import gradlebuild.basics.flakyTestStrategy
 import gradlebuild.basics.maxParallelForks
-import gradlebuild.basics.maxTestDistributionRemoteExecutors
 import gradlebuild.basics.maxTestDistributionLocalExecutors
 import gradlebuild.basics.maxTestDistributionPartitionSecond
+import gradlebuild.basics.maxTestDistributionRemoteExecutors
 import gradlebuild.basics.predictiveTestSelectionEnabled
 import gradlebuild.basics.rerunAllTests
 import gradlebuild.basics.testDistributionEnabled
@@ -198,6 +198,10 @@ fun Test.configureJvmForTest() {
     }
     javaLauncher = launcher
     if (jvmVersionForTest().canCompileOrRun(9)) {
+        // Required by JdkTools and JdkJavaCompiler
+        jvmArgs(listOf("--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED"))
+        jvmArgs(listOf("--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"))
+
         if (isUnitTest() || usesEmbeddedExecuter()) {
             jvmArgs(org.gradle.internal.jvm.JpmsConfiguration.GRADLE_DAEMON_JPMS_ARGS)
         } else {

--- a/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
+++ b/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
@@ -19,6 +19,8 @@ package org.gradle.workers.internal
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.IntegTestPreconditions
 import org.gradle.workers.fixtures.WorkerExecutorFixture
 import org.junit.Rule
 import spock.lang.Issue
@@ -226,6 +228,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
     }
 
     @Issue("https://github.com/gradle/gradle/issues/10411")
+    @Requires(value = IntegTestPreconditions.NotEmbeddedExecutor, reason = "This test requires isolated daemons")
     def "does not leak project state across multiple builds"() {
         fixture.withWorkActionClassInBuildSrc()
         executer.withBuildJvmOpts('-Xms256m', '-Xmx512m').requireIsolatedDaemons().requireDaemon()

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.jvm;
 
+import org.gradle.api.NonNullApi;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -27,13 +29,16 @@ import java.util.List;
  * a warning they can do nothing about. On Java 16+, strong encapsulation of JDK internals is
  * enforced and not having the explicit permissions for reflective accesses will result in runtime exceptions.
  */
+@NonNullApi
 public class JpmsConfiguration {
 
     public static final List<String> GROOVY_JPMS_ARGS = Collections.unmodifiableList(Arrays.asList(
         "--add-opens=java.base/java.lang=ALL-UNNAMED",
         "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
         "--add-opens=java.base/java.util=ALL-UNNAMED",
-        "--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED" // required by PreferenceCleaningGroovySystemLoader
+        "--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED", // required by PreferenceCleaningGroovySystemLoader
+        "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED", // Required by JdkTools and JdkJavaCompiler
+        "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED" // Required by JdkTools and JdkJavaCompiler
     ));
 
     public static final List<String> GRADLE_DAEMON_JPMS_ARGS;

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonJvmSettingsIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonJvmSettingsIntegrationTest.groovy
@@ -45,7 +45,7 @@ assert java.lang.management.ManagementFactory.runtimeMXBean.inputArguments.conta
         file('build.gradle') << """
             def inputArguments = java.lang.management.ManagementFactory.runtimeMXBean.inputArguments
             assert inputArguments.contains('-Xmx1024m')
-            assert inputArguments.count { !it.startsWith('--add-opens=') && !it.startsWith('-D') && !it.startsWith('-javaagent:') } == 1
+            assert inputArguments.count { !it.startsWith('--add-opens=') && !it.startsWith('--add-exports') && !it.startsWith('-D') && !it.startsWith('-javaagent:') } == 1
         """
 
         when:

--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractConsoleDeprecationMessageGroupedTaskFunctionalTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractConsoleDeprecationMessageGroupedTaskFunctionalTest.groovy
@@ -18,20 +18,14 @@ package org.gradle.internal.logging.console.taskgrouping
 
 import org.gradle.integtests.fixtures.console.AbstractConsoleGroupedTaskFunctionalTest
 
-import static org.gradle.util.internal.TextUtil.normaliseFileSeparators
-
 abstract class AbstractConsoleDeprecationMessageGroupedTaskFunctionalTest extends AbstractConsoleGroupedTaskFunctionalTest {
 
     private static final String JAVA_SRC_DIR_PATH = 'src/main/java'
 
-    def setup() {
-        executer.expectDeprecationWarning()
-    }
-
     def "compiler warnings emitted from compilation task are grouped"() {
         given:
         def javaSourceFile = file("$JAVA_SRC_DIR_PATH/MyClass.java")
-        def normalizedJavaSourceFilePath = normaliseFileSeparators(javaSourceFile.absolutePath)
+        def expectedOutput = "${javaSourceFile.absolutePath}:4: warning: [deprecation] Legacy in unnamed package has been deprecated"
 
         buildFile << """
             apply plugin: 'java'
@@ -55,11 +49,11 @@ abstract class AbstractConsoleDeprecationMessageGroupedTaskFunctionalTest extend
         """
 
         when:
+        executer.expectDeprecationWarning(expectedOutput)
         succeeds('compileJava')
 
         then:
-        def expectedOutput = "${normalizedJavaSourceFilePath}:4: warning: [deprecation] Legacy in unnamed package has been deprecated"
         def actualOutput = errorsShouldAppearOnStdout() ? result.groupedOutput.task(':compileJava').output : result.getError()
-        normaliseFileSeparators(actualOutput).contains(expectedOutput)
+        actualOutput.contains(expectedOutput)
     }
 }

--- a/platforms/documentation/docs/src/snippets/java-library/module-disabled/tests/buildJavaModule.out
+++ b/platforms/documentation/docs/src/snippets/java-library/module-disabled/tests/buildJavaModule.out
@@ -7,7 +7,6 @@
 /home/user/gradle/samples/src/main/java/module-info.java:3: error: module not found: org.apache.commons.lang3
     requires org.apache.commons.lang3; // automatic module
                                ^
-2 errors
 
 FAILURE: Build failed with an exception.
 

--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerConsoleInputEndUserIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerConsoleInputEndUserIntegrationTest.groovy
@@ -32,6 +32,8 @@ class GradleRunnerConsoleInputEndUserIntegrationTest extends BaseTestKitEndUserI
 
     def setup() {
         buildFile << """
+            import org.gradle.internal.jvm.JpmsConfiguration
+
             apply plugin: 'groovy'
 
             dependencies {
@@ -42,6 +44,17 @@ class GradleRunnerConsoleInputEndUserIntegrationTest extends BaseTestKitEndUserI
             testing {
                 suites {
                     test {
+                        targets {
+                            all {
+                                testTask.configure {
+                                    if (JavaVersion.current().isJava9Compatible()) {
+                                        // Normally, test runners are not inheriting the JVM arguments from the Gradle daemon.
+                                        // This case though, we need it, as we are executing a compilation task inside the nested build.
+                                        jvmArgs = JpmsConfiguration.GRADLE_DAEMON_JPMS_ARGS
+                                    }
+                                }
+                            }
+                        }
                         useSpock()
                     }
                 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/GradleCoreProblemGroup.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/GradleCoreProblemGroup.java
@@ -49,6 +49,8 @@ public abstract class GradleCoreProblemGroup implements ProblemGroup {
     public interface CompilationProblemGroup extends ProblemGroup {
         ProblemGroup java();
 
+        ProblemGroup groovy();
+
         ProblemGroup groovyDsl();
     }
 
@@ -61,6 +63,7 @@ public abstract class GradleCoreProblemGroup implements ProblemGroup {
     private static class DefaultCompilationProblemGroup extends DefaultProblemGroup implements CompilationProblemGroup {
 
         private final ProblemGroup java = new DefaultProblemGroup("java", "Java compilation", this);
+        private final ProblemGroup groovy = new DefaultProblemGroup("groovy", "Groovy compilation", this);
         public ProblemGroup groovyDsl = new DefaultProblemGroup("groovy-dsl", "Groovy DSL script compilation", this);
 
         private DefaultCompilationProblemGroup(String id, String displayName) {
@@ -70,6 +73,11 @@ public abstract class GradleCoreProblemGroup implements ProblemGroup {
         @Override
         public ProblemGroup java() {
             return this.java;
+        }
+
+        @Override
+        public ProblemGroup groovy() {
+            return this.groovy;
         }
 
         @Override

--- a/platforms/jvm/java-compiler-plugin/src/main/java/org/gradle/internal/compiler/java/IncrementalCompileTask.java
+++ b/platforms/jvm/java-compiler-plugin/src/main/java/org/gradle/internal/compiler/java/IncrementalCompileTask.java
@@ -63,7 +63,7 @@ public class IncrementalCompileTask implements JavaCompiler.CompilationTask {
         if (delegate instanceof JavacTask) {
             this.delegate = (JavacTask) delegate;
         } else {
-            throw new UnsupportedOperationException("Unexpected Java compile task : " + delegate.getClass().getName());
+            throw new UnsupportedOperationException("Unexpected Java compile task: " + delegate.getClass().getName());
         }
     }
 

--- a/platforms/jvm/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/DefaultGroovyJavaJointCompileSpecFactory.java
+++ b/platforms/jvm/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/DefaultGroovyJavaJointCompileSpecFactory.java
@@ -33,8 +33,8 @@ public class DefaultGroovyJavaJointCompileSpecFactory extends AbstractJavaCompil
     }
 
     @Override
-    protected DefaultGroovyJavaJointCompileSpec getForkingSpec(File javaHome) {
-        return new DefaultForkingGroovyJavaJointCompileSpec(javaHome);
+    protected DefaultGroovyJavaJointCompileSpec getForkingSpec(File javaHome, int javaLanguageVersion) {
+        return new DefaultForkingGroovyJavaJointCompileSpec(javaHome, javaLanguageVersion);
     }
 
     @Override
@@ -57,14 +57,21 @@ public class DefaultGroovyJavaJointCompileSpecFactory extends AbstractJavaCompil
 
     private static class DefaultForkingGroovyJavaJointCompileSpec extends DefaultGroovyJavaJointCompileSpec implements ForkingJavaCompileSpec {
         private final File javaHome;
+        private final int javaLanguageVersion;
 
-        private DefaultForkingGroovyJavaJointCompileSpec(File javaHome) {
+        private DefaultForkingGroovyJavaJointCompileSpec(File javaHome, int javaLanguageVersion) {
             this.javaHome = javaHome;
+            this.javaLanguageVersion = javaLanguageVersion;
         }
 
         @Override
         public File getJavaHome() {
             return javaHome;
+        }
+
+        @Override
+        public int getJavaLanguageVersion() {
+            return javaLanguageVersion;
         }
     }
 }

--- a/platforms/jvm/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/GroovyCompilerFactory.java
+++ b/platforms/jvm/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/GroovyCompilerFactory.java
@@ -51,8 +51,9 @@ public class GroovyCompilerFactory implements CompilerFactory<GroovyJavaJointCom
     private final ClassLoaderRegistry classLoaderRegistry;
     private final ActionExecutionSpecFactory actionExecutionSpecFactory;
     private final ProjectCacheDir projectCacheDir;
+    private final InternalProblems problems;
 
-    public GroovyCompilerFactory(WorkerDaemonFactory workerDaemonFactory, IsolatedClassloaderWorkerFactory inProcessWorkerFactory, JavaForkOptionsFactory forkOptionsFactory, AnnotationProcessorDetector processorDetector, JvmVersionDetector jvmVersionDetector, WorkerDirectoryProvider workerDirectoryProvider, ClassPathRegistry classPathRegistry, ClassLoaderRegistry classLoaderRegistry, ActionExecutionSpecFactory actionExecutionSpecFactory, ProjectCacheDir projectCacheDir) {
+    public GroovyCompilerFactory(WorkerDaemonFactory workerDaemonFactory, IsolatedClassloaderWorkerFactory inProcessWorkerFactory, JavaForkOptionsFactory forkOptionsFactory, AnnotationProcessorDetector processorDetector, JvmVersionDetector jvmVersionDetector, WorkerDirectoryProvider workerDirectoryProvider, ClassPathRegistry classPathRegistry, ClassLoaderRegistry classLoaderRegistry, ActionExecutionSpecFactory actionExecutionSpecFactory, ProjectCacheDir projectCacheDir, InternalProblems problems) {
         this.workerDaemonFactory = workerDaemonFactory;
         this.inProcessWorkerFactory = inProcessWorkerFactory;
         this.forkOptionsFactory = forkOptionsFactory;
@@ -63,6 +64,7 @@ public class GroovyCompilerFactory implements CompilerFactory<GroovyJavaJointCom
         this.classLoaderRegistry = classLoaderRegistry;
         this.actionExecutionSpecFactory = actionExecutionSpecFactory;
         this.projectCacheDir = projectCacheDir;
+        this.problems = problems;
     }
 
     @Override
@@ -73,7 +75,7 @@ public class GroovyCompilerFactory implements CompilerFactory<GroovyJavaJointCom
                 new ProcessIsolatedCompilerWorkerExecutor(workerDaemonFactory, actionExecutionSpecFactory, projectCacheDir) :
                 new ClassloaderIsolatedCompilerWorkerExecutor(inProcessWorkerFactory, actionExecutionSpecFactory, projectCacheDir);
 
-        Compiler<GroovyJavaJointCompileSpec> groovyCompiler = new DaemonGroovyCompiler(workerDirectoryProvider.getWorkingDirectory(), DaemonSideCompiler.class, classPathRegistry, compilerWorkerExecutor, classLoaderRegistry, forkOptionsFactory, jvmVersionDetector);
+        Compiler<GroovyJavaJointCompileSpec> groovyCompiler = new DaemonGroovyCompiler(workerDirectoryProvider.getWorkingDirectory(), DaemonSideCompiler.class, classPathRegistry, compilerWorkerExecutor, classLoaderRegistry, forkOptionsFactory, jvmVersionDetector, problems.getInternalReporter());
         return new AnnotationProcessorDiscoveringCompiler<>(new NormalizingGroovyCompiler(groovyCompiler), processorDetector);
     }
 

--- a/platforms/jvm/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/GroovyServices.java
+++ b/platforms/jvm/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/GroovyServices.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.compile;
 
 import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDetector;
+import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.initialization.ClassLoaderRegistry;
 import org.gradle.initialization.layout.ProjectCacheDir;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
@@ -46,7 +47,8 @@ public class GroovyServices extends AbstractPluginServiceRegistry {
             ClassPathRegistry classPathRegistry,
             ClassLoaderRegistry classLoaderRegistry,
             ActionExecutionSpecFactory actionExecutionSpecFactory,
-            ProjectCacheDir projectCacheDir
+            ProjectCacheDir projectCacheDir,
+            InternalProblems problems
         ) {
             return new GroovyCompilerFactory(
                 workerDaemonFactory,
@@ -58,7 +60,8 @@ public class GroovyServices extends AbstractPluginServiceRegistry {
                 classPathRegistry,
                 classLoaderRegistry,
                 actionExecutionSpecFactory,
-                projectCacheDir
+                projectCacheDir,
+                problems
             );
         }
     }

--- a/platforms/jvm/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
+++ b/platforms/jvm/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
@@ -21,15 +21,21 @@ import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.tasks.compile.ApiCompilerResult;
 import org.gradle.api.internal.tasks.compile.BaseForkOptionsConverter;
 import org.gradle.api.internal.tasks.compile.GroovyJavaJointCompileSpec;
+import org.gradle.api.internal.tasks.compile.MinimalGroovyCompilerDaemonForkOptions;
+import org.gradle.api.internal.tasks.compile.MinimalJavaCompilerDaemonForkOptions;
 import org.gradle.api.internal.tasks.compile.incremental.compilerapi.constants.ConstantsAnalysisResult;
 import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessingResult;
-import org.gradle.api.internal.tasks.compile.MinimalJavaCompilerDaemonForkOptions;
-import org.gradle.api.internal.tasks.compile.MinimalGroovyCompilerDaemonForkOptions;
+import org.gradle.api.problems.Severity;
+import org.gradle.api.problems.internal.GradleCoreProblemGroup;
+import org.gradle.api.problems.internal.InternalProblemReporter;
 import org.gradle.initialization.ClassLoaderRegistry;
 import org.gradle.internal.classloader.FilteringClassLoader;
 import org.gradle.internal.classloader.VisitableURLClassLoader;
+import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.classpath.DefaultClassPath;
+import org.gradle.internal.jvm.JavaInfo;
 import org.gradle.internal.jvm.JpmsConfiguration;
+import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.process.JavaForkOptions;
@@ -42,6 +48,7 @@ import org.gradle.workers.internal.KeepAliveMode;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 
 public class DaemonGroovyCompiler extends AbstractDaemonCompiler<GroovyJavaJointCompileSpec> {
     private final Class<? extends Compiler<GroovyJavaJointCompileSpec>> compilerClass;
@@ -51,8 +58,18 @@ public class DaemonGroovyCompiler extends AbstractDaemonCompiler<GroovyJavaJoint
     private final JavaForkOptionsFactory forkOptionsFactory;
     private final File daemonWorkingDir;
     private final JvmVersionDetector jvmVersionDetector;
+    private final InternalProblemReporter problemReporter;
 
-    public DaemonGroovyCompiler(File daemonWorkingDir, Class<? extends Compiler<GroovyJavaJointCompileSpec>> compilerClass, ClassPathRegistry classPathRegistry, CompilerWorkerExecutor compilerWorkerExecutor, ClassLoaderRegistry classLoaderRegistry, JavaForkOptionsFactory forkOptionsFactory, JvmVersionDetector jvmVersionDetector) {
+    public DaemonGroovyCompiler(
+        File daemonWorkingDir,
+        Class<? extends Compiler<GroovyJavaJointCompileSpec>> compilerClass,
+        ClassPathRegistry classPathRegistry,
+        CompilerWorkerExecutor compilerWorkerExecutor,
+        ClassLoaderRegistry classLoaderRegistry,
+        JavaForkOptionsFactory forkOptionsFactory,
+        JvmVersionDetector jvmVersionDetector,
+        InternalProblemReporter problemReporter
+    ) {
         super(compilerWorkerExecutor);
         this.compilerClass = compilerClass;
         this.classPathRegistry = classPathRegistry;
@@ -60,6 +77,7 @@ public class DaemonGroovyCompiler extends AbstractDaemonCompiler<GroovyJavaJoint
         this.forkOptionsFactory = forkOptionsFactory;
         this.daemonWorkingDir = daemonWorkingDir;
         this.jvmVersionDetector = jvmVersionDetector;
+        this.problemReporter = problemReporter;
     }
 
     @Override
@@ -78,8 +96,7 @@ public class DaemonGroovyCompiler extends AbstractDaemonCompiler<GroovyJavaJoint
         Iterable<File> classpath = Iterables.concat(spec.getGroovyClasspath(), antFiles);
         VisitableURLClassLoader.Spec targetGroovyClasspath = new VisitableURLClassLoader.Spec("worker-loader", DefaultClassPath.of(classpath).getAsURLs());
 
-        Collection<File> languageGroovyFiles = classPathRegistry.getClassPath("GROOVY-COMPILER").getAsFiles();
-        VisitableURLClassLoader.Spec compilerClasspath = new VisitableURLClassLoader.Spec("compiler-loader", DefaultClassPath.of(languageGroovyFiles).getAsURLs());
+        ClassPath languageGroovyClasspath = classPathRegistry.getClassPath("GROOVY-COMPILER");
 
         FilteringClassLoader.Spec gradleAndUserFilter = getMinimalGradleFilter();
 
@@ -87,19 +104,37 @@ public class DaemonGroovyCompiler extends AbstractDaemonCompiler<GroovyJavaJoint
             gradleAndUserFilter.allowPackage(sharedPackage);
         }
 
+        JavaForkOptions javaForkOptions = new BaseForkOptionsConverter(forkOptionsFactory).transform(mergeForkOptions(javaOptions, groovyOptions));
+        javaForkOptions.setWorkingDir(daemonWorkingDir);
+        javaForkOptions.setExecutable(javaOptions.getExecutable());
+        if (jvmVersionDetector.getJavaVersion(javaForkOptions.getExecutable()).isJava9Compatible()) {
+            javaForkOptions.jvmArgs(JpmsConfiguration.GROOVY_JPMS_ARGS);
+        } else {
+            // In JDK 8 and below, we need to attach the 'tools.jar' to the classpath.
+            File javaExecutable = new File(javaForkOptions.getExecutable());
+            JavaInfo jvm = Jvm.forHome(javaExecutable.getParentFile().getParentFile());
+            File toolsJar = jvm.getToolsJar();
+            if (toolsJar == null) {
+                String contextualMessage = String.format("The 'tools.jar' cannot be found in the JDK '%s'.", jvm.getJavaHome());
+                throw problemReporter.throwing(problemSpec -> problemSpec
+                    .id("groovy-daemon-compiler", "Missing tools.jar", GradleCoreProblemGroup.compilation().groovy())
+                    .contextualLabel(contextualMessage)
+                    .solution("Check if the installation is not a JRE but a JDK.")
+                    .severity(Severity.ERROR)
+                    .withException(new IllegalStateException(contextualMessage))
+                );
+            } else {
+                languageGroovyClasspath = languageGroovyClasspath.plus(Collections.singletonList(toolsJar));
+            }
+        }
+
+        VisitableURLClassLoader.Spec compilerClasspath = new VisitableURLClassLoader.Spec("compiler-loader", languageGroovyClasspath.getAsURLs());
         HierarchicalClassLoaderStructure classLoaderStructure =
             new HierarchicalClassLoaderStructure(classLoaderRegistry.getGradleWorkerExtensionSpec())
                 .withChild(getMinimalGradleFilter())
                 .withChild(targetGroovyClasspath)
                 .withChild(gradleAndUserFilter)
                 .withChild(compilerClasspath);
-
-        JavaForkOptions javaForkOptions = new BaseForkOptionsConverter(forkOptionsFactory).transform(mergeForkOptions(javaOptions, groovyOptions));
-        javaForkOptions.setWorkingDir(daemonWorkingDir);
-        javaForkOptions.setExecutable(javaOptions.getExecutable());
-        if (jvmVersionDetector.getJavaVersion(javaForkOptions.getExecutable()).isJava9Compatible()) {
-            javaForkOptions.jvmArgs(JpmsConfiguration.GROOVY_JPMS_ARGS);
-        }
 
         return new DaemonForkOptionsBuilder(forkOptionsFactory)
             .javaForkOptions(javaForkOptions)

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
@@ -469,7 +469,6 @@ class JavaCompileToolchainIntegrationTest extends AbstractIntegrationSpec implem
             }
         """
 
-        //noinspection GrDeprecatedAPIUsage
         executer.expectDeprecationWarning("$fileWithDeprecation:5: warning: $deprecationMessage")
 
         when:

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AbstractJavaCompileSpecFactory.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AbstractJavaCompileSpecFactory.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.compile;
 
+import org.gradle.api.JavaVersion;
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.internal.Factory;
 import org.gradle.internal.jvm.Jvm;
@@ -59,7 +60,7 @@ public abstract class AbstractJavaCompileSpecFactory<T extends JavaCompileSpec> 
         }
 
         if (!toolchain.isCurrentJvm()) {
-            return getForkingSpec(toolchainJavaHome);
+            return getForkingSpec(toolchainJavaHome, toolchain.getLanguageVersion().asInt());
         }
 
         return getDefaultSpec();
@@ -76,12 +77,19 @@ public abstract class AbstractJavaCompileSpecFactory<T extends JavaCompileSpec> 
             return getCommandLineSpec(JavaExecutableUtils.resolveExecutable(forkExecutable));
         }
 
-        return getForkingSpec(fallbackJavaHome);
+        final int languageVersion;
+        if (toolchain != null) {
+            languageVersion = toolchain.getLanguageVersion().asInt();
+        } else {
+            languageVersion = JavaVersion.current().ordinal() + 1;
+        }
+
+        return getForkingSpec(fallbackJavaHome, languageVersion);
     }
 
     abstract protected T getCommandLineSpec(File executable);
 
-    abstract protected T getForkingSpec(File javaHome);
+    abstract protected T getForkingSpec(File javaHome, int javaLanguageVersion);
 
     abstract protected T getDefaultSpec();
 }

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/ContextAwareJavaCompiler.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/ContextAwareJavaCompiler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile;
+
+import com.sun.source.util.JavacTask;
+import com.sun.tools.javac.util.Context;
+
+import javax.tools.DiagnosticListener;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileManager;
+import javax.tools.JavaFileObject;
+import java.io.Writer;
+
+/**
+ * This interface extends the standard {@link JavaCompiler} interface with {@link com.sun.tools.javac.api.JavacTool}'s internal method
+ * {@link com.sun.tools.javac.api.JavacTool#getTask(Writer, JavaFileManager, DiagnosticListener, Iterable, Iterable, Iterable, Context)}, which has an additional {@link Context} parameter.
+ */
+public interface ContextAwareJavaCompiler extends JavaCompiler {
+
+    JavacTask getTask(
+        Writer out,
+        JavaFileManager fileManager,
+        DiagnosticListener<? super JavaFileObject> diagnosticListener,
+        Iterable<String> options,
+        Iterable<String> classes,
+        Iterable<? extends JavaFileObject> compilationUnits,
+        Context context
+    );
+
+}

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpecFactory.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpecFactory.java
@@ -33,8 +33,8 @@ public class DefaultJavaCompileSpecFactory extends AbstractJavaCompileSpecFactor
     }
 
     @Override
-    protected DefaultJavaCompileSpec getForkingSpec(File javaHome) {
-        return new DefaultForkingJavaCompileSpec(javaHome);
+    protected DefaultJavaCompileSpec getForkingSpec(File javaHome, int javaLanguageVersion) {
+        return new DefaultForkingJavaCompileSpec(javaHome, javaLanguageVersion);
     }
 
     @Override
@@ -57,14 +57,21 @@ public class DefaultJavaCompileSpecFactory extends AbstractJavaCompileSpecFactor
 
     private static class DefaultForkingJavaCompileSpec extends DefaultJavaCompileSpec implements ForkingJavaCompileSpec {
         private final File javaHome;
+        private final int javaLanguageVersion;
 
-        private DefaultForkingJavaCompileSpec(File javaHome) {
+        private DefaultForkingJavaCompileSpec(File javaHome, int javaLanguageVersion) {
             this.javaHome = javaHome;
+            this.javaLanguageVersion = javaLanguageVersion;
         }
 
         @Override
         public File getJavaHome() {
             return javaHome;
+        }
+
+        @Override
+        public int getJavaLanguageVersion() {
+            return javaLanguageVersion;
         }
     }
 }

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactory.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactory.java
@@ -20,7 +20,6 @@ import org.gradle.api.internal.tasks.compile.daemon.ProcessIsolatedCompilerWorke
 import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDetector;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.initialization.layout.ProjectCacheDir;
-import org.gradle.internal.Factory;
 import org.gradle.jvm.toolchain.internal.JavaCompilerFactory;
 import org.gradle.language.base.internal.compile.CompileSpec;
 import org.gradle.language.base.internal.compile.Compiler;
@@ -30,8 +29,6 @@ import org.gradle.process.internal.worker.child.WorkerDirectoryProvider;
 import org.gradle.workers.internal.ActionExecutionSpecFactory;
 import org.gradle.workers.internal.WorkerDaemonFactory;
 
-import javax.tools.JavaCompiler;
-
 public class DefaultJavaCompilerFactory implements JavaCompilerFactory {
     private final WorkerDirectoryProvider workingDirProvider;
     private final WorkerDaemonFactory workerDaemonFactory;
@@ -40,7 +37,7 @@ public class DefaultJavaCompilerFactory implements JavaCompilerFactory {
     private final AnnotationProcessorDetector processorDetector;
     private final ClassPathRegistry classPathRegistry;
     private final ActionExecutionSpecFactory actionExecutionSpecFactory;
-    private Factory<JavaCompiler> javaHomeBasedJavaCompilerFactory;
+    private JavaHomeBasedJavaCompilerFactory javaHomeBasedJavaCompilerFactory;
     private final InternalProblems problems;
     private final ProjectCacheDir projectCacheDir;
 
@@ -66,7 +63,7 @@ public class DefaultJavaCompilerFactory implements JavaCompilerFactory {
         this.projectCacheDir = projectCacheDir;
     }
 
-    private Factory<JavaCompiler> getJavaHomeBasedJavaCompilerFactory() {
+    private JavaHomeBasedJavaCompilerFactory getJavaHomeBasedJavaCompilerFactory() {
         if (javaHomeBasedJavaCompilerFactory == null) {
             javaHomeBasedJavaCompilerFactory = new JavaHomeBasedJavaCompilerFactory(classPathRegistry.getClassPath("JAVA-COMPILER-PLUGIN").getAsFiles());
         }

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/ForkingJavaCompileSpec.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/ForkingJavaCompileSpec.java
@@ -22,4 +22,6 @@ public interface ForkingJavaCompileSpec {
 
     File getJavaHome();
 
+    int getJavaLanguageVersion();
+
 }

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/IncrementalCompilationAwareJavaCompiler.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/IncrementalCompilationAwareJavaCompiler.java
@@ -21,7 +21,7 @@ import javax.tools.JavaCompiler;
 import java.util.Map;
 import java.util.Set;
 
-public interface IncrementalCompilationAwareJavaCompiler extends JavaCompiler {
+public interface IncrementalCompilationAwareJavaCompiler extends ContextAwareJavaCompiler {
     JavaCompiler.CompilationTask makeIncremental(
         JavaCompiler.CompilationTask task,
         Map<String, Set<String>> sourceToClassMapping,

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaHomeBasedJavaCompilerFactory.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaHomeBasedJavaCompilerFactory.java
@@ -17,16 +17,14 @@
 package org.gradle.api.internal.tasks.compile;
 
 import org.gradle.internal.Factory;
-import org.gradle.internal.jvm.Jvm;
 
-import javax.tools.JavaCompiler;
 import java.io.File;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class JavaHomeBasedJavaCompilerFactory implements Factory<JavaCompiler>, Serializable {
+public class JavaHomeBasedJavaCompilerFactory implements Factory<ContextAwareJavaCompiler>, Serializable {
     private final List<File> compilerPluginsClasspath;
     // We use a static cache here because we want to reuse classloaders in compiler workers as
     // it has a huge impact on performance. Previously there was a single, JdkTools.current()
@@ -39,12 +37,12 @@ public class JavaHomeBasedJavaCompilerFactory implements Factory<JavaCompiler>, 
     }
 
     @Override
-    public JavaCompiler create() {
+    public ContextAwareJavaCompiler create() {
         JdkTools jdkTools = JavaHomeBasedJavaCompilerFactory.JDK_TOOLS.computeIfAbsent(compilerPluginsClasspath, JavaHomeBasedJavaCompilerFactory::createJdkTools);
         return jdkTools.getSystemJavaCompiler();
     }
 
     private static JdkTools createJdkTools(List<File> compilerPluginsClasspath) {
-        return new JdkTools(Jvm.current(), compilerPluginsClasspath);
+        return new JdkTools(compilerPluginsClasspath);
     }
 }

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.tasks.compile;
 
+import com.sun.tools.javac.util.Context;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDeclaration;
 import org.gradle.api.internal.tasks.compile.reflect.GradleStandardJavaFileManager;
@@ -27,7 +28,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import javax.tools.DiagnosticListener;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
@@ -36,18 +36,24 @@ import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable {
     private static final Logger LOGGER = LoggerFactory.getLogger(JdkJavaCompiler.class);
 
-    private final Factory<JavaCompiler> javaHomeBasedJavaCompilerFactory;
+    private final Context context;
+    private final Factory<ContextAwareJavaCompiler> compilerFactory;
     private final DiagnosticToProblemListener diagnosticToProblemListener;
 
     @Inject
-    public JdkJavaCompiler(Factory<JavaCompiler> javaHomeBasedJavaCompilerFactory, InternalProblems problemsService) {
-        this.javaHomeBasedJavaCompilerFactory = javaHomeBasedJavaCompilerFactory;
-        this.diagnosticToProblemListener = new DiagnosticToProblemListener(problemsService.getInternalReporter());
+    public JdkJavaCompiler(
+        Factory<ContextAwareJavaCompiler> compilerFactory,
+        InternalProblems problemsService
+    ) {
+        this.context = new Context();
+        this.compilerFactory = compilerFactory;
+        this.diagnosticToProblemListener = new DiagnosticToProblemListener(problemsService.getInternalReporter(), context);
     }
 
     @Override
@@ -63,20 +69,22 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
         return result;
     }
 
+    @SuppressWarnings("DefaultCharset")
     private JavaCompiler.CompilationTask createCompileTask(JavaCompileSpec spec, ApiCompilerResult result) {
-        // We check here if the Problems API is used
-        // If it's not used, the compiler interfaces interpret "null" as "use the default diagnostic listener"
-        DiagnosticListener<JavaFileObject> diagnosticListener = shouldUseProblemsApiReporting() ? diagnosticToProblemListener : null;
-
         List<String> options = new JavaCompilerArgumentsBuilder(spec).build();
-        JavaCompiler compiler = javaHomeBasedJavaCompilerFactory.create();
+        ContextAwareJavaCompiler compiler = compilerFactory.create();
+
         MinimalJavaCompileOptions compileOptions = spec.getCompileOptions();
-        Charset charset = compileOptions.getEncoding() != null ? Charset.forName(compileOptions.getEncoding()) : null;
-        StandardJavaFileManager standardFileManager = compiler.getStandardFileManager(diagnosticListener, null, charset);
+        Charset charset = Optional.ofNullable(compileOptions.getEncoding())
+            .map(Charset::forName)
+            .orElse(null);
+        StandardJavaFileManager standardFileManager = compiler.getStandardFileManager(diagnosticToProblemListener, null, charset);
+
         Iterable<? extends JavaFileObject> compilationUnits = standardFileManager.getJavaFileObjectsFromFiles(spec.getSourceFiles());
         boolean hasEmptySourcepaths = JavaVersion.current().isJava9Compatible() && emptySourcepathIn(options);
         JavaFileManager fileManager = GradleStandardJavaFileManager.wrap(standardFileManager, DefaultClassPath.of(spec.getAnnotationProcessorPath()), hasEmptySourcepaths);
-        JavaCompiler.CompilationTask task = compiler.getTask(null, fileManager, diagnosticListener, options, spec.getClassesToProcess(), compilationUnits);
+
+        JavaCompiler.CompilationTask task = compiler.getTask(null, fileManager, diagnosticToProblemListener, options, spec.getClassesToProcess(), compilationUnits, context);
         if (compiler instanceof IncrementalCompilationAwareJavaCompiler) {
             task = ((IncrementalCompilationAwareJavaCompiler) compiler).makeIncremental(
                 task,
@@ -92,11 +100,6 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
         return task;
     }
 
-    private static boolean shouldUseProblemsApiReporting() {
-        String property = System.getProperty("org.gradle.internal.emit-compiler-problems");
-        return Boolean.parseBoolean(property);
-    }
-
     private static boolean emptySourcepathIn(List<String> options) {
         Iterator<String> optionsIter = options.iterator();
         while (optionsIter.hasNext()) {
@@ -107,4 +110,5 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
         }
         return false;
     }
+
 }

--- a/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactoryTest.groovy
+++ b/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactoryTest.groovy
@@ -83,14 +83,21 @@ class DefaultJavaCompilerFactoryTest extends Specification {
 
     private static class TestForkingJavaCompileSpec extends DefaultJavaCompileSpec implements ForkingJavaCompileSpec {
         private final File javaHome;
+        private final int javaLanguageVersion;
 
-        private TestForkingJavaCompileSpec(File javaHome) {
-            this.javaHome = javaHome;
+        private TestForkingJavaCompileSpec(File javaHome, int javaLanguageVersion) {
+            this.javaHome = javaHome
+            this.javaLanguageVersion = javaLanguageVersion
         }
 
         @Override
-        public File getJavaHome() {
-            return javaHome;
+        File getJavaHome() {
+            return javaHome
+        }
+
+        @Override
+        int getJavaLanguageVersion() {
+            return javaLanguageVersion
         }
     }
 }

--- a/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListenerTest.groovy
+++ b/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListenerTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.tasks.compile
 
 
-import org.gradle.api.problems.ProblemSpec
+import org.gradle.api.problems.internal.InternalProblemSpec
 import spock.lang.Specification
 
 import javax.tools.Diagnostic
@@ -25,8 +25,12 @@ import javax.tools.JavaFileObject
 
 class DiagnosticToProblemListenerTest extends Specification {
 
-    // Create a mock for ProblemReporter, which will
-    def spec = Mock(ProblemSpec)
+    def spec = Mock(InternalProblemSpec) {
+        // We report the formatted message in all cases
+        1 * additionalData("formatted", "Formatted message")
+    }
+
+    def diagnosticToProblemListener = new DiagnosticToProblemListener(null, null, (fo) -> "Formatted message")
 
     def "file location is correctly reported"() {
         given:
@@ -38,7 +42,7 @@ class DiagnosticToProblemListenerTest extends Specification {
         diagnostic.lineNumber | diagnostic.columnNumber | diagnostic.startPosition | diagnostic.endPosition >> Diagnostic.NOPOS
 
         when:
-        DiagnosticToProblemListener.buildProblem(diagnostic, spec)
+        diagnosticToProblemListener.buildProblem(diagnostic, spec)
 
         then:
         1 * spec.fileLocation("SomeFile.java")
@@ -59,7 +63,7 @@ class DiagnosticToProblemListenerTest extends Specification {
         diagnostic.columnNumber | diagnostic.startPosition | diagnostic.endPosition >> Diagnostic.NOPOS
 
         when:
-        DiagnosticToProblemListener.buildProblem(diagnostic, spec)
+        diagnosticToProblemListener.buildProblem(diagnostic, spec)
 
         then:
         1 * spec.fileLocation("SomeFile.java")
@@ -82,7 +86,7 @@ class DiagnosticToProblemListenerTest extends Specification {
         diagnostic.startPosition | diagnostic.endPosition >> Diagnostic.NOPOS
 
         when:
-        DiagnosticToProblemListener.buildProblem(diagnostic, spec)
+        diagnosticToProblemListener.buildProblem(diagnostic, spec)
 
         then:
         1 * spec.fileLocation("SomeFile.java")
@@ -109,7 +113,7 @@ class DiagnosticToProblemListenerTest extends Specification {
         diagnostic.endPosition >> Diagnostic.NOPOS
 
         when:
-        DiagnosticToProblemListener.buildProblem(diagnostic, spec)
+        diagnosticToProblemListener.buildProblem(diagnostic, spec)
 
         then:
         // Behavior should be the same as when only line and column are defined
@@ -135,7 +139,7 @@ class DiagnosticToProblemListenerTest extends Specification {
         diagnostic.endPosition >> 1
 
         when:
-        DiagnosticToProblemListener.buildProblem(diagnostic, spec)
+        diagnosticToProblemListener.buildProblem(diagnostic, spec)
 
         then:
         // Behavior should be the same as when only line and column are defined
@@ -161,7 +165,7 @@ class DiagnosticToProblemListenerTest extends Specification {
         diagnostic.endPosition >> 20
 
         when:
-        DiagnosticToProblemListener.buildProblem(diagnostic, spec)
+        diagnosticToProblemListener.buildProblem(diagnostic, spec)
 
         then:
         1 * spec.fileLocation("SomeFile.java")

--- a/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JdkToolsTest.groovy
+++ b/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JdkToolsTest.groovy
@@ -16,10 +16,7 @@
 
 package org.gradle.api.internal.tasks.compile
 
-import org.gradle.api.JavaVersion
-import org.gradle.internal.jvm.Jvm
-import org.gradle.test.precondition.Requires
-import org.gradle.test.preconditions.UnitTestPreconditions
+
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -27,7 +24,7 @@ import javax.tools.JavaCompiler
 
 class JdkToolsTest extends Specification {
     @Subject
-    JdkTools current = new JdkTools(Jvm.current(), [])
+    JdkTools current = new JdkTools([])
 
     def "can get java compiler"() {
         def compiler = current.systemJavaCompiler
@@ -37,44 +34,4 @@ class JdkToolsTest extends Specification {
         compiler.class == current.systemJavaCompiler.class
     }
 
-    def "throws when no tools"() {
-        when:
-        new JdkTools(Mock(Jvm) {
-            getToolsJar() >> null
-            getJavaVersion() >> JavaVersion.VERSION_1_8
-            getJavaHome() >> new File('.')
-        }, [])
-
-        then:
-        thrown IllegalStateException
-    }
-
-    @Requires(UnitTestPreconditions.Jdk8OrEarlier)
-    def "throws when tools doesn't contain compiler"() {
-        when:
-        if (defaultCompilerClassAlreadyInjectedIntoExtensionClassLoader()) {
-            throw new IllegalStateException()
-        }
-        new JdkTools(Mock(Jvm) {
-            getToolsJar() >> new File("/nothing")
-        }, []).systemJavaCompiler
-
-        then:
-        thrown IllegalStateException
-    }
-
-    /*
-     * See https://github.com/gradle/gradle-private/issues/1299
-     *
-     * Previously, before this test class is executed, DEFAULT_COMPILER_IMPL_NAME may already be injected into Extension Classloader,
-     * so here we check for prerequisite.
-     */
-    private static boolean defaultCompilerClassAlreadyInjectedIntoExtensionClassLoader() {
-        try {
-            ClassLoader.getSystemClassLoader().loadClass(JdkTools.DEFAULT_COMPILER_IMPL_NAME)
-            return true
-        } catch (ClassNotFoundException ignored) {
-            return false
-        }
-    }
 }

--- a/platforms/jvm/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/AbstractDaemonCompiler.java
+++ b/platforms/jvm/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/AbstractDaemonCompiler.java
@@ -60,5 +60,4 @@ public abstract class AbstractDaemonCompiler<T extends CompileSpec> implements C
         return merged;
     }
 
-
 }

--- a/testing/architecture-test/src/changes/archunit_store/internal-api-nullability.txt
+++ b/testing/architecture-test/src/changes/archunit_store/internal-api-nullability.txt
@@ -2052,7 +2052,6 @@ Class <org.gradle.internal.jvm.JavaHomeException> is not annotated (directly or 
 Class <org.gradle.internal.jvm.JavaInfo> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (JavaInfo.java:0)
 Class <org.gradle.internal.jvm.JavaModuleDetector$ModuleInfoLocator> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (JavaModuleDetector.java:0)
 Class <org.gradle.internal.jvm.JavaModuleDetector> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (JavaModuleDetector.java:0)
-Class <org.gradle.internal.jvm.JpmsConfiguration> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (JpmsConfiguration.java:0)
 Class <org.gradle.internal.jvm.Jvm> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (Jvm.java:0)
 Class <org.gradle.internal.jvm.UnsupportedJavaRuntimeException> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (UnsupportedJavaRuntimeException.java:0)
 Class <org.gradle.internal.jvm.inspection.CachingJvmMetadataDetector> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (CachingJvmMetadataDetector.java:0)

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/ReceivedProblem.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/ReceivedProblem.groovy
@@ -112,6 +112,14 @@ class ReceivedProblem implements Problem {
         locations
     }
 
+    <T extends ProblemLocation> T getSingleLocation(Class<T> locationType) {
+        def location = locations.find {
+            locationType.isInstance(it)
+        }
+        assert location != null : "Expected a location of type $locationType, but found none."
+        return locationType.cast(location)
+    }
+
     @Override
     Map<String, Object> getAdditionalData() {
        additionalData


### PR DESCRIPTION
Solves #27823

The solution presented here uses `JavacTool` with an explicit `Context` object we can keep.
This allows us to gain access to `RichDiagnosticsFormatter`, which we can use to format the same String as the one which would be printed to `stderr`.