### PR TITLE
Make `Task` extend `Named`, just like `Configuration`

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -35,6 +35,18 @@ The previous step will help you identify potential problems by issuing deprecati
 . Run `gradle wrapper --gradle-version {gradleVersion}` to update the project to {gradleVersion}.
 . Try to run the project and debug any errors using the <<troubleshooting.adoc#troubleshooting, Troubleshooting Guide>>.
 
+[[changes_8.8]]
+== Upgrading from 8.7 and earlier
+
+=== Deprecations
+
+[[deprecated_namers]]
+==== Deprecated `Namer` of `Task` and `Configuration`
+`Task` and `Configuration` have a link:{javadocPath}/org/gradle/api/Namer.html[`Namer`] inner class (also called `Namer`) that could be used as a common way to retrieve the name of a task or configuration. Now that these types
+implement link:{javadocPath}/org/gradle/api/Named.html[`Named`], these classes are no longer necessary and have been deprecated. It will be removed in Gradle 9.0. Use link:{javadocPath}/org/gradle/api/Named.Namer.html#INSTANCE[`Named.Namer.INSTANCE`] instead.
+
+The superinterface, link:{javadocPath}/org/gradle/api/Namer.html[`Namer`], is *not* being deprecated.
+
 [[changes_8.7]]
 == Upgrading from 8.6 and earlier
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -42,8 +42,10 @@ The previous step will help you identify potential problems by issuing deprecati
 
 [[deprecated_namers]]
 ==== Deprecated `Namer` of `Task` and `Configuration`
-`Task` and `Configuration` have a link:{javadocPath}/org/gradle/api/Namer.html[`Namer`] inner class (also called `Namer`) that could be used as a common way to retrieve the name of a task or configuration. Now that these types
-implement link:{javadocPath}/org/gradle/api/Named.html[`Named`], these classes are no longer necessary and have been deprecated. It will be removed in Gradle 9.0. Use link:{javadocPath}/org/gradle/api/Named.Namer.html#INSTANCE[`Named.Namer.INSTANCE`] instead.
+`Task` and `Configuration` have a link:{javadocPath}/org/gradle/api/Namer.html[`Namer`] inner class (also called `Namer`) that can be used as a common way to retrieve the name of a task or configuration. 
+Now that these types implement link:{javadocPath}/org/gradle/api/Named.html[`Named`], these classes are no longer necessary and have been deprecated. 
+They will be removed in Gradle 9.0. 
+Use link:{javadocPath}/org/gradle/api/Named.Namer.html#INSTANCE[`Named.Namer.INSTANCE`] instead.
 
 The superinterface, link:{javadocPath}/org/gradle/api/Namer.html[`Namer`], is *not* being deprecated.
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -20,6 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.GradleException;
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.UnknownDomainObjectException;
 import org.gradle.api.artifacts.Configuration;
@@ -69,7 +70,7 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
         DefaultConfigurationFactory defaultConfigurationFactory,
         ResolutionStrategyFactory resolutionStrategyFactory
     ) {
-        super(Configuration.class, instantiator, new Configuration.Namer(), callbackDecorator);
+        super(Configuration.class, instantiator, Named.Namer.INSTANCE, callbackDecorator);
 
         this.rootComponentMetadataBuilder = rootComponentMetadataBuilderFactory.create(this);
         this.defaultConfigurationFactory = defaultConfigurationFactory;

--- a/platforms/software/platform-base/src/main/java/org/gradle/platform/base/internal/registry/BinaryTasksModelRuleExtractor.java
+++ b/platforms/software/platform-base/src/main/java/org/gradle/platform/base/internal/registry/BinaryTasksModelRuleExtractor.java
@@ -18,6 +18,7 @@ package org.gradle.platform.base.internal.registry;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.Action;
+import org.gradle.api.Named;
 import org.gradle.api.Task;
 import org.gradle.internal.Cast;
 import org.gradle.model.ModelMap;
@@ -94,7 +95,7 @@ public class BinaryTasksModelRuleExtractor extends AbstractAnnotationDrivenCompo
                     Task.class,
                     binary.getTasks(),
                     taskFactory,
-                    new Task.Namer(),
+                    Named.Namer.INSTANCE,
                     new Action<Task>() {
                         @Override
                         public void execute(Task task) {

--- a/platforms/software/platform-base/src/test/groovy/org/gradle/model/internal/core/DomainObjectCollectionBackedModelMapTest.groovy
+++ b/platforms/software/platform-base/src/test/groovy/org/gradle/model/internal/core/DomainObjectCollectionBackedModelMapTest.groovy
@@ -31,7 +31,7 @@ class DomainObjectCollectionBackedModelMapTest extends Specification {
         given:
         def backingCollection = Mock(DomainObjectCollection)
         def instantiator = Mock(NamedEntityInstantiator)
-        def modelMap = DomainObjectCollectionBackedModelMap.wrap("thing", SomeType, backingCollection, instantiator, new Named.Namer(), Actions.doNothing())
+        def modelMap = DomainObjectCollectionBackedModelMap.wrap("thing", SomeType, backingCollection, instantiator, Named.Namer.INSTANCE, Actions.doNothing())
 
         when:
         modelMap.create("alma")
@@ -56,7 +56,7 @@ class DomainObjectCollectionBackedModelMapTest extends Specification {
                 return new SomeType(name: name)
             }
         })
-        def modelMap = new DomainObjectCollectionBackedModelMap("thing", SomeType, backingCollection, instantiator, new Named.Namer(), Actions.doNothing())
+        def modelMap = new DomainObjectCollectionBackedModelMap("thing", SomeType, backingCollection, instantiator, Named.Namer.INSTANCE, Actions.doNothing())
 
         when:
         modelMap.create("alma", List)

--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -34,6 +34,7 @@ import org.gradle.api.tasks.TaskInputs;
 import org.gradle.api.tasks.TaskLocalState;
 import org.gradle.api.tasks.TaskOutputs;
 import org.gradle.api.tasks.TaskState;
+import org.gradle.internal.deprecation.DeprecationLogger;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -194,6 +195,16 @@ public interface Task extends Comparable<Task>, ExtensionAware, Named {
      */
     @Deprecated
     class Namer implements org.gradle.api.Namer<Task> {
+
+        public Namer() {
+            DeprecationLogger.deprecateType(Namer.class)
+                .replaceWith("Named.Namer.INSTANCE")
+                .withContext("Task implements Named, so you can use Named.Namer.INSTANCE instead of Task.Namer")
+                .willBeRemovedInGradle9()
+                .withUpgradeGuideSection(8, "deprecated_namers")
+                .nagUser();
+        }
+
         @Override
         public String determineName(Task task) {
             return Named.Namer.INSTANCE.determineName(task);

--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -156,7 +156,7 @@ import java.util.Set;
  * Parallel execution can be enabled by the <code>--parallel</code> flag when the build is initiated.
  * In parallel mode, the tasks of different projects (i.e. in a multi project build) are able to be executed in parallel.
  */
-public interface Task extends Comparable<Task>, ExtensionAware {
+public interface Task extends Comparable<Task>, ExtensionAware, Named {
     String TASK_NAME = "name";
 
     String TASK_DESCRIPTION = "description";
@@ -184,15 +184,19 @@ public interface Task extends Comparable<Task>, ExtensionAware {
      * @return The name of the task. Never returns null.
      */
     @Internal
+    @Override
     String getName();
 
     /**
-     * A {@link org.gradle.api.Namer} namer for tasks that returns {@link #getName()}.
+     * An implementation of the namer interface for tasks that returns {@link #getName()}.
+     *
+     * @deprecated Use {@link Named.Namer#INSTANCE} instead (since {@link Task} now extends {@link Named}).
      */
+    @Deprecated
     class Namer implements org.gradle.api.Namer<Task> {
         @Override
-        public String determineName(Task c) {
-            return c.getName();
+        public String determineName(Task task) {
+            return Named.Namer.INSTANCE.determineName(task);
         }
     }
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
@@ -26,6 +26,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.HasInternalProtocol;
+import org.gradle.internal.deprecation.DeprecationLogger;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -109,6 +110,16 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      */
     @Deprecated
     class Namer implements org.gradle.api.Namer<Configuration> {
+
+        public Namer() {
+            DeprecationLogger.deprecateType(Namer.class)
+                .replaceWith("Named.Namer.INSTANCE")
+                .withContext("Configuration implements Named, so you can use Named.Namer.INSTANCE instead of Configuration.Namer")
+                .willBeRemovedInGradle9()
+                .withUpgradeGuideSection(8, "deprecated_namers")
+                .nagUser();
+        }
+
         @Override
         public String determineName(Configuration configuration) {
             return Named.Namer.INSTANCE.determineName(configuration);

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
@@ -103,12 +103,15 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
     State getState();
 
     /**
-     * A {@link org.gradle.api.Namer} namer for configurations that returns {@link #getName()}.
+     * An implementation of the namer interface for configurations that returns {@link #getName()}.
+     *
+     * @deprecated Use {@link Named.Namer#INSTANCE} instead (since {@link Configuration} now extends {@link Named}).
      */
+    @Deprecated
     class Namer implements org.gradle.api.Namer<Configuration> {
         @Override
-        public String determineName(Configuration c) {
-            return c.getName();
+        public String determineName(Configuration configuration) {
+            return Named.Namer.INSTANCE.determineName(configuration);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskCollection.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Iterables;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectCollectionSchema;
 import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;
@@ -44,26 +45,25 @@ import java.util.Map;
 import static org.gradle.api.reflect.TypeOf.typeOf;
 
 public class DefaultTaskCollection<T extends Task> extends DefaultNamedDomainObjectSet<T> implements TaskCollection<T> {
-    private static final Task.Namer NAMER = new Task.Namer();
 
     protected final ProjectInternal project;
 
     private final MutationGuard parentMutationGuard;
 
     public DefaultTaskCollection(Class<T> type, Instantiator instantiator, ProjectInternal project, MutationGuard parentMutationGuard, CollectionCallbackActionDecorator decorator) {
-        super(type, instantiator, NAMER, decorator);
+        super(type, instantiator, Named.Namer.INSTANCE, decorator);
         this.project = project;
         this.parentMutationGuard = parentMutationGuard;
     }
 
     public DefaultTaskCollection(DefaultTaskCollection<? super T> collection, CollectionFilter<T> filter, Instantiator instantiator, ProjectInternal project, MutationGuard parentMutationGuard) {
-        super(collection, filter, instantiator, NAMER);
+        super(collection, filter, instantiator, Named.Namer.INSTANCE);
         this.project = project;
         this.parentMutationGuard = parentMutationGuard;
     }
 
     public DefaultTaskCollection(DefaultTaskCollection<? super T> collection, Spec<String> nameFilter, CollectionFilter<T> elementFilter, Instantiator instantiator, ProjectInternal project, MutationGuard parentMutationGuard) {
-        super(collection, nameFilter, elementFilter, instantiator, NAMER);
+        super(collection, nameFilter, elementFilter, instantiator, Named.Namer.INSTANCE);
         this.project = project;
         this.parentMutationGuard = parentMutationGuard;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainerFactory.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.tasks;
 
+import org.gradle.api.Named;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.Transformer;
@@ -104,7 +105,7 @@ public class DefaultTaskContainerFactory implements Factory<TaskContainerInterna
                             return tasks;
                         }
                     },
-                    new Task.Namer(),
+                    Named.Namer.INSTANCE,
                     "Project.<init>.tasks()",
                     new Namer()
                 );


### PR DESCRIPTION
### Context

Instances implementing [the `Task` interface already have a `String getName()` method](https://github.com/gradle/gradle/blob/v8.7.0-RC1/subprojects/core-api/src/main/java/org/gradle/api/Task.java#L182-L188). This name is final, non-null, and unique ([as implemented in `AbstractTask`](https://github.com/gradle/gradle/blob/v8.7.0-RC1/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java#L242-L246)), so it fits all the criteria of [the same method declared by the `Named` interface](https://github.com/gradle/gradle/blob/v8.7.0-RC1/platforms/core-runtime/base-services/src/main/java/org/gradle/api/Named.java#L23-L30). Logically, `Task` should implement `Named`, but currently it doesn't.

The `Configuration` interface was in the same situation, but [a recent improvement](https://github.com/gradle/gradle/pull/25700/files#diff-dbb1f60f3b7333a865639935e0f5e44cce63fb5864cb77eba9e96260da6ea150) now allows instances implementing that interface to be cast to `Named`. This change aims to provide the same improvement for instances of `Task`. It also deprecates both the  `Configuration.Namer` and the `Task.Namer` classes, as they are not really needed anymore.

This change is also required for https://github.com/gradle/gradle/pull/28198 to provide improved error reporting.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew :sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew :dependency-management:quickTest :platform-base:quickTest :core-api:quickTest :core:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
