### PR TITLE
Fix realised Maven module metadata not adding variants from rules

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/AdditionalVariantsMetadataRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/AdditionalVariantsMetadataRulesIntegrationTest.groovy
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests.resolve.rules
+
+import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
+import spock.lang.Issue
+
+class AdditionalVariantsMetadataRulesIntegrationTest extends AbstractModuleDependencyResolveTest {
+
+    ResolveTestFixture resolve
+
+    def setup() {
+        resolve = new ResolveTestFixture(buildFile, "samples")
+        resolve.prepare()
+    }
+
+    @Override
+    boolean isJavaEcosystem() {
+        false
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/20145")
+    def "component metadata rules can add variants even if no derivation rules are present"() {
+        given: "a published module"
+        repository {
+            group("org") {
+                module("a") {
+                    version("1") {
+                        withModule {
+                            undeclaredArtifact(type: 'jar', classifier: "my-samples")
+                        }
+                        withoutGradleMetadata()
+                    }
+                }
+            }
+        }
+
+        and: "a component metadata rule that adds a variant"
+        file("buildSrc/build.gradle") << """
+            plugins {
+                id("java")
+            }
+        """
+        file("buildSrc/src/main/java/AddVariantRule.java") << """
+            package com.example;
+
+            import org.gradle.api.artifacts.ComponentMetadataContext;
+            import org.gradle.api.artifacts.ComponentMetadataRule;
+            import org.gradle.api.artifacts.ModuleVersionIdentifier;
+            import org.gradle.api.attributes.Category;
+            import org.gradle.api.attributes.DocsType;
+            import org.gradle.api.model.ObjectFactory;
+
+            import javax.inject.Inject;
+
+            public class AddVariantRule implements ComponentMetadataRule {
+                private final ObjectFactory objectFactory;
+
+                @Inject
+                public AddVariantRule(ObjectFactory objectFactory) {
+                    this.objectFactory = objectFactory;
+                }
+
+                @Override
+                public void execute(ComponentMetadataContext componentMetadataContext) {
+                    Category category = objectFactory.named(Category.class, Category.DOCUMENTATION);
+                    DocsType docsType = objectFactory.named(DocsType.class, "my-classifier");
+
+                    ModuleVersionIdentifier id = componentMetadataContext.getDetails().getId();
+                    componentMetadataContext.getDetails().addVariant("my-samples", variantMetadata -> {
+                        variantMetadata.attributes(attributeContainer -> {
+                            attributeContainer.attribute(Category.CATEGORY_ATTRIBUTE, category);
+                            attributeContainer.attribute(DocsType.DOCS_TYPE_ATTRIBUTE, docsType);
+                        });
+                        variantMetadata.withFiles(variantFiles -> {
+                            variantFiles.addFile(id.getName() + "-" + id.getVersion() + "-my-samples.jar");
+                        });
+                    });
+                }
+            }
+        """
+
+        when: "a project does not apply the ecosystem plugins and therefore doesn't have derivation rules"
+        buildFile << """
+            configurations {
+                create("samples") {
+                    canBeResolved = true
+                    canBeConsumed = false
+                    attributes {
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.DOCUMENTATION))
+                        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType.class, "my-classifier"))
+                    }
+                }
+            }
+
+            dependencies {
+                samples("org:a:1")
+            }
+
+            dependencies.components.all(com.example.AddVariantRule)
+        """
+
+        then: "the variant added by the rule should be present and should be chosen as the resolution result"
+        repositoryInteractions {
+            group("org") {
+                module("a") {
+                    version("1") {
+                        expectGetMetadata()
+                        allowAll()
+                    }
+                }
+            }
+        }
+        succeeds 'checkDeps'
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module("org:a:1") {
+                    variant("my-samples", [
+                        "org.gradle.category": "documentation",
+                        "org.gradle.docstype": "my-classifier",
+                        "org.gradle.status": GradleMetadataResolveRunner.useIvy() ? 'integration' : 'release'
+                    ]).artifact(classifier: "my-samples")
+                }
+            }
+        }
+    }
+
+    def getRepo() {
+        return maven(file('repo'))
+    }
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
@@ -75,7 +75,7 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
         VariantMetadataRules variantMetadataRules = metadata.getVariantMetadataRules();
         ImmutableList<? extends ComponentVariant> variants = LazyToRealisedModuleComponentResolveMetadataHelper.realiseVariants(metadata, variantMetadataRules, metadata.getVariants());
         Map<String, ModuleConfigurationMetadata> configurations = Maps.newHashMapWithExpectedSize(metadata.getConfigurationNames().size());
-        List<ModuleConfigurationMetadata> derivedVariants = ImmutableList.of();
+        ImmutableList<ModuleConfigurationMetadata> derivedVariants = ImmutableList.of();
         if (variants.isEmpty()) {
             Optional<List<? extends ModuleConfigurationMetadata>> sourceVariants = metadata.deriveVariants();
             if (sourceVariants.isPresent()) {
@@ -101,8 +101,9 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
                     );
                     builder.add(derivedVariantMetadata);
                 }
-                derivedVariants = addVariantsFromRules(metadata, builder.build(), variantMetadataRules);
+                derivedVariants = builder.build();
             }
+            derivedVariants = addVariantsFromRules(metadata, derivedVariants, variantMetadataRules);
         }
         for (String configurationName : metadata.getConfigurationNames()) {
             configurations.put(configurationName, createConfiguration(metadata, configurationName));
@@ -110,7 +111,7 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
         return new RealisedMavenModuleResolveMetadata(metadata, variants, derivedVariants, configurations);
     }
 
-    private static List<ModuleConfigurationMetadata> addVariantsFromRules(
+    private static ImmutableList<ModuleConfigurationMetadata> addVariantsFromRules(
         ModuleComponentResolveMetadata componentMetadata,
         ImmutableList<ModuleConfigurationMetadata> derivedVariants,
         VariantMetadataRules variantMetadataRules

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/CachedCodePathComponentMetadataProcessorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/CachedCodePathComponentMetadataProcessorTest.groovy
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.dsl
+
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
+import org.gradle.api.internal.artifacts.MetadataResolutionContext
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleDescriptorHashModuleSource
+import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstraintMetadataImpl
+import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependencyMetadataImpl
+import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.api.internal.notations.ComponentIdentifierParserFactory
+import org.gradle.api.internal.notations.DependencyMetadataNotationParser
+import org.gradle.api.specs.Specs
+import org.gradle.cache.CacheBuilder
+import org.gradle.cache.CacheDecorator
+import org.gradle.cache.FileLockManager
+import org.gradle.cache.IndexedCache
+import org.gradle.cache.IndexedCacheParameters
+import org.gradle.cache.PersistentCache
+import org.gradle.cache.internal.DefaultInMemoryCacheDecoratorFactory
+import org.gradle.cache.scopes.GlobalScopedCacheBuilderFactory
+import org.gradle.internal.action.DefaultConfigurableRule
+import org.gradle.internal.component.external.model.AbstractMutableModuleComponentResolveMetadata
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.internal.component.external.model.MutableComponentVariant
+import org.gradle.internal.component.external.model.NoOpDerivationStrategy
+import org.gradle.internal.component.model.MutableModuleSources
+import org.gradle.internal.hash.HashCode
+import org.gradle.internal.resolve.caching.ComponentMetadataRuleExecutor
+import org.gradle.internal.serialize.Serializer
+import org.gradle.internal.snapshot.ValueSnapshotter
+import org.gradle.internal.snapshot.impl.StringValueSnapshot
+import org.gradle.util.AttributeTestUtil
+import org.gradle.util.TestUtil
+import org.gradle.util.internal.BuildCommencedTimeProvider
+import org.gradle.util.internal.SimpleMapInterner
+import org.junit.Assert
+import spock.lang.Issue
+import spock.lang.Specification
+
+import static org.hamcrest.CoreMatchers.sameInstance
+import static org.junit.Assume.assumeThat
+
+class CachedCodePathComponentMetadataProcessorTest extends Specification {
+    def instantiator = TestUtil.instantiatorFactory().decorateLenient()
+    def stringInterner = SimpleMapInterner.notThreadSafe()
+    def mavenMetadataFactory = DependencyManagementTestUtil.mavenMetadataFactory()
+    def ivyMetadataFactory = DependencyManagementTestUtil.ivyMetadataFactory()
+    def dependencyMetadataNotationParser = DependencyMetadataNotationParser.parser(instantiator, DirectDependencyMetadataImpl, stringInterner)
+    def dependencyConstraintMetadataNotationParser = DependencyMetadataNotationParser.parser(instantiator, DependencyConstraintMetadataImpl, stringInterner)
+    def componentIdentifierNotationParser = new ComponentIdentifierParserFactory().create()
+    def metadataRuleContainer = new ComponentMetadataRuleContainer()
+    MetadataResolutionContext context = Mock(MetadataResolutionContext) {
+        injectingInstantiator >> instantiator
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/20145")
+    def "keeps additional variants produced by rules in #metadataKind metadata with #ownVariants own variants"() {
+        given: "a component metadata with no derivation strategy"
+        def metadata = metadata(metadataKind)
+        assumeThat(metadata.getVariantDerivationStrategy(), sameInstance(NoOpDerivationStrategy.instance))
+
+        and: "some variants in the component, or none"
+        (0..<ownVariants).forEach {
+            metadata.addVariant("variant$it", ImmutableAttributes.EMPTY)
+        }
+
+        and: "a rule that adds a variant to all components"
+        metadataRuleContainer.addClassRule(
+            new SpecConfigurableRule(
+                DefaultConfigurableRule.of(TestAddVariantComponentMetadataRule),
+                Specs.satisfyAll()
+            )
+        )
+
+        when: "a processor runs on this metadata through the caching code path"
+        def processor = processorWithCacheThatNeverHits()
+        def result = processor.processMetadata(metadata.asImmutable())
+
+        then: "the result should have the variant added by the rule"
+        def variantsForGraphTraversal = result.variantsForGraphTraversal.get()
+        variantsForGraphTraversal.size() == ownVariants + 1
+        def variant = variantsForGraphTraversal.find { it.name == "test" }
+        variant != null
+        "org.gradle.test" in variant.attributes.keySet().collect { it.name }
+
+        where:
+        metadataKind | ownVariants
+        "maven"      | 0
+        "maven"      | 2
+        "ivy"        | 0
+        "ivy"        | 2
+    }
+
+    private DefaultComponentMetadataProcessor processorWithCacheThatNeverHits() {
+        CacheBuilder cacheBuilder
+        cacheBuilder = Mock(CacheBuilder) {
+            withInitialLockMode(_ as FileLockManager.LockMode) >> { cacheBuilder }
+            open() >> {
+                Mock(PersistentCache) {
+                    createIndexedCache(_ as IndexedCacheParameters) >> {
+                        Mock(IndexedCache) {
+                            getIfPresent(_) >> null
+                        }
+                    }
+                }
+            }
+        }
+        GlobalScopedCacheBuilderFactory cacheRepository = Mock(GlobalScopedCacheBuilderFactory) {
+            createCacheBuilder(_ as String) >> cacheBuilder
+        }
+
+        DefaultInMemoryCacheDecoratorFactory cacheDecoratorFactory = Mock(DefaultInMemoryCacheDecoratorFactory) {
+            decorator(_ as int, _ as boolean) >> Mock(CacheDecorator)
+        }
+        BuildCommencedTimeProvider timeProvider = Stub(BuildCommencedTimeProvider) {
+            getCurrentTime() >> { 0L }
+        }
+
+        def snapshotter = Mock(ValueSnapshotter) {
+            snapshot(_) >> {
+                new StringValueSnapshot(it.toString())
+            }
+        }
+        def executorWithCache = new ComponentMetadataRuleExecutor(cacheRepository, cacheDecoratorFactory, snapshotter, timeProvider, Mock(Serializer))
+
+        new DefaultComponentMetadataProcessor(
+            metadataRuleContainer, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser,
+            AttributeTestUtil.attributesFactory(), executorWithCache, DependencyManagementTestUtil.platformSupport(), context
+        )
+    }
+
+    private AbstractMutableModuleComponentResolveMetadata metadata(String metadataKind, MutableComponentVariant... variants) {
+        def module = DefaultModuleIdentifier.newId("group", "module")
+        def metadata =
+            metadataKind == "maven" ?
+                mavenMetadataFactory.create(DefaultModuleComponentIdentifier.newId(module, "version"), []) :
+                metadataKind == "ivy" ?
+                    ivyMetadataFactory.create(DefaultModuleComponentIdentifier.newId(module, "version"), [])
+                    : Assert.fail("unexpected metadataKind")
+        for (final def variant in variants) {
+            metadata.addVariant(variant)
+        }
+        metadata.status = "integration"
+        metadata.statusScheme = ["integration", "release"]
+        metadata.sources = MutableModuleSources.of(Stub(ModuleDescriptorHashModuleSource) {
+            getDescriptorHash() >> HashCode.fromBytes([0, 0, 0, 0] as byte[])
+        })
+        return metadata as AbstractMutableModuleComponentResolveMetadata
+    }
+}

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/TestAddVariantComponentMetadataRule.java
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/TestAddVariantComponentMetadataRule.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.dsl;
+
+import org.gradle.api.artifacts.CacheableRule;
+import org.gradle.api.artifacts.ComponentMetadataContext;
+import org.gradle.api.artifacts.ComponentMetadataRule;
+import org.gradle.api.attributes.Attribute;
+
+@CacheableRule
+public class TestAddVariantComponentMetadataRule implements ComponentMetadataRule {
+    @Override
+    public void execute(ComponentMetadataContext componentMetadataContext) {
+        componentMetadataContext.getDetails().addVariant("test", variantMetadata -> {
+            variantMetadata.attributes(attributeContainer -> {
+                attributeContainer.attribute(Attribute.of("org.gradle.test", String.class), "test");
+            });
+        });
+    }
+}

--- a/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractModuleDependencyResolveTest.groovy
+++ b/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractModuleDependencyResolveTest.groovy
@@ -148,6 +148,10 @@ abstract class AbstractModuleDependencyResolveTest extends AbstractHttpDependenc
         false
     }
 
+    boolean isJavaEcosystem() {
+        true
+    }
+
     def setup() {
         resolve = new ResolveTestFixture(buildFile, testConfiguration)
         resolve.expectDefaultConfiguration(usesJavaLibraryVariants() ? "runtime" : "default")
@@ -169,7 +173,9 @@ abstract class AbstractModuleDependencyResolveTest extends AbstractHttpDependenc
                 $testConfiguration
             }
         """
-        resolve.addJavaEcosystem()
+        if (isJavaEcosystem()) {
+            resolve.addJavaEcosystem()
+        }
     }
 
     void repository(@DelegatesTo(RemoteRepositorySpec) Closure<Void> spec) {


### PR DESCRIPTION
Rebasing #21213 onto current master and fixing issues. 

If there were no variants in the component metadata and no variants were added by the derivation strategy, RealisedMavenModuleResolveMetadata would ignore additional variants produced by component metadata rules. This was inconsistent with the behavior of the default (lazy) implementation.

Fix the inconsistency by adding the variants produced by the component metadata rules during realization even if the variant's own variants are empty.

Fixes #20145 
Supersedes #21213 