### PR TITLE
Revert "Increase TeamCity history/artifact retention to 28/14 days"

### DIFF
--- a/.teamcity/src/main/kotlin/projects/CheckProject.kt
+++ b/.teamcity/src/main/kotlin/projects/CheckProject.kt
@@ -75,8 +75,8 @@ class CheckProject(
     subProjectsOrder = subProjects
 
     cleanupRule(
-        historyDays = 28,
-        artifactsDays = 14,
+        historyDays = 14,
+        artifactsDays = 7,
         artifactsPatterns = """
                 +:**/*
                 +:$hiddenArtifactDestination/**/*"

--- a/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
+++ b/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
@@ -11,7 +11,7 @@ class PromotionProject(branch: VersionedSettingsBranch) : Project({
     id("Promotion")
     name = "Promotion"
 
-    cleanupRule(historyDays = 28, artifactsDays = 14)
+    cleanupRule(historyDays = 14, artifactsDays = 7)
 
     buildType(SanityCheck)
     buildType(PublishNightlySnapshot(branch))


### PR DESCRIPTION
This reverts commit f66094f032c1566514dfcd79663d2d36b6e18311.

TC runs out of disk recently. We probably don't need to keep the build logs two weeks ago.