### PR TITLE
Fix implementation of version catalog (enforced) platform

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
@@ -1213,14 +1213,14 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module('org.gradle.test:lib:1.1') {
+                edge('org.gradle.test:lib:{strictly 1.1}', 'org.gradle.test:lib:1.1') {
                     variant('enforced-platform-runtime', [
                         'org.gradle.status': 'release',
                         'org.gradle.usage': 'java-runtime',
                         'org.gradle.category': 'enforced-platform'])
                     noArtifacts()
                 }
-                module('org.gradle.test:lib.subgroup:1.1') {
+                edge('org.gradle.test:lib.subgroup:{strictly 1.1}', 'org.gradle.test:lib.subgroup:1.1') {
                     variant('enforced-platform-runtime', [
                         'org.gradle.status': 'release',
                         'org.gradle.usage': 'java-runtime',

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -349,6 +349,7 @@ public abstract class DefaultDependencyHandler implements DependencyHandlerInter
     public Dependency platform(Object notation) {
         Dependency dependency = create(notation);
         if (dependency instanceof ModuleDependency) {
+            // Changes here may require changes in DefaultExternalModuleDependencyVariantSpec
             ModuleDependency moduleDependency = (ModuleDependency) dependency;
             moduleDependency.endorseStrictVersions();
             platformSupport.addPlatformAttribute(moduleDependency, toCategory(Category.REGULAR_PLATFORM));
@@ -370,6 +371,7 @@ public abstract class DefaultDependencyHandler implements DependencyHandlerInter
     public Dependency enforcedPlatform(Object notation) {
         Dependency platformDependency = create(notation);
         if (platformDependency instanceof ExternalModuleDependency) {
+            // Changes here may require changes in DefaultExternalModuleDependencyVariantSpec
             AbstractExternalModuleDependency externalModuleDependency = (AbstractExternalModuleDependency) platformDependency;
             MutableVersionConstraint constraint = (MutableVersionConstraint) externalModuleDependency.getVersionConstraint();
             constraint.strictly(externalModuleDependency.getVersion());
@@ -394,6 +396,7 @@ public abstract class DefaultDependencyHandler implements DependencyHandlerInter
             ProjectDependency projectDependency = (ProjectDependency) testFixturesDependency;
             projectDependency.capabilities(new ProjectTestFixtures(projectDependency.getDependencyProject()));
         } else if (testFixturesDependency instanceof ModuleDependency) {
+            // Changes here may require changes in DefaultExternalModuleDependencyVariantSpec
             ModuleDependency moduleDependency = (ModuleDependency) testFixturesDependency;
             moduleDependency.capabilities(capabilities -> capabilities.requireCapability(new DefaultImmutableCapability(
                 moduleDependency.getGroup(),
@@ -429,6 +432,8 @@ public abstract class DefaultDependencyHandler implements DependencyHandlerInter
     public Provider<MinimalExternalModuleDependency> enforcedPlatform(Provider<MinimalExternalModuleDependency> dependencyProvider) {
         return variantOf(dependencyProvider, spec -> {
             DefaultExternalModuleDependencyVariantSpec defaultSpec = (DefaultExternalModuleDependencyVariantSpec) spec;
+            MutableVersionConstraint versionConstraint = (MutableVersionConstraint) defaultSpec.dep.getVersionConstraint();
+            versionConstraint.strictly(defaultSpec.dep.getVersion());
             defaultSpec.attributesAction = attrs -> attrs.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.ENFORCED_PLATFORM));
         });
     }
@@ -463,6 +468,7 @@ public abstract class DefaultDependencyHandler implements DependencyHandlerInter
 
         @Override
         public void platform() {
+            this.dep.endorseStrictVersions();
             this.attributesAction = attrs -> attrs.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.REGULAR_PLATFORM));
         }
 


### PR DESCRIPTION
Fixes #27282 

Possible extra additions:
- Test to ensure that implementation doesn't drift again in the future? Maybe re-using some of the notation-merging concepts from #28168 
- Test of the `endorseStrictVersions()` call I added, I'm not really sure how to test that properly as the existing `endorse` tests aren't even using `platform()`...

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
