### PR TITLE
Speed up runtime classpath fingerprinting

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -202,6 +202,7 @@ fun Test.configureJvmForTest() {
     if (jvmVersionForTest().canCompileOrRun(9)) {
         if (isUnitTest() || usesEmbeddedExecuter()) {
             jvmArgs(org.gradle.internal.jvm.JpmsConfiguration.GRADLE_DAEMON_JPMS_ARGS)
+            jvmArgs("--add-opens=java.base/java.io=ALL-UNNAMED") //Newly added to JpmsConfiguration
         } else {
             jvmArgs(listOf("--add-opens", "java.base/java.util=ALL-UNNAMED")) // Used in tests by native platform library: WrapperProcess.getEnv
             jvmArgs(listOf("--add-opens", "java.base/java.lang=ALL-UNNAMED")) // Used in tests by ClassLoaderUtils

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -202,7 +202,7 @@ fun Test.configureJvmForTest() {
     if (jvmVersionForTest().canCompileOrRun(9)) {
         if (isUnitTest() || usesEmbeddedExecuter()) {
             jvmArgs(org.gradle.internal.jvm.JpmsConfiguration.GRADLE_DAEMON_JPMS_ARGS)
-            jvmArgs("--add-opens=java.base/java.io=ALL-UNNAMED") //Newly added to JpmsConfiguration
+            jvmArgs("--add-opens=java.base/java.io=ALL-UNNAMED") // Newly added to JpmsConfiguration
         } else {
             jvmArgs(listOf("--add-opens", "java.base/java.util=ALL-UNNAMED")) // Used in tests by native platform library: WrapperProcess.getEnv
             jvmArgs(listOf("--add-opens", "java.base/java.lang=ALL-UNNAMED")) // Used in tests by ClassLoaderUtils

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
@@ -33,6 +33,7 @@ public class JpmsConfiguration {
         "--add-opens=java.base/java.lang=ALL-UNNAMED",
         "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
         "--add-opens=java.base/java.util=ALL-UNNAMED",
+        "--add-opens=java.base/java.io=ALL-UNNAMED" ,// required by FileZipInput
         "--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED" // required by PreferenceCleaningGroovySystemLoader
     ));
 

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
@@ -33,7 +33,7 @@ public class JpmsConfiguration {
         "--add-opens=java.base/java.lang=ALL-UNNAMED",
         "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
         "--add-opens=java.base/java.util=ALL-UNNAMED",
-        "--add-opens=java.base/java.io=ALL-UNNAMED" ,// required by FileZipInput
+        "--add-opens=java.base/java.io=ALL-UNNAMED", // required by FileZipInput
         "--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED" // required by PreferenceCleaningGroovySystemLoader
     ));
 

--- a/platforms/core-runtime/files/src/main/java/org/gradle/api/internal/file/archive/ZipEntry.java
+++ b/platforms/core-runtime/files/src/main/java/org/gradle/api/internal/file/archive/ZipEntry.java
@@ -52,7 +52,7 @@ public interface ZipEntry {
     byte[] getContent() throws IOException;
 
     /**
-     * Declare an action to be run against this ZipEntry's content as a {@link InputStream}.
+     * Declare an action to be run against this ZipEntry's decompressed content as a {@link InputStream}.
      * The {@link InputStream} passed to the {@link IoFunction#apply(Object)} will
      * be closed right after the action's return.
      *
@@ -60,6 +60,16 @@ public interface ZipEntry {
      * Use {@link #canReopen()} to determine if more than one call is supported.
      */
     <T> T withInputStream(IoFunction<InputStream, T> action) throws IOException;
+
+    /**
+     * Declare an action to be run against this ZipEntry's compressed content as a {@link InputStream}.
+     * The {@link InputStream} passed to the {@link IoFunction#apply(Object)} will
+     * be closed right after the action's return.
+     *
+     * This method may not be supported by all {@link ZipEntry} implementations.
+     * Use {@link #supportsRawStream()} to determine if this method can be called.
+     */
+    <T> T withRawInputStream(IoFunction<InputStream, T> action) throws IOException;
 
     /**
      * The size of the content in bytes, or -1 if not known.
@@ -71,6 +81,8 @@ public interface ZipEntry {
      * have already been read from it.
      */
     boolean canReopen();
+
+    boolean supportsRawStream();
 
     ZipCompressionMethod getCompressionMethod();
 }

--- a/platforms/core-runtime/files/src/main/java/org/gradle/api/internal/file/archive/impl/StreamZipInput.java
+++ b/platforms/core-runtime/files/src/main/java/org/gradle/api/internal/file/archive/impl/StreamZipInput.java
@@ -78,6 +78,16 @@ public class StreamZipInput implements ZipInput {
             }
         }
 
+        @Override
+        public <T> T withRawInputStream(IoFunction<InputStream, T> action) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean supportsRawStream() {
+            return false;
+        }
+
         private void closeEntry() {
             try {
                 inputStream.closeEntry();

--- a/platforms/jvm/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/FallbackHandlingResourceHasher.java
+++ b/platforms/jvm/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/FallbackHandlingResourceHasher.java
@@ -151,6 +151,11 @@ abstract class FallbackHandlingResourceHasher implements ResourceHasher {
         }
 
         @Override
+        public <T> T withRawInputStream(IoFunction<InputStream, T> action) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public int size() {
             return delegate.size();
         }
@@ -158,6 +163,11 @@ abstract class FallbackHandlingResourceHasher implements ResourceHasher {
         @Override
         public boolean canReopen() {
             return true;
+        }
+
+        @Override
+        public boolean supportsRawStream() {
+            return false;
         }
 
         @Override

--- a/platforms/jvm/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/RuntimeClasspathResourceHasher.java
+++ b/platforms/jvm/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/RuntimeClasspathResourceHasher.java
@@ -42,7 +42,12 @@ public class RuntimeClasspathResourceHasher implements ResourceHasher {
 
     @Override
     public HashCode hash(ZipEntryContext zipEntryContext) throws IOException {
-        return zipEntryContext.getEntry().withInputStream(Hashing::hashStream);
+        ZipEntry entry = zipEntryContext.getEntry();
+        if (entry.supportsRawStream()) {
+            return entry.withRawInputStream(Hashing::hashStream);
+        } else  {
+            return entry.withInputStream(Hashing::hashStream);
+        }
     }
 
     @Override

--- a/platforms/jvm/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/LineEndingNormalizingResourceHasherTest.groovy
+++ b/platforms/jvm/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/LineEndingNormalizingResourceHasherTest.groovy
@@ -226,6 +226,16 @@ class LineEndingNormalizingResourceHasherTest extends Specification {
             ZipEntry.ZipCompressionMethod getCompressionMethod() {
                 return ZipEntry.ZipCompressionMethod.DEFLATED
             }
+
+            @Override
+            boolean supportsRawStream() {
+                return false
+            }
+
+            @Override
+            <T> T withRawInputStream(IoFunction<InputStream, T> action) throws IOException {
+                throw new UnsupportedOperationException()
+            }
         }
         return new DefaultZipEntryContext(zipEntry, file.path, "foo.zip")
     }

--- a/platforms/jvm/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/MetaInfAwareClasspathResourceHasherTest.groovy
+++ b/platforms/jvm/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/MetaInfAwareClasspathResourceHasherTest.groovy
@@ -488,6 +488,16 @@ class MetaInfAwareClasspathResourceHasherTest extends Specification {
             ZipEntry.ZipCompressionMethod getCompressionMethod() {
                 return ZipEntry.ZipCompressionMethod.DEFLATED
             }
+
+            @Override
+            boolean supportsRawStream() {
+                return false
+            }
+
+            @Override
+            <T> T withRawInputStream(IoFunction<InputStream, T> action) throws IOException {
+                throw new UnsupportedOperationException()
+            }
         }
         return new DefaultZipEntryContext(zipEntry, path, "foo.zip")
     }

--- a/platforms/jvm/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/PropertiesFileAwareClasspathResourceHasherTest.groovy
+++ b/platforms/jvm/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/PropertiesFileAwareClasspathResourceHasherTest.groovy
@@ -385,6 +385,16 @@ class PropertiesFileAwareClasspathResourceHasherTest extends Specification {
             ZipEntry.ZipCompressionMethod getCompressionMethod() {
                 return ZipEntry.ZipCompressionMethod.DEFLATED
             }
+
+            @Override
+            boolean supportsRawStream() {
+                return false
+            }
+
+            @Override
+            <T> T withRawInputStream(IoFunction<InputStream, T> action) throws IOException {
+                throw new UnsupportedOperationException()
+            }
         }
         return new DefaultZipEntryContext(zipEntry, path, "foo.zip")
     }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/classpath/impl/DefaultClasspathFingerprinterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/classpath/impl/DefaultClasspathFingerprinterTest.groovy
@@ -121,7 +121,7 @@ class DefaultClasspathFingerprinterTest extends Specification {
         then:
 
         fileCollectionFingerprint == [
-            ['library.jar', '', 'e3f8c5a79d138a40570261fa7de40642'],
+            ['library.jar', '', '87bfc1a3665090c2cad6ff720d62dc55'],
             ['fourthFile.txt', 'fourthFile.txt', '37b040e234b12a70145edbdb79683ee9'],
             ['build.log', 'subdir/build.log', '224c45bdc38a7e3c52cdcc6126d78946'],
             ['thirdFile.txt', 'thirdFile.txt', '138f1960a77eecec5f03362421bf967a'],
@@ -129,7 +129,7 @@ class DefaultClasspathFingerprinterTest extends Specification {
 
         resourceHashesCache.keySet().size() == 1
         def key = resourceHashesCache.keySet().iterator().next()
-        resourceHashesCache.getIfPresent(key).toString() == 'e3f8c5a79d138a40570261fa7de40642'
+        resourceHashesCache.getIfPresent(key).toString() == '87bfc1a3665090c2cad6ff720d62dc55'
     }
 
     def "detects moving of files in jars and directories"() {
@@ -147,7 +147,7 @@ class DefaultClasspathFingerprinterTest extends Specification {
         def fileCollectionFingerprint = fingerprint(zipFile, classes)
         then:
         fileCollectionFingerprint == [
-            ['library.jar', '', 'eaafc4a09214a09ffe2de2d02d5abd3c'],
+            ['library.jar', '', 'e7f288506219d82dce5ad07058953027'],
             ['thirdFile.txt', 'thirdFile.txt', '138f1960a77eecec5f03362421bf967a'],
         ]
 
@@ -160,7 +160,7 @@ class DefaultClasspathFingerprinterTest extends Specification {
 
         then:
         fileCollectionFingerprint == [
-            ['library.jar', '', 'c23694a1b7e494fab2aa21f5d644d0bc'],
+            ['library.jar', '', '4ed2e60cde24c6fa0f6843affea636ca'],
             ['thirdFile.txt', 'subdir/thirdFile.txt', '138f1960a77eecec5f03362421bf967a'],
         ]
     }
@@ -189,12 +189,12 @@ class DefaultClasspathFingerprinterTest extends Specification {
 
         then:
         fileCollectionFingerprint == [
-            ['library.jar', '', 'e3f8c5a79d138a40570261fa7de40642'],
-            ['another-library.jar', '', '5d9e97561e1c86c891600c8df838f7de']
+            ['library.jar', '', '87bfc1a3665090c2cad6ff720d62dc55'],
+            ['another-library.jar', '', 'a1669b999ebc91eec76862915dd51f80']
         ]
         resourceHashesCache.keySet().size() == 2
         def values = resourceHashesCache.keySet().collect { resourceHashesCache.getIfPresent(it).toString() } as Set
-        values == ['e3f8c5a79d138a40570261fa7de40642', '5d9e97561e1c86c891600c8df838f7de'] as Set
+        values == ['a1669b999ebc91eec76862915dd51f80', '87bfc1a3665090c2cad6ff720d62dc55'] as Set
 
         when:
         fileCollectionFingerprint = fingerprint(zipFile, zipFile2)
@@ -202,11 +202,11 @@ class DefaultClasspathFingerprinterTest extends Specification {
 
         then:
         fileCollectionFingerprint == [
-            ['library.jar', '', 'e3f8c5a79d138a40570261fa7de40642'],
-            ['another-library.jar', '', '5d9e97561e1c86c891600c8df838f7de']
+            ['library.jar', '', '87bfc1a3665090c2cad6ff720d62dc55'],
+            ['another-library.jar', '', 'a1669b999ebc91eec76862915dd51f80']
         ]
         resourceHashesCache.keySet().size() == 2
-        values == ['e3f8c5a79d138a40570261fa7de40642', '5d9e97561e1c86c891600c8df838f7de'] as Set
+        values == ['a1669b999ebc91eec76862915dd51f80', '87bfc1a3665090c2cad6ff720d62dc55'] as Set
     }
 
     def "empty jars are not ignored"() {
@@ -222,7 +222,7 @@ class DefaultClasspathFingerprinterTest extends Specification {
         then:
         classpathFingerprint == [
             ['empty.jar', '', '73aaa2573075495cce6048c54637763c'],
-            ['nonEmpty.jar', '', '252a9e49dedde612c99dd76008d11b03']
+            ['nonEmpty.jar', '', 'accff544c487abc24733070ca90c4809']
         ]
     }
 


### PR DESCRIPTION
The RuntimeClasspathResourceHasher does not inspect the contents of JAR entries, but just hashes them in their entirety. This means we don't have to unpack them and can instead hash their compressed bytes. This both saves the unpacking time and means less bytes to be hashed.

The ZipFile API does not give direct access to the raw input stream, but it is easy to obtain by unwrapping the InflaterInputStream.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
