### PR TITLE
Increase heap size for `docs:userguideSinglePagePdf`

### DIFF
--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleUserManualPlugin.java
@@ -239,7 +239,7 @@ public class GradleUserManualPlugin implements Plugin<Project> {
             // TODO: This breaks the provider
             task.setOutputDir(extension.getUserManual().getStagingRoot().dir("render-single-pdf").get().getAsFile());
             // The PDF rendering needs at least 2GB of heap
-            task.jvm(options -> options.setMaxHeapSize("2g"));
+            task.jvm(options -> options.setMaxHeapSize("3g"));
         });
 
         TaskProvider<AsciidoctorTask> userguideMultiPage = tasks.register("userguideMultiPage", AsciidoctorTask.class, task -> {


### PR DESCRIPTION
We've seen it 5 times this week: https://ge.gradle.org/scans/failures?failures.failureClassification=all_failures&failures.failureMessage=Execution%20failed%20for%20task%20%27:docs:userguideSinglePagePdf%27.%0A%3E%20A%20failure%20occurred%20while%20executing%20org.ysb33r.grolifant.internal.v6.jvm.worker.InternalWorkerAppExecutor%0A%20%20%20%3E%20org.asciidoctor.gradle.remote.AsciidoctorRemoteExecutionException:%20ERROR:%20Running%20Asciidoctor%20whilst%20attempting%20to%20process%20%2F*%2Ftcagent1%2F*work%2Ff63322e10dd6b396%2Fplatforms%2Fdocumentation%2Fdocs%2Fbuild%2Fworking%2Fusermanual%2Fraw%2Fuserguide_single.adoc%20using%20backend%20pdf&search.timeZoneId=Asia%2FShanghai


Let's try to increase heap size from 2g -> 3g to see if the situation gets improved.