### PR TITLE
Handle exception with circular causes in Gradle build

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/buildevents/BuildFailureIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/buildevents/BuildFailureIntegrationTest.groovy
@@ -39,4 +39,16 @@ throw new BadException()
         failure.assertHasDescription("A problem occurred evaluating root project")
         failure.assertHasCause("Unable to get message for failure of type BadException due to null")
     }
+
+    def "can handle circular exception"() {
+        buildFile << """
+            Exception selfReferencingException = new Exception("boom")
+            selfReferencingException.initCause(new Exception("boom", selfReferencingException))
+            throw selfReferencingException
+        """
+
+        expect:
+        fails("help", "-s")
+        result.assertHasErrorOutput("Caused by: java.lang.Throwable: [CIRCULAR REFERENCE: java.lang.Exception: boom]")
+    }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/buildevents/BuildFailureIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/buildevents/BuildFailureIntegrationTest.groovy
@@ -42,13 +42,16 @@ throw new BadException()
 
     def "can handle circular exception"() {
         buildFile << """
-            Exception selfReferencingException = new Exception("boom")
-            selfReferencingException.initCause(new Exception("boom", selfReferencingException))
+            Exception selfReferencingException = new Exception("BOOM self")
+            selfReferencingException.initCause(new Exception("BOOM cause", selfReferencingException))
             throw selfReferencingException
         """
 
-        expect:
+        when:
         fails("help", "-s")
-        result.assertHasErrorOutput("Caused by: java.lang.Throwable: [CIRCULAR REFERENCE: java.lang.Exception: boom]")
+
+        then:
+        failureCauseContains("BOOM self")
+        result.assertHasErrorOutput("Caused by: java.lang.Throwable: [CIRCULAR REFERENCE: java.lang.Exception: BOOM self]")
     }
 }


### PR DESCRIPTION
It is possible for exception to have circular causes. This shouldn't happen normally, though when it does, Gradle should still finish the build.

This PR uses a similar strategy as `Throwable.printStackTrace()` to break the cycle in our exception analyzers.

Fixes https://github.com/gradle/gradle/issues/28316

This is the adjusted failure after the change:

```
FAILURE: Build failed with an exception.

* Where:
Build file '/Users/wolfs/projects/gradle/co/build-tool/subprojects/core/build/tmp/teŝt files/BuildFailur.Test/qx0jr/build.gradle' line: 2

* What went wrong:
A problem occurred evaluating root project 'qx0jr'.
> BOOM self

* Try:
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

* Exception is:
org.gradle.api.GradleScriptException: A problem occurred evaluating root project 'qx0jr'.
	at org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java:93)
...
	at org.gradle.launcher.daemon.server.DaemonStateCoordinator$1.run(DaemonStateCoordinator.java:297)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:47)
Caused by: java.lang.Exception: BOOM self
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
	at org.gradle.internal.classpath.intercept.DefaultCallSiteDecorator$DecoratingCallSite.access$401(DefaultCallSiteDecorator.java:156)
	at org.gradle.internal.classpath.intercept.DefaultCallSiteDecorator$DecoratingCallSite$4.callOriginal(DefaultCallSiteDecorator.java:210)
	at org.gradle.internal.classpath.intercept.DefaultCallSiteDecorator$1.doIntercept(DefaultCallSiteDecorator.java:69)
	at org.gradle.internal.classpath.intercept.DefaultCallSiteDecorator$DecoratingCallSite.callConstructor(DefaultCallSiteDecorator.java:207)
	at build_8zl6uexm8tfp03f84r60rc432.run(projects/gradle/co/build-tool/subprojects/core/build/tmp/teŝt files/BuildFailur.Test/qx0jr/build.gradle:2)
	at org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java:91)
	... 163 more
Caused by: java.lang.Exception: BOOM cause
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
	at org.gradle.internal.classpath.intercept.DefaultCallSiteDecorator$DecoratingCallSite.access$401(DefaultCallSiteDecorator.java:156)
	at org.gradle.internal.classpath.intercept.DefaultCallSiteDecorator$DecoratingCallSite$4.callOriginal(DefaultCallSiteDecorator.java:210)
	at org.gradle.internal.classpath.intercept.DefaultCallSiteDecorator$1.doIntercept(DefaultCallSiteDecorator.java:69)
	at org.gradle.internal.classpath.intercept.DefaultCallSiteDecorator$DecoratingCallSite.callConstructor(DefaultCallSiteDecorator.java:207)
	at build_8zl6uexm8tfp03f84r60rc432.run(projects/gradle/co/build-tool/subprojects/core/build/tmp/teŝt files/BuildFailur.Test/qx0jr/build.gradle:3)
	... 164 more
Caused by: java.lang.Throwable: [CIRCULAR REFERENCE: java.lang.Exception: BOOM self]
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
	at org.gradle.internal.classpath.intercept.DefaultCallSiteDecorator$DecoratingCallSite.access$401(DefaultCallSiteDecorator.java:156)
	at org.gradle.internal.classpath.intercept.DefaultCallSiteDecorator$DecoratingCallSite$4.callOriginal(DefaultCallSiteDecorator.java:210)
	at org.gradle.internal.classpath.intercept.DefaultCallSiteDecorator$1.doIntercept(DefaultCallSiteDecorator.java:69)
	at org.gradle.internal.classpath.intercept.DefaultCallSiteDecorator$DecoratingCallSite.callConstructor(DefaultCallSiteDecorator.java:207)
	at build_8zl6uexm8tfp03f84r60rc432.run(projects/gradle/co/build-tool/subprojects/core/build/tmp/teŝt files/BuildFailur.Test/qx0jr/build.gradle:2)
	... 164 more


BUILD FAILED in 3s
```