### PR TITLE
Surface errors committing config cache report

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheReport.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheReport.kt
@@ -166,9 +166,9 @@ class ConfigurationCacheReport(
                     val unfinishedTasks = shutdownNow()
                     logger.warn(
                         "Configuration cache report is taking too long to write... "
-                            + "The build might finish before the report has been completely written. Unfinished tasks: "
-                            + unfinishedTasks
+                            + "The build might finish before the report has been completely written."
                     )
+                    logger.info("Unfinished tasks: {}", unfinishedTasks)
                 }
             }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheReport.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheReport.kt
@@ -162,7 +162,7 @@ class ConfigurationCacheReport(
             private
             fun ManagedExecutor.shutdownAndAwaitTermination() {
                 shutdown()
-                if (!awaitTermination(30, TimeUnit.SECONDS)) {
+                if (!awaitTermination(1, TimeUnit.SECONDS)) {
                     val unfinishedTasks = shutdownNow()
                     logger.warn(
                         "Configuration cache report is taking too long to write... "


### PR DESCRIPTION
Previously if the executor shutdown timed out, or one of the tasks threw an exception that killed the executors thread, `lateinit var reportFile` would still be uninitialised, which hides the actual underlying problem (that there were tasks on the executor that didn't complete successfully).

By submitting a `Callable` and waiting on the resulting `Future<File>` we will surface the actual problem, whether an `ExecutionException` or a `TimeoutException`, which will help in diagnosis.

Also, hopefully log the tasks that didn't complete which may also help in diagnosis.

<!--- The issue this PR addresses -->
Fixes #25570

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
