### PR TITLE
Speed up FileBackedBlockStore

### DIFF
--- a/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/btree/BTreeIndexedCacheTest.java
+++ b/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/btree/BTreeIndexedCacheTest.java
@@ -388,6 +388,17 @@ public class BTreeIndexedCacheTest {
         cache.close();
     }
 
+    @Test
+    public void canReadFromReadOnlyFile() {
+        createCache();
+        cache.put("1", 1);
+        verifyAndCloseCache();
+        cacheFile.setReadOnly();
+        createCache();
+        assertThat(cache.get("1"), equalTo(1));
+        verifyAndCloseCache();
+    }
+
     private void checkAdds(Integer... values) {
         checkAdds(Arrays.asList(values));
     }


### PR DESCRIPTION
We only need to flush padding information to disk when we release the file to another process. This drastically reduces ftruncate system calls, which may be slow in some environments like EBS volumes on AWS.

Fixes #28236

See the improvement numbers posted in the linked issue when one affected user tried out this branch.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
