### PR TITLE
Allow `plugins { }` in `settings.gradle.something`

### DIFF
--- a/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/settings/DeclarativeDslProjectSettingsIntegrationSpec.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/settings/DeclarativeDslProjectSettingsIntegrationSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.declarativedsl
+package org.gradle.internal.declarativedsl.settings
 
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
@@ -84,5 +84,72 @@ class DeclarativeDslProjectSettingsIntegrationSpec extends AbstractIntegrationSp
         "syntax"           | "..."                 | "2:13: parsing error: Expecting an element"
         "language feature" | "@A dependencies { }" | "2:13: unsupported language feature: AnnotationUsage"
         "semantic"         | "x = 1"               | "2:13: unresolved reference 'x'"
+    }
+
+    def 'can apply settings plugins'() {
+        given:
+        file("included-settings-plugin/build.gradle") << """
+            plugins {
+                id('java-gradle-plugin')
+            }
+            gradlePlugin {
+                plugins {
+                    create("settingsPlugin") {
+                        id = "com.example.restricted.settings"
+                        implementationClass = "com.example.restricted.RestrictedSettingsPlugin"
+                    }
+                }
+            }
+        """
+
+        file("included-settings-plugin/src/main/java/com/example/restricted/Extension.java") << """
+            package com.example.restricted;
+
+            import org.gradle.declarative.dsl.model.annotations.Restricted;
+            import org.gradle.api.provider.Property;
+
+            import javax.inject.Inject;
+
+            @Restricted
+            public abstract class Extension {
+                @Restricted
+                public abstract Property<String> getId();
+            }
+        """
+
+        file("included-settings-plugin/src/main/java/com/example/restricted/RestrictedSettingsPlugin.java") << """
+            package com.example.restricted;
+
+            import org.gradle.api.Plugin;
+            import org.gradle.api.initialization.Settings;
+
+            public class RestrictedSettingsPlugin implements Plugin<Settings> {
+                @Override
+                public void apply(Settings target) {
+                    Extension restricted = target.getExtensions().create("restricted", Extension.class);
+                    target.getGradle().settingsEvaluated(settings -> {
+                        System.out.println("id = " + restricted.getId().get());
+                    });
+                }
+            }
+        """
+
+        file("settings.gradle.something") << """
+            pluginManagement {
+                includeBuild("included-settings-plugin")
+            }
+
+            plugins {
+                id("com.example.restricted.settings")
+            }
+
+            restricted {
+                id = "test"
+            }
+        """
+
+        expect:
+        succeeds("help")
+        outputContains("id = test")
     }
 }

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/evaluationSchema/InterpretationSequence.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/evaluationSchema/InterpretationSequence.kt
@@ -30,3 +30,19 @@ interface InterpretationSequenceStep<R : Any> {
     fun topLevelReceiver(): R
     fun whenEvaluated(resultReceiver: R)
 }
+
+
+/**
+ * Implements a straightforward interpretation sequence step that uses the specified [topLevelReceiver]
+ * and produces an evaluation schema with [buildEvaluationSchema] immediately before the step runs.
+ */
+internal
+class SimpleInterpretationSequenceStep<T : Any>(
+    override val stepIdentifier: String,
+    private val topLevelReceiver: T,
+    private val buildEvaluationSchema: () -> EvaluationSchema
+) : InterpretationSequenceStep<T> {
+    override fun evaluationSchemaForStep(): EvaluationSchema = buildEvaluationSchema()
+    override fun topLevelReceiver(): T = topLevelReceiver
+    override fun whenEvaluated(resultReceiver: T) = Unit
+}

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/evaluator/InterpretationSchemaBuilder.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/evaluator/InterpretationSchemaBuilder.kt
@@ -44,8 +44,10 @@ sealed interface RestrictedScriptContext {
         val scriptSource: ScriptSource
     }
 
-    object SettingsScript : RestrictedScriptContext
-    object PluginsBlock : RestrictedScriptContext
+    data class SettingsScript(
+        override val targetScope: ClassLoaderScope,
+        override val scriptSource: ScriptSource
+    ) : ScriptDependentContext
 
     class ProjectScript(
         override val targetScope: ClassLoaderScope,

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/plugins/PluginsInterpretationSequenceStep.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/plugins/PluginsInterpretationSequenceStep.kt
@@ -37,11 +37,11 @@ import org.gradle.plugin.use.internal.PluginRequestApplicator
 
 internal
 class PluginsInterpretationSequenceStep<T>(
+    override val stepIdentifier: String = "plugins",
     private val target: T,
     private val targetScope: ClassLoaderScope,
     private val scriptSource: ScriptSource,
     private val getTargetServices: (T) -> ServiceRegistry,
-    override val stepIdentifier: String = "plugins",
 ) : InterpretationSequenceStep<PluginsTopLevelReceiver> {
     override fun evaluationSchemaForStep(): EvaluationSchema = EvaluationSchema(
         schemaForPluginsBlock,
@@ -74,5 +74,13 @@ val analyzeTopLevelPluginsBlockOnly = AnalysisStatementFilter { statement, scope
 
 
 internal
+val analyzeEverythingExceptPluginsBlock = AnalysisStatementFilter { statement, scopes ->
+    if (scopes.last().receiver is ObjectOrigin.TopLevelReceiver) {
+        !isPluginsCall(statement)
+    } else true
+}
+
+
+private
 fun isPluginsCall(statement: DataStatement) =
     statement is FunctionCall && statement.name == "plugins" && statement.args.size == 1 && statement.args.single() is FunctionArgument.Lambda

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/ProjectSchema.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/ProjectSchema.kt
@@ -25,7 +25,7 @@ import org.gradle.internal.declarativedsl.evaluationSchema.SimpleInterpretationS
 import org.gradle.internal.declarativedsl.evaluationSchema.buildEvaluationSchema
 import org.gradle.internal.declarativedsl.evaluationSchema.plus
 import org.gradle.internal.declarativedsl.plugins.PluginsInterpretationSequenceStep
-import org.gradle.internal.declarativedsl.plugins.analyzeEverythingExceptPluginsBlock
+import org.gradle.internal.declarativedsl.plugins.ignoreTopLevelPluginsBlock
 
 
 internal
@@ -51,5 +51,5 @@ fun projectEvaluationSchema(
         DependencyConfigurationsComponent(target) +
         TypesafeProjectAccessorsComponent(targetScope)
 
-    return buildEvaluationSchema(ProjectTopLevelReceiver::class, component, analyzeEverythingExceptPluginsBlock)
+    return buildEvaluationSchema(ProjectTopLevelReceiver::class, component, ignoreTopLevelPluginsBlock)
 }

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/ProjectSchema.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/ProjectSchema.kt
@@ -19,16 +19,13 @@ package org.gradle.internal.declarativedsl.project
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.groovy.scripts.ScriptSource
-import org.gradle.internal.declarativedsl.analysis.AnalysisStatementFilter
-import org.gradle.internal.declarativedsl.analysis.ObjectOrigin
 import org.gradle.internal.declarativedsl.evaluationSchema.EvaluationSchema
 import org.gradle.internal.declarativedsl.evaluationSchema.InterpretationSequence
-import org.gradle.internal.declarativedsl.evaluationSchema.InterpretationSequenceStep
+import org.gradle.internal.declarativedsl.evaluationSchema.SimpleInterpretationSequenceStep
 import org.gradle.internal.declarativedsl.evaluationSchema.buildEvaluationSchema
 import org.gradle.internal.declarativedsl.evaluationSchema.plus
 import org.gradle.internal.declarativedsl.plugins.PluginsInterpretationSequenceStep
-import org.gradle.internal.declarativedsl.plugins.PluginsTopLevelReceiver
-import org.gradle.internal.declarativedsl.plugins.isPluginsCall
+import org.gradle.internal.declarativedsl.plugins.analyzeEverythingExceptPluginsBlock
 
 
 internal
@@ -38,46 +35,21 @@ fun projectInterpretationSequence(
     scriptSource: ScriptSource
 ) = InterpretationSequence(
     listOf(
-        step1Plugins(target, targetScope, scriptSource),
-        step2Project(target, targetScope)
+        PluginsInterpretationSequenceStep("plugins", target, targetScope, scriptSource, ProjectInternal::getServices),
+        SimpleInterpretationSequenceStep("project", target) { projectEvaluationSchema(target, targetScope) }
     )
 )
 
 
 private
-fun step1Plugins(target: ProjectInternal, targetScope: ClassLoaderScope, scriptSource: ScriptSource): InterpretationSequenceStep<PluginsTopLevelReceiver> =
-    PluginsInterpretationSequenceStep(target, targetScope, scriptSource, ProjectInternal::getServices)
-
-
-private
-fun step2Project(target: ProjectInternal, targetScope: ClassLoaderScope) = object : InterpretationSequenceStep<ProjectInternal> {
-    override val stepIdentifier: String = "project"
-
-    override fun evaluationSchemaForStep(): EvaluationSchema = buildEvaluationSchema(
-        ProjectTopLevelReceiver::class,
-        projectEvaluationSchemaComponent(target, targetScope),
-        analysisStatementFilter = analyzeEverythingExceptPluginsBlock,
-    )
-
-    override fun topLevelReceiver(): ProjectInternal = target
-
-    override fun whenEvaluated(resultReceiver: ProjectInternal) = Unit
-}
-
-
-private
-fun projectEvaluationSchemaComponent(
+fun projectEvaluationSchema(
     target: ProjectInternal,
     targetScope: ClassLoaderScope
-) = gradleDslGeneralSchemaComponent() +
-    ThirdPartyExtensionsComponent(ProjectTopLevelReceiver::class, target, "projectExtension") +
-    DependencyConfigurationsComponent(target) +
-    TypesafeProjectAccessorsComponent(targetScope)
+): EvaluationSchema {
+    val component = gradleDslGeneralSchemaComponent() +
+        ThirdPartyExtensionsComponent(ProjectTopLevelReceiver::class, target, "projectExtension") +
+        DependencyConfigurationsComponent(target) +
+        TypesafeProjectAccessorsComponent(targetScope)
 
-
-private
-val analyzeEverythingExceptPluginsBlock = AnalysisStatementFilter { statement, scopes ->
-    if (scopes.last().receiver is ObjectOrigin.TopLevelReceiver) {
-        !isPluginsCall(statement)
-    } else true
+    return buildEvaluationSchema(ProjectTopLevelReceiver::class, component, analyzeEverythingExceptPluginsBlock)
 }

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/schemaFromGradleExtensions.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/schemaFromGradleExtensions.kt
@@ -26,7 +26,6 @@ import org.gradle.internal.declarativedsl.schemaBuilder.DataSchemaBuilder
 import org.gradle.internal.declarativedsl.schemaBuilder.FunctionExtractor
 import org.gradle.internal.declarativedsl.schemaBuilder.TypeDiscovery
 import org.gradle.internal.declarativedsl.schemaBuilder.toDataTypeRef
-import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.declarative.dsl.model.annotations.Restricted
 import org.gradle.internal.declarativedsl.evaluationSchema.EvaluationSchemaComponent
@@ -62,7 +61,7 @@ class ThirdPartyExtensionsComponent(
     )
 
     override fun functionExtractors(): List<FunctionExtractor> = listOf(
-        projectExtensionConfiguringFunctions(extensions)
+        extensionConfiguringFunctions(schemaTypeToExtend, extensions)
     )
 
     override fun runtimeCustomAccessors(): List<RuntimeCustomAccessors> = listOf(
@@ -107,16 +106,14 @@ class RuntimeExtensionAccessors(info: List<ExtensionInfo>) : RuntimeCustomAccess
     val extensionsByIdentifier = info.associate { it.customAccessorId to it.extensionProvider() }
 
     override fun getObjectFromCustomAccessor(receiverObject: Any, accessor: ConfigureAccessor.Custom): Any? =
-        if (receiverObject is Project)
-            extensionsByIdentifier[accessor.customAccessorIdentifier]
-        else null
+        extensionsByIdentifier[accessor.customAccessorIdentifier]
 }
 
 
 private
-fun projectExtensionConfiguringFunctions(extensionInfo: Iterable<ExtensionInfo>): FunctionExtractor = object : FunctionExtractor {
+fun extensionConfiguringFunctions(typeToExtend: KClass<*>, extensionInfo: Iterable<ExtensionInfo>): FunctionExtractor = object : FunctionExtractor {
     override fun memberFunctions(kClass: KClass<*>, preIndex: DataSchemaBuilder.PreIndex): Iterable<SchemaMemberFunction> =
-        if (kClass == ProjectTopLevelReceiver::class) extensionInfo.map(ExtensionInfo::schemaFunction) else emptyList()
+        if (kClass == typeToExtend) extensionInfo.map(ExtensionInfo::schemaFunction) else emptyList()
 
     override fun constructors(kClass: KClass<*>, preIndex: DataSchemaBuilder.PreIndex): Iterable<DataConstructor> = emptyList()
 

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/settings/SettingsDslSchema.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/settings/SettingsDslSchema.kt
@@ -17,12 +17,32 @@
 package org.gradle.internal.declarativedsl.settings
 
 import org.gradle.api.initialization.Settings
+import org.gradle.api.internal.SettingsInternal
+import org.gradle.api.internal.initialization.ClassLoaderScope
+import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.internal.declarativedsl.analysis.analyzeEverything
 import org.gradle.internal.declarativedsl.evaluationSchema.EvaluationSchema
+import org.gradle.internal.declarativedsl.evaluationSchema.InterpretationSequence
+import org.gradle.internal.declarativedsl.evaluationSchema.SimpleInterpretationSequenceStep
 import org.gradle.internal.declarativedsl.evaluationSchema.buildEvaluationSchema
 import org.gradle.internal.declarativedsl.evaluationSchema.plus
+import org.gradle.internal.declarativedsl.plugins.PluginsInterpretationSequenceStep
 import org.gradle.internal.declarativedsl.project.ThirdPartyExtensionsComponent
 import org.gradle.internal.declarativedsl.project.gradleDslGeneralSchemaComponent
+
+
+internal
+fun settingsInterpretationSequence(
+    settings: SettingsInternal,
+    targetScope: ClassLoaderScope,
+    scriptSource: ScriptSource
+): InterpretationSequence =
+    InterpretationSequence(
+        listOf(
+            PluginsInterpretationSequenceStep("settingsPlugins", settings, targetScope, scriptSource) { it.services },
+            SimpleInterpretationSequenceStep("settings", settings) { settingsEvaluationSchema(settings) }
+        )
+    )
 
 
 internal


### PR DESCRIPTION
* Evaluate `pluginManagement { ... }` and `plugins { ... }` before everything else in `settings.gradle.something`.
* Introduce some utilities for `AnalysisStatementFilter`, allowing use-sites to be more declarative.