### PR TITLE
Handle missing extension when publishing and consuming GMM

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/gmm/GradleModuleMetadataResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/gmm/GradleModuleMetadataResolveIntegrationTest.groovy
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.gmm
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
+
+class GradleModuleMetadataResolveIntegrationTest extends AbstractIntegrationSpec {
+
+    @Issue("https://github.com/gradle/gradle/issues/26468")
+    def "can consume gmm with dependency missing artifactSelector extension"() {
+        given:
+        mavenRepo.module("org", "transitive", "1.0").artifact(classifier: "cls").withNoPom().withModuleMetadata().publish()
+
+        def module = mavenRepo.module("org", "foo")
+        module.withNoPom().publish()
+        module.artifactFile(type: "module").text = """
+            {
+                "formatVersion": "1.1",
+                "component": {
+                    "group": "org",
+                    "module": "foo",
+                    "version": "1.0",
+                    "attributes": {
+                        "org.gradle.status": "release"
+                    }
+                },
+                "variants": [
+                    {
+                        "name": "runtime",
+                        "dependencies": [
+                            {
+                                "group": "org",
+                                "module": "transitive",
+                                "version": {
+                                    "requires": "1.0"
+                                },
+                                "thirdPartyCompatibility": {
+                                    "artifactSelector": {
+                                        "name": "transitive",
+                                        "type": "jar",
+                                        ${artifactDeclaration}
+                                        "classifier": "cls"
+                                    }
+                                }
+                            }
+                        ],
+                        "attributes": {
+                            "org.gradle.usage": "java-runtime",
+                            "org.gradle.libraryelements": "jar",
+                            "org.gradle.category": "library"
+                        },
+                        "files": [
+                            {
+                                "name": "foo-1.0.jar",
+                                "url": "foo-1.0.jar"
+                            }
+                        ]
+                    }
+                ]
+            }
+        """
+
+        buildFile << """
+            plugins {
+                id("java-library")
+            }
+
+            repositories {
+                maven {
+                    url "${mavenRepo.uri}"
+                    metadataSources {
+                        gradleMetadata()
+                    }
+                }
+            }
+
+            dependencies {
+                implementation("org:foo:1.0")
+            }
+
+            task resolve {
+                def files = configurations.runtimeClasspath
+                doLast {
+                    assert files*.name == ["foo-1.0.jar", "transitive-1.0-cls.jar"]
+                }
+            }
+        """
+
+        expect:
+        succeeds("resolve")
+
+        where:
+        artifactDeclaration << ['', '"extension": "",']
+    }
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
@@ -399,7 +399,9 @@ public class GradleModuleMetadataParser {
         }
         assertDefined(reader, "name", artifactName);
         assertDefined(reader, "type", type);
-        extension = StringUtils.isEmpty(extension) ? type : extension;
+        if (extension == null) {
+            extension = type;
+        }
         reader.endObject();
         return new DefaultIvyArtifactName(artifactName, type, extension, classifier);
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
@@ -399,6 +399,7 @@ public class GradleModuleMetadataParser {
         }
         assertDefined(reader, "name", artifactName);
         assertDefined(reader, "type", type);
+        extension = StringUtils.isEmpty(extension) ? type : extension;
         reader.endObject();
         return new DefaultIvyArtifactName(artifactName, type, extension, classifier);
     }

--- a/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/metadata/ModuleMetadataSpecBuilder.java
+++ b/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/metadata/ModuleMetadataSpecBuilder.java
@@ -286,7 +286,7 @@ public class ModuleMetadataSpecBuilder {
         return new ModuleMetadataSpec.ArtifactSelector(
             dependencyArtifact.getName(),
             dependencyArtifact.getType(),
-            isNullOrEmpty(dependencyArtifact.getExtension()) ? dependencyArtifact.getType() : dependencyArtifact.getExtension(),
+            dependencyArtifact.getExtension() == null ? dependencyArtifact.getType() : dependencyArtifact.getExtension(),
             isNullOrEmpty(dependencyArtifact.getClassifier()) ? null : dependencyArtifact.getClassifier()
         );
     }

--- a/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/metadata/ModuleMetadataSpecBuilder.java
+++ b/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/metadata/ModuleMetadataSpecBuilder.java
@@ -286,7 +286,7 @@ public class ModuleMetadataSpecBuilder {
         return new ModuleMetadataSpec.ArtifactSelector(
             dependencyArtifact.getName(),
             dependencyArtifact.getType(),
-            isNullOrEmpty(dependencyArtifact.getExtension()) ? null : dependencyArtifact.getExtension(),
+            isNullOrEmpty(dependencyArtifact.getExtension()) ? dependencyArtifact.getType() : dependencyArtifact.getExtension(),
             isNullOrEmpty(dependencyArtifact.getClassifier()) ? null : dependencyArtifact.getClassifier()
         );
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
@@ -510,7 +510,7 @@ class GradleModuleMetadata {
             this.excludes = excludes*.toString()
             this.requestedCapabilities = requestedCapabilities.collect { new Capability(it.group, it.name, it.version) }
             this.endorseStrictVersions = endorseStrictVersions
-            this.artifactSelector = artifactSelector != null ? new ArtifactSelectorSpec(artifactSelector.name, artifactSelector.type, artifactSelector.extesion, artifactSelector.classifier) : null
+            this.artifactSelector = artifactSelector != null ? new ArtifactSelectorSpec(artifactSelector.name, artifactSelector.type, artifactSelector.extension, artifactSelector.classifier) : null
         }
 
         String toString() {


### PR DESCRIPTION
In some cases, the extension field of a published artifact is missing when the type field is present. This happens when using the 'artifact { classifier = 'foo' }} syntax.

When this happens, we publish the GMM without the extension field, and when consuming that dependency, we look for an artifact without an extension. This differs from the behavior of local resolution, where we default the extension to the type if there is no extension present.

This commit updates behavior to publish the extension field as the type field, if the extension field is missing, thus new versions of Gradle will publish GMM that work for old broken versions of Gradle. We also update behavior to default the extension field to the type field when consuming GMM with a missing extension field, thus allowing new versions of Gradle to consume broken GMM published by old versions of Gradle.


Fixes: #26468 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
