### PR TITLE
Do not select root node for constraints

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -226,7 +226,7 @@ class EdgeState implements DependencyGraphEdge {
         if (isConstraint && !isVirtualDependency()) {
             List<NodeState> nodes = targetComponent.getNodes();
             for (NodeState node : nodes) {
-                if (node.isSelected()) {
+                if (node.isSelected() && !node.isRoot()) {
                     targetNodes.add(node);
                 }
             }
@@ -247,7 +247,7 @@ class EdgeState implements DependencyGraphEdge {
                     }
                 }
                 for (NodeState node : nodes) {
-                    if (node.isSelected()) {
+                    if (node.isSelected() && !node.isRoot()) {
                         targetNodes.add(node);
                     }
                 }


### PR DESCRIPTION
The root node is always selected.
Previously, constraints would add incoming edges to the root node if the constraint was on the same module as the root node There is a deprecation warning to ensure no dependencies select the root node. We avoid that deprecation warning for this case, since we do not need to add edges to the root node

This behavior was seen on the AndroidX build.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
