### PR TITLE
Use build operations instead of progress logger in persistent caches

### DIFF
--- a/platforms/core-execution/build-cache/build.gradle.kts
+++ b/platforms/core-execution/build-cache/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     jmhImplementation(libs.snappy)
 
     testImplementation(testFixtures(project(":base-services")))
+    testImplementation(testFixtures(project(":build-operations")))
     testImplementation(testFixtures(project(":core")))
     testImplementation(testFixtures(project(":snapshots")))
 

--- a/platforms/core-execution/build-cache/src/test/groovy/org/gradle/caching/internal/controller/DefaultBuildCacheControllerPackOperationExecutorTest.groovy
+++ b/platforms/core-execution/build-cache/src/test/groovy/org/gradle/caching/internal/controller/DefaultBuildCacheControllerPackOperationExecutorTest.groovy
@@ -32,7 +32,7 @@ import org.gradle.internal.file.TreeType
 import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.operations.BuildOperationContext
-import org.gradle.internal.operations.BuildOperationExecutor
+import org.gradle.internal.operations.BuildOperationRunner
 import org.gradle.internal.operations.CallableBuildOperation
 import org.gradle.internal.operations.RunnableBuildOperation
 import org.gradle.internal.snapshot.DirectorySnapshot
@@ -57,8 +57,8 @@ class DefaultBuildCacheControllerPackOperationExecutorTest extends Specification
     def originFactory = Mock(OriginMetadataFactory)
     def stringInterner = new StringInterner()
     def buildOperationContext = Mock(BuildOperationContext)
-    def buildOperationExecutor = Mock(BuildOperationExecutor)
-    PackOperationExecutor packOperationExecutor = new PackOperationExecutor(buildOperationExecutor, packer, originFactory, stringInterner)
+    def buildOperationRunner = Mock(BuildOperationRunner)
+    PackOperationExecutor packOperationExecutor = new PackOperationExecutor(buildOperationRunner, packer, originFactory, stringInterner)
 
     def key = new DefaultBuildCacheKey(TestHashCodes.hashCodeFrom(1234))
 
@@ -88,7 +88,7 @@ class DefaultBuildCacheControllerPackOperationExecutorTest extends Specification
         def result = packOperationExecutor.unpack(key, entity, input)
 
         then:
-        1 * buildOperationExecutor.call(_) >> { CallableBuildOperation action -> action.call(buildOperationContext)}
+        1 * buildOperationRunner.call(_) >> { CallableBuildOperation action -> action.call(buildOperationContext)}
         1 * originFactory.createReader() >> originReader
 
         then:
@@ -117,7 +117,7 @@ class DefaultBuildCacheControllerPackOperationExecutorTest extends Specification
         packOperationExecutor.unpack(key, entity, input)
 
         then:
-        1 * buildOperationExecutor.call(_) >> { CallableBuildOperation action -> action.call(buildOperationContext)}
+        1 * buildOperationRunner.call(_) >> { CallableBuildOperation action -> action.call(buildOperationContext)}
         1 * originFactory.createReader() >> originReader
 
         then:
@@ -142,7 +142,7 @@ class DefaultBuildCacheControllerPackOperationExecutorTest extends Specification
         packOperationExecutor.pack(output, key, entity, outputSnapshots, Duration.ofMillis(421L))
 
         then:
-        1 * buildOperationExecutor.run(_) >> { RunnableBuildOperation action -> action.run(buildOperationContext)}
+        1 * buildOperationRunner.run(_) >> { RunnableBuildOperation action -> action.run(buildOperationContext)}
         1 * originFactory.createWriter(entity.identity, entity.type, TestHashCodes.hashCodeFrom(1234), Duration.ofMillis(421L)) >> originWriter
 
         then:

--- a/platforms/core-execution/build-cache/src/test/groovy/org/gradle/caching/internal/controller/DefaultBuildCacheControllerTest.groovy
+++ b/platforms/core-execution/build-cache/src/test/groovy/org/gradle/caching/internal/controller/DefaultBuildCacheControllerTest.groovy
@@ -30,7 +30,7 @@ import org.gradle.caching.local.internal.LocalBuildCacheService
 import org.gradle.caching.local.internal.TemporaryFileFactory
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.operations.NoOpBuildOperationProgressEventEmitter
-import org.gradle.internal.operations.TestBuildOperationExecutor
+import org.gradle.internal.operations.TestBuildOperationRunner
 import org.gradle.internal.snapshot.FileSystemSnapshot
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.Path
@@ -64,7 +64,7 @@ class DefaultBuildCacheControllerTest extends Specification {
     OriginMetadataFactory originMetadataFactory = Stub(OriginMetadataFactory)
     Interner<String> stringInterner = Stub(Interner)
 
-    def operations = new TestBuildOperationExecutor()
+    def operations = new TestBuildOperationRunner()
     def buildOperationProgressEmitter = new NoOpBuildOperationProgressEventEmitter()
 
     @Rule

--- a/platforms/core-execution/execution/build.gradle.kts
+++ b/platforms/core-execution/execution/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     testImplementation(project(":resources"))
     testImplementation(libs.commonsIo)
     testImplementation(testFixtures(project(":base-services")))
+    testImplementation(testFixtures(project(":build-operations")))
     testImplementation(testFixtures(project(":file-collections")))
     testImplementation(testFixtures(project(":messaging")))
     testImplementation(testFixtures(project(":snapshots")))

--- a/platforms/core-execution/execution/src/test/groovy/org/gradle/internal/execution/steps/StepSpec.groovy
+++ b/platforms/core-execution/execution/src/test/groovy/org/gradle/internal/execution/steps/StepSpec.groovy
@@ -19,6 +19,7 @@ package org.gradle.internal.execution.steps
 import org.gradle.internal.execution.UnitOfWork
 import org.gradle.internal.operations.BuildOperationType
 import org.gradle.internal.operations.TestBuildOperationExecutor
+import org.gradle.internal.operations.TestBuildOperationRunner
 
 import java.util.function.Consumer
 
@@ -53,7 +54,7 @@ abstract class StepSpec<C extends Context> extends StepSpecBase<C> {
 
     protected <D, R, T extends BuildOperationType<D, R>> void withOnlyOperation(
         Class<T> operationType,
-        Consumer<TestBuildOperationExecutor.Log.TypedRecord<D, R>> verifier
+        Consumer<TestBuildOperationRunner.Log.TypedRecord<D, R>> verifier
     ) {
         assert buildOperationExecutor.log.records.size() == 1
         interaction {

--- a/platforms/core-execution/file-watching/build.gradle.kts
+++ b/platforms/core-execution/file-watching/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     testImplementation(project(":persistent-cache"))
     testImplementation(project(":build-option"))
     testImplementation(project(":enterprise-operations"))
+    testImplementation(testFixtures(project(":build-operations")))
     testImplementation(testFixtures(project(":core")))
     testImplementation(testFixtures(project(":file-collections")))
     testImplementation(testFixtures(project(":tooling-api")))

--- a/platforms/core-execution/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystemTest.groovy
+++ b/platforms/core-execution/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystemTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.watch.vfs.impl
 
-import org.gradle.internal.operations.TestBuildOperationExecutor
+import org.gradle.internal.operations.TestBuildOperationRunner
 import org.gradle.internal.snapshot.CaseSensitivity
 import org.gradle.internal.snapshot.SnapshotHierarchy
 import org.gradle.internal.vfs.impl.DefaultSnapshotHierarchy
@@ -31,7 +31,7 @@ class WatchingNotSupportedVirtualFileSystemTest extends Specification {
         empty() >> emptySnapshotHierarchy
     }
     def watchingNotSupportedVfs = new WatchingNotSupportedVirtualFileSystem(nonEmptySnapshotHierarchy)
-    def buildOperationRunner = new TestBuildOperationExecutor()
+    def buildOperationRunner = new TestBuildOperationRunner()
 
     def "invalidates the virtual file system before and after the build (watch mode: #watchMode.description)"() {
         when:

--- a/platforms/core-execution/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystemTest.groovy
+++ b/platforms/core-execution/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystemTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.internal.watch.vfs.impl
 
 import net.rubygrapefruit.platform.NativeException
-import org.gradle.internal.operations.TestBuildOperationExecutor
+import org.gradle.internal.operations.TestBuildOperationRunner
 import org.gradle.internal.snapshot.CaseSensitivity
 import org.gradle.internal.snapshot.SnapshotHierarchy
 import org.gradle.internal.vfs.impl.DefaultSnapshotHierarchy
@@ -40,7 +40,7 @@ class WatchingVirtualFileSystemTest extends Specification {
     }
     def daemonDocumentationIndex = Mock(DaemonDocumentationIndex)
     def locationsUpdatedByCurrentBuild = Mock(FileWatchingFilter)
-    def buildOperationRunner = new TestBuildOperationExecutor()
+    def buildOperationRunner = new TestBuildOperationRunner()
     def watchableFileSystemDetector = Mock(WatchableFileSystemDetector)
     def fileChangeListeners = Mock(FileChangeListeners)
     def watchingVirtualFileSystem = new WatchingVirtualFileSystem(

--- a/platforms/core-execution/persistent-cache/build.gradle.kts
+++ b/platforms/core-execution/persistent-cache/build.gradle.kts
@@ -33,8 +33,6 @@ dependencies {
     api(libs.jsr305)
     api(libs.guava)
 
-    implementation(project(":build-operations"))
-
     implementation(libs.slf4jApi)
     implementation(libs.commonsIo)
     implementation(libs.commonsLang)

--- a/platforms/core-execution/persistent-cache/build.gradle.kts
+++ b/platforms/core-execution/persistent-cache/build.gradle.kts
@@ -23,7 +23,7 @@ errorprone {
 
 dependencies {
     api(project(":base-annotations"))
-    api(project(":enterprise-logging"))
+    api(project(":build-operations"))
     api(project(":base-services"))
     api(project(":messaging"))
     api(project(":native"))

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheFactory.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheFactory.java
@@ -27,7 +27,7 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.FileUtils;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.concurrent.ExecutorFactory;
-import org.gradle.internal.logging.progress.ProgressLoggerFactory;
+import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.serialize.Serializer;
 
 import javax.annotation.Nullable;
@@ -45,13 +45,13 @@ public class DefaultCacheFactory implements CacheFactory, Closeable {
     private final Map<File, DirCacheReference> dirCaches = new HashMap<>();
     private final FileLockManager lockManager;
     private final ExecutorFactory executorFactory;
-    private final ProgressLoggerFactory progressLoggerFactory;
+    private final BuildOperationRunner buildOperationRunner;
     private final Lock lock = new ReentrantLock();
 
-    public DefaultCacheFactory(FileLockManager fileLockManager, ExecutorFactory executorFactory, ProgressLoggerFactory progressLoggerFactory) {
+    public DefaultCacheFactory(FileLockManager fileLockManager, ExecutorFactory executorFactory, BuildOperationRunner buildOperationRunner) {
         this.lockManager = fileLockManager;
         this.executorFactory = executorFactory;
-        this.progressLoggerFactory = progressLoggerFactory;
+        this.buildOperationRunner = buildOperationRunner;
     }
 
     void onOpen(Object cache) {
@@ -99,9 +99,9 @@ public class DefaultCacheFactory implements CacheFactory, Closeable {
         if (dirCacheReference == null) {
             ReferencablePersistentCache cache;
             if (!properties.isEmpty() || initializer != null) {
-                cache = new DefaultPersistentDirectoryCache(canonicalDir, displayName, properties, lockOptions, initializer, cacheCleanupStrategy, lockManager, executorFactory, progressLoggerFactory);
+                cache = new DefaultPersistentDirectoryCache(canonicalDir, displayName, properties, lockOptions, initializer, cacheCleanupStrategy, lockManager, executorFactory, buildOperationRunner);
             } else {
-                cache = new DefaultPersistentDirectoryStore(canonicalDir, displayName, lockOptions, cacheCleanupStrategy, lockManager, executorFactory, progressLoggerFactory);
+                cache = new DefaultPersistentDirectoryStore(canonicalDir, displayName, lockOptions, cacheCleanupStrategy, lockManager, executorFactory, buildOperationRunner);
             }
             cache.open();
             dirCacheReference = new DirCacheReference(cache, properties, lockOptions);

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCleanupProgressMonitor.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCleanupProgressMonitor.java
@@ -17,17 +17,16 @@
 package org.gradle.cache.internal;
 
 import org.gradle.cache.CleanupProgressMonitor;
-import org.gradle.internal.logging.progress.ProgressLogger;
+import org.gradle.internal.operations.BuildOperationContext;
 
 public class DefaultCleanupProgressMonitor implements CleanupProgressMonitor {
 
-    private final ProgressLogger progressLogger;
-
+    private final BuildOperationContext buildOperationContext;
     private long deleted;
     private long skipped;
 
-    public DefaultCleanupProgressMonitor(ProgressLogger progressLogger) {
-        this.progressLogger = progressLogger;
+    public DefaultCleanupProgressMonitor(BuildOperationContext buildOperationContext) {
+        this.buildOperationContext = buildOperationContext;
     }
 
     @Override
@@ -48,8 +47,7 @@ public class DefaultCleanupProgressMonitor implements CleanupProgressMonitor {
     }
 
     private void updateProgress() {
-        progressLogger.progress(progressLogger.getDescription() + ": "
-            + mandatoryNumber(deleted, " entry", " entries") + " deleted"
+        buildOperationContext.progress(mandatoryNumber(deleted, " entry", " entries") + " deleted"
             + optionalNumber(", ", skipped, " skipped"));
     }
 

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryCache.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryCache.java
@@ -23,7 +23,7 @@ import org.gradle.cache.FileLockManager;
 import org.gradle.cache.LockOptions;
 import org.gradle.cache.PersistentCache;
 import org.gradle.internal.concurrent.ExecutorFactory;
-import org.gradle.internal.logging.progress.ProgressLoggerFactory;
+import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.util.internal.GFileUtils;
 import org.gradle.util.internal.GUtil;
 import org.slf4j.Logger;
@@ -41,8 +41,18 @@ public class DefaultPersistentDirectoryCache extends DefaultPersistentDirectoryS
     private final Properties properties = new Properties();
     private final Action<? super PersistentCache> initAction;
 
-    public DefaultPersistentDirectoryCache(File dir, String displayName, Map<String, ?> properties, LockOptions lockOptions, @Nullable Action<? super PersistentCache> initAction, @Nullable CacheCleanupStrategy cacheCleanupStrategy, FileLockManager lockManager, ExecutorFactory executorFactory, ProgressLoggerFactory progressLoggerFactory) {
-        super(dir, displayName, lockOptions, cacheCleanupStrategy, lockManager, executorFactory, progressLoggerFactory);
+    public DefaultPersistentDirectoryCache(
+        File dir,
+        String displayName,
+        Map<String, ?> properties,
+        LockOptions lockOptions,
+        @Nullable Action<? super PersistentCache> initAction,
+        @Nullable CacheCleanupStrategy cacheCleanupStrategy,
+        FileLockManager lockManager,
+        ExecutorFactory executorFactory,
+        BuildOperationRunner buildOperationRunner
+    ) {
+        super(dir, displayName, lockOptions, cacheCleanupStrategy, lockManager, executorFactory, buildOperationRunner);
         this.initAction = initAction;
         this.properties.putAll(properties);
     }

--- a/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultCleanupProgressMonitorTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultCleanupProgressMonitorTest.groovy
@@ -16,36 +16,36 @@
 
 package org.gradle.cache.internal
 
-import org.gradle.internal.logging.progress.ProgressLogger
+
+import org.gradle.internal.operations.BuildOperationContext
 import spock.lang.Specification
 import spock.lang.Subject
 
 class DefaultCleanupProgressMonitorTest extends Specification {
 
-    def progressLogger = Mock(ProgressLogger) {
-        getDescription() >> "Progress"
+    def context = Mock(BuildOperationContext) {
     }
 
-    @Subject def progressMonitor = new DefaultCleanupProgressMonitor(progressLogger)
+    @Subject def progressMonitor = new DefaultCleanupProgressMonitor(context)
 
     def "reports deleted and skipped"() {
         when:
         progressMonitor.incrementDeleted()
 
         then:
-        1 * progressLogger.progress("Progress: 1 entry deleted")
+        1 * context.progress("1 entry deleted")
 
         when:
         progressMonitor.incrementSkipped()
 
         then:
-        1 * progressLogger.progress("Progress: 1 entry deleted, 1 skipped")
+        1 * context.progress("1 entry deleted, 1 skipped")
 
         when:
         progressMonitor.incrementDeleted()
 
         then:
-        1 * progressLogger.progress("Progress: 2 entries deleted, 1 skipped")
+        1 * context.progress("2 entries deleted, 1 skipped")
     }
 
     def "always reports deleted, even if all entries are skipped"() {
@@ -53,6 +53,6 @@ class DefaultCleanupProgressMonitorTest extends Specification {
         progressMonitor.incrementSkipped()
 
         then:
-        1 * progressLogger.progress("Progress: 0 entries deleted, 1 skipped")
+        1 * context.progress("0 entries deleted, 1 skipped")
     }
 }

--- a/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryCacheTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryCacheTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.cache.FileLockManager
 import org.gradle.cache.PersistentCache
 import org.gradle.cache.internal.locklistener.NoOpFileLockContentionHandler
 import org.gradle.internal.concurrent.ExecutorFactory
-import org.gradle.internal.logging.progress.ProgressLoggerFactory
+import org.gradle.internal.operations.BuildOperationRunner
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.internal.GUtil
@@ -38,7 +38,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
     def lockManager = new DefaultFileLockManager(metaDataProvider, new NoOpFileLockContentionHandler())
     def initializationAction = Mock(Action)
     def cacheCleanup = Stub(CacheCleanupStrategy)
-    def progressLoggerFactory = Stub(ProgressLoggerFactory)
+    def buildOperationRunner = Stub(BuildOperationRunner)
 
     def properties = ['prop': 'value', 'prop2': 'other-value']
 
@@ -50,7 +50,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         emptyDir.assertDoesNotExist()
 
         when:
-        def cache = new DefaultPersistentDirectoryCache(emptyDir, "<display-name>", properties, mode(FileLockManager.LockMode.Shared), initializationAction, cacheCleanup, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
+        def cache = new DefaultPersistentDirectoryCache(emptyDir, "<display-name>", properties, mode(FileLockManager.LockMode.Shared), initializationAction, cacheCleanup, lockManager, Mock(ExecutorFactory), buildOperationRunner)
         try {
             cache.open()
         } finally {
@@ -66,7 +66,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
     def initializesCacheWhenPropertiesFileDoesNotExist() {
         given:
         def dir = temporaryFolder.getTestDirectory().file("dir").createDir()
-        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, mode(FileLockManager.LockMode.Shared), initializationAction, cacheCleanup, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
+        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, mode(FileLockManager.LockMode.Shared), initializationAction, cacheCleanup, lockManager, Mock(ExecutorFactory), buildOperationRunner)
 
         when:
         try {
@@ -84,7 +84,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
     def rebuildsCacheWhenPropertiesHaveChanged() {
         given:
         def dir = createCacheDir(prop: "other-value")
-        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, mode(FileLockManager.LockMode.Shared), initializationAction, cacheCleanup, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
+        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, mode(FileLockManager.LockMode.Shared), initializationAction, cacheCleanup, lockManager, Mock(ExecutorFactory), buildOperationRunner)
 
         when:
         try {
@@ -103,7 +103,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         given:
         def dir = createCacheDir()
         def properties = properties + [newProp: 'newValue']
-        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, mode(FileLockManager.LockMode.Shared), initializationAction, cacheCleanup, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
+        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, mode(FileLockManager.LockMode.Shared), initializationAction, cacheCleanup, lockManager, Mock(ExecutorFactory), buildOperationRunner)
 
         when:
         try {
@@ -125,7 +125,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         Action<PersistentCache> failingAction = Stub(Action) {
             execute(_ as PersistentCache) >> { throw failure }
         }
-        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, mode(FileLockManager.LockMode.Shared), failingAction, cacheCleanup, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
+        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, mode(FileLockManager.LockMode.Shared), failingAction, cacheCleanup, lockManager, Mock(ExecutorFactory), buildOperationRunner)
 
         when:
         try {
@@ -139,7 +139,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         e.cause.is(failure)
 
         when:
-        cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, mode(FileLockManager.LockMode.Shared), initializationAction, cacheCleanup, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
+        cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, mode(FileLockManager.LockMode.Shared), initializationAction, cacheCleanup, lockManager, Mock(ExecutorFactory), buildOperationRunner)
         try {
             cache.open()
         } finally {
@@ -155,7 +155,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
     def doesNotInitializeCacheWhenCacheDirExistsAndIsNotInvalid() {
         given:
         def dir = createCacheDir()
-        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, mode(FileLockManager.LockMode.Shared), initializationAction, cacheCleanup, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
+        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, mode(FileLockManager.LockMode.Shared), initializationAction, cacheCleanup, lockManager, Mock(ExecutorFactory), buildOperationRunner)
 
         when:
         try {
@@ -175,7 +175,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         def dir = temporaryFolder.testDirectory.createDir("cache")
         def initialized = false
         def init = { initialized = true } as Action
-        def cache = new DefaultPersistentDirectoryCache(dir, "test", [:], mode(FileLockManager.LockMode.Exclusive), init, cacheCleanup, createDefaultFileLockManager(), Mock(ExecutorFactory), progressLoggerFactory)
+        def cache = new DefaultPersistentDirectoryCache(dir, "test", [:], mode(FileLockManager.LockMode.Exclusive), init, cacheCleanup, createDefaultFileLockManager(), Mock(ExecutorFactory), buildOperationRunner)
 
         when:
         unlockUncleanly(dir.file("cache.properties"))
@@ -195,7 +195,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         def init = { initialized = true } as Action
         def properties = [foo: 'bar']
         def cache = new DefaultPersistentDirectoryCache(dir, "test", properties,
-            mode(FileLockManager.LockMode.Exclusive), init, cacheCleanup, createDefaultFileLockManager(), Mock(ExecutorFactory), progressLoggerFactory)
+            mode(FileLockManager.LockMode.Exclusive), init, cacheCleanup, createDefaultFileLockManager(), Mock(ExecutorFactory), buildOperationRunner)
 
         when:
         dir.file("cache.properties").delete()
@@ -215,7 +215,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         def init = { initialized = true } as Action
         def properties = [:]
         def cache = new DefaultPersistentDirectoryCache(dir, "test", properties,
-            mode(FileLockManager.LockMode.Exclusive), init, cacheCleanup, createDefaultFileLockManager(), Mock(ExecutorFactory), progressLoggerFactory)
+            mode(FileLockManager.LockMode.Exclusive), init, cacheCleanup, createDefaultFileLockManager(), Mock(ExecutorFactory), buildOperationRunner)
 
         when:
         dir.file("cache.properties").delete()
@@ -244,7 +244,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         properties.putAll(this.properties)
         properties.putAll(extraProps)
 
-        DefaultPersistentDirectoryCache cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, mode(FileLockManager.LockMode.Shared), null, null, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
+        DefaultPersistentDirectoryCache cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, mode(FileLockManager.LockMode.Shared), null, null, lockManager, Mock(ExecutorFactory), buildOperationRunner)
 
         try {
             cache.open()

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/operations/BuildOperationExecutor.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/operations/BuildOperationExecutor.java
@@ -21,6 +21,7 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -36,7 +37,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 @ServiceScope(Scopes.BuildSession.class)
-public interface BuildOperationExecutor extends BuildOperationRunner {
+public interface BuildOperationExecutor {
     /**
      * Runs the given build operation synchronously. Invokes the given operation from the current thread.
      *
@@ -44,7 +45,6 @@ public interface BuildOperationExecutor extends BuildOperationRunner {
      * Runtime exceptions are rethrown as is.
      * Checked exceptions are wrapped in {@link BuildOperationInvocationException}.</p>
      */
-    @Override
     void run(RunnableBuildOperation buildOperation);
 
     /**
@@ -55,15 +55,18 @@ public interface BuildOperationExecutor extends BuildOperationRunner {
      * Runtime exceptions are rethrown as is.
      * Checked exceptions are wrapped in {@link BuildOperationInvocationException}.</p>
      */
-    @Override
     <T> T call(CallableBuildOperation<T> buildOperation);
+
+    /**
+     * Executes the given build operation with the given worker, returns the result.
+     */
+    <O extends BuildOperation> void execute(O buildOperation, BuildOperationWorker<O> worker, @Nullable BuildOperationState defaultParent);
 
     /**
      * Starts an operation that can be finished later.
      *
      * When a parent operation is finished any unfinished child operations will be failed.
      */
-    @Override
     BuildOperationContext start(BuildOperationDescriptor.Builder descriptor);
 
     /**

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/operations/BuildOperationExecutor.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/operations/BuildOperationExecutor.java
@@ -45,6 +45,7 @@ public interface BuildOperationExecutor {
      * Runtime exceptions are rethrown as is.
      * Checked exceptions are wrapped in {@link BuildOperationInvocationException}.</p>
      */
+    // TODO Use BuildOperationRunner directly
     void run(RunnableBuildOperation buildOperation);
 
     /**
@@ -55,11 +56,13 @@ public interface BuildOperationExecutor {
      * Runtime exceptions are rethrown as is.
      * Checked exceptions are wrapped in {@link BuildOperationInvocationException}.</p>
      */
+    // TODO Use BuildOperationRunner directly
     <T> T call(CallableBuildOperation<T> buildOperation);
 
     /**
      * Executes the given build operation with the given worker, returns the result.
      */
+    // TODO Use BuildOperationRunner directly
     <O extends BuildOperation> void execute(O buildOperation, BuildOperationWorker<O> worker, @Nullable BuildOperationState defaultParent);
 
     /**
@@ -67,6 +70,7 @@ public interface BuildOperationExecutor {
      *
      * When a parent operation is finished any unfinished child operations will be failed.
      */
+    // TODO Use BuildOperationRunner directly
     BuildOperationContext start(BuildOperationDescriptor.Builder descriptor);
 
     /**

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/operations/BuildOperationExecutor.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/operations/BuildOperationExecutor.java
@@ -21,7 +21,6 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/operations/BuildOperationExecutor.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/operations/BuildOperationExecutor.java
@@ -60,12 +60,6 @@ public interface BuildOperationExecutor {
     <T> T call(CallableBuildOperation<T> buildOperation);
 
     /**
-     * Executes the given build operation with the given worker, returns the result.
-     */
-    // TODO Use BuildOperationRunner directly
-    <O extends BuildOperation> void execute(O buildOperation, BuildOperationWorker<O> worker, @Nullable BuildOperationState defaultParent);
-
-    /**
      * Starts an operation that can be finished later.
      *
      * When a parent operation is finished any unfinished child operations will be failed.

--- a/platforms/core-runtime/build-operations/build.gradle.kts
+++ b/platforms/core-runtime/build-operations/build.gradle.kts
@@ -18,4 +18,6 @@ dependencies {
     api(project(":base-annotations"))
 
     implementation(libs.slf4jApi)
+
+    testFixturesImplementation(libs.guava)
 }

--- a/platforms/core-runtime/build-operations/src/testFixtures/groovy/org/gradle/internal/operations/TestBuildOperationRunner.java
+++ b/platforms/core-runtime/build-operations/src/testFixtures/groovy/org/gradle/internal/operations/TestBuildOperationRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
-import org.gradle.internal.UncheckedException;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -33,7 +32,6 @@ import java.util.concurrent.LinkedBlockingDeque;
  * A BuildOperationRunner for tests.
  * Simply execute given operations, does not support current/parent operations.
  */
-// TODO Move to :build-operations' test fixtures
 public class TestBuildOperationRunner implements BuildOperationRunner {
 
     public final Log log = new Log();
@@ -137,14 +135,17 @@ public class TestBuildOperationRunner implements BuildOperationRunner {
                 .toList();
         }
 
+        @SuppressWarnings("unused")
         public <R, D, T extends BuildOperationType<D, R>> D mostRecentDetails(Class<T> type) {
             return mostRecent(type).details;
         }
 
+        @SuppressWarnings("unused")
         public <R, D, T extends BuildOperationType<D, R>> R mostRecentResult(Class<T> type) {
             return mostRecent(type).result;
         }
 
+        @SuppressWarnings("unused")
         public <D, R, T extends BuildOperationType<D, R>> Throwable mostRecentFailure(Class<T> type) {
             return mostRecent(type).failure;
         }
@@ -216,7 +217,7 @@ public class TestBuildOperationRunner implements BuildOperationRunner {
                 if (record.failure == null) {
                     record.failure = failure;
                 }
-                throw UncheckedException.throwAsUncheckedException(failure);
+                throw new RuntimeException(failure);
             }
         }
 
@@ -231,7 +232,7 @@ public class TestBuildOperationRunner implements BuildOperationRunner {
                 if (record.failure == null) {
                     record.failure = failure;
                 }
-                throw UncheckedException.throwAsUncheckedException(failure);
+                throw new RuntimeException(failure);
             }
             return t;
         }
@@ -246,7 +247,7 @@ public class TestBuildOperationRunner implements BuildOperationRunner {
                 if (record.failure == null) {
                     record.failure = failure;
                 }
-                throw UncheckedException.throwAsUncheckedException(failure);
+                throw new RuntimeException(failure);
             }
         }
 

--- a/platforms/core-runtime/build-operations/src/testFixtures/groovy/org/gradle/internal/operations/TestBuildOperationRunner.java
+++ b/platforms/core-runtime/build-operations/src/testFixtures/groovy/org/gradle/internal/operations/TestBuildOperationRunner.java
@@ -22,6 +22,8 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
 
 import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.Iterator;
@@ -32,6 +34,7 @@ import java.util.concurrent.LinkedBlockingDeque;
  * A BuildOperationRunner for tests.
  * Simply execute given operations, does not support current/parent operations.
  */
+@SuppressWarnings("Since15")
 public class TestBuildOperationRunner implements BuildOperationRunner {
 
     public final Log log = new Log();
@@ -217,7 +220,7 @@ public class TestBuildOperationRunner implements BuildOperationRunner {
                 if (record.failure == null) {
                     record.failure = failure;
                 }
-                throw new RuntimeException(failure);
+                throw throwAsUncheckedException(failure);
             }
         }
 
@@ -232,7 +235,7 @@ public class TestBuildOperationRunner implements BuildOperationRunner {
                 if (record.failure == null) {
                     record.failure = failure;
                 }
-                throw new RuntimeException(failure);
+                throw throwAsUncheckedException(failure);
             }
             return t;
         }
@@ -247,7 +250,7 @@ public class TestBuildOperationRunner implements BuildOperationRunner {
                 if (record.failure == null) {
                     record.failure = failure;
                 }
-                throw new RuntimeException(failure);
+                throw throwAsUncheckedException(failure);
             }
         }
 
@@ -286,5 +289,21 @@ public class TestBuildOperationRunner implements BuildOperationRunner {
 
     public void reset() {
         log.records.clear();
+    }
+
+    private static RuntimeException throwAsUncheckedException(Throwable t) {
+        if (t instanceof InterruptedException) {
+            Thread.currentThread().interrupt();
+        }
+        if (t instanceof RuntimeException) {
+            throw (RuntimeException) t;
+        }
+        if (t instanceof Error) {
+            throw (Error) t;
+        }
+        if (t instanceof IOException) {
+            throw new UncheckedIOException((IOException) t);
+        }
+        throw new RuntimeException(t);
     }
 }

--- a/platforms/native/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/NativeCompilerTest.groovy
+++ b/platforms/native/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/NativeCompilerTest.groovy
@@ -18,13 +18,11 @@ package org.gradle.nativeplatform.toolchain.internal
 
 import org.gradle.api.Action
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.internal.concurrent.DefaultExecutorFactory
 import org.gradle.internal.concurrent.DefaultParallelismConfiguration
 import org.gradle.internal.operations.BuildOperationExecutor
+import org.gradle.internal.operations.BuildOperationExecutorSupport
 import org.gradle.internal.operations.BuildOperationListener
-import org.gradle.internal.operations.DefaultBuildOperationExecutor
-import org.gradle.internal.operations.DefaultBuildOperationIdFactory
-import org.gradle.internal.operations.DefaultBuildOperationQueueFactory
+import org.gradle.internal.operations.BuildOperationProgressEventListenerAdapter
 import org.gradle.internal.operations.logging.BuildOperationLogger
 import org.gradle.internal.progress.NoOpProgressLoggerFactory
 import org.gradle.internal.time.Clock
@@ -58,11 +56,13 @@ abstract class NativeCompilerTest extends Specification {
 
     WorkerLeaseService workerLeaseService = new TestWorkerLeaseService()
 
-    private BuildOperationListener buildOperationListener = Mock(BuildOperationListener)
-    private Clock timeProvider = Mock(Clock)
+    protected final BuildOperationListener buildOperationListener = Mock(BuildOperationListener)
+    protected final Clock timeProvider = Mock(Clock)
     private parallelismConfiguration = DefaultParallelismConfiguration.DEFAULT
-    protected BuildOperationExecutor buildOperationExecutor = new DefaultBuildOperationExecutor(buildOperationListener, timeProvider, new NoOpProgressLoggerFactory(),
-        new DefaultBuildOperationQueueFactory(workerLeaseService), new DefaultExecutorFactory(), parallelismConfiguration, new DefaultBuildOperationIdFactory())
+    protected BuildOperationExecutor buildOperationExecutor = BuildOperationExecutorSupport.builder(parallelismConfiguration)
+        .withWorkerLeaseService(workerLeaseService)
+        .withExecutionListenerFactory { new BuildOperationProgressEventListenerAdapter(buildOperationListener, new NoOpProgressLoggerFactory(), timeProvider) }
+        .build()
 
     def setup() {
         _ * workerLeaseService.withLocks(_) >> { args ->
@@ -166,7 +166,7 @@ abstract class NativeCompilerTest extends Specification {
         sourceFiles.each { sourceFile ->
             1 * commandLineTool.execute(_, _)
         }
-        4 * timeProvider.getCurrentTime()
+        2 * timeProvider.getCurrentTime()
         2 * buildOperationListener.started(_, _)
         2 * buildOperationListener.finished(_, _)
         0 * _

--- a/platforms/native/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/NativeCompilerTest.groovy
+++ b/platforms/native/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/NativeCompilerTest.groovy
@@ -61,6 +61,7 @@ abstract class NativeCompilerTest extends Specification {
     private parallelismConfiguration = DefaultParallelismConfiguration.DEFAULT
     protected BuildOperationExecutor buildOperationExecutor = BuildOperationExecutorSupport.builder(parallelismConfiguration)
         .withWorkerLeaseService(workerLeaseService)
+        .withTimeSupplier { timeProvider.currentTime }
         .withExecutionListenerFactory { new BuildOperationProgressEventListenerAdapter(buildOperationListener, new NoOpProgressLoggerFactory(), timeProvider) }
         .build()
 
@@ -166,7 +167,7 @@ abstract class NativeCompilerTest extends Specification {
         sourceFiles.each { sourceFile ->
             1 * commandLineTool.execute(_, _)
         }
-        2 * timeProvider.getCurrentTime()
+        4 * timeProvider.getCurrentTime()
         2 * buildOperationListener.started(_, _)
         2 * buildOperationListener.finished(_, _)
         0 * _

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
@@ -17,16 +17,9 @@
 package org.gradle.api.internal.tasks.testing.junit.result
 
 import org.gradle.api.Action
-import org.gradle.internal.concurrent.DefaultExecutorFactory
-import org.gradle.internal.concurrent.DefaultParallelismConfiguration
 import org.gradle.internal.operations.BuildOperationExecutor
-import org.gradle.internal.operations.BuildOperationListener
-import org.gradle.internal.operations.DefaultBuildOperationExecutor
-import org.gradle.internal.operations.DefaultBuildOperationIdFactory
-import org.gradle.internal.operations.DefaultBuildOperationQueueFactory
+import org.gradle.internal.operations.BuildOperationExecutorSupport
 import org.gradle.internal.operations.MultipleBuildOperationFailures
-import org.gradle.internal.progress.NoOpProgressLoggerFactory
-import org.gradle.internal.time.Clock
 import org.gradle.internal.work.WorkerLeaseService
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.test.fixtures.work.TestWorkerLeaseService
@@ -43,10 +36,7 @@ class Binary2JUnitXmlReportGeneratorSpec extends Specification {
     final WorkerLeaseService workerLeaseService = new TestWorkerLeaseService()
 
     def generatorWithMaxThreads(int numThreads) {
-        def parallelismConfiguration = new DefaultParallelismConfiguration(false, numThreads)
-        buildOperationExecutor = new DefaultBuildOperationExecutor(
-                Mock(BuildOperationListener), Mock(Clock), new NoOpProgressLoggerFactory(),
-                new DefaultBuildOperationQueueFactory(workerLeaseService), new DefaultExecutorFactory(), parallelismConfiguration, new DefaultBuildOperationIdFactory())
+        buildOperationExecutor = BuildOperationExecutorSupport.builder(numThreads).build()
         Binary2JUnitXmlReportGenerator reportGenerator = new Binary2JUnitXmlReportGenerator(temp.testDirectory, resultsProvider, new JUnitXmlResultOptions(false, false), buildOperationExecutor, "localhost")
         reportGenerator.xmlWriter = Mock(JUnitXmlResultWriter)
         return reportGenerator

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/report/DefaultTestReportTest.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/report/DefaultTestReportTest.groovy
@@ -18,15 +18,8 @@ package org.gradle.api.internal.tasks.testing.report
 import org.gradle.api.internal.tasks.testing.BuildableTestResultsProvider
 import org.gradle.api.internal.tasks.testing.junit.result.AggregateTestResultsProvider
 import org.gradle.api.internal.tasks.testing.junit.result.TestResultsProvider
-import org.gradle.internal.concurrent.DefaultExecutorFactory
-import org.gradle.internal.concurrent.DefaultParallelismConfiguration
 import org.gradle.internal.operations.BuildOperationExecutor
-import org.gradle.internal.operations.BuildOperationListener
-import org.gradle.internal.operations.DefaultBuildOperationExecutor
-import org.gradle.internal.operations.DefaultBuildOperationIdFactory
-import org.gradle.internal.operations.DefaultBuildOperationQueueFactory
-import org.gradle.internal.progress.NoOpProgressLoggerFactory
-import org.gradle.internal.time.Clock
+import org.gradle.internal.operations.BuildOperationExecutorSupport
 import org.gradle.internal.work.WorkerLeaseService
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -46,10 +39,9 @@ class DefaultTestReportTest extends Specification {
     final WorkerLeaseService workerLeaseService = new TestWorkerLeaseService()
 
     def reportWithMaxThreads(int numThreads) {
-        def parallelismConfiguration = new DefaultParallelismConfiguration(false, numThreads)
-        buildOperationExecutor = new DefaultBuildOperationExecutor(
-                Mock(BuildOperationListener), Mock(Clock), new NoOpProgressLoggerFactory(),
-                new DefaultBuildOperationQueueFactory(workerLeaseService), new DefaultExecutorFactory(), parallelismConfiguration, new DefaultBuildOperationIdFactory())
+        buildOperationExecutor = BuildOperationExecutorSupport.builder(false, numThreads)
+            .withWorkerLeaseService(workerLeaseService)
+            .build()
         return new DefaultTestReport(buildOperationExecutor)
     }
 

--- a/subprojects/architecture-test/src/changes/archunit_store/internal-api-nullability.txt
+++ b/subprojects/architecture-test/src/changes/archunit_store/internal-api-nullability.txt
@@ -1563,6 +1563,7 @@ Class <org.gradle.initialization.layout.BuildLayout> is not annotated (directly 
 Class <org.gradle.initialization.layout.BuildLayoutConfiguration> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (BuildLayoutConfiguration.java:0)
 Class <org.gradle.initialization.layout.BuildLayoutFactory> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (BuildLayoutFactory.java:0)
 Class <org.gradle.initialization.layout.GlobalCacheDir> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (GlobalCacheDir.java:0)
+Class <org.gradle.initialization.layout.ProjectCacheDir$1> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (ProjectCacheDir.java:0)
 Class <org.gradle.initialization.layout.ProjectCacheDir> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (ProjectCacheDir.java:0)
 Class <org.gradle.initialization.layout.ResolvedBuildLayout> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (ResolvedBuildLayout.java:0)
 Class <org.gradle.initialization.properties.DefaultProjectPropertiesLoader> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (DefaultProjectPropertiesLoader.java:0)

--- a/subprojects/composite-builds/build.gradle.kts
+++ b/subprojects/composite-builds/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
 
     testImplementation(project(":file-watching"))
     testImplementation(project(":build-option"))
+    testImplementation(testFixtures(project(":build-operations")))
     testImplementation(testFixtures(project(":dependency-management")))
     testImplementation(testFixtures(project(":core")))
 

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphParallelTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphParallelTest.groovy
@@ -62,6 +62,7 @@ import org.gradle.internal.concurrent.DefaultParallelismConfiguration
 import org.gradle.internal.concurrent.ExecutorFactory
 import org.gradle.internal.file.Stat
 import org.gradle.internal.operations.TestBuildOperationExecutor
+import org.gradle.internal.operations.TestBuildOperationRunner
 import org.gradle.internal.properties.bean.PropertyWalker
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
 import org.gradle.internal.resources.ResourceLock
@@ -295,7 +296,7 @@ class DefaultIncludedBuildTaskGraphParallelTest extends AbstractIncludedBuildTas
 
     private BuildWorkGraphController buildWorkGraphController(String displayName, BuildServices services) {
         def builder = Mock(BuildLifecycleController.WorkGraphBuilder)
-        def nodeFactory = new TaskNodeFactory(services.gradle, Stub(BuildTreeWorkGraphController), Stub(NodeValidator), new TestBuildOperationExecutor(), new ExecutionNodeAccessHierarchies(CaseSensitivity.CASE_INSENSITIVE, Stub(Stat)))
+        def nodeFactory = new TaskNodeFactory(services.gradle, Stub(BuildTreeWorkGraphController), Stub(NodeValidator), new TestBuildOperationRunner(), new ExecutionNodeAccessHierarchies(CaseSensitivity.CASE_INSENSITIVE, Stub(Stat)))
         def hierarchies = new ExecutionNodeAccessHierarchies(CaseSensitivity.CASE_SENSITIVE, TestFiles.fileSystem())
         def dependencyResolver = Stub(TaskDependencyResolver)
         _ * dependencyResolver.resolveDependenciesFor(_, _) >> { TaskInternal task, Object dependencies ->

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultRootBuildStateTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultRootBuildStateTest.groovy
@@ -31,6 +31,7 @@ import org.gradle.internal.buildtree.BuildTreeLifecycleControllerFactory
 import org.gradle.internal.buildtree.BuildTreeState
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.operations.TestBuildOperationExecutor
+import org.gradle.internal.operations.TestBuildOperationRunner
 import org.gradle.internal.service.DefaultServiceRegistry
 import spock.lang.Specification
 
@@ -48,13 +49,16 @@ class DefaultRootBuildStateTest extends Specification {
     def exceptionAnalyzer = Mock(ExceptionAnalyser)
     def buildTreeController = Mock(BuildTreeLifecycleController)
     def buildTreeControllerFactory = Mock(BuildTreeLifecycleControllerFactory)
+    def buildOperationRunner = new TestBuildOperationRunner()
+    def buildOperationExecutor = new TestBuildOperationExecutor(buildOperationRunner)
     DefaultRootBuildState build
 
     def setup() {
         _ * factory.servicesForBuild(buildDefinition, _, null) >> Mock(BuildModelControllerServices.Supplier)
         _ * listenerManager.getBroadcaster(RootBuildLifecycleListener) >> lifecycleListener
         def services = new DefaultServiceRegistry()
-        services.add(new TestBuildOperationExecutor())
+        services.add(buildOperationRunner)
+        services.add(buildOperationExecutor)
         services.add(gradle)
         services.add(exceptionAnalyzer)
         services.add(controller)

--- a/subprojects/core/build.gradle.kts
+++ b/subprojects/core/build.gradle.kts
@@ -204,6 +204,9 @@ dependencies {
     testFixturesApi(project(":resources")) {
         because("test fixtures expose file resource types")
     }
+    testFixturesApi(testFixtures(project(":build-operations"))) {
+        because("test fixtures expose test build operations runner")
+    }
     testFixturesApi(testFixtures(project(":persistent-cache"))) {
         because("test fixtures expose cross-build cache factory")
     }

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/GradleUserHomeCleanupServices.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/GradleUserHomeCleanupServices.java
@@ -22,7 +22,7 @@ import org.gradle.cache.scopes.GlobalScopedCacheBuilderFactory;
 import org.gradle.initialization.GradleUserHomeDirProvider;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.file.Deleter;
-import org.gradle.internal.logging.progress.ProgressLoggerFactory;
+import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.session.BuildSessionLifecycleListener;
 
@@ -33,7 +33,7 @@ public class GradleUserHomeCleanupServices {
         GlobalScopedCacheBuilderFactory cacheBuilderFactory,
         Deleter deleter,
         GradleUserHomeDirProvider gradleUserHomeDirProvider,
-        ProgressLoggerFactory progressLoggerFactory,
+        BuildOperationRunner buildOperationRunner,
         CacheConfigurationsInternal cacheConfigurations,
         ListenerManager listenerManager,
         CacheFactory cacheFactory
@@ -42,7 +42,7 @@ public class GradleUserHomeCleanupServices {
         registration.add(UsedGradleVersions.class, usedGradleVersions);
 
         // register eagerly so stop() is triggered when services are being stopped
-        GradleUserHomeCleanupService gradleUserHomeCleanupService = new GradleUserHomeCleanupService(deleter, gradleUserHomeDirProvider, cacheBuilderFactory, usedGradleVersions, progressLoggerFactory, cacheConfigurations);
+        GradleUserHomeCleanupService gradleUserHomeCleanupService = new GradleUserHomeCleanupService(deleter, gradleUserHomeDirProvider, cacheBuilderFactory, usedGradleVersions, buildOperationRunner, cacheConfigurations);
         registration.add(
             GradleUserHomeCleanupService.class,
             gradleUserHomeCleanupService

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/BuildCacheServices.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/BuildCacheServices.java
@@ -46,8 +46,8 @@ import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.hash.StreamHasher;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
-import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
+import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resource.local.DefaultPathKeyFileStore;
 import org.gradle.internal.resource.local.PathKeyFileStore;
@@ -171,7 +171,7 @@ public final class BuildCacheServices extends AbstractPluginServiceRegistry {
 
             BuildCacheControllerFactory createBuildCacheControllerFactory(
                 StartParameterInternal startParameter,
-                BuildOperationExecutor buildOperationExecutor,
+                BuildOperationRunner buildOperationRunner,
                 BuildOperationProgressEventEmitter buildOperationProgressEventEmitter,
                 TemporaryFileProvider temporaryFileProvider,
                 BuildCacheEntryPacker packer,
@@ -180,7 +180,7 @@ public final class BuildCacheServices extends AbstractPluginServiceRegistry {
             ) {
                 return new DefaultBuildCacheControllerFactory(
                     startParameter,
-                    buildOperationExecutor,
+                    buildOperationRunner,
                     buildOperationProgressEventEmitter,
                     originMetadataFactory,
                     stringInterner,

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/services/AbstractBuildCacheControllerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/services/AbstractBuildCacheControllerFactory.java
@@ -35,7 +35,7 @@ import org.gradle.internal.Cast;
 import org.gradle.internal.instantiation.InstanceGenerator;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
-import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.operations.CallableBuildOperation;
 import org.gradle.util.Path;
 import org.slf4j.Logger;
@@ -52,7 +52,7 @@ public abstract class AbstractBuildCacheControllerFactory<L extends BuildCacheSe
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractBuildCacheControllerFactory.class);
     protected final StartParameter startParameter;
     protected final StringInterner stringInterner;
-    protected final BuildOperationExecutor buildOperationExecutor;
+    protected final BuildOperationRunner buildOperationRunner;
     protected final OriginMetadataFactory originMetadataFactory;
 
     public enum BuildCacheMode {
@@ -65,12 +65,12 @@ public abstract class AbstractBuildCacheControllerFactory<L extends BuildCacheSe
 
     public AbstractBuildCacheControllerFactory(
         StartParameter startParameter,
-        BuildOperationExecutor buildOperationExecutor,
+        BuildOperationRunner buildOperationRunner,
         OriginMetadataFactory originMetadataFactory,
         StringInterner stringInterner
     ) {
         this.startParameter = startParameter;
-        this.buildOperationExecutor = buildOperationExecutor;
+        this.buildOperationRunner = buildOperationRunner;
         this.originMetadataFactory = originMetadataFactory;
         this.stringInterner = stringInterner;
     }
@@ -86,7 +86,7 @@ public abstract class AbstractBuildCacheControllerFactory<L extends BuildCacheSe
         BuildCacheMode buildCacheState = startParameter.isBuildCacheEnabled() ? AbstractBuildCacheControllerFactory.BuildCacheMode.ENABLED : AbstractBuildCacheControllerFactory.BuildCacheMode.DISABLED;
         RemoteAccessMode remoteAccessMode = startParameter.isOffline() ? AbstractBuildCacheControllerFactory.RemoteAccessMode.OFFLINE : AbstractBuildCacheControllerFactory.RemoteAccessMode.ONLINE;
 
-        return buildOperationExecutor.call(new CallableBuildOperation<BuildCacheController>() {
+        return buildOperationRunner.call(new CallableBuildOperation<BuildCacheController>() {
             @Override
             public BuildCacheController call(BuildOperationContext context) {
                 if (buildCacheState == BuildCacheMode.DISABLED) {

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/services/DefaultBuildCacheControllerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/services/DefaultBuildCacheControllerFactory.java
@@ -29,8 +29,8 @@ import org.gradle.caching.internal.origin.OriginMetadataFactory;
 import org.gradle.caching.internal.packaging.BuildCacheEntryPacker;
 import org.gradle.caching.local.DirectoryBuildCache;
 import org.gradle.caching.local.internal.DirectoryBuildCacheService;
-import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
+import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.util.Path;
 
 import javax.annotation.Nullable;
@@ -43,7 +43,7 @@ public class DefaultBuildCacheControllerFactory extends AbstractBuildCacheContro
 
     public DefaultBuildCacheControllerFactory(
         StartParameter startParameter,
-        BuildOperationExecutor buildOperationExecutor,
+        BuildOperationRunner buildOperationRunner,
         BuildOperationProgressEventEmitter buildOperationProgressEmitter,
         OriginMetadataFactory originMetadataFactory,
         StringInterner stringInterner,
@@ -52,7 +52,7 @@ public class DefaultBuildCacheControllerFactory extends AbstractBuildCacheContro
     ) {
         super(
             startParameter,
-            buildOperationExecutor,
+            buildOperationRunner,
             originMetadataFactory,
             stringInterner
         );
@@ -77,7 +77,7 @@ public class DefaultBuildCacheControllerFactory extends AbstractBuildCacheContro
 
         return new DefaultBuildCacheController(
             config,
-            buildOperationExecutor,
+            buildOperationRunner,
             buildOperationProgressEmitter,
             temporaryFileProvider::createTemporaryFile,
             logStackTraces,

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/BuildOperationProgressEventListenerAdapter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/BuildOperationProgressEventListenerAdapter.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.operations;
+
+import org.gradle.internal.logging.progress.ProgressLogger;
+import org.gradle.internal.logging.progress.ProgressLoggerFactory;
+import org.gradle.internal.time.Clock;
+
+import javax.annotation.Nullable;
+
+public class BuildOperationProgressEventListenerAdapter implements DefaultBuildOperationRunner.BuildOperationExecutionListener {
+    private final BuildOperationListener buildOperationListener;
+    private final ProgressLoggerFactory progressLoggerFactory;
+    private final Clock clock;
+    private ProgressLogger progressLogger;
+    private ProgressLogger statusProgressLogger;
+
+    public BuildOperationProgressEventListenerAdapter(BuildOperationListener buildOperationListener, ProgressLoggerFactory progressLoggerFactory, Clock clock) {
+        this.buildOperationListener = buildOperationListener;
+        this.progressLoggerFactory = progressLoggerFactory;
+        this.clock = clock;
+    }
+
+    @Override
+    public void start(BuildOperationDescriptor descriptor, BuildOperationState operationState) {
+        buildOperationListener.started(descriptor, new OperationStartEvent(operationState.getStartTime()));
+        ProgressLogger progressLogger = progressLoggerFactory.newOperation(DefaultBuildOperationExecutor.class, descriptor);
+        this.progressLogger = progressLogger.start(descriptor.getDisplayName(), descriptor.getProgressDisplayName());
+    }
+
+    @Override
+    public void progress(BuildOperationDescriptor descriptor, String status) {
+        // Currently, need to start a new progress operation to hold the status, as changing the status of the progress operation replaces the
+        // progress display name on the console, whereas we want to display both the progress display name and the status
+        // This should be pushed down into the progress logger infrastructure so that an operation can have both a display name (that doesn't change) and
+        // a status (that does)
+        if (statusProgressLogger == null) {
+            statusProgressLogger = progressLoggerFactory.newOperation(DefaultBuildOperationExecutor.class, progressLogger);
+            statusProgressLogger.start(descriptor.getDisplayName(), status);
+        } else {
+            statusProgressLogger.progress(status);
+        }
+    }
+
+    @Override
+    public void progress(BuildOperationDescriptor descriptor, long progress, long total, String units, String status) {
+        progress(descriptor, status);
+        buildOperationListener.progress(descriptor.getId(), new OperationProgressEvent(clock.getCurrentTime(), new OperationProgressDetails(progress, total, units)));
+    }
+
+    @Override
+    public void stop(BuildOperationDescriptor descriptor, BuildOperationState operationState, @Nullable BuildOperationState parent, DefaultBuildOperationRunner.ReadableBuildOperationContext context) {
+        if (statusProgressLogger != null) {
+            statusProgressLogger.completed();
+        }
+        progressLogger.completed(context.getStatus(), context.getFailure() != null);
+        buildOperationListener.finished(descriptor, new OperationFinishEvent(operationState.getStartTime(), clock.getCurrentTime(), context.getFailure(), context.getResult()));
+    }
+
+    @Override
+    public void close(BuildOperationDescriptor descriptor, BuildOperationState operationState) {
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/DefaultBuildOperationExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/DefaultBuildOperationExecutor.java
@@ -24,9 +24,6 @@ import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.concurrent.ManagedExecutor;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.exceptions.DefaultMultiCauseException;
-import org.gradle.internal.logging.progress.ProgressLogger;
-import org.gradle.internal.logging.progress.ProgressLoggerFactory;
-import org.gradle.internal.time.Clock;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -41,23 +38,17 @@ public class DefaultBuildOperationExecutor implements BuildOperationExecutor, St
     private final BuildOperationRunner runner;
     private final BuildOperationQueueFactory buildOperationQueueFactory;
     private final Map<BuildOperationConstraint, ManagedExecutor> managedExecutors = new HashMap<>();
-    private final CurrentBuildOperationRef currentBuildOperationRef = CurrentBuildOperationRef.instance();
+    private final CurrentBuildOperationRef currentBuildOperationRef;
+
     public DefaultBuildOperationExecutor(
-        BuildOperationListener listener,
-        Clock clock,
-        ProgressLoggerFactory progressLoggerFactory,
+        BuildOperationRunner buildOperationRunner,
+        CurrentBuildOperationRef currentBuildOperationRef,
         BuildOperationQueueFactory buildOperationQueueFactory,
         ExecutorFactory executorFactory,
-        ParallelismConfiguration parallelismConfiguration,
-        BuildOperationIdFactory buildOperationIdFactory
+        ParallelismConfiguration parallelismConfiguration
     ) {
-
-        this.runner = new DefaultBuildOperationRunner(
-            currentBuildOperationRef,
-            clock::getCurrentTime,
-            buildOperationIdFactory,
-            () -> new ListenerAdapter(listener, progressLoggerFactory, clock)
-        );
+        this.runner = buildOperationRunner;
+        this.currentBuildOperationRef = currentBuildOperationRef;
         this.buildOperationQueueFactory = buildOperationQueueFactory;
         managedExecutors.put(BuildOperationConstraint.MAX_WORKERS, executorFactory.create("Build operations", parallelismConfiguration.getMaxWorkerCount()));
         managedExecutors.put(BuildOperationConstraint.UNCONSTRAINED, executorFactory.create("Unconstrained build operations", parallelismConfiguration.getMaxWorkerCount() * 10));
@@ -162,60 +153,6 @@ public class DefaultBuildOperationExecutor implements BuildOperationExecutor, St
     public void stop() {
         for (ManagedExecutor pool : managedExecutors.values()) {
             pool.stop();
-        }
-    }
-
-    private static class ListenerAdapter implements DefaultBuildOperationRunner.BuildOperationExecutionListener {
-        private final BuildOperationListener buildOperationListener;
-        private final ProgressLoggerFactory progressLoggerFactory;
-        private final Clock clock;
-        private ProgressLogger progressLogger;
-        private ProgressLogger statusProgressLogger;
-
-        public ListenerAdapter(BuildOperationListener buildOperationListener, ProgressLoggerFactory progressLoggerFactory, Clock clock) {
-            this.buildOperationListener = buildOperationListener;
-            this.progressLoggerFactory = progressLoggerFactory;
-            this.clock = clock;
-        }
-
-        @Override
-        public void start(BuildOperationDescriptor descriptor, BuildOperationState operationState) {
-            buildOperationListener.started(descriptor, new OperationStartEvent(operationState.getStartTime()));
-            ProgressLogger progressLogger = progressLoggerFactory.newOperation(DefaultBuildOperationExecutor.class, descriptor);
-            this.progressLogger = progressLogger.start(descriptor.getDisplayName(), descriptor.getProgressDisplayName());
-        }
-
-        @Override
-        public void progress(BuildOperationDescriptor descriptor, String status) {
-            // Currently, need to start a new progress operation to hold the status, as changing the status of the progress operation replaces the
-            // progress display name on the console, whereas we want to display both the progress display name and the status
-            // This should be pushed down into the progress logger infrastructure so that an operation can have both a display name (that doesn't change) and
-            // a status (that does)
-            if (statusProgressLogger == null) {
-                statusProgressLogger = progressLoggerFactory.newOperation(DefaultBuildOperationExecutor.class, progressLogger);
-                statusProgressLogger.start(descriptor.getDisplayName(), status);
-            } else {
-                statusProgressLogger.progress(status);
-            }
-        }
-
-        @Override
-        public void progress(BuildOperationDescriptor descriptor, long progress, long total, String units, String status) {
-            progress(descriptor, status);
-            buildOperationListener.progress(descriptor.getId(), new OperationProgressEvent(clock.getCurrentTime(), new OperationProgressDetails(progress, total, units)));
-        }
-
-        @Override
-        public void stop(BuildOperationDescriptor descriptor, BuildOperationState operationState, @Nullable BuildOperationState parent, DefaultBuildOperationRunner.ReadableBuildOperationContext context) {
-            if (statusProgressLogger != null) {
-                statusProgressLogger.completed();
-            }
-            progressLogger.completed(context.getStatus(), context.getFailure() != null);
-            buildOperationListener.finished(descriptor, new OperationFinishEvent(operationState.getStartTime(), clock.getCurrentTime(), context.getFailure(), context.getResult()));
-        }
-
-        @Override
-        public void close(BuildOperationDescriptor descriptor, BuildOperationState operationState) {
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/DefaultBuildOperationExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/DefaultBuildOperationExecutor.java
@@ -65,11 +65,6 @@ public class DefaultBuildOperationExecutor implements BuildOperationExecutor, St
     }
 
     @Override
-    public <O extends BuildOperation> void execute(O buildOperation, BuildOperationWorker<O> worker, @Nullable BuildOperationState defaultParent) {
-        runner.execute(buildOperation, worker, defaultParent);
-    }
-
-    @Override
     public BuildOperationContext start(BuildOperationDescriptor.Builder descriptor) {
         return runner.start(descriptor);
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -77,7 +77,6 @@ import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.operations.BuildOperationListenerManager;
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
 import org.gradle.internal.operations.CurrentBuildOperationRef;
-import org.gradle.internal.operations.DefaultBuildOperationListenerManager;
 import org.gradle.internal.operations.DefaultBuildOperationProgressEventEmitter;
 import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.internal.scripts.DefaultScriptFileResolver;
@@ -139,14 +138,6 @@ public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
         registration.add(DefaultScriptFileResolverListeners.class);
         registration.add(BuildLayoutFactory.class);
         registration.add(DefaultUserInputReader.class);
-    }
-
-    CurrentBuildOperationRef createCurrentBuildOperationRef() {
-        return CurrentBuildOperationRef.instance();
-    }
-
-    BuildOperationListenerManager createBuildOperationListenerManager() {
-        return new DefaultBuildOperationListenerManager();
     }
 
     ScriptFileResolver createScriptFileResolver(DefaultScriptFileResolverListeners listeners) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedGlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedGlobalScopeServices.java
@@ -48,16 +48,31 @@ import org.gradle.internal.installation.CurrentGradleInstallation;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.logging.progress.DefaultProgressLoggerFactory;
+import org.gradle.internal.logging.progress.ProgressLogger;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.logging.services.ProgressLoggingBridge;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
+import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationIdFactory;
+import org.gradle.internal.operations.BuildOperationListener;
+import org.gradle.internal.operations.BuildOperationListenerManager;
+import org.gradle.internal.operations.BuildOperationRunner;
+import org.gradle.internal.operations.BuildOperationState;
+import org.gradle.internal.operations.CurrentBuildOperationRef;
+import org.gradle.internal.operations.DefaultBuildOperationExecutor;
 import org.gradle.internal.operations.DefaultBuildOperationIdFactory;
+import org.gradle.internal.operations.DefaultBuildOperationRunner;
+import org.gradle.internal.operations.OperationFinishEvent;
+import org.gradle.internal.operations.OperationProgressDetails;
+import org.gradle.internal.operations.OperationProgressEvent;
+import org.gradle.internal.operations.OperationStartEvent;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.state.DefaultManagedFactoryRegistry;
 import org.gradle.internal.state.ManagedFactoryRegistry;
 import org.gradle.internal.time.Clock;
 import org.gradle.internal.time.Time;
+
+import javax.annotation.Nullable;
 
 import static org.gradle.api.internal.file.ManagedFactories.DirectoryManagedFactory;
 import static org.gradle.api.internal.file.ManagedFactories.DirectoryPropertyManagedFactory;
@@ -153,5 +168,75 @@ public class WorkerSharedGlobalScopeServices extends BasicGlobalScopeServices {
 
     ClassLoaderFactory createClassLoaderFactory() {
         return new DefaultClassLoaderFactory();
+    }
+
+    BuildOperationRunner createBuildOperationRunner(
+        Clock clock,
+        CurrentBuildOperationRef currentBuildOperationRef,
+        ProgressLoggerFactory progressLoggerFactory,
+        BuildOperationIdFactory buildOperationIdFactory,
+        BuildOperationListenerManager buildOperationListenerManager
+    ) {
+        BuildOperationListener listener = buildOperationListenerManager.getBroadcaster();
+        return new DefaultBuildOperationRunner(
+            currentBuildOperationRef,
+            clock::getCurrentTime,
+            buildOperationIdFactory,
+            () -> new ProgressListenerAdapter(listener, progressLoggerFactory, clock)
+        );
+    }
+
+    private static class ProgressListenerAdapter implements DefaultBuildOperationRunner.BuildOperationExecutionListener {
+        private final BuildOperationListener buildOperationListener;
+        private final ProgressLoggerFactory progressLoggerFactory;
+        private final Clock clock;
+        private ProgressLogger progressLogger;
+        private ProgressLogger statusProgressLogger;
+
+        public ProgressListenerAdapter(BuildOperationListener buildOperationListener, ProgressLoggerFactory progressLoggerFactory, Clock clock) {
+            this.buildOperationListener = buildOperationListener;
+            this.progressLoggerFactory = progressLoggerFactory;
+            this.clock = clock;
+        }
+
+        @Override
+        public void start(BuildOperationDescriptor descriptor, BuildOperationState operationState) {
+            buildOperationListener.started(descriptor, new OperationStartEvent(operationState.getStartTime()));
+            ProgressLogger progressLogger = progressLoggerFactory.newOperation(DefaultBuildOperationExecutor.class, descriptor);
+            this.progressLogger = progressLogger.start(descriptor.getDisplayName(), descriptor.getProgressDisplayName());
+        }
+
+        @Override
+        public void progress(BuildOperationDescriptor descriptor, String status) {
+            // Currently, need to start a new progress operation to hold the status, as changing the status of the progress operation replaces the
+            // progress display name on the console, whereas we want to display both the progress display name and the status
+            // This should be pushed down into the progress logger infrastructure so that an operation can have both a display name (that doesn't change) and
+            // a status (that does)
+            if (statusProgressLogger == null) {
+                statusProgressLogger = progressLoggerFactory.newOperation(DefaultBuildOperationExecutor.class, progressLogger);
+                statusProgressLogger.start(descriptor.getDisplayName(), status);
+            } else {
+                statusProgressLogger.progress(status);
+            }
+        }
+
+        @Override
+        public void progress(BuildOperationDescriptor descriptor, long progress, long total, String units, String status) {
+            progress(descriptor, status);
+            buildOperationListener.progress(descriptor.getId(), new OperationProgressEvent(clock.getCurrentTime(), new OperationProgressDetails(progress, total, units)));
+        }
+
+        @Override
+        public void stop(BuildOperationDescriptor descriptor, BuildOperationState operationState, @Nullable BuildOperationState parent, DefaultBuildOperationRunner.ReadableBuildOperationContext context) {
+            if (statusProgressLogger != null) {
+                statusProgressLogger.completed();
+            }
+            progressLogger.completed(context.getStatus(), context.getFailure() != null);
+            buildOperationListener.finished(descriptor, new OperationFinishEvent(operationState.getStartTime(), clock.getCurrentTime(), context.getFailure(), context.getResult()));
+        }
+
+        @Override
+        public void close(BuildOperationDescriptor descriptor, BuildOperationState operationState) {
+        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedGlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedGlobalScopeServices.java
@@ -58,6 +58,7 @@ import org.gradle.internal.operations.BuildOperationProgressEventListenerAdapter
 import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.gradle.internal.operations.DefaultBuildOperationIdFactory;
+import org.gradle.internal.operations.DefaultBuildOperationListenerManager;
 import org.gradle.internal.operations.DefaultBuildOperationRunner;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.state.DefaultManagedFactoryRegistry;
@@ -159,6 +160,14 @@ public class WorkerSharedGlobalScopeServices extends BasicGlobalScopeServices {
 
     ClassLoaderFactory createClassLoaderFactory() {
         return new DefaultClassLoaderFactory();
+    }
+
+    BuildOperationListenerManager createBuildOperationListenerManager() {
+        return new DefaultBuildOperationListenerManager();
+    }
+
+    CurrentBuildOperationRef createCurrentBuildOperationRef() {
+        return CurrentBuildOperationRef.instance();
     }
 
     BuildOperationRunner createBuildOperationRunner(

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedGlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedGlobalScopeServices.java
@@ -48,31 +48,22 @@ import org.gradle.internal.installation.CurrentGradleInstallation;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.logging.progress.DefaultProgressLoggerFactory;
-import org.gradle.internal.logging.progress.ProgressLogger;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.logging.services.ProgressLoggingBridge;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
-import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationIdFactory;
 import org.gradle.internal.operations.BuildOperationListener;
 import org.gradle.internal.operations.BuildOperationListenerManager;
+import org.gradle.internal.operations.BuildOperationProgressEventListenerAdapter;
 import org.gradle.internal.operations.BuildOperationRunner;
-import org.gradle.internal.operations.BuildOperationState;
 import org.gradle.internal.operations.CurrentBuildOperationRef;
-import org.gradle.internal.operations.DefaultBuildOperationExecutor;
 import org.gradle.internal.operations.DefaultBuildOperationIdFactory;
 import org.gradle.internal.operations.DefaultBuildOperationRunner;
-import org.gradle.internal.operations.OperationFinishEvent;
-import org.gradle.internal.operations.OperationProgressDetails;
-import org.gradle.internal.operations.OperationProgressEvent;
-import org.gradle.internal.operations.OperationStartEvent;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.state.DefaultManagedFactoryRegistry;
 import org.gradle.internal.state.ManagedFactoryRegistry;
 import org.gradle.internal.time.Clock;
 import org.gradle.internal.time.Time;
-
-import javax.annotation.Nullable;
 
 import static org.gradle.api.internal.file.ManagedFactories.DirectoryManagedFactory;
 import static org.gradle.api.internal.file.ManagedFactories.DirectoryPropertyManagedFactory;
@@ -93,8 +84,8 @@ public class WorkerSharedGlobalScopeServices extends BasicGlobalScopeServices {
         this.additionalModuleClassPath = additionalModuleClassPath;
     }
 
-    protected CacheFactory createCacheFactory(FileLockManager fileLockManager, ExecutorFactory executorFactory, ProgressLoggerFactory progressLoggerFactory) {
-        return new DefaultCacheFactory(fileLockManager, executorFactory, progressLoggerFactory);
+    protected CacheFactory createCacheFactory(FileLockManager fileLockManager, ExecutorFactory executorFactory, BuildOperationRunner buildOperationRunner) {
+        return new DefaultCacheFactory(fileLockManager, executorFactory, buildOperationRunner);
     }
 
     LegacyTypesSupport createLegacyTypesSupport() {
@@ -182,61 +173,7 @@ public class WorkerSharedGlobalScopeServices extends BasicGlobalScopeServices {
             currentBuildOperationRef,
             clock::getCurrentTime,
             buildOperationIdFactory,
-            () -> new ProgressListenerAdapter(listener, progressLoggerFactory, clock)
+            () -> new BuildOperationProgressEventListenerAdapter(listener, progressLoggerFactory, clock)
         );
-    }
-
-    private static class ProgressListenerAdapter implements DefaultBuildOperationRunner.BuildOperationExecutionListener {
-        private final BuildOperationListener buildOperationListener;
-        private final ProgressLoggerFactory progressLoggerFactory;
-        private final Clock clock;
-        private ProgressLogger progressLogger;
-        private ProgressLogger statusProgressLogger;
-
-        public ProgressListenerAdapter(BuildOperationListener buildOperationListener, ProgressLoggerFactory progressLoggerFactory, Clock clock) {
-            this.buildOperationListener = buildOperationListener;
-            this.progressLoggerFactory = progressLoggerFactory;
-            this.clock = clock;
-        }
-
-        @Override
-        public void start(BuildOperationDescriptor descriptor, BuildOperationState operationState) {
-            buildOperationListener.started(descriptor, new OperationStartEvent(operationState.getStartTime()));
-            ProgressLogger progressLogger = progressLoggerFactory.newOperation(DefaultBuildOperationExecutor.class, descriptor);
-            this.progressLogger = progressLogger.start(descriptor.getDisplayName(), descriptor.getProgressDisplayName());
-        }
-
-        @Override
-        public void progress(BuildOperationDescriptor descriptor, String status) {
-            // Currently, need to start a new progress operation to hold the status, as changing the status of the progress operation replaces the
-            // progress display name on the console, whereas we want to display both the progress display name and the status
-            // This should be pushed down into the progress logger infrastructure so that an operation can have both a display name (that doesn't change) and
-            // a status (that does)
-            if (statusProgressLogger == null) {
-                statusProgressLogger = progressLoggerFactory.newOperation(DefaultBuildOperationExecutor.class, progressLogger);
-                statusProgressLogger.start(descriptor.getDisplayName(), status);
-            } else {
-                statusProgressLogger.progress(status);
-            }
-        }
-
-        @Override
-        public void progress(BuildOperationDescriptor descriptor, long progress, long total, String units, String status) {
-            progress(descriptor, status);
-            buildOperationListener.progress(descriptor.getId(), new OperationProgressEvent(clock.getCurrentTime(), new OperationProgressDetails(progress, total, units)));
-        }
-
-        @Override
-        public void stop(BuildOperationDescriptor descriptor, BuildOperationState operationState, @Nullable BuildOperationState parent, DefaultBuildOperationRunner.ReadableBuildOperationContext context) {
-            if (statusProgressLogger != null) {
-                statusProgressLogger.completed();
-            }
-            progressLogger.completed(context.getStatus(), context.getFailure() != null);
-            buildOperationListener.finished(descriptor, new OperationFinishEvent(operationState.getStartTime(), clock.getCurrentTime(), context.getFailure(), context.getResult()));
-        }
-
-        @Override
-        public void close(BuildOperationDescriptor descriptor, BuildOperationState operationState) {
-        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/session/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/session/BuildSessionScopeServices.java
@@ -59,11 +59,11 @@ import org.gradle.internal.file.Deleter;
 import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.hash.DefaultChecksumService;
 import org.gradle.internal.jvm.JavaModuleDetector;
-import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.model.StateTransitionControllerFactory;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.scopeids.PersistentScopeIdLoader;
 import org.gradle.internal.scopeids.ScopeIdsServices;
@@ -150,11 +150,11 @@ public class BuildSessionScopeServices extends WorkerSharedBuildSessionScopeServ
         GradleUserHomeDirProvider userHomeDirProvider,
         BuildLayout buildLayout,
         Deleter deleter,
-        ProgressLoggerFactory progressLoggerFactory,
+        BuildOperationRunner buildOperationRunner,
         StartParameter startParameter
     ) {
         BuildScopeCacheDir cacheDir = new BuildScopeCacheDir(userHomeDirProvider, buildLayout, startParameter);
-        return new ProjectCacheDir(cacheDir.getDir(), progressLoggerFactory, deleter);
+        return new ProjectCacheDir(cacheDir.getDir(), buildOperationRunner, deleter);
     }
 
     BuildTreeScopedCacheBuilderFactory createBuildTreeScopedCache(ProjectCacheDir projectCacheDir, UnscopedCacheBuilderFactory unscopedCacheBuilderFactory) {

--- a/subprojects/core/src/main/java/org/gradle/internal/session/CrossBuildSessionState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/session/CrossBuildSessionState.java
@@ -29,25 +29,14 @@ import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.concurrent.DefaultParallelismConfiguration;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.event.ListenerManager;
-import org.gradle.internal.logging.progress.ProgressLogger;
-import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.logging.sink.OutputEventListenerManager;
-import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
-import org.gradle.internal.operations.BuildOperationIdFactory;
-import org.gradle.internal.operations.BuildOperationListener;
 import org.gradle.internal.operations.BuildOperationListenerManager;
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
 import org.gradle.internal.operations.BuildOperationRunner;
-import org.gradle.internal.operations.BuildOperationState;
 import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.gradle.internal.operations.DefaultBuildOperationExecutor;
 import org.gradle.internal.operations.DefaultBuildOperationQueueFactory;
-import org.gradle.internal.operations.DefaultBuildOperationRunner;
-import org.gradle.internal.operations.OperationFinishEvent;
-import org.gradle.internal.operations.OperationProgressDetails;
-import org.gradle.internal.operations.OperationProgressEvent;
-import org.gradle.internal.operations.OperationStartEvent;
 import org.gradle.internal.operations.logging.LoggingBuildOperationProgressBroadcaster;
 import org.gradle.internal.operations.notify.BuildOperationNotificationBridge;
 import org.gradle.internal.operations.notify.BuildOperationNotificationValve;
@@ -58,11 +47,9 @@ import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.ServiceRegistryBuilder;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
-import org.gradle.internal.time.Clock;
 import org.gradle.internal.work.DefaultWorkerLeaseService;
 import org.gradle.internal.work.WorkerLeaseService;
 
-import javax.annotation.Nullable;
 import java.io.Closeable;
 
 /**
@@ -120,22 +107,6 @@ public class CrossBuildSessionState implements Closeable {
             return new DefaultParallelismConfiguration(startParameter.isParallelProjectExecutionEnabled(), startParameter.getMaxWorkerCount());
         }
 
-        BuildOperationRunner createBuildOperationRunner(
-            Clock clock,
-            CurrentBuildOperationRef currentBuildOperationRef,
-            ProgressLoggerFactory progressLoggerFactory,
-            BuildOperationIdFactory buildOperationIdFactory,
-            BuildOperationListenerManager buildOperationListenerManager
-        ) {
-            BuildOperationListener listener = buildOperationListenerManager.getBroadcaster();
-            return new DefaultBuildOperationRunner(
-                currentBuildOperationRef,
-                clock::getCurrentTime,
-                buildOperationIdFactory,
-                () -> new ProgressListenerAdapter(listener, progressLoggerFactory, clock)
-            );
-        }
-
         BuildOperationExecutor createBuildOperationExecutor(
             BuildOperationRunner buildOperationRunner,
             CurrentBuildOperationRef currentBuildOperationRef,
@@ -180,59 +151,4 @@ public class CrossBuildSessionState implements Closeable {
             return buildOperationNotificationBridge.getValve();
         }
     }
-
-    private static class ProgressListenerAdapter implements DefaultBuildOperationRunner.BuildOperationExecutionListener {
-        private final BuildOperationListener buildOperationListener;
-        private final ProgressLoggerFactory progressLoggerFactory;
-        private final Clock clock;
-        private ProgressLogger progressLogger;
-        private ProgressLogger statusProgressLogger;
-
-        public ProgressListenerAdapter(BuildOperationListener buildOperationListener, ProgressLoggerFactory progressLoggerFactory, Clock clock) {
-            this.buildOperationListener = buildOperationListener;
-            this.progressLoggerFactory = progressLoggerFactory;
-            this.clock = clock;
-        }
-
-        @Override
-        public void start(BuildOperationDescriptor descriptor, BuildOperationState operationState) {
-            buildOperationListener.started(descriptor, new OperationStartEvent(operationState.getStartTime()));
-            ProgressLogger progressLogger = progressLoggerFactory.newOperation(DefaultBuildOperationExecutor.class, descriptor);
-            this.progressLogger = progressLogger.start(descriptor.getDisplayName(), descriptor.getProgressDisplayName());
-        }
-
-        @Override
-        public void progress(BuildOperationDescriptor descriptor, String status) {
-            // Currently, need to start a new progress operation to hold the status, as changing the status of the progress operation replaces the
-            // progress display name on the console, whereas we want to display both the progress display name and the status
-            // This should be pushed down into the progress logger infrastructure so that an operation can have both a display name (that doesn't change) and
-            // a status (that does)
-            if (statusProgressLogger == null) {
-                statusProgressLogger = progressLoggerFactory.newOperation(DefaultBuildOperationExecutor.class, progressLogger);
-                statusProgressLogger.start(descriptor.getDisplayName(), status);
-            } else {
-                statusProgressLogger.progress(status);
-            }
-        }
-
-        @Override
-        public void progress(BuildOperationDescriptor descriptor, long progress, long total, String units, String status) {
-            progress(descriptor, status);
-            buildOperationListener.progress(descriptor.getId(), new OperationProgressEvent(clock.getCurrentTime(), new OperationProgressDetails(progress, total, units)));
-        }
-
-        @Override
-        public void stop(BuildOperationDescriptor descriptor, BuildOperationState operationState, @Nullable BuildOperationState parent, DefaultBuildOperationRunner.ReadableBuildOperationContext context) {
-            if (statusProgressLogger != null) {
-                statusProgressLogger.completed();
-            }
-            progressLogger.completed(context.getStatus(), context.getFailure() != null);
-            buildOperationListener.finished(descriptor, new OperationFinishEvent(operationState.getStartTime(), clock.getCurrentTime(), context.getFailure(), context.getResult()));
-        }
-
-        @Override
-        public void close(BuildOperationDescriptor descriptor, BuildOperationState operationState) {
-        }
-    }
-
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/session/CrossBuildSessionState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/session/CrossBuildSessionState.java
@@ -29,14 +29,25 @@ import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.concurrent.DefaultParallelismConfiguration;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.logging.progress.ProgressLogger;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.logging.sink.OutputEventListenerManager;
+import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationIdFactory;
+import org.gradle.internal.operations.BuildOperationListener;
 import org.gradle.internal.operations.BuildOperationListenerManager;
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
+import org.gradle.internal.operations.BuildOperationRunner;
+import org.gradle.internal.operations.BuildOperationState;
+import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.gradle.internal.operations.DefaultBuildOperationExecutor;
 import org.gradle.internal.operations.DefaultBuildOperationQueueFactory;
+import org.gradle.internal.operations.DefaultBuildOperationRunner;
+import org.gradle.internal.operations.OperationFinishEvent;
+import org.gradle.internal.operations.OperationProgressDetails;
+import org.gradle.internal.operations.OperationProgressEvent;
+import org.gradle.internal.operations.OperationStartEvent;
 import org.gradle.internal.operations.logging.LoggingBuildOperationProgressBroadcaster;
 import org.gradle.internal.operations.notify.BuildOperationNotificationBridge;
 import org.gradle.internal.operations.notify.BuildOperationNotificationValve;
@@ -51,6 +62,7 @@ import org.gradle.internal.time.Clock;
 import org.gradle.internal.work.DefaultWorkerLeaseService;
 import org.gradle.internal.work.WorkerLeaseService;
 
+import javax.annotation.Nullable;
 import java.io.Closeable;
 
 /**
@@ -108,23 +120,35 @@ public class CrossBuildSessionState implements Closeable {
             return new DefaultParallelismConfiguration(startParameter.isParallelProjectExecutionEnabled(), startParameter.getMaxWorkerCount());
         }
 
-        BuildOperationExecutor createBuildOperationExecutor(
+        BuildOperationRunner createBuildOperationRunner(
             Clock clock,
+            CurrentBuildOperationRef currentBuildOperationRef,
             ProgressLoggerFactory progressLoggerFactory,
-            WorkerLeaseService workerLeaseService,
-            ExecutorFactory executorFactory,
-            ParallelismConfiguration parallelismConfiguration,
             BuildOperationIdFactory buildOperationIdFactory,
             BuildOperationListenerManager buildOperationListenerManager
         ) {
+            BuildOperationListener listener = buildOperationListenerManager.getBroadcaster();
+            return new DefaultBuildOperationRunner(
+                currentBuildOperationRef,
+                clock::getCurrentTime,
+                buildOperationIdFactory,
+                () -> new ProgressListenerAdapter(listener, progressLoggerFactory, clock)
+            );
+        }
+
+        BuildOperationExecutor createBuildOperationExecutor(
+            BuildOperationRunner buildOperationRunner,
+            CurrentBuildOperationRef currentBuildOperationRef,
+            WorkerLeaseService workerLeaseService,
+            ExecutorFactory executorFactory,
+            ParallelismConfiguration parallelismConfiguration
+        ) {
             return new DefaultBuildOperationExecutor(
-                buildOperationListenerManager.getBroadcaster(),
-                clock,
-                progressLoggerFactory,
+                buildOperationRunner,
+                currentBuildOperationRef,
                 new DefaultBuildOperationQueueFactory(workerLeaseService),
                 executorFactory,
-                parallelismConfiguration,
-                buildOperationIdFactory
+                parallelismConfiguration
             );
         }
 
@@ -156,4 +180,59 @@ public class CrossBuildSessionState implements Closeable {
             return buildOperationNotificationBridge.getValve();
         }
     }
+
+    private static class ProgressListenerAdapter implements DefaultBuildOperationRunner.BuildOperationExecutionListener {
+        private final BuildOperationListener buildOperationListener;
+        private final ProgressLoggerFactory progressLoggerFactory;
+        private final Clock clock;
+        private ProgressLogger progressLogger;
+        private ProgressLogger statusProgressLogger;
+
+        public ProgressListenerAdapter(BuildOperationListener buildOperationListener, ProgressLoggerFactory progressLoggerFactory, Clock clock) {
+            this.buildOperationListener = buildOperationListener;
+            this.progressLoggerFactory = progressLoggerFactory;
+            this.clock = clock;
+        }
+
+        @Override
+        public void start(BuildOperationDescriptor descriptor, BuildOperationState operationState) {
+            buildOperationListener.started(descriptor, new OperationStartEvent(operationState.getStartTime()));
+            ProgressLogger progressLogger = progressLoggerFactory.newOperation(DefaultBuildOperationExecutor.class, descriptor);
+            this.progressLogger = progressLogger.start(descriptor.getDisplayName(), descriptor.getProgressDisplayName());
+        }
+
+        @Override
+        public void progress(BuildOperationDescriptor descriptor, String status) {
+            // Currently, need to start a new progress operation to hold the status, as changing the status of the progress operation replaces the
+            // progress display name on the console, whereas we want to display both the progress display name and the status
+            // This should be pushed down into the progress logger infrastructure so that an operation can have both a display name (that doesn't change) and
+            // a status (that does)
+            if (statusProgressLogger == null) {
+                statusProgressLogger = progressLoggerFactory.newOperation(DefaultBuildOperationExecutor.class, progressLogger);
+                statusProgressLogger.start(descriptor.getDisplayName(), status);
+            } else {
+                statusProgressLogger.progress(status);
+            }
+        }
+
+        @Override
+        public void progress(BuildOperationDescriptor descriptor, long progress, long total, String units, String status) {
+            progress(descriptor, status);
+            buildOperationListener.progress(descriptor.getId(), new OperationProgressEvent(clock.getCurrentTime(), new OperationProgressDetails(progress, total, units)));
+        }
+
+        @Override
+        public void stop(BuildOperationDescriptor descriptor, BuildOperationState operationState, @Nullable BuildOperationState parent, DefaultBuildOperationRunner.ReadableBuildOperationContext context) {
+            if (statusProgressLogger != null) {
+                statusProgressLogger.completed();
+            }
+            progressLogger.completed(context.getStatus(), context.getFailure() != null);
+            buildOperationListener.finished(descriptor, new OperationFinishEvent(operationState.getStartTime(), clock.getCurrentTime(), context.getFailure(), context.getResult()));
+        }
+
+        @Override
+        public void close(BuildOperationDescriptor descriptor, BuildOperationState operationState) {
+        }
+    }
+
 }

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/TestGlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/TestGlobalScopeServices.java
@@ -21,9 +21,9 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.agents.AgentStatus;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
-import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.operations.BuildOperationListenerManager;
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
+import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.gradle.internal.operations.NoOpBuildOperationProgressEventEmitter;
 import org.gradle.internal.service.scopes.GlobalScopeServices;
@@ -35,7 +35,7 @@ public class TestGlobalScopeServices extends GlobalScopeServices {
     }
 
     @Override
-    protected CacheFactory createCacheFactory(FileLockManager fileLockManager, ExecutorFactory executorFactory, ProgressLoggerFactory progressLoggerFactory) {
+    protected CacheFactory createCacheFactory(FileLockManager fileLockManager, ExecutorFactory executorFactory, BuildOperationRunner buildOperationRunner) {
         return new TestInMemoryCacheFactory();
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceTest.groovy
@@ -16,14 +16,14 @@
 
 package org.gradle.cache.internal
 
-import org.gradle.api.internal.cache.CacheResourceConfigurationInternal
 import org.gradle.api.internal.cache.CacheConfigurationsInternal
+import org.gradle.api.internal.cache.CacheResourceConfigurationInternal
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.provider.Property
 import org.gradle.cache.CleanupFrequency
 import org.gradle.cache.scopes.GlobalScopedCacheBuilderFactory
 import org.gradle.initialization.GradleUserHomeDirProvider
-import org.gradle.internal.logging.progress.ProgressLoggerFactory
+import org.gradle.internal.operations.TestBuildOperationRunner
 import org.gradle.internal.time.TimestampSuppliers
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -54,7 +54,6 @@ class GradleUserHomeCleanupServiceTest extends Specification implements GradleUs
     def usedGradleVersions = Stub(UsedGradleVersions) {
         getUsedGradleVersions() >> ([] as SortedSet)
     }
-    def progressLoggerFactory = Stub(ProgressLoggerFactory)
 
     def releasedWrappers = Stub(CacheResourceConfigurationInternal) {
         getRemoveUnusedEntriesOlderThanAsSupplier() >> TimestampSuppliers.daysAgo(CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_RELEASED_DISTS)
@@ -79,7 +78,7 @@ class GradleUserHomeCleanupServiceTest extends Specification implements GradleUs
             userHomeDirProvider,
             cacheBuilderFactory,
             usedGradleVersions,
-            progressLoggerFactory,
+            new TestBuildOperationRunner(),
             cacheConfigurations
     )
 

--- a/subprojects/core/src/test/groovy/org/gradle/caching/internal/controller/DefaultBuildCacheControllerFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/caching/internal/controller/DefaultBuildCacheControllerFactoryTest.groovy
@@ -36,7 +36,7 @@ import org.gradle.caching.local.DirectoryBuildCache
 import org.gradle.caching.local.internal.LocalBuildCacheService
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.operations.NoOpBuildOperationProgressEventEmitter
-import org.gradle.internal.operations.TestBuildOperationExecutor
+import org.gradle.internal.operations.TestBuildOperationRunner
 import org.gradle.util.Path
 import org.gradle.util.TestUtil
 import spock.lang.Specification
@@ -46,7 +46,7 @@ import java.util.function.Consumer
 class DefaultBuildCacheControllerFactoryTest extends Specification {
 
     def buildCacheEnabled = true
-    def buildOperationExecuter = new TestBuildOperationExecutor()
+    def buildOperationRunner = new TestBuildOperationRunner()
     def buildOperationProgressEmitter = new NoOpBuildOperationProgressEventEmitter()
     def config = new DefaultBuildCacheConfiguration(TestUtil.instantiatorFactory().inject(), [
         new DefaultBuildCacheServiceRegistration(DirectoryBuildCache, TestDirectoryBuildCacheServiceFactory),
@@ -63,7 +63,7 @@ class DefaultBuildCacheControllerFactoryTest extends Specification {
             Stub(StartParameterInternal) {
                 isBuildCacheEnabled() >> buildCacheEnabled
             },
-            buildOperationExecuter,
+            buildOperationRunner,
             buildOperationProgressEmitter,
             Stub(OriginMetadataFactory),
             Stub(StringInterner),

--- a/subprojects/core/src/test/groovy/org/gradle/caching/internal/controller/DefaultBuildCacheControllerFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/caching/internal/controller/DefaultBuildCacheControllerFactoryTest.groovy
@@ -75,7 +75,7 @@ class DefaultBuildCacheControllerFactoryTest extends Specification {
     }
 
     private FinalizeBuildCacheConfigurationBuildOperationType.Result buildOpResult() {
-        buildOperationExecuter.log.mostRecentResult(FinalizeBuildCacheConfigurationBuildOperationType)
+        buildOperationRunner.log.mostRecentResult(FinalizeBuildCacheConfigurationBuildOperationType)
     }
 
     def 'local cache service is created when remote is not configured'() {

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/project/LifecycleProjectEvaluatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/project/LifecycleProjectEvaluatorTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.internal.project.ProjectState
 import org.gradle.api.internal.project.ProjectStateInternal
 import org.gradle.initialization.BuildCancellationToken
 import org.gradle.internal.operations.TestBuildOperationExecutor
+import org.gradle.internal.operations.TestBuildOperationRunner
 import org.gradle.util.Path
 import spock.lang.Specification
 
@@ -223,7 +224,7 @@ class LifecycleProjectEvaluatorTest extends Specification {
         evaluator.evaluate(project, state)
     }
 
-    static void assertConfigureOp(TestBuildOperationExecutor.Log.Record op, Throwable failureCause = null) {
+    static void assertConfigureOp(TestBuildOperationRunner.Log.Record op, Throwable failureCause = null) {
         assert op.descriptor.name == 'Configure project :project1'
         assert op.descriptor.displayName == 'Configure project :project1'
 
@@ -234,7 +235,7 @@ class LifecycleProjectEvaluatorTest extends Specification {
         assertOpFailureOrNot(op, ConfigureProjectBuildOperationType.Result, failureCause)
     }
 
-    static void assertBeforeEvaluateOp(TestBuildOperationExecutor.Log.Record op, Throwable failureCause = null) {
+    static void assertBeforeEvaluateOp(TestBuildOperationRunner.Log.Record op, Throwable failureCause = null) {
         assert op.descriptor.name == 'Notify beforeEvaluate listeners of :project1'
         assert op.descriptor.displayName == 'Notify beforeEvaluate listeners of :project1'
 
@@ -245,7 +246,7 @@ class LifecycleProjectEvaluatorTest extends Specification {
         assertOpFailureOrNot(op, NotifyProjectBeforeEvaluatedBuildOperationType.Result, failureCause)
     }
 
-    static void assertAfterEvaluateOp(TestBuildOperationExecutor.Log.Record op, Throwable failureCause = null) {
+    static void assertAfterEvaluateOp(TestBuildOperationRunner.Log.Record op, Throwable failureCause = null) {
         assert op.descriptor.name == 'Notify afterEvaluate listeners of :project1'
         assert op.descriptor.displayName == 'Notify afterEvaluate listeners of :project1'
 
@@ -256,7 +257,7 @@ class LifecycleProjectEvaluatorTest extends Specification {
         assertOpFailureOrNot(op, NotifyProjectAfterEvaluatedBuildOperationType.Result, failureCause)
     }
 
-    private static void assertOpFailureOrNot(TestBuildOperationExecutor.Log.Record op, Class<?> resultType, Throwable failureCause) {
+    private static void assertOpFailureOrNot(TestBuildOperationRunner.Log.Record op, Class<?> resultType, Throwable failureCause) {
         if (failureCause) {
             assert op.result == null
             assert op.failure instanceof ProjectConfigurationException
@@ -268,7 +269,7 @@ class LifecycleProjectEvaluatorTest extends Specification {
         }
     }
 
-    List<TestBuildOperationExecutor.Log.Record> getOperations() {
+    List<TestBuildOperationRunner.Log.Record> getOperations() {
         buildOperationExecutor.log.records.toList()
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
@@ -34,7 +34,7 @@ import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.TaskAction
 import org.gradle.composite.internal.BuildTreeWorkGraphController
 import org.gradle.internal.file.Stat
-import org.gradle.internal.operations.TestBuildOperationExecutor
+import org.gradle.internal.operations.TestBuildOperationRunner
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
@@ -52,7 +52,7 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
     DefaultFinalizedExecutionPlan finalizedPlan
 
     def accessHierarchies = new ExecutionNodeAccessHierarchies(CASE_SENSITIVE, Stub(Stat))
-    def taskNodeFactory = new TaskNodeFactory(project.gradle, Stub(BuildTreeWorkGraphController), nodeValidator, new TestBuildOperationExecutor(), accessHierarchies)
+    def taskNodeFactory = new TaskNodeFactory(project.gradle, Stub(BuildTreeWorkGraphController), nodeValidator, new TestBuildOperationRunner(), accessHierarchies)
 
     def setup() {
         def dependencyResolver = new TaskDependencyResolver([new TaskNodeDependencyResolver(taskNodeFactory)])

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
@@ -25,7 +25,7 @@ import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.composite.internal.BuildTreeWorkGraphController
 import org.gradle.internal.file.Stat
-import org.gradle.internal.operations.TestBuildOperationExecutor
+import org.gradle.internal.operations.TestBuildOperationRunner
 import org.gradle.util.Path
 import org.gradle.util.internal.TextUtil
 import spock.lang.Issue
@@ -41,7 +41,7 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
     DefaultFinalizedExecutionPlan finalizedPlan
 
     def accessHierarchies = new ExecutionNodeAccessHierarchies(CASE_SENSITIVE, Stub(Stat))
-    def taskNodeFactory = new TaskNodeFactory(thisBuild, Stub(BuildTreeWorkGraphController), nodeValidator, new TestBuildOperationExecutor(), accessHierarchies)
+    def taskNodeFactory = new TaskNodeFactory(thisBuild, Stub(BuildTreeWorkGraphController), nodeValidator, new TestBuildOperationRunner(), accessHierarchies)
     def dependencyResolver = new TaskDependencyResolver([new TaskNodeDependencyResolver(taskNodeFactory)])
 
     def setup() {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/TaskNodeFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/TaskNodeFactoryTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.plugins.PluginManagerInternal
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.composite.internal.BuildTreeWorkGraphController
-import org.gradle.internal.operations.TestBuildOperationExecutor
+import org.gradle.internal.operations.TestBuildOperationRunner
 import spock.lang.Specification
 
 class TaskNodeFactoryTest extends Specification {
@@ -38,7 +38,7 @@ class TaskNodeFactoryTest extends Specification {
         project.gradle >> gradle
         project.pluginManager >> Stub(PluginManagerInternal)
 
-        factory = new TaskNodeFactory(gradle, Stub(BuildTreeWorkGraphController), Stub(NodeValidator), new TestBuildOperationExecutor(), Stub(ExecutionNodeAccessHierarchies))
+        factory = new TaskNodeFactory(gradle, Stub(BuildTreeWorkGraphController), Stub(NodeValidator), new TestBuildOperationRunner(), Stub(ExecutionNodeAccessHierarchies))
     }
 
     private TaskInternal task(String name) {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
@@ -63,6 +63,7 @@ import org.gradle.internal.concurrent.ManagedExecutor
 import org.gradle.internal.event.DefaultListenerManager
 import org.gradle.internal.file.Stat
 import org.gradle.internal.operations.TestBuildOperationExecutor
+import org.gradle.internal.operations.TestBuildOperationRunner
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.internal.service.scopes.Scopes
 import org.gradle.internal.work.DefaultWorkerLeaseService
@@ -84,7 +85,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
     def workerLeases = new DefaultWorkerLeaseService(coordinator, parallelismConfiguration)
     def executorFactory = Mock(ExecutorFactory)
     def accessHierarchies = new ExecutionNodeAccessHierarchies(CASE_SENSITIVE, Stub(Stat))
-    def taskNodeFactory = new TaskNodeFactory(thisBuild, Stub(BuildTreeWorkGraphController), nodeValidator, new TestBuildOperationExecutor(), accessHierarchies)
+    def taskNodeFactory = new TaskNodeFactory(thisBuild, Stub(BuildTreeWorkGraphController), nodeValidator, new TestBuildOperationRunner(), accessHierarchies)
     def dependencyResolver = new TaskDependencyResolver([new TaskNodeDependencyResolver(taskNodeFactory)])
     def projectStateRegistry = Stub(ProjectStateRegistry)
     def executionPlan = newExecutionPlan()

--- a/subprojects/core/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationExecutorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationExecutorTest.groovy
@@ -16,9 +16,6 @@
 
 package org.gradle.internal.operations
 
-
-import org.gradle.internal.concurrent.DefaultParallelismConfiguration
-import org.gradle.internal.concurrent.ExecutorFactory
 import org.gradle.internal.progress.NoOpProgressLoggerFactory
 import org.gradle.internal.time.Clock
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
@@ -29,7 +26,10 @@ class DefaultBuildOperationExecutorTest extends ConcurrentSpec {
     def listener = Mock(BuildOperationListener)
     def timeProvider = Mock(Clock)
     def progressLoggerFactory = Spy(NoOpProgressLoggerFactory)
-    def operationExecutor = new DefaultBuildOperationExecutor(listener, timeProvider, progressLoggerFactory, Mock(BuildOperationQueueFactory), Mock(ExecutorFactory), new DefaultParallelismConfiguration(true, 1), new DefaultBuildOperationIdFactory())
+    def operationExecutor = BuildOperationExecutorSupport.builder(true, 1)
+        .withTimeSupplier(() -> timeProvider.currentTime)
+        .withExecutionListenerFactory { new BuildOperationProgressEventListenerAdapter(listener, progressLoggerFactory, timeProvider) }
+        .build()
 
     def setup() {
         CurrentBuildOperationRef.instance().clear()

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/internal/operations/BuildOperationExecutorSupport.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/internal/operations/BuildOperationExecutorSupport.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.operations;
+
+import org.gradle.concurrent.ParallelismConfiguration;
+import org.gradle.internal.concurrent.DefaultExecutorFactory;
+import org.gradle.internal.concurrent.DefaultParallelismConfiguration;
+import org.gradle.internal.concurrent.ExecutorFactory;
+import org.gradle.internal.work.WorkerLeaseService;
+import org.gradle.test.fixtures.work.TestWorkerLeaseService;
+
+public class BuildOperationExecutorSupport {
+    public static Builder builder(int numThreads) {
+        return builder(false, numThreads);
+    }
+
+    public static Builder builder(boolean parallelProjectExecution, int numThreads) {
+        return builder(new DefaultParallelismConfiguration(parallelProjectExecution, numThreads));
+    }
+
+    public static Builder builder(ParallelismConfiguration parallelismConfiguration) {
+        return new Builder(parallelismConfiguration);
+    }
+
+    public static class Builder {
+        private final ParallelismConfiguration parallelismConfiguration;
+        private BuildOperationTimeSupplier timeSupplier;
+        private WorkerLeaseService workerLeaseService;
+        private BuildOperationQueueFactory queueFactory;
+        private DefaultBuildOperationRunner.BuildOperationExecutionListenerFactory executionListenerFactory;
+        private ExecutorFactory executorFactory;
+
+        private Builder(ParallelismConfiguration parallelismConfiguration) {
+            this.parallelismConfiguration = parallelismConfiguration;
+        }
+
+        public Builder withTimeSupplier(BuildOperationTimeSupplier timeSupplier) {
+            this.timeSupplier = timeSupplier;
+            return this;
+        }
+
+        public Builder withWorkerLeaseService(WorkerLeaseService workerLeaseService) {
+            this.workerLeaseService = workerLeaseService;
+            return this;
+        }
+
+        public Builder withQueueFactory(BuildOperationQueueFactory queueFactory) {
+            this.queueFactory = queueFactory;
+            return this;
+        }
+
+        public Builder withExecutionListenerFactory(DefaultBuildOperationRunner.BuildOperationExecutionListenerFactory executionListenerFactory) {
+            this.executionListenerFactory = executionListenerFactory;
+            return this;
+        }
+
+        public Builder withExecutorFactory(ExecutorFactory executorFactory) {
+            this.executorFactory = executorFactory;
+            return this;
+        }
+
+        public BuildOperationExecutor build() {
+            BuildOperationTimeSupplier timeSupplier = this.timeSupplier != null
+                ? this.timeSupplier
+                : System::currentTimeMillis;
+            DefaultBuildOperationRunner.BuildOperationExecutionListenerFactory executionListenerFactory = this.executionListenerFactory != null
+                ? this.executionListenerFactory
+                : () -> DefaultBuildOperationRunner.BuildOperationExecutionListener.NO_OP;
+            WorkerLeaseService workerLeaseService = this.workerLeaseService != null
+                ? this.workerLeaseService
+                : new TestWorkerLeaseService();
+            BuildOperationQueueFactory queueFactory = this.queueFactory != null
+                ? this.queueFactory
+                : new DefaultBuildOperationQueueFactory(workerLeaseService);
+            ExecutorFactory executorFactory = this.executorFactory != null
+                ? this.executorFactory
+                : new DefaultExecutorFactory();
+
+            BuildOperationRunner buildOperationRunner = new DefaultBuildOperationRunner(
+                CurrentBuildOperationRef.instance(),
+                timeSupplier,
+                new DefaultBuildOperationIdFactory(),
+                executionListenerFactory
+            );
+
+            return new DefaultBuildOperationExecutor(
+                buildOperationRunner,
+                CurrentBuildOperationRef.instance(),
+                queueFactory,
+                executorFactory,
+                parallelismConfiguration);
+        }
+    }
+}

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/internal/operations/TestBuildOperationExecutor.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/internal/operations/TestBuildOperationExecutor.java
@@ -16,19 +16,10 @@
 
 package org.gradle.internal.operations;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.Lists;
 import org.gradle.api.Action;
-import org.gradle.internal.UncheckedException;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Deque;
-import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.LinkedBlockingDeque;
 
 /**
  * A BuildOperationExecutor for tests.
@@ -36,7 +27,17 @@ import java.util.concurrent.LinkedBlockingDeque;
  */
 public class TestBuildOperationExecutor implements BuildOperationExecutor {
 
-    public final Log log = new Log();
+    private final TestBuildOperationRunner runner;
+    public final TestBuildOperationRunner.Log log;
+
+    public TestBuildOperationExecutor() {
+        this(new TestBuildOperationRunner());
+    }
+
+    public TestBuildOperationExecutor(TestBuildOperationRunner buildOperationRunner) {
+        this.runner = buildOperationRunner;
+        this.log = runner.log;
+    }
 
     @Override
     public BuildOperationRef getCurrentOperation() {
@@ -54,27 +55,27 @@ public class TestBuildOperationExecutor implements BuildOperationExecutor {
     }
 
     public List<BuildOperationDescriptor> getOperations() {
-        return log.getDescriptors();
+        return runner.getOperations();
     }
 
     @Override
     public void run(RunnableBuildOperation buildOperation) {
-        log.run(buildOperation);
+        runner.run(buildOperation);
     }
 
     @Override
     public <T> T call(CallableBuildOperation<T> buildOperation) {
-        return log.call(buildOperation);
+        return runner.call(buildOperation);
     }
 
     @Override
     public <O extends BuildOperation> void execute(O buildOperation, BuildOperationWorker<O> worker, @Nullable BuildOperationState defaultParent) {
-        log.execute(buildOperation, worker);
+        runner.execute(buildOperation, worker, defaultParent);
     }
 
     @Override
     public BuildOperationContext start(BuildOperationDescriptor.Builder descriptor) {
-        return log.start(descriptor);
+        return runner.start(descriptor);
     }
 
     @Override
@@ -84,7 +85,7 @@ public class TestBuildOperationExecutor implements BuildOperationExecutor {
 
     @Override
     public <O extends RunnableBuildOperation> void runAll(Action<BuildOperationQueue<O>> schedulingAction, BuildOperationConstraint buildOperationConstraint) {
-        schedulingAction.execute(new TestBuildOperationQueue<O>(log));
+        schedulingAction.execute(new TestBuildOperationQueue<O>(runner));
     }
 
     @Override
@@ -107,52 +108,21 @@ public class TestBuildOperationExecutor implements BuildOperationExecutor {
         throw new UnsupportedOperationException();
     }
 
-    private static class TestBuildOperationContext implements BuildOperationContext {
-
-        private final Log.Record record;
-
-        public TestBuildOperationContext(Log.Record record) {
-            this.record = record;
-        }
-
-        @Override
-        public void failed(@Nullable Throwable failure) {
-            this.record.failure = failure;
-        }
-
-        @Override
-        public void setResult(@Nullable Object result) {
-            this.record.result = result;
-        }
-
-        @Override
-        public void setStatus(String status) {
-        }
-
-        @Override
-        public void progress(String status) {
-        }
-
-        @Override
-        public void progress(long progress, long total, String units, String status) {
-        }
-    }
-
     public static class TestBuildOperationQueue<O extends RunnableBuildOperation> implements BuildOperationQueue<O> {
 
-        public final Log log;
+        public final BuildOperationRunner runner;
 
         public TestBuildOperationQueue() {
-            this(new Log());
+            this(new TestBuildOperationRunner());
         }
 
-        private TestBuildOperationQueue(Log log) {
-            this.log = log;
+        private TestBuildOperationQueue(BuildOperationRunner runner) {
+            this.runner = runner;
         }
 
         @Override
         public void add(O operation) {
-            log.run(operation);
+            runner.run(operation);
         }
 
         @Override
@@ -171,197 +141,7 @@ public class TestBuildOperationExecutor implements BuildOperationExecutor {
         }
     }
 
-    public static class Log {
-        public final Deque<Record> records = new LinkedBlockingDeque<Record>();
-
-        public List<BuildOperationDescriptor> getDescriptors() {
-            return Lists.transform(new ArrayList<Record>(records), new Function<Record, BuildOperationDescriptor>() {
-                @Override
-                public BuildOperationDescriptor apply(Record input) {
-                    return input.descriptor;
-                }
-            });
-        }
-
-        public <D, R, T extends BuildOperationType<D, R>> TypedRecord<D, R> mostRecent(Class<T> type) {
-            Class<D> detailsType = BuildOperationTypes.detailsType(type);
-            Iterator<Record> iterator = records.descendingIterator();
-            while (iterator.hasNext()) {
-                Record record = iterator.next();
-                Object details = record.descriptor.getDetails();
-                if (detailsType.isInstance(details)) {
-                    return record.asTyped(type);
-                }
-            }
-
-            throw new AssertionError("Did not find operation with details of type: " + detailsType.getName());
-        }
-
-        public <D, R, T extends BuildOperationType<D, R>> List<TypedRecord<D, R>> all(final Class<T> type) {
-            final Class<D> detailsType = BuildOperationTypes.detailsType(type);
-            return FluentIterable.from(records)
-                .filter(new Predicate<Record>() {
-                    @Override
-                    public boolean apply(Record input) {
-                        return detailsType.isInstance(input.descriptor.getDetails());
-                    }
-                })
-                .transform(new Function<Record, TypedRecord<D, R>>() {
-                    @Override
-                    public TypedRecord<D, R> apply(Record input) {
-                        return input.asTyped(type);
-                    }
-                })
-                .toList();
-        }
-
-        public <R, D, T extends BuildOperationType<D, R>> D mostRecentDetails(Class<T> type) {
-            return mostRecent(type).details;
-        }
-
-        public <R, D, T extends BuildOperationType<D, R>> R mostRecentResult(Class<T> type) {
-            return mostRecent(type).result;
-        }
-
-        public <D, R, T extends BuildOperationType<D, R>> Throwable mostRecentFailure(Class<T> type) {
-            return mostRecent(type).failure;
-        }
-
-        @Override
-        public String toString() {
-            return records.toString();
-        }
-
-        public static class Record {
-
-            public final BuildOperationDescriptor descriptor;
-
-            public Object result;
-            public Throwable failure;
-
-            private Record(BuildOperationDescriptor descriptor) {
-                this.descriptor = descriptor;
-            }
-
-            @Override
-            public String toString() {
-                return descriptor.getDisplayName();
-            }
-
-            private <D, R, T extends BuildOperationType<D, R>> TypedRecord<D, R> asTyped(Class<? extends T> buildOperationType) {
-                if (descriptor.getDetails() == null) {
-                    throw new IllegalStateException("operation has null details");
-                }
-
-                return new TypedRecord<D, R>(
-                    descriptor,
-                    BuildOperationTypes.detailsType(buildOperationType).cast(descriptor.getDetails()),
-                    BuildOperationTypes.resultType(buildOperationType).cast(result),
-                    failure
-                );
-            }
-
-        }
-
-        public static class TypedRecord<D, R> {
-
-            public final BuildOperationDescriptor descriptor;
-            public final D details;
-            public final R result;
-            public final Throwable failure;
-
-            private TypedRecord(BuildOperationDescriptor descriptor, D details, R result, Throwable failure) {
-                this.descriptor = descriptor;
-                this.details = details;
-                this.result = result;
-                this.failure = failure;
-            }
-
-            @Override
-            public String toString() {
-                return descriptor.getDisplayName();
-            }
-        }
-
-
-        private void run(RunnableBuildOperation buildOperation) {
-            Record record = new Record(buildOperation.description().build());
-            records.add(record);
-            TestBuildOperationContext context = new TestBuildOperationContext(record);
-            try {
-                buildOperation.run(context);
-            } catch (Throwable failure) {
-                if (record.failure == null) {
-                    record.failure = failure;
-                }
-                throw UncheckedException.throwAsUncheckedException(failure);
-            }
-        }
-
-        private <T> T call(CallableBuildOperation<T> buildOperation) {
-            Record record = new Record(buildOperation.description().build());
-            records.add(record);
-            TestBuildOperationContext context = new TestBuildOperationContext(record);
-            T t;
-            try {
-                t = buildOperation.call(context);
-            } catch (Throwable failure) {
-                if (record.failure == null) {
-                    record.failure = failure;
-                }
-                throw UncheckedException.throwAsUncheckedException(failure);
-            }
-            return t;
-        }
-
-        private <O extends BuildOperation> void execute(O buildOperation, BuildOperationWorker<O> worker) {
-            Record record = new Record(buildOperation.description().build());
-            records.add(record);
-            TestBuildOperationContext context = new TestBuildOperationContext(record);
-            try {
-                worker.execute(buildOperation, context);
-            } catch (Throwable failure) {
-                if (record.failure == null) {
-                    record.failure = failure;
-                }
-                throw UncheckedException.throwAsUncheckedException(failure);
-            }
-        }
-
-        private BuildOperationContext start(final BuildOperationDescriptor.Builder descriptor) {
-            Record record = new Record(descriptor.build());
-            records.add(record);
-            final TestBuildOperationContext context = new TestBuildOperationContext(record);
-            return new BuildOperationContext() {
-                @Override
-                public void failed(@Nullable Throwable failure) {
-                    context.failed(failure);
-                }
-
-                @Override
-                public void setResult(@Nullable Object result) {
-                    context.setResult(result);
-                }
-
-                @Override
-                public void setStatus(String status) {
-                    context.setStatus(status);
-                }
-
-                @Override
-                public void progress(String status) {
-                    context.progress(status);
-                }
-
-                @Override
-                public void progress(long progress, long total, String units, String status) {
-                    context.progress(progress, total, units, status);
-                }
-            };
-        }
-    }
-
     public void reset() {
-        log.records.clear();
+        runner.reset();
     }
 }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/internal/operations/TestBuildOperationExecutor.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/internal/operations/TestBuildOperationExecutor.java
@@ -18,7 +18,6 @@ package org.gradle.internal.operations;
 
 import org.gradle.api.Action;
 
-import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -66,11 +65,6 @@ public class TestBuildOperationExecutor implements BuildOperationExecutor {
     @Override
     public <T> T call(CallableBuildOperation<T> buildOperation) {
         return runner.call(buildOperation);
-    }
-
-    @Override
-    public <O extends BuildOperation> void execute(O buildOperation, BuildOperationWorker<O> worker, @Nullable BuildOperationState defaultParent) {
-        runner.execute(buildOperation, worker, defaultParent);
     }
 
     @Override

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/internal/operations/TestBuildOperationRunner.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/internal/operations/TestBuildOperationRunner.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.operations;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.Lists;
+import org.gradle.internal.UncheckedException;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.LinkedBlockingDeque;
+
+/**
+ * A BuildOperationRunner for tests.
+ * Simply execute given operations, does not support current/parent operations.
+ */
+// TODO Move to :build-operations' test fixtures
+public class TestBuildOperationRunner implements BuildOperationRunner {
+
+    public final Log log = new Log();
+
+    public List<BuildOperationDescriptor> getOperations() {
+        return log.getDescriptors();
+    }
+
+    @Override
+    public void run(RunnableBuildOperation buildOperation) {
+        log.run(buildOperation);
+    }
+
+    @Override
+    public <T> T call(CallableBuildOperation<T> buildOperation) {
+        return log.call(buildOperation);
+    }
+
+    @Override
+    public <O extends BuildOperation> void execute(O buildOperation, BuildOperationWorker<O> worker, @Nullable BuildOperationState defaultParent) {
+        log.execute(buildOperation, worker);
+    }
+
+    @Override
+    public BuildOperationContext start(BuildOperationDescriptor.Builder descriptor) {
+        return log.start(descriptor);
+    }
+
+    private static class TestBuildOperationContext implements BuildOperationContext {
+
+        private final Log.Record record;
+
+        public TestBuildOperationContext(Log.Record record) {
+            this.record = record;
+        }
+
+        @Override
+        public void failed(@Nullable Throwable failure) {
+            this.record.failure = failure;
+        }
+
+        @Override
+        public void setResult(@Nullable Object result) {
+            this.record.result = result;
+        }
+
+        @Override
+        public void setStatus(String status) {
+        }
+
+        @Override
+        public void progress(String status) {
+        }
+
+        @Override
+        public void progress(long progress, long total, String units, String status) {
+        }
+    }
+
+    public static class Log {
+        public final Deque<Record> records = new LinkedBlockingDeque<Record>();
+
+        public List<BuildOperationDescriptor> getDescriptors() {
+            return Lists.transform(new ArrayList<Record>(records), new Function<Record, BuildOperationDescriptor>() {
+                @Override
+                public BuildOperationDescriptor apply(Record input) {
+                    return input.descriptor;
+                }
+            });
+        }
+
+        public <D, R, T extends BuildOperationType<D, R>> TypedRecord<D, R> mostRecent(Class<T> type) {
+            Class<D> detailsType = BuildOperationTypes.detailsType(type);
+            Iterator<Record> iterator = records.descendingIterator();
+            while (iterator.hasNext()) {
+                Record record = iterator.next();
+                Object details = record.descriptor.getDetails();
+                if (detailsType.isInstance(details)) {
+                    return record.asTyped(type);
+                }
+            }
+
+            throw new AssertionError("Did not find operation with details of type: " + detailsType.getName());
+        }
+
+        public <D, R, T extends BuildOperationType<D, R>> List<TypedRecord<D, R>> all(final Class<T> type) {
+            final Class<D> detailsType = BuildOperationTypes.detailsType(type);
+            return FluentIterable.from(records)
+                .filter(new Predicate<Record>() {
+                    @Override
+                    public boolean apply(Record input) {
+                        return detailsType.isInstance(input.descriptor.getDetails());
+                    }
+                })
+                .transform(new Function<Record, TypedRecord<D, R>>() {
+                    @Override
+                    public TypedRecord<D, R> apply(Record input) {
+                        return input.asTyped(type);
+                    }
+                })
+                .toList();
+        }
+
+        public <R, D, T extends BuildOperationType<D, R>> D mostRecentDetails(Class<T> type) {
+            return mostRecent(type).details;
+        }
+
+        public <R, D, T extends BuildOperationType<D, R>> R mostRecentResult(Class<T> type) {
+            return mostRecent(type).result;
+        }
+
+        public <D, R, T extends BuildOperationType<D, R>> Throwable mostRecentFailure(Class<T> type) {
+            return mostRecent(type).failure;
+        }
+
+        @Override
+        public String toString() {
+            return records.toString();
+        }
+
+        public static class Record {
+
+            public final BuildOperationDescriptor descriptor;
+
+            public Object result;
+            public Throwable failure;
+
+            private Record(BuildOperationDescriptor descriptor) {
+                this.descriptor = descriptor;
+            }
+
+            @Override
+            public String toString() {
+                return descriptor.getDisplayName();
+            }
+
+            private <D, R, T extends BuildOperationType<D, R>> TypedRecord<D, R> asTyped(Class<? extends T> buildOperationType) {
+                if (descriptor.getDetails() == null) {
+                    throw new IllegalStateException("operation has null details");
+                }
+
+                return new TypedRecord<D, R>(
+                    descriptor,
+                    BuildOperationTypes.detailsType(buildOperationType).cast(descriptor.getDetails()),
+                    BuildOperationTypes.resultType(buildOperationType).cast(result),
+                    failure
+                );
+            }
+
+        }
+
+        public static class TypedRecord<D, R> {
+
+            public final BuildOperationDescriptor descriptor;
+            public final D details;
+            public final R result;
+            public final Throwable failure;
+
+            private TypedRecord(BuildOperationDescriptor descriptor, D details, R result, Throwable failure) {
+                this.descriptor = descriptor;
+                this.details = details;
+                this.result = result;
+                this.failure = failure;
+            }
+
+            @Override
+            public String toString() {
+                return descriptor.getDisplayName();
+            }
+        }
+
+
+        private void run(RunnableBuildOperation buildOperation) {
+            Record record = new Record(buildOperation.description().build());
+            records.add(record);
+            TestBuildOperationContext context = new TestBuildOperationContext(record);
+            try {
+                buildOperation.run(context);
+            } catch (Throwable failure) {
+                if (record.failure == null) {
+                    record.failure = failure;
+                }
+                throw UncheckedException.throwAsUncheckedException(failure);
+            }
+        }
+
+        private <T> T call(CallableBuildOperation<T> buildOperation) {
+            Record record = new Record(buildOperation.description().build());
+            records.add(record);
+            TestBuildOperationContext context = new TestBuildOperationContext(record);
+            T t;
+            try {
+                t = buildOperation.call(context);
+            } catch (Throwable failure) {
+                if (record.failure == null) {
+                    record.failure = failure;
+                }
+                throw UncheckedException.throwAsUncheckedException(failure);
+            }
+            return t;
+        }
+
+        private <O extends BuildOperation> void execute(O buildOperation, BuildOperationWorker<O> worker) {
+            Record record = new Record(buildOperation.description().build());
+            records.add(record);
+            TestBuildOperationContext context = new TestBuildOperationContext(record);
+            try {
+                worker.execute(buildOperation, context);
+            } catch (Throwable failure) {
+                if (record.failure == null) {
+                    record.failure = failure;
+                }
+                throw UncheckedException.throwAsUncheckedException(failure);
+            }
+        }
+
+        private BuildOperationContext start(final BuildOperationDescriptor.Builder descriptor) {
+            Record record = new Record(descriptor.build());
+            records.add(record);
+            final TestBuildOperationContext context = new TestBuildOperationContext(record);
+            return new BuildOperationContext() {
+                @Override
+                public void failed(@Nullable Throwable failure) {
+                    context.failed(failure);
+                }
+
+                @Override
+                public void setResult(@Nullable Object result) {
+                    context.setResult(result);
+                }
+
+                @Override
+                public void setStatus(String status) {
+                    context.setStatus(status);
+                }
+
+                @Override
+                public void progress(String status) {
+                    context.progress(status);
+                }
+
+                @Override
+                public void progress(long progress, long total, String units, String status) {
+                    context.progress(progress, total, units, status);
+                }
+            };
+        }
+    }
+
+    public void reset() {
+        log.records.clear();
+    }
+}


### PR DESCRIPTION
The PR replaces the dependency between `:persistent-cache` and `:enterprise-logging` by `:build-operations`. This is needed to simplify using the build cache library (which relies on `:persistent-cache`) in non-Gradle clients. It also means we don't need to publish `:enterprise-logging`, `:logging-api` and `:logging` to be part of the build cache library.

This is also a step towards replacing `ProgressLogger` with `BuildOperationRunner` in general.

The PR separates `BuildOperationRunner` and `BuildOperationExecutor` more clearly. The latter used to extend the former, but this is not the case anymore:
- `BuildOperationRunner` is responsible for running individual build operations, and is part of the build cache library, and has few dependencies.
- `BuildOperationExecutor` is about parallel execution of several operations using a `BuildOperationQueue`. It has many more dependencies, and is not part of the published build cache library.
  **Note:** For now, the type still provides the same method signatures as `BuildOperationRunner` to keep compatible with existing code. We should follow up and replace these usages with `BuildOperationRunner` and remove the delegating methods from `BuildOperationExecutor`. We should probably rename the executor to something like `ParallelBuildOperationExecutor` or something to signal that it is only about parallelism.

As part of the changes I now moved `BuildOperationRunner`, `BuildOperationListenerManager` and `CurrentBuildOperationRef` to the `WorkerSharedGlobalScopeServices` from `GlobalScopeServices`, so `CacheFactory` has access to them.

Since both the build operation executor and runner are used in a number of unit tests (some more integration-test-like than the others), I've added some test fixtures to easily create these in tests.