### PR TITLE
Reuse ScriptClassPathResolver to instrument build logic classpath for GeneratePrecompiledScriptPluginAccessors

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
@@ -224,9 +224,7 @@ fun Project.enableScriptCompilationOf(
             ) {
                 dependsOn(compilePluginsBlocks)
                 classPathFiles.from(compileClasspath)
-                val runtimeClassPath = configurations["runtimeClasspath"].incoming.artifacts
-                runtimeClassPathFiles.from(runtimeClassPath.artifactFiles)
-                runtimeClassPathArtifactCollection.set(runtimeClassPath)
+                runtimeClassPathArtifactCollection.set(configurations["runtimeClasspath"].incoming.artifacts)
                 sourceCodeOutputDir.set(it)
                 metadataOutputDir.set(accessorsMetadata)
                 compiledPluginsBlocksDir.set(compiledPluginsBlocks)

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
@@ -224,7 +224,9 @@ fun Project.enableScriptCompilationOf(
             ) {
                 dependsOn(compilePluginsBlocks)
                 classPathFiles.from(compileClasspath)
-                runtimeClassPathFiles.from(configurations["runtimeClasspath"])
+                val runtimeClassPath = configurations["runtimeClasspath"].incoming.artifacts
+                runtimeClassPathFiles.from(runtimeClassPath.artifactFiles)
+                runtimeClassPathArtifactCollection.set(runtimeClassPath)
                 sourceCodeOutputDir.set(it)
                 metadataOutputDir.set(accessorsMetadata)
                 compiledPluginsBlocksDir.set(compiledPluginsBlocks)

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyFactoryInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyFactoryInternal.java
@@ -31,7 +31,8 @@ public interface DependencyFactoryInternal extends DependencyFactory {
         GRADLE_API("Gradle API"),
         GRADLE_KOTLIN_DSL("Gradle Kotlin DSL"),
         GRADLE_TEST_KIT("Gradle TestKit"),
-        LOCAL_GROOVY("Local Groovy");
+        LOCAL_GROOVY("Local Groovy"),
+        LOCAL_PROJECT_AS_OPAQUE_DEPENDENCY("Local project as an opaque dependency");
 
         public final String displayName;
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptClassPathResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptClassPathResolver.java
@@ -33,7 +33,7 @@ import org.gradle.api.attributes.java.TargetJvmVersion;
 import org.gradle.api.attributes.plugin.GradlePluginApiVersion;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.artifacts.dsl.DependencyHandlerInternal;
-import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactoryInternal;
+import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactoryInternal.ClassPathNotation;
 import org.gradle.api.internal.initialization.transform.registration.InstrumentationTransformRegisterer;
 import org.gradle.api.internal.initialization.transform.services.CacheInstrumentationDataBuildService;
 import org.gradle.api.internal.initialization.transform.services.CacheInstrumentationDataBuildService.ResolutionScope;
@@ -61,9 +61,9 @@ import static org.gradle.api.internal.initialization.transform.utils.Instrumenta
 
 public class DefaultScriptClassPathResolver implements ScriptClassPathResolver {
 
-    private static final Set<DependencyFactoryInternal.ClassPathNotation> GRADLE_API_NOTATIONS = EnumSet.of(
-        DependencyFactoryInternal.ClassPathNotation.GRADLE_API,
-        DependencyFactoryInternal.ClassPathNotation.LOCAL_GROOVY
+    private static final Set<ClassPathNotation> GRADLE_API_NOTATIONS = EnumSet.of(
+        ClassPathNotation.GRADLE_API,
+        ClassPathNotation.LOCAL_GROOVY
     );
 
     public enum InstrumentationPhase {
@@ -177,13 +177,16 @@ public class DefaultScriptClassPathResolver implements ScriptClassPathResolver {
 
     private static boolean isGradleApi(ComponentIdentifier componentId) {
         if (componentId instanceof OpaqueComponentIdentifier) {
-            DependencyFactoryInternal.ClassPathNotation classPathNotation = ((OpaqueComponentIdentifier) componentId).getClassPathNotation();
+            ClassPathNotation classPathNotation = ((OpaqueComponentIdentifier) componentId).getClassPathNotation();
             return DefaultScriptClassPathResolver.GRADLE_API_NOTATIONS.contains(classPathNotation);
         }
         return false;
     }
 
     private static boolean isProjectDependency(ComponentIdentifier componentId) {
+        if (componentId instanceof OpaqueComponentIdentifier) {
+            return ((OpaqueComponentIdentifier) componentId).getClassPathNotation() == ClassPathNotation.LOCAL_PROJECT_AS_OPAQUE_DEPENDENCY;
+        }
         return componentId instanceof ProjectComponentIdentifier;
     }
 


### PR DESCRIPTION
This replaces old instrumentation with new one that uses artifact transform.

Ideally we would pass already instrumented classpath to `GeneratePrecompiledScriptPluginAccessors` and then just export it to the classloader. But since we do some artifact transform caching via BuildService, that would add some complexity when wiring GeneratePrecompiledScriptPluginAccessors task.

That is why we reuse instrumentation logic via `ScriptClassPathResolver`. 

Since we want to do only instrumentation for project dependencies, we also introduce:
`ClassPathNotation.LOCAL_PROJECT_AS_OPAQUE_DEPENDENCY` so we can filter them in `ScriptClassPathResolver`.

Fixes https://github.com/gradle/gradle/issues/28045