### PR TITLE
Allow circular reference chains that go through TaskProvider

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/OrElseValueProducer.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/OrElseValueProducer.java
@@ -20,6 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Task;
 
 import javax.annotation.Nullable;
+import java.util.Objects;
 
 class OrElseValueProducer implements ValueSupplier.ValueProducer {
     private final EvaluationContext.EvaluationOwner owner;
@@ -38,7 +39,7 @@ class OrElseValueProducer implements ValueSupplier.ValueProducer {
     }
 
     private OrElseValueProducer(EvaluationContext.ScopeContext context, ProviderInternal<?> left, @Nullable ProviderInternal<?> right, ValueSupplier.ValueProducer rightProducer) {
-        this.owner = context.getOwner();
+        this.owner = Objects.requireNonNull(context.getOwner());
         this.left = left;
         this.right = right;
         this.leftProducer = left.getProducer();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -33,6 +33,7 @@ import org.gradle.api.internal.collections.CollectionFilter;
 import org.gradle.api.internal.collections.ElementSource;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.internal.provider.AbstractMinimalProvider;
+import org.gradle.api.internal.provider.EvaluationContext;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.provider.Provider;
@@ -998,13 +999,20 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
                 // Collect any container level add actions added since the last call to configure()
                 onCreate = onCreate.mergeFrom(getEventRegister().getAddActions());
 
-                // Create the domain object
-                object = createDomainObject();
-
-                // Register the domain object
-                add(object, onCreate);
-                realized(AbstractDomainObjectCreatingProvider.this);
-                onLazyDomainObjectRealized();
+                try (EvaluationContext.ScopeContext scope = openScope()) {
+                    // Create the domain object
+                    object = createDomainObject();
+                    // Configuring the domain object may cause circular evaluation, but after initializing this.object
+                    // calculateOwnValue short-circuits it at a cost of exposing a partially constructed value.
+                    // Because of that the circular evaluation that goes through this provider doesn't cause stack overflow.
+                    // To avoid breaking existing code, we open a nested evaluation scope here to allow re-entering the chain.
+                    try (EvaluationContext.ScopeContext ignored = scope.nested()) {
+                        // Register the domain object
+                        add(object, onCreate);
+                        realized(AbstractDomainObjectCreatingProvider.this);
+                        onLazyDomainObjectRealized();
+                    }
+                }
             } catch (Throwable ex) {
                 failure = domainObjectCreationException(ex);
                 throw failure;

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractNamedDomainObjectContainerSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractNamedDomainObjectContainerSpec.groovy
@@ -111,4 +111,17 @@ abstract class AbstractNamedDomainObjectContainerSpec<T> extends AbstractNamedDo
         ops[0].details.applicationId == id1.longValue()
         ops[1].details.applicationId == id2.longValue()
     }
+
+    def "can configure task based on its provider"() {
+        given:
+        setupContainerDefaults()
+        def p = container.register("r1")
+        def derived = p.map { "value" }
+        p.configure {
+            derived.get()
+        }
+
+        expect:
+        "value" == derived.get()
+    }
 }


### PR DESCRIPTION
TaskProvider short-circuits its evaluation the second time it is obtained, so there is no stack overflow, even though some parts of the chain may be evaluated twice.

This commit restores the old behavior, and it is going to be deprecated in the next release.

Fixes #28368.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
