### PR TITLE
Ignore CACHE_MISSes in GradleceptionWithJavaMaxLts

### DIFF
--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.cache-miss-monitor.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.cache-miss-monitor.gradle.kts
@@ -95,6 +95,7 @@ fun Project.isExpectedCompileCacheMiss() =
         "Component_GradlePlugin_Performance_PerformanceLatestMaster",
         "Component_GradlePlugin_Performance_PerformanceLatestReleased",
         "Check_Gradleception",
+        "Check_GradleceptionWithJavaMaxLts",
         "Check_GradleceptionWithGroovy4",
         "CompileAllBuild_BuildCacheNG",
         "CompileAllBuild_NGRemote"


### PR DESCRIPTION
We observed some consistent CACHE_MISS alerts from GradleceptionWithJavaMaxLts builds, which should be ignored.
