### PR TITLE
Rename ProblemId.getParent() to ProblemId.getGroup()

### DIFF
--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/AbstractInputFilePropertyAnnotationHandler.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/AbstractInputFilePropertyAnnotationHandler.java
@@ -115,7 +115,7 @@ public abstract class AbstractInputFilePropertyAnnotationHandler extends Abstrac
                 String propertyName = propertyMetadata.getPropertyName();
                 problem
                     .forProperty(propertyName)
-                    .id(MISSING_NORMALIZATION_ID.getName(), MISSING_NORMALIZATION_ID.getDisplayName(), MISSING_NORMALIZATION_ID.getParent())
+                    .id(MISSING_NORMALIZATION_ID.getName(), MISSING_NORMALIZATION_ID.getDisplayName(), MISSING_NORMALIZATION_ID.getGroup())
                     .contextualLabel(String.format("is annotated with @%s but missing a normalization strategy", getAnnotationType().getSimpleName()))
                     .documentedAt(userManual("validation_problems", MISSING_NORMALIZATION_ANNOTATION.toLowerCase()))
                     .severity(Severity.ERROR)

--- a/platforms/extensibility/plugin-development/src/test/groovy/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerializationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/test/groovy/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerializationTest.groovy
@@ -44,9 +44,9 @@ class ValidationProblemSerializationTest extends Specification {
         deserialized.size() == 1
         deserialized[0].definition.id.name == "id"
         deserialized[0].definition.id.displayName == "label"
-        deserialized[0].definition.id.parent.name == "validation"
-        deserialized[0].definition.id.parent.displayName == "Validation"
-        deserialized[0].definition.id.parent.parent == null
+        deserialized[0].definition.id.group.name == "validation"
+        deserialized[0].definition.id.group.displayName == "Validation"
+        deserialized[0].definition.id.group.parent == null
 
         deserialized[0].locations.isEmpty()
         deserialized[0].definition.documentationLink == null

--- a/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
+++ b/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
@@ -47,7 +47,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
         problem['definition']['id'] == [
             name: 'missing-id',
             displayName: 'Problem id must be specified',
-            parent: [
+            group: [
                 'name': 'problems-api',
                 'displayName': 'Problems API',
                 'parent': null
@@ -73,7 +73,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
         problem['definition']['id'] == [
             name: 'type',
             displayName: 'label',
-            parent: [
+            group: [
                 name: 'generic',
                 displayName: 'Generic',
                 parent: null
@@ -101,7 +101,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
         problem['definition']['id'] == [
             name: 'type',
             displayName: 'label',
-            parent: [
+            group: [
                 name: 'generic',
                 displayName: 'Generic',
                 parent: null
@@ -265,7 +265,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
         problem['definition']['id'] == [
             name: 'invalid-additional-data',
             displayName: 'ProblemBuilder.additionalData() only supports values of type String',
-            parent: [
+            group: [
                 name: 'problems-api',
                 displayName: 'Problems API',
                 parent: null

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/ProblemId.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/ProblemId.java
@@ -21,7 +21,7 @@ import org.gradle.api.Incubating;
 /**
  * Represents an identifier for a problem definition.
  * <p>
- * Two problem IDs are considered equal if their {@link #getName()} and their parents' are equal.
+ * Two problem IDs are considered equal if their {@link #getName()} and their groups are equal.
  *
  * @since 8.8
  */
@@ -47,5 +47,5 @@ public interface ProblemId {
      *
      * @since 8.8
      */
-    ProblemGroup getParent();
+    ProblemGroup getGroup();
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemBuilder.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemBuilder.java
@@ -64,7 +64,7 @@ public class DefaultProblemBuilder implements InternalProblemBuilder {
         // Label is mandatory
         if (id == null) {
             return invalidProblem("missing-id", "Problem id must be specified");
-        } else if (id.getParent() == null) {
+        } else if (id.getGroup() == null) {
             return invalidProblem("missing-parent", "Problem id must have a parent");
         }
 

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemId.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemId.java
@@ -44,7 +44,7 @@ public class DefaultProblemId implements ProblemId, Serializable {
     }
 
     @Override
-    public ProblemGroup getParent() {
+    public ProblemGroup getGroup() {
         return parent;
     }
 
@@ -62,7 +62,7 @@ public class DefaultProblemId implements ProblemId, Serializable {
         if (!id.equals(that.getName())) {
             return false;
         }
-        return parent.equals(that.getParent());
+        return parent.equals(that.getGroup());
     }
 
     @Override

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ProblemsProgressEventConsumer.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ProblemsProgressEventConsumer.java
@@ -140,7 +140,7 @@ public class ProblemsProgressEventConsumer extends ClientForwardingBuildOperatio
         List<String> categories = new ArrayList<>();
         // put the problem id at the beginning of the list
         categories.add(0, problemId.getName());
-        ProblemGroup current = problemId.getParent();
+        ProblemGroup current = problemId.getGroup();
         while (current != null) {
             categories.add(0, current.getName());
             current = current.getParent();

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
@@ -29,7 +29,11 @@ class KnownProblemIds {
     }
 
     private static String toFullyQualifiedId(problem) {
-         return "${problem['parent'] ? toFullyQualifiedId(problem['parent']) + ":" :  ""}" + problem['name']
+        "${toFullyQualifiedGroup(problem['group'])}:${problem['name']}"
+    }
+
+    private static String toFullyQualifiedGroup(group) {
+        return "${group['parent'] ? toFullyQualifiedGroup(group['parent']) + ":" :  ""}" + group['name']
     }
 
     private static final def KNOWN_IDS = [


### PR DESCRIPTION
This change increases comprehensibility of the API.