### PR TITLE
Make file-collections tolerant to absent providers used as sources

### DIFF
--- a/platforms/core-configuration/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
+++ b/platforms/core-configuration/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
@@ -53,6 +53,23 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec implements T
         succeeds()
     }
 
+    def "can set a none-provider as source for file collection"() {
+        buildFile """
+            def fileName
+            def files = objects.fileCollection().from([provider { fileName }], 'b')
+            def elements = files.elements
+
+            fileName = 'a'
+            assert elements.get().asFile == [file('a'), file('b')]
+
+            fileName = null
+            assert elements.get().asFile == [file('b')]
+        """
+
+        expect:
+        succeeds()
+    }
+
     @Issue("https://github.com/gradle/gradle/issues/10322")
     def "can construct file collection from the elements of a source directory set"() {
         buildFile """

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
@@ -184,7 +184,7 @@ public class DefaultFileCollectionFactory implements FileCollectionFactory {
 
     @Override
     public FileCollectionInternal resolving(Object sources) {
-        return resolving(ProviderResolutionStrategy.REQUIRE_PRESENT, sources);
+        return resolving(ProviderResolutionStrategy.ALLOW_ABSENT, sources);
     }
 
     @Override

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
@@ -182,9 +182,13 @@ public class DefaultFileCollectionFactory implements FileCollectionFactory {
         return new ResolvingFileCollection(displayName, fileResolver, taskDependencyFactory, patternSetFactory, providerResolutionStrategy, sources);
     }
 
+    public FileCollectionInternal resolvingStrictly(Object sources) {
+        return resolving(ProviderResolutionStrategy.REQUIRE_PRESENT, sources);
+    }
+
     @Override
     public FileCollectionInternal resolving(Object sources) {
-        return resolving(ProviderResolutionStrategy.ALLOW_ABSENT, sources);
+        return resolvingLeniently(sources);
     }
 
     @Override

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.internal.file.UnionFileCollection;
 import org.gradle.api.internal.provider.HasConfigurableValueInternal;
 import org.gradle.api.internal.provider.PropertyHost;
+import org.gradle.api.internal.provider.ProviderResolutionStrategy;
 import org.gradle.api.internal.provider.ValueState;
 import org.gradle.api.internal.provider.ValueSupplier;
 import org.gradle.api.internal.provider.support.LazyGroovySupport;
@@ -589,7 +590,7 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
 
         @Override
         public void visitContents(Consumer<FileCollectionInternal> visitor) {
-            UnpackingVisitor nested = new UnpackingVisitor(visitor, resolver, taskDependencyFactory, patternSetFactory);
+            UnpackingVisitor nested = new UnpackingVisitor(visitor, resolver, taskDependencyFactory, patternSetFactory, ProviderResolutionStrategy.ALLOW_ABSENT, true);
             for (Object item : items) {
                 nested.add(item);
             }

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/ProviderBackedFileCollection.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/ProviderBackedFileCollection.java
@@ -53,14 +53,14 @@ public class ProviderBackedFileCollection extends CompositeFileCollection {
             producer.visitProducerTasks(context);
         } else {
             // Producer is unknown, so unpack the value
-            UnpackingVisitor unpackingVisitor = new UnpackingVisitor(context::add, resolver, taskDependencyFactory, patternSetFactory);
+            UnpackingVisitor unpackingVisitor = new UnpackingVisitor(context::add, resolver, taskDependencyFactory, patternSetFactory, ProviderResolutionStrategy.ALLOW_ABSENT, true);
             unpackingVisitor.add(providerResolutionStrategy.resolve(provider));
         }
     }
 
     @Override
     protected void visitChildren(Consumer<FileCollectionInternal> visitor) {
-        UnpackingVisitor unpackingVisitor = new UnpackingVisitor(visitor, resolver, taskDependencyFactory, patternSetFactory);
+        UnpackingVisitor unpackingVisitor = new UnpackingVisitor(visitor, resolver, taskDependencyFactory, patternSetFactory, ProviderResolutionStrategy.ALLOW_ABSENT, true);
         unpackingVisitor.add(providerResolutionStrategy.resolve(provider));
     }
 

--- a/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFileCollectionFactoryTest.groovy
+++ b/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFileCollectionFactoryTest.groovy
@@ -335,7 +335,7 @@ class DefaultFileCollectionFactoryTest extends Specification {
     }
 
     def 'fails on resolving absent Provider#description in file collection'() {
-        def collection = factory.resolving(provider)
+        def collection = factory.resolvingStrictly(provider)
 
         when:
         collection.files


### PR DESCRIPTION
Make file-collections tolerant to absent providers used as sources

Issue: #28304

