### PR TITLE
Remove -Dorg.gradle.native=false from ForkingTestClassProcessor

### DIFF
--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
@@ -110,7 +110,6 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
         builder.applicationClasspath(classpath.getApplicationClasspath());
         builder.applicationModulePath(classpath.getApplicationModulepath());
         options.copyTo(builder.getJavaCommand());
-        builder.getJavaCommand().jvmArgs("-Dorg.gradle.native=false");
         buildConfigAction.execute(builder);
 
         workerProcess = builder.build();


### PR DESCRIPTION
`-Dorg.gradle.native=false` is now respected with https://github.com/gradle/gradle/issues/28203. But that means that all Gradle builds running in tests will have native services disabled by default. We should probably remove native services flag, so we don't disable it for Gradle builds inside forked test process.

Let's see what happens if we remove the flag.