### PR TITLE
Move Global scope to Scopes

### DIFF
--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -34,7 +34,6 @@ import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
 import org.gradle.internal.file.PathToFileResolver;
-import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.state.Managed;
@@ -45,7 +44,7 @@ import java.io.File;
 import static org.gradle.api.internal.lambdas.SerializableLambdas.bifunction;
 import static org.gradle.api.internal.lambdas.SerializableLambdas.transformer;
 
-@ServiceScope({Scope.Global.class, Scopes.Project.class})
+@ServiceScope({Scopes.Global.class, Scopes.Project.class})
 public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFactory {
     private final PropertyHost host;
     private final FileResolver fileResolver;

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionFactory.java
@@ -30,7 +30,6 @@ import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.Factory;
 import org.gradle.internal.file.PathToFileResolver;
-import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -40,7 +39,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 
-@ServiceScope({Scope.Global.class, Scopes.BuildTree.class, Scopes.Build.class, Scopes.Project.class})
+@ServiceScope({Scopes.Global.class, Scopes.BuildTree.class, Scopes.Build.class, Scopes.Project.class})
 public interface FileCollectionFactory {
     /**
      * Creates a copy of this factory that uses the given resolver to convert various types to File instances.

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileResolver.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileResolver.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.file;
 import org.gradle.api.PathValidation;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.file.RelativeFilePathResolver;
-import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.typeconversion.NotationParser;
@@ -26,7 +25,7 @@ import org.gradle.internal.typeconversion.NotationParser;
 import java.io.File;
 import java.net.URI;
 
-@ServiceScope({Scope.Global.class, Scopes.BuildSession.class, Scopes.Project.class})
+@ServiceScope({Scopes.Global.class, Scopes.BuildSession.class, Scopes.Project.class})
 public interface FileResolver extends RelativeFilePathResolver, PathToFileResolver {
     File resolve(Object path, PathValidation validation);
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/InstanceGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/InstanceGenerator.java
@@ -19,10 +19,10 @@ package org.gradle.internal.instantiation;
 import org.gradle.api.Describable;
 import org.gradle.api.reflect.ObjectInstantiationException;
 import org.gradle.internal.reflect.Instantiator;
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-@ServiceScope(Scope.Global.class)
+@ServiceScope(Scopes.Global.class)
 public interface InstanceGenerator extends Instantiator {
     /**
      * Create a new instance of T with the given display name, using {@code parameters} as the construction parameters.

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/WorkInputListener.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/WorkInputListener.java
@@ -18,7 +18,7 @@ package org.gradle.internal.execution;
 
 import org.gradle.internal.properties.InputBehavior;
 import org.gradle.internal.service.scopes.EventScope;
-import org.gradle.internal.service.scopes.Scope.Global;
+import org.gradle.internal.service.scopes.Scopes.Global;
 
 import java.util.EnumSet;
 

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/WorkInputListeners.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/WorkInputListeners.java
@@ -17,7 +17,7 @@
 package org.gradle.internal.execution;
 
 import org.gradle.internal.properties.InputBehavior;
-import org.gradle.internal.service.scopes.Scope.Global;
+import org.gradle.internal.service.scopes.Scopes.Global;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.util.EnumSet;

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/FileLockManager.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/FileLockManager.java
@@ -16,13 +16,13 @@
 package org.gradle.cache;
 
 import org.gradle.api.Action;
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.Nullable;
 import java.io.File;
 
-@ServiceScope(Scope.Global.class)
+@ServiceScope(Scopes.Global.class)
 public interface FileLockManager {
     /**
      * Creates a lock for the given file with the given mode. Acquires a lock with the given mode, which is held until the lock is

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCacheFactory.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCacheFactory.java
@@ -16,7 +16,7 @@
 
 package org.gradle.cache.internal;
 
-import org.gradle.internal.service.scopes.Scope.Global;
+import org.gradle.internal.service.scopes.Scopes.Global;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.concurrent.ThreadSafe;

--- a/platforms/core-execution/worker-processes/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
+++ b/platforms/core-execution/worker-processes/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
@@ -33,7 +33,7 @@ import org.gradle.internal.remote.services.MessagingServices;
 import org.gradle.internal.serialize.InputStreamBackedDecoder;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistry;
-import org.gradle.internal.service.scopes.Scope.Global;
+import org.gradle.internal.service.scopes.Scopes.Global;
 import org.gradle.process.internal.health.memory.DefaultJvmMemoryInfo;
 import org.gradle.process.internal.health.memory.DefaultMemoryManager;
 import org.gradle.process.internal.health.memory.DisabledOsMemoryInfo;

--- a/platforms/core-runtime/base-annotations/src/main/java/org/gradle/internal/service/scopes/Scope.java
+++ b/platforms/core-runtime/base-annotations/src/main/java/org/gradle/internal/service/scopes/Scope.java
@@ -16,11 +16,8 @@
 
 package org.gradle.internal.service.scopes;
 
+/**
+ * @see Scopes
+ */
 public interface Scope {
-    /**
-     * These services are reused across builds in the same process.
-     *
-     * <p>Global services are visible to all other services.</p>
-     */
-    interface Global extends Scope {}
 }

--- a/platforms/core-runtime/base-annotations/src/main/java/org/gradle/internal/service/scopes/Scopes.java
+++ b/platforms/core-runtime/base-annotations/src/main/java/org/gradle/internal/service/scopes/Scopes.java
@@ -20,13 +20,21 @@ package org.gradle.internal.service.scopes;
  * @see ServiceScope
  */
 public interface Scopes {
+
+    /**
+     * These services are reused across builds in the same process.
+     *
+     * <p>Global services are visible to all other services.</p>
+     */
+    interface Global extends Scope {}
+
     /**
      * These services are reused across builds in the same process while the Gradle user home directory remains unchanged.
      * The services are closed when the Gradle user home directory changes.
      *
-     * <p>{@link Scope.Global} and parent scope services are visible to {@link UserHome} scope services, but not vice versa.</p>
+     * <p>{@link Global} and parent scope services are visible to {@link UserHome} scope services, but not vice versa.</p>
      */
-    interface UserHome extends Scope.Global {}
+    interface UserHome extends Global {}
 
     /**
      * These services are reused across build invocations in a session.

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/concurrent/ExecutorFactory.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/concurrent/ExecutorFactory.java
@@ -16,12 +16,12 @@
 
 package org.gradle.internal.concurrent;
 
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.util.concurrent.TimeUnit;
 
-@ServiceScope(Scope.Global.class)
+@ServiceScope(Scopes.Global.class)
 public interface ExecutorFactory {
     /**
      * Creates an executor which can run multiple actions concurrently. It is the caller's responsibility to stop the executor.

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/scopes/PluginServiceRegistry.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/scopes/PluginServiceRegistry.java
@@ -30,7 +30,7 @@ public interface PluginServiceRegistry {
      *
      * <p>Global services are visible to all other services.</p>
      *
-     * @see Scope.Global
+     * @see Scopes.Global
      */
     void registerGlobalServices(ServiceRegistration registration);
 

--- a/platforms/core-runtime/base-services/src/test/groovy/org/gradle/internal/service/ScopedServiceRegistryTest.groovy
+++ b/platforms/core-runtime/base-services/src/test/groovy/org/gradle/internal/service/ScopedServiceRegistryTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.service
 
-import org.gradle.internal.service.scopes.Scope
+
 import org.gradle.internal.service.scopes.Scopes
 import org.gradle.internal.service.scopes.ServiceScope
 import spock.lang.Specification
@@ -113,14 +113,14 @@ class ScopedServiceRegistryTest extends Specification {
         registry.get(GlobalAndBuildScopedService) === service
 
         where:
-        scope << [Scope.Global, Scopes.Build]
+        scope << [Scopes.Global, Scopes.Build]
         scopeName = scope.simpleName
     }
 
     @ServiceScope(Scopes.BuildTree)
     static class BuildTreeScopedService {}
 
-    @ServiceScope([Scope.Global, Scopes.Build])
+    @ServiceScope([Scopes.Global, Scopes.Build])
     static class GlobalAndBuildScopedService {}
 
     static class UnscopedService {}

--- a/platforms/core-runtime/build-operations/src/main/java/org/gradle/internal/operations/BuildOperationAncestryTracker.java
+++ b/platforms/core-runtime/build-operations/src/main/java/org/gradle/internal/operations/BuildOperationAncestryTracker.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.operations;
 
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.Nullable;
@@ -25,7 +25,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 @SuppressWarnings("Since15")
-@ServiceScope(Scope.Global.class)
+@ServiceScope(Scopes.Global.class)
 public interface BuildOperationAncestryTracker {
     Optional<OperationIdentifier> findClosestMatchingAncestor(@Nullable OperationIdentifier id, Predicate<? super OperationIdentifier> predicate);
 

--- a/platforms/core-runtime/build-operations/src/main/java/org/gradle/internal/operations/BuildOperationListener.java
+++ b/platforms/core-runtime/build-operations/src/main/java/org/gradle/internal/operations/BuildOperationListener.java
@@ -16,7 +16,7 @@
 package org.gradle.internal.operations;
 
 import org.gradle.internal.service.scopes.EventScope;
-import org.gradle.internal.service.scopes.Scope.Global;
+import org.gradle.internal.service.scopes.Scopes.Global;
 
 /**
  * A listener that is notified as build operations are executed.

--- a/platforms/core-runtime/build-operations/src/main/java/org/gradle/internal/operations/BuildOperationListenerManager.java
+++ b/platforms/core-runtime/build-operations/src/main/java/org/gradle/internal/operations/BuildOperationListenerManager.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.operations;
 
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 /**
@@ -35,7 +35,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
  *
  * @since 3.5
  */
-@ServiceScope(Scope.Global.class)
+@ServiceScope(Scopes.Global.class)
 public interface BuildOperationListenerManager {
 
     void addListener(BuildOperationListener listener);

--- a/platforms/core-runtime/build-operations/src/main/java/org/gradle/internal/operations/BuildOperationProgressEventEmitter.java
+++ b/platforms/core-runtime/build-operations/src/main/java/org/gradle/internal/operations/BuildOperationProgressEventEmitter.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.operations;
 
-import org.gradle.internal.service.scopes.Scope.Global;
+import org.gradle.internal.service.scopes.Scopes.Global;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.Nullable;

--- a/platforms/core-runtime/files/src/main/java/org/gradle/internal/file/Deleter.java
+++ b/platforms/core-runtime/files/src/main/java/org/gradle/internal/file/Deleter.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.file;
 
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.io.File;
@@ -25,7 +25,7 @@ import java.io.IOException;
 /**
  * A file deleter that doesn't give up if deletion doesn't work on the first try.
  */
-@ServiceScope(Scope.Global.class)
+@ServiceScope(Scopes.Global.class)
 public interface Deleter {
     /**
      * Attempts to delete the given file or directory recursively.

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/BuildActionsFactory.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/BuildActionsFactory.java
@@ -42,7 +42,7 @@ import org.gradle.internal.service.ServiceRegistryBuilder;
 import org.gradle.internal.service.scopes.BasicGlobalScopeServices;
 import org.gradle.internal.service.scopes.GlobalScopeServices;
 import org.gradle.internal.service.scopes.GradleUserHomeScopeServiceRegistry;
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.launcher.bootstrap.ExecutionListener;
 import org.gradle.launcher.daemon.bootstrap.ForegroundDaemonAction;
 import org.gradle.launcher.daemon.client.DaemonClient;
@@ -70,7 +70,7 @@ class BuildActionsFactory implements CommandLineActionCreator {
 
     public BuildActionsFactory(ServiceRegistry loggingServices) {
         basicServices = ServiceRegistryBuilder.builder()
-            .scope(Scope.Global.class)
+            .scope(Scopes.Global.class)
             .displayName("Basic global services")
             .parent(loggingServices)
             .parent(NativeServices.getInstance())
@@ -146,7 +146,7 @@ class BuildActionsFactory implements CommandLineActionCreator {
 
     private Runnable runBuildInProcess(StartParameterInternal startParameter, DaemonParameters daemonParameters) {
         ServiceRegistry globalServices = ServiceRegistryBuilder.builder()
-            .scope(Scope.Global.class)
+            .scope(Scopes.Global.class)
             .displayName("Global services")
             .parent(loggingServices)
             .parent(NativeServices.getInstance())

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/client/DaemonStartListener.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/client/DaemonStartListener.java
@@ -17,7 +17,7 @@
 package org.gradle.launcher.daemon.client;
 
 import org.gradle.internal.service.scopes.EventScope;
-import org.gradle.internal.service.scopes.Scope.Global;
+import org.gradle.internal.service.scopes.Scopes.Global;
 import org.gradle.launcher.daemon.context.DaemonConnectDetails;
 
 /**

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/expiry/DaemonExpirationListener.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/expiry/DaemonExpirationListener.java
@@ -17,7 +17,7 @@
 package org.gradle.launcher.daemon.server.expiry;
 
 import org.gradle.internal.service.scopes.EventScope;
-import org.gradle.internal.service.scopes.Scope.Global;
+import org.gradle.internal.service.scopes.Scopes.Global;
 
 /**
  * Represents an event where a daemon expiration condition was detected and the daemon

--- a/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/daemon/server/scaninfo/DefaultDaemonScanInfoSpec.groovy
+++ b/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/daemon/server/scaninfo/DefaultDaemonScanInfoSpec.groovy
@@ -21,7 +21,6 @@ import org.gradle.BuildResult
 import org.gradle.api.Action
 import org.gradle.internal.event.DefaultListenerManager
 import org.gradle.internal.event.ListenerManager
-import org.gradle.internal.service.scopes.Scope
 import org.gradle.internal.service.scopes.Scopes
 import org.gradle.launcher.daemon.registry.DaemonRegistry
 import org.gradle.launcher.daemon.server.expiry.DaemonExpirationListener
@@ -85,7 +84,7 @@ class DefaultDaemonScanInfoSpec extends ConcurrentSpec {
     }
 
     def "should not deadlock with daemon scan info"() {
-        def manager = new DefaultListenerManager(Scope.Global)
+        def manager = new DefaultListenerManager(Scopes.Global)
         def daemonScanInfo = new DefaultDaemonScanInfo(new DaemonRunningStats(), 1000, false, Mock(DaemonRegistry), manager)
         daemonScanInfo.notifyOnUnhealthy {
             println "Hello"

--- a/platforms/core-runtime/launcher/src/test/groovy/org/gradle/tooling/internal/provider/continuous/ContinuousBuildActionExecutorTest.groovy
+++ b/platforms/core-runtime/launcher/src/test/groovy/org/gradle/tooling/internal/provider/continuous/ContinuousBuildActionExecutorTest.groovy
@@ -37,7 +37,6 @@ import org.gradle.internal.logging.text.TestStyledTextOutputFactory
 import org.gradle.internal.properties.InputBehavior
 import org.gradle.internal.service.scopes.DefaultFileChangeListeners
 import org.gradle.internal.service.scopes.DefaultWorkInputListeners
-import org.gradle.internal.service.scopes.Scope
 import org.gradle.internal.service.scopes.Scopes
 import org.gradle.internal.session.BuildSessionActionExecutor
 import org.gradle.internal.session.BuildSessionContext
@@ -68,7 +67,7 @@ class ContinuousBuildActionExecutorTest extends ConcurrentSpec {
     def action = Stub(BuildAction) {
         getStartParameter() >> startParameter
     }
-    def globalListenerManager = new DefaultListenerManager(Scope.Global)
+    def globalListenerManager = new DefaultListenerManager(Scopes.Global)
     def userHomeListenerManager = globalListenerManager.createChild(Scopes.UserHome)
     def inputListeners = new DefaultWorkInputListeners(globalListenerManager)
     def changeListeners = new DefaultFileChangeListeners(userHomeListenerManager)

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/api/internal/DocumentationRegistry.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/api/internal/DocumentationRegistry.java
@@ -17,14 +17,14 @@
 package org.gradle.api.internal;
 
 import org.gradle.api.problems.internal.DocLink;
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.util.GradleVersion;
 
 /**
  * Locates documentation for various features.
  */
-@ServiceScope(Scope.Global.class)
+@ServiceScope(Scopes.Global.class)
 public class DocumentationRegistry {
     public static final String BASE_URL = "https://docs.gradle.org/" + GradleVersion.current().getVersion();
     public static final String DSL_PROPERTY_URL_FORMAT = "%s/dsl/%s.html#%s:%s";

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/console/GlobalUserInputReceiver.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/console/GlobalUserInputReceiver.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.logging.console;
 
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -24,7 +24,7 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * The global {@link UserInputReceiver} instance.
  */
-@ServiceScope(Scope.Global.class)
+@ServiceScope(Scopes.Global.class)
 @ThreadSafe
 public interface GlobalUserInputReceiver extends UserInputReceiver {
     /**

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/progress/ProgressListener.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/progress/ProgressListener.java
@@ -20,7 +20,7 @@ import org.gradle.internal.logging.events.ProgressCompleteEvent;
 import org.gradle.internal.logging.events.ProgressEvent;
 import org.gradle.internal.logging.events.ProgressStartEvent;
 import org.gradle.internal.service.scopes.EventScope;
-import org.gradle.internal.service.scopes.Scope.Global;
+import org.gradle.internal.service.scopes.Scopes.Global;
 
 @EventScope(Global.class)
 public interface ProgressListener {

--- a/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/event/ListenerManager.java
+++ b/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/event/ListenerManager.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.event;
 
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 /**
@@ -28,7 +28,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
  * <p>Implementations are thread-safe: A listener is notified by at most 1 thread at a time, and so do not need to be thread-safe. All listeners
  * of a given type receive events in the same order. Listeners can be added and removed at any time.
  */
-@ServiceScope(Scope.Global.class)
+@ServiceScope(Scopes.Global.class)
 public interface ListenerManager {
     /**
      * Adds a listener.  A single object can implement multiple interfaces, and all interfaces are registered by a

--- a/platforms/core-runtime/messaging/src/test/groovy/org/gradle/internal/event/DefaultListenerManagerTest.groovy
+++ b/platforms/core-runtime/messaging/src/test/groovy/org/gradle/internal/event/DefaultListenerManagerTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.internal.event
 
 import com.google.common.reflect.ClassPath
 import org.gradle.internal.service.scopes.EventScope
-import org.gradle.internal.service.scopes.Scope
 import org.gradle.internal.service.scopes.Scopes
 import org.gradle.internal.service.scopes.StatefulListener
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
@@ -1052,7 +1051,7 @@ class DefaultListenerManagerTest extends ConcurrentSpec {
         void baz()
     }
 
-    @EventScope(Scope.Global)
+    @EventScope(Scopes.Global)
     interface TestListenerWithWrongScope {
         void foo(String param)
     }

--- a/platforms/core-runtime/process-services/src/main/java/org/gradle/process/internal/health/memory/JvmMemoryStatusListener.java
+++ b/platforms/core-runtime/process-services/src/main/java/org/gradle/process/internal/health/memory/JvmMemoryStatusListener.java
@@ -17,7 +17,7 @@
 package org.gradle.process.internal.health.memory;
 
 import org.gradle.internal.service.scopes.EventScope;
-import org.gradle.internal.service.scopes.Scope.Global;
+import org.gradle.internal.service.scopes.Scopes.Global;
 
 @EventScope(Global.class)
 public interface JvmMemoryStatusListener {

--- a/platforms/core-runtime/process-services/src/main/java/org/gradle/process/internal/health/memory/OsMemoryStatusListener.java
+++ b/platforms/core-runtime/process-services/src/main/java/org/gradle/process/internal/health/memory/OsMemoryStatusListener.java
@@ -17,7 +17,7 @@
 package org.gradle.process.internal.health.memory;
 
 import org.gradle.internal.service.scopes.EventScope;
-import org.gradle.internal.service.scopes.Scope.Global;
+import org.gradle.internal.service.scopes.Scopes.Global;
 
 @EventScope(Global.class)
 public interface OsMemoryStatusListener {

--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/PropertyValidationAccess.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/PropertyValidationAccess.java
@@ -25,6 +25,7 @@ import org.gradle.api.tasks.Nested;
 import org.gradle.cache.internal.DefaultCrossBuildInMemoryCacheFactory;
 import org.gradle.internal.event.DefaultListenerManager;
 import org.gradle.internal.instantiation.generator.DefaultInstantiatorFactory;
+import org.gradle.internal.properties.annotations.NestedValidationUtil;
 import org.gradle.internal.properties.annotations.PropertyMetadata;
 import org.gradle.internal.properties.annotations.TypeMetadata;
 import org.gradle.internal.properties.annotations.TypeMetadataStore;
@@ -35,9 +36,8 @@ import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.ServiceRegistryBuilder;
 import org.gradle.internal.service.scopes.PluginServiceRegistry;
-import org.gradle.internal.service.scopes.Scope.Global;
+import org.gradle.internal.service.scopes.Scopes.Global;
 import org.gradle.internal.state.DefaultManagedFactoryRegistry;
-import org.gradle.internal.properties.annotations.NestedValidationUtil;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.Modifier;

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/SynchronizedLogging.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/SynchronizedLogging.java
@@ -22,7 +22,7 @@ import org.gradle.internal.logging.progress.DefaultProgressLoggerFactory;
 import org.gradle.internal.logging.progress.ProgressListener;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.operations.BuildOperationIdFactory;
-import org.gradle.internal.service.scopes.Scope.Global;
+import org.gradle.internal.service.scopes.Scopes.Global;
 import org.gradle.internal.time.Clock;
 
 /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ImmutableModuleIdentifierFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ImmutableModuleIdentifierFactory.java
@@ -17,7 +17,7 @@ package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.internal.service.scopes.Scope.Global;
+import org.gradle.internal.service.scopes.Scopes.Global;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 @ServiceScope(Global.class)

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/PreferJavaRuntimeVariant.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/PreferJavaRuntimeVariant.java
@@ -24,7 +24,7 @@ import org.gradle.api.internal.attributes.EmptySchema;
 import org.gradle.api.internal.attributes.MultipleCandidatesResult;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.internal.Cast;
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.Nullable;
@@ -40,7 +40,7 @@ import java.util.Set;
  * metadata format by default without breaking a bunch of consumers that depend on this assumption,
  * declaring no preference for a particular variant.
  */
-@ServiceScope(Scope.Global.class)
+@ServiceScope(Scopes.Global.class)
 public class PreferJavaRuntimeVariant extends EmptySchema {
     private static final Set<Attribute<?>> SUPPORTED_ATTRIBUTES = Sets.newHashSet(Usage.USAGE_ATTRIBUTE, LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE);
     private final PreferRuntimeVariantUsageDisambiguationRule usageDisambiguationRule;

--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/BuildEventListenerFactory.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/BuildEventListenerFactory.java
@@ -17,10 +17,10 @@
 package org.gradle.internal.build.event;
 
 import org.gradle.initialization.BuildEventConsumer;
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-@ServiceScope(Scope.Global.class)
+@ServiceScope(Scopes.Global.class)
 public interface BuildEventListenerFactory {
     Iterable<Object> createListeners(BuildEventSubscriptions subscriptions, BuildEventConsumer consumer);
 }

--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/BuildEventListenerRegistryInternal.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/BuildEventListenerRegistryInternal.java
@@ -19,12 +19,12 @@ package org.gradle.internal.build.event;
 import org.gradle.api.provider.Provider;
 import org.gradle.build.event.BuildEventsListenerRegistry;
 import org.gradle.internal.operations.BuildOperationListener;
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.util.List;
 
-@ServiceScope(Scope.Global.class)
+@ServiceScope(Scopes.Global.class)
 public interface BuildEventListenerRegistryInternal extends BuildEventsListenerRegistry {
     /**
      * Subscribes the given listener to build operation completion events. Note that no start events are forwarded to the listener.

--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/OperationResultPostProcessorFactory.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/OperationResultPostProcessorFactory.java
@@ -17,12 +17,12 @@
 package org.gradle.internal.build.event;
 
 import org.gradle.initialization.BuildEventConsumer;
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.util.List;
 
-@ServiceScope(Scope.Global.class)
+@ServiceScope(Scopes.Global.class)
 public interface OperationResultPostProcessorFactory {
     /**
      * Creates the post processors relevant for the given subscriptions. The processors are also registered as listeners.

--- a/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
@@ -35,7 +35,6 @@ import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.reflect.ObjectInstantiationException;
-import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -51,7 +50,7 @@ import java.util.Set;
  *
  * @since 4.0
  */
-@ServiceScope({Scope.Global.class, Scopes.Project.class})
+@ServiceScope({Scopes.Global.class, Scopes.Project.class})
 public interface ObjectFactory {
     /**
      * Creates a simple immutable {@link Named} object of the given type and name.

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/util/internal/PatternSpecFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/util/internal/PatternSpecFactory.java
@@ -26,7 +26,7 @@ import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.file.excludes.FileSystemDefaultExcludesListener;
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.util.ArrayList;
@@ -45,7 +45,7 @@ import java.util.Set;
  * used, no matter which other includes and excludes a {@link PatternSet} has. For an
  * implementation that caches all other patterns as well, see {@link CachingPatternSpecFactory}.
  */
-@ServiceScope(Scope.Global.class)
+@ServiceScope(Scopes.Global.class)
 public class PatternSpecFactory implements FileSystemDefaultExcludesListener {
     public static final PatternSpecFactory INSTANCE = new PatternSpecFactory();
     private Set<String> previousDefaultExcludes = new HashSet<String>();

--- a/subprojects/core-api/src/main/java/org/gradle/internal/scripts/ScriptFileResolvedListener.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/scripts/ScriptFileResolvedListener.java
@@ -17,11 +17,11 @@
 package org.gradle.internal.scripts;
 
 import org.gradle.internal.service.scopes.EventScope;
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 
 import java.io.File;
 
-@EventScope(Scope.Global.class)
+@EventScope(Scopes.Global.class)
 public interface ScriptFileResolvedListener {
 
     void onScriptFileResolved(File scriptFile);

--- a/subprojects/core-api/src/main/java/org/gradle/internal/scripts/ScriptFileResolver.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/scripts/ScriptFileResolver.java
@@ -15,20 +15,20 @@
  */
 package org.gradle.internal.scripts;
 
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.scripts.ScriptingLanguage;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.List;
-import javax.annotation.Nullable;
 
 /**
  * Resolves script files according to available {@link ScriptingLanguage} providers.
  *
  * @since 4.0
  */
-@ServiceScope(Scope.Global.class)
+@ServiceScope(Scopes.Global.class)
 public interface ScriptFileResolver {
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/userinput/UserInputReader.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/userinput/UserInputReader.java
@@ -16,13 +16,13 @@
 
 package org.gradle.api.internal.tasks.userinput;
 
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 /**
  * Receives interactive responses from the user.
  */
-@ServiceScope(Scope.Global.class)
+@ServiceScope(Scopes.Global.class)
 public interface UserInputReader {
     void startInput();
 

--- a/subprojects/core/src/main/java/org/gradle/configuration/project/BuiltInCommand.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/project/BuiltInCommand.java
@@ -16,7 +16,7 @@
 
 package org.gradle.configuration.project;
 
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.util.List;
@@ -27,7 +27,7 @@ import java.util.List;
  *
  * A built-in command can be invoked from any directory, and does not require a Gradle build definition to be present.
  */
-@ServiceScope(Scope.Global.class)
+@ServiceScope(Scopes.Global.class)
 public interface BuiltInCommand {
     /**
      * Returns the list of task paths that should be used when none are specified by the user. Returns an empty list if this command should not be used as a default.

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutFactory.java
@@ -20,14 +20,14 @@ import org.gradle.api.internal.SettingsInternal;
 import org.gradle.internal.FileUtils;
 import org.gradle.internal.scripts.DefaultScriptFileResolver;
 import org.gradle.internal.scripts.ScriptFileResolver;
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 
-@ServiceScope(Scope.Global.class)
+@ServiceScope(Scopes.Global.class)
 public class BuildLayoutFactory {
 
     private static final String DEFAULT_SETTINGS_FILE_BASENAME = "settings";

--- a/subprojects/core/src/main/java/org/gradle/internal/agents/AgentInitializer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/agents/AgentInitializer.java
@@ -16,13 +16,13 @@
 
 package org.gradle.internal.agents;
 
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 /**
  * Initializes the instrumenting agent.
  */
-@ServiceScope(Scope.Global.class)
+@ServiceScope(Scopes.Global.class)
 public class AgentInitializer {
     private final AgentStatus agentStatus;
 

--- a/subprojects/core/src/main/java/org/gradle/internal/agents/AgentStatus.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/agents/AgentStatus.java
@@ -16,13 +16,13 @@
 
 package org.gradle.internal.agents;
 
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 /**
  * A build service to query the status of the Gradle's Java agents. Prefer using this service to accessing the {@link AgentControl} directly.
  */
-@ServiceScope(Scope.Global.class)
+@ServiceScope(Scopes.Global.class)
 public interface AgentStatus {
     /**
      * Checks if the agent-based bytecode instrumentation is enabled for the current JVM process.

--- a/subprojects/core/src/main/java/org/gradle/internal/execution/WorkExecutionTracker.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/execution/WorkExecutionTracker.java
@@ -17,7 +17,7 @@
 package org.gradle.internal.execution;
 
 import org.gradle.api.internal.TaskInternal;
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.util.Optional;
@@ -25,7 +25,7 @@ import java.util.Optional;
 /**
  * Provides access to the work executing on the current thread.
  */
-@ServiceScope(Scope.Global.class)
+@ServiceScope(Scopes.Global.class)
 public interface WorkExecutionTracker {
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/internal/scripts/ScriptFileResolverListeners.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scripts/ScriptFileResolverListeners.java
@@ -16,10 +16,10 @@
 
 package org.gradle.internal.scripts;
 
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-@ServiceScope(Scope.Global.class)
+@ServiceScope(Scopes.Global.class)
 public interface ScriptFileResolverListeners {
 
     void addListener(ScriptFileResolvedListener scriptFileResolvedListener);

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BasicGlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BasicGlobalScopeServices.java
@@ -53,7 +53,7 @@ import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.remote.internal.inet.InetAddressFactory;
 import org.gradle.internal.remote.services.MessagingServices;
 import org.gradle.internal.service.ServiceRegistration;
-import org.gradle.internal.service.scopes.Scope.Global;
+import org.gradle.internal.service.scopes.Scopes.Global;
 import org.gradle.process.internal.DefaultExecActionFactory;
 import org.gradle.process.internal.ExecFactory;
 import org.gradle.process.internal.ExecHandleFactory;

--- a/subprojects/core/src/main/java/org/gradle/process/internal/ExecActionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/ExecActionFactory.java
@@ -16,10 +16,10 @@
 
 package org.gradle.process.internal;
 
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-@ServiceScope(Scope.Global.class)
+@ServiceScope(Scopes.Global.class)
 public interface ExecActionFactory {
     /**
      * Creates an {@link ExecAction} that is not decorated. Use this when the action is not made visible to the DSL.

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/request/WorkerAction.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/request/WorkerAction.java
@@ -33,7 +33,7 @@ import org.gradle.internal.remote.ObjectConnection;
 import org.gradle.internal.remote.internal.hub.StreamFailureHandler;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistry;
-import org.gradle.internal.service.scopes.Scope.Global;
+import org.gradle.internal.service.scopes.Scopes.Global;
 import org.gradle.process.internal.worker.RequestHandler;
 import org.gradle.process.internal.worker.WorkerProcessContext;
 import org.gradle.process.internal.worker.child.WorkerLogEventListener;

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -49,7 +49,7 @@ import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.ServiceRegistryBuilder;
 import org.gradle.internal.service.scopes.GlobalScopeServices;
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.jvm.toolchain.internal.AutoDetectingInstallationSupplier;
 import org.gradle.launcher.cli.DefaultCommandLineActionFactory;
 import org.gradle.launcher.daemon.configuration.DaemonBuildOptions;
@@ -107,7 +107,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
     private static final String ALLOW_INSTRUMENTATION_AGENT_SYSPROP = "org.gradle.integtest.agent.allowed";
 
     protected static final ServiceRegistry GLOBAL_SERVICES = ServiceRegistryBuilder.builder()
-        .scope(Scope.Global.class)
+        .scope(Scopes.Global.class)
         .displayName("Global services")
         .parent(newCommandLineProcessLogging())
         .parent(NativeServicesTestFixture.getInstance())


### PR DESCRIPTION
It seems for historical reasons the `Scope.Global` ended up separately from the rest of the scopes defined in `Scopes`.
However, there is no reason special reason for this scope to be separated. At time this also causes confusion among developers.