### PR TITLE
Implement += support for Map/Set/ListProperty and ConfigurableFileCollection

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ConfigurableFileCollectionExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ConfigurableFileCollectionExtensions.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.kotlin.dsl
 
+import org.gradle.api.Incubating
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileCollection
 import kotlin.reflect.KProperty
@@ -47,4 +48,16 @@ operator fun ConfigurableFileCollection.setValue(receiver: Any?, property: KProp
  */
 fun ConfigurableFileCollection.assign(fileCollection: FileCollection) {
     this.setFrom(fileCollection)
+}
+
+
+/**
+ * Adds the elements from the `fileCollection` to this file collection.
+ *
+ * @see ConfigurableFileCollection.from
+ * @since 8.8
+ */
+@Incubating
+operator fun ConfigurableFileCollection.plusAssign(fileCollection: FileCollection) {
+    this.from(fileCollection)
 }

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PropertyExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PropertyExtensions.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.kotlin.dsl
 
+import org.gradle.api.Incubating
 import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.file.FileSystemLocationProperty
 import org.gradle.api.provider.HasMultipleValues
@@ -102,4 +103,166 @@ fun <K, V> MapProperty<K, V>.assign(entries: Map<out K?, V?>?) {
  */
 fun <K, V> MapProperty<K, V>.assign(provider: Provider<out Map<out K?, V?>?>) {
     this.set(provider)
+}
+
+
+/**
+ * Adds an element to the property value.
+ *
+ * When invoked on a property with no value, this method first sets the value
+ * of the property to its current convention value, if set, or an empty collection.
+ *
+ * @see [HasMultipleValues.append]
+ * @since 8.8
+ */
+@Incubating
+operator fun <T : Any> HasMultipleValues<T>.plusAssign(element: T) {
+    this.append(element)
+}
+
+
+/**
+ * Adds an element to the property value.
+ *
+ * The given provider will be queried when the value of this property is queried.
+ *
+ * When invoked on a property with no value, this method first sets the value
+ * of the property to its current convention value, if set, or an empty collection.
+
+ * Even if the given provider has no value, after this method is invoked,
+ * the actual value of this property is guaranteed to be present.
+ *
+ * @see HasMultipleValues.append
+ * @since 8.8
+ */
+@Incubating
+@JvmName("plusAssignElementProvider")
+operator fun <T : Any> HasMultipleValues<T>.plusAssign(provider: Provider<out T>) {
+    this.append(provider)
+}
+
+
+/**
+ * Adds zero or more elements to the property value.
+ *
+ * The given iterable will be queried when the value of this property is queried.
+ *
+ * When invoked on a property with no value, this method first sets the value
+ * of the property to its current convention value, if set, or an empty collection.
+ *
+ * @see HasMultipleValues.appendAll
+ * @since 8.8
+ */
+@Incubating
+operator fun <T : Any> HasMultipleValues<T>.plusAssign(elements: Iterable<T>) {
+    this.appendAll(elements)
+}
+
+
+/**
+ * Adds zero or more elements to the property value.
+ *
+ * When invoked on a property with no value, this method first sets the value
+ * of the property to its current convention value, if set, or an empty collection.
+ *
+ * @see HasMultipleValues.append
+ * @since 8.8
+ */
+@Incubating
+operator fun <T : Any> HasMultipleValues<T>.plusAssign(elements: Array<T>) {
+    this.appendAll(*elements)
+}
+
+
+/**
+ * Adds zero or more elements to the property value.
+ *
+ * The given provider will be queried when the value of this property is queried.
+ *
+ * When invoked on a property with no value, this method first sets the value
+ * of the property to its current convention value, if set, or an empty collection.
+ *
+ * Even if the given provider has no value, after this method is invoked,
+ * the actual value of this property is guaranteed to be present.
+ *
+ * @see HasMultipleValues.appendAll
+ * @since 8.8
+ */
+@Incubating
+@JvmName("plusAssignElementsProvider")
+operator fun <T : Any> HasMultipleValues<T>.plusAssign(provider: Provider<out Iterable<T>>) {
+    this.appendAll(provider)
+}
+
+
+/**
+ * Adds a map entry to the property value.
+ *
+ * When invoked on a property with no value, this method first sets the value
+ * of the property to its current convention value, if set, or an empty map.
+ *
+ * @see MapProperty.insert
+ * @since 8.8
+ */
+@Incubating
+operator fun <K : Any, V : Any> MapProperty<K, V>.plusAssign(value: Pair<K, V>) {
+    this.insert(value.first, value.second)
+}
+
+
+/**
+ * Adds a map entry to the property value.
+ *
+ * The given provider will be queried when the value of this property is queried.
+ *
+ * When invoked on a property with no value, this method first sets the value
+ * of the property to its current convention value, if set, or an empty map.
+ *
+ * Even if the given provider has no value, after this method is invoked,
+ * the actual value of this property is guaranteed to be present.
+ *
+ * @see MapProperty.insert
+ * @since 8.8
+ */
+@Incubating
+@JvmName("plusAssignItem")
+operator fun <K : Any, V : Any> MapProperty<K, V>.plusAssign(value: Provider<out Pair<K, V>>) {
+    this.insertAll(value.map { pair -> mapOf(pair) })
+}
+
+
+/**
+ * Adds all entries from another [Map] to the property value.
+ *
+ * When invoked on a property with no value, this method first sets the value
+ * of the property to its current convention value, if set, or an empty map.
+ *
+ * @see MapProperty.insertAll
+ * @since 8.8
+ */
+@Incubating
+operator fun <K : Any, V : Any> MapProperty<K, V>.plusAssign(value: Map<out K, V>) {
+    this.insertAll(value)
+}
+
+
+/**
+ * Adds all entries from another [Map] to the property value.
+ *
+ * The given provider will be queried when the value of this property is queried.
+ *
+ * When invoked on a property with no value, this method first sets the value
+ * of the property to its current convention value, if set, or an empty map.
+ *
+ * Even if the given provider has no value, after this method is invoked,
+ * the actual value of this property is guaranteed to be present.
+ *
+ * @see MapProperty.insertAll
+ *
+ * @since 8.8
+ */
+@Incubating
+@JvmName("plusAssignElements")
+operator fun <K : Any, V : Any> MapProperty<K, V>.plusAssign(value: Provider<out Map<out K, V>>) {
+    this.insertAll(value)
 }

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyAssignmentIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyAssignmentIntegrationTest.groovy
@@ -248,19 +248,20 @@ class PropertyAssignmentIntegrationTest extends AbstractIntegrationSpec {
         runAndAssert("myTask", expectedResult)
 
         where:
-        description                        | operation | inputType                    | inputValue              | expectedResult
-        "FileCollection = FileCollection"  | "="       | "ConfigurableFileCollection" | 'files("a.txt")'        | '[a.txt]'
-        "FileCollection = String"          | "="       | "ConfigurableFileCollection" | '"a.txt"'               | unsupportedWithCause("Failed to cast object")
-        "FileCollection = Object"          | "="       | "ConfigurableFileCollection" | 'new MyObject("a.txt")' | unsupportedWithCause("Failed to cast object")
-        "FileCollection = File"            | "="       | "ConfigurableFileCollection" | 'file("a.txt")'         | unsupportedWithCause("Failed to cast object")
-        "FileCollection = Iterable<File>"  | "="       | "ConfigurableFileCollection" | '[file("a.txt")]'       | unsupportedWithCause("Failed to cast object")
-        "FileCollection += FileCollection" | "+="      | "ConfigurableFileCollection" | 'files("a.txt")'        | unsupportedWithCause("Self-referencing ConfigurableFileCollections are not supported. Use the from() method to add to a ConfigurableFileCollection.")
-        "FileCollection << FileCollection" | "<<"      | "ConfigurableFileCollection" | 'files("a.txt")'        | unsupportedWithCause("No signature of method")
-        "FileCollection += String"         | "+="      | "ConfigurableFileCollection" | '"a.txt"'               | unsupportedWithCause("Failed to cast object")
-        "FileCollection += Object"         | "+="      | "ConfigurableFileCollection" | 'new MyObject("a.txt")' | unsupportedWithCause("Failed to cast object")
-        "FileCollection += File"           | "+="      | "ConfigurableFileCollection" | 'file("a.txt")'         | unsupportedWithCause("Failed to cast object")
-        "FileCollection += Iterable<?>"    | "+="      | "ConfigurableFileCollection" | '["a.txt"]'             | unsupportedWithCause("Failed to cast object")
-        "FileCollection += Iterable<File>" | "+="      | "ConfigurableFileCollection" | '[file("a.txt")]'       | unsupportedWithCause("Failed to cast object")
+        description                              | operation | inputType                    | inputValue               | expectedResult
+        "FileCollection = FileCollection"        | "="       | "ConfigurableFileCollection" | 'files("a.txt")'         | '[a.txt]'
+        "FileCollection = this + FileCollection" | "="       | "ConfigurableFileCollection" | 'input + files("a.txt")' | unsupportedWithCause("Self-referencing ConfigurableFileCollections are not supported. Use the from() method to add to a ConfigurableFileCollection.")
+        "FileCollection = String"                | "="       | "ConfigurableFileCollection" | '"a.txt"'                | unsupportedWithCause("Failed to cast object")
+        "FileCollection = Object"                | "="       | "ConfigurableFileCollection" | 'new MyObject("a.txt")'  | unsupportedWithCause("Failed to cast object")
+        "FileCollection = File"                  | "="       | "ConfigurableFileCollection" | 'file("a.txt")'          | unsupportedWithCause("Failed to cast object")
+        "FileCollection = Iterable<File>"        | "="       | "ConfigurableFileCollection" | '[file("a.txt")]'        | unsupportedWithCause("Failed to cast object")
+        "FileCollection += FileCollection"       | "+="      | "ConfigurableFileCollection" | 'files("a.txt")'         | '[a.txt]'
+        "FileCollection << FileCollection"       | "<<"      | "ConfigurableFileCollection" | 'files("a.txt")'         | unsupportedWithCause("No signature of method")
+        "FileCollection += String"               | "+="      | "ConfigurableFileCollection" | '"a.txt"'                | unsupportedWithCause("Failed to cast object")
+        "FileCollection += Object"               | "+="      | "ConfigurableFileCollection" | 'new MyObject("a.txt")'  | unsupportedWithCause("Failed to cast object")
+        "FileCollection += File"                 | "+="      | "ConfigurableFileCollection" | 'file("a.txt")'          | unsupportedWithCause("Failed to cast object")
+        "FileCollection += Iterable<?>"          | "+="      | "ConfigurableFileCollection" | '["a.txt"]'              | unsupportedWithCause("Failed to cast object")
+        "FileCollection += Iterable<File>"       | "+="      | "ConfigurableFileCollection" | '[file("a.txt")]'        | unsupportedWithCause("Failed to cast object")
     }
 
     def "test Kotlin eager FileCollection types assignment for #description"() {
@@ -293,18 +294,19 @@ class PropertyAssignmentIntegrationTest extends AbstractIntegrationSpec {
         runAndAssert("myTask", expectedResult)
 
         where:
-        description                        | operation | inputType                    | inputValue                         | expectedResult
-        "FileCollection = FileCollection"  | "="       | "ConfigurableFileCollection" | 'files("a.txt") as FileCollection' | '[a.txt]'
-        "FileCollection = String"          | "="       | "ConfigurableFileCollection" | '"a.txt"'                          | unsupportedWithDescription("Val cannot be reassigned")
-        "FileCollection = Object"          | "="       | "ConfigurableFileCollection" | 'MyObject("a.txt")'                | unsupportedWithDescription("Val cannot be reassigned")
-        "FileCollection = File"            | "="       | "ConfigurableFileCollection" | 'file("a.txt")'                    | unsupportedWithDescription("Val cannot be reassigned")
-        "FileCollection = Iterable<File>"  | "="       | "ConfigurableFileCollection" | 'listOf(file("a.txt"))'            | unsupportedWithDescription("Val cannot be reassigned")
-        "FileCollection += FileCollection" | "+="      | "ConfigurableFileCollection" | 'files("a.txt") as FileCollection' | unsupportedWithDescription("Val cannot be reassigned")
-        "FileCollection += String"         | "+="      | "ConfigurableFileCollection" | '"a.txt"'                          | unsupportedWithDescription("Val cannot be reassigned")
-        "FileCollection += Object"         | "+="      | "ConfigurableFileCollection" | 'MyObject("a.txt")'                | unsupportedWithDescription("Val cannot be reassigned")
-        "FileCollection += File"           | "+="      | "ConfigurableFileCollection" | 'file("a.txt")'                    | unsupportedWithDescription("Val cannot be reassigned")
-        "FileCollection += Iterable<?>"    | "+="      | "ConfigurableFileCollection" | 'listOf("a.txt")'                  | unsupportedWithDescription("Val cannot be reassigned")
-        "FileCollection += Iterable<File>" | "+="      | "ConfigurableFileCollection" | 'listOf(file("a.txt"))'            | unsupportedWithDescription("Val cannot be reassigned")
+        description                              | operation | inputType                    | inputValue                         | expectedResult
+        "FileCollection = FileCollection"        | "="       | "ConfigurableFileCollection" | 'files("a.txt") as FileCollection' | '[a.txt]'
+        "FileCollection = this + FileCollection" | "="       | "ConfigurableFileCollection" | 'input + files("a.txt")'           | '[a.txt]'
+        "FileCollection = String"                | "="       | "ConfigurableFileCollection" | '"a.txt"'                          | unsupportedWithDescription("Type mismatch")
+        "FileCollection = Object"                | "="       | "ConfigurableFileCollection" | 'MyObject("a.txt")'                | unsupportedWithDescription("Type mismatch")
+        "FileCollection = File"                  | "="       | "ConfigurableFileCollection" | 'file("a.txt")'                    | unsupportedWithDescription("Type mismatch")
+        "FileCollection = Iterable<File>"        | "="       | "ConfigurableFileCollection" | 'listOf(file("a.txt"))'            | unsupportedWithDescription("Type mismatch")
+        "FileCollection += FileCollection"       | "+="      | "ConfigurableFileCollection" | 'files("a.txt") as FileCollection' | '[a.txt]'
+        "FileCollection += String"               | "+="      | "ConfigurableFileCollection" | '"a.txt"'                          | unsupportedWithDescription("Type mismatch")
+        "FileCollection += Object"               | "+="      | "ConfigurableFileCollection" | 'MyObject("a.txt")'                | unsupportedWithDescription("Type mismatch")
+        "FileCollection += File"                 | "+="      | "ConfigurableFileCollection" | 'file("a.txt")'                    | unsupportedWithDescription("Type mismatch")
+        "FileCollection += Iterable<?>"          | "+="      | "ConfigurableFileCollection" | 'listOf("a.txt")'                  | unsupportedWithDescription("Type mismatch")
+        "FileCollection += Iterable<File>"       | "+="      | "ConfigurableFileCollection" | 'listOf(file("a.txt"))'            | unsupportedWithDescription("Type mismatch")
     }
 
     def "test Groovy lazy property assignment with NamedDomainObjectContainer"() {

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyAssignmentIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyAssignmentIntegrationTest.groovy
@@ -149,21 +149,22 @@ class PropertyAssignmentIntegrationTest extends AbstractIntegrationSpec {
         "Collection<T> = T[]"                    | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | unsupportedWithCause("Cannot set the value of a property of type java.util.List using an instance of type [LMyObject;")
         "Collection<T> = Iterable<T>"            | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | '[a]'
         "Collection<T> = Provider<Iterable<T>>"  | "="       | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | '[a]'
-        "Collection<T> += T"                     | "+="      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | unsupportedWithCause("No signature of method")
+        "Collection<T> += T"                     | "+="      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | '[a]'
+        "Collection<T> += !T"                    | "+="      | "ListProperty<MyObject>"        | '"a"'                                                    | unsupportedWithCause("Cannot add an element of type String to a property of type List<MyObject>")
         "Collection<T> << T"                     | "<<"      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | unsupportedWithCause("No signature of method")
-        "Collection<T> += Provider<T>"           | "+="      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | unsupportedWithCause("No signature of method")
+        "Collection<T> += Provider<T>"           | "+="      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | '[a]'
         "Collection<T> << Provider<T>"           | "<<"      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | unsupportedWithCause("No signature of method")
-        "Collection<T> += T[]"                   | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | unsupportedWithCause("No signature of method")
+        "Collection<T> += T[]"                   | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | unsupportedWithCause("Cannot add an element of type MyObject[] to a property of type List<MyObject>")
         "Collection<T> << T[]"                   | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | unsupportedWithCause("No signature of method")
-        "Collection<T> += Iterable<T>"           | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | unsupportedWithCause("No signature of method")
+        "Collection<T> += Iterable<T>"           | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | '[a]'
         "Collection<T> << Iterable<T>"           | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | unsupportedWithCause("No signature of method")
-        "Collection<T> += Provider<Iterable<T>>" | "+="      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | unsupportedWithCause("No signature of method")
+        "Collection<T> += Provider<Iterable<T>>" | "+="      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | '[a]'
         "Collection<T> << Provider<Iterable<T>>" | "<<"      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | unsupportedWithCause("No signature of method")
         "Map<K, V> = Map<K, V>"                  | "="       | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | '[a:b]'
         "Map<K, V> = Provider<Map<K, V>>"        | "="       | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | '[a:b]'
-        "Map<K, V> += Map<K, V>"                 | "+="      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | unsupportedWithCause("No signature of method")
+        "Map<K, V> += Map<K, V>"                 | "+="      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | '[a:b]'
         "Map<K, V> << Map<K, V>"                 | "<<"      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | unsupportedWithCause("No signature of method")
-        "Map<K, V> += Provider<Map<K, V>>"       | "+="      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | unsupportedWithCause("No signature of method")
+        "Map<K, V> += Provider<Map<K, V>>"       | "+="      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | '[a:b]'
         "Map<K, V> << Provider<Map<K, V>>"       | "<<"      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | unsupportedWithCause("No signature of method")
     }
 

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyAssignmentIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyAssignmentIntegrationTest.groovy
@@ -206,17 +206,17 @@ class PropertyAssignmentIntegrationTest extends AbstractIntegrationSpec {
         "Collection<T> = T[]"                    | "="       | "ListProperty<MyObject>"        | 'arrayOf(MyObject("a"))'                                   | unsupportedWithDescription("No applicable 'assign' function found for '=' overload")
         "Collection<T> = Iterable<T>"            | "="       | "ListProperty<MyObject>"        | 'listOf(MyObject("a")) as Iterable<MyObject>'              | '[a]'
         "Collection<T> = Provider<Iterable<T>>"  | "="       | "ListProperty<MyObject>"        | 'provider { listOf(MyObject("a")) as Iterable<MyObject> }' | '[a]'
-        "Collection<T> += T"                     | "+="      | "ListProperty<MyObject>"        | 'MyObject("a")'                                            | unsupportedWithDescription("Unresolved reference. None of the following candidates is applicable because of receiver type mismatch:")
-        "Collection<T> += Provider<T>"           | "+="      | "ListProperty<MyObject>"        | 'provider { MyObject("a") }'                               | unsupportedWithDescription("Unresolved reference. None of the following candidates is applicable because of receiver type mismatch:")
-        "Collection<T> += T[]"                   | "+="      | "ListProperty<MyObject>"        | 'arrayOf(MyObject("a"))'                                   | unsupportedWithDescription("Unresolved reference. None of the following candidates is applicable because of receiver type mismatch:")
-        "Collection<T> += Iterable<T>"           | "+="      | "ListProperty<MyObject>"        | 'listOf(MyObject("a")) as Iterable<MyObject>'              | unsupportedWithDescription("Unresolved reference. None of the following candidates is applicable because of receiver type mismatch:")
-        "Collection<T> += Provider<Iterable<T>>" | "+="      | "ListProperty<MyObject>"        | 'provider { listOf(MyObject("a")) as Iterable<MyObject> }' | unsupportedWithDescription("Unresolved reference. None of the following candidates is applicable because of receiver type mismatch:")
+        "Collection<T> += T"                     | "+="      | "ListProperty<MyObject>"        | 'MyObject("a")'                                            | '[a]'
+        "Collection<T> += Provider<T>"           | "+="      | "ListProperty<MyObject>"        | 'provider { MyObject("a") }'                               | '[a]'
+        "Collection<T> += T[]"                   | "+="      | "ListProperty<MyObject>"        | 'arrayOf(MyObject("a"))'                                   | '[a]'
+        "Collection<T> += Iterable<T>"           | "+="      | "ListProperty<MyObject>"        | 'listOf(MyObject("a")) as Iterable<MyObject>'              | '[a]'
+        "Collection<T> += Provider<Iterable<T>>" | "+="      | "ListProperty<MyObject>"        | 'provider { listOf(MyObject("a")) as Iterable<MyObject> }' | '[a]'
         "Map<K, V> = Map<K, V>"                  | "="       | "MapProperty<String, MyObject>" | 'mapOf("a" to MyObject("b"))'                              | '{a=b}'
         "Map<K, V> = Provider<Map<K, V>>"        | "="       | "MapProperty<String, MyObject>" | 'provider { mapOf("a" to MyObject("b")) }'                 | '{a=b}'
-        "Map<K, V> += Pair<K, V>"                | "+="      | "MapProperty<String, MyObject>" | '"a" to MyObject("b")'                                     | unsupportedWithDescription("Unresolved reference. None of the following candidates is applicable because of receiver type mismatch:")
-        "Map<K, V> += Provider<Pair<K, V>>"      | "+="      | "MapProperty<String, MyObject>" | 'provider { "a" to MyObject("b") }'                        | unsupportedWithDescription("Unresolved reference. None of the following candidates is applicable because of receiver type mismatch:")
-        "Map<K, V> += Map<K, V>"                 | "+="      | "MapProperty<String, MyObject>" | 'mapOf("a" to MyObject("b"))'                              | unsupportedWithDescription("Unresolved reference. None of the following candidates is applicable because of receiver type mismatch:")
-        "Map<K, V> += Provider<Map<K, V>>"       | "+="      | "MapProperty<String, MyObject>" | 'provider { mapOf("a" to MyObject("b")) }'                 | unsupportedWithDescription("Unresolved reference. None of the following candidates is applicable because of receiver type mismatch:")
+        "Map<K, V> += Pair<K, V>"                | "+="      | "MapProperty<String, MyObject>" | '"a" to MyObject("b")'                                     | '{a=b}'
+        "Map<K, V> += Provider<Pair<K, V>>"      | "+="      | "MapProperty<String, MyObject>" | 'provider { "a" to MyObject("b") }'                        | '{a=b}'
+        "Map<K, V> += Map<K, V>"                 | "+="      | "MapProperty<String, MyObject>" | 'mapOf("a" to MyObject("b"))'                              | '{a=b}'
+        "Map<K, V> += Provider<Map<K, V>>"       | "+="      | "MapProperty<String, MyObject>" | 'provider { mapOf("a" to MyObject("b")) }'                 | '{a=b}'
     }
 
     def "test Groovy eager FileCollection types assignment for #description"() {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/CompoundAssignmentResult.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/CompoundAssignmentResult.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.support;
+
+import com.google.common.base.Preconditions;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+/**
+ * A helper class to implement a result of a compound assignment operation.
+ * It can be assigned to the assignment target (the left-hand-side symbol), but only once, so it cannot be used in multi-step operations like
+ * {@code a += (b += c)}.
+ */
+public final class CompoundAssignmentResult {
+    private final Object owner;
+    @Nullable
+    private Runnable assignToOwnerAction;
+
+    public CompoundAssignmentResult(Object owner, Runnable assignToOwnerAction) {
+        this.owner = owner;
+        this.assignToOwnerAction = Objects.requireNonNull(assignToOwnerAction);
+    }
+
+    public boolean isOwnedBy(Object target) {
+        return target == owner;
+    }
+
+    public void assignToOwner() {
+        Runnable action = assignToOwnerAction;
+        Preconditions.checkState(action != null, "The property is already consumed by the owner");
+        assignToOwnerAction = null;
+        action.run();
+    }
+}

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/LazyGroovySupport.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/LazyGroovySupport.java
@@ -20,6 +20,8 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.Property;
 import org.gradle.internal.instantiation.generator.AsmBackedClassGenerator;
 
+import javax.annotation.Nullable;
+
 /**
  * An interface used to support lazy assignment for types like {@link Property} and {@link ConfigurableFileCollection} in Groovy DSL.
  * Call to this interface is generated via {@link AsmBackedClassGenerator}.
@@ -29,5 +31,5 @@ public interface LazyGroovySupport {
     /**
      * Sets the value from some arbitrary object. Used from the Groovy DSL.
      */
-    void setFromAnyValue(Object object);
+    void setFromAnyValue(@Nullable Object object);
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/SupportsCompoundAssignment.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/SupportsCompoundAssignment.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.support;
+
+import javax.annotation.Nullable;
+
+/**
+ * Implementors of this interface support custom handling of the compound assignment operators ({@code +=, -=}) in Groovy.
+ * Groovy doesn't support overloading of just compound assignments, and instead generates a combination of a base operator and an assignment.
+ * For example, an expression {@code a += b} is transformed into {@code a = a + b}.
+ * <p>
+ * Implementing this interface allows an object to provide a stand-in operand for the base operator invocation.
+ * The stand-in can implement necessary protocol even if the class itself doesn't overload the operator.
+ */
+public interface SupportsCompoundAssignment<T> {
+    T toCompoundOperand();
+
+    static <T> T wrap(SupportsCompoundAssignment<T> lhs) {
+        return lhs.toCompoundOperand();
+    }
+
+    @Nullable
+    static Object wrap(@Nullable Object lhs) {
+        return lhs;
+    }
+}

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/package-info.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Classes and interfaces that help provide syntactic sugar for Providers and Properties.
+ */
+@org.gradle.api.NonNullApi
+package org.gradle.api.internal.provider.support;

--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -9,6 +9,54 @@
             ]
         },
         {
+            "type": "org.gradle.kotlin.dsl.PropertyExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.PropertyExtensionsKt.plusAssign(org.gradle.api.provider.HasMultipleValues,java.lang.Object)",
+            "acceptation": "Compatibility check has issues with generic methods and JvmName",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.PropertyExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.PropertyExtensionsKt.plusAssign(org.gradle.api.provider.HasMultipleValues,java.lang.Object[])",
+            "acceptation": "Compatibility check has issues with generic methods and JvmName",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.PropertyExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.PropertyExtensionsKt.plusAssignElementProvider(org.gradle.api.provider.HasMultipleValues,org.gradle.api.provider.Provider)",
+            "acceptation": "Compatibility check has issues with generic methods and JvmName",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.PropertyExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.PropertyExtensionsKt.plusAssignElements(org.gradle.api.provider.MapProperty,org.gradle.api.provider.Provider)",
+            "acceptation": "Compatibility check has issues with generic methods and JvmName",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.PropertyExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.PropertyExtensionsKt.plusAssignElementsProvider(org.gradle.api.provider.HasMultipleValues,org.gradle.api.provider.Provider)",
+            "acceptation": "Compatibility check has issues with generic methods and JvmName",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.PropertyExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.PropertyExtensionsKt.plusAssignItem(org.gradle.api.provider.MapProperty,org.gradle.api.provider.Provider)",
+            "acceptation": "Compatibility check has issues with generic methods and JvmName",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
             "type": "org.gradle.tooling.events.problems.ProblemDescriptor",
             "member": "Method org.gradle.tooling.events.problems.ProblemDescriptor.getDetails()",
             "acceptation": "This is an incubating API and therefore the change is acceptable",

--- a/subprojects/architecture-test/src/changes/archunit_store/internal-api-nullability.txt
+++ b/subprojects/architecture-test/src/changes/archunit_store/internal-api-nullability.txt
@@ -535,7 +535,6 @@ Class <org.gradle.api.internal.provider.sources.process.ProcessOutputValueSource
 Class <org.gradle.api.internal.provider.sources.process.ProviderCompatibleBaseExecSpec> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (ProviderCompatibleBaseExecSpec.java:0)
 Class <org.gradle.api.internal.provider.sources.process.ProviderCompatibleExecSpec> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (ProviderCompatibleExecSpec.java:0)
 Class <org.gradle.api.internal.provider.sources.process.ProviderCompatibleJavaExecSpec> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (ProviderCompatibleJavaExecSpec.java:0)
-Class <org.gradle.api.internal.provider.support.LazyGroovySupport> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (LazyGroovySupport.java:0)
 Class <org.gradle.api.internal.resolve.DefaultLocalLibraryResolver> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (DefaultLocalLibraryResolver.java:0)
 Class <org.gradle.api.internal.resolve.DefaultProjectModelResolver> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (DefaultProjectModelResolver.java:0)
 Class <org.gradle.api.internal.resolve.LibraryResolutionErrorMessageBuilder> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (LibraryResolutionErrorMessageBuilder.java:0)

--- a/subprojects/architecture-test/src/test/java/org/gradle/architecture/test/PublicApiCorrectnessTest.java
+++ b/subprojects/architecture-test/src/test/java/org/gradle/architecture/test/PublicApiCorrectnessTest.java
@@ -80,6 +80,7 @@ public class PublicApiCorrectnessTest {
                 .or(type(KClass.class))
                 .or(type(KClass[].class))
                 .or(type(KProperty.class))
+                .or(type(Pair.class))
                 .or(type(Pair[].class))
                 .as("Kotlin classes")
             );

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/BuildScriptTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/BuildScriptTransformer.java
@@ -53,6 +53,7 @@ public class BuildScriptTransformer implements Transformer, Factory<BuildScriptD
         new StatementLabelsScriptTransformer().register(compilationUnit);
         new ModelBlockTransformer(scriptSource.getDisplayName(), scriptSource.getResource().getLocation().getURI()).register(compilationUnit);
         imperativeStatementDetectingTransformer.register(compilationUnit);
+        new PlusAssignTransformer().register(compilationUnit);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/PlusAssignTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/PlusAssignTransformer.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.groovy.scripts.internal;
+
+import org.codehaus.groovy.ast.ClassCodeExpressionTransformer;
+import org.codehaus.groovy.ast.ClassHelper;
+import org.codehaus.groovy.ast.expr.ArgumentListExpression;
+import org.codehaus.groovy.ast.expr.BinaryExpression;
+import org.codehaus.groovy.ast.expr.ClosureExpression;
+import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.expr.PropertyExpression;
+import org.codehaus.groovy.ast.expr.StaticMethodCallExpression;
+import org.codehaus.groovy.ast.expr.VariableExpression;
+import org.codehaus.groovy.control.CompilationFailedException;
+import org.codehaus.groovy.control.Phases;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.syntax.Token;
+import org.codehaus.groovy.syntax.Types;
+import org.gradle.api.internal.provider.support.SupportsCompoundAssignment;
+
+public class PlusAssignTransformer extends AbstractScriptTransformer {
+    @Override
+    protected int getPhase() {
+        return Phases.CANONICALIZATION;
+    }
+
+    @Override
+    public void call(SourceUnit source) throws CompilationFailedException {
+        PlusAssignExpressionRewriter visitor = new PlusAssignExpressionRewriter(source);
+        source.getAST().getStatementBlock().visit(visitor);
+        source.getAST().getClasses().forEach(visitor::visitClass);
+        source.getAST().getMethods().forEach(visitor::visitMethod);
+    }
+
+    private static class PlusAssignExpressionRewriter extends ClassCodeExpressionTransformer {
+        private final SourceUnit sourceUnit;
+
+        public PlusAssignExpressionRewriter(SourceUnit sourceUnit) {
+            this.sourceUnit = sourceUnit;
+        }
+
+        @Override
+        public Expression transform(Expression expr) {
+            Expression transformedExpr = super.transform(expr);
+            if (transformedExpr instanceof BinaryExpression) {
+                return transformBinaryExpression((BinaryExpression) transformedExpr);
+            }
+            if (transformedExpr instanceof ClosureExpression) {
+                // Closure expression contains code, but ClosureExpression.transform doesn't descend into it.
+                ClosureExpression closureExpression = (ClosureExpression) transformedExpr;
+                closureExpression.visit(this);
+            }
+            return transformedExpr;
+        }
+
+        private BinaryExpression transformBinaryExpression(BinaryExpression expr) {
+            String operation = expr.getOperation().getText();
+            if (operation.equals("+=")) {
+                return transformCompoundAssignment(expr, Types.PLUS);
+            }
+            return expr;
+        }
+
+        private BinaryExpression transformCompoundAssignment(BinaryExpression expr, int compoundOperation) {
+            Expression lhs = expr.getLeftExpression();
+            Expression rhs = expr.getRightExpression();
+
+            if (!isValidDestination(lhs)) {
+                return expr;
+            }
+
+            // Rewriting `foo <OP>= bar` into `foo = SupportsCompoundAssignment.wrap(foo) <OP> (bar)`.
+            BinaryExpression transformed = new BinaryExpression(
+                lhs,
+                rewriteToken(expr.getOperation(), Types.ASSIGN),
+                new BinaryExpression(
+                    wrapLhs(lhs),
+                    rewriteToken(expr.getOperation(), compoundOperation),
+                    rhs
+                )
+            );
+            return withSourceLocationOf(expr, transformed);
+        }
+
+        private Token rewriteToken(Token originalOperation, int newType) {
+            return Token.newSymbol(newType, originalOperation.getStartLine(), originalOperation.getStartColumn());
+        }
+
+        private Expression wrapLhs(Expression lhs) {
+            return new StaticMethodCallExpression(ClassHelper.make(SupportsCompoundAssignment.class), "wrap", new ArgumentListExpression(lhs));
+        }
+
+        private static boolean isValidDestination(Expression expr) {
+            return expr instanceof VariableExpression || expr instanceof PropertyExpression;
+        }
+
+        private static <T extends Expression> T withSourceLocationOf(Expression original, T transformed) {
+            transformed.setSourcePosition(original);
+            return transformed;
+        }
+
+        @Override
+        protected SourceUnit getSourceUnit() {
+            return sourceUnit;
+        }
+    }
+}


### PR DESCRIPTION
This only adds support for += and not +.

Groovy uses "+" to implement "+=" under the hood, which introduces a self-referencing evaluation when used with lazy types. We want to allow it only for "+=" context and not for "+" in general (because the result of `+` may come from afar), so we use AST transform to intercept these. The AST transform has no type information, so it rewrites all "+=" in code, and the rewritten code should therefore be able to handle arbitrary types.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
