### PR TITLE
Improve error reporting when repositories are disabled

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyUnresolvedModuleIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyUnresolvedModuleIntegrationTest.groovy
@@ -223,7 +223,7 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
 
         then: "the original failure cause is reported and the subsequent failures which only duplicate the same info are skipped"
         assertDependencyMetaDataReadTimeout(moduleA)
-        assertAdditionalFailuresMessagePrinted(2)
+        failure.assertHasErrorOutput("There are 2 more failures with identical causes.")
         outputDoesNotContain("Could not resolve ${mavenModuleCoordinates(moduleD)}")
         outputDoesNotContain("Could not resolve ${mavenModuleCoordinates(moduleE)}")
         !downloadedLibsDir.isDirectory()
@@ -462,11 +462,6 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
         failure.assertHasCause("Could not get resource '${mavenHttpRepo.uri.toString()}/${mavenModuleRepositoryPath(module)}.pom'.")
         failure.assertHasCause("Could not GET '${mavenHttpRepo.uri.toString()}/${mavenModuleRepositoryPath(module)}.pom'.")
         failure.assertHasCause("Read timed out")
-    }
-
-    private void assertAdditionalFailuresMessagePrinted(int count) {
-        def plural = count > 1
-        failure.assertHasErrorOutput("> There were $count additional failure${plural ? "s" : ""} with the same cause that ${plural ? "were" : "was"} not printed.")
     }
 
     private void assertDependencyMetaDataInternalServerError(MavenModule module) {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyUnresolvedModuleIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyUnresolvedModuleIntegrationTest.groovy
@@ -229,6 +229,7 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
         !downloadedLibsDir.isDirectory()
     }
 
+    @ToBeFixedForConfigurationCache(because = "task uses Configuration API")
     def "when repository timeout resolving a configuration is swallowed, trying to re-resolve that configuration still prints the original cause"() {
         given:
         MavenHttpModule moduleB = publishMavenModule(mavenHttpRepo, 'b')
@@ -268,6 +269,7 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
         assertDependencyMetaDataReadTimeout(moduleA)
     }
 
+    @ToBeFixedForConfigurationCache(because = "task uses Configuration API")
     def "when repository timeout resolving a configuration is swallowed, trying to resolve another configuration using the same repository still prints original cause"() {
         given:
         MavenHttpModule moduleB = publishMavenModule(mavenHttpRepo, 'b')

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyUnresolvedModuleIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyUnresolvedModuleIntegrationTest.groovy
@@ -223,6 +223,7 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
 
         then: "the original failure cause is reported and the subsequent failures which only duplicate the same info are skipped"
         assertDependencyMetaDataReadTimeout(moduleA)
+        assertAdditionalFailuresMessagePrinted(2)
         outputDoesNotContain("Could not resolve ${mavenModuleCoordinates(moduleD)}")
         outputDoesNotContain("Could not resolve ${mavenModuleCoordinates(moduleE)}")
         !downloadedLibsDir.isDirectory()
@@ -461,6 +462,11 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
         failure.assertHasCause("Could not get resource '${mavenHttpRepo.uri.toString()}/${mavenModuleRepositoryPath(module)}.pom'.")
         failure.assertHasCause("Could not GET '${mavenHttpRepo.uri.toString()}/${mavenModuleRepositoryPath(module)}.pom'.")
         failure.assertHasCause("Read timed out")
+    }
+
+    private void assertAdditionalFailuresMessagePrinted(int count) {
+        def plural = count > 1
+        failure.assertHasErrorOutput("> There were $count additional failure${plural ? "s" : ""} with the same cause that ${plural ? "were" : "was"} not printed.")
     }
 
     private void assertDependencyMetaDataInternalServerError(MavenModule module) {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyUnresolvedModuleIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyUnresolvedModuleIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
-import org.gradle.internal.buildevents.BuildExceptionReporter
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.keystore.TestKeyStore
 import org.gradle.test.fixtures.maven.MavenFileRepository
@@ -497,7 +496,7 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
 
     private void assertDependencySkipped(MavenModule module, String repositoryName) {
         failure.assertHasCause("Could not resolve ${mavenModuleCoordinates(module)}.")
-        failure.assertHasCause("Repository $repositoryName is disabled ${BuildExceptionReporter.SKIPPABLE_ERROR_MESSAGE_SUFFIX}")
+        failure.assertHasCause("Repository $repositoryName is disabled due to earlier error below:")
     }
 
     private String mavenModuleCoordinates(MavenHttpModule module) {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyUnresolvedModuleIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyUnresolvedModuleIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.internal.buildevents.BuildExceptionReporter
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.keystore.TestKeyStore
 import org.gradle.test.fixtures.maven.MavenFileRepository
@@ -202,7 +203,7 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
         downloadedLibsDir.assertContainsDescendants('a-1.0.jar')
     }
 
-    def "skips subsequent dependency resolution if HTTP connection exceeds timeout"() {
+    def "skips subsequent dependency resolution if HTTP connection exceeds timeout, and only prints original cause once"() {
         given:
         MavenHttpModule moduleB = publishMavenModule(mavenHttpRepo, 'b')
         MavenHttpModule moduleC = publishMavenModule(mavenHttpRepo, 'c')
@@ -221,11 +222,90 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
         moduleA.pom.expectGetBlocking()
         fails('resolve', '--max-workers=1')
 
-        then:
+        then: "the original failure cause is reported and the subsequent failures which only duplicate the same info are skipped"
         assertDependencyMetaDataReadTimeout(moduleA)
-        assertDependencySkipped(moduleB)
-        assertDependencySkipped(moduleC)
+        outputDoesNotContain("Could not resolve ${mavenModuleCoordinates(moduleD)}")
+        outputDoesNotContain("Could not resolve ${mavenModuleCoordinates(moduleE)}")
         !downloadedLibsDir.isDirectory()
+    }
+
+    def "when repository timeout resolving a configuration is swallowed, trying to re-resolve that configuration still prints the original cause"() {
+        given:
+        MavenHttpModule moduleB = publishMavenModule(mavenHttpRepo, 'b')
+
+        buildFile << """
+            ${mavenRepository(mavenHttpRepo)}
+            configurations {
+                fail
+                lax
+            }
+            dependencies {
+                fail "${mavenModuleCoordinates(moduleB)}"
+                lax "${mavenModuleCoordinates(moduleA)}"
+            }
+
+            task resolve {
+                doLast {
+                    // Try to resolve configuration "lax" and swallow any exception to continue the build
+                    try {
+                        configurations.lax.files
+                    } catch (Exception e) {
+                        println "Lax failure swallowed"
+                    }
+
+                    // Try to resolve configuration "lax" again - this exception is printed
+                    configurations.lax.files
+                }
+            }
+        """
+
+        when:
+        moduleA.pom.expectGetBlocking()
+        fails('resolve', '--max-workers=1')
+
+        then:
+        outputContains("Lax failure swallowed")
+        assertDependencyMetaDataReadTimeout(moduleA)
+    }
+
+    def "when repository timeout resolving a configuration is swallowed, trying to resolve another configuration using the same repository still prints original cause"() {
+        given:
+        MavenHttpModule moduleB = publishMavenModule(mavenHttpRepo, 'b')
+
+        buildFile << """
+            ${mavenRepository(mavenHttpRepo)}
+            configurations {
+                lax
+                fail
+            }
+            dependencies {
+                lax "${mavenModuleCoordinates(moduleA)}"
+                fail "${mavenModuleCoordinates(moduleB)}"
+            }
+
+            task resolve {
+                doLast {
+                    // Try to resolve configuration "lax" and swallow any exception to continue the build
+                    try {
+                        configurations.lax.files
+                    } catch (Exception e) {
+                        println "Lax failure swallowed"
+                    }
+
+                    // Try to resolve configuration "fail" - this fails due to the repository being disabled, and the original cause is also printed underneath
+                    configurations.fail.files
+                }
+            }
+        """
+
+        when:
+        moduleA.pom.expectGetBlocking()
+        fails('resolve', '--max-workers=1')
+
+        then:
+        outputContains("Lax failure swallowed")
+        assertDependencySkipped(moduleB, "maven")
+        assertDependencyMetaDataReadTimeout(moduleA)
     }
 
     def "fails build and #abortDescriptor repository search if HTTP connection #reason when resolving metadata"() {
@@ -413,9 +493,9 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
         failure.assertHasCause("Could not GET '${mavenHttpRepo.uri.toString()}/${mavenModuleRepositoryPath(module)}.jar'. Received status code 401 from server: Unauthorized")
     }
 
-    private void assertDependencySkipped(MavenModule module) {
+    private void assertDependencySkipped(MavenModule module, String repositoryName) {
         failure.assertHasCause("Could not resolve ${mavenModuleCoordinates(module)}.")
-        failure.assertHasCause("Skipped due to earlier error")
+        failure.assertHasCause("Repository $repositoryName is disabled ${BuildExceptionReporter.SKIPPABLE_ERROR_MESSAGE_SUFFIX}")
     }
 
     private String mavenModuleCoordinates(MavenHttpModule module) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ConnectionFailureRepositoryDisabler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ConnectionFailureRepositoryDisabler.java
@@ -46,7 +46,7 @@ public class ConnectionFailureRepositoryDisabler implements RepositoryDisabler {
     }
 
     @Override
-    public boolean disableRepository(String repositoryId, Throwable reason) {
+    public boolean tryDisableRepository(String repositoryId, Throwable reason) {
         boolean disabled = isDisabled(repositoryId);
 
         if (disabled) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepository.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepository.java
@@ -27,9 +27,9 @@ import org.gradle.api.internal.artifacts.repositories.transport.NetworkingIssueV
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.action.InstantiatingAction;
+import org.gradle.internal.buildevents.BuildExceptionReporter;
 import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
@@ -61,10 +61,12 @@ public class ErrorHandlingModuleComponentRepository implements ModuleComponentRe
     private final ErrorHandlingModuleComponentRepositoryAccess local;
     private final ErrorHandlingModuleComponentRepositoryAccess remote;
 
-    public ErrorHandlingModuleComponentRepository(ModuleComponentRepository<ModuleComponentGraphResolveState> delegate, RepositoryDisabler remoteRepositoryBlacklister) {
+    private final static String DISABLED_REPOSITORY_ERROR_MSG_TEMPLATE = "Repository %s is disabled " + BuildExceptionReporter.SKIPPABLE_ERROR_MESSAGE_SUFFIX;
+
+    public ErrorHandlingModuleComponentRepository(ModuleComponentRepository<ModuleComponentGraphResolveState> delegate, RepositoryDisabler remoteRepositoryDisabler) {
         this.delegate = delegate;
-        local = new ErrorHandlingModuleComponentRepositoryAccess(delegate.getLocalAccess(), getId(), RepositoryDisabler.NoOpBlacklister.INSTANCE, getName());
-        remote = new ErrorHandlingModuleComponentRepositoryAccess(delegate.getRemoteAccess(), getId(), remoteRepositoryBlacklister, getName());
+        local = new ErrorHandlingModuleComponentRepositoryAccess(delegate.getLocalAccess(), getId(), RepositoryDisabler.NoOpDisabler.INSTANCE, getName());
+        remote = new ErrorHandlingModuleComponentRepositoryAccess(delegate.getRemoteAccess(), getId(), remoteRepositoryDisabler, getName());
     }
 
     @Override
@@ -104,29 +106,27 @@ public class ErrorHandlingModuleComponentRepository implements ModuleComponentRe
 
     private static final class ErrorHandlingModuleComponentRepositoryAccess implements ModuleComponentRepositoryAccess<ModuleComponentGraphResolveState> {
         private static final Logger LOGGER = Logging.getLogger(ErrorHandlingModuleComponentRepositoryAccess.class);
-        private final static String MAX_TENTATIVES_BEFORE_BLACKLISTING = "org.gradle.internal.repository.max.tentatives";
+        private final static String MAX_TENTATIVES_BEFORE_DISABLING = "org.gradle.internal.repository.max.tentatives";
         private final static String INITIAL_BACKOFF_MS = "org.gradle.internal.repository.initial.backoff";
-
-        private final static String BLACKLISTED_REPOSITORY_ERROR_MESSAGE = "Skipped due to earlier error";
 
         private final ModuleComponentRepositoryAccess<ModuleComponentGraphResolveState> delegate;
         private final String repositoryId;
-        private final RepositoryDisabler repositoryBlacklister;
+        private final RepositoryDisabler repositoryDisabler;
         private final int maxTentativesCount;
         private final int initialBackOff;
         private final String repositoryName;
 
-        private ErrorHandlingModuleComponentRepositoryAccess(ModuleComponentRepositoryAccess<ModuleComponentGraphResolveState> delegate, String repositoryId, RepositoryDisabler repositoryBlacklister, String repositoryName) {
-            this(delegate, repositoryId, repositoryBlacklister, Integer.getInteger(MAX_TENTATIVES_BEFORE_BLACKLISTING, 3), Integer.getInteger(INITIAL_BACKOFF_MS, 1000), repositoryName);
+        private ErrorHandlingModuleComponentRepositoryAccess(ModuleComponentRepositoryAccess<ModuleComponentGraphResolveState> delegate, String repositoryId, RepositoryDisabler repositoryDisabler, String repositoryName) {
+            this(delegate, repositoryId, repositoryDisabler, Integer.getInteger(MAX_TENTATIVES_BEFORE_DISABLING, 3), Integer.getInteger(INITIAL_BACKOFF_MS, 1000), repositoryName);
         }
 
-        private ErrorHandlingModuleComponentRepositoryAccess(ModuleComponentRepositoryAccess<ModuleComponentGraphResolveState> delegate, String repositoryId, RepositoryDisabler repositoryBlacklister, int maxTentativesCount, int initialBackoff, String repositoryName) {
+        private ErrorHandlingModuleComponentRepositoryAccess(ModuleComponentRepositoryAccess<ModuleComponentGraphResolveState> delegate, String repositoryId, RepositoryDisabler repositoryDisabler, int maxTentativesCount, int initialBackoff, String repositoryName) {
             this.repositoryName = repositoryName;
             assert maxTentativesCount > 0 : "Max tentatives must be > 0";
             assert initialBackoff >= 0 : "Initial backoff must be >= 0";
             this.delegate = delegate;
             this.repositoryId = repositoryId;
-            this.repositoryBlacklister = repositoryBlacklister;
+            this.repositoryDisabler = repositoryDisabler;
             this.maxTentativesCount = maxTentativesCount;
             this.initialBackOff = initialBackoff;
         }
@@ -139,83 +139,91 @@ public class ErrorHandlingModuleComponentRepository implements ModuleComponentRe
         @Override
         public void listModuleVersions(ModuleDependencyMetadata dependency, BuildableModuleVersionListingResolveResult result) {
             performOperationWithRetries(result,
-                    () -> delegate.listModuleVersions(dependency, result),
-                    () -> new ModuleVersionResolveException(dependency.getSelector(), () -> BLACKLISTED_REPOSITORY_ERROR_MESSAGE),
-                    throwable -> {
-                        ModuleComponentSelector selector = dependency.getSelector();
-                        return new ModuleVersionResolveException(selector, () -> "Failed to list versions for " + selector.getGroup() + ":" + selector.getModule() + ".", throwable);
-                    });
+                () -> delegate.listModuleVersions(dependency, result),
+                cause -> new ModuleVersionResolveException(dependency.getSelector(), () -> String.format(DISABLED_REPOSITORY_ERROR_MSG_TEMPLATE, repositoryName)),
+                cause -> {
+                    ModuleComponentSelector selector = dependency.getSelector();
+                    return new ModuleVersionResolveException(selector, () -> "Failed to list versions for " + selector.getGroup() + ":" + selector.getModule() + ".", cause);
+                });
         }
 
         @Override
         public void resolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata requestMetaData, BuildableModuleComponentMetaDataResolveResult<ModuleComponentGraphResolveState> result) {
             performOperationWithRetries(result,
-                    () -> delegate.resolveComponentMetaData(moduleComponentIdentifier, requestMetaData, result),
-                    () -> new ModuleVersionResolveException(moduleComponentIdentifier, () -> BLACKLISTED_REPOSITORY_ERROR_MESSAGE),
-                    throwable -> new ModuleVersionResolveException(moduleComponentIdentifier, throwable)
+                () -> delegate.resolveComponentMetaData(moduleComponentIdentifier, requestMetaData, result),
+                cause -> new ModuleVersionResolveException(moduleComponentIdentifier, () -> String.format(DISABLED_REPOSITORY_ERROR_MSG_TEMPLATE, repositoryName), cause),
+                cause -> new ModuleVersionResolveException(moduleComponentIdentifier, cause)
             );
         }
 
         @Override
         public void resolveArtifactsWithType(ComponentResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
             performOperationWithRetries(result,
-                    () -> delegate.resolveArtifactsWithType(component, artifactType, result),
-                    () -> new ArtifactResolveException(component.getId(), BLACKLISTED_REPOSITORY_ERROR_MESSAGE),
-                    throwable -> new ArtifactResolveException(component.getId(), throwable)
+                () -> delegate.resolveArtifactsWithType(component, artifactType, result),
+                cause -> new ArtifactResolveException(component.getId(), String.format(DISABLED_REPOSITORY_ERROR_MSG_TEMPLATE, repositoryName), cause),
+                cause -> new ArtifactResolveException(component.getId(), cause)
             );
         }
 
         @Override
         public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactFileResolveResult result) {
             performOperationWithRetries(result,
-                    () -> {
-                        delegate.resolveArtifact(artifact, moduleSources, result);
-                        if (result.hasResult()) {
-                            ArtifactResolveException failure = result.getFailure();
-                            if (!(failure instanceof ArtifactNotFoundException)) {
-                                return failure;
-                            }
+                () -> {
+                    delegate.resolveArtifact(artifact, moduleSources, result);
+                    if (result.hasResult()) {
+                        ArtifactResolveException failure = result.getFailure();
+                        if (!(failure instanceof ArtifactNotFoundException)) {
+                            return failure;
                         }
-                        return null;
-                    },
-                    () -> new ArtifactResolveException(artifact.getId(), BLACKLISTED_REPOSITORY_ERROR_MESSAGE),
-                    throwable -> new ArtifactResolveException(artifact.getId(), throwable));
+                    }
+                    return null;
+                },
+                cause -> new ArtifactResolveException(artifact.getId(), String.format(DISABLED_REPOSITORY_ERROR_MSG_TEMPLATE, repositoryName), cause),
+                cause -> new ArtifactResolveException(artifact.getId(), cause));
         }
 
         private <E extends Throwable, R extends ErroringResolveResult<E>> void performOperationWithRetries(R result,
                                                                                                            Callable<E> operation,
-                                                                                                           Factory<E> onBlacklisted,
+                                                                                                           Transformer<E, Throwable> onDisabled,
                                                                                                            Transformer<E, Throwable> onError) {
-            if (repositoryBlacklister.isDisabled(repositoryId)) {
-                result.failed(onBlacklisted.create());
+            if (checkToHandleDisabledRepository(result, onDisabled)) {
                 return;
             }
-
-            tryResolveAndMaybeBlacklist(result, operation, onError);
+            tryResolveAndMaybeDisable(result, operation, onError);
         }
 
         private <E extends Throwable, R extends ErroringResolveResult<E>> void performOperationWithRetries(R result,
                                                                                                            Runnable operation,
-                                                                                                           Factory<E> onBlacklisted,
+                                                                                                           Transformer<E, Throwable> onDisabled,
                                                                                                            Transformer<E, Throwable> onError) {
-            if (repositoryBlacklister.isDisabled(repositoryId)) {
-                result.failed(onBlacklisted.create());
+            if (checkToHandleDisabledRepository(result, onDisabled)) {
                 return;
             }
-
-            tryResolveAndMaybeBlacklist(result, operation, onError);
+            tryResolveAndMaybeDisable(result, operation, onError);
         }
 
-        private <E extends Throwable, R extends ErroringResolveResult<E>> void tryResolveAndMaybeBlacklist(R result,
-                                                                                                           Runnable operation,
-                                                                                                           Transformer<E, Throwable> onError) {
-            tryResolveAndMaybeBlacklist(result, () -> {
+        private <E extends Throwable, R extends ErroringResolveResult<E>> boolean checkToHandleDisabledRepository(R result, Transformer<E, Throwable> onDisabled) {
+            if (repositoryDisabler.isDisabled(repositoryId)) {
+                Throwable reason = repositoryDisabler.getDisabledReason(repositoryId).get();
+                E failure = onDisabled.transform(reason);
+                result.failed(failure);
+                return true;
+            }
+            return false;
+        }
+
+        private <E extends Throwable, R extends ErroringResolveResult<E>> void tryResolveAndMaybeDisable(R result,
+                                                                                                         Runnable operation,
+                                                                                                         Transformer<E, Throwable> onError) {
+            tryResolveAndMaybeDisable(result, () -> {
                 operation.run();
                 return null;
             }, onError);
         }
 
-        private <E extends Throwable, R extends ErroringResolveResult<E>> void tryResolveAndMaybeBlacklist(R result, Callable<E> operation, Transformer<E, Throwable> onError) {
+        private <E extends Throwable, R extends ErroringResolveResult<E>> void tryResolveAndMaybeDisable(R result,
+                                                                                                         Callable<E> operation,
+                                                                                                         Transformer<E, Throwable> onError) {
             int retries = 0;
             int backoff = initialBackOff;
 
@@ -238,7 +246,7 @@ public class ErrorHandlingModuleComponentRepository implements ModuleComponentRe
                 boolean doNotRetry = NetworkingIssueVerifier.isLikelyPermanentNetworkIssue(failure) || !NetworkingIssueVerifier.isLikelyTransientNetworkingIssue(failure);
                 if (doNotRetry || retries == maxTentativesCount) {
                     if (unexpectedFailure != null) {
-                        repositoryBlacklister.disableRepository(repositoryId, unexpectedFailure);
+                        repositoryDisabler.disableRepository(repositoryId, failure);
                     }
                     result.failed(failure);
                     break;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryDisabler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryDisabler.java
@@ -35,7 +35,7 @@ public interface RepositoryDisabler {
      *
      * @param repositoryId The id of the repository to disable
      * @param throwable    The reason why the repository is being disabled
-     * @return {@code true} if the repository was disabled, {@code false} if it was already disabled
+     * @return {@code true} if the repository is now disabled, {@code false} if it was already disabled
      */
     boolean disableRepository(String repositoryId, Throwable throwable);
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryDisabler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryDisabler.java
@@ -16,18 +16,40 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
+import java.util.Optional;
+
 public interface RepositoryDisabler {
 
     boolean isDisabled(String repositoryId);
 
+    /**
+     * Gets the reason why the repository was disabled, if it was disabled.
+     *
+     * @param repositoryId The id of the repository to check
+     * @return the reason why the repository was disabled, if it was disabled; otherwise, an empty {@link Optional}
+     */
+    Optional<Throwable> getDisabledReason(String repositoryId);
+
+    /**
+     * Disables the repository with the given id, recording the exception causing it to be disabled.
+     *
+     * @param repositoryId The id of the repository to disable
+     * @param throwable    The reason why the repository is being disabled
+     * @return {@code true} if the repository was disabled, {@code false} if it was already disabled
+     */
     boolean disableRepository(String repositoryId, Throwable throwable);
 
-    enum NoOpBlacklister implements RepositoryDisabler {
+    enum NoOpDisabler implements RepositoryDisabler {
         INSTANCE;
 
         @Override
         public boolean isDisabled(String repositoryId) {
             return false;
+        }
+
+        @Override
+        public Optional<Throwable> getDisabledReason(String repositoryId) {
+            return Optional.empty();
         }
 
         @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryDisabler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryDisabler.java
@@ -31,13 +31,16 @@ public interface RepositoryDisabler {
     Optional<Throwable> getDisabledReason(String repositoryId);
 
     /**
-     * Disables the repository with the given id, recording the exception causing it to be disabled.
+     * Attempts to disable the repository with the given id, recording the exception causing it to be disabled, if
+     * that exception is deemed critical.
      *
-     * @param repositoryId The id of the repository to disable
-     * @param throwable    The reason why the repository is being disabled
-     * @return {@code true} if the repository is now disabled, {@code false} if it was already disabled
+     * @param repositoryId the id of the repository to disable
+     * @param throwable the reason why the repository is being disabled
+     * @return {@code true} if the repository is now disabled, {@code false} if it was already disabled or could not be disabled
+     * (<strong>Be sure to note the ambiguity in this value</strong>)
+     * @implSpec implementations <strong>MUST</strong> return {@code false} if the repository is not disabled by this call
      */
-    boolean disableRepository(String repositoryId, Throwable throwable);
+    boolean tryDisableRepository(String repositoryId, Throwable throwable);
 
     enum NoOpDisabler implements RepositoryDisabler {
         INSTANCE;
@@ -53,7 +56,7 @@ public interface RepositoryDisabler {
         }
 
         @Override
-        public boolean disableRepository(String repositoryId, Throwable throwable) {
+        public boolean tryDisableRepository(String repositoryId, Throwable throwable) {
             return false;
         }
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/ArtifactResolveException.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/ArtifactResolveException.java
@@ -39,12 +39,20 @@ public class ArtifactResolveException extends GradleException {
         super(format(component, message));
     }
 
+    public ArtifactResolveException(ComponentIdentifier component, String message, Throwable cause) {
+        super(format(component, message), cause);
+    }
+
     public ArtifactResolveException(ComponentArtifactIdentifier artifact, Throwable cause) {
         super(format(artifact, ""), cause);
     }
 
     public ArtifactResolveException(ComponentArtifactIdentifier artifact, String message) {
         super(format(artifact, message));
+    }
+
+    public ArtifactResolveException(ComponentArtifactIdentifier artifact, String message, Throwable cause) {
+        super(format(artifact, message), cause);
     }
 
     private static String format(ComponentArtifactIdentifier artifact, String message) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/ModuleVersionResolveException.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/ModuleVersionResolveException.java
@@ -71,6 +71,10 @@ public class ModuleVersionResolveException extends DefaultMultiCauseExceptionNoS
         this(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(id.getGroup(), id.getModule()), DefaultImmutableVersionConstraint.of(id.getVersion())), messageFormat);
     }
 
+    public ModuleVersionResolveException(ModuleComponentIdentifier id, Factory<String> messageFormat, Throwable cause) {
+        this(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(id.getGroup(), id.getModule()), DefaultImmutableVersionConstraint.of(id.getVersion())), messageFormat, cause);
+    }
+
     public ModuleVersionResolveException(ModuleComponentIdentifier id, Throwable cause) {
         this(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(id.getGroup(), id.getModule()), DefaultImmutableVersionConstraint.of(id.getVersion())), Collections.singletonList(cause));
     }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ConnectionFailureRepositoryDisablerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ConnectionFailureRepositoryDisablerTest.groovy
@@ -30,7 +30,7 @@ class ConnectionFailureRepositoryDisablerTest extends Specification {
         def repositoryId2 = 'def'
 
         when:
-        boolean disabled = disabler.disableRepository(repositoryId1, exception)
+        boolean disabled = disabler.tryDisableRepository(repositoryId1, exception)
 
         then:
         disabled
@@ -38,7 +38,7 @@ class ConnectionFailureRepositoryDisablerTest extends Specification {
         disabler.disabledRepositories.contains(repositoryId1)
 
         when:
-        disabled = disabler.disableRepository(repositoryId1, exception)
+        disabled = disabler.tryDisableRepository(repositoryId1, exception)
 
         then:
         disabled
@@ -46,7 +46,7 @@ class ConnectionFailureRepositoryDisablerTest extends Specification {
         disabler.disabledRepositories.contains(repositoryId1)
 
         when:
-        disabled = disabler.disableRepository(repositoryId2, exception)
+        disabled = disabler.tryDisableRepository(repositoryId2, exception)
 
         then:
         disabled
@@ -60,7 +60,7 @@ class ConnectionFailureRepositoryDisablerTest extends Specification {
 
     def "does not disable repository for #type"() {
         when:
-        boolean disabled = disabler.disableRepository('abc', exception)
+        boolean disabled = disabler.tryDisableRepository('abc', exception)
 
         then:
         !disabled

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepositoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepositoryTest.groovy
@@ -105,7 +105,7 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
         access.listModuleVersions(dependency, result)
 
         then: 'resolution fails and repo is disabled'
-        1 * repositoryBlacklister.disableRepository(REPOSITORY_ID, { hasCause(it, exception) })
+        1 * repositoryBlacklister.tryDisableRepository(REPOSITORY_ID, { hasCause(it, exception) })
         1 * result.failed(_ as ModuleVersionResolveException)
 
         when: 'repo is already disabled'
@@ -143,7 +143,7 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
         access.resolveComponentMetaData(moduleComponentIdentifier, requestMetaData, result)
 
         then: 'resolution fails and repo is disabled'
-        1 * repositoryBlacklister.disableRepository(REPOSITORY_ID, { hasCause(it, exception) })
+        1 * repositoryBlacklister.tryDisableRepository(REPOSITORY_ID, { hasCause(it, exception) })
         1 * result.failed(_ as ModuleVersionResolveException)
 
         when: 'repo is already disabled'
@@ -183,7 +183,7 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
         access.resolveArtifactsWithType(component, artifactType, result)
 
         then: 'resolution fails and repo is disabled'
-        1 * repositoryBlacklister.disableRepository(REPOSITORY_ID, { hasCause(it, exception) })
+        1 * repositoryBlacklister.tryDisableRepository(REPOSITORY_ID, { hasCause(it, exception) })
         1 * result.failed(_ as ArtifactResolveException)
 
         when: 'repo is already disabled'
@@ -224,7 +224,7 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
         access.resolveArtifact(artifact, moduleSources, result)
 
         then: 'resolution fails and repo is disabled'
-        1 * repositoryBlacklister.disableRepository(REPOSITORY_ID, { hasCause(it, exception) })
+        1 * repositoryBlacklister.tryDisableRepository(REPOSITORY_ID, { hasCause(it, exception) })
         1 * result.failed(_ as ArtifactResolveException)
 
         when: 'repo is already disabled'
@@ -258,7 +258,7 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
         access.resolveArtifact(artifact, moduleSources, result)
 
         then: 'resolution fails and repo is disabled'
-        1 * repositoryBlacklister.disableRepository(REPOSITORY_ID, { hasCause(it, exception) })
+        1 * repositoryBlacklister.tryDisableRepository(REPOSITORY_ID, { hasCause(it, exception) })
         1 * result.failed(_ as ArtifactResolveException)
 
         when: 'repo is already disabled'

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepositoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepositoryTest.groovy
@@ -100,6 +100,7 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
         1 * delegate.listModuleVersions(dependency, result)
 
         when: 'exception is thrown in resolution'
+        repositoryBlacklister.getDisabledReason(REPOSITORY_ID) >> Optional.of(exception)
         effectiveRetries * delegate.listModuleVersions(dependency, result) >> { throw exception }
         access.listModuleVersions(dependency, result)
 
@@ -109,6 +110,7 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
 
         when: 'repo is already disabled'
         repositoryBlacklister.isDisabled(REPOSITORY_ID) >> true
+        repositoryBlacklister.getDisabledReason(REPOSITORY_ID) >> Optional.of(exception)
         access.listModuleVersions(dependency, result)
 
         then: 'resolution fails directly'
@@ -136,6 +138,7 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
         1 * delegate.resolveComponentMetaData(moduleComponentIdentifier, requestMetaData, result)
 
         when: 'exception is thrown in resolution'
+        repositoryBlacklister.getDisabledReason(REPOSITORY_ID) >> Optional.of(exception)
         effectiveRetries * delegate.resolveComponentMetaData(moduleComponentIdentifier, requestMetaData, result) >> { throw exception }
         access.resolveComponentMetaData(moduleComponentIdentifier, requestMetaData, result)
 
@@ -145,6 +148,7 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
 
         when: 'repo is already disabled'
         repositoryBlacklister.isDisabled(REPOSITORY_ID) >> true
+        repositoryBlacklister.getDisabledReason(REPOSITORY_ID) >> Optional.of(exception)
         access.resolveComponentMetaData(moduleComponentIdentifier, requestMetaData, result)
 
         then: 'resolution fails directly'
@@ -174,6 +178,7 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
         1 * delegate.resolveArtifactsWithType(component, artifactType, result)
 
         when: 'exception is thrown in resolution'
+        repositoryBlacklister.getDisabledReason(REPOSITORY_ID) >> Optional.of(exception)
         effectiveRetries * delegate.resolveArtifactsWithType(component, artifactType, result) >> { throw exception }
         access.resolveArtifactsWithType(component, artifactType, result)
 
@@ -183,6 +188,7 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
 
         when: 'repo is already disabled'
         repositoryBlacklister.isDisabled(REPOSITORY_ID) >> true
+        repositoryBlacklister.getDisabledReason(REPOSITORY_ID) >> Optional.of(exception)
         access.resolveArtifactsWithType(component, artifactType, result)
 
         then: 'resolution fails directly'
@@ -207,11 +213,13 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
         when: 'repo is not disabled'
         repositoryBlacklister.isDisabled(REPOSITORY_ID) >> false
         access.resolveArtifact(artifact, moduleSources, result)
+        repositoryBlacklister.getDisabledReason(REPOSITORY_ID) >> Optional.of(exception)
 
         then: 'work is delegated'
         1 * delegate.resolveArtifact(artifact, moduleSources, result)
 
         when: 'exception is thrown in resolution'
+        repositoryBlacklister.getDisabledReason(REPOSITORY_ID) >> Optional.of(exception)
         effectiveRetries * delegate.resolveArtifact(artifact, moduleSources, result) >> { throw exception }
         access.resolveArtifact(artifact, moduleSources, result)
 
@@ -221,6 +229,7 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
 
         when: 'repo is already disabled'
         repositoryBlacklister.isDisabled(REPOSITORY_ID) >> true
+        repositoryBlacklister.getDisabledReason(REPOSITORY_ID) >> Optional.of(exception)
         access.resolveArtifact(artifact, moduleSources, result)
 
         then: 'resolution fails directly'
@@ -241,6 +250,7 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
         def moduleSources = ImmutableModuleSources.of(Mock(ModuleSource))
         def result = Mock(BuildableArtifactFileResolveResult)
         artifact.getId() >> artifactId
+        repositoryBlacklister.getDisabledReason(REPOSITORY_ID) >> Optional.of(exception)
         delegate.resolveArtifact(artifact, moduleSources, result) >> { throw exception }
         repositoryBlacklister.isDisabled(REPOSITORY_ID) >> false
 
@@ -253,6 +263,7 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
 
         when: 'repo is already disabled'
         repositoryBlacklister.isDisabled(REPOSITORY_ID) >> true
+        repositoryBlacklister.getDisabledReason(REPOSITORY_ID) >> Optional.of(exception)
         access.resolveArtifact(artifact, moduleSources, result)
 
         then: 'resolution fails directly'

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -357,7 +357,7 @@ public class BuildExceptionReporter implements Action<Throwable> {
     }
 
     private void addBuildScanMessage(ContextImpl context) {
-        context.appendResolution(output -> runtWithOption(output, LONG_OPTION, " to get full insights."));
+        context.appendResolution(output -> runWithOption(output, LONG_OPTION, " to get full insights."));
     }
 
     private boolean isGradleEnterprisePluginApplied() {

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -41,7 +41,8 @@ import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
 import org.gradle.util.internal.GUtil;
 
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
+import java.util.ArrayDeque;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Queue;
@@ -103,7 +104,7 @@ public class BuildExceptionReporter implements Action<Throwable> {
     }
 
     @Override
-    public void execute(@Nullable Throwable failure) {
+    public void execute(@Nonnull Throwable failure) {
         if (failure instanceof MultipleBuildFailures) {
             renderMultipleBuildExceptions((MultipleBuildFailures) failure);
         } else {
@@ -231,14 +232,16 @@ public class BuildExceptionReporter implements Action<Throwable> {
          * @return {@code true} if the node should be printed; {@code false} otherwise
          */
         private boolean shouldBePrinted(Throwable node) {
-            Queue<Throwable> next = new java.util.LinkedList<>();
+            if (printedNodes.isEmpty()) {
+                return true;
+            }
+
+            Queue<Throwable> next = new ArrayDeque<>();
             next.add(node);
 
             while (!next.isEmpty()) {
                 Throwable curr = next.poll();
-                if (printedNodes.isEmpty()) {
-                    return true;
-                } else if (printedNodes.contains(curr)) {
+                if (printedNodes.contains(curr)) {
                     return false;
                 } else {
                     if (curr.getCause() != null) {

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -288,9 +288,13 @@ public class BuildExceptionReporter implements Action<Throwable> {
         @Override
         protected void endVisiting() {
             if (suppressedDuplicateBranchCount > 0) {
-                boolean plural = suppressedDuplicateBranchCount > 1;
                 LinePrefixingStyledTextOutput output = getLinePrefixingStyledTextOutput(failureDetails);
-                output.append(String.format("There were %d additional failure%s with the same cause that %s not printed.", suppressedDuplicateBranchCount, plural ? "s" : "", plural ? "were" : "was"));
+                boolean plural = suppressedDuplicateBranchCount > 1;
+                if (plural) {
+                    output.append(String.format("There were %d additional failures with the same cause that were not printed.", suppressedDuplicateBranchCount));
+                } else {
+                    output.append("There was 1 additional failure with the same cause that was not printed.");
+                }
             }
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -293,7 +293,7 @@ public class BuildExceptionReporter implements Action<Throwable> {
                 if (plural) {
                     output.append(String.format("There are %d more failures with identical causes.", suppressedDuplicateBranchCount));
                 } else {
-                    output.append("There was 1 additional failure with the same cause that was not printed.");
+                    output.append("There is 1 more failure with an identical cause.");
                 }
             }
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -69,7 +69,6 @@ import static org.gradle.internal.logging.text.StyledTextOutput.Style.UserInput;
  */
 public class BuildExceptionReporter implements Action<Throwable> {
     private static final String NO_ERROR_MESSAGE_INDICATOR = "(no error message)";
-    public static final String SKIPPABLE_ERROR_MESSAGE_SUFFIX = "due to earlier error below:";
 
     public static final String RESOLUTION_LINE_PREFIX = "> ";
     public static final String LINE_PREFIX_LENGTH_SPACES = repeat(" ", RESOLUTION_LINE_PREFIX.length());

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -286,7 +286,7 @@ public class BuildExceptionReporter implements Action<Throwable> {
         }
 
         @Override
-        protected void uponFinishedVisiting() {
+        protected void endVisiting() {
             if (suppressedDuplicateBranchCount > 0) {
                 boolean plural = suppressedDuplicateBranchCount > 1;
                 LinePrefixingStyledTextOutput output = getLinePrefixingStyledTextOutput(failureDetails);

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -291,7 +291,7 @@ public class BuildExceptionReporter implements Action<Throwable> {
                 LinePrefixingStyledTextOutput output = getLinePrefixingStyledTextOutput(failureDetails);
                 boolean plural = suppressedDuplicateBranchCount > 1;
                 if (plural) {
-                    output.append(String.format("There were %d additional failures with the same cause that were not printed.", suppressedDuplicateBranchCount));
+                    output.append(String.format("There are %d more failures with identical causes.", suppressedDuplicateBranchCount));
                 } else {
                     output.append("There was 1 additional failure with the same cause that was not printed.");
                 }

--- a/subprojects/core/src/main/java/org/gradle/internal/exceptions/ContextAwareException.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/exceptions/ContextAwareException.java
@@ -51,6 +51,7 @@ public class ContextAwareException extends GradleException {
             contextVisitor.visitCause(cause);
             visitCauses(cause, contextVisitor);
         }
+        contextVisitor.uponFinishedVisiting();
     }
 
     private void visitCauses(Throwable t, TreeVisitor<? super Throwable> visitor) {

--- a/subprojects/core/src/main/java/org/gradle/internal/exceptions/ContextAwareException.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/exceptions/ContextAwareException.java
@@ -51,7 +51,7 @@ public class ContextAwareException extends GradleException {
             contextVisitor.visitCause(cause);
             visitCauses(cause, contextVisitor);
         }
-        contextVisitor.uponFinishedVisiting();
+        contextVisitor.endVisiting();
     }
 
     private void visitCauses(Throwable t, TreeVisitor<? super Throwable> visitor) {

--- a/subprojects/core/src/main/java/org/gradle/internal/exceptions/ExceptionContextVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/exceptions/ExceptionContextVisitor.java
@@ -22,4 +22,14 @@ public abstract class ExceptionContextVisitor extends TreeVisitor<Throwable> {
     protected abstract void visitCause(Throwable cause);
 
     protected abstract void visitLocation(String location);
+
+    /**
+     * Should be called after each time this visitor has finished visiting.
+     *
+     * This method can be used to perform any cleanup or final processing related
+     * to the visitor's purpose.
+     */
+    protected void uponFinishedVisiting() {
+        // default is no-op
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/exceptions/ExceptionContextVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/exceptions/ExceptionContextVisitor.java
@@ -29,7 +29,7 @@ public abstract class ExceptionContextVisitor extends TreeVisitor<Throwable> {
      * This method can be used to perform any cleanup or final processing related
      * to the visitor's purpose.
      */
-    protected void uponFinishedVisiting() {
+    protected void endVisiting() {
         // default is no-op
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
@@ -464,7 +464,7 @@ $GET_HELP
     }
 
     // region Duplicate Exception Branch Filtering
-    def "multi-cause exceptions summaries branches with identical root causes"() {
+    def "multi-cause exceptions have branches with identical root causes summarized properly"() {
         def ultimateCause = new RuntimeException("ultimate cause")
         def branch1 = new DefaultMultiCauseException("first failure", ultimateCause)
         def branch2 = new DefaultMultiCauseException("second failure", ultimateCause)
@@ -492,7 +492,7 @@ $GET_HELP
 """
     }
 
-    def "multi-cause exceptions summaries branches with identical root causes with additional intermediate failures"() {
+    def "multi-cause exceptions have branches with identical root causes and additional intermediate failures summarized properly"() {
         def ultimateCause = new RuntimeException("ultimate cause")
         def branch1 = new DefaultMultiCauseException("first failure", ultimateCause)
         def branch2 = new DefaultMultiCauseException("second failure", ultimateCause)
@@ -522,7 +522,7 @@ $GET_HELP
 """
     }
 
-    def "multi-cause exceptions summaries branches properly when identical root cause is self-caused"() {
+    def "multi-cause exceptions have branches with identical root causes summarized properly when ultimate cause is self-caused"() {
         def ultimateCause = new RuntimeException("ultimate cause")
         ultimateCause.cause = ultimateCause
         def branch1 = new DefaultMultiCauseException("first failure", ultimateCause)

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
@@ -37,6 +37,8 @@ import org.gradle.internal.logging.text.StyledTextOutputFactory
 import org.gradle.internal.logging.text.TestStyledTextOutput
 import spock.lang.Specification
 
+import java.lang.reflect.Field
+
 class BuildExceptionReporterTest extends Specification {
     final TestStyledTextOutput output = new TestStyledTextOutput()
     final StyledTextOutputFactory factory = Mock()
@@ -524,7 +526,10 @@ $GET_HELP
 
     def "multi-cause exceptions have branches with identical root causes summarized properly when ultimate cause is self-caused"() {
         def ultimateCause = new RuntimeException("ultimate cause")
-        ultimateCause.cause = ultimateCause
+        Field field = Throwable.class.getDeclaredField("cause")
+        field.setAccessible(true)
+        field.set(ultimateCause, ultimateCause)
+
         def branch1 = new DefaultMultiCauseException("first failure", ultimateCause)
         def branch2 = new DefaultMultiCauseException("second failure", ultimateCause)
         Throwable exception = new ContextAwareException(new DefaultLenientConfiguration.ArtifactResolveException("task dependencies", "org:example:1.0", [branch1, branch2]))

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
@@ -484,7 +484,7 @@ $GET_HELP
 Could not resolve all task dependencies for org:example:1.0.
 {info}> {normal}first failure
    {info}> {normal}ultimate cause
-{info}> {normal}There was 1 additional failure with the same cause that was not printed.
+{info}> {normal}There is 1 more failure with an identical cause.
 
 * Try:
 $STACKTRACE
@@ -514,7 +514,7 @@ $GET_HELP
 Could not resolve all task dependencies for org:example:1.0.
 {info}> {normal}first failure
    {info}> {normal}ultimate cause
-{info}> {normal}There were 2 additional failures with the same cause that were not printed.
+{info}> {normal}There are 2 more failures with identical causes.
 
 * Try:
 $STACKTRACE
@@ -546,7 +546,7 @@ $GET_HELP
 Could not resolve all task dependencies for org:example:1.0.
 {info}> {normal}first failure
    {info}> {normal}ultimate cause
-{info}> {normal}There was 1 additional failure with the same cause that was not printed.
+{info}> {normal}There is 1 more failure with an identical cause.
 
 * Try:
 $STACKTRACE
@@ -585,7 +585,7 @@ Could not resolve all task dependencies for org:example:1.0.
    {info}> {normal}ultimate cause 1
 {info}> {normal}forth failure
    {info}> {normal}ultimate cause 2
-{info}> {normal}There were 4 additional failures with the same cause that were not printed.
+{info}> {normal}There are 4 more failures with identical causes.
 
 * Try:
 $STACKTRACE

--- a/subprojects/core/src/test/groovy/org/gradle/internal/exceptions/ContextAwareExceptionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/exceptions/ContextAwareExceptionTest.groovy
@@ -19,8 +19,9 @@ package org.gradle.internal.exceptions
 import spock.lang.Specification
 
 class ContextAwareExceptionTest extends Specification {
+    private ExceptionContextVisitor visitor = Mock()
+
     def "visitor does not visit direct cause"() {
-        ExceptionContextVisitor visitor = Mock()
         def cause = new RuntimeException()
         def e = new ContextAwareException(cause)
 
@@ -29,6 +30,7 @@ class ContextAwareExceptionTest extends Specification {
 
         then:
         1 * visitor.visitCause(cause)
+        1 * visitor.uponFinishedVisiting()
         0 * visitor._
 
         and:
@@ -36,7 +38,6 @@ class ContextAwareExceptionTest extends Specification {
     }
 
     def "visitor visits indirect cause"() {
-        ExceptionContextVisitor visitor = Mock()
         def childCause = new RuntimeException()
         def cause = new RuntimeException(childCause)
         def e = new ContextAwareException(cause)
@@ -46,6 +47,7 @@ class ContextAwareExceptionTest extends Specification {
 
         then:
         1 * visitor.visitCause(cause)
+        1 * visitor.uponFinishedVisiting()
         1 * visitor.startChildren()
 
         and:
@@ -60,7 +62,6 @@ class ContextAwareExceptionTest extends Specification {
     }
 
     def "visitor visits causes of contextual exception"() {
-        ExceptionContextVisitor visitor = Mock()
         def childCause = new RuntimeException()
         def cause = new TestContextualException(childCause)
         def e = new ContextAwareException(cause)
@@ -70,6 +71,7 @@ class ContextAwareExceptionTest extends Specification {
 
         then:
         1 * visitor.visitCause(cause)
+        1 * visitor.uponFinishedVisiting()
         1 * visitor.startChildren()
 
         and:
@@ -84,7 +86,6 @@ class ContextAwareExceptionTest extends Specification {
     }
 
     def "visitor visits all contextual exceptions and direct cause of last contextual exception"() {
-        ExceptionContextVisitor visitor = Mock()
         def unreportedCause = new RuntimeException()
         def reportedCause = new RuntimeException(unreportedCause)
         def lastContextual = new TestContextualException(reportedCause)
@@ -99,6 +100,7 @@ class ContextAwareExceptionTest extends Specification {
 
         then:
         1 * visitor.visitCause(cause)
+        1 * visitor.uponFinishedVisiting()
 
         1 * visitor.node(contextual)
         1 * visitor.node(lastContextual)
@@ -114,7 +116,6 @@ class ContextAwareExceptionTest extends Specification {
     }
 
     def "visitor visits causes of multi-cause exception"() {
-        ExceptionContextVisitor visitor = Mock()
         def childCause1 = new RuntimeException()
         def childCause2 = new RuntimeException()
         def cause = new DefaultMultiCauseException("broken", childCause1, childCause2)
@@ -125,6 +126,7 @@ class ContextAwareExceptionTest extends Specification {
 
         then:
         1 * visitor.visitCause(cause)
+        1 * visitor.uponFinishedVisiting()
 
         1 * visitor.startChildren()
 
@@ -143,7 +145,6 @@ class ContextAwareExceptionTest extends Specification {
     }
 
     def "visitor treats multi-cause exception as contextual"() {
-        ExceptionContextVisitor visitor = Mock()
         def childCause1 = new RuntimeException()
         def detail = new RuntimeException()
         def childCause2 = new TestContextualException(detail)
@@ -157,6 +158,7 @@ class ContextAwareExceptionTest extends Specification {
 
         then:
         1 * visitor.visitCause(intermediate2)
+        1 * visitor.uponFinishedVisiting()
 
         1 * visitor.startChildren()
 
@@ -187,7 +189,6 @@ class ContextAwareExceptionTest extends Specification {
     }
 
     def "visitor visits causes recursively"() {
-        ExceptionContextVisitor visitor = Mock()
         def ignored = new RuntimeException()
         def childCause1 = new RuntimeException(ignored)
         def childCause2 = new RuntimeException()
@@ -201,6 +202,7 @@ class ContextAwareExceptionTest extends Specification {
 
         then:
         1 * visitor.visitCause(cause)
+        1 * visitor.uponFinishedVisiting()
 
         3 * visitor.startChildren()
         1 * visitor.node(childCause1)

--- a/subprojects/core/src/test/groovy/org/gradle/internal/exceptions/ContextAwareExceptionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/exceptions/ContextAwareExceptionTest.groovy
@@ -30,7 +30,7 @@ class ContextAwareExceptionTest extends Specification {
 
         then:
         1 * visitor.visitCause(cause)
-        1 * visitor.uponFinishedVisiting()
+        1 * visitor.endVisiting()
         0 * visitor._
 
         and:
@@ -47,7 +47,7 @@ class ContextAwareExceptionTest extends Specification {
 
         then:
         1 * visitor.visitCause(cause)
-        1 * visitor.uponFinishedVisiting()
+        1 * visitor.endVisiting()
         1 * visitor.startChildren()
 
         and:
@@ -71,7 +71,7 @@ class ContextAwareExceptionTest extends Specification {
 
         then:
         1 * visitor.visitCause(cause)
-        1 * visitor.uponFinishedVisiting()
+        1 * visitor.endVisiting()
         1 * visitor.startChildren()
 
         and:
@@ -100,7 +100,7 @@ class ContextAwareExceptionTest extends Specification {
 
         then:
         1 * visitor.visitCause(cause)
-        1 * visitor.uponFinishedVisiting()
+        1 * visitor.endVisiting()
 
         1 * visitor.node(contextual)
         1 * visitor.node(lastContextual)
@@ -126,7 +126,7 @@ class ContextAwareExceptionTest extends Specification {
 
         then:
         1 * visitor.visitCause(cause)
-        1 * visitor.uponFinishedVisiting()
+        1 * visitor.endVisiting()
 
         1 * visitor.startChildren()
 
@@ -158,7 +158,7 @@ class ContextAwareExceptionTest extends Specification {
 
         then:
         1 * visitor.visitCause(intermediate2)
-        1 * visitor.uponFinishedVisiting()
+        1 * visitor.endVisiting()
 
         1 * visitor.startChildren()
 
@@ -202,7 +202,7 @@ class ContextAwareExceptionTest extends Specification {
 
         then:
         1 * visitor.visitCause(cause)
-        1 * visitor.uponFinishedVisiting()
+        1 * visitor.endVisiting()
 
         3 * visitor.startChildren()
         1 * visitor.node(childCause1)

--- a/subprojects/core/src/test/groovy/org/gradle/internal/exceptions/LocationAwareExceptionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/exceptions/LocationAwareExceptionTest.groovy
@@ -29,6 +29,7 @@ class LocationAwareExceptionTest extends Specification {
 
         then:
         1 * visitor.visitCause(cause)
+        1 * visitor.uponFinishedVisiting()
         1 * visitor.visitLocation("Location line: 42")
         0 * visitor._
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/exceptions/LocationAwareExceptionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/exceptions/LocationAwareExceptionTest.groovy
@@ -29,7 +29,7 @@ class LocationAwareExceptionTest extends Specification {
 
         then:
         1 * visitor.visitCause(cause)
-        1 * visitor.uponFinishedVisiting()
+        1 * visitor.endVisiting()
         1 * visitor.visitLocation("Location line: 42")
         0 * visitor._
 


### PR DESCRIPTION
Fixes #12358 

This tracks the reason for a repository being disabled, and adds it as the cause of any subsequent errors that short-circuit to report only the fact that a repo was disabled.  Tracking the ultimate cause like this allows for always printing it.

The BuildExceptionReporter gains some additional intelligence to avoid repeating failure trees which stem from the same cause.

This change also:
- Adds some additional tests around scenarios where (possibly improper) manual exception handling would have previously hidden the original cause - it is now shown.
- Displays the name of the repo that has been disabled when displaying the failure.
- Renames blacklist to disabled list throughout.
