### PR TITLE
Improve Error Messages for External Variable Capturing in Tasks

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/Jsr330ConstructorSelector.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/Jsr330ConstructorSelector.java
@@ -67,7 +67,7 @@ class Jsr330ConstructorSelector implements ConstructorSelector {
         if (!type.isInterface() && type.getEnclosingClass() != null && !Modifier.isStatic(type.getModifiers())) {
             TreeFormatter formatter = new TreeFormatter();
             formatter.node(type);
-            formatter.append(" is a non-static inner class.");
+            formatter.append(" is a non-static inner class, it probably captures a variable from the outer scope.");
             throw new IllegalArgumentException(formatter.toString());
         }
     }


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
When tasks attempt to capture variables from the outer scope, the error message `Class_ XXX is a non-static inner class` is not that helpful. This PR improves error message to help developers better resolve problems.
<!--- Link to relevant issues or forum discussions here -->
Fixes https://github.com/gradle/gradle/issues/25494

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
