### PR TITLE
Expose root variant in ResolutionResult

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheUnsupportedTypesIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheUnsupportedTypesIntegrationTest.groovy
@@ -59,7 +59,6 @@ import org.gradle.api.internal.artifacts.DefaultDependencySet
 import org.gradle.api.internal.artifacts.DefaultResolvedArtifact
 import org.gradle.api.internal.artifacts.DefaultResolvedDependency
 import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.ConfigurationResolvableDependencies
-import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.ConfigurationResolvableDependencies.ConfigurationArtifactView
 import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer
 import org.gradle.api.internal.artifacts.configurations.DefaultResolvableConfiguration
 import org.gradle.api.internal.artifacts.configurations.DefaultUnlockedConfiguration
@@ -74,6 +73,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ShortCircuitEmptyConfigurati
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy
 import org.gradle.api.internal.artifacts.query.DefaultArtifactResolutionQuery
 import org.gradle.api.internal.artifacts.repositories.DefaultMavenArtifactRepository
+import org.gradle.api.internal.artifacts.resolver.DefaultResolutionOutputs.DefaultArtifactView
 import org.gradle.api.internal.artifacts.result.DefaultArtifactResolutionResult
 import org.gradle.api.internal.artifacts.result.DefaultComponentArtifactsResult
 import org.gradle.api.internal.artifacts.result.DefaultResolutionResult
@@ -304,7 +304,7 @@ class ConfigurationCacheUnsupportedTypesIntegrationTest extends AbstractConfigur
         DefaultDependencyLockingHandler       | DependencyLockingHandler       | "project.dependencyLocking"
         DefaultResolvedDependency             | ResolvedDependency             | "project.configurations.create(java.util.UUID.randomUUID().toString()).tap { project.dependencies.add(name, 'junit:junit:4.13') }.resolvedConfiguration.firstLevelModuleDependencies.first()"
         DefaultResolvedArtifact               | ResolvedArtifact               | "project.configurations.create(java.util.UUID.randomUUID().toString()).tap { project.dependencies.add(name, 'junit:junit:4.13') }.resolvedConfiguration.resolvedArtifacts.first()"
-        ConfigurationArtifactView             | ArtifactView                   | "project.configurations.maybeCreate('some').incoming.artifactView {}"
+        DefaultArtifactView                   | ArtifactView                   | "project.configurations.maybeCreate('some').incoming.artifactView {}"
         DefaultArtifactResolutionResult       | ArtifactResolutionResult       | "project.dependencies.createArtifactResolutionQuery().forModule('junit', 'junit', '4.13').withArtifacts(JvmLibrary).execute()"
         DefaultComponentArtifactsResult       | ComponentArtifactsResult       | "project.dependencies.createArtifactResolutionQuery().forModule('junit', 'junit', '4.13').withArtifacts(JvmLibrary).execute().components.first()"
         DefaultUnresolvedComponentResult      | UnresolvedComponentResult      | "project.dependencies.createArtifactResolutionQuery().forModule('junit', 'junit', '100').withArtifacts(JvmLibrary).execute().components.first()"

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolutionResultApiIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolutionResultApiIntegrationTest.groovy
@@ -700,8 +700,12 @@ testRuntimeClasspath
                 assert result_${configuration}.requestedAttributes.keySet().size() == consumerAttributes_${configuration}.keySet().size()
                 consumerAttributes_${configuration}.keySet().each {
                     println "Checking \$it of type \$it.type"
-                    def desugared = Attribute.of(it.name, String)
-                    assert result_${configuration}.requestedAttributes.getAttribute(desugared) == consumerAttributes_${configuration}.getAttribute(it).toString()
+                    if (it.type == String || it.type == Integer || it.type == Boolean) {
+                        assert result_${configuration}.requestedAttributes.getAttribute(it).toString() == consumerAttributes_${configuration}.getAttribute(it).toString()
+                    } else {
+                        def desugared = Attribute.of(it.name, String)
+                        assert result_${configuration}.requestedAttributes.getAttribute(desugared) == consumerAttributes_${configuration}.getAttribute(it).toString()
+                    }
                 }
             """
         }
@@ -862,5 +866,118 @@ testRuntimeClasspath
         and:
         fails("selectArtifacts")
         failure.assertHasCause("Realized artifact task")
+    }
+
+    def "exposes root variant"() {
+        mavenRepo.module("org", "foo").publish()
+
+        buildFile << """
+            plugins {
+                id("java-library")
+            }
+
+            ${mavenTestRepository()}
+
+            dependencies {
+                ${hasDependencies ? 'implementation("org:foo:1.0")' : "" }
+            }
+
+            task resolve {
+                def rootComponent = configurations.runtimeClasspath.incoming.resolutionResult.rootComponent
+                def rootVariant = configurations.runtimeClasspath.incoming.resolutionResult.rootVariant
+                doLast {
+                    def componentRootVariant = rootComponent.get().variants.find { it.displayName == "runtimeClasspath" }
+                    assert rootVariant.get() == componentRootVariant
+                }
+            }
+        """
+
+        expect:
+        succeeds("resolve")
+
+        where:
+        hasDependencies << [true, false]
+    }
+
+    def "handles graphs with cycles"() {
+        settingsFile << """
+            include 'other'
+        """
+        file("other/build.gradle") << """
+            configurations {
+                dependencyScope("implementation")
+                consumable("runtimeElements") {
+                    extendsFrom(implementation)
+                    attributes {
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "cat"))
+                    }
+                }
+            }
+
+            dependencies {
+                implementation(project(":"))
+            }
+        """
+
+        buildFile << """
+            configurations {
+                dependencyScope("implementation")
+                consumable("runtimeElements") {
+                    extendsFrom(implementation)
+                    attributes {
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "cat"))
+                    }
+                }
+                resolvable("runtimeClasspath") {
+                    extendsFrom(implementation)
+                    attributes {
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "cat"))
+                    }
+                }
+            }
+
+            dependencies {
+                implementation(project(":other"))
+            }
+
+            task resolve {
+                def rootVariantProvider = configurations.runtimeClasspath.incoming.resolutionResult.rootVariant
+                def rootComponentProvider = configurations.runtimeClasspath.incoming.resolutionResult.rootComponent
+                doLast {
+                    def rootVariant = rootVariantProvider.get()
+                    def rootComponent = rootComponentProvider.get()
+
+                    def rootDependencies = rootComponent.getDependenciesForVariant(rootVariant)
+                    assert rootComponent.dependencies.size() == 1
+                    assert rootDependencies.size() == 1
+                    assert rootDependencies[0] == rootComponent.dependencies[0]
+
+                    def rootDependency = rootDependencies[0]
+                    assert rootDependency instanceof ResolvedDependencyResult
+
+                    def otherComponent = rootDependency.selected
+                    def otherVariant = rootDependency.resolvedVariant
+
+                    def otherDependencies = otherComponent.getDependenciesForVariant(otherVariant)
+                    assert otherComponent.dependencies.size() == 1
+                    assert otherDependencies.size() == 1
+                    assert otherDependencies[0] == otherComponent.dependencies[0]
+
+                    def otherDependency = otherDependencies[0]
+                    assert otherDependency instanceof ResolvedDependencyResult
+                    assert otherDependency.selected == rootComponent
+
+                    def runtimeElements = otherDependency.resolvedVariant
+                    def runtimeElementsDependencies = rootComponent.getDependenciesForVariant(runtimeElements)
+
+                    assert runtimeElementsDependencies.size() == 1
+                    assert runtimeElementsDependencies[0].selected == otherComponent
+                    assert runtimeElementsDependencies[0].resolvedVariant == otherVariant
+                }
+            }
+        """
+
+        expect:
+        succeeds("resolve")
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -99,7 +99,6 @@ import org.gradle.api.internal.artifacts.transform.TransformRegistrationFactory;
 import org.gradle.api.internal.artifacts.transform.VariantSelectorFactory;
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeRegistry;
-import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.DefaultAttributesSchema;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -521,7 +520,6 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             BuildState currentBuild,
             ComponentSelectionDescriptorFactory componentSelectionDescriptorFactory,
             ResolvedArtifactSetResolver artifactSetResolver,
-            AttributeDesugaring attributeDesugaring,
             ResolveExceptionContextualizer resolveExceptionContextualizer,
             ComponentDetailsSerializer componentDetailsSerializer,
             SelectedVariantSerializer selectedVariantSerializer,
@@ -549,7 +547,6 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 componentSelectorConverter,
                 attributeContainerSerializer,
                 currentBuild,
-                attributeDesugaring,
                 artifactSetResolver,
                 componentSelectionDescriptorFactory,
                 resolveExceptionContextualizer,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -99,6 +99,7 @@ import org.gradle.api.internal.artifacts.transform.TransformRegistrationFactory;
 import org.gradle.api.internal.artifacts.transform.VariantSelectorFactory;
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeRegistry;
+import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.DefaultAttributesSchema;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -530,7 +531,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             List<ResolverProviderFactory> resolverFactories,
             ExternalModuleComponentResolverFactory moduleDependencyResolverFactory,
             ProjectDependencyResolver projectDependencyResolver,
-            DependencyLockingProvider dependencyLockingProvider
+            DependencyLockingProvider dependencyLockingProvider,
+            AttributeDesugaring attributeDesugaring
         ) {
             DefaultConfigurationResolver defaultResolver = new DefaultConfigurationResolver(
                 dependencyGraphResolver,
@@ -566,7 +568,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 defaultResolver,
                 componentIdentifierFactory,
                 moduleIdentifierFactory,
-                currentBuild.getBuildIdentifier()
+                attributeDesugaring
             );
         }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -76,11 +76,12 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvi
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSelectionSpec;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults;
 import org.gradle.api.internal.artifacts.resolver.DefaultResolutionOutputs;
 import org.gradle.api.internal.artifacts.resolver.ResolutionHandle;
 import org.gradle.api.internal.artifacts.resolver.ResolutionOutputsInternal;
 import org.gradle.api.internal.artifacts.result.DefaultResolutionResult;
+import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
+import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal;
 import org.gradle.api.internal.artifacts.transform.DefaultTransformUpstreamDependenciesResolverFactory;
 import org.gradle.api.internal.artifacts.transform.TransformUpstreamDependenciesResolverFactory;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
@@ -145,6 +146,7 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -813,8 +815,12 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
                 // because:
                 // 1. the `failed` method will have been called with the user facing error
                 // 2. such an error may still lead to a valid dependency graph
-                ResolutionResult resolutionResult = new DefaultResolutionResult(results.getVisitedGraph().getResolutionResult(), attributeDesugaring);
-                context.setResult(ResolveConfigurationResolutionBuildOperationResult.create(resolutionResult, attributesFactory));
+                MinimalResolutionResult resolutionResult = results.getVisitedGraph().getResolutionResult();
+                context.setResult(new ResolveConfigurationResolutionBuildOperationResult(
+                    resolutionResult.getRootSource(),
+                    resolutionResult.getRequestedAttributes(),
+                    attributeDesugaring
+                ));
             }
 
             @Override
@@ -912,13 +918,13 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     public TransformUpstreamDependenciesResolverFactory getDependenciesResolverFactory() {
         warnOnInvalidInternalAPIUsage("getDependenciesResolverFactory()", ProperMethodUsage.RESOLVABLE);
         if (dependenciesResolverFactory == null) {
-            ResolutionResultProvider<ResolutionResult> resolutionResultProvider =
+            ResolutionResultProvider<Supplier<ResolvedComponentResultInternal>> rootComponentProvider =
                 new ResolverResultsResolutionResultProvider(true)
-                    .map(results -> new DefaultResolutionResult(results.getVisitedGraph().getResolutionResult(), attributeDesugaring));
+                    .map(results -> results.getVisitedGraph().getResolutionResult().getRootSource());
 
             dependenciesResolverFactory = new DefaultTransformUpstreamDependenciesResolverFactory(
                 getIdentity(),
-                resolutionResultProvider,
+                rootComponentProvider,
                 domainObjectContext,
                 calculatedValueContainerFactory,
                 (attributes, filter) -> {
@@ -1928,13 +1934,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         @Override
         public ResolutionResult getResolutionResult() {
             assertIsResolvable();
-            return new DefaultResolutionResult(() -> {
-                VisitedGraphResults graph = resolutionOutputs.getSource().getResults().getValue().getVisitedGraph();
-                graph.getResolutionFailure().ifPresent(ex -> {
-                    throw ex;
-                });
-                return graph.getResolutionResult();
-            }, attributeDesugaring);
+            return new DefaultResolutionResult(resolutionOutputs, attributeDesugaring);
         }
 
         @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationFactory.java
@@ -27,6 +27,7 @@ import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory;
 import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParserFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder;
+import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -64,6 +65,7 @@ public class DefaultConfigurationFactory {
     private final NotationParser<Object, Capability> capabilityNotationParser;
     private final ImmutableAttributesFactory attributesFactory;
     private final ResolveExceptionContextualizer exceptionContextualizer;
+    private final AttributeDesugaring attributeDesugaring;
     private final UserCodeApplicationContext userCodeApplicationContext;
     private final ProjectStateRegistry projectStateRegistry;
     private final WorkerThreadRegistry workerThreadRegistry;
@@ -85,6 +87,7 @@ public class DefaultConfigurationFactory {
         PublishArtifactNotationParserFactory artifactNotationParserFactory,
         ImmutableAttributesFactory attributesFactory,
         ResolveExceptionContextualizer exceptionContextualizer,
+        AttributeDesugaring attributeDesugaring,
         UserCodeApplicationContext userCodeApplicationContext,
         ProjectStateRegistry projectStateRegistry,
         WorkerThreadRegistry workerThreadRegistry,
@@ -105,6 +108,7 @@ public class DefaultConfigurationFactory {
         this.capabilityNotationParser = new CapabilityNotationParserFactory(true).create();
         this.attributesFactory = attributesFactory;
         this.exceptionContextualizer = exceptionContextualizer;
+        this.attributeDesugaring = attributeDesugaring;
         this.userCodeApplicationContext = userCodeApplicationContext;
         this.projectStateRegistry = projectStateRegistry;
         this.workerThreadRegistry = workerThreadRegistry;
@@ -144,6 +148,7 @@ public class DefaultConfigurationFactory {
                 attributesFactory,
                 rootComponentMetadataBuilder,
                 exceptionContextualizer,
+                attributeDesugaring,
                 userCodeApplicationContext,
                 projectStateRegistry,
                 workerThreadRegistry,
@@ -187,6 +192,7 @@ public class DefaultConfigurationFactory {
             attributesFactory,
             rootComponentMetadataBuilder,
             exceptionContextualizer,
+            attributeDesugaring,
             userCodeApplicationContext,
             projectStateRegistry,
             workerThreadRegistry,
@@ -229,6 +235,7 @@ public class DefaultConfigurationFactory {
             attributesFactory,
             rootComponentMetadataBuilder,
             exceptionContextualizer,
+            attributeDesugaring,
             userCodeApplicationContext,
             projectStateRegistry,
             workerThreadRegistry,
@@ -271,6 +278,7 @@ public class DefaultConfigurationFactory {
             attributesFactory,
             rootComponentMetadataBuilder,
             exceptionContextualizer,
+            attributeDesugaring,
             userCodeApplicationContext,
             projectStateRegistry,
             workerThreadRegistry,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConsumableConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConsumableConfiguration.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.artifacts.ResolveExceptionContextualizer;
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder;
+import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -63,6 +64,7 @@ public class DefaultConsumableConfiguration extends DefaultConfiguration impleme
         ImmutableAttributesFactory attributesFactory,
         RootComponentMetadataBuilder rootComponentMetadataBuilder,
         ResolveExceptionContextualizer exceptionContextualizer,
+        AttributeDesugaring attributeDesugaring,
         UserCodeApplicationContext userCodeApplicationContext,
         ProjectStateRegistry projectStateRegistry,
         WorkerThreadRegistry workerThreadRegistry,
@@ -89,6 +91,7 @@ public class DefaultConsumableConfiguration extends DefaultConfiguration impleme
             attributesFactory,
             rootComponentMetadataBuilder,
             exceptionContextualizer,
+            attributeDesugaring,
             userCodeApplicationContext,
             projectStateRegistry,
             workerThreadRegistry,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultDependencyScopeConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultDependencyScopeConfiguration.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.artifacts.ResolveExceptionContextualizer;
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder;
+import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -63,6 +64,7 @@ public class DefaultDependencyScopeConfiguration extends DefaultConfiguration im
         ImmutableAttributesFactory attributesFactory,
         RootComponentMetadataBuilder rootComponentMetadataBuilder,
         ResolveExceptionContextualizer exceptionContextualizer,
+        AttributeDesugaring attributeDesugaring,
         UserCodeApplicationContext userCodeApplicationContext,
         ProjectStateRegistry projectStateRegistry,
         WorkerThreadRegistry workerThreadRegistry,
@@ -89,6 +91,7 @@ public class DefaultDependencyScopeConfiguration extends DefaultConfiguration im
             attributesFactory,
             rootComponentMetadataBuilder,
             exceptionContextualizer,
+            attributeDesugaring,
             userCodeApplicationContext,
             projectStateRegistry,
             workerThreadRegistry,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultResolvableConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultResolvableConfiguration.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.artifacts.ResolveExceptionContextualizer;
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder;
+import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -63,6 +64,7 @@ public class DefaultResolvableConfiguration extends DefaultConfiguration impleme
         ImmutableAttributesFactory attributesFactory,
         RootComponentMetadataBuilder rootComponentMetadataBuilder,
         ResolveExceptionContextualizer exceptionContextualizer,
+        AttributeDesugaring attributeDesugaring,
         UserCodeApplicationContext userCodeApplicationContext,
         ProjectStateRegistry projectStateRegistry,
         WorkerThreadRegistry workerThreadRegistry,
@@ -89,6 +91,7 @@ public class DefaultResolvableConfiguration extends DefaultConfiguration impleme
             attributesFactory,
             rootComponentMetadataBuilder,
             exceptionContextualizer,
+            attributeDesugaring,
             userCodeApplicationContext,
             projectStateRegistry,
             workerThreadRegistry,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultUnlockedConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultUnlockedConfiguration.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.ResolveExceptionContextualizer;
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder;
+import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -62,6 +63,7 @@ public class DefaultUnlockedConfiguration extends DefaultConfiguration {
         ImmutableAttributesFactory attributesFactory,
         RootComponentMetadataBuilder rootComponentMetadataBuilder,
         ResolveExceptionContextualizer exceptionContextualizer,
+        AttributeDesugaring attributeDesugaring,
         UserCodeApplicationContext userCodeApplicationContext,
         ProjectStateRegistry projectStateRegistry,
         WorkerThreadRegistry workerThreadRegistry,
@@ -89,6 +91,7 @@ public class DefaultUnlockedConfiguration extends DefaultConfiguration {
             attributesFactory,
             rootComponentMetadataBuilder,
             exceptionContextualizer,
+            attributeDesugaring,
             userCodeApplicationContext,
             projectStateRegistry,
             workerThreadRegistry,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolvableDependenciesInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolvableDependenciesInternal.java
@@ -16,8 +16,12 @@
 package org.gradle.api.internal.artifacts.configurations;
 
 import org.gradle.api.artifacts.ResolvableDependencies;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults;
+import org.gradle.api.internal.artifacts.resolver.ResolutionOutputsInternal;
 
 public interface ResolvableDependenciesInternal extends ResolvableDependencies  {
-    ResolutionResultProvider<VisitedGraphResults> getGraphResultsProvider();
+
+    /**
+     * An experimental representation of dependency resolution outputs.
+     */
+    ResolutionOutputsInternal getResolutionOutputs();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolveConfigurationResolutionBuildOperationResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolveConfigurationResolutionBuildOperationResult.java
@@ -18,45 +18,40 @@ package org.gradle.api.internal.artifacts.configurations;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import org.gradle.api.Named;
-import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
-import org.gradle.api.internal.attributes.AttributeValue;
+import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
-import org.gradle.api.provider.Provider;
+import org.gradle.internal.Actions;
+import org.gradle.internal.lazy.Lazy;
 import org.gradle.internal.operations.trace.CustomOperationTraceSerialization;
 
-import javax.annotation.Nullable;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.gradle.api.internal.artifacts.result.DefaultResolvedComponentResult.eachElement;
 
 class ResolveConfigurationResolutionBuildOperationResult implements ResolveConfigurationDependenciesBuildOperationType.Result, CustomOperationTraceSerialization {
-    private final ResolutionResult resolutionResult;
-    private final AttributeContainer requestedAttributes;
+    private final Supplier<ResolvedComponentResultInternal> rootSource;
+    private final Lazy<ImmutableAttributes> desugaredAttributes;
 
-    static ResolveConfigurationResolutionBuildOperationResult create(ResolutionResult resolutionResult, ImmutableAttributesFactory attributesFactory) {
-        return new ResolveConfigurationResolutionBuildOperationResult(
-                resolutionResult,
-                new LazyDesugaringAttributeContainer(resolutionResult.getRequestedAttributes(), attributesFactory)
-        );
-    }
-
-    private ResolveConfigurationResolutionBuildOperationResult(ResolutionResult resolutionResult, AttributeContainer requestedAttributes) {
-        this.resolutionResult = resolutionResult;
-        this.requestedAttributes = requestedAttributes;
+    public ResolveConfigurationResolutionBuildOperationResult(
+        Supplier<ResolvedComponentResultInternal> rootSource,
+        ImmutableAttributes requestedAttributes,
+        AttributeDesugaring attributeDesugaring
+    ) {
+        this.rootSource = rootSource;
+        this.desugaredAttributes = Lazy.unsafe().of(() -> attributeDesugaring.desugar(requestedAttributes));
     }
 
     @Override
     public ResolvedComponentResult getRootComponent() {
-        return resolutionResult.getRoot();
+        return rootSource.get();
     }
 
     @Override
@@ -68,149 +63,27 @@ class ResolveConfigurationResolutionBuildOperationResult implements ResolveConfi
     public Object getCustomOperationTraceSerializableModel() {
         Map<String, Object> model = new HashMap<>();
         model.put("resolvedDependenciesCount", getRootComponent().getDependencies().size());
+
         final Map<String, Map<String, String>> components = new HashMap<>();
-        resolutionResult.allComponents(component -> components.put(
+        eachElement(rootSource.get(), component -> components.put(
             component.getId().getDisplayName(),
             Collections.singletonMap("repoId", getRepositoryId(component))
-        ));
+        ), Actions.doNothing(), new HashSet<>());
         model.put("components", components);
+
+        AttributeContainer requestedAttributes = desugaredAttributes.get();
         ImmutableList.Builder<Object> requestedAttributesBuilder = new ImmutableList.Builder<>();
         for (Attribute<?> att : requestedAttributes.keySet()) {
             requestedAttributesBuilder.add(ImmutableMap.of("name", att.getName(), "value", requestedAttributes.getAttribute(att).toString()));
         }
         model.put("requestedAttributes", requestedAttributesBuilder.build());
+
         return model;
     }
 
     @Override
     public AttributeContainer getRequestedAttributes() {
-        return requestedAttributes;
-    }
-
-    // This does almost the same thing as passing through DesugaredAttributeContainerSerializer / DesugaringAttributeContainerSerializer.
-    // Those make some assumptions about allowed attribute value types that we can't - we serialize everything else to a string instead.
-    private static final class LazyDesugaringAttributeContainer implements ImmutableAttributes {
-
-        private final AttributeContainer source;
-        private final ImmutableAttributesFactory attributesFactory;
-        private ImmutableAttributes desugared;
-
-        private LazyDesugaringAttributeContainer(@Nullable AttributeContainer source, ImmutableAttributesFactory attributesFactory) {
-            this.source = source;
-            this.attributesFactory = attributesFactory;
-        }
-
-        @Override
-        public ImmutableSet<Attribute<?>> keySet() {
-            return getDesugared().keySet();
-        }
-
-        @Deprecated
-        @Override
-        public <T> AttributeContainer attribute(Attribute<T> key, T value) {
-            return getDesugared().attribute(key, value);
-        }
-
-        @Deprecated
-        @Override
-        public <T> AttributeContainer attributeProvider(Attribute<T> key, Provider<? extends T> provider) {
-            return getDesugared().attributeProvider(key, provider);
-        }
-
-        @Nullable
-        @Override
-        public <T> T getAttribute(Attribute<T> key) {
-            return getDesugared().getAttribute(key);
-        }
-
-        @Override
-        public boolean isEmpty() {
-            return getDesugared().isEmpty();
-        }
-
-        @Override
-        public boolean contains(Attribute<?> key) {
-            return getDesugared().contains(key);
-        }
-
-        @Override
-        public AttributeContainer getAttributes() {
-            return getDesugared().getAttributes();
-        }
-
-        @Override
-        public ImmutableAttributes asImmutable() {
-            return getDesugared();
-        }
-
-        @Override
-        public Map<Attribute<?>, ?> asMap() {
-            return getDesugared().asMap();
-        }
-
-        @Override
-        public <T> AttributeValue<T> findEntry(Attribute<T> key) {
-            return getDesugared().findEntry(key);
-        }
-
-        @Override
-        public AttributeValue<?> findEntry(String name) {
-            return getDesugared().findEntry(name);
-        }
-
-        @Override
-        public String toString() {
-            return getDesugared().toString();
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            return getDesugared().equals(obj);
-        }
-
-        @Override
-        public int hashCode() {
-            return getDesugared().hashCode();
-        }
-
-        private ImmutableAttributes getDesugared() {
-            if (desugared == null) {
-                desugarAttributes();
-            }
-            return desugared;
-        }
-
-        @SuppressWarnings("unchecked")
-        private void desugarAttributes() {
-            AttributeContainerInternal result = attributesFactory.mutable();
-            if (source != null) {
-                for (Attribute<?> attribute : source.keySet()) {
-                    String name = attribute.getName();
-                    Class<?> type = attribute.getType();
-                    Object attributeValue = source.getAttribute(attribute);
-                    if (type.equals(Boolean.class)) {
-                        result.attribute((Attribute<Boolean>) attribute, (Boolean) attributeValue);
-                    } else if (type.equals(String.class)) {
-                        result.attribute((Attribute<String>) attribute, (String) attributeValue);
-                    } else if (type.equals(Integer.class)) {
-                        result.attribute((Attribute<Integer>) attribute, (Integer) attributeValue);
-                    } else {
-                        // just serialize as a String as best we can
-                        Attribute<String> stringAtt = Attribute.of(name, String.class);
-                        String stringValue;
-                        if (attributeValue instanceof Named) {
-                            stringValue = ((Named) attributeValue).getName();
-                        } else if (attributeValue instanceof Object[]) { // don't bother trying to handle primitive arrays specially
-                            stringValue = Arrays.toString((Object[]) attributeValue);
-                        } else {
-                            stringValue = attributeValue.toString();
-                        }
-                        result.attribute(stringAtt, stringValue);
-                    }
-                }
-            }
-            desugared = result.asImmutable();
-        }
+        return desugaredAttributes.get();
     }
 
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -25,7 +25,6 @@ import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.UnresolvedDependency;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
@@ -84,10 +83,10 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.store.StoreSet
 import org.gradle.api.internal.artifacts.repositories.ContentFilteringRepository;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
 import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
+import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal;
 import org.gradle.api.internal.artifacts.transform.ArtifactVariantSelector;
 import org.gradle.api.internal.artifacts.transform.VariantSelectorFactory;
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
-import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.project.ProjectStateRegistry;
@@ -127,7 +126,6 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
     private final ComponentSelectorConverter componentSelectorConverter;
     private final AttributeContainerSerializer attributeContainerSerializer;
     private final BuildIdentifier currentBuild;
-    private final AttributeDesugaring attributeDesugaring;
     private final ResolvedArtifactSetResolver artifactSetResolver;
     private final ComponentSelectionDescriptorFactory componentSelectionDescriptorFactory;
     private final ResolveExceptionContextualizer exceptionContextualizer;
@@ -157,7 +155,6 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         ComponentSelectorConverter componentSelectorConverter,
         AttributeContainerSerializer attributeContainerSerializer,
         BuildState currentBuild,
-        AttributeDesugaring attributeDesugaring,
         ResolvedArtifactSetResolver artifactSetResolver,
         ComponentSelectionDescriptorFactory componentSelectionDescriptorFactory,
         ResolveExceptionContextualizer exceptionContextualizer,
@@ -186,7 +183,6 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         this.componentSelectorConverter = componentSelectorConverter;
         this.attributeContainerSerializer = attributeContainerSerializer;
         this.currentBuild = currentBuild.getBuildIdentifier();
-        this.attributeDesugaring = attributeDesugaring;
         this.artifactSetResolver = artifactSetResolver;
         this.componentSelectionDescriptorFactory = componentSelectionDescriptorFactory;
         this.exceptionContextualizer = exceptionContextualizer;
@@ -245,9 +241,9 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         ResolvedConfigurationDependencyGraphVisitor oldModelVisitor = new ResolvedConfigurationDependencyGraphVisitor(oldModelBuilder);
 
         BinaryStore newModelStore = stores.nextBinaryStore();
-        Store<ResolvedComponentResult> newModelCache = stores.newModelCache();
+        Store<ResolvedComponentResultInternal> newModelCache = stores.newModelCache();
         ResolutionStrategyInternal resolutionStrategy = resolveContext.getResolutionStrategy();
-        StreamingResolutionResultBuilder newModelBuilder = new StreamingResolutionResultBuilder(newModelStore, newModelCache, attributeContainerSerializer, componentDetailsSerializer, selectedVariantSerializer, attributeDesugaring, componentSelectionDescriptorFactory, resolutionStrategy.getReturnAllVariants());
+        StreamingResolutionResultBuilder newModelBuilder = new StreamingResolutionResultBuilder(newModelStore, newModelCache, attributeContainerSerializer, componentDetailsSerializer, selectedVariantSerializer, componentSelectionDescriptorFactory, resolutionStrategy.getReturnAllVariants());
 
         ResolvedLocalComponentsResultGraphVisitor localComponentsVisitor = new ResolvedLocalComponentsResultGraphVisitor(currentBuild, projectStateRegistry);
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/InMemoryResolutionResultBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/InMemoryResolutionResultBuilder.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.ivyservice;
 
 import org.gradle.api.artifacts.result.ResolutionResult;
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphComponent;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
@@ -27,6 +26,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGrap
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.DefaultResolutionResultBuilder;
 import org.gradle.api.internal.artifacts.result.DefaultMinimalResolutionResult;
 import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
+import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 
 /**
@@ -38,8 +38,17 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
 public class InMemoryResolutionResultBuilder implements DependencyGraphVisitor {
 
     private final DefaultResolutionResultBuilder resolutionResultBuilder = new DefaultResolutionResultBuilder();
-    private ResolvedComponentResult root;
+
+    private long rootVariantId;
+    private long rootComponentId;
     private ImmutableAttributes requestAttributes;
+
+    @Override
+    public void start(RootGraphNode root) {
+        this.rootVariantId = root.getNodeId();
+        this.rootComponentId = root.getOwner().getResultId();
+        this.requestAttributes = root.getResolveState().getAttributes();
+    }
 
     @Override
     public void visitNode(DependencyGraphNode node) {
@@ -58,17 +67,11 @@ public class InMemoryResolutionResultBuilder implements DependencyGraphVisitor {
         resolutionResultBuilder.visitOutgoingEdges(node.getOwner().getResultId(), node.getOutgoingEdges());
     }
 
-    @Override
-    public void finish(RootGraphNode root) {
-        Long resultId = root.getOwner().getResultId();
-        this.root = resolutionResultBuilder.getRoot(resultId);
-        this.requestAttributes = root.getResolveState().getAttributes();
-    }
-
     public MinimalResolutionResult getResolutionResult() {
         if (requestAttributes == null) {
             throw new IllegalStateException("Resolution result not computed yet");
         }
-        return new DefaultMinimalResolutionResult(() -> root, requestAttributes);
+        ResolvedComponentResultInternal root = resolutionResultBuilder.getRoot(rootComponentId);
+        return new DefaultMinimalResolutionResult(rootVariantId, () -> root, requestAttributes);
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
@@ -24,7 +24,6 @@ import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.UnresolvedDependency;
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
 import org.gradle.api.internal.artifacts.DefaultResolverResults;
@@ -44,6 +43,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.DefaultResolutionResultBuilder;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
 import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
+import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.specs.Spec;
@@ -58,13 +58,18 @@ public class ShortCircuitEmptyConfigurationResolver implements ConfigurationReso
     private final ConfigurationResolver delegate;
     private final ComponentIdentifierFactory componentIdentifierFactory;
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
-    private final BuildIdentifier thisBuild;
+    private final AttributeDesugaring attributeDesugaring;
 
-    public ShortCircuitEmptyConfigurationResolver(ConfigurationResolver delegate, ComponentIdentifierFactory componentIdentifierFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory, BuildIdentifier thisBuild) {
+    public ShortCircuitEmptyConfigurationResolver(
+        ConfigurationResolver delegate,
+        ComponentIdentifierFactory componentIdentifierFactory,
+        ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+        AttributeDesugaring attributeDesugaring
+    ) {
         this.delegate = delegate;
         this.componentIdentifierFactory = componentIdentifierFactory;
         this.moduleIdentifierFactory = moduleIdentifierFactory;
-        this.thisBuild = thisBuild;
+        this.attributeDesugaring = attributeDesugaring;
     }
 
     @Override
@@ -117,7 +122,7 @@ public class ShortCircuitEmptyConfigurationResolver implements ConfigurationReso
         Module module = resolveContext.getModule();
         ModuleVersionIdentifier id = moduleIdentifierFactory.moduleWithVersion(module.getGroup(), module.getName(), module.getVersion());
         ComponentIdentifier componentIdentifier = componentIdentifierFactory.createComponentIdentifier(module);
-        MinimalResolutionResult emptyResult = DefaultResolutionResultBuilder.empty(id, componentIdentifier, resolveContext.getAttributes().asImmutable());
+        MinimalResolutionResult emptyResult = DefaultResolutionResultBuilder.empty(id, componentIdentifier, resolveContext.getAttributes().asImmutable(), resolveContext.getName(), attributeDesugaring);
         return new DefaultVisitedGraphResults(emptyResult, Collections.emptySet(), null);
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphComponent.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphComponent.java
@@ -33,7 +33,7 @@ public interface ResolvedGraphComponent {
      * Returns a simple id for this component, unique across components in the same graph.
      * This id cannot be used across graphs.
      */
-    Long getResultId();
+    long getResultId();
 
     ComponentGraphResolveState getResolveState();
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphDependency.java
@@ -50,7 +50,7 @@ public interface ResolvedGraphDependency {
     /**
      * Returns the simple id of the source variant, as per {@link ResolvedGraphVariant#getNodeId()}.
      */
-    Long getFromVariant();
+    long getFromVariant();
 
     /**
      * Returns the simple id of the selected variant, as per {@link ResolvedGraphVariant#getNodeId()}.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -77,14 +77,14 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
     private boolean root;
     private Pair<Capability, Collection<NodeState>> capabilityReject;
 
-    ComponentState(Long resultId, ModuleResolveState module, ModuleVersionIdentifier id, ComponentIdentifier componentIdentifier, ComponentMetaDataResolver resolver) {
+    ComponentState(long resultId, ModuleResolveState module, ModuleVersionIdentifier id, ComponentIdentifier componentIdentifier, ComponentMetaDataResolver resolver) {
         this.resultId = resultId;
         this.module = module;
         this.id = id;
         this.componentIdentifier = componentIdentifier;
         this.resolver = resolver;
         this.implicitCapability = DefaultImmutableCapability.defaultCapabilityForComponent(id);
-        this.hashCode = 31 * id.hashCode() ^ resultId.hashCode();
+        this.hashCode = 31 * id.hashCode() ^ Long.hashCode(resultId);
     }
 
     @Override
@@ -98,7 +98,7 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
     }
 
     @Override
-    public Long getResultId() {
+    public long getResultId() {
         return resultId;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -416,7 +416,7 @@ class EdgeState implements DependencyGraphEdge {
     }
 
     @Override
-    public Long getFromVariant() {
+    public long getFromVariant() {
         return from.getNodeId();
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -77,7 +77,7 @@ import java.util.stream.Collectors;
  */
 public class NodeState implements DependencyGraphNode {
     private static final Logger LOGGER = LoggerFactory.getLogger(NodeState.class);
-    private final Long nodeId;
+    private final long nodeId;
     private final ComponentState component;
     private final List<EdgeState> incomingEdges = new ArrayList<>();
     private final List<EdgeState> outgoingEdges = new ArrayList<>();
@@ -168,7 +168,7 @@ public class NodeState implements DependencyGraphNode {
     }
 
     @Override
-    public Long getNodeId() {
+    public long getNodeId() {
         return nodeId;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilder.java
@@ -28,13 +28,13 @@ import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.artifacts.result.ComponentSelectionCause;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
 import org.gradle.api.artifacts.result.DependencyResult;
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphDependency;
 import org.gradle.api.internal.artifacts.result.DefaultMinimalResolutionResult;
 import org.gradle.api.internal.artifacts.result.DefaultResolvedComponentResult;
 import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
+import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Describables;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
@@ -64,13 +64,14 @@ public class DefaultResolutionResultBuilder implements ResolvedComponentVisitor 
         DefaultResolutionResultBuilder builder = new DefaultResolutionResultBuilder();
         builder.startVisitComponent(0L, ComponentSelectionReasons.root(), null);
         builder.visitComponentDetails(componentIdentifier, id);
+        // TODO: An empty root component should have a root variant.
         builder.visitComponentVariants(Collections.emptyList());
         builder.endVisitComponent();
-        ResolvedComponentResult root = builder.getRoot(0L);
-        return new DefaultMinimalResolutionResult(() -> root, attributes);
+        ResolvedComponentResultInternal root = builder.getRoot(0L);
+        return new DefaultMinimalResolutionResult(-1, () -> root, attributes);
     }
 
-    public ResolvedComponentResult getRoot(long rootId) {
+    public ResolvedComponentResultInternal getRoot(long rootId) {
         return components.get(rootId);
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DetachedResolvedGraphDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DetachedResolvedGraphDependency.java
@@ -32,7 +32,7 @@ public class DetachedResolvedGraphDependency implements ResolvedGraphDependency 
     private final ComponentSelectionReason reason;
     private final ModuleVersionResolveException failure;
     private final boolean constraint;
-    private final Long fromVariant;
+    private final long fromVariant;
     private final Long targetVariant;
 
     public DetachedResolvedGraphDependency(ComponentSelector requested,
@@ -40,7 +40,7 @@ public class DetachedResolvedGraphDependency implements ResolvedGraphDependency 
                                            ComponentSelectionReason reason,
                                            ModuleVersionResolveException failure,
                                            boolean constraint,
-                                           Long fromVariant,
+                                           long fromVariant,
                                            Long targetVariant
     ) {
         assert requested != null;
@@ -81,7 +81,7 @@ public class DetachedResolvedGraphDependency implements ResolvedGraphDependency 
     }
 
     @Override
-    public Long getFromVariant() {
+    public long getFromVariant() {
         return fromVariant;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.UnresolvedDependency;
 import org.gradle.api.artifacts.component.ComponentSelector;
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphComponent;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphEdge;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
@@ -29,7 +28,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.Resolved
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode;
 import org.gradle.api.internal.artifacts.result.DefaultMinimalResolutionResult;
 import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
-import org.gradle.api.internal.attributes.AttributeDesugaring;
+import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -61,22 +60,21 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
     private final Map<ComponentSelector, ModuleVersionResolveException> failures = new HashMap<>();
     private final BinaryStore store;
     private final ComponentResultSerializer componentResultSerializer;
-    private final Store<ResolvedComponentResult> cache;
+    private final Store<ResolvedComponentResultInternal> cache;
     private final ComponentSelectorSerializer componentSelectorSerializer;
     private final DependencyResultSerializer dependencyResultSerializer;
     private final Set<Long> visitedComponents = new HashSet<>();
-    private final AttributeDesugaring desugaring;
 
+    private long rootVariantId;
     private ImmutableAttributes rootAttributes;
     private boolean mayHaveVirtualPlatforms;
 
     public StreamingResolutionResultBuilder(
         BinaryStore store,
-        Store<ResolvedComponentResult> cache,
+        Store<ResolvedComponentResultInternal> cache,
         AttributeContainerSerializer attributeContainerSerializer,
         ComponentDetailsSerializer componentDetailsSerializer,
         SelectedVariantSerializer selectedVariantSerializer,
-        AttributeDesugaring desugaring,
         ComponentSelectionDescriptorFactory componentSelectionDescriptorFactory,
         boolean returnAllVariants
     ) {
@@ -85,19 +83,19 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
         this.store = store;
         this.cache = cache;
         this.componentSelectorSerializer = new ComponentSelectorSerializer(attributeContainerSerializer);
-        this.desugaring = desugaring;
     }
 
     public MinimalResolutionResult complete(Set<UnresolvedDependency> dependencyLockingFailures) {
         BinaryStore.BinaryData data = store.done();
         RootFactory rootSource = new RootFactory(data, failures, cache, componentSelectorSerializer, dependencyResultSerializer, componentResultSerializer, dependencyLockingFailures);
-        return new DefaultMinimalResolutionResult(rootSource::create, rootAttributes);
+        return new DefaultMinimalResolutionResult(rootVariantId, rootSource::create, rootAttributes);
     }
 
     @Override
     public void start(final RootGraphNode root) {
-        rootAttributes = desugaring.desugar(root.getMetadata().getAttributes());
-        mayHaveVirtualPlatforms = root.getResolveOptimizations().mayHaveVirtualPlatforms();
+        this.rootVariantId = root.getNodeId();
+        this.rootAttributes = root.getMetadata().getAttributes();
+        this.mayHaveVirtualPlatforms = root.getResolveOptimizations().mayHaveVirtualPlatforms();
     }
 
     @Override
@@ -153,20 +151,20 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
         }
     }
 
-    private static class RootFactory implements Factory<ResolvedComponentResult> {
+    private static class RootFactory implements Factory<ResolvedComponentResultInternal> {
 
         private final static Logger LOG = Logging.getLogger(RootFactory.class);
         private final ComponentResultSerializer componentResultSerializer;
 
         private final BinaryStore.BinaryData data;
         private final Map<ComponentSelector, ModuleVersionResolveException> failures;
-        private final Store<ResolvedComponentResult> cache;
+        private final Store<ResolvedComponentResultInternal> cache;
         private final Object lock = new Object();
         private final ComponentSelectorSerializer componentSelectorSerializer;
         private final DependencyResultSerializer dependencyResultSerializer;
         private final Set<UnresolvedDependency> dependencyLockingFailures;
 
-        RootFactory(BinaryStore.BinaryData data, Map<ComponentSelector, ModuleVersionResolveException> failures, Store<ResolvedComponentResult> cache, ComponentSelectorSerializer componentSelectorSerializer, DependencyResultSerializer dependencyResultSerializer, ComponentResultSerializer componentResultSerializer, Set<UnresolvedDependency> dependencyLockingFailures) {
+        RootFactory(BinaryStore.BinaryData data, Map<ComponentSelector, ModuleVersionResolveException> failures, Store<ResolvedComponentResultInternal> cache, ComponentSelectorSerializer componentSelectorSerializer, DependencyResultSerializer dependencyResultSerializer, ComponentResultSerializer componentResultSerializer, Set<UnresolvedDependency> dependencyLockingFailures) {
             this.data = data;
             this.failures = failures;
             this.cache = cache;
@@ -177,7 +175,7 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
         }
 
         @Override
-        public ResolvedComponentResult create() {
+        public ResolvedComponentResultInternal create() {
             synchronized (lock) {
                 return cache.load(() -> {
                     try {
@@ -193,7 +191,7 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
             }
         }
 
-        private ResolvedComponentResult deserialize(Decoder decoder) {
+        private ResolvedComponentResultInternal deserialize(Decoder decoder) {
             componentSelectorSerializer.reset();
             int valuesRead = 0;
             byte type = -1;
@@ -209,7 +207,7 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
                             // Last entry, complete the result
                             Long rootId = decoder.readSmallLong();
                             builder.addDependencyLockingFailures(rootId, dependencyLockingFailures);
-                            ResolvedComponentResult root = builder.getRoot(rootId);
+                            ResolvedComponentResultInternal root = builder.getRoot(rootId);
                             LOG.debug("Loaded resolution results ({}) from {}", clock.getElapsed(), data);
                             return root;
                         case COMPONENT:

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/ResolutionResultsStoreFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/ResolutionResultsStoreFactory.java
@@ -16,8 +16,8 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.store;
 
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.TransientConfigurationResults;
+import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal;
 import org.gradle.api.internal.file.temp.TemporaryFileProvider;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -40,7 +40,7 @@ public class ResolutionResultsStoreFactory implements Closeable {
     private final int maxSize;
 
     private CachedStoreFactory<TransientConfigurationResults> oldModelCache;
-    private CachedStoreFactory<ResolvedComponentResult> newModelCache;
+    private CachedStoreFactory<ResolvedComponentResultInternal> newModelCache;
 
     private final AtomicInteger storeSetBaseId = new AtomicInteger();
 
@@ -80,7 +80,7 @@ public class ResolutionResultsStoreFactory implements Closeable {
         return oldModelCache;
     }
 
-    private synchronized CachedStoreFactory<ResolvedComponentResult> getNewModelCache() {
+    private synchronized CachedStoreFactory<ResolvedComponentResultInternal> getNewModelCache() {
         if (newModelCache == null) {
             newModelCache = new CachedStoreFactory<>("Resolution result");
             cleanUpLater.add(newModelCache);
@@ -100,7 +100,7 @@ public class ResolutionResultsStoreFactory implements Closeable {
             }
 
             @Override
-            public Store<ResolvedComponentResult> newModelCache() {
+            public Store<ResolvedComponentResultInternal> newModelCache() {
                 return getNewModelCache().createCachedStore(storeSetId);
             }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/StoreSet.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/StoreSet.java
@@ -15,15 +15,15 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.store;
 
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.TransientConfigurationResults;
+import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal;
 import org.gradle.cache.internal.BinaryStore;
 import org.gradle.cache.internal.Store;
 
 public interface StoreSet {
     BinaryStore nextBinaryStore();
 
-    Store<ResolvedComponentResult> newModelCache();
+    Store<ResolvedComponentResultInternal> newModelCache();
 
     Store<TransientConfigurationResults> oldModelCache();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/resolver/DefaultResolutionOutputs.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/resolver/DefaultResolutionOutputs.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.resolver;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.ArtifactView;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.artifacts.result.ResolvedVariantResult;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.artifacts.ResolverResults;
+import org.gradle.api.internal.artifacts.configurations.ArtifactCollectionInternal;
+import org.gradle.api.internal.artifacts.configurations.DefaultArtifactCollection;
+import org.gradle.api.internal.artifacts.configurations.ResolutionBackedFileCollection;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSelectionSpec;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.SelectedArtifactSet;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults;
+import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.file.FileCollectionInternal;
+import org.gradle.api.internal.provider.DefaultProvider;
+import org.gradle.api.internal.tasks.TaskDependencyFactory;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.specs.Spec;
+import org.gradle.api.specs.Specs;
+import org.gradle.internal.Actions;
+import org.gradle.internal.model.CalculatedValueContainerFactory;
+import org.gradle.internal.reflect.Instantiator;
+
+/**
+ * Default implementation of {@link ResolutionOutputsInternal}. This class is in charge of
+ * converting internal results in the form of {@link ResolverResults} into public facing types like:
+ *
+ * <ul>
+ *     <li>{@link org.gradle.api.file.FileCollection}</li>
+ *     <li>{@link org.gradle.api.artifacts.ArtifactCollection}</li>
+ *     <li>{@link org.gradle.api.artifacts.ArtifactView}</li>
+ *     <li>{@link org.gradle.api.artifacts.result.ResolvedVariantResult}</li>
+ *     <li>{@link org.gradle.api.artifacts.result.ResolvedComponentResult}</li>
+ * </ul>
+ */
+public class DefaultResolutionOutputs implements ResolutionOutputsInternal {
+
+    private final ResolutionHandle resolutionHandle;
+    private final TaskDependencyFactory taskDependencyFactory;
+    private final CalculatedValueContainerFactory calculatedValueContainerFactory;
+    private final ImmutableAttributesFactory attributesFactory;
+    private final Instantiator instantiator;
+
+    public DefaultResolutionOutputs(
+        ResolutionHandle resolutionHandle,
+        TaskDependencyFactory taskDependencyFactory,
+        CalculatedValueContainerFactory calculatedValueContainerFactory,
+        ImmutableAttributesFactory attributesFactory,
+        Instantiator instantiator
+    ) {
+        this.resolutionHandle = resolutionHandle;
+        this.taskDependencyFactory = taskDependencyFactory;
+        this.calculatedValueContainerFactory = calculatedValueContainerFactory;
+        this.attributesFactory = attributesFactory;
+        this.instantiator = instantiator;
+    }
+
+    @Override
+    public ResolutionHandle getSource() {
+        return resolutionHandle;
+    }
+
+    @Override
+    public Provider<ResolvedVariantResult> getRootVariant() {
+        return new DefaultProvider<>(() -> {
+            MinimalResolutionResult resolutionResult = getVisitedGraphResults().getResolutionResult();
+            return resolutionResult.getRootSource().get().getVariant(resolutionResult.getRootVariantId());
+        });
+    }
+
+    @Override
+    public Provider<ResolvedComponentResult> getRootComponent() {
+        return new DefaultProvider<>(() -> getVisitedGraphResults().getResolutionResult().getRootSource().get());
+    }
+
+    /**
+     * Get the resolved graph, throwing any non-fatal exception that occurred during resolution.
+     */
+    private VisitedGraphResults getVisitedGraphResults() {
+        VisitedGraphResults graph = resolutionHandle.getResults().getValue().getVisitedGraph();
+        graph.getResolutionFailure().ifPresent(ex -> {
+            throw ex;
+        });
+        return graph;
+    }
+
+    @Override
+    public FileCollectionInternal getFiles() {
+        return doGetArtifactView(Actions.doNothing()).getFiles();
+    }
+
+    @Override
+    public ArtifactCollectionInternal getArtifacts() {
+        return doGetArtifactView(Actions.doNothing()).getArtifacts();
+    }
+
+    @Override
+    public ArtifactView artifactView(Action<? super ArtifactView.ViewConfiguration> action) {
+        return doGetArtifactView(action);
+    }
+
+    private DefaultArtifactView doGetArtifactView(Action<? super ArtifactView.ViewConfiguration> action) {
+        // We use the instantiator to generate closure-accepting methods.
+        DefaultArtifactViewConfiguration viewConfiguration = instantiator.newInstance(DefaultArtifactViewConfiguration.class, attributesFactory);
+        action.execute(viewConfiguration);
+
+        return new DefaultArtifactView(
+            viewConfiguration.lenient,
+            viewConfiguration.componentFilter,
+            viewConfiguration.reselectVariants,
+            viewConfiguration.viewAttributes.asImmutable(),
+
+            resolutionHandle,
+            taskDependencyFactory,
+            calculatedValueContainerFactory,
+            attributesFactory
+        );
+    }
+
+    @VisibleForTesting
+    public static class DefaultArtifactView implements ArtifactView {
+
+        // View configuration
+        private final boolean lenient;
+        private final Spec<? super ComponentIdentifier> componentFilter;
+        private final boolean reselectVariants;
+        private final ImmutableAttributes viewAttributes;
+
+        // Services
+        private final ResolutionHandle resolutionHandle;
+        private final TaskDependencyFactory taskDependencyFactory;
+        private final CalculatedValueContainerFactory calculatedValueContainerFactory;
+        private final ImmutableAttributesFactory attributesFactory;
+
+        public DefaultArtifactView(
+            boolean lenient,
+            Spec<? super ComponentIdentifier> componentFilter,
+            boolean reselectVariants,
+            ImmutableAttributes viewAttributes,
+
+            ResolutionHandle resolutionHandle,
+            TaskDependencyFactory taskDependencyFactory,
+            CalculatedValueContainerFactory calculatedValueContainerFactory,
+            ImmutableAttributesFactory attributesFactory
+        ) {
+            this.lenient = lenient;
+            this.componentFilter = componentFilter;
+            this.reselectVariants = reselectVariants;
+            this.viewAttributes = viewAttributes;
+
+            this.resolutionHandle = resolutionHandle;
+            this.taskDependencyFactory = taskDependencyFactory;
+            this.calculatedValueContainerFactory = calculatedValueContainerFactory;
+            this.attributesFactory = attributesFactory;
+        }
+
+        @Override
+        public ArtifactCollectionInternal getArtifacts() {
+            return new DefaultArtifactCollection(
+                getFiles(),
+                lenient,
+                resolutionHandle.getHost(),
+                calculatedValueContainerFactory
+            );
+        }
+
+        @Override
+        public ResolutionBackedFileCollection getFiles() {
+            return new ResolutionBackedFileCollection(
+                resolutionHandle.getResults().map(this::selectArtifacts),
+                lenient,
+                resolutionHandle.getHost(),
+                taskDependencyFactory
+            );
+        }
+
+        private SelectedArtifactSet selectArtifacts(ResolverResults results) {
+            // If the user set the view attributes, we allow variant matching to fail for no matching variants.
+            // If we are using the original request attributes, variant matching should not fail.
+            boolean allowNoMatchingVariants = !viewAttributes.isEmpty();
+
+            return results.getVisitedArtifacts().select(new ArtifactSelectionSpec(
+                getAttributes(),
+                componentFilter,
+                reselectVariants,
+                allowNoMatchingVariants,
+                resolutionHandle.getDefaultSortOrder()
+            ));
+        }
+
+        @Override
+        public ImmutableAttributes getAttributes() {
+            ImmutableAttributes baseAttributes = resolutionHandle.getAttributes();
+
+            // The user did not specify any attributes. Use the original request attributes.
+            if (viewAttributes.isEmpty()) {
+                return baseAttributes;
+            }
+
+            // When re-selecting, we do not base the view attributes on the original request attributes.
+            if (reselectVariants) {
+                return viewAttributes;
+            }
+
+            // Otherwise, artifact views without re-selection are based on the original request attributes.
+            return attributesFactory.concat(baseAttributes, viewAttributes);
+        }
+    }
+
+    public static class DefaultArtifactViewConfiguration implements ArtifactView.ViewConfiguration {
+        private final AttributeContainerInternal viewAttributes;
+        private Spec<? super ComponentIdentifier> componentFilter = Specs.satisfyAll();
+        private boolean lenient;
+        private boolean reselectVariants;
+
+        public DefaultArtifactViewConfiguration(ImmutableAttributesFactory attributesFactory) {
+            this.viewAttributes = attributesFactory.mutable();
+        }
+
+        @Override
+        public AttributeContainer getAttributes() {
+            return viewAttributes;
+        }
+
+        @Override
+        public ArtifactView.ViewConfiguration attributes(Action<? super AttributeContainer> action) {
+            action.execute(viewAttributes);
+            return this;
+        }
+
+        @Override
+        public ArtifactView.ViewConfiguration componentFilter(Spec<? super ComponentIdentifier> componentFilter) {
+            if (this.componentFilter != Specs.SATISFIES_ALL) {
+                throw new IllegalStateException("The component filter can only be set once before the view was computed");
+            }
+            this.componentFilter = componentFilter;
+            return this;
+        }
+
+        @Override
+        public boolean isLenient() {
+            return lenient;
+        }
+
+        @Override
+        public void setLenient(boolean lenient) {
+            this.lenient = lenient;
+        }
+
+        // TODO: Deprecate this in favor of setLenient(Boolean)
+        @Override
+        public ArtifactView.ViewConfiguration lenient(boolean lenient) {
+            this.lenient = lenient;
+            return this;
+        }
+
+        @Override
+        public ArtifactView.ViewConfiguration withVariantReselection() {
+            this.reselectVariants = true;
+            return this;
+        }
+    }
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/resolver/ResolutionHandle.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/resolver/ResolutionHandle.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.resolver;
+
+import org.gradle.api.artifacts.ResolutionStrategy;
+import org.gradle.api.internal.artifacts.ResolverResults;
+import org.gradle.api.internal.artifacts.configurations.ResolutionHost;
+import org.gradle.api.internal.artifacts.configurations.ResolutionResultProvider;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+
+/**
+ * An internal lazy reference to a graph resolution. Provides access to the inputs and
+ * raw outputs of a graph resolution.
+ */
+public interface ResolutionHandle {
+
+    /**
+     * Get the owner of the resolution.
+     */
+    ResolutionHost getHost();
+
+    /**
+     * Get the request attributes for this resolution. Calling this method will lock-in the
+     * request attributes from further mutation but will not perform resolution.
+     */
+    ImmutableAttributes getAttributes();
+
+    /**
+     * Get the default sort order for this resolution.
+     */
+    ResolutionStrategy.SortOrder getDefaultSortOrder();
+
+    /**
+     * Get the raw results of the resolution. The returned results are lazy. Calling
+     * this method will not perform resolution.
+     */
+    ResolutionResultProvider<ResolverResults> getResults();
+
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/resolver/ResolutionOutputs.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/resolver/ResolutionOutputs.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.resolver;
+
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.ArtifactCollection;
+import org.gradle.api.artifacts.ArtifactView;
+import org.gradle.api.artifacts.result.ResolvedVariantResult;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.provider.Provider;
+import org.gradle.internal.HasInternalProtocol;
+
+/**
+ * The outputs of a graph resolution. All results on this type are lazy. Resolution is only performed
+ * when the results are accessed.
+ *
+ * TODO: This type is intended to be made public in future Gradle versions.
+ */
+@HasInternalProtocol
+public interface ResolutionOutputs {
+
+    /**
+     * Returns the resolved dependency graph as a reference to the root variant.
+     */
+    Provider<ResolvedVariantResult> getRootVariant();
+
+    /**
+     * A {@link FileCollection} containing all resolved files. The returned collection
+     * carries all task dependencies required to build the resolved files, and when used
+     * as a task input the files will be built before the task executes.
+     */
+    FileCollection getFiles();
+
+    /**
+     * A set of resolved artifacts corresponding to the resolved files.
+     */
+    ArtifactCollection getArtifacts();
+
+    /**
+     * Creates a view of the resolved graph that can be used to filter the resolved artifacts,
+     * perform transformations on the resolved artifacts, or reselect the variants of the resolved
+     * graph to adjacent artifacts.
+     */
+    ArtifactView artifactView(Action<? super ArtifactView.ViewConfiguration> action);
+
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/resolver/ResolutionOutputsInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/resolver/ResolutionOutputsInternal.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.resolver;
+
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.internal.artifacts.configurations.ArtifactCollectionInternal;
+import org.gradle.api.internal.file.FileCollectionInternal;
+import org.gradle.api.provider.Provider;
+
+/**
+ * Internal counterpart of {@link ResolutionOutputs} that exposes the raw results.
+ */
+public interface ResolutionOutputsInternal extends ResolutionOutputs {
+
+    /**
+     * Get the source resolution for these outputs. This includes all inputs and outputs that produced these outputs.
+     */
+    ResolutionHandle getSource();
+
+    /**
+     * Returns the resolved dependency graph as a reference to the root component.
+     *
+     * <p>This is here to support the existing public APIs. However, it is much more useful to expose
+     * the root variant, which the public interface exposes at {@link #getRootVariant()}.</p>
+     */
+    Provider<ResolvedComponentResult> getRootComponent();
+
+    @Override
+    FileCollectionInternal getFiles();
+
+    @Override
+    ArtifactCollectionInternal getArtifacts();
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/resolver/package-info.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/resolver/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,9 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph;
-
-import org.gradle.internal.component.model.VariantGraphResolveState;
-
-import javax.annotation.Nullable;
-
-public interface ResolvedGraphVariant {
-    /**
-     * Returns a simple id for this node, unique across all nodes in the same graph.
-     * This id cannot be used across graphs.
-     */
-    long getNodeId();
-
-    VariantGraphResolveState getResolveState();
-
-    @Nullable
-    ResolvedGraphVariant getExternalVariant();
-}
+/**
+ * Contains classes implementing an enhanced dependency resolution API, intended to
+ * replace resolvable configurations.
+ */
+@org.gradle.api.NonNullApi
+package org.gradle.api.internal.artifacts.resolver;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultMinimalResolutionResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultMinimalResolutionResult.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts.result;
 
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 
 import java.util.function.Supplier;
@@ -26,19 +25,27 @@ import java.util.function.Supplier;
  */
 public class DefaultMinimalResolutionResult implements MinimalResolutionResult {
 
-    private final Supplier<ResolvedComponentResult> rootSource;
+    private final long rootVariantId;
+    private final Supplier<ResolvedComponentResultInternal> rootSource;
     private final ImmutableAttributes requestedAttributes;
 
     public DefaultMinimalResolutionResult(
-        Supplier<ResolvedComponentResult> rootSource,
+        long rootVariantId,
+        Supplier<ResolvedComponentResultInternal> rootSource,
         ImmutableAttributes requestedAttributes
     ) {
+        this.rootVariantId = rootVariantId;
         this.rootSource = rootSource;
         this.requestedAttributes = requestedAttributes;
     }
 
     @Override
-    public Supplier<ResolvedComponentResult> getRootSource() {
+    public long getRootVariantId() {
+        return rootVariantId;
+    }
+
+    @Override
+    public Supplier<ResolvedComponentResultInternal> getRootSource() {
         return rootSource;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolutionResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolutionResult.java
@@ -21,9 +21,10 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.artifacts.resolver.ResolutionOutputsInternal;
 import org.gradle.api.internal.attributes.AttributeDesugaring;
-import org.gradle.api.internal.provider.DefaultProvider;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Actions;
 import org.gradle.util.internal.ConfigureUtil;
@@ -32,37 +33,40 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Supplier;
 
 import static org.gradle.api.internal.artifacts.result.DefaultResolvedComponentResult.eachElement;
 
 public class DefaultResolutionResult implements ResolutionResult {
 
-    private final Supplier<MinimalResolutionResult> minimal;
+    private final ResolutionOutputsInternal resolutionOutputs;
     private final AttributeDesugaring attributeDesugaring;
 
-    public DefaultResolutionResult(MinimalResolutionResult minimal, AttributeDesugaring attributeDesugaring) {
-        this(() -> minimal, attributeDesugaring);
-    }
-
-    public DefaultResolutionResult(Supplier<MinimalResolutionResult> minimal, AttributeDesugaring attributeDesugaring) {
-        this.minimal = minimal;
+    public DefaultResolutionResult(
+        ResolutionOutputsInternal resolutionOutputs,
+        AttributeDesugaring attributeDesugaring
+    ) {
+        this.resolutionOutputs = resolutionOutputs;
         this.attributeDesugaring = attributeDesugaring;
     }
 
     @Override
     public ResolvedComponentResult getRoot() {
-        return minimal.get().getRootSource().get();
+        return getRootComponent().get();
     }
 
     @Override
     public Provider<ResolvedComponentResult> getRootComponent() {
-        return new DefaultProvider<>(() -> minimal.get().getRootSource().get());
+        return resolutionOutputs.getRootComponent();
+    }
+
+    @Override
+    public Provider<ResolvedVariantResult> getRootVariant() {
+        return resolutionOutputs.getRootVariant();
     }
 
     @Override
     public AttributeContainer getRequestedAttributes() {
-        return attributeDesugaring.desugar(minimal.get().getRequestedAttributes());
+        return attributeDesugaring.desugar(resolutionOutputs.getSource().getAttributes());
     }
 
     @Override
@@ -110,11 +114,11 @@ public class DefaultResolutionResult implements ResolutionResult {
             return false;
         }
         DefaultResolutionResult that = (DefaultResolutionResult) o;
-        return Objects.equals(minimal.get(), that.minimal.get());
+        return Objects.equals(resolutionOutputs, that.resolutionOutputs);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(minimal.get());
+        return resolutionOutputs.hashCode();
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResult.java
@@ -143,8 +143,9 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
         throw new InvalidUserCodeException("Variant '" + variant.getDisplayName() + "' doesn't belong to resolved component '" + this + "'. " + moreInfo + " Most likely you are using a variant from another component to get the dependencies of this component.");
     }
 
+    @Override
     @Nullable
-    public ResolvedVariantResult getVariant(Long id) {
+    public ResolvedVariantResult getVariant(long id) {
         return selectedVariantsById.get(id);
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/MinimalResolutionResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/MinimalResolutionResult.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts.result;
 
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 
 import java.util.function.Supplier;
@@ -27,12 +26,17 @@ import java.util.function.Supplier;
 public interface MinimalResolutionResult {
 
     /**
-     * A function which provides root of the dependency graph.
+     * The ID of the root variant of the root component.
      */
-    Supplier<ResolvedComponentResult> getRootSource();
+    long getRootVariantId();
 
     /**
-     * The desugared request attributes used to initially build the dependency graph.
+     * A function which provides root of the dependency graph.
+     */
+    Supplier<ResolvedComponentResultInternal> getRootSource();
+
+    /**
+     * The request attributes used to initially build the dependency graph.
      */
     ImmutableAttributes getRequestedAttributes();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/ResolvedComponentResultInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/ResolvedComponentResultInternal.java
@@ -49,4 +49,10 @@ public interface ResolvedComponentResultInternal extends ResolvedComponentResult
      * @since 7.5
      */
     List<ResolvedVariantResult> getAvailableVariants();
+
+    /**
+     * Get a variant by its node ID.
+     */
+    @Nullable
+    ResolvedVariantResult getVariant(long id);
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformUpstreamDependenciesResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformUpstreamDependenciesResolver.java
@@ -20,14 +20,15 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.result.DependencyResult;
-import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.configurations.ResolutionResultProvider;
+import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.file.FileCollectionInternal;
+import org.gradle.api.internal.lambdas.SerializableLambdas;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.NodeExecutionContext;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
@@ -44,15 +45,16 @@ import org.gradle.internal.model.ValueCalculator;
 import org.gradle.operations.dependencies.configurations.ConfigurationIdentity;
 
 import javax.annotation.Nullable;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-
-import static org.gradle.api.internal.lambdas.SerializableLambdas.spec;
+import java.util.function.Supplier;
 
 public class DefaultTransformUpstreamDependenciesResolver implements TransformUpstreamDependenciesResolver {
     public static final TransformDependencies NO_RESULT = new TransformDependencies() {
@@ -90,7 +92,7 @@ public class DefaultTransformUpstreamDependenciesResolver implements TransformUp
 
     private final ComponentIdentifier componentIdentifier;
     private final ConfigurationIdentity configurationIdentity;
-    private final ResolutionResultProvider<ResolutionResult> resolutionResultProvider;
+    private final ResolutionResultProvider<Supplier<ResolvedComponentResultInternal>> rootSource;
     private final DomainObjectContext owner;
     private final FilteredResultFactory filteredResultFactory;
     private final CalculatedValueContainerFactory calculatedValueContainerFactory;
@@ -100,14 +102,14 @@ public class DefaultTransformUpstreamDependenciesResolver implements TransformUp
     public DefaultTransformUpstreamDependenciesResolver(
         ComponentIdentifier componentIdentifier,
         ConfigurationIdentity configurationIdentity,
-        ResolutionResultProvider<ResolutionResult> resolutionResultProvider,
+        ResolutionResultProvider<Supplier<ResolvedComponentResultInternal>> rootSource,
         DomainObjectContext owner,
         FilteredResultFactory filteredResultFactory,
         CalculatedValueContainerFactory calculatedValueContainerFactory
     ) {
         this.componentIdentifier = componentIdentifier;
         this.configurationIdentity = configurationIdentity;
-        this.resolutionResultProvider = resolutionResultProvider;
+        this.rootSource = rootSource;
         this.owner = owner;
         this.filteredResultFactory = filteredResultFactory;
         this.calculatedValueContainerFactory = calculatedValueContainerFactory;
@@ -127,56 +129,83 @@ public class DefaultTransformUpstreamDependenciesResolver implements TransformUp
 
     private FileCollectionInternal selectedArtifactsFor(ImmutableAttributes fromAttributes) {
         if (dependencies == null) {
-            ResolutionResult result = resolutionResultProvider.getValue();
-            dependencies = computeDependencies(componentIdentifier, ComponentIdentifier.class, result.getAllComponents(), false);
+            dependencies = computeDependencies(rootSource.getValue(), false);
         }
         return filteredResultFactory.resultsMatching(fromAttributes, selectDependenciesWithId(dependencies));
     }
 
     private void computeDependenciesFor(ImmutableAttributes fromAttributes, TaskDependencyResolveContext context) {
         if (buildDependencies == null) {
-            ResolutionResult result = resolutionResultProvider.getTaskDependencyValue();
-            buildDependencies = computeDependencies(componentIdentifier, ComponentIdentifier.class, result.getAllComponents(), true);
+            buildDependencies = computeDependencies(rootSource.getTaskDependencyValue(), true);
         }
         FileCollectionInternal files = filteredResultFactory.resultsMatching(fromAttributes, selectDependenciesWithId(buildDependencies));
         context.add(files);
     }
 
-    private Spec<ComponentIdentifier> selectDependenciesWithId(Set<ComponentIdentifier> dependencies) {
-        return spec(element -> dependencies.contains(element));
+    private static Spec<ComponentIdentifier> selectDependenciesWithId(Set<ComponentIdentifier> dependencies) {
+        return SerializableLambdas.spec(element -> dependencies.contains(element));
     }
 
-    private static Set<ComponentIdentifier> computeDependencies(ComponentIdentifier componentIdentifier, Class<? extends ComponentIdentifier> type, Set<ResolvedComponentResult> componentResults, boolean strict) {
-        ResolvedComponentResult targetComponent = null;
-        for (ResolvedComponentResult component : componentResults) {
-            if (component.getId().equals(componentIdentifier)) {
-                targetComponent = component;
-                break;
-            }
-        }
+    private Set<ComponentIdentifier> computeDependencies(Supplier<ResolvedComponentResultInternal> value, boolean strict) {
+        ResolvedComponentResult targetComponent = findComponent(value.get(), componentIdentifier);
+
         if (targetComponent == null) {
+            // TODO: This is very suspicious. We should always fail here.
+            // `strict` was added because file dependencies' components are never included in the graph.
+            // We should detect this earlier and return no dependencies there to avoid `strict`.
             if (strict) {
                 throw new AssertionError("Could not find component " + componentIdentifier + " in provided results.");
             } else {
                 return Collections.emptySet();
             }
         }
+
         Set<ComponentIdentifier> buildDependencies = new HashSet<>();
-        collectDependenciesIdentifiers(buildDependencies, type, new HashSet<>(), targetComponent.getDependencies());
+        collectReachableComponents(buildDependencies, new HashSet<>(), targetComponent.getDependencies());
         return buildDependencies;
     }
 
-    private static void collectDependenciesIdentifiers(Set<ComponentIdentifier> dependenciesIdentifiers, Class<? extends ComponentIdentifier> type, Set<ComponentIdentifier> visited, Set<? extends DependencyResult> dependencies) {
+    /**
+     * Search the graph for a component with the given identifier, starting from the given root component.
+     *
+     * @return null if the component is not found.
+     */
+    @Nullable
+    public static ResolvedComponentResult findComponent(ResolvedComponentResult rootComponent, ComponentIdentifier componentIdentifier) {
+        Set<ResolvedComponentResult> seen = new HashSet<>();
+        Deque<ResolvedComponentResult> pending = new ArrayDeque<>();
+        pending.push(rootComponent);
+
+        while (!pending.isEmpty()) {
+            ResolvedComponentResult component = pending.pop();
+
+            if (component.getId().equals(componentIdentifier)) {
+                return component;
+            }
+
+            for (DependencyResult d : component.getDependencies()) {
+                if (d instanceof ResolvedDependencyResult) {
+                    ResolvedDependencyResult resolved = (ResolvedDependencyResult) d;
+                    ResolvedComponentResult selected = resolved.getSelected();
+                    if (seen.add(selected)) {
+                        pending.push(selected);
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static void collectReachableComponents(Set<ComponentIdentifier> dependenciesIdentifiers, Set<ComponentIdentifier> visited, Set<? extends DependencyResult> dependencies) {
         for (DependencyResult dependency : dependencies) {
             if (dependency instanceof ResolvedDependencyResult && !dependency.isConstraint()) {
                 ResolvedDependencyResult resolvedDependency = (ResolvedDependencyResult) dependency;
                 ResolvedComponentResult selected = resolvedDependency.getSelected();
-                if (type.isInstance(selected.getId())) {
-                    dependenciesIdentifiers.add(selected.getId());
-                }
+                dependenciesIdentifiers.add(selected.getId());
                 if (visited.add(selected.getId())) {
                     // Do not traverse if seen already
-                    collectDependenciesIdentifiers(dependenciesIdentifiers, type, visited, selected.getDependencies());
+                    collectReachableComponents(dependenciesIdentifiers, visited, selected.getDependencies());
                 }
             }
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformUpstreamDependenciesResolverFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformUpstreamDependenciesResolverFactory.java
@@ -17,11 +17,13 @@
 package org.gradle.api.internal.artifacts.transform;
 
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.configurations.ResolutionResultProvider;
+import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.operations.dependencies.configurations.ConfigurationIdentity;
+
+import java.util.function.Supplier;
 
 public class DefaultTransformUpstreamDependenciesResolverFactory implements TransformUpstreamDependenciesResolverFactory {
     public static final TransformUpstreamDependenciesResolver NO_DEPENDENCIES_RESOLVER = transformStep -> DefaultTransformUpstreamDependenciesResolver.NO_DEPENDENCIES;
@@ -30,16 +32,17 @@ public class DefaultTransformUpstreamDependenciesResolverFactory implements Tran
     private final FilteredResultFactory filteredResultFactory;
     private final CalculatedValueContainerFactory calculatedValueContainerFactory;
     private final ConfigurationIdentity configurationIdentity;
-    private final ResolutionResultProvider<ResolutionResult> resolutionResultProvider;
+    private final ResolutionResultProvider<Supplier<ResolvedComponentResultInternal>> rootComponentProvider;
 
     public DefaultTransformUpstreamDependenciesResolverFactory(
-        ConfigurationIdentity configurationIdentity, ResolutionResultProvider<ResolutionResult> resolutionResultProvider,
+        ConfigurationIdentity configurationIdentity,
+        ResolutionResultProvider<Supplier<ResolvedComponentResultInternal>> rootComponentProvider,
         DomainObjectContext owner,
         CalculatedValueContainerFactory calculatedValueContainerFactory,
         FilteredResultFactory filteredResultFactory
     ) {
         this.configurationIdentity = configurationIdentity;
-        this.resolutionResultProvider = resolutionResultProvider;
+        this.rootComponentProvider = rootComponentProvider;
         this.owner = owner;
         this.filteredResultFactory = filteredResultFactory;
         this.calculatedValueContainerFactory = calculatedValueContainerFactory;
@@ -50,6 +53,6 @@ public class DefaultTransformUpstreamDependenciesResolverFactory implements Tran
         if (!transformChain.requiresDependencies()) {
             return NO_DEPENDENCIES_RESOLVER;
         }
-        return new DefaultTransformUpstreamDependenciesResolver(componentIdentifier, configurationIdentity, resolutionResultProvider, owner, filteredResultFactory, calculatedValueContainerFactory);
+        return new DefaultTransformUpstreamDependenciesResolver(componentIdentifier, configurationIdentity, rootComponentProvider, owner, filteredResultFactory, calculatedValueContainerFactory);
     }
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDepen
 import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParserFactory
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultRootComponentMetadataBuilder
+import org.gradle.api.internal.attributes.AttributeDesugaring
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
@@ -81,6 +82,7 @@ class DefaultConfigurationContainerSpec extends Specification {
         Stub(PublishArtifactNotationParserFactory),
         immutableAttributesFactory,
         Stub(ResolveExceptionContextualizer),
+        new AttributeDesugaring(AttributeTestUtil.attributesFactory()),
         userCodeApplicationContext,
         projectStateRegistry,
         Mock(WorkerThreadRegistry),

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
@@ -33,6 +33,7 @@ import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory
 import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParserFactory
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultRootComponentMetadataBuilder
+import org.gradle.api.internal.attributes.AttributeDesugaring
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
@@ -89,6 +90,7 @@ class DefaultConfigurationContainerTest extends Specification {
         ),
         immutableAttributesFactory,
         Stub(ResolveExceptionContextualizer),
+        new AttributeDesugaring(AttributeTestUtil.attributesFactory()),
         userCodeApplicationContext,
         projectStateRegistry,
         Mock(WorkerThreadRegistry),

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -33,7 +33,6 @@ import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.artifacts.ResolvableDependencies
 import org.gradle.api.artifacts.ResolveException
 import org.gradle.api.artifacts.ResolvedConfiguration
-import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.DocumentationRegistry
@@ -57,6 +56,8 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults
 import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact
 import org.gradle.api.internal.artifacts.result.DefaultMinimalResolutionResult
+import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal
+import org.gradle.api.internal.attributes.AttributeDesugaring
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
@@ -533,7 +534,7 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         _ * artifactTaskDependencies.getDependencies(_) >> requiredTasks
 
         and:
-        _ * resolver.resolveBuildDependencies(_) >> DefaultResolverResults.buildDependenciesResolved(Mock(VisitedGraphResults), visitedArtifactSet, Mock(ResolverResults.LegacyResolverResults))
+        _ * resolver.resolveBuildDependencies(_) >> DefaultResolverResults.buildDependenciesResolved(Stub(VisitedGraphResults), visitedArtifactSet, Mock(ResolverResults.LegacyResolverResults))
 
         expect:
         configuration.buildDependencies.getDependencies(targetTask) == requiredTasks
@@ -1042,9 +1043,9 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
 
     def "provides resolution result"() {
         def config = conf("conf")
-        def resolvedComponentResult = Mock(ResolvedComponentResult)
-        Supplier<ResolvedComponentResult> rootSource = () -> resolvedComponentResult
-        def result = new DefaultMinimalResolutionResult(rootSource, ImmutableAttributes.EMPTY)
+        def resolvedComponentResult = Mock(ResolvedComponentResultInternal)
+        Supplier<ResolvedComponentResultInternal> rootSource = () -> resolvedComponentResult
+        def result = new DefaultMinimalResolutionResult(0, rootSource, ImmutableAttributes.EMPTY)
         def graphResults = new DefaultVisitedGraphResults(result, [] as Set, null)
 
         resolver.resolveGraph(config) >> DefaultResolverResults.graphResolved(graphResults, visitedArtifacts(), Mock(ResolverResults.LegacyResolverResults))
@@ -1746,13 +1747,13 @@ All Artifacts:
     }
 
     private ResolverResults buildDependenciesResolved() {
-        def resolutionResult = new DefaultMinimalResolutionResult(() -> Stub(ResolvedComponentResult), ImmutableAttributes.EMPTY)
+        def resolutionResult = new DefaultMinimalResolutionResult(0, () -> Stub(ResolvedComponentResultInternal), ImmutableAttributes.EMPTY)
         def visitedGraphResults = new DefaultVisitedGraphResults(resolutionResult, [] as Set, null)
         DefaultResolverResults.buildDependenciesResolved(visitedGraphResults, visitedArtifacts([] as Set), Mock(ResolverResults.LegacyResolverResults))
     }
 
     private ResolverResults graphResolved(ResolveException failure) {
-        def resolutionResult = new DefaultMinimalResolutionResult(() -> Stub(ResolvedComponentResult), ImmutableAttributes.EMPTY)
+        def resolutionResult = new DefaultMinimalResolutionResult(0, () -> Stub(ResolvedComponentResultInternal), ImmutableAttributes.EMPTY)
         def visitedGraphResults = new DefaultVisitedGraphResults(resolutionResult, [] as Set, failure)
 
         def visitedArtifactSet = Stub(VisitedArtifactSet) {
@@ -1770,7 +1771,7 @@ All Artifacts:
     }
 
     private ResolverResults graphResolved(Set<File> files = []) {
-        def resolutionResult = new DefaultMinimalResolutionResult(() -> Stub(ResolvedComponentResult), ImmutableAttributes.EMPTY)
+        def resolutionResult = new DefaultMinimalResolutionResult(0, () -> Stub(ResolvedComponentResultInternal), ImmutableAttributes.EMPTY)
         def visitedGraphResults = new DefaultVisitedGraphResults(resolutionResult, [] as Set, null)
 
         def legacyResults = DefaultResolverResults.DefaultLegacyResolverResults.graphResolved(
@@ -1782,7 +1783,7 @@ All Artifacts:
     }
 
     private visitedArtifacts(Set<File> files = []) {
-        Stub(VisitedArtifactSet) {
+        Mock(VisitedArtifactSet) {
             select(_) >> selectedArtifacts(files)
         }
     }
@@ -1842,6 +1843,7 @@ All Artifacts:
             publishArtifactNotationParser,
             immutableAttributesFactory,
             new ResolveExceptionContextualizer(Mock(DomainObjectContext), Mock(DocumentationRegistry)),
+            new AttributeDesugaring(AttributeTestUtil.attributesFactory()),
             userCodeApplicationContext,
             projectStateRegistry,
             Stub(WorkerThreadRegistry),

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolverSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolverSpec.groovy
@@ -16,10 +16,10 @@
 package org.gradle.api.internal.artifacts.ivyservice
 
 import org.gradle.api.artifacts.Dependency
-import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.internal.artifacts.ConfigurationResolver
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
+import org.gradle.api.internal.artifacts.ProjectComponentIdentifierInternal
 import org.gradle.api.internal.artifacts.ResolveContext
 import org.gradle.api.internal.artifacts.ResolverResults
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory
@@ -28,19 +28,23 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvi
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSelectionSpec
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor
+import org.gradle.api.internal.attributes.AttributeDesugaring
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.specs.Specs
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.util.AttributeTestUtil
 import spock.lang.Specification
 
 class ShortCircuitEmptyConfigurationResolverSpec extends Specification {
 
     def delegate = Mock(ConfigurationResolver)
     def resolveContext = Stub(ResolveContext)
-    def componentIdentifierFactory = Mock(ComponentIdentifierFactory)
+    def componentIdentifierFactory = Mock(ComponentIdentifierFactory) {
+        createComponentIdentifier(_) >> Mock(ProjectComponentIdentifierInternal)
+    }
     def moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
 
-    def dependencyResolver = new ShortCircuitEmptyConfigurationResolver(delegate, componentIdentifierFactory, moduleIdentifierFactory, Stub(BuildIdentifier))
+    def dependencyResolver = new ShortCircuitEmptyConfigurationResolver(delegate, componentIdentifierFactory, moduleIdentifierFactory, new AttributeDesugaring(AttributeTestUtil.attributesFactory()))
 
     def "returns empty build dependencies when no dependencies"() {
         def depVisitor = Mock(TaskDependencyResolveContext)

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/results/DefaultVisitedGraphResultsTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/results/DefaultVisitedGraphResultsTest.groovy
@@ -31,7 +31,7 @@ import java.util.function.Supplier
  */
 class DefaultVisitedGraphResultsTest extends Specification {
 
-    MinimalResolutionResult resolutionResult = new DefaultMinimalResolutionResult(Mock(Supplier), ImmutableAttributes.EMPTY)
+    MinimalResolutionResult resolutionResult = new DefaultMinimalResolutionResult(0, Mock(Supplier), ImmutableAttributes.EMPTY)
 
     def "hasResolutionFailure returns true if there is a failure"() {
         given:

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilderSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilderSpec.groovy
@@ -274,7 +274,7 @@ class DefaultResolutionResultBuilderSpec extends Specification {
     }
 
     class DummyModuleVersionSelection implements ResolvedGraphComponent {
-        Long resultId
+        long resultId
         ModuleVersionIdentifier moduleVersion
         ComponentSelectionReason selectionReason
         ComponentIdentifier componentId

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilderTest.groovy
@@ -28,7 +28,6 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.Dependen
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphVariant
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode
-import org.gradle.api.internal.attributes.AttributeDesugaring
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import org.gradle.internal.component.local.model.LocalConfigurationGraphResolveMetadata
@@ -52,7 +51,6 @@ class StreamingResolutionResultBuilderTest extends Specification {
         new DesugaredAttributeContainerSerializer(AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator()),
         new ThisBuildOnlyComponentDetailsSerializer(new DefaultImmutableModuleIdentifierFactory()),
         new ThisBuildOnlySelectedVariantSerializer(AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator()),
-        new AttributeDesugaring(AttributeTestUtil.attributesFactory()),
         DependencyManagementTestUtil.componentSelectionDescriptorFactory(),
         false
     )

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolutionResultTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolutionResultTest.groovy
@@ -25,10 +25,12 @@ import org.gradle.api.artifacts.result.ResolvedVariantResult
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
+import org.gradle.api.internal.attributes.AttributeDesugaring
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.UnresolvedDependencyEdge
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import org.gradle.internal.resolve.ModuleVersionNotFoundException
+import org.gradle.util.AttributeTestUtil
 import org.gradle.util.Path
 import spock.lang.Specification
 
@@ -150,8 +152,8 @@ class DefaultResolutionResultTest extends Specification {
         from.is(projectId)
     }
 
-    private static ResolutionResult newResolutionResult(root) {
-        new DefaultResolutionResult(new DefaultMinimalResolutionResult(() -> root, ImmutableAttributes.EMPTY))
+    private static ResolutionResult newResolutionResult(ResolvedComponentResultInternal root) {
+        new DefaultResolutionResult(new DefaultMinimalResolutionResult(0, () -> root, ImmutableAttributes.EMPTY), new AttributeDesugaring(AttributeTestUtil.attributesFactory()))
     }
 
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolutionResultTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolutionResultTest.groovy
@@ -25,8 +25,9 @@ import org.gradle.api.artifacts.result.ResolvedVariantResult
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
+import org.gradle.api.internal.artifacts.resolver.ResolutionOutputsInternal
 import org.gradle.api.internal.attributes.AttributeDesugaring
-import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.api.internal.provider.Providers
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.UnresolvedDependencyEdge
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import org.gradle.internal.resolve.ModuleVersionNotFoundException
@@ -152,8 +153,11 @@ class DefaultResolutionResultTest extends Specification {
         from.is(projectId)
     }
 
-    private static ResolutionResult newResolutionResult(ResolvedComponentResultInternal root) {
-        new DefaultResolutionResult(new DefaultMinimalResolutionResult(0, () -> root, ImmutableAttributes.EMPTY), new AttributeDesugaring(AttributeTestUtil.attributesFactory()))
+    private ResolutionResult newResolutionResult(ResolvedComponentResultInternal root) {
+        ResolutionOutputsInternal outputs = Mock(ResolutionOutputsInternal) {
+            getRootComponent() >> Providers.of(root)
+        }
+        new DefaultResolutionResult(outputs, new AttributeDesugaring(AttributeTestUtil.attributesFactory()))
     }
 
 }

--- a/platforms/software/publish/src/test/groovy/org/gradle/api/publish/internal/mapping/DefaultDependencyCoordinateResolverFactoryTest.groovy
+++ b/platforms/software/publish/src/test/groovy/org/gradle/api/publish/internal/mapping/DefaultDependencyCoordinateResolverFactoryTest.groovy
@@ -16,31 +16,25 @@
 
 package org.gradle.api.publish.internal.mapping
 
-
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.ResolvableDependencies
-import org.gradle.api.artifacts.result.ResolutionResult
-import org.gradle.api.artifacts.result.ResolvedComponentResult
-import org.gradle.api.artifacts.result.ResolvedVariantResult
 import org.gradle.api.component.SoftwareComponentVariant
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver
 import org.gradle.api.internal.attributes.AttributeDesugaring
 import org.gradle.api.internal.attributes.ImmutableAttributes
-import org.gradle.api.internal.provider.Providers
 import org.gradle.api.publish.internal.component.ResolutionBackedVariant
 import org.gradle.api.publish.internal.versionmapping.VariantVersionMappingStrategyInternal
 import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInternal
-import spock.lang.Specification
+import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 
 import javax.annotation.Nullable
 
 /**
  * Tests {@link DefaultDependencyCoordinateResolverFactory}.
  */
-class DefaultDependencyCoordinateResolverFactoryTest extends Specification {
+class DefaultDependencyCoordinateResolverFactoryTest extends AbstractProjectBuilderSpec {
 
     ProjectDependencyPublicationResolver projectDependencyResolver = Mock()
     ImmutableModuleIdentifierFactory moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
@@ -88,7 +82,7 @@ class DefaultDependencyCoordinateResolverFactoryTest extends Specification {
 
     def "returns legacy resolver if dependency version mapping is enabled with default configuration and variant is not resolution-backed"() {
         given:
-        def conf = conf()
+        def conf = project.configurations.create("conf")
         def variant = nonResolutionBacked()
         def versionMappingStrategy = versionMappingStrategy(true, conf, null)
 
@@ -101,7 +95,7 @@ class DefaultDependencyCoordinateResolverFactoryTest extends Specification {
 
     def "returns legacy resolver if dependency version mapping is enabled with explicit configuration and variant is not resolution-backed"() {
         given:
-        def conf = conf()
+        def conf = project.configurations.create("conf")
         def variant = nonResolutionBacked()
         def versionMappingStrategy = versionMappingStrategy(true, null, conf)
 
@@ -114,8 +108,8 @@ class DefaultDependencyCoordinateResolverFactoryTest extends Specification {
 
     def "returns legacy resolver if version mapping is enabled with default configuration and dependency mapping is disabled with resolution configuration"() {
         given:
-        def dependencyMappingConf = conf()
-        def versionMappingConf = conf()
+        def dependencyMappingConf = project.configurations.create("conf1")
+        def versionMappingConf = project.configurations.create("conf2")
         def variant = resolutionBacked(false, dependencyMappingConf)
         def versionMappingStrategy = versionMappingStrategy(true, versionMappingConf, null)
 
@@ -128,8 +122,8 @@ class DefaultDependencyCoordinateResolverFactoryTest extends Specification {
 
     def "returns legacy resolver if version mapping is enabled with user configuration and dependency mapping is disabled with resolution configuration"() {
         given:
-        def dependencyMappingConf = conf()
-        def versionMappingConf = conf()
+        def dependencyMappingConf = project.configurations.create("conf1")
+        def versionMappingConf = project.configurations.create("conf2")
         def variant = resolutionBacked(false, dependencyMappingConf)
         def versionMappingStrategy = versionMappingStrategy(true, null, versionMappingConf)
 
@@ -155,7 +149,7 @@ class DefaultDependencyCoordinateResolverFactoryTest extends Specification {
 
     def "returns resolution backed resolver if dependency mapping is enabled with configuration"() {
         given:
-        def conf = conf()
+        def conf = project.configurations.create("conf")
         def variant = resolutionBacked(true, conf)
         def versionMappingStrategy = Mock(VersionMappingStrategyInternal)
 
@@ -163,25 +157,6 @@ class DefaultDependencyCoordinateResolverFactoryTest extends Specification {
         with(factory.createCoordinateResolvers(variant, versionMappingStrategy).get()) {
             variantResolver instanceof ResolutionBackedVariantDependencyResolver
             componentResolver instanceof ResolutionBackedComponentDependencyResolver
-        }
-    }
-
-    Configuration conf() {
-        ResolvedVariantResult rootVariant = Mock(ResolvedVariantResult) {
-            getDisplayName() >> "conf"
-        }
-        ResolvedComponentResult root = Mock(ResolvedComponentResult) {
-            getVariants() >> [rootVariant]
-            getDependenciesForVariant(_) >> []
-            getDependencies() >> []
-        }
-        Stub(Configuration) {
-            getName() >> "conf"
-            getIncoming() >> Mock(ResolvableDependencies) {
-                getResolutionResult() >> Mock(ResolutionResult) {
-                    getRootComponent() >> Providers.of(root)
-                }
-            }
         }
     }
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolutionResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolutionResult.java
@@ -19,6 +19,7 @@ package org.gradle.api.artifacts.result;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.HasInternalProtocol;
@@ -51,10 +52,21 @@ public interface ResolutionResult {
      * You can walk the graph recursively from the root to obtain information about resolved dependencies.
      * For example, Gradle's built-in 'dependencies' task uses this to render the dependency tree.
      *
-     * @return a provider for the root node of the resolved dependency graph
+     * @return a provider for the root component of the resolved dependency graph
      * @since 7.4
      */
     Provider<ResolvedComponentResult> getRootComponent();
+
+    /**
+     * The root variant of the dependency graph. This is a synthetic variant that represents the thing being resolved.
+     * All outgoing dependencies of this variant represent first-level declared dependencies of the resolution.
+     *
+     * @return a provider for the root variant of the dependency graph.
+     *
+     * @since 8.8
+     */
+    @Incubating
+    Provider<ResolvedVariantResult> getRootVariant();
 
     /**
      * Retrieves all dependencies, including unresolved dependencies.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedComponentResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedComponentResult.java
@@ -17,6 +17,7 @@
 package org.gradle.api.artifacts.result;
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.internal.HasInternalProtocol;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
 import javax.annotation.Nullable;
@@ -27,6 +28,7 @@ import java.util.Set;
  * Represents a component instance in the resolved dependency graph. Provides some basic identity and dependency information about the component.
  */
 @UsedByScanPlugin
+@HasInternalProtocol
 public interface ResolvedComponentResult extends ComponentResult {
 
     /**

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -31,6 +31,7 @@ import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.HasAttributes;
+import org.gradle.api.internal.artifacts.ResolverResults;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.configurations.ResolutionResultProvider;
 import org.gradle.api.internal.artifacts.configurations.ResolvableDependenciesInternal;
@@ -38,6 +39,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionC
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults;
+import org.gradle.api.internal.artifacts.resolver.ResolutionOutputsInternal;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.provider.Property;
@@ -162,8 +164,8 @@ public abstract class DependencyInsightReportTask extends DefaultTask {
             zConfigurationAttributes = getProject().provider(configuration::getAttributes);
 
             ProviderFactory providerFactory = getProject().getProviders();
-            ResolutionResultProvider<VisitedGraphResults> graphResultsProvider =
-                ((ResolvableDependenciesInternal) configuration.getIncoming()).getGraphResultsProvider();
+            ResolutionOutputsInternal resolutionOutputs = ((ResolvableDependenciesInternal) configuration.getIncoming()).getResolutionOutputs();
+            ResolutionResultProvider<VisitedGraphResults> graphResultsProvider = resolutionOutputs.getSource().getResults().map(ResolverResults::getVisitedGraph);
             errorHandler.addErrorSource(providerFactory.provider(() ->
                 graphResultsProvider.getValue().getResolutionFailure()
                     .map(Collections::singletonList)


### PR DESCRIPTION
There is no way to get the root variant of the root component from a ResolutionResult without looping through all varaints and finding the root variant with its display name.

This commit exposes the root varaint so that users do not need to rely on variant display names to begin traversing dependency graphs.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
