### PR TITLE
Move platform windows builds to ReadyForRelease stage

### DIFF
--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -88,7 +88,6 @@ data class CIBuildModel(
             ),
             functionalTests = listOf(
                 TestCoverage(3, TestType.platform, Os.LINUX, JvmCategory.MIN_VERSION, DEFAULT_LINUX_FUNCTIONAL_TEST_BUCKET_SIZE),
-                TestCoverage(4, TestType.platform, Os.WINDOWS, JvmCategory.MAX_VERSION),
                 TestCoverage(20, TestType.configCache, Os.LINUX, JvmCategory.MIN_VERSION, DEFAULT_LINUX_FUNCTIONAL_TEST_BUCKET_SIZE)
             ),
             docsTests = listOf(
@@ -120,6 +119,7 @@ data class CIBuildModel(
                 SpecificBuild.GradleceptionWithMaxLtsJdk,
             ),
             functionalTests = listOf(
+                TestCoverage(4, TestType.platform, Os.WINDOWS, JvmCategory.MAX_VERSION),
                 TestCoverage(7, TestType.parallel, Os.LINUX, JvmCategory.MAX_LTS_VERSION, DEFAULT_LINUX_FUNCTIONAL_TEST_BUCKET_SIZE),
                 TestCoverage(8, TestType.soak, Os.LINUX, JvmCategory.MAX_LTS_VERSION, 1),
                 TestCoverage(9, TestType.soak, Os.WINDOWS, JvmCategory.MIN_VERSION_WINDOWS, 1),


### PR DESCRIPTION
Today I reviewed the build time statistics from TeamCity. Surprisingly, platform windows builds take ~20% of total build time (45%*43%), even higher than performance tests.

![image](https://github.com/gradle/gradle/assets/12689835/1f490357-dc6f-4f1a-982d-24ce771f49d7)

![image](https://github.com/gradle/gradle/assets/12689835/ea5d2640-f87d-4355-a4ba-e0b4150e86c6)

I doubt if brings more value to us as most of its tests will also be executed in other build configurations. I checked a few pages of failed platform windows builds in build scan, there seems no tests "failing only in platform windows builds but not in other configurations".

This PR intends to move the time-consuming platform windows builds to later stage (ReadyForRelease, which runs once per day). If it breaks a lot (the failure is not captured by other builds), we can move it back.