### PR TITLE
Split AbstractMavenConversionIntegrationTest

### DIFF
--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionDynamicPomIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionDynamicPomIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl
 import org.gradle.internal.jvm.Jvm
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
+import static MavenConversionIntegrationTest.assertContainsPublishingConfig
 
 /**
  * MavenConversionIntegrationTest tests that use a dynamically-generated POM to ensure cross-version compatibility.
@@ -74,7 +75,7 @@ abstract class MavenConversionDynamicPomIntegrationTest extends AbstractInitInte
         then:
         dsl.assertGradleFilesGenerated()
         dsl.getSettingsFile().text.contains("rootProject.name = 'util'") || dsl.getSettingsFile().text.contains('rootProject.name = "util"')
-        MavenConversionIntegrationTest.assertContainsPublishingConfig(dsl.getBuildFile(), scriptDsl)
+        assertContainsPublishingConfig(dsl.getBuildFile(), scriptDsl)
         dsl.getBuildFile(targetDir).text.contains("java.sourceCompatibility = JavaVersion.${source.name()}")
         !dsl.getBuildFile(targetDir).text.contains("java.targetCompatibility = ")
 
@@ -100,7 +101,7 @@ abstract class MavenConversionDynamicPomIntegrationTest extends AbstractInitInte
         then:
         dsl.assertGradleFilesGenerated()
         dsl.getSettingsFile().text.contains("rootProject.name = 'util'") || dsl.getSettingsFile().text.contains('rootProject.name = "util"')
-        MavenConversionIntegrationTest.assertContainsPublishingConfig(dsl.getBuildFile(), scriptDsl)
+        assertContainsPublishingConfig(dsl.getBuildFile(), scriptDsl)
         dsl.getBuildFile(targetDir).text.contains("java.sourceCompatibility = JavaVersion.${source.name()}")
         dsl.getBuildFile(targetDir).text.contains("java.targetCompatibility = JavaVersion.${target.name()}")
 
@@ -126,7 +127,7 @@ abstract class MavenConversionDynamicPomIntegrationTest extends AbstractInitInte
         then:
         dsl.assertGradleFilesGenerated()
         dsl.getSettingsFile().text.contains("rootProject.name = 'util'") || dsl.getSettingsFile().text.contains('rootProject.name = "util"')
-        MavenConversionIntegrationTest.assertContainsPublishingConfig(dsl.getBuildFile(), scriptDsl)
+        assertContainsPublishingConfig(dsl.getBuildFile(), scriptDsl)
         dsl.getBuildFile(targetDir).text.contains("java.sourceCompatibility = JavaVersion.${source.name()}")
         // target defaults to 1.8
         dsl.getBuildFile(targetDir).text.contains("java.targetCompatibility = JavaVersion.VERSION_1_8")
@@ -154,7 +155,7 @@ abstract class MavenConversionDynamicPomIntegrationTest extends AbstractInitInte
         then:
         dsl.assertGradleFilesGenerated()
         dsl.getSettingsFile().text.contains("rootProject.name = 'util'") || dsl.getSettingsFile().text.contains('rootProject.name = "util"')
-        MavenConversionIntegrationTest.assertContainsPublishingConfig(dsl.getBuildFile(), scriptDsl)
+        assertContainsPublishingConfig(dsl.getBuildFile(), scriptDsl)
         // source defaults to 1.8
         dsl.getBuildFile(targetDir).text.contains("java.sourceCompatibility = JavaVersion.VERSION_1_8")
         dsl.getBuildFile(targetDir).text.contains("java.targetCompatibility = JavaVersion.${target.name()}")

--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
@@ -32,7 +32,7 @@ import org.gradle.util.internal.TextUtil
 import org.junit.Rule
 import spock.lang.Issue
 
-abstract class AbstractMavenConversionIntegrationTest extends AbstractInitIntegrationSpec {
+abstract class MavenConversionIntegrationTest extends AbstractInitIntegrationSpec {
 
     @Rule
     public final TestResources resources = new TestResources(temporaryFolder)
@@ -140,7 +140,7 @@ ${TextUtil.indent(configLines.join("\n"), "                    ")}
 
 }
 
-abstract class MavenConversionPart1IntegrationTest extends AbstractMavenConversionIntegrationTest {
+abstract class MavenConversionPart1IntegrationTest extends MavenConversionIntegrationTest {
 
     def "multiModule init with incubating"() {
         def dsl = dslFixtureFor(scriptDsl)
@@ -579,7 +579,7 @@ Root project 'webinar-parent'
     }
 }
 
-abstract class MavenConversionPart2IntegrationTest extends AbstractMavenConversionIntegrationTest {
+abstract class MavenConversionPart2IntegrationTest extends MavenConversionIntegrationTest {
 
     @Issue("GRADLE-2820")
     def "remoteparent"() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/TestResources.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/TestResources.java
@@ -57,8 +57,10 @@ public class TestResources implements MethodRule {
             @Override
             public void evaluate() throws Throwable {
                 String className = method.getMethod().getDeclaringClass().getSimpleName();
+                String superClassName = method.getMethod().getDeclaringClass().getSuperclass().getSimpleName();
                 maybeCopy(String.format("%s/shared", className));
                 maybeCopy(String.format("%s/%s", className, method.getName()));
+                maybeCopy(String.format("%s/%s", superClassName, method.getName()));
                 for (String extraResource : extraResources) {
                     maybeCopy(extraResource);
                 }


### PR DESCRIPTION
It sometimes takes longer than 5m and triggers long running time alerts: https://ge.gradle.org/scans/tests?search.relativeStartTime=P28D&search.timeZoneId=Asia%2FShanghai&tests.container=*KotlinDslMavenConversionIntegrationTest*