### PR TITLE
Auto-configure Java 11 in the shell with SDKMAN

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=11.0.22-tem


### PR DESCRIPTION
Gradle's own build requires running Gradle on Java 11 JVM, failing with an error if it's not the case:
```
This build requires JDK 11. It's currently /Users/asemin/.sdkman/candidates/java/17.0.4-amzn. You can ignore this check by passing '-Dorg.gradle.ignoreBuildJavaVersionCheck=true'
```

Sometimes trying to work with other projects that have similar requirements with a different Java version, it becomes annoying fighting those errors, when the tooling could have solved it automatically for you.

This PR adds an `.sdkmanrc` file for [SDKMAN](https://sdkman.io/) that allows automatic switch to an appropriate Java in the environment. Other projects [like Spring Framework](https://github.com/spring-projects/spring-framework/blob/4b732d62c22297aea536a09477d2272c3e87a221/.sdkmanrc) do this as well.

SDKMAN requires to specify exact vendor for the JVM to be used. This PR suggests using a Temurin distribution provided by the Eclipse Foundation.