### PR TITLE
Do not ignore attributes on project dependency constraints

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
@@ -107,6 +107,163 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         outputDoesNotContain("Cannot set attributes for constraint \"org:test:1.0\": it was probably created by a plugin using internal APIs")
     }
 
+    def "attributes declared on constraints contribute to graph selection"() {
+        given:
+        settingsFile << """
+            include 'producer'
+        """
+        file("producer/build.gradle") << """
+            plugins {
+                id("base")
+            }
+
+            task wrongZip(type: Zip) {
+                archiveBaseName = "wrong"
+            }
+            task firstZip(type: Zip) {
+                archiveBaseName = "first"
+            }
+
+            configurations {
+                consumable("blah") {
+                    attributes {
+                        attribute(Attribute.of('custom', String), "foo")
+                        attribute(Attribute.of('attr', String), "incorrect")
+                    }
+                    outgoing {
+                        artifact(wrongZip)
+                    }
+                }
+                consumable("foo") {
+                    attributes {
+                        attribute(Attribute.of('custom', String), "foo")
+                        attribute(Attribute.of('attr', String), "correct")
+                    }
+                    outgoing {
+                        artifact(firstZip)
+                    }
+                }
+            }
+        """
+        buildFile << """
+            configurations {
+                dependencyScope("deps")
+                resolvable("res") {
+                    extendsFrom(deps)
+                    attributes {
+                        attribute(CUSTOM_ATTRIBUTE, "foo")
+                    }
+                }
+            }
+
+            dependencies {
+                deps(project(":producer"))
+                constraints {
+                    deps(project(":producer")) {
+                        attributes { attrs ->
+                            attrs.attribute(Attribute.of('attr', String), "correct")
+                        }
+                    }
+                }
+            }
+
+            task resolve {
+                def files = configurations.res
+                dependsOn(files)
+                doLast {
+                    assert files*.name == ["first.zip"]
+                }
+            }
+        """
+
+        expect:
+        succeeds("resolve")
+    }
+
+    def "attributes declared on constraints contribute to artifact selection"() {
+        given:
+        settingsFile << """
+            include 'producer'
+        """
+        file("producer/build.gradle") << """
+            plugins {
+                id("base")
+            }
+
+            task wrongZip(type: Zip) {
+                archiveBaseName = "wrong"
+            }
+            task firstZip(type: Zip) {
+                archiveBaseName = "first"
+            }
+            task secondZip(type: Zip) {
+                archiveBaseName = "second"
+            }
+
+            configurations {
+                consumable("blah") {
+                    attributes {
+                        attribute(Attribute.of('custom', String), "foo")
+                        attribute(Attribute.of('attr', String), "incorrect")
+                    }
+                    outgoing {
+                        artifact(wrongZip)
+                    }
+                }
+                consumable("foo") {
+                    attributes {
+                        attribute(Attribute.of('custom', String), "foo")
+                        attribute(Attribute.of('attr', String), "correct")
+                    }
+                    outgoing {
+                        artifact(firstZip)
+                        variants {
+                            secondary {
+                                artifact(secondZip)
+                                attributes {
+                                    attribute(Attribute.of("another", String), "value")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        """
+        buildFile << """
+            configurations {
+                dependencyScope("deps")
+                resolvable("res") {
+                    extendsFrom(deps)
+                    attributes {
+                        attribute(CUSTOM_ATTRIBUTE, "foo")
+                    }
+                }
+            }
+
+            dependencies {
+                deps(project(":producer"))
+                constraints {
+                    deps(project(":producer")) {
+                        attributes { attrs ->
+                            attrs.attribute(Attribute.of("another", String), "value")
+                            attrs.attribute(Attribute.of('attr', String), "correct")
+                        }
+                    }
+                }
+            }
+
+            task resolve {
+                def files = configurations.res
+                dependsOn(files)
+                doLast {
+                    assert files*.name == ["second.zip"]
+                }
+            }
+        """
+
+        expect:
+        succeeds("resolve")
+    }
 
     @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     @Unroll("Selects variant #expectedVariant using custom attribute value #attributeValue")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
@@ -160,8 +160,8 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
                 deps(project(":producer"))
                 constraints {
                     deps(project(":producer")) {
-                        attributes { attrs ->
-                            attrs.attribute(Attribute.of('attr', String), "correct")
+                        attributes {
+                            attribute(Attribute.of('attr', String), "correct")
                         }
                     }
                 }
@@ -244,9 +244,9 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
                 deps(project(":producer"))
                 constraints {
                     deps(project(":producer")) {
-                        attributes { attrs ->
-                            attrs.attribute(Attribute.of("another", String), "value")
-                            attrs.attribute(Attribute.of('attr', String), "correct")
+                        attributes {
+                            attribute(Attribute.of("another", String), "value")
+                            attribute(Attribute.of('attr', String), "correct")
                         }
                     }
                 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ComponentSelectorParsers.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ComponentSelectorParsers.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.local.model.DefaultProjectComponentSelector;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
 import org.gradle.internal.typeconversion.MapKey;
@@ -33,6 +34,7 @@ import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.internal.typeconversion.NotationParserBuilder;
 import org.gradle.internal.typeconversion.TypeConversionException;
 
+import java.util.Collections;
 import java.util.Set;
 
 import static org.gradle.internal.component.external.model.DefaultModuleComponentSelector.newSelector;
@@ -103,7 +105,7 @@ public class ComponentSelectorParsers {
 
         @Override
         public void convert(Project notation, NotationConvertResult<? super ComponentSelector> result) throws TypeConversionException {
-            result.converted(DefaultProjectComponentSelector.newSelector(notation));
+            result.converted(DefaultProjectComponentSelector.newSelector(notation, ImmutableAttributes.EMPTY, Collections.emptyList()));
         }
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyMetadataFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyMetadataFactory.java
@@ -20,10 +20,12 @@ import com.google.common.collect.ImmutableList;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependencyConstraint;
 import org.gradle.api.internal.artifacts.dependencies.DependencyConstraintInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.component.local.model.DefaultProjectComponentSelector;
 import org.gradle.internal.component.model.LocalComponentDependencyMetadata;
@@ -56,7 +58,12 @@ public class DefaultDependencyMetadataFactory implements DependencyMetadataFacto
 
     private ComponentSelector createSelector(DependencyConstraint dependencyConstraint) {
         if (dependencyConstraint instanceof DefaultProjectDependencyConstraint) {
-            return DefaultProjectComponentSelector.newSelector(((DefaultProjectDependencyConstraint) dependencyConstraint).getProjectDependency().getDependencyProject());
+            ProjectDependency projectDependency = ((DefaultProjectDependencyConstraint) dependencyConstraint).getProjectDependency();
+            return DefaultProjectComponentSelector.newSelector(
+                projectDependency.getDependencyProject(),
+                ((ImmutableAttributes) projectDependency.getAttributes()).asImmutable(),
+                Collections.emptyList()
+            );
         }
         return DefaultModuleComponentSelector.newSelector(
             DefaultModuleIdentifier.newId(nullToEmpty(dependencyConstraint.getGroup()), nullToEmpty(dependencyConstraint.getName())), dependencyConstraint.getVersionConstraint(), dependencyConstraint.getAttributes(), ImmutableList.of());

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyConstraintNotationParser.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyConstraintNotationParser.java
@@ -43,13 +43,13 @@ public class DependencyConstraintNotationParser {
     public static DependencyConstraintNotationParser parser(Instantiator instantiator, DefaultProjectDependencyFactory dependencyFactory, Interner<String> stringInterner, ImmutableAttributesFactory attributesFactory) {
         DependencyStringNotationConverter<DefaultDependencyConstraint> stringNotationConverter = new DependencyStringNotationConverter<>(instantiator, DefaultDependencyConstraint.class, stringInterner);
         MinimalExternalDependencyNotationConverter minimalExternalDependencyNotationConverter = new MinimalExternalDependencyNotationConverter(instantiator, attributesFactory);
-        ProjectDependencyNotationConverter projectDependencyNotationConverter = new ProjectDependencyNotationConverter();
+        ProjectDependencyNotationConverter projectDependencyNotationConverter = new ProjectDependencyNotationConverter(instantiator);
         NotationParser<Object, DependencyConstraint> notationParser = NotationParserBuilder
             .toType(DependencyConstraint.class)
             .fromType(MinimalExternalModuleDependency.class, minimalExternalDependencyNotationConverter)
             .fromCharSequence(stringNotationConverter)
             .converter(new DependencyMapNotationConverter<>(instantiator, DefaultDependencyConstraint.class))
-            .fromType(Project.class, new DependencyConstraintProjectNotationConverter(dependencyFactory))
+            .fromType(Project.class, new DependencyConstraintProjectNotationConverter(instantiator, dependencyFactory))
             .converter(projectDependencyNotationConverter)
             .invalidNotationMessage("Comprehensive documentation on dependency notations is available in DSL reference for DependencyHandler type.")
             .toComposite();
@@ -95,14 +95,16 @@ public class DependencyConstraintNotationParser {
     }
 
     private static class ProjectDependencyNotationConverter extends TypedNotationConverter<ProjectDependency, DependencyConstraint> {
+        private final Instantiator instantiator;
 
-        public ProjectDependencyNotationConverter() {
+        public ProjectDependencyNotationConverter(Instantiator instantiator) {
             super(ProjectDependency.class);
+            this.instantiator = instantiator;
         }
 
         @Override
         protected DependencyConstraint parseType(ProjectDependency notation) {
-            return new DefaultProjectDependencyConstraint(notation);
+            return instantiator.newInstance(DefaultProjectDependencyConstraint.class, notation);
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyConstraintProjectNotationConverter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyConstraintProjectNotationConverter.java
@@ -21,15 +21,18 @@ import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.internal.artifacts.DefaultProjectDependencyFactory;
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependencyConstraint;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
+import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationConvertResult;
 import org.gradle.internal.typeconversion.NotationConverter;
 import org.gradle.internal.typeconversion.TypeConversionException;
 
 public class DependencyConstraintProjectNotationConverter implements NotationConverter<Project, DependencyConstraint> {
 
+    private final Instantiator instantiator;
     private final DefaultProjectDependencyFactory factory;
 
-    public DependencyConstraintProjectNotationConverter(DefaultProjectDependencyFactory factory) {
+    public DependencyConstraintProjectNotationConverter(Instantiator instantiator, DefaultProjectDependencyFactory factory) {
+        this.instantiator = instantiator;
         this.factory = factory;
     }
 
@@ -40,6 +43,6 @@ public class DependencyConstraintProjectNotationConverter implements NotationCon
 
     @Override
     public void convert(Project notation, NotationConvertResult<? super DependencyConstraint> result) throws TypeConversionException {
-        result.converted(new DefaultProjectDependencyConstraint(factory.create(notation)));
+        result.converted(instantiator.newInstance(DefaultProjectDependencyConstraint.class, factory.create(notation)));
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectComponentSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectComponentSelector.java
@@ -153,10 +153,6 @@ public class DefaultProjectComponentSelector implements ProjectComponentSelector
         return getDisplayName();
     }
 
-    public static ProjectComponentSelector newSelector(Project project) {
-        return newSelector(project, ImmutableAttributes.EMPTY, Collections.emptyList());
-    }
-
     public static ProjectComponentSelector newSelector(Project project, ImmutableAttributes attributes, List<Capability> requestedCapabilities) {
         ProjectInternal projectInternal = (ProjectInternal) project;
         ProjectComponentIdentifier projectComponentIdentifier = projectInternal.getOwner().getComponentIdentifier();


### PR DESCRIPTION
Previously, when constructing component selectors sourced from a project dependency constraint,
attributes declared on the constraint were ignored. Now, we do not ignore these attributes.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
