### PR TITLE
Rebaseline performance tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ gradle.internal.testdistribution.writeTraceFile=false
 systemProp.gradle.internal.testdistribution.writeTraceFile=false
 systemProp.gradle.internal.testdistribution.queryResponseTimeout=PT20S
 # Default performance baseline
-defaultPerformanceBaselines=8.8-commit-eb067290149
+defaultPerformanceBaselines=8.8-commit-69bcb288dad
 
 # Skip dependency analysis for tests
 systemProp.dependency.analysis.test.analysis=false


### PR DESCRIPTION
Because some merge queue builds are failing due to flakiness.
