### PR TITLE
Fix CC serialization problem in Scala base plugin

### DIFF
--- a/platforms/jvm/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
+++ b/platforms/jvm/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
@@ -251,7 +251,7 @@ public abstract class ScalaBasePlugin implements Plugin<Project> {
         }
         scalaCompile.getAnalysisFiles().from(incrementalAnalysis.getIncoming().artifactView(viewConfiguration -> {
             viewConfiguration.lenient(true);
-            viewConfiguration.componentFilter(element -> element instanceof ProjectComponentIdentifier);
+            viewConfiguration.componentFilter(spec(element -> element instanceof ProjectComponentIdentifier));
         }).getFiles());
 
         // See https://github.com/gradle/gradle/issues/14434.  We do this so that the incrementalScalaAnalysisForXXX configuration


### PR DESCRIPTION
A lambda was not serializable.

This was probably not caught by tests, because `load-after-store` is currently [disabled](https://github.com/gradle/gradle/blob/5709d75a3fed2392e775ae3b15ed0a3b0272ea73/platforms/jvm/scala/build.gradle.kts#L99) for the `scala` project. The test coverage will be added later as part of fixing enabling `load-after-store` in the tests.