### PR TITLE
Rework Kotlin compatibility table

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
@@ -58,7 +58,7 @@ Beta and RC versions may or may not work.
 
 .Embedded Kotlin version
 |===
-| Gradle version | Embedded Kotlin version | Kotlin Language version
+| Minimum Gradle version | Embedded Kotlin version | Kotlin Language version
 
 | 5.0 | 1.3.10 | 1.3
 | 5.1 | 1.3.11 | 1.3
@@ -82,7 +82,6 @@ Beta and RC versions may or may not work.
 | 8.3 | 1.9.0  | 1.8
 | 8.4 | 1.9.10 | 1.8
 | 8.5 | 1.9.20 | 1.8
-| 8.6 | 1.9.20 | 1.8
 | 8.7 | 1.9.22 | 1.8
 |===
 


### PR DESCRIPTION
* Remove 8.6 line as other values are the same as for 8.5
* Update header to indicate that Gradle version is the minimum one

Issue #28333