### PR TITLE
Don't include branch qualifier in distribution zip root dir name

### DIFF
--- a/build-logic/packaging/src/main/kotlin/gradlebuild.distributions.gradle.kts
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild.distributions.gradle.kts
@@ -263,10 +263,10 @@ fun configureDistribution(name: String, distributionSpec: CopySpec, buildDistLif
     val zipRootFolder = if (normalized) {
         moduleIdentity.version.map { "gradle-${it.baseVersion.version}" }
     } else {
-        moduleIdentity.version.map { "gradle-${it.version}" }
-            .zip(buildVersionQualifier) { version: String, branchQualifier: String ->
-                version.replace("-$branchQualifier", "")
-            }
+        moduleIdentity.version.map { "gradle-${it.version}" }.map {
+            if (buildVersionQualifier.isPresent) it.replace("-${buildVersionQualifier.get()}", "")
+            else it
+        }
     }
 
     val installation = tasks.register<Sync>("${name}Installation") {


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-private/issues/4103

In the past, the root directory of all/src distribution zips are version string, wehich could be very long for branch promotion build:

```
Archive:  gradle-8.6-src-branch-promote.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  02-01-1980 00:00   gradle-8.6-branch-myBranch-20240129112253+0000/
     8714  02-01-1980 00:00   gradle-8.6-branch-myBranch-20240129112253+0000/gradlew
...
```

This would explode the zip distributions because every entry include the long string.

This PR removes the branch qualifier for the root directory name.
