### PR TITLE
Append .jar extension to instrumented artifact if it doesn't have it

### DIFF
--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/classpath/TransformedClassPath.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/classpath/TransformedClassPath.java
@@ -330,10 +330,13 @@ public class TransformedClassPath implements ClassPath {
     }
 
     private static boolean areInstrumentedAndOriginalJarValid(File instrumentedJar, File originalJar) {
+        String expectedInstrumentedJarName = originalJar.getName().endsWith(".jar")
+            ? originalJar.getName()
+            : originalJar.getName() + ".jar";
         return instrumentedJar.getParentFile() != null
             && instrumentedJar.getParentFile().getName().equals(INSTRUMENTED_JAR_DIR_NAME)
             && !originalJar.equals(instrumentedJar)
-            && instrumentedJar.getName().equals(INSTRUMENTED_ENTRY_PREFIX + originalJar.getName());
+            && instrumentedJar.getName().equals(INSTRUMENTED_ENTRY_PREFIX + expectedInstrumentedJarName);
     }
 
     private static boolean isInstrumentedMarkerFile(File classPathEntry) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/BaseInstrumentingArtifactTransform.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/BaseInstrumentingArtifactTransform.java
@@ -135,7 +135,9 @@ public abstract class BaseInstrumentingArtifactTransform implements TransformAct
     private static String getOutputPath(File input, Function<String, String> instrumentedEntryNameMapper) {
         // Currently every artifact is instrumented in to a jar. Even if it's originally a directory.
         // So let's append .jar if original name doesn't have it: this can happen in case we instrument a directory.
-        String entryName = input.getName().endsWith(".jar") ? input.getName() : input.getName() + ".jar";
+        String entryName = input.getName().endsWith(".jar")
+            ? input.getName()
+            : input.getName() + ".jar";
         return INSTRUMENTED_JAR_DIR_NAME + "/" + instrumentedEntryNameMapper.apply(entryName);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/BaseInstrumentingArtifactTransform.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/BaseInstrumentingArtifactTransform.java
@@ -133,7 +133,10 @@ public abstract class BaseInstrumentingArtifactTransform implements TransformAct
     }
 
     private static String getOutputPath(File input, Function<String, String> instrumentedEntryNameMapper) {
-        return INSTRUMENTED_JAR_DIR_NAME + "/" + instrumentedEntryNameMapper.apply(input.getName());
+        // Currently every artifact is instrumented in to a jar. Even if it's originally a directory.
+        // So let's append .jar if original name doesn't have it: this can happen in case we instrument a directory.
+        String entryName = input.getName().endsWith(".jar") ? input.getName() : input.getName() + ".jar";
+        return INSTRUMENTED_JAR_DIR_NAME + "/" + instrumentedEntryNameMapper.apply(entryName);
     }
 
     private boolean isAgentSupported() {


### PR DESCRIPTION
Also add tests for generated accessors in debug mode.

So we currently instrument everything (even directories) to a jar. The problem is, that generated accessors task generates accessors only for artifacts that have [.jar extension](https://github.com/gradle/gradle/blob/f0ab9c6081907317ba44fd7fb2a90eb0543689c6/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/GeneratePluginSpecBuilderAccessors.kt#L374).
This is not a problem on master since we instrument directories to directoris since https://github.com/gradle/gradle/pull/28017.

Fixes https://github.com/gradle/gradle/issues/28458
