### PR TITLE
Fix build generated by Maven2Gradle converter

### DIFF
--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
@@ -279,6 +279,27 @@ Root project 'webinar-parent'
         failure.assertHasCause("There were failing tests.")
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/28251")
+    def "singleModule init with incubating"() {
+        def dsl = dslFixtureFor(scriptDsl)
+
+        when:
+        run 'init', '--dsl', scriptDsl.id as String, '--incubating'
+
+        then:
+        dsl.assertGradleFilesGenerated()
+        dsl.getSettingsFile().text.contains("rootProject.name = 'util'") || dsl.getSettingsFile().text.contains('rootProject.name = "util"')
+        assertContainsPublishingConfig(dsl.getBuildFile(), scriptDsl)
+
+        when:
+        fails 'clean', 'build'
+
+        then:
+        // when tests fail, jar may not exist
+        failure.assertHasDescription("Execution failed for task ':test'.")
+        failure.assertHasCause("There were failing tests.")
+    }
+
     def "singleModule - with continue, when tests fail, jar should exist"() {
         def dsl = dslFixtureFor(scriptDsl)
 


### PR DESCRIPTION
Fixes #28251

The `init` task can convert Maven projects to Gradle. During the conversion, convention plugins may be created in a build-logic folder. However, this only happens multi-module Maven projects. This PR adjusts the `init` task implementation not to add an `includeBuild` statement in the generated settings script when a single-module Maven project is being converted and there's no generated build logic directory.