### PR TITLE
Split ConfigurationBoundExternalDependencyMetadata

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyModuleResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyModuleResolveIntegrationTest.groovy
@@ -136,7 +136,7 @@ task retrieve(type: Sync) {
 
         expect:
         fails 'retrieve'
-        failure.assertHasCause("Test:target:1.0 declares a dependency from configuration 'something' to configuration 'unknown' which is not declared in the descriptor for test:b:1.0.")
+        failure.assertHasCause("A dependency was declared from configuration 'something' to configuration 'unknown' which is not declared in the descriptor for test:b:1.0.")
     }
 
     def "correctly handles configuration mapping rule '#rule'"() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependencyMetadataAdapter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependencyMetadataAdapter.java
@@ -21,12 +21,12 @@ import org.gradle.api.artifacts.DirectDependencyMetadata;
 import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyArtifact;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.component.external.descriptor.Artifact;
-import org.gradle.internal.component.external.model.ConfigurationBoundExternalDependencyMetadata;
-import org.gradle.internal.component.external.model.ExternalDependencyDescriptor;
 import org.gradle.internal.component.external.model.GradleDependencyMetadata;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.external.model.ivy.IvyDependencyDescriptor;
+import org.gradle.internal.component.external.model.ivy.IvyDependencyMetadata;
 import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor;
+import org.gradle.internal.component.external.model.maven.MavenDependencyMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 
 import java.util.Collections;
@@ -65,15 +65,12 @@ public class DirectDependencyMetadataAdapter extends AbstractDependencyMetadataA
 
     private List<IvyArtifactName> getIvyArtifacts() {
         ModuleDependencyMetadata originalMetadata = getMetadata();
-        if (originalMetadata instanceof ConfigurationBoundExternalDependencyMetadata) {
-            ConfigurationBoundExternalDependencyMetadata externalMetadata = (ConfigurationBoundExternalDependencyMetadata) originalMetadata;
-            ExternalDependencyDescriptor descriptor = externalMetadata.getDependencyDescriptor();
-            if (descriptor instanceof MavenDependencyDescriptor) {
-                return fromMavenDescriptor((MavenDependencyDescriptor) descriptor);
-            }
-            if (descriptor instanceof IvyDependencyDescriptor) {
-                return fromIvyDescriptor((IvyDependencyDescriptor) descriptor);
-            }
+        if (originalMetadata instanceof MavenDependencyMetadata) {
+            MavenDependencyMetadata mavenMetadata = (MavenDependencyMetadata) originalMetadata;
+            return fromMavenDescriptor(mavenMetadata.getDependencyDescriptor());
+        } else if (originalMetadata instanceof IvyDependencyMetadata) {
+            IvyDependencyMetadata ivyMetadata = (IvyDependencyMetadata) originalMetadata;
+            return fromIvyDescriptor(ivyMetadata.getDependencyDescriptor());
         } else if (originalMetadata instanceof GradleDependencyMetadata){
             return fromGradleMetadata((GradleDependencyMetadata) originalMetadata);
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/ResolutionFailureHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/ResolutionFailureHandler.java
@@ -41,9 +41,9 @@ import org.gradle.internal.component.resolution.failure.type.AmbiguousArtifactTr
 import org.gradle.internal.component.resolution.failure.type.AmbiguousResolutionFailure;
 import org.gradle.internal.component.resolution.failure.type.ExternalRequestedConfigurationNotFoundFailure;
 import org.gradle.internal.component.resolution.failure.type.IncompatibleGraphVariantFailure;
+import org.gradle.internal.component.resolution.failure.type.IncompatibleMultipleNodeSelectionFailure;
 import org.gradle.internal.component.resolution.failure.type.IncompatibleRequestedConfigurationFailure;
 import org.gradle.internal.component.resolution.failure.type.IncompatibleResolutionFailure;
-import org.gradle.internal.component.resolution.failure.type.IncompatibleMultipleNodeSelectionFailure;
 import org.gradle.internal.component.resolution.failure.type.NoMatchingCapabilitiesFailure;
 import org.gradle.internal.component.resolution.failure.type.RequestedConfigurationNotFoundFailure;
 import org.gradle.internal.component.resolution.failure.type.ResolutionFailure;
@@ -168,8 +168,8 @@ public class ResolutionFailureHandler {
         RequestedConfigurationNotFoundFailure failure = new RequestedConfigurationNotFoundFailure(toConfigurationName, toComponent);
         return describeFailure(failure);
     }
-    public AbstractResolutionFailureException externalConfigurationNotFoundFailure(ComponentIdentifier fromComponent, String fromConfigurationName, ComponentIdentifier toComponent, String toConfigurationName) {
-        ExternalRequestedConfigurationNotFoundFailure failure = new ExternalRequestedConfigurationNotFoundFailure(toConfigurationName, toComponent, fromComponent, fromConfigurationName);
+    public AbstractResolutionFailureException externalConfigurationNotFoundFailure(String fromConfigurationName, ComponentIdentifier toComponent, String toConfigurationName) {
+        ExternalRequestedConfigurationNotFoundFailure failure = new ExternalRequestedConfigurationNotFoundFailure(toConfigurationName, toComponent, fromConfigurationName);
         return describeFailure(failure);
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ExternalDependencyDescriptor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ExternalDependencyDescriptor.java
@@ -16,17 +16,7 @@
 
 package org.gradle.internal.component.external.model;
 
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
-import org.gradle.internal.component.ResolutionFailureHandler;
-import org.gradle.internal.component.model.ComponentGraphResolveState;
-import org.gradle.internal.component.model.ConfigurationMetadata;
-import org.gradle.internal.component.model.ExcludeMetadata;
-import org.gradle.internal.component.model.IvyArtifactName;
-import org.gradle.internal.component.model.GraphVariantSelectionResult;
-
-import java.util.Collection;
-import java.util.List;
 
 /**
  * Represents dependency information as stored in an external descriptor file (POM or IVY.XML).
@@ -45,10 +35,4 @@ public abstract class ExternalDependencyDescriptor {
     public abstract boolean isTransitive();
 
     protected abstract ExternalDependencyDescriptor withRequested(ModuleComponentSelector newRequested);
-
-    protected abstract GraphVariantSelectionResult selectLegacyConfigurations(ComponentIdentifier fromComponent, ConfigurationMetadata fromConfiguration, ComponentGraphResolveState targetComponent, ResolutionFailureHandler resolutionFailureHandler);
-
-    public abstract List<ExcludeMetadata> getConfigurationExcludes(Collection<String> configurations);
-
-    public abstract List<IvyArtifactName> getConfigurationArtifacts(ConfigurationMetadata fromConfiguration);
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ExternalModuleDependencyMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ExternalModuleDependencyMetadata.java
@@ -15,10 +15,8 @@
  */
 package org.gradle.internal.component.external.model;
 
-import com.google.common.base.Objects;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ComponentSelector;
-import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
 import org.gradle.api.capabilities.Capability;
@@ -26,7 +24,6 @@ import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.local.model.DefaultProjectDependencyMetadata;
 import org.gradle.internal.component.model.ComponentGraphResolveState;
-import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.GraphVariantSelectionResult;
@@ -40,57 +37,20 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * A `ModuleDependencyMetadata` implementation that is backed by an `ExternalDependencyDescriptor` bound to a particular
- * source `ConfigurationMetadata`. The reason for this is that the Ivy and Maven dependency descriptors resolve target components
- * differently based on the configuration that they are sourced from.
+ * A {@link ModuleDependencyMetadata} implementation that is backed by an {@link ExternalDependencyDescriptor}.
  */
-public class ConfigurationBoundExternalDependencyMetadata implements ModuleDependencyMetadata {
-    private final ConfigurationMetadata configuration;
-    private final ModuleComponentIdentifier componentId;
-    private final ExternalDependencyDescriptor dependencyDescriptor;
+public abstract class ExternalModuleDependencyMetadata implements ModuleDependencyMetadata {
     private final String reason;
-    private final boolean isTransitive;
-    private final boolean isConstraint;
     private final boolean isEndorsing;
     private final List<IvyArtifactName> artifacts;
 
-    // TODO: This is likely misnamed now. We should evaluate whether we can remove this flag.
-    private final boolean alwaysUseAttributeMatching;
-
-    private ConfigurationBoundExternalDependencyMetadata(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor dependencyDescriptor, boolean alwaysUseAttributeMatching, @Nullable String reason, boolean endorsing) {
-        this(configuration,
-            componentId,
-            dependencyDescriptor,
-            alwaysUseAttributeMatching,
-            reason,
-            endorsing,
-            dependencyDescriptor.getConfigurationArtifacts(configuration)
-        );
-    }
-
-    private ConfigurationBoundExternalDependencyMetadata(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor dependencyDescriptor, boolean alwaysUseAttributeMatching, @Nullable String reason, boolean endorsing, List<IvyArtifactName> artifacts) {
-        this.configuration = configuration;
-        this.componentId = componentId;
-        this.dependencyDescriptor = dependencyDescriptor;
-        this.alwaysUseAttributeMatching = alwaysUseAttributeMatching;
+    public ExternalModuleDependencyMetadata(@Nullable String reason, boolean endorsing, List<IvyArtifactName> artifacts) {
         this.reason = reason;
-        this.isTransitive = dependencyDescriptor.isTransitive();
-        this.isConstraint = dependencyDescriptor.isConstraint();
         this.isEndorsing = endorsing;
         this.artifacts = artifacts;
     }
 
-    public ConfigurationBoundExternalDependencyMetadata(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor dependencyDescriptor, boolean alwaysUseAttributeMatching) {
-        this(configuration, componentId, dependencyDescriptor, alwaysUseAttributeMatching, null, false);
-    }
-
-    public ConfigurationBoundExternalDependencyMetadata(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor dependencyDescriptor) {
-        this(configuration, componentId, dependencyDescriptor, false, null, false);
-    }
-
-    public ExternalDependencyDescriptor getDependencyDescriptor() {
-        return dependencyDescriptor;
-    }
+    public abstract ExternalDependencyDescriptor getDependencyDescriptor();
 
     /**
      * Choose a set of target configurations based on: a) the consumer attributes (with associated schema) and b) the target component.
@@ -111,14 +71,20 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
             return new GraphVariantSelectionResult(Collections.singletonList(selected), true);
         }
 
-        // Fallback to legacy variant selection for target components without variants.
-        if (alwaysUseAttributeMatching) {
-            VariantGraphResolveState selected = variantSelector.selectLegacyConfiguration(consumerAttributes, targetComponentState, consumerSchema);
-            return new GraphVariantSelectionResult(Collections.singletonList(selected), false);
-        }
-
-        return dependencyDescriptor.selectLegacyConfigurations(componentId, configuration, targetComponentState, variantSelector.getFailureProcessor());
+        return selectLegacyConfigurations(variantSelector, consumerAttributes, targetComponentState, consumerSchema);
     }
+
+    /**
+     * Select target graph variants in an ecosystem-dependent manner.
+     *
+     * This method is called when the target component does not have variants to select from.
+     */
+    protected abstract GraphVariantSelectionResult selectLegacyConfigurations(
+        GraphVariantSelector variantSelector,
+        ImmutableAttributes consumerAttributes,
+        ComponentGraphResolveState targetComponentState,
+        AttributesSchemaInternal consumerSchema
+    );
 
     @Override
     public List<IvyArtifactName> getArtifacts() {
@@ -126,9 +92,7 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
     }
 
     @Override
-    public List<ExcludeMetadata> getExcludes() {
-        return dependencyDescriptor.getConfigurationExcludes(configuration.getHierarchy());
-    }
+    public abstract List<ExcludeMetadata> getExcludes();
 
     @Override
     public DependencyMetadata withTarget(ComponentSelector target) {
@@ -174,54 +138,28 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
         return withRequested(newSelector);
     }
 
-    @Override
-    public ModuleDependencyMetadata withReason(String reason) {
-        if (Objects.equal(reason, this.getReason())) {
-            return this;
-        }
-        return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, dependencyDescriptor, alwaysUseAttributeMatching, reason, isEndorsing);
-    }
+    protected abstract ModuleDependencyMetadata withRequested(ModuleComponentSelector newSelector);
 
-    @Override
-    public ModuleDependencyMetadata withEndorseStrictVersions(boolean endorse) {
-        if (this.isEndorsing == endorse) {
-            return this;
-        }
-        return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, dependencyDescriptor, alwaysUseAttributeMatching, reason, endorse);
-    }
-
-    public ConfigurationBoundExternalDependencyMetadata withDescriptor(ExternalDependencyDescriptor descriptor) {
-        return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, descriptor, alwaysUseAttributeMatching, reason, isEndorsing);
-    }
-
-    private ModuleDependencyMetadata withRequested(ModuleComponentSelector newSelector) {
-        ExternalDependencyDescriptor newDelegate = dependencyDescriptor.withRequested(newSelector);
-        return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, newDelegate, alwaysUseAttributeMatching, reason, isEndorsing);
-    }
-
-    private ModuleDependencyMetadata withRequestedAndArtifacts(ModuleComponentSelector newSelector, List<IvyArtifactName> artifacts) {
-        ExternalDependencyDescriptor newDelegate = dependencyDescriptor.withRequested(newSelector);
-        return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, newDelegate, alwaysUseAttributeMatching, reason, isEndorsing, artifacts);
-    }
+    protected abstract ModuleDependencyMetadata withRequestedAndArtifacts(ModuleComponentSelector newSelector, List<IvyArtifactName> artifacts);
 
     @Override
     public ModuleComponentSelector getSelector() {
-        return dependencyDescriptor.getSelector();
+        return getDependencyDescriptor().getSelector();
     }
 
     @Override
     public boolean isChanging() {
-        return dependencyDescriptor.isChanging();
+        return getDependencyDescriptor().isChanging();
     }
 
     @Override
     public boolean isTransitive() {
-        return isTransitive;
+        return getDependencyDescriptor().isTransitive();
     }
 
     @Override
     public boolean isConstraint() {
-        return isConstraint;
+        return getDependencyDescriptor().isConstraint();
     }
 
     @Override
@@ -237,6 +175,6 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
 
     @Override
     public String toString() {
-        return dependencyDescriptor.toString();
+        return getDependencyDescriptor().toString();
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/IvyConfigurationHelper.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/IvyConfigurationHelper.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.internal.component.external.descriptor.Artifact;
-import org.gradle.internal.component.external.model.ConfigurationBoundExternalDependencyMetadata;
 import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactMetadata;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
@@ -89,14 +88,10 @@ class IvyConfigurationHelper {
         ImmutableList.Builder<ModuleDependencyMetadata> filteredDependencies = ImmutableList.builder();
         for (IvyDependencyDescriptor dependency : dependencies) {
             if (include(dependency, config.getName(), config.getHierarchy())) {
-                filteredDependencies.add(contextualize(config, componentId, dependency));
+                filteredDependencies.add(new IvyDependencyMetadata(config, dependency));
             }
         }
         return filteredDependencies.build();
-    }
-
-    ModuleDependencyMetadata contextualize(ConfigurationMetadata config, ModuleComponentIdentifier componentId, IvyDependencyDescriptor incoming) {
-        return new ConfigurationBoundExternalDependencyMetadata(config, componentId, incoming);
     }
 
     private boolean include(IvyDependencyDescriptor dependency, String configName, Collection<String> hierarchy) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/IvyDependencyMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/IvyDependencyMetadata.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.external.model.ivy;
+
+import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.internal.attributes.AttributesSchemaInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.component.external.model.ExternalModuleDependencyMetadata;
+import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
+import org.gradle.internal.component.model.ComponentGraphResolveState;
+import org.gradle.internal.component.model.ConfigurationMetadata;
+import org.gradle.internal.component.model.ExcludeMetadata;
+import org.gradle.internal.component.model.GraphVariantSelectionResult;
+import org.gradle.internal.component.model.GraphVariantSelector;
+import org.gradle.internal.component.model.IvyArtifactName;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * Represents a dependency declared in an Ivy descriptor file.
+ * <p>
+ * This dependency metadata is bound to a source configuration, since Ivy resolves
+ * target components differently based on the configuration that they are sourced from.
+ * </p>
+ */
+public class IvyDependencyMetadata extends ExternalModuleDependencyMetadata {
+
+    private final ConfigurationMetadata configuration;
+    private final IvyDependencyDescriptor dependencyDescriptor;
+
+    public IvyDependencyMetadata(ConfigurationMetadata configuration, IvyDependencyDescriptor dependencyDescriptor) {
+        this(configuration, dependencyDescriptor, null, false);
+    }
+
+    public IvyDependencyMetadata(ConfigurationMetadata configuration, IvyDependencyDescriptor dependencyDescriptor, @Nullable String reason, boolean endorsing) {
+        this(configuration, dependencyDescriptor, reason, endorsing, dependencyDescriptor.getConfigurationArtifacts(configuration));
+    }
+
+    private IvyDependencyMetadata(ConfigurationMetadata configuration, IvyDependencyDescriptor dependencyDescriptor, @Nullable String reason, boolean endorsing, List<IvyArtifactName> artifacts) {
+        super(reason, endorsing, artifacts);
+        this.configuration = configuration;
+        this.dependencyDescriptor = dependencyDescriptor;
+    }
+
+    @Override
+    public IvyDependencyDescriptor getDependencyDescriptor() {
+        return dependencyDescriptor;
+    }
+
+    @Override
+    protected GraphVariantSelectionResult selectLegacyConfigurations(
+        GraphVariantSelector variantSelector,
+        ImmutableAttributes consumerAttributes,
+        ComponentGraphResolveState targetComponentState,
+        AttributesSchemaInternal consumerSchema
+    ) {
+        return getDependencyDescriptor().selectLegacyConfigurations(configuration, targetComponentState, variantSelector.getFailureProcessor());
+    }
+
+    @Override
+    public List<ExcludeMetadata> getExcludes() {
+        return getDependencyDescriptor().getConfigurationExcludes(configuration.getHierarchy());
+    }
+
+    @Override
+    public ModuleDependencyMetadata withReason(String reason) {
+        return new IvyDependencyMetadata(configuration, dependencyDescriptor, reason, isEndorsingStrictVersions(), getArtifacts());
+    }
+
+    @Override
+    public ModuleDependencyMetadata withEndorseStrictVersions(boolean endorse) {
+        return new IvyDependencyMetadata(configuration, dependencyDescriptor, getReason(), endorse, getArtifacts());
+    }
+
+    @Override
+    protected ModuleDependencyMetadata withRequested(ModuleComponentSelector newSelector) {
+        IvyDependencyDescriptor newDescriptor = dependencyDescriptor.withRequested(newSelector);
+        return new IvyDependencyMetadata(configuration, newDescriptor, getReason(), isEndorsingStrictVersions(), getArtifacts());
+    }
+
+    @Override
+    protected ModuleDependencyMetadata withRequestedAndArtifacts(ModuleComponentSelector newSelector, List<IvyArtifactName> artifacts) {
+        IvyDependencyDescriptor newDelegate = dependencyDescriptor.withRequested(newSelector);
+        return new IvyDependencyMetadata(configuration, newDelegate, getReason(), isEndorsingStrictVersions(), artifacts);
+    }
+
+    public ModuleDependencyMetadata withDescriptor(IvyDependencyDescriptor descriptor) {
+        return new IvyDependencyMetadata(configuration, descriptor, getReason(), isEndorsingStrictVersions(), dependencyDescriptor.getConfigurationArtifacts(configuration));
+    }
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/RealisedIvyModuleResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/RealisedIvyModuleResolveMetadata.java
@@ -31,7 +31,6 @@ import org.gradle.internal.component.external.descriptor.Configuration;
 import org.gradle.internal.component.external.model.AbstractRealisedModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.AdditionalVariant;
 import org.gradle.internal.component.external.model.ComponentVariant;
-import org.gradle.internal.component.external.model.ConfigurationBoundExternalDependencyMetadata;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.external.model.LazyToRealisedModuleComponentResolveMetadataHelper;
@@ -330,8 +329,10 @@ public class RealisedIvyModuleResolveMetadata extends AbstractRealisedModuleComp
             List<? extends DependencyMetadata> dependencies = configuration.getDependencies();
             ImmutableList.Builder<ModuleDependencyMetadata> transformedConfigurationDependencies = ImmutableList.builder();
             for (DependencyMetadata dependency : dependencies) {
-                if (dependency instanceof ConfigurationBoundExternalDependencyMetadata) {
-                    transformedConfigurationDependencies.add(((ConfigurationBoundExternalDependencyMetadata) dependency).withDescriptor(transformed.get(((ConfigurationBoundExternalDependencyMetadata) dependency).getDependencyDescriptor())));
+                if (dependency instanceof IvyDependencyMetadata) {
+                    IvyDependencyMetadata ivyDependency = (IvyDependencyMetadata) dependency;
+                    IvyDependencyDescriptor newDescriptor = transformed.get(ivyDependency.getDependencyDescriptor());
+                    transformedConfigurationDependencies.add(ivyDependency.withDescriptor(newDescriptor));
                 } else {
                     transformedConfigurationDependencies.add((ModuleDependencyMetadata) dependency);
                 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MavenDependencyMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MavenDependencyMetadata.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.external.model.maven;
+
+import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.internal.attributes.AttributesSchemaInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.component.external.model.ExternalModuleDependencyMetadata;
+import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
+import org.gradle.internal.component.model.ComponentGraphResolveState;
+import org.gradle.internal.component.model.ExcludeMetadata;
+import org.gradle.internal.component.model.GraphVariantSelectionResult;
+import org.gradle.internal.component.model.GraphVariantSelector;
+import org.gradle.internal.component.model.IvyArtifactName;
+import org.gradle.internal.component.model.VariantGraphResolveState;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents a dependency declared in a Maven POM file.
+ */
+public class MavenDependencyMetadata extends ExternalModuleDependencyMetadata {
+
+    private final MavenDependencyDescriptor dependencyDescriptor;
+
+    public MavenDependencyMetadata(MavenDependencyDescriptor dependencyDescriptor) {
+        this(dependencyDescriptor, null, false);
+    }
+
+    public MavenDependencyMetadata(MavenDependencyDescriptor dependencyDescriptor, @Nullable String reason, boolean endorsing) {
+        this(dependencyDescriptor, reason, endorsing, dependencyDescriptor.getConfigurationArtifacts());
+    }
+
+    private MavenDependencyMetadata(MavenDependencyDescriptor dependencyDescriptor, @Nullable String reason, boolean endorsing, List<IvyArtifactName> artifacts) {
+        super(reason, endorsing, artifacts);
+        this.dependencyDescriptor = dependencyDescriptor;
+    }
+
+    @Override
+    public MavenDependencyDescriptor getDependencyDescriptor() {
+        return dependencyDescriptor;
+    }
+
+    @Override
+    protected GraphVariantSelectionResult selectLegacyConfigurations(
+        GraphVariantSelector variantSelector,
+        ImmutableAttributes consumerAttributes,
+        ComponentGraphResolveState targetComponentState,
+        AttributesSchemaInternal consumerSchema
+    ) {
+        VariantGraphResolveState selected = variantSelector.selectLegacyConfiguration(consumerAttributes, targetComponentState, consumerSchema);
+        return new GraphVariantSelectionResult(Collections.singletonList(selected), false);
+    }
+
+    @Override
+    public List<ExcludeMetadata> getExcludes() {
+        return getDependencyDescriptor().getConfigurationExcludes();
+    }
+
+    @Override
+    public ModuleDependencyMetadata withReason(String reason) {
+        return new MavenDependencyMetadata(dependencyDescriptor, reason, isEndorsingStrictVersions(), getArtifacts());
+    }
+
+    @Override
+    public ModuleDependencyMetadata withEndorseStrictVersions(boolean endorse) {
+        return new MavenDependencyMetadata(dependencyDescriptor, getReason(), endorse, getArtifacts());
+    }
+
+    @Override
+    protected ModuleDependencyMetadata withRequested(ModuleComponentSelector newSelector) {
+        MavenDependencyDescriptor newDescriptor = dependencyDescriptor.withRequested(newSelector);
+        return new MavenDependencyMetadata(newDescriptor, getReason(), isEndorsingStrictVersions(), getArtifacts());
+    }
+
+    @Override
+    protected ModuleDependencyMetadata withRequestedAndArtifacts(ModuleComponentSelector newSelector, List<IvyArtifactName> artifacts) {
+        MavenDependencyDescriptor newDelegate = dependencyDescriptor.withRequested(newSelector);
+        return new MavenDependencyMetadata(newDelegate, getReason(), isEndorsingStrictVersions(), artifacts);
+    }
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
@@ -31,7 +31,6 @@ import org.gradle.internal.component.external.descriptor.Configuration;
 import org.gradle.internal.component.external.model.AbstractRealisedModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.AdditionalVariant;
 import org.gradle.internal.component.external.model.ComponentVariant;
-import org.gradle.internal.component.external.model.ConfigurationBoundExternalDependencyMetadata;
 import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactMetadata;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.external.model.LazyToRealisedModuleComponentResolveMetadataHelper;
@@ -222,10 +221,6 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
                     metadata.artifact("jar", "jar", null)));
             }
         }
-    }
-
-    static ModuleDependencyMetadata contextualize(ConfigurationMetadata config, ModuleComponentIdentifier componentId, MavenDependencyDescriptor incoming) {
-        return new ConfigurationBoundExternalDependencyMetadata(config, componentId, incoming, true);
     }
 
     private final NamedObjectInstantiator objectInstantiator;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
@@ -22,7 +22,7 @@ import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
-import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor;
+import org.gradle.internal.component.external.model.ivy.IvyDependencyDescriptor;
 
 import java.util.List;
 import java.util.Set;
@@ -41,7 +41,7 @@ public interface ConfigurationMetadata extends VariantArtifactGraphResolveMetada
      * The set of configurations that this configuration extends. Includes this configuration.
      *
      * It would be good to remove this from the API, as consumers of this interface generally have no need
-     * for this information. However it _is_ currently used by {@link MavenDependencyDescriptor#selectLegacyConfigurations}
+     * for this information. However it _is_ currently used by {@link IvyDependencyDescriptor#selectLegacyConfigurations}
      * to determine if the target 'runtime' configuration includes the target 'compile' configuration.
      */
     ImmutableSet<String> getHierarchy();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ExternalRequestedConfigurationNotFoundFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ExternalRequestedConfigurationNotFoundFailureDescriber.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.component.resolution.failure.describer;
 
-import org.apache.commons.lang.StringUtils;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.internal.component.resolution.failure.exception.ConfigurationSelectionException;
 import org.gradle.internal.component.resolution.failure.type.ExternalRequestedConfigurationNotFoundFailure;
@@ -36,6 +35,6 @@ public abstract class ExternalRequestedConfigurationNotFoundFailureDescriber ext
     }
 
     private String buildExternalConfigurationNotFoundFailureMsg(ExternalRequestedConfigurationNotFoundFailure failure) {
-        return String.format("%s declares a dependency from configuration '%s' to configuration '%s' which is not declared in the descriptor for %s.", StringUtils.capitalize(failure.getFromComponent().getDisplayName()), failure.getFromConfigurationName(), failure.getRequestedName(), failure.getRequestedComponentDisplayName());
+        return String.format("A dependency was declared from configuration '%s' to configuration '%s' which is not declared in the descriptor for %s.", failure.getFromConfigurationName(), failure.getRequestedName(), failure.getRequestedComponentDisplayName());
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/ExternalRequestedConfigurationNotFoundFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/ExternalRequestedConfigurationNotFoundFailure.java
@@ -23,17 +23,11 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
  * a configuration is requested by name on an external dependency and does not exist on the target component.
  */
 public final class ExternalRequestedConfigurationNotFoundFailure extends RequestedConfigurationNotFoundFailure {
-    private final ComponentIdentifier fromComponent;
     private final String fromConfigurationName;
 
-    public ExternalRequestedConfigurationNotFoundFailure(String requestedName, ComponentIdentifier requestedComponent, ComponentIdentifier fromComponent, String fromConfigurationName) {
+    public ExternalRequestedConfigurationNotFoundFailure(String requestedName, ComponentIdentifier requestedComponent, String fromConfigurationName) {
         super(requestedName, requestedComponent);
-        this.fromComponent = fromComponent;
         this.fromConfigurationName = fromConfigurationName;
-    }
-
-    public ComponentIdentifier getFromComponent() {
-        return fromComponent;
     }
 
     public String getFromConfigurationName() {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterOnIvyMetadataTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterOnIvyMetadataTest.groovy
@@ -18,18 +18,16 @@ package org.gradle.api.internal.artifacts.repositories.resolver
 
 import com.google.common.collect.ArrayListMultimap
 import org.gradle.api.artifacts.component.ModuleComponentSelector
-import org.gradle.internal.component.external.model.ConfigurationBoundExternalDependencyMetadata
-import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
-import org.gradle.internal.component.external.model.ExternalDependencyDescriptor
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata
 import org.gradle.internal.component.external.model.ivy.IvyDependencyDescriptor
+import org.gradle.internal.component.external.model.ivy.IvyDependencyMetadata
 
 class DependenciesMetadataAdapterOnIvyMetadataTest extends DependenciesMetadataAdapterTest {
 
     @Override
     ModuleDependencyMetadata newDependency(ModuleComponentSelector requested) {
-        ExternalDependencyDescriptor dependencyDescriptor = new IvyDependencyDescriptor(requested, ArrayListMultimap.create())
-        return new ConfigurationBoundExternalDependencyMetadata(null, DefaultModuleComponentIdentifier.newId(requested.moduleIdentifier, requested.version), dependencyDescriptor)
+        IvyDependencyDescriptor dependencyDescriptor = new IvyDependencyDescriptor(requested, ArrayListMultimap.create())
+        return new IvyDependencyMetadata(null, dependencyDescriptor)
     }
 
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterOnPomMetadataTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterOnPomMetadataTest.groovy
@@ -18,18 +18,16 @@ package org.gradle.api.internal.artifacts.repositories.resolver
 
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.internal.component.external.descriptor.MavenScope
-import org.gradle.internal.component.external.model.ConfigurationBoundExternalDependencyMetadata
-import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
-import org.gradle.internal.component.external.model.ExternalDependencyDescriptor
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata
 import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor
+import org.gradle.internal.component.external.model.maven.MavenDependencyMetadata
 import org.gradle.internal.component.external.model.maven.MavenDependencyType
 
 class DependenciesMetadataAdapterOnPomMetadataTest extends DependenciesMetadataAdapterTest {
 
     @Override
     ModuleDependencyMetadata newDependency(ModuleComponentSelector requested) {
-        ExternalDependencyDescriptor dependencyDescriptor = new MavenDependencyDescriptor(MavenScope.Compile, MavenDependencyType.DEPENDENCY, requested, null, [])
-        return new ConfigurationBoundExternalDependencyMetadata(null, DefaultModuleComponentIdentifier.newId(requested.moduleIdentifier, requested.version), dependencyDescriptor)
+        MavenDependencyDescriptor dependencyDescriptor = new MavenDependencyDescriptor(MavenScope.Compile, MavenDependencyType.DEPENDENCY, requested, null, [])
+        return new MavenDependencyMetadata(dependencyDescriptor)
     }
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/IvyDependencyDescriptorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/IvyDependencyDescriptorTest.groovy
@@ -169,7 +169,7 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
 
         expect:
         def metadata = new IvyDependencyDescriptor(requested, "12", true, true, false, ImmutableListMultimap.of(), [], [])
-        metadata.selectLegacyConfigurations(fromComponent, fromConfig, toComponent, resolutionFailureHandler).variants.empty
+        metadata.selectLegacyConfigurations(fromConfig, toComponent, resolutionFailureHandler).variants.empty
     }
 
     def "selects configurations from target component that match configuration mappings"() {
@@ -188,7 +188,7 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
 
         expect:
         def metadata = new IvyDependencyDescriptor(requested, "12", true, true, false, configMapping, [], [])
-        metadata.selectLegacyConfigurations(fromComponent, fromConfig, toComponent, resolutionFailureHandler).variants == [toConfig1, toConfig2] // verify order as well
+        metadata.selectLegacyConfigurations(fromConfig, toComponent, resolutionFailureHandler).variants == [toConfig1, toConfig2] // verify order as well
     }
 
     def "selects matching configurations for super-configurations"() {
@@ -207,7 +207,7 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
 
         expect:
         def metadata = new IvyDependencyDescriptor(requested, "12", true, true, false, configMapping, [], [])
-        metadata.selectLegacyConfigurations(fromComponent, fromConfig, toComponent, resolutionFailureHandler).variants == [toConfig1, toConfig2]
+        metadata.selectLegacyConfigurations(fromConfig, toComponent, resolutionFailureHandler).variants == [toConfig1, toConfig2]
     }
 
     def "configuration mapping can use wildcard on LHS"() {
@@ -227,8 +227,8 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
 
         expect:
         def metadata = new IvyDependencyDescriptor(requested, "12", true, true, false, configMapping, [], [])
-        metadata.selectLegacyConfigurations(fromComponent, fromConfig, toComponent, resolutionFailureHandler).variants == [toConfig1, toConfig2]
-        metadata.selectLegacyConfigurations(fromComponent, fromConfig2, toComponent, resolutionFailureHandler).variants == [toConfig2]
+        metadata.selectLegacyConfigurations(fromConfig, toComponent, resolutionFailureHandler).variants == [toConfig1, toConfig2]
+        metadata.selectLegacyConfigurations(fromConfig2, toComponent, resolutionFailureHandler).variants == [toConfig2]
     }
 
     def "configuration mapping can use wildcard on RHS to select all public configurations"() {
@@ -252,7 +252,7 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
 
         expect:
         def metadata = new IvyDependencyDescriptor(requested, "12", true, true, false, configMapping, [], [])
-        metadata.selectLegacyConfigurations(fromComponent, fromConfig, toComponent, resolutionFailureHandler).variants == [toConfig1, toConfig2]
+        metadata.selectLegacyConfigurations(fromConfig, toComponent, resolutionFailureHandler).variants == [toConfig1, toConfig2]
     }
 
     private ConfigurationGraphResolveState config(name, visible) {
@@ -287,9 +287,9 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
 
         expect:
         def metadata = new IvyDependencyDescriptor(requested, "12", true, true, false, configMapping, [], [])
-        metadata.selectLegacyConfigurations(fromComponent, fromConfig, toComponent, resolutionFailureHandler).variants == [toConfig1]
-        metadata.selectLegacyConfigurations(fromComponent, fromConfig2, toComponent, resolutionFailureHandler).variants == [toConfig1]
-        metadata.selectLegacyConfigurations(fromComponent, fromConfig3, toComponent, resolutionFailureHandler).variants == [toConfig2]
+        metadata.selectLegacyConfigurations(fromConfig, toComponent, resolutionFailureHandler).variants == [toConfig1]
+        metadata.selectLegacyConfigurations(fromConfig2, toComponent, resolutionFailureHandler).variants == [toConfig1]
+        metadata.selectLegacyConfigurations(fromConfig3, toComponent, resolutionFailureHandler).variants == [toConfig2]
     }
 
     def "configuration mapping can include fallback on LHS"() {
@@ -313,9 +313,9 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
 
         expect:
         def metadata = new IvyDependencyDescriptor(requested, "12", true, true, false, configMapping, [], [])
-        metadata.selectLegacyConfigurations(fromComponent, fromConfig, toComponent, resolutionFailureHandler).variants == [toConfig1, toConfig3]
-        metadata.selectLegacyConfigurations(fromComponent, fromConfig2, toComponent, resolutionFailureHandler).variants == [toConfig1, toConfig3]
-        metadata.selectLegacyConfigurations(fromComponent, fromConfig3, toComponent, resolutionFailureHandler).variants == [toConfig2, toConfig3]
+        metadata.selectLegacyConfigurations(fromConfig, toComponent, resolutionFailureHandler).variants == [toConfig1, toConfig3]
+        metadata.selectLegacyConfigurations(fromConfig2, toComponent, resolutionFailureHandler).variants == [toConfig1, toConfig3]
+        metadata.selectLegacyConfigurations(fromConfig3, toComponent, resolutionFailureHandler).variants == [toConfig2, toConfig3]
     }
 
     def "configuration mapping can include fallback on RHS"() {
@@ -344,9 +344,9 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
 
         expect:
         def metadata = new IvyDependencyDescriptor(requested, "12", true, true, false, configMapping, [], [])
-        metadata.selectLegacyConfigurations(fromComponent, fromConfig, toComponent, resolutionFailureHandler).variants == [toConfig1, toConfig2]
-        metadata.selectLegacyConfigurations(fromComponent, fromConfig2, toComponent, resolutionFailureHandler).variants == [toConfig1]
-        metadata.selectLegacyConfigurations(fromComponent, fromConfig3, toComponent, resolutionFailureHandler).variants == [toConfig2]
+        metadata.selectLegacyConfigurations(fromConfig, toComponent, resolutionFailureHandler).variants == [toConfig1, toConfig2]
+        metadata.selectLegacyConfigurations(fromConfig2, toComponent, resolutionFailureHandler).variants == [toConfig1]
+        metadata.selectLegacyConfigurations(fromConfig3, toComponent, resolutionFailureHandler).variants == [toConfig2]
     }
 
     def "configuration mapping can include self placeholder on RHS"() {
@@ -364,8 +364,8 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
 
         expect:
         def metadata = new IvyDependencyDescriptor(requested, "12", true, true, false, configMapping, [], [])
-        metadata.selectLegacyConfigurations(fromComponent, fromConfig, toComponent, resolutionFailureHandler).variants == [toConfig1]
-        metadata.selectLegacyConfigurations(fromComponent, fromConfig2, toComponent, resolutionFailureHandler).variants == [toConfig1]
+        metadata.selectLegacyConfigurations(fromConfig, toComponent, resolutionFailureHandler).variants == [toConfig1]
+        metadata.selectLegacyConfigurations(fromConfig2, toComponent, resolutionFailureHandler).variants == [toConfig1]
     }
 
     def "configuration mapping can include this placeholder on RHS"() {
@@ -386,8 +386,8 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
 
         expect:
         def metadata = new IvyDependencyDescriptor(requested, "12", true, true, false, configMapping, [], [])
-        metadata.selectLegacyConfigurations(fromComponent, fromConfig, toComponent, resolutionFailureHandler).variants == [toConfig1]
-        metadata.selectLegacyConfigurations(fromComponent, fromConfig2, toComponent, resolutionFailureHandler).variants == [toConfig2]
+        metadata.selectLegacyConfigurations(fromConfig, toComponent, resolutionFailureHandler).variants == [toConfig1]
+        metadata.selectLegacyConfigurations(fromConfig2, toComponent, resolutionFailureHandler).variants == [toConfig2]
     }
 
     def "configuration mapping can include wildcard on LHS and placeholder on RHS"() {
@@ -408,8 +408,8 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
 
         expect:
         def metadata = new IvyDependencyDescriptor(requested, "12", true, true, false, configMapping, [], [])
-        metadata.selectLegacyConfigurations(fromComponent, fromConfig, toComponent, resolutionFailureHandler).variants == [toConfig1]
-        metadata.selectLegacyConfigurations(fromComponent, fromConfig2, toComponent, resolutionFailureHandler).variants == [toConfig2]
+        metadata.selectLegacyConfigurations(fromConfig, toComponent, resolutionFailureHandler).variants == [toConfig1]
+        metadata.selectLegacyConfigurations(fromConfig2, toComponent, resolutionFailureHandler).variants == [toConfig2]
 
         where:
         // these all map to the same thing
@@ -422,9 +422,6 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
 
     def "fails when target component does not have matching configurations"() {
         def resolutionFailureHandler = new ResolutionFailureHandler(DependencyManagementTestUtil.standardResolutionFailureDescriberRegistry())
-        def fromComponent = Stub(ComponentIdentifier) {
-            getDisplayName() >> "thing a"
-        }
         def toId = Stub(ComponentIdentifier) {
             getDisplayName() >> "thing b"
         }
@@ -441,11 +438,11 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         def metadata = new IvyDependencyDescriptor(requested, "12", true, true, false, configMapping, [], [])
 
         when:
-        metadata.selectLegacyConfigurations(fromComponent, fromConfig, toComponent, resolutionFailureHandler)
+        metadata.selectLegacyConfigurations(fromConfig, toComponent, resolutionFailureHandler)
 
         then:
         ConfigurationSelectionException e = thrown()
-        e.message == "Thing a declares a dependency from configuration 'from' to configuration 'to' which is not declared in the descriptor for thing b."
+        e.message == "A dependency was declared from configuration 'from' to configuration 'to' which is not declared in the descriptor for thing b."
 
         where:
         lhs    | rhs

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/MavenDependencyDescriptorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/MavenDependencyDescriptorTest.groovy
@@ -32,37 +32,28 @@
 package org.gradle.internal.component.external.model
 
 import com.google.common.collect.ImmutableList
-import com.google.common.collect.ImmutableSet
-import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
-import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.PatternMatchers
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ExcludeSpec
-
-import org.gradle.internal.component.ResolutionFailureHandler
 import org.gradle.internal.component.external.descriptor.DefaultExclude
 import org.gradle.internal.component.external.descriptor.MavenScope
 import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor
 import org.gradle.internal.component.external.model.maven.MavenDependencyType
-import org.gradle.internal.component.model.ComponentGraphResolveState
-import org.gradle.internal.component.model.ConfigurationMetadata
 import org.gradle.internal.component.model.Exclude
 import org.gradle.internal.component.model.ExcludeMetadata
-import org.gradle.internal.component.model.ModuleConfigurationMetadata
-import org.gradle.internal.component.resolution.failure.exception.ConfigurationSelectionException
 
 class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
     final ModuleExclusions moduleExclusions = new ModuleExclusions()
     final ExcludeSpec nothing = moduleExclusions.nothing()
 
     @Override
-    ExternalDependencyDescriptor create(ModuleComponentSelector selector) {
+    MavenDependencyDescriptor create(ModuleComponentSelector selector) {
         return mavenDependencyMetadata(MavenScope.Compile, selector, [])
     }
 
-    ExternalDependencyDescriptor createWithExcludes(ModuleComponentSelector selector, List<Exclude> excludes) {
+    MavenDependencyDescriptor createWithExcludes(ModuleComponentSelector selector, List<Exclude> excludes) {
         return mavenDependencyMetadata(MavenScope.Compile, selector, excludes)
     }
 
@@ -84,153 +75,6 @@ class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         def exclusions = moduleExclusions.excludeAny(dep.allExcludes)
         exclusions == moduleExclusions.excludeAny(ImmutableList.of(exclude1, exclude2))
         exclusions.is(moduleExclusions.excludeAny(dep.allExcludes))
-    }
-
-    def "selects compile and master configurations from target when traversing from compile configuration"() {
-        def resolutionFailureHandler = Stub(ResolutionFailureHandler)
-        def fromComponent = Stub(ComponentIdentifier)
-        def toComponent = Stub(ComponentGraphResolveState)
-        def fromCompile = Stub(ModuleConfigurationMetadata)
-        def toCompile = configuration(toComponent, "compile")
-        def toMaster = configurationWithArtifacts(toComponent, "master")
-        fromCompile.name >> "compile"
-
-        def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
-
-        expect:
-        dep.selectLegacyConfigurations(fromComponent, fromCompile, toComponent, resolutionFailureHandler).variants == [toCompile, toMaster]
-    }
-
-    def "selects compile, runtime and master configurations from target when traversing from other configuration"() {
-        def resolutionFailureHandler = Stub(ResolutionFailureHandler)
-        def fromComponent = Stub(ComponentIdentifier)
-        def toComponent = Stub(ComponentGraphResolveState)
-        def fromRuntime = Stub(ModuleConfigurationMetadata)
-        def fromRuntime2 = Stub(ModuleConfigurationMetadata)
-        def toRuntime = configuration(toComponent, "runtime")
-        def toCompile = configuration(toComponent, "compile")
-        def toMaster = configurationWithArtifacts(toComponent, "master")
-        fromRuntime.name >> "runtime"
-        fromRuntime2.name >> "provided"
-
-        def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
-
-        expect:
-        dep.selectLegacyConfigurations(fromComponent, fromRuntime, toComponent, resolutionFailureHandler).variants == [toRuntime, toCompile, toMaster]
-        dep.selectLegacyConfigurations(fromComponent, fromRuntime2, toComponent, resolutionFailureHandler).variants == [toRuntime, toCompile, toMaster]
-    }
-
-    def "selects runtime and master configurations from target when traversing from other configuration and target's runtime extends compile"() {
-        def resolutionFailureHandler = Stub(ResolutionFailureHandler)
-        def fromComponent = Stub(ComponentIdentifier)
-        def toComponent = Stub(ComponentGraphResolveState)
-        def fromRuntime = Stub(ModuleConfigurationMetadata)
-        def fromRuntime2 = Stub(ModuleConfigurationMetadata)
-        def toRuntime = configurationWithHierarchy(toComponent, "runtime", ImmutableSet.of("runtime", "compile"))
-        def toMaster = configurationWithArtifacts(toComponent, "master")
-        fromRuntime.name >> "runtime"
-        fromRuntime2.name >> "provided"
-
-        def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
-
-        expect:
-        dep.selectLegacyConfigurations(fromComponent, fromRuntime, toComponent, resolutionFailureHandler).variants == [toRuntime, toMaster]
-        dep.selectLegacyConfigurations(fromComponent, fromRuntime2, toComponent, resolutionFailureHandler).variants == [toRuntime, toMaster]
-    }
-
-    def "ignores missing master configuration"() {
-        def resolutionFailureHandler = Stub(ResolutionFailureHandler)
-        def fromComponent = Stub(ComponentIdentifier)
-        def toComponent = Stub(ComponentGraphResolveState)
-        def fromRuntime = Stub(ModuleConfigurationMetadata)
-        def toRuntime = configurationWithHierarchy(toComponent, "runtime", ImmutableSet.of("compile", "runtime"))
-        fromRuntime.name >> "runtime"
-
-        def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
-
-        expect:
-        dep.selectLegacyConfigurations(fromComponent, fromRuntime, toComponent, resolutionFailureHandler).variants == [toRuntime]
-    }
-
-    def "ignores empty master configuration"() {
-        def resolutionFailureHandler = Stub(ResolutionFailureHandler)
-        def fromComponent = Stub(ComponentIdentifier)
-        def toComponent = Stub(ComponentGraphResolveState)
-        def fromRuntime = Stub(ModuleConfigurationMetadata)
-        def toRuntime = configurationWithHierarchy(toComponent, "runtime", ImmutableSet.of("compile", "runtime"))
-        configuration(toComponent, "master")
-        fromRuntime.name >> "runtime"
-
-        def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
-
-        expect:
-        dep.selectLegacyConfigurations(fromComponent, fromRuntime, toComponent, resolutionFailureHandler).variants == [toRuntime]
-    }
-
-    def "falls back to default configuration when compile is not defined in target component"() {
-        def resolutionFailureHandler = Stub(ResolutionFailureHandler)
-        def fromComponent = Stub(ComponentIdentifier)
-        def toComponent = Stub(ComponentGraphResolveState)
-        def fromCompile = Stub(ModuleConfigurationMetadata)
-        def toDefault = configuration(toComponent, "default")
-        def toMaster = configurationWithArtifacts(toComponent, "master")
-        fromCompile.name >> "compile"
-        toComponent.getConfiguration(_) >> null
-
-        def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
-
-        expect:
-        dep.selectLegacyConfigurations(fromComponent, fromCompile, toComponent, resolutionFailureHandler).variants == [toDefault, toMaster]
-    }
-
-    def "falls back to default configuration when runtime is not defined in target component"() {
-        def resolutionFailureHandler = Stub(ResolutionFailureHandler)
-        def fromComponent = Stub(ComponentIdentifier)
-        def toComponent = Stub(ComponentGraphResolveState)
-        def fromRuntime = Stub(ModuleConfigurationMetadata)
-        def toDefault = configurationWithHierarchy(toComponent, "default", ImmutableSet.of("compile", "default"))
-        def toMaster = configurationWithArtifacts(toComponent, "master")
-        fromRuntime.name >> "runtime"
-        toComponent.getConfiguration(_) >> null
-
-        def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
-
-        expect:
-        dep.selectLegacyConfigurations(fromComponent, fromRuntime, toComponent, resolutionFailureHandler).variants == [toDefault, toMaster]
-    }
-
-    def "fails when compile configuration is not defined in target component"() {
-        def resolutionFailureHandler = new ResolutionFailureHandler(DependencyManagementTestUtil.standardResolutionFailureDescriberRegistry())
-        def fromComponent = Stub(ComponentIdentifier)
-        def toComponent = Stub(ComponentGraphResolveState)
-        def fromCompile = Stub(ConfigurationMetadata)
-        fromCompile.name >> "compile"
-        toComponent.getConfiguration(_) >> null
-
-        def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
-
-        when:
-        dep.selectLegacyConfigurations(fromComponent, fromCompile, toComponent, resolutionFailureHandler)
-
-        then:
-        thrown(ConfigurationSelectionException)
-    }
-
-    def "fails when runtime configuration is not defined in target component"() {
-        def resolutionFailureHandler = new ResolutionFailureHandler(DependencyManagementTestUtil.standardResolutionFailureDescriberRegistry())
-        def fromComponent = Stub(ComponentIdentifier)
-        def toComponent = Stub(ComponentGraphResolveState)
-        def fromRuntime = Stub(ConfigurationMetadata)
-        fromRuntime.name >> "runtime"
-        toComponent.getConfiguration(_) >> null
-
-        def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
-
-        when:
-        dep.selectLegacyConfigurations(fromComponent, fromRuntime, toComponent, resolutionFailureHandler)
-
-        then:
-        thrown(ConfigurationSelectionException)
     }
 
     private static MavenDependencyDescriptor mavenDependencyMetadata(MavenScope scope, ModuleComponentSelector selector, List<ExcludeMetadata> excludes) {


### PR DESCRIPTION
This class was for dependency metadata implementations that change behavior relative to some source configuration. The class was used to implement both Ivy and Maven dependencies, and had a flag 'alwaysUseAttributeMatching'.

For maven dependencies, this was always true. As a result, the maven instances were never actually configuration-bound anymore.

This commit splits up the configuration bound metadata into two implementations, IvyDependencyMetadata, which remains configuration-bound, and MavenDependencyMetadata which no longer relies on a source configuration.

Eventually, we should try to merge MavenDependencyMetadata with GradleDependencyMetadata, as GradleDependenyMetadata is seemingly more like DefaultDependencyMetadata.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
