### PR TITLE
Add support for using project dependencies in the declarative DSL with DependencyCollector

### DIFF
--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/dependencyConfigurationSchema.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/dependencyConfigurationSchema.kt
@@ -86,7 +86,7 @@ class DependencyFunctionsExtractor(val configurations: DependencyConfigurations)
                 DataMemberFunction(
                     kClass.toDataTypeRef(),
                     configurationName,
-                    listOf(DataParameter("dependency", ProjectDependency::class.toDataTypeRef(), false, ParameterSemantics.Unknown)),
+                    listOf(projectDependencyParam),
                     false,
                     FunctionSemantics.AddAndConfigure(ProjectDependency::class.toDataTypeRef(), NOT_ALLOWED)
                 )
@@ -109,14 +109,14 @@ class ImplicitDependencyCollectorFunctionExtractor(val configurations: Dependenc
                 DataMemberFunction(
                     kClass.toDataTypeRef(),
                     confName,
-                    listOf(DataParameter("dependency", String::class.toDataTypeRef(), false, ParameterSemantics.Unknown)),
+                    listOf(gavDependencyParam),
                     false,
                     FunctionSemantics.AddAndConfigure(kClass.toDataTypeRef(), NOT_ALLOWED)
                 ),
                 DataMemberFunction(
                     kClass.toDataTypeRef(),
                     confName,
-                    listOf(DataParameter("dependency", ProjectDependency::class.toDataTypeRef(), false, ParameterSemantics.Unknown)),
+                    listOf(projectDependencyParam),
                     false,
                     FunctionSemantics.AddAndConfigure(kClass.toDataTypeRef(), NOT_ALLOWED)
                 )
@@ -157,9 +157,7 @@ class ImplicitDependencyCollectorFunctionResolver(configurations: DependencyConf
         if (name in configurationNames) {
             val getterFunction = getDependencyCollectorGetter(receiverClass, name)
             if (getterFunction != null) {
-                val gavParam = DataParameter("dependency", String::class.toDataTypeRef(), false, ParameterSemantics.Unknown)
-                val projectParam = DataParameter("dependency", ProjectDependency::class.toDataTypeRef(), false, ParameterSemantics.Unknown)
-                if (parameterValueBinding.bindingMap.containsKey(gavParam)) {
+                if (parameterValueBinding.bindingMap.containsKey(gavDependencyParam)) {
                     return RuntimeFunctionResolver.Resolution.Resolved(object : DeclarativeRuntimeFunction {
                         override fun callBy(receiver: Any, binding: Map<DataParameter, Any?>, hasLambda: Boolean): DeclarativeRuntimeFunction.InvocationResult {
                             val dependencyNotation = binding.values.single().toString()
@@ -168,7 +166,7 @@ class ImplicitDependencyCollectorFunctionResolver(configurations: DependencyConf
                             return DeclarativeRuntimeFunction.InvocationResult(Unit, null)
                         }
                     })
-                } else if (parameterValueBinding.bindingMap.containsKey(projectParam)) {
+                } else if (parameterValueBinding.bindingMap.containsKey(projectDependencyParam)) {
                     return RuntimeFunctionResolver.Resolution.Resolved(object : DeclarativeRuntimeFunction {
                         override fun callBy(receiver: Any, binding: Map<DataParameter, Any?>, hasLambda: Boolean): DeclarativeRuntimeFunction.InvocationResult {
                             val dependencyNotation = binding.values.single() as ProjectDependency
@@ -202,3 +200,11 @@ fun hasDependencyCollectorGetterSignature(function: KFunction<*>): Boolean {
     }
     return function.name.startsWith("get") && returnType == DependencyCollector::class.java && function.parameters.size == 1
 }
+
+
+private
+val gavDependencyParam = DataParameter("dependency", String::class.toDataTypeRef(), false, ParameterSemantics.Unknown)
+
+
+private
+val projectDependencyParam = DataParameter("dependency", ProjectDependency::class.toDataTypeRef(), false, ParameterSemantics.Unknown)

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/dependencyConfigurationSchema.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/dependencyConfigurationSchema.kt
@@ -176,7 +176,7 @@ class ImplicitDependencyCollectorFunctionResolver(configurations: DependencyConf
                         }
                     })
                 } else {
-                    throw IllegalStateException()
+                    throw IllegalStateException("Unexpected parameter binding contents: ${parameterValueBinding.bindingMap.keys} for function: $name in: $receiverClass")
                 }
             }
         }

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/dependencyConfigurationSchema.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/dependencyConfigurationSchema.kt
@@ -104,13 +104,22 @@ class ImplicitDependencyCollectorFunctionExtractor(val configurations: Dependenc
         .filter { function -> hasDependencyCollectorGetterSignature(function) }
         .map { function -> function.name.removePrefix("get").replaceFirstChar { it.lowercase(Locale.getDefault()) } }
         .filter { confName -> confName in configurations.configurationNames }
-        .map { confName ->
-            DataMemberFunction(
-                kClass.toDataTypeRef(),
-                confName,
-                listOf(DataParameter("dependency", String::class.toDataTypeRef(), false, ParameterSemantics.Unknown)),
-                false,
-                FunctionSemantics.AddAndConfigure(kClass.toDataTypeRef(), NOT_ALLOWED)
+        .flatMap { confName ->
+            listOf(
+                DataMemberFunction(
+                    kClass.toDataTypeRef(),
+                    confName,
+                    listOf(DataParameter("dependency", String::class.toDataTypeRef(), false, ParameterSemantics.Unknown)),
+                    false,
+                    FunctionSemantics.AddAndConfigure(kClass.toDataTypeRef(), NOT_ALLOWED)
+                ),
+                DataMemberFunction(
+                    kClass.toDataTypeRef(),
+                    confName,
+                    listOf(DataParameter("dependency", ProjectDependency::class.toDataTypeRef(), false, ParameterSemantics.Unknown)),
+                    false,
+                    FunctionSemantics.AddAndConfigure(kClass.toDataTypeRef(), NOT_ALLOWED)
+                )
             )
         }
 
@@ -148,14 +157,29 @@ class ImplicitDependencyCollectorFunctionResolver(configurations: DependencyConf
         if (name in configurationNames) {
             val getterFunction = getDependencyCollectorGetter(receiverClass, name)
             if (getterFunction != null) {
-                return RuntimeFunctionResolver.Resolution.Resolved(object : DeclarativeRuntimeFunction {
-                    override fun callBy(receiver: Any, binding: Map<DataParameter, Any?>, hasLambda: Boolean): DeclarativeRuntimeFunction.InvocationResult {
-                        val dependencyNotation = binding.values.single().toString()
-                        val collector: DependencyCollector = getterFunction.call(receiver) as DependencyCollector
-                        collector.add(dependencyNotation)
-                        return DeclarativeRuntimeFunction.InvocationResult(Unit, null)
-                    }
-                })
+                val gavParam = DataParameter("dependency", String::class.toDataTypeRef(), false, ParameterSemantics.Unknown)
+                val projectParam = DataParameter("dependency", ProjectDependency::class.toDataTypeRef(), false, ParameterSemantics.Unknown)
+                if (parameterValueBinding.bindingMap.containsKey(gavParam)) {
+                    return RuntimeFunctionResolver.Resolution.Resolved(object : DeclarativeRuntimeFunction {
+                        override fun callBy(receiver: Any, binding: Map<DataParameter, Any?>, hasLambda: Boolean): DeclarativeRuntimeFunction.InvocationResult {
+                            val dependencyNotation = binding.values.single().toString()
+                            val collector: DependencyCollector = getterFunction.call(receiver) as DependencyCollector
+                            collector.add(dependencyNotation)
+                            return DeclarativeRuntimeFunction.InvocationResult(Unit, null)
+                        }
+                    })
+                } else if (parameterValueBinding.bindingMap.containsKey(projectParam)) {
+                    return RuntimeFunctionResolver.Resolution.Resolved(object : DeclarativeRuntimeFunction {
+                        override fun callBy(receiver: Any, binding: Map<DataParameter, Any?>, hasLambda: Boolean): DeclarativeRuntimeFunction.InvocationResult {
+                            val dependencyNotation = binding.values.single() as ProjectDependency
+                            val collector: DependencyCollector = getterFunction.call(receiver) as DependencyCollector
+                            collector.add(dependencyNotation)
+                            return DeclarativeRuntimeFunction.InvocationResult(Unit, null)
+                        }
+                    })
+                } else {
+                    throw IllegalStateException()
+                }
             }
         }
         return RuntimeFunctionResolver.Resolution.Unresolved


### PR DESCRIPTION
This is pairing work done with @eskatos when attempting to convert additional subprojects in Now In Android.

It is necessary for https://github.com/gradle/nowinandroid/pull/5.