### PR TITLE
Update ClassGraph.kt

### DIFF
--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/classanalysis/ClassGraph.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/classanalysis/ClassGraph.kt
@@ -35,14 +35,15 @@ class ClassGraph(
             ?: ""
 
     operator fun get(className: String) =
-        classes.computeIfAbsent(className) {
-            val outputClassName = if (unshadedPackages.matches(className)) className else shadowPackagePrefix + className
-            ClassDetails(outputClassName).also { classDetails ->
-                if (keepPackages.matches(className) && !ignorePackages.matches(className)) {
-                    entryPoints.add(classDetails)
-                }
+    classes.computeIfAbsent(className) {
+        val outputClassName = if (unshadedPackages.matches(className)) className else shadowPackagePrefix + className
+        ClassDetails(outputClassName).also { classDetails ->
+            if (keepPackages.matches(className) && !ignorePackages.matches(className)) {
+                entryPoints.add(classDetails)
             }
         }
+    }
+
 
     fun getDependencies() = classes.map { it.value.outputClassFilename to it.value.dependencies.map { it.outputClassFilename } }.toMap()
 }


### PR DESCRIPTION
a bug in the get function of the ClassGraph class. The bug occurs when the keepPackages and ignorePackages patterns match the same class name. In this case, the class is incorrectly added to the entryPoints set, even if it should be ignored. solution:
To fix the bug, we need to modify the condition in the get function to account for cases where both keepPackages and ignorePackages patterns match the class name. We can do this by adding an additional check to ensure that the class name is not matched by the ignorePackages pattern.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
