### PR TITLE
Fix Gradle-Junit4 integration doesn't support junit parametrized tests with dot in the parameter

### DIFF
--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
@@ -148,9 +148,16 @@ public class TestSelectionMatcher {
             this.classNameSelector = patternStartsWithUpperCase(pattern) ?
                 new SimpleClassNameSelector() : new FullQualifiedClassNameSelector();
             int firstWildcardIndex = pattern.indexOf('*');
+            //https://github.com/gradle/gradle/issues/27572
+            int firstParametrizeIndex = pattern.indexOf('[');
             if (firstWildcardIndex == -1) {
                 segments = splitPreserveAllTokens(pattern, '.');
-                lastElementMatcher = new NoWildcardMatcher();
+                if(firstParametrizeIndex == -1){
+                    lastElementMatcher = new NoWildcardMatcher();
+                }else{
+                    segments = splitPreserveAllTokens(pattern.substring(0, firstParametrizeIndex), '.');
+                    segments[segments.length-1] += pattern.substring(firstParametrizeIndex);
+                }
             } else {
                 segments = splitPreserveAllTokens(pattern.substring(0, firstWildcardIndex), '.');
                 lastElementMatcher = new WildcardMatcher();

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
@@ -247,13 +247,14 @@ class TestSelectionMatcherTest extends Specification {
         matcher(pattern1, [], pattern2).mayIncludeClass(fullQualifiedName) == maybeMatch
 
         where:
-        pattern1                | pattern2                 | fullQualifiedName    | maybeMatch
-        ['FooTest*']            | ['FooTest']              | 'FooTest'            | true
-        ['FooTest*']            | ['BarTest*']             | 'FooTest'            | false
-        ['FooTest*']            | ['BarTest*']             | 'FooBarTest'         | false
-        []                      | []                       | 'anything'           | true
-        ['org.gradle.FooTest*'] | ['org.gradle.BarTest*']  | 'org.gradle.FooTest' | false
-        ['org.gradle.FooTest*'] | ['*org.gradle.BarTest*'] | 'org.gradle.FooTest' | true
+        pattern1                | pattern2                        | fullQualifiedName     | maybeMatch
+        ['']                    | ['com.my.Test.test[first.com]'] | 'com.my.Test'         | true
+        ['FooTest*']            | ['FooTest']                     | 'FooTest'             | true
+        ['FooTest*']            | ['BarTest*']                    | 'FooTest'             | false
+        ['FooTest*']            | ['BarTest*']                    | 'FooBarTest'          | false
+        []                      | []                              | 'anything'            | true
+        ['org.gradle.FooTest*'] | ['org.gradle.BarTest*']         | 'org.gradle.FooTest'  | false
+        ['org.gradle.FooTest*'] | ['*org.gradle.BarTest*']        | 'org.gradle.FooTest'  | true
     }
 
     def matcher(Collection<String> includedTests, Collection<String> excludedTests, Collection<String> includedTestsCommandLine) {


### PR DESCRIPTION
Aim to fix the issue of Gradle-Junit4 integration doesn't support junit parametrized tests with dot in the parameter name(https://github.com/gradle/gradle/issues/27572), via adding an extra step into where segments were broken up based on the '.' to consider the case where parametrized test could contain a dot inside.

<!--- The issue this PR addresses -->
Fixes: https://github.com/gradle/gradle/issues/27572
<!-- Fixes #? -->

### Context
There exists use cases where users might have dot inside their parameter name, whilst its nice to have walkarounds, it would even be better if this issue is fixed.

