### PR TITLE
Fix Creating a Kotlin library with JUnit 5 testing is unsupported with gradle init

### DIFF
--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinLibraryInitIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinLibraryInitIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
 import org.gradle.test.fixtures.file.LeaksFileHandles
 
 import static org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl.KOTLIN
+import static org.hamcrest.CoreMatchers.containsString
 
 @LeaksFileHandles
 class KotlinLibraryInitIntegrationTest extends AbstractJvmLibraryInitIntegrationSpec {
@@ -153,5 +154,17 @@ class KotlinLibraryInitIntegrationTest extends AbstractJvmLibraryInitIntegration
 
         where:
         scriptDsl << ScriptDslFixture.SCRIPT_DSLS
+    }
+
+    def "initializes Kotlin library with JUnit Jupiter test framework"() {
+        when:
+        run('init', '--type', 'kotlin-library', '--test-framework', 'junit-jupiter')
+
+        then:
+        subprojectDir.file("build.gradle.kts").assertExists()
+
+        and:
+        subprojectDir.file("build.gradle.kts").assertContents(containsString("junit.jupiter"))
+
     }
 }

--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinLibraryInitIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinLibraryInitIntegrationTest.groovy
@@ -166,5 +166,14 @@ class KotlinLibraryInitIntegrationTest extends AbstractJvmLibraryInitIntegration
         and:
         subprojectDir.file("build.gradle.kts").assertContents(containsString("junit.jupiter"))
 
+        when:
+        run("build")
+
+        then:
+        assertTestPassed("org.example.LibraryTest", "someLibraryMethodReturnsTrue")
+
+        where:
+        scriptDsl << ScriptDslFixture.SCRIPT_DSLS
+
     }
 }

--- a/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/model/Description.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/model/Description.java
@@ -60,7 +60,7 @@ public class Description {
     public final static Description KOTLIN = new Description(
         Language.KOTLIN,
         KOTLINTEST,
-        singletonList(KOTLINTEST),
+        asList(KOTLINTEST,JUNIT_JUPITER),
         "org.jetbrains.kotlin.jvm", "kotlin"
     );
 

--- a/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/model/Description.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/model/Description.java
@@ -60,7 +60,7 @@ public class Description {
     public final static Description KOTLIN = new Description(
         Language.KOTLIN,
         KOTLINTEST,
-        asList(KOTLINTEST,JUNIT_JUPITER),
+        asList(KOTLINTEST, JUNIT_JUPITER),
         "org.jetbrains.kotlin.jvm", "kotlin"
     );
 

--- a/platforms/software/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/kotlinlibrary/junitjupiter/LibraryTest.kt.template
+++ b/platforms/software/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/kotlinlibrary/junitjupiter/LibraryTest.kt.template
@@ -1,0 +1,11 @@
+${fileComment.multilineComment}${packageDecl.javaStatement}
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+
+class LibraryTest {
+    @Test
+    fun someLibraryMethodReturnsTrue() {
+        val classUnderTest = Library()
+        assertTrue(classUnderTest.someLibraryMethod(), "someLibraryMethod should return 'true'")
+    }
+}


### PR DESCRIPTION
Allows for the creation of a kotlin libaray with junit 5 for kotlin(https://github.com/gradle/gradle/issues/28414) along with an integration test case added to capture the bug.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->
Fixes:https://github.com/gradle/gradle/issues/28414

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
