### PR TITLE
Re-enable writing TD trace file

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,10 @@ systemProp.org.gradle.internal.ide.scan=true
 # If you're experimenting with changes and don't want to update the verification file right away, please change the mode to "lenient" (not "off")
 org.gradle.dependency.verification=strict
 # TD releated properties
-gradle.internal.testdistribution.writeTraceFile=false
-systemProp.gradle.internal.testdistribution.writeTraceFile=false
-systemProp.gradle.internal.testdistribution.queryResponseTimeout=PT20S
+gradle.internal.testdistribution.writeTraceFile=true
+develocity.internal.testdistribution.writeTraceFile=true
+gradle.internal.testdistribution.queryResponseTimeout=PT20S
+develocity.internal.testdistribution.queryResponseTimeout=PT20S
 # Default performance baseline
 defaultPerformanceBaselines=8.8-commit-69bcb288dad
 


### PR DESCRIPTION
Was disabled because of https://github.com/gradle/gradle-private/issues/3972

Now it's solved in https://github.com/gradle/ge/pull/27277

Also added new property names in case we forget when updating to develocity plugin.