### PR TITLE
Improve handling of inconsistent immutable workspaces

### DIFF
--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/AssignImmutableWorkspaceStep.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/AssignImmutableWorkspaceStep.java
@@ -150,6 +150,7 @@ public class AssignImmutableWorkspaceStep<C extends IdentityContext> implements 
             if (moveSuccessful) {
                 return Optional.empty();
             }
+            // We couldn't move the inconsistent workspace out of the way, falling back to reusing it
         }
 
         return Optional.of(loadImmutableWorkspace(work, immutableLocation, metadata, outputSnapshots));

--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -280,7 +280,7 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         2.times {
             executer.expectDeprecationWarning("The Task.someFeature() method has been deprecated. This is scheduled to be removed in Gradle 9.0.")
             executer.expectDeprecationWarning("The Task.someFeature() method has been deprecated. This is scheduled to be removed in Gradle 9.0.")
-            executer.expectDeprecationWarningPattern(/The Task\.\w+\(\) method has been deprecated\. This is scheduled to be removed in Gradle 9\.0\./)
+            executer.expectDeprecationWarningWithPattern(/The Task\.\w+\(\) method has been deprecated\. This is scheduled to be removed in Gradle 9\.0\./)
             run("broken", "buildSrc:broken", "included:broken")
 
             outputContains("Build file '${file("included/build.gradle")}': line 5")

--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -280,7 +280,7 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         2.times {
             executer.expectDeprecationWarning("The Task.someFeature() method has been deprecated. This is scheduled to be removed in Gradle 9.0.")
             executer.expectDeprecationWarning("The Task.someFeature() method has been deprecated. This is scheduled to be removed in Gradle 9.0.")
-            executer.expectDeprecationWarning("The Task.someFeature() method has been deprecated. This is scheduled to be removed in Gradle 9.0.")
+            executer.expectDeprecationWarningPattern(/The Task\.\w+\(\) method has been deprecated\. This is scheduled to be removed in Gradle 9\.0\./)
             run("broken", "buildSrc:broken", "included:broken")
 
             outputContains("Build file '${file("included/build.gradle")}': line 5")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -1346,7 +1346,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         def outputDir = immutableOutputDir("lib1.jar", "0/lib1-green.jar")
         def workspaceDir = outputDir.parentFile
         outputDir.file("tamper-tamper.txt").text = "Making a mess"
-        executer.expectDeprecationWarningMultilinePattern("""The contents of the immutable workspace '.*' have been modified. This behavior has been deprecated. This will fail with an error in Gradle 9.0. These workspace directories are not supposed to be modified once they are created. The modification might have been caused by an external process, or could be the result of disk corruption. The inconsistent workspace has been moved to '.*', and will be recreated.
+        executer.expectDeprecationWarningWithMultilinePattern("""The contents of the immutable workspace '.*' have been modified. This behavior has been deprecated. This will fail with an error in Gradle 9.0. These workspace directories are not supposed to be modified once they are created. The modification might have been caused by an external process, or could be the result of disk corruption. The inconsistent workspace has been moved to '.*', and will be recreated.
 outputDirectory:
  - transformed \\(Directory, [0-9a-f]+\\)
    - 0 \\(Directory, [0-9a-f]+\\)

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -1346,7 +1346,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         def outputDir = immutableOutputDir("lib1.jar", "0/lib1-green.jar")
         def workspaceDir = outputDir.parentFile
         outputDir.file("tamper-tamper.txt").text = "Making a mess"
-        executer.expectDeprecationWarningWithMultilinePattern("""The contents of the immutable workspace '.*' have been modified. This behavior has been deprecated. This will fail with an error in Gradle 9.0. These workspace directories are not supposed to be modified once they are created. The modification might have been caused by an external process, or could be the result of disk corruption. The inconsistent workspace has been moved to '.*', and will be recreated.
+        executer.expectDeprecationWarningWithMultilinePattern("""The contents of the immutable workspace '.*' have been modified. This behavior has been deprecated. This will fail with an error in Gradle 9.0. These workspace directories are not supposed to be modified once they are created. The modification might have been caused by an external process, or could be the result of disk corruption. The inconsistent workspace will be moved to '.*', and will be recreated.
 outputDirectory:
  - transformed \\(Directory, [0-9a-f]+\\)
    - 0 \\(Directory, [0-9a-f]+\\)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -93,7 +93,6 @@ import static org.gradle.integtests.fixtures.executer.AbstractGradleExecuter.Cli
 import static org.gradle.integtests.fixtures.executer.AbstractGradleExecuter.CliDaemonArgument.FOREGROUND;
 import static org.gradle.integtests.fixtures.executer.AbstractGradleExecuter.CliDaemonArgument.NOT_DEFINED;
 import static org.gradle.integtests.fixtures.executer.AbstractGradleExecuter.CliDaemonArgument.NO_DAEMON;
-import static org.gradle.integtests.fixtures.executer.DocumentationUtils.normalizeDocumentationLink;
 import static org.gradle.internal.service.scopes.DefaultGradleUserHomeScopeServiceRegistry.REUSE_USER_HOME_SERVICES;
 import static org.gradle.util.internal.CollectionUtils.collect;
 import static org.gradle.util.internal.CollectionUtils.join;
@@ -1334,11 +1333,6 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
     public GradleExecuter expectDeprecationWarning(ExpectedDeprecationWarning warning) {
         expectedDeprecationWarnings.add(warning);
         return this;
-    }
-
-    @Override
-    public GradleExecuter expectDocumentedDeprecationWarning(ExpectedDeprecationWarning warning) {
-        return expectDeprecationWarning(normalizeDocumentationLink(warning.getMessage()));
     }
 
     @Override

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -360,6 +360,10 @@ public interface GradleExecuter extends Stoppable {
         return expectDeprecationWarning(ExpectedDeprecationWarning.withSingleLinePattern(pattern));
     }
 
+    default GradleExecuter expectDeprecationWarningMultilinePattern(String pattern) {
+        return expectDeprecationWarningMultilinePattern(pattern, pattern.split("\n").length);
+    }
+
     default GradleExecuter expectDeprecationWarningMultilinePattern(String pattern, int numLines) {
         return expectDeprecationWarning(ExpectedDeprecationWarning.withMultiLinePattern(pattern, numLines));
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -35,6 +35,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static org.gradle.integtests.fixtures.executer.DocumentationUtils.normalizeDocumentationLink;
+
 public interface GradleExecuter extends Stoppable {
     /**
      * Sets the working directory to use. Defaults to the test's temporary directory.
@@ -351,7 +353,15 @@ public interface GradleExecuter extends Stoppable {
      * link and you don't want to (ironically) see code testing deprecation appearing as if it itself were deprecated.
      */
     default GradleExecuter expectDeprecationWarning(String warning) {
-        return expectDeprecationWarning(new ExpectedDeprecationWarning(warning));
+        return expectDeprecationWarning(ExpectedDeprecationWarning.withMessage(warning));
+    }
+
+    default GradleExecuter expectDeprecationWarningPattern(String pattern) {
+        return expectDeprecationWarning(ExpectedDeprecationWarning.withSingleLinePattern(pattern));
+    }
+
+    default GradleExecuter expectDeprecationWarningMultilinePattern(String pattern, int numLines) {
+        return expectDeprecationWarning(ExpectedDeprecationWarning.withMultiLinePattern(pattern, numLines));
     }
 
     GradleExecuter expectDeprecationWarning(ExpectedDeprecationWarning warning);
@@ -360,10 +370,8 @@ public interface GradleExecuter extends Stoppable {
      * Expects the given deprecation warning, allowing to pass documentation url with /current/ version and asserting against the actual current version instead.
      */
     default GradleExecuter expectDocumentedDeprecationWarning(String warning) {
-        return expectDocumentedDeprecationWarning(new ExpectedDeprecationWarning(warning));
+        return expectDeprecationWarning(normalizeDocumentationLink(warning));
     }
-
-    GradleExecuter expectDocumentedDeprecationWarning(ExpectedDeprecationWarning warning);
 
     /**
      * Expects exactly the given number of deprecation warnings. If fewer or more warnings are produced during

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -356,15 +356,15 @@ public interface GradleExecuter extends Stoppable {
         return expectDeprecationWarning(ExpectedDeprecationWarning.withMessage(warning));
     }
 
-    default GradleExecuter expectDeprecationWarningPattern(String pattern) {
+    default GradleExecuter expectDeprecationWarningWithPattern(String pattern) {
         return expectDeprecationWarning(ExpectedDeprecationWarning.withSingleLinePattern(pattern));
     }
 
-    default GradleExecuter expectDeprecationWarningMultilinePattern(String pattern) {
-        return expectDeprecationWarningMultilinePattern(pattern, pattern.split("\n").length);
+    default GradleExecuter expectDeprecationWarningWithMultilinePattern(String pattern) {
+        return expectDeprecationWarningWithMultilinePattern(pattern, pattern.split("\n").length);
     }
 
-    default GradleExecuter expectDeprecationWarningMultilinePattern(String pattern, int numLines) {
+    default GradleExecuter expectDeprecationWarningWithMultilinePattern(String pattern, int numLines) {
         return expectDeprecationWarning(ExpectedDeprecationWarning.withMultiLinePattern(pattern, numLines));
     }
 


### PR DESCRIPTION
Improves #28475

Previously when we detected an inconsistent immutable workspace, we'd fail the build. Now instead we attempt to move the offending workspace to a temporary location, and re-try re-creating the content. When this happens, the following deprecation warning is produced:

```text
> Transform lib1.jar (project :lib) with Duplicator
The contents of the immutable workspace '...' have been modified. This behavior has been deprecated. This will fail with an error in Gradle 9.0. These workspace directories are not supposed to be modified once they are created. The modification might have been caused by an external process, or could be the result of disk corruption. The inconsistent workspace has been moved to '...', and will be recreated.
outputDirectory:
 - transformed (Directory, 7cfc7dbc0901a39cf9a5f44f7ea491b8)
   - 0 (Directory, 78af062fd74d95b8d382f5adabb136f5)
     - lib1-green.jar (RegularFile, 1ba4170a71868b572bca2e747af7a707)
   - tamper-tamper.txt (RegularFile, c2a9b87422fcb39f4f55ff182939992b)

resultsFile:
 - results.bin (RegularFile, 44ec6391aaade3532e59b1d99d292b4d)
```

This makes the build more resilient against consistency problems caused by disk corruption, or external processes making changes to the workspaces.

In a separate PR we still need to fix cache cleanup causing problems, see details at https://github.com/gradle/gradle/issues/28475#issuecomment-2004778241.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
