### PR TITLE
Do not instrument abstract doCall methods of Closures

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/ClosureInstrumentationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/ClosureInstrumentationIntegrationTest.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.classpath
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
+
+class ClosureInstrumentationIntegrationTest extends AbstractIntegrationSpec {
+    @Issue("https://github.com/gradle/gradle/issues/28389")
+    def "can instrument abstract closure classes"() {
+        given:
+        createDir("buildSrc") {
+            dir("src/main/java") {
+                file("MyBaseClosure.java") << """
+                    import ${Closure.name};
+                    public abstract class MyBaseClosure extends Closure<String> {
+                        protected MyBaseClosure(Object owner) {
+                            super(owner);
+                        }
+
+                        protected final void setDelegateBase(Object delegate) {
+                            super.setDelegate(delegate);
+                        }
+
+                        @Override
+                        public abstract void setDelegate(Object delegate);
+
+                        public abstract String doCall(String argument);
+                    }
+                """
+
+                file("ReverseClosure.java") << """
+                    public class ReverseClosure extends MyBaseClosure {
+                        protected ReverseClosure(Object owner) {
+                            super(owner);
+                        }
+
+                        @Override
+                        public void setDelegate(Object delegate) {
+                            setDelegateBase(delegate);
+                        }
+
+                        @Override
+                        public String doCall(String argument) {
+                            return new StringBuilder(argument).reverse().toString();
+                        }
+                    }
+                """
+            }
+            file("settings.gradle") << "\n"
+        }
+
+        buildFile("""
+            task("hello") {
+                doLast {
+                    def cl = new ReverseClosure(this)
+                    println("closure = " + cl("hello"))
+                }
+            }
+        """)
+
+        when:
+        run("hello")
+
+        then:
+        outputContains("closure = olleh")
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/CallInterceptionClosureInstrumentingClassVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/CallInterceptionClosureInstrumentingClassVisitor.java
@@ -107,10 +107,11 @@ public class CallInterceptionClosureInstrumentingClassVisitor extends ClassVisit
          * Renames the Closure's original `doCall` method and adds a wrapper method that invokes the original one.
          */
         RENAME_ORIGINAL_DO_CALL("doCall", null, false, (clazz, methodData) -> {
-            boolean isDoCallMethod = methodData.name.equals("doCall");
-            String methodNameToVisit = isDoCallMethod ? "doCall$original" : methodData.name;
+            // A Closure implementation may have an abstract doCall method. It makes no sense to rewrite that.
+            boolean isValidDoCallMethod = !methodData.isAbstract() && methodData.name.equals("doCall");
+            String methodNameToVisit = isValidDoCallMethod ? "doCall$original" : methodData.name;
             MethodVisitor original = clazz.visitor.visitMethod(methodData.access, methodNameToVisit, methodData.descriptor, methodData.signature, methodData.exceptions);
-            if (isDoCallMethod) {
+            if (isValidDoCallMethod) {
                 @NonNullApi
                 class MethodVisitorScopeImpl extends MethodVisitorScope {
                     public MethodVisitorScopeImpl(MethodVisitor methodVisitor) {
@@ -229,6 +230,10 @@ public class CallInterceptionClosureInstrumentingClassVisitor extends ClassVisit
                 this.descriptor = descriptor;
                 this.signature = signature;
                 this.exceptions = exceptions;
+            }
+
+            public boolean isAbstract() {
+                return (access & Opcodes.ACC_ABSTRACT) != 0;
             }
         }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/transforms/InstrumentingClassTransform.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/transforms/InstrumentingClassTransform.java
@@ -70,7 +70,7 @@ public class InstrumentingClassTransform implements ClassTransform {
     /**
      * Decoration format. Increment this when making changes.
      */
-    private static final int DECORATION_FORMAT = 35;
+    private static final int DECORATION_FORMAT = 36;
 
     private static final Type SYSTEM_TYPE = getType(System.class);
     private static final Type INTEGER_TYPE = getType(Integer.class);

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
@@ -272,7 +272,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/46be64fb645b6862b6ca71ccee62da52/thing.jar")
+        def cachedFile = testDir.file("cached/81ce855514a44b94a5a32d6f9040cc34/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -301,7 +301,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def dir = testDir.file("thing.dir")
         classesDir(dir)
         def classpath = DefaultClassPath.of(dir)
-        def cachedFile = testDir.file("cached/0b371d5ebfeeba14a4cc4903b48dee77/thing.dir")
+        def cachedFile = testDir.file("cached/44eba99864a0061bf21b4b8b91235288/thing.dir")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -332,8 +332,8 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(dir, file)
-        def cachedDir = testDir.file("cached/0b371d5ebfeeba14a4cc4903b48dee77/thing.dir")
-        def cachedFile = testDir.file("cached/46be64fb645b6862b6ca71ccee62da52/thing.jar")
+        def cachedDir = testDir.file("cached/44eba99864a0061bf21b4b8b91235288/thing.dir")
+        def cachedFile = testDir.file("cached/81ce855514a44b94a5a32d6f9040cc34/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -390,8 +390,8 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file3 = testDir.file("thing3.jar")
         jar(file3)
         def classpath = DefaultClassPath.of(dir, file, dir2, file2, dir3, file3)
-        def cachedDir = testDir.file("cached/0b371d5ebfeeba14a4cc4903b48dee77/thing.dir")
-        def cachedFile = testDir.file("cached/46be64fb645b6862b6ca71ccee62da52/thing.jar")
+        def cachedDir = testDir.file("cached/44eba99864a0061bf21b4b8b91235288/thing.dir")
+        def cachedFile = testDir.file("cached/81ce855514a44b94a5a32d6f9040cc34/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -445,7 +445,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jarWithStoredResource(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/9887cf59e55e07a7da0f3ad17dbea9fa/thing.jar")
+        def cachedFile = testDir.file("cached/d6067f6fe41da98247e6c867585958b2/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)


### PR DESCRIPTION
It makes no sense and breaks valid classes.

Fixes #28389 
