### PR TITLE
Handle duplicated artifacts with different paths in the instrumentation logic

### DIFF
--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/classpath/TransformedClassPath.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/classpath/TransformedClassPath.java
@@ -18,6 +18,7 @@ package org.gradle.internal.classpath;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.specs.Spec;
 
@@ -27,7 +28,6 @@ import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -319,7 +319,7 @@ public class TransformedClassPath implements ClassPath {
     }
 
     private static ClassPath fromInstrumentingArtifactTransformOutput(List<File> inputFiles) {
-        Map<File, File> transformedEntries = new LinkedHashMap<File, File>(inputFiles.size());
+        Map<File, File> transformedEntries = Maps.newLinkedHashMapWithExpectedSize(inputFiles.size());
         for (int i = 0; i < inputFiles.size();) {
             File markerFile = inputFiles.get(i++);
             FileMarker fileMarker = FileMarker.of(markerFile.getName());
@@ -360,7 +360,6 @@ public class TransformedClassPath implements ClassPath {
         }
         return result.build();
     }
-
 
     /**
      * Base-services still uses Java 6, so we can't use Map#putIfAbsent.

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/classpath/TransformedClassPath.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/classpath/TransformedClassPath.java
@@ -350,6 +350,7 @@ public class TransformedClassPath implements ClassPath {
                     // Ignore these markers
                     break;
                 case UNKNOWN_FILE_MARKER:
+                default:
                     throw new IllegalArgumentException("Unexpected marker file: " + markerFile + " in instrumented buildscript classpath. " +
                         "Possible reason: Injecting custom artifact transform in between instrumentation stages is not supported.");
             }

--- a/platforms/core-runtime/base-services/src/test/groovy/org/gradle/internal/classpath/TransformedClassPathTest.groovy
+++ b/platforms/core-runtime/base-services/src/test/groovy/org/gradle/internal/classpath/TransformedClassPathTest.groovy
@@ -19,10 +19,10 @@ package org.gradle.internal.classpath
 
 import spock.lang.Specification
 
-import static org.gradle.internal.classpath.TransformedClassPath.AGENT_INSTRUMENTATION_MARKER_FILE_NAME
-import static org.gradle.internal.classpath.TransformedClassPath.INSTRUMENTATION_CLASSPATH_MARKER_FILE_NAME
-import static org.gradle.internal.classpath.TransformedClassPath.LEGACY_INSTRUMENTATION_MARKER_FILE_NAME
-import static org.gradle.internal.classpath.TransformedClassPath.ORIGINAL_FILE_DOES_NOT_EXIST_MARKER
+import static org.gradle.internal.classpath.TransformedClassPath.FileMarker.AGENT_INSTRUMENTATION_MARKER
+import static org.gradle.internal.classpath.TransformedClassPath.FileMarker.INSTRUMENTATION_CLASSPATH_MARKER
+import static org.gradle.internal.classpath.TransformedClassPath.FileMarker.LEGACY_INSTRUMENTATION_MARKER
+import static org.gradle.internal.classpath.TransformedClassPath.FileMarker.ORIGINAL_FILE_DOES_NOT_EXIST_MARKER
 import static org.gradle.util.internal.TextUtil.normaliseFileSeparators
 
 class TransformedClassPathTest extends Specification {
@@ -188,12 +188,12 @@ class TransformedClassPathTest extends Specification {
         cp.findTransformedEntryFor(file(original)) == (transformed != null ? file(transformed) : null)
 
         where:
-        inputClassPath                                                                                                                                                                                    | outputClassPath             | original | transformed
-        classPathAsList(AGENT_INSTRUMENTATION_MARKER_FILE_NAME, "instrumented/instrumented-1.jar", "1.jar")                                                                                               | classPath("1.jar")          | "1.jar"  | "instrumented/instrumented-1.jar"
-        classPathAsList(AGENT_INSTRUMENTATION_MARKER_FILE_NAME, "instrumented/instrumented-1.jar", "1.jar", ORIGINAL_FILE_DOES_NOT_EXIST_MARKER)                                                          | classPath("1.jar")          | "1.jar"  | "instrumented/instrumented-1.jar"
-        classPathAsList("1/$LEGACY_INSTRUMENTATION_MARKER_FILE_NAME", "1.jar", "2/$LEGACY_INSTRUMENTATION_MARKER_FILE_NAME", "2.jar")                                                                     | classPath("1.jar", "2.jar") | "2.jar"  | null
-        classPathAsList(INSTRUMENTATION_CLASSPATH_MARKER_FILE_NAME, ORIGINAL_FILE_DOES_NOT_EXIST_MARKER)                                                                                                  | classPath()                 | ""       | null
-        classPathAsList("1/$AGENT_INSTRUMENTATION_MARKER_FILE_NAME", "instrumented/instrumented-1.jar", "1.jar", "2/$AGENT_INSTRUMENTATION_MARKER_FILE_NAME", "instrumented/instrumented-2.jar", "2.jar") | classPath("1.jar", "2.jar") | "1.jar"  | "instrumented/instrumented-1.jar"
+        inputClassPath                                                                                                                                                                                      | outputClassPath             | original | transformed
+        classPathAsList(AGENT_INSTRUMENTATION_MARKER.fileName, "instrumented/instrumented-1.jar", "1.jar")                                                                                                  | classPath("1.jar")          | "1.jar"  | "instrumented/instrumented-1.jar"
+        classPathAsList(AGENT_INSTRUMENTATION_MARKER.fileName, "instrumented/instrumented-1.jar", "1.jar", ORIGINAL_FILE_DOES_NOT_EXIST_MARKER.fileName)                                                    | classPath("1.jar")          | "1.jar"  | "instrumented/instrumented-1.jar"
+        classPathAsList("1/${LEGACY_INSTRUMENTATION_MARKER.fileName}", "1.jar", "2/${LEGACY_INSTRUMENTATION_MARKER.fileName}", "2.jar")                                                                     | classPath("1.jar", "2.jar") | "2.jar"  | null
+        classPathAsList(INSTRUMENTATION_CLASSPATH_MARKER.fileName, ORIGINAL_FILE_DOES_NOT_EXIST_MARKER.fileName)                                                                                            | classPath()                 | ""       | null
+        classPathAsList("1/${AGENT_INSTRUMENTATION_MARKER.fileName}", "instrumented/instrumented-1.jar", "1.jar", "2/${AGENT_INSTRUMENTATION_MARKER.fileName}", "instrumented/instrumented-2.jar", "2.jar") | classPath("1.jar", "2.jar") | "1.jar"  | "instrumented/instrumented-1.jar"
     }
 
     def "invalid instrumenting artifact transform outputs are detected"() {
@@ -205,13 +205,13 @@ class TransformedClassPathTest extends Specification {
         normaliseFileSeparators(e.message) == normaliseFileSeparators(message)
 
         where:
-        inputClassPath                                                                                                                                                        | message
-        classPathAsList("instrumented/instrumented-1.jar", "1.jar")                                                                                                           | "Unexpected marker file: instrumented/instrumented-1.jar in instrumented buildscript classpath. Possible reason: Injecting custom artifact transform in between instrumentation stages is not supported."
-        classPathAsList(AGENT_INSTRUMENTATION_MARKER_FILE_NAME, "instrumented/instrumented-1.jar")                                                                            | "Missing the instrumented or original entry for classpath [.gradle-agent-instrumented.marker, instrumented/instrumented-1.jar]"
-        classPathAsList(AGENT_INSTRUMENTATION_MARKER_FILE_NAME, "instrumented/instrumented-1.jar", AGENT_INSTRUMENTATION_MARKER_FILE_NAME, "instrumented/instrumented-2.jar") | "Instrumented entry ${file("instrumented/instrumented-1.jar").absolutePath} doesn't match original entry ${file(AGENT_INSTRUMENTATION_MARKER_FILE_NAME).absolutePath}"
-        classPathAsList(AGENT_INSTRUMENTATION_MARKER_FILE_NAME, "instrumented/instrumented-1.jar", "2.jar")                                                                   | "Instrumented entry ${file("instrumented/instrumented-1.jar").absolutePath} doesn't match original entry ${file("2.jar").absolutePath}"
-        classPathAsList(LEGACY_INSTRUMENTATION_MARKER_FILE_NAME, "instrumented/instrumented-1.jar", "1.jar")                                                                  | "Unexpected marker file: 1.jar in instrumented buildscript classpath. Possible reason: Injecting custom artifact transform in between instrumentation stages is not supported."
-        classPathAsList(AGENT_INSTRUMENTATION_MARKER_FILE_NAME, "1.jar", "instrumented/instrumented-1.jar")                                                                   | "Instrumented entry ${file("1.jar").absolutePath} doesn't match original entry ${file("instrumented/instrumented-1.jar").absolutePath}"
+        inputClassPath                                                                                                                                                      | message
+        classPathAsList("instrumented/instrumented-1.jar", "1.jar")                                                                                                         | "Unexpected marker file: instrumented/instrumented-1.jar in instrumented buildscript classpath. Possible reason: Injecting custom artifact transform in between instrumentation stages is not supported."
+        classPathAsList(AGENT_INSTRUMENTATION_MARKER.fileName, "instrumented/instrumented-1.jar")                                                                           | "Missing the instrumented or original entry for classpath [.gradle-agent-instrumented.marker, instrumented/instrumented-1.jar]"
+        classPathAsList(AGENT_INSTRUMENTATION_MARKER.fileName, "instrumented/instrumented-1.jar", AGENT_INSTRUMENTATION_MARKER.fileName, "instrumented/instrumented-2.jar") | "Instrumented entry ${file("instrumented/instrumented-1.jar").absolutePath} doesn't match original entry ${file(AGENT_INSTRUMENTATION_MARKER.fileName).absolutePath}"
+        classPathAsList(AGENT_INSTRUMENTATION_MARKER.fileName, "instrumented/instrumented-1.jar", "2.jar")                                                                  | "Instrumented entry ${file("instrumented/instrumented-1.jar").absolutePath} doesn't match original entry ${file("2.jar").absolutePath}"
+        classPathAsList(LEGACY_INSTRUMENTATION_MARKER.fileName, "instrumented/instrumented-1.jar", "1.jar")                                                                 | "Unexpected marker file: 1.jar in instrumented buildscript classpath. Possible reason: Injecting custom artifact transform in between instrumentation stages is not supported."
+        classPathAsList(AGENT_INSTRUMENTATION_MARKER.fileName, "1.jar", "instrumented/instrumented-1.jar")                                                                  | "Instrumented entry ${file("1.jar").absolutePath} doesn't match original entry ${file("instrumented/instrumented-1.jar").absolutePath}"
     }
 
     private static File file(String path) {

--- a/platforms/core-runtime/messaging/src/test/groovy/org/gradle/internal/serialize/HierarchicalNameSerializerTest.groovy
+++ b/platforms/core-runtime/messaging/src/test/groovy/org/gradle/internal/serialize/HierarchicalNameSerializerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.tasks.compile.incremental.serialization
+package org.gradle.internal.serialize
 
 import org.gradle.api.internal.cache.StringInterner
-import org.gradle.internal.serialize.HierarchicalNameSerializer
 import org.gradle.internal.serialize.kryo.KryoBackedDecoder
 import org.gradle.internal.serialize.kryo.KryoBackedEncoder
 import spock.lang.Specification

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/BaseInstrumentingArtifactTransform.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/BaseInstrumentingArtifactTransform.java
@@ -46,12 +46,12 @@ import java.io.File;
 import static org.gradle.api.internal.initialization.transform.BaseInstrumentingArtifactTransform.Parameters;
 import static org.gradle.api.internal.initialization.transform.utils.InstrumentationTransformUtils.createInstrumentationClasspathMarker;
 import static org.gradle.api.internal.initialization.transform.utils.InstrumentationTransformUtils.createNewFile;
-import static org.gradle.internal.classpath.TransformedClassPath.AGENT_INSTRUMENTATION_MARKER_FILE_NAME;
+import static org.gradle.internal.classpath.TransformedClassPath.FileMarker.AGENT_INSTRUMENTATION_MARKER;
+import static org.gradle.internal.classpath.TransformedClassPath.FileMarker.LEGACY_INSTRUMENTATION_MARKER;
+import static org.gradle.internal.classpath.TransformedClassPath.FileMarker.ORIGINAL_FILE_DOES_NOT_EXIST_MARKER;
 import static org.gradle.internal.classpath.TransformedClassPath.INSTRUMENTED_DIR_NAME;
 import static org.gradle.internal.classpath.TransformedClassPath.INSTRUMENTED_ENTRY_PREFIX;
-import static org.gradle.internal.classpath.TransformedClassPath.LEGACY_INSTRUMENTATION_MARKER_FILE_NAME;
 import static org.gradle.internal.classpath.TransformedClassPath.ORIGINAL_DIR_NAME;
-import static org.gradle.internal.classpath.TransformedClassPath.ORIGINAL_FILE_DOES_NOT_EXIST_MARKER;
 
 /**
  * Base artifact transform that instruments plugins with Gradle instrumentation, e.g. for configuration cache detection or property upgrades.
@@ -80,7 +80,7 @@ public abstract class BaseInstrumentingArtifactTransform implements TransformAct
     protected void doTransform(File artifactToTransform, TransformOutputs outputs) {
         createInstrumentationClasspathMarker(outputs);
         if (!artifactToTransform.exists()) {
-            createNewFile(outputs.file(ORIGINAL_FILE_DOES_NOT_EXIST_MARKER));
+            createNewFile(outputs.file(ORIGINAL_FILE_DOES_NOT_EXIST_MARKER.getFileName()));
             return;
         }
 
@@ -88,10 +88,10 @@ public abstract class BaseInstrumentingArtifactTransform implements TransformAct
             // When agent is supported, we output an instrumented jar and an original jar,
             // so we can then later reconstruct instrumented jars classpath and original jars classpath.
             // We add `instrumented-` prefix to the file since names for the same transform needs to be unique when querying results via ArtifactCollection.
-            createNewFile(outputs.file(AGENT_INSTRUMENTATION_MARKER_FILE_NAME));
+            createNewFile(outputs.file(AGENT_INSTRUMENTATION_MARKER.getFileName()));
             doTransform(artifactToTransform, outputs, originalName -> INSTRUMENTED_ENTRY_PREFIX + originalName);
         } else {
-            createNewFile(outputs.file(LEGACY_INSTRUMENTATION_MARKER_FILE_NAME));
+            createNewFile(outputs.file(LEGACY_INSTRUMENTATION_MARKER.getFileName()));
             doTransform(artifactToTransform, outputs, originalName -> originalName);
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/services/CacheInstrumentationDataBuildService.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/services/CacheInstrumentationDataBuildService.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.initialization.transform.services;
 
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
@@ -36,7 +37,6 @@ import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -136,7 +136,7 @@ public abstract class CacheInstrumentationDataBuildService implements BuildServi
             this.hashCache = new ConcurrentHashMap<>();
             this.hashToOriginalFile = Lazy.locking().of(() -> {
                 Set<File> originalClasspath = getOriginalClasspath().getFiles();
-                Map<String, File> originalFiles = new HashMap<>(originalClasspath.size());
+                Map<String, File> originalFiles = Maps.newHashMapWithExpectedSize(originalClasspath.size());
                 originalClasspath.forEach(file -> {
                     String fileHash = getArtifactHash(file);
                     if (fileHash != null) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/utils/InstrumentationTransformUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/utils/InstrumentationTransformUtils.java
@@ -22,7 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
-import static org.gradle.internal.classpath.TransformedClassPath.INSTRUMENTATION_CLASSPATH_MARKER_FILE_NAME;
+import static org.gradle.internal.classpath.TransformedClassPath.FileMarker.INSTRUMENTATION_CLASSPATH_MARKER;
 
 public class InstrumentationTransformUtils {
 
@@ -51,7 +51,7 @@ public class InstrumentationTransformUtils {
     }
 
     public static boolean isInstrumentationMarkerFile(File input) {
-        return input.getName().equals(INSTRUMENTATION_CLASSPATH_MARKER_FILE_NAME);
+        return input.getName().equals(INSTRUMENTATION_CLASSPATH_MARKER.getFileName());
     }
 
     public static void outputOriginalArtifact(TransformOutputs outputs, File originalArtifact) {
@@ -71,6 +71,6 @@ public class InstrumentationTransformUtils {
     }
 
     public static void createInstrumentationClasspathMarker(TransformOutputs outputs) {
-        createNewFile(outputs.file(INSTRUMENTATION_CLASSPATH_MARKER_FILE_NAME));
+        createNewFile(outputs.file(INSTRUMENTATION_CLASSPATH_MARKER.getFileName()));
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/mutator/ClearArtifactTransformCacheWithoutInstrumentedJarsMutator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/mutator/ClearArtifactTransformCacheWithoutInstrumentedJarsMutator.groovy
@@ -28,10 +28,17 @@ import java.nio.file.attribute.BasicFileAttributes
 import static org.gradle.api.internal.initialization.transform.utils.InstrumentationTransformUtils.ANALYSIS_OUTPUT_DIR
 import static org.gradle.api.internal.initialization.transform.utils.InstrumentationTransformUtils.MERGE_OUTPUT_DIR
 import static org.gradle.internal.classpath.TransformedClassPath.FileMarker.INSTRUMENTATION_CLASSPATH_MARKER
+
 /**
  * A mutator that cleans up the artifact transform cache directory, but leaves folders with the instrumented jars.
  *
- * This mutator should be moved to the gradle-profiler.
+ * Since buildscript classpath instrumentation also uses artifact transforms, we can avoid
+ * re-instrumenting jars by applying this mutator.
+ *
+ * In other words, this mutator can be applied to a scenario that tests performance of artifact transforms,
+ * but does not want to test impact of re-instrumenting jars.
+ *
+ * This mutator could be also moved to the gradle-profiler.
  */
 class ClearArtifactTransformCacheWithoutInstrumentedJarsMutator extends ClearArtifactTransformCacheMutator {
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/mutator/ClearArtifactTransformCacheWithoutInstrumentedJarsMutator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/mutator/ClearArtifactTransformCacheWithoutInstrumentedJarsMutator.groovy
@@ -27,7 +27,7 @@ import java.nio.file.attribute.BasicFileAttributes
 
 import static org.gradle.api.internal.initialization.transform.utils.InstrumentationTransformUtils.ANALYSIS_OUTPUT_DIR
 import static org.gradle.api.internal.initialization.transform.utils.InstrumentationTransformUtils.MERGE_OUTPUT_DIR
-import static org.gradle.internal.classpath.TransformedClassPath.INSTRUMENTATION_CLASSPATH_MARKER_FILE_NAME
+import static org.gradle.internal.classpath.TransformedClassPath.FileMarker.INSTRUMENTATION_CLASSPATH_MARKER
 /**
  * A mutator that cleans up the artifact transform cache directory, but leaves folders with the instrumented jars.
  *
@@ -50,9 +50,9 @@ class ClearArtifactTransformCacheWithoutInstrumentedJarsMutator extends ClearArt
             }
 
             private boolean hasInstrumentationClasspathMarkerFile(Path transformedDir) {
-                return Files.exists(transformedDir.resolve("transformed/$INSTRUMENTATION_CLASSPATH_MARKER_FILE_NAME")) ||
-                    Files.exists(transformedDir.resolve("transformed/$ANALYSIS_OUTPUT_DIR/$INSTRUMENTATION_CLASSPATH_MARKER_FILE_NAME")) ||
-                    Files.exists(transformedDir.resolve("transformed/$MERGE_OUTPUT_DIR/$INSTRUMENTATION_CLASSPATH_MARKER_FILE_NAME"))
+                return Files.exists(transformedDir.resolve("transformed/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}")) ||
+                    Files.exists(transformedDir.resolve("transformed/$ANALYSIS_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}")) ||
+                    Files.exists(transformedDir.resolve("transformed/$MERGE_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}"))
             }
 
             @Override

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/mutator/ClearArtifactTransformCacheWithoutInstrumentedJarsMutatorTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/mutator/ClearArtifactTransformCacheWithoutInstrumentedJarsMutatorTest.groovy
@@ -22,7 +22,7 @@ import spock.lang.TempDir
 
 import static org.gradle.api.internal.initialization.transform.utils.InstrumentationTransformUtils.ANALYSIS_OUTPUT_DIR
 import static org.gradle.api.internal.initialization.transform.utils.InstrumentationTransformUtils.MERGE_OUTPUT_DIR
-import static org.gradle.internal.classpath.TransformedClassPath.INSTRUMENTATION_CLASSPATH_MARKER_FILE_NAME
+import static org.gradle.internal.classpath.TransformedClassPath.FileMarker.INSTRUMENTATION_CLASSPATH_MARKER
 import static org.gradle.profiler.mutations.AbstractCleanupMutator.CleanupSchedule.BUILD
 
 class ClearArtifactTransformCacheWithoutInstrumentedJarsMutatorTest extends Specification {
@@ -39,14 +39,14 @@ class ClearArtifactTransformCacheWithoutInstrumentedJarsMutatorTest extends Spec
         createFile(new File(gradleUserHome, "caches/transforms-2/first/transformed/instrumented/file"))
         createFile(new File(gradleUserHome, "caches/transforms-2/first/transformed/original/file"))
         createFile(new File(gradleUserHome, "caches/transforms-2/second/metadata.bin"))
-        createFile(new File(gradleUserHome, "caches/transforms-2/second/transformed/$INSTRUMENTATION_CLASSPATH_MARKER_FILE_NAME"))
+        createFile(new File(gradleUserHome, "caches/transforms-2/second/transformed/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}"))
         createFile(new File(gradleUserHome, "caches/transforms-2/second/transformed/instrumented/file"))
         createFile(new File(gradleUserHome, "caches/transforms-2/second/transformed/original/file"))
         createFile(new File(gradleUserHome, "caches/transforms-2/third/metadata.bin"))
-        createFile(new File(gradleUserHome, "caches/transforms-2/third/transformed/$ANALYSIS_OUTPUT_DIR/$INSTRUMENTATION_CLASSPATH_MARKER_FILE_NAME"))
+        createFile(new File(gradleUserHome, "caches/transforms-2/third/transformed/$ANALYSIS_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}"))
         createFile(new File(gradleUserHome, "caches/transforms-2/third/transformed/original/file"))
         createFile(new File(gradleUserHome, "caches/transforms-2/fourth/metadata.bin"))
-        createFile(new File(gradleUserHome, "caches/transforms-2/fourth/transformed/$MERGE_OUTPUT_DIR/$INSTRUMENTATION_CLASSPATH_MARKER_FILE_NAME"))
+        createFile(new File(gradleUserHome, "caches/transforms-2/fourth/transformed/$MERGE_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}"))
         createFile(new File(gradleUserHome, "caches/transforms-2/fourth/transformed/original/file"))
         def mutator = new ClearArtifactTransformCacheWithoutInstrumentedJarsMutator(gradleUserHome, BUILD)
 
@@ -57,14 +57,14 @@ class ClearArtifactTransformCacheWithoutInstrumentedJarsMutatorTest extends Spec
         !new File(gradleUserHome, "caches/transforms-1/").exists()
         !new File(gradleUserHome, "caches/transforms-2/first").exists()
         new File(gradleUserHome, "caches/transforms-2/second/metadata.bin").exists()
-        new File(gradleUserHome, "caches/transforms-2/second/transformed/$INSTRUMENTATION_CLASSPATH_MARKER_FILE_NAME").exists()
+        new File(gradleUserHome, "caches/transforms-2/second/transformed/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}").exists()
         new File(gradleUserHome, "caches/transforms-2/second/transformed/instrumented/file").exists()
         new File(gradleUserHome, "caches/transforms-2/second/transformed/original/file").exists()
         new File(gradleUserHome, "caches/transforms-2/third/metadata.bin").exists()
-        new File(gradleUserHome, "caches/transforms-2/third/transformed/$ANALYSIS_OUTPUT_DIR/$INSTRUMENTATION_CLASSPATH_MARKER_FILE_NAME").exists()
+        new File(gradleUserHome, "caches/transforms-2/third/transformed/$ANALYSIS_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}").exists()
         new File(gradleUserHome, "caches/transforms-2/third/transformed/original/file").exists()
         new File(gradleUserHome, "caches/transforms-2/fourth/metadata.bin").exists()
-        new File(gradleUserHome, "caches/transforms-2/fourth/transformed/$MERGE_OUTPUT_DIR/$INSTRUMENTATION_CLASSPATH_MARKER_FILE_NAME").exists()
+        new File(gradleUserHome, "caches/transforms-2/fourth/transformed/$MERGE_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}").exists()
         new File(gradleUserHome, "caches/transforms-2/fourth/transformed/original/file").exists()
     }
 


### PR DESCRIPTION
Long story short: user can add two artifacts with the same name to the classpath as files, e.g.:
```
buildscript {
    dependencies {
        classpath(files("./jars/first/test-plugin-0.2.jar"))
        classpath(files("./jars/second/test-plugin-0.2.jar"))
    }
}
```

And we will copy these two jars via transform to the same location (since they have the same content and name). And with that we get duplicated jars on the instrumented classpath which breaks a build. We now do a deduplication in `TransformedClassPath`.  

That was not a problem before 8.8, since we did deduplication "unknowingly" by passing `ClassPath` instead of `List<File>` to `TransformedClassPath.fromInstrumentingArtifactTransformOutput()`. But I think more explicit solution is better in this case.

Fixes https://github.com/gradle/gradle/issues/28496

Follow up from https://github.com/gradle/gradle/pull/28296.

Also addresses some comments from https://github.com/gradle/gradle/pull/28296