### PR TITLE
Integrate build-cache cleanup with global cache configuration

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
@@ -716,6 +716,7 @@ class ConfigurationCacheState(
             write(cacheConfigurations.snapshotWrappers.removeUnusedEntriesOlderThan)
             write(cacheConfigurations.downloadedResources.removeUnusedEntriesOlderThan)
             write(cacheConfigurations.createdResources.removeUnusedEntriesOlderThan)
+            write(cacheConfigurations.buildCache.removeUnusedEntriesOlderThan)
             write(cacheConfigurations.cleanup)
             write(cacheConfigurations.markingStrategy)
         }
@@ -728,6 +729,7 @@ class ConfigurationCacheState(
             cacheConfigurations.snapshotWrappers.removeUnusedEntriesOlderThan.value(readNonNull<Provider<Long>>())
             cacheConfigurations.downloadedResources.removeUnusedEntriesOlderThan.value(readNonNull<Provider<Long>>())
             cacheConfigurations.createdResources.removeUnusedEntriesOlderThan.value(readNonNull<Provider<Long>>())
+            cacheConfigurations.buildCache.removeUnusedEntriesOlderThan.value(readNonNull<Provider<Long>>())
             cacheConfigurations.cleanup.value(readNonNull<Provider<Cleanup>>())
             cacheConfigurations.markingStrategy.value(readNonNull<Provider<MarkingStrategy>>())
         }

--- a/platforms/core-execution/build-cache-local/src/integTest/groovy/org/gradle/caching/local/internal/AbstractBuildCacheCleanupIntegrationTest.groovy
+++ b/platforms/core-execution/build-cache-local/src/integTest/groovy/org/gradle/caching/local/internal/AbstractBuildCacheCleanupIntegrationTest.groovy
@@ -66,14 +66,8 @@ abstract class AbstractBuildCacheCleanupIntegrationTest extends AbstractIntegrat
         """
     }
 
-    def withLocalBuildCacheRetentionInDays(long period) {
-        settingsFile << """
-            buildCache {
-                local {
-                    removeUnusedEntriesAfterDays = ${period}
-                }
-            }
-        """
+    def withDeprecatedBuildCacheRetentionInDays(long period) {
+        withBuildCacheRetentionInDays(period)
     }
 
     def "cleans up entries when #cleanupTrigger"() {
@@ -145,11 +139,11 @@ abstract class AbstractBuildCacheCleanupIntegrationTest extends AbstractIntegrat
     def "cleans up entries after #scenario"() {
         def lastCleanupCheck = initializeHome()
 
-        if (createdResourcesCleanup != null) {
-            withCreatedResourcesRetentionInDays(createdResourcesCleanup)
-        }
         if (buildCacheCleanup != null) {
-            withLocalBuildCacheRetentionInDays(buildCacheCleanup)
+            withBuildCacheRetentionInDays(buildCacheCleanup)
+        }
+        if (deprecatedCacheCleanup != null) {
+            withDeprecatedBuildCacheRetentionInDays(deprecatedCacheCleanup)
         }
 
         when:
@@ -177,11 +171,11 @@ abstract class AbstractBuildCacheCleanupIntegrationTest extends AbstractIntegrat
         assertCacheWasCleanedUpSince(lastCleanupCheck)
 
         where:
-        createdResourcesCleanup | buildCacheCleanup | effectiveCleanup | scenario
-        null                    | null              | 7                | "default period when not explicitly configured"
-        2                       | null              | 2                | "configured period for created resources"
-        null                    | 2                 | 2                | "configured period for build cache cleanup"
-        1                       | 10                | 10               | "configured period for build cache cleanup when both are configured"
+        buildCacheCleanup | deprecatedCacheCleanup | effectiveCleanup | scenario
+        null              | null                   | 7                | "default period when not explicitly configured"
+        2                 | null                   | 2                | "configured period for build cache cleanup"
+        null              | 2                      | 2                | "configured period for deprecated build cache cleanup"
+        1                 | 10                     | 10               | "configured period for deprecated build cache cleanup when both are configured"
     }
 
     def "produces reasonable message when cache retention is too short (#days days)"() {

--- a/platforms/core-execution/build-cache-local/src/integTest/groovy/org/gradle/caching/local/internal/AbstractBuildCacheCleanupIntegrationTest.groovy
+++ b/platforms/core-execution/build-cache-local/src/integTest/groovy/org/gradle/caching/local/internal/AbstractBuildCacheCleanupIntegrationTest.groovy
@@ -138,7 +138,7 @@ abstract class AbstractBuildCacheCleanupIntegrationTest extends AbstractIntegrat
 
         when:
         lastCleanupCheck = markCacheLastCleaned(twoDaysAgo())
-        cleanupMethod.maybeExpectDeprecationWarning(executer)
+        executer.noDeprecationChecks()
         run()
 
         then:
@@ -179,9 +179,7 @@ abstract class AbstractBuildCacheCleanupIntegrationTest extends AbstractIntegrat
 
         when:
         lastCleanupCheck = markCacheLastCleaned(twoDaysAgo())
-        if (deprecatedCacheCleanup != null) {
-            expectRetentionMethodDeprecationWarning()
-        }
+        executer.noDeprecationChecks()
         run()
 
         then:

--- a/platforms/core-execution/build-cache-local/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactory.java
+++ b/platforms/core-execution/build-cache-local/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactory.java
@@ -84,15 +84,17 @@ public class DirectoryBuildCacheServiceFactory implements BuildCacheServiceFacto
         }
         checkDirectory(target);
 
+        @SuppressWarnings("deprecation")
         int removeUnusedEntriesAfterDays = configuration.getRemoveUnusedEntriesAfterDays();
 
         describer.type(DIRECTORY_BUILD_CACHE_TYPE).
             config("location", target.getAbsolutePath()).
             config("removeUnusedEntriesAfter", removeUnusedEntriesAfterDays + " days");
 
-        // Use the days configured for the local build cache, or the global 'createdResources' config if not specified.
-        Supplier<Long> removeUnusedEntriesOlderThan = removeUnusedEntriesAfterDays < 1
-            ? cacheConfigurations.getCreatedResources().getRemoveUnusedEntriesOlderThanAsSupplier()
+        // Use the deprecated retention period if configured on `DirectoryBuildCache`, or use the central 'buildCache' cleanup config if not.
+        // If the deprecated property remains at the default, we can safely use the central value (which has the same default).
+        Supplier<Long> removeUnusedEntriesOlderThan = removeUnusedEntriesAfterDays == CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_BUILD_CACHE_ENTRIES
+            ? cacheConfigurations.getBuildCache().getRemoveUnusedEntriesOlderThanAsSupplier()
             : TimestampSuppliers.daysAgo(removeUnusedEntriesAfterDays);
 
         PersistentCache persistentCache = unscopedCacheBuilderFactory

--- a/platforms/core-execution/build-cache-local/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactory.java
+++ b/platforms/core-execution/build-cache-local/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactory.java
@@ -85,10 +85,15 @@ public class DirectoryBuildCacheServiceFactory implements BuildCacheServiceFacto
         checkDirectory(target);
 
         int removeUnusedEntriesAfterDays = configuration.getRemoveUnusedEntriesAfterDays();
-        Supplier<Long> removeUnusedEntriesOlderThan = TimestampSuppliers.daysAgo(removeUnusedEntriesAfterDays);
+
         describer.type(DIRECTORY_BUILD_CACHE_TYPE).
             config("location", target.getAbsolutePath()).
             config("removeUnusedEntriesAfter", removeUnusedEntriesAfterDays + " days");
+
+        // Use the days configured for the local build cache, or the global 'createdResources' config if not specified.
+        Supplier<Long> removeUnusedEntriesOlderThan = removeUnusedEntriesAfterDays < 1
+            ? cacheConfigurations.getCreatedResources().getRemoveUnusedEntriesOlderThanAsSupplier()
+            : TimestampSuppliers.daysAgo(removeUnusedEntriesAfterDays);
 
         PersistentCache persistentCache = unscopedCacheBuilderFactory
             .cache(target)

--- a/platforms/core-execution/build-cache-local/src/test/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactoryTest.groovy
+++ b/platforms/core-execution/build-cache-local/src/test/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactoryTest.groovy
@@ -16,7 +16,9 @@
 
 package org.gradle.caching.local.internal
 
+import org.gradle.api.internal.cache.CacheConfigurationsInternal
 import org.gradle.api.internal.file.FileResolver
+import org.gradle.api.provider.Provider
 import org.gradle.cache.CacheBuilder
 import org.gradle.cache.CleanupAction
 import org.gradle.cache.UnscopedCacheBuilderFactory
@@ -41,7 +43,8 @@ class DirectoryBuildCacheServiceFactoryTest extends Specification {
     def resolver = Mock(FileResolver)
     def cleanupActionDecorator = Mock(CleanupActionDecorator)
     def fileAccessTimeJournal = Mock(FileAccessTimeJournal)
-    def factory = new DirectoryBuildCacheServiceFactory(cacheRepository, globalScopedCache, resolver, cleanupActionDecorator, fileAccessTimeJournal)
+    def cacheConfigurations = Mock(CacheConfigurationsInternal)
+    def factory = new DirectoryBuildCacheServiceFactory(cacheRepository, globalScopedCache, resolver, cleanupActionDecorator, fileAccessTimeJournal, cacheConfigurations)
     def cacheBuilder = Stub(CacheBuilder)
     def config = Mock(DirectoryBuildCache)
     def buildCacheDescriber = new NoopBuildCacheDescriber()
@@ -58,6 +61,7 @@ class DirectoryBuildCacheServiceFactoryTest extends Specification {
         1 * globalScopedCache.baseDirForCrossVersionCache("build-cache-1") >> cacheDir
         1 * cacheRepository.cache(cacheDir) >> cacheBuilder
         1 * cleanupActionDecorator.decorate(_) >> Mock(CleanupAction)
+        1 * cacheConfigurations.getCleanupFrequency() >> Mock(Provider)
         0 * _
     }
 
@@ -73,6 +77,7 @@ class DirectoryBuildCacheServiceFactoryTest extends Specification {
         1 * resolver.resolve(cacheDir) >> cacheDir
         1 * cacheRepository.cache(cacheDir) >> cacheBuilder
         1 * cleanupActionDecorator.decorate(_) >> Mock(CleanupAction)
+        1 * cacheConfigurations.getCleanupFrequency() >> Mock(Provider)
         0 * _
     }
 

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/other/directory_layout.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/other/directory_layout.adoc
@@ -91,7 +91,7 @@ Unused distributions are deleted.
 ==== Configuring cleanup of caches and distributions
 The retention periods of the various caches can be configured.
 
-Caches are classified into four categories:
+Caches are classified into five categories:
 
 - *Released wrapper distributions:* Distributions and related version-specific caches corresponding to released versions (e.g., `4.6.2` or `8.0`).
 +
@@ -105,6 +105,9 @@ Default retention for unused resources is 30 days.
 - *Created resources:* Shared caches that Gradle creates during a build (e.g., artifact transforms).
 +
 Default retention for unused resources is 7 days.
+- *Build cache:* The local build cache (e.g., build-cache-1).
++
+Default retention for unused build-cache entries is 7 days.
 
 The retention period for each category can be configured independently via an init script in Gradle User Home:
 

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache.adoc
@@ -273,13 +273,6 @@ The remote build cache can be configured by specifying the type of build cache t
 The built-in local build cache, link:{groovyDslPath}/org.gradle.caching.local.DirectoryBuildCache.html[DirectoryBuildCache], uses a directory to store build cache artifacts.
 By default, this directory resides in the Gradle User Home, but its location is configurable.
 
-Gradle will periodically clean-up the local cache directory by removing entries that have not been used recently to conserve disk space.
-How often Gradle will perform this clean-up is configurable as shown in the example below.
-Note that cache entries are cleaned-up regardless of the project they were produced by.
-If different projects configure this clean-up to run at different periods, the shortest period will clean-up cache entries for all projects.
-Therefore it is recommended to configure this setting globally in the <<init_scripts.adoc#sec:using_an_init_script,init script>>.
-The <<sec:build_cache_configure_use_cases, Configuration use-cases>> section has an example of putting cache configuration in the init script.
-
 For more details on the configuration options refer to the DSL documentation of link:{groovyDslPath}/org.gradle.caching.local.DirectoryBuildCache.html[DirectoryBuildCache].
 Here is an example of the configuration.
 
@@ -288,6 +281,10 @@ Here is an example of the configuration.
 include::sample[dir="snippets/buildCache/configure-built-in-caches/kotlin",files="settings.gradle.kts[tags=configure-directory-build-cache]"]
 include::sample[dir="snippets/buildCache/configure-built-in-caches/groovy",files="settings.gradle[tags=configure-directory-build-cache]"]
 ====
+
+Gradle will periodically clean-up the local cache directory by removing entries that have not been used recently to conserve disk space.
+How often Gradle will perform this clean-up and how long entries will be retained is configurable via an init-script as demonstrated
+link:{userManualPath}/directory_layout.html#dir:gradle_user_home:configure_cache_cleanup[in this section].
 
 [[sec:build_cache_configure_remote]]
 === Remote HTTP build cache

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -143,12 +143,20 @@ The new API has now been promoted to stable and the old methods have been deprec
 - link:{javadocPath}/org/gradle/api/file/FileTreeElement.html#getMode--[FileTreeElement.getMode]
 - link:{javadocPath}/org/gradle/api/file/FileCopyDetails.html#setMode-int-[FileCopyDetails.setMode]
 
+[[directory_build_cache_retention_deprecated]]
+==== Deprecated setting retention period directly on local build cache ====
+
+In Gradle 8.0, link:{userManualPath}/directory_layout.html#dir:gradle_user_home:configure_cache_cleanup[a new mechanism] was added to configure the cleanup and retention periods for various resources in Gradle User Home.
+In Gradle 8.8, this mechanism was extended to permit configuration of retention of local build cache entries.
+This mechanism replaces the previous method of configuring retention in the local build cache settings.
+
+Calling link:{javadocPath}/org/gradle/caching/local/DirectoryBuildCache.html#setRemoveUnusedEntriesAfterDays-int-[DirectoryBuildCache.removeUnusedEntriesAfterDays] is deprecated and this method will be removed in Gradle 9.0.
 
 === Potential breaking changes
 
 ==== Changes in the Problems API
 
-We have implemented several refactorings of the Problems API, including a significant change in the way problem definitions and contextual information are handled. 
+We have implemented several refactorings of the Problems API, including a significant change in the way problem definitions and contextual information are handled.
 The complete design specification can be found [here](https://docs.google.com/document/d/1T_vM-Upa23aA21sanFTTLZa3j9xV6R32djJk6-muWzI/edit#heading=h.610fausqnpu6).
 
 In implementing this spec, we have introduced the following breaking changes to the `ProblemSpec` interface:

--- a/platforms/documentation/docs/src/snippets/buildCache/configure-built-in-caches/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/buildCache/configure-built-in-caches/groovy/settings.gradle
@@ -4,7 +4,6 @@ rootProject.name = 'configure-built-in-caches'
 buildCache {
     local {
         directory = new File(rootDir, 'build-cache')
-        removeUnusedEntriesAfterDays = 30
     }
 }
 // end::configure-directory-build-cache[]

--- a/platforms/documentation/docs/src/snippets/buildCache/configure-built-in-caches/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/buildCache/configure-built-in-caches/kotlin/settings.gradle.kts
@@ -3,7 +3,6 @@ rootProject.name = "configure-built-in-caches"
 buildCache {
     local {
         directory = File(rootDir, "build-cache")
-        removeUnusedEntriesAfterDays = 30
     }
 }
 // end::configure-directory-build-cache[]

--- a/platforms/documentation/docs/src/snippets/initScripts/cacheRetention/groovy/gradleUserHome/init.d/cache-settings.gradle
+++ b/platforms/documentation/docs/src/snippets/initScripts/cacheRetention/groovy/gradleUserHome/init.d/cache-settings.gradle
@@ -4,5 +4,6 @@ beforeSettings { settings ->
         snapshotWrappers.removeUnusedEntriesAfterDays = 10
         downloadedResources.removeUnusedEntriesAfterDays = 45
         createdResources.removeUnusedEntriesAfterDays = 10
+        buildCache.removeUnusedEntriesAfterDays = 5
     }
 }

--- a/platforms/documentation/docs/src/snippets/initScripts/cacheRetention/kotlin/gradleUserHome/init.d/cache-settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/initScripts/cacheRetention/kotlin/gradleUserHome/init.d/cache-settings.gradle.kts
@@ -4,5 +4,6 @@ beforeSettings {
         snapshotWrappers.setRemoveUnusedEntriesAfterDays(10)
         downloadedResources.setRemoveUnusedEntriesAfterDays(45)
         createdResources.setRemoveUnusedEntriesAfterDays(10)
+        buildCache.setRemoveUnusedEntriesAfterDays(5)
     }
 }

--- a/platforms/documentation/docs/src/snippets/initScripts/multiVersionCacheRetention/groovy/gradleUserHome/init.d/gradle8/cache-settings.gradle
+++ b/platforms/documentation/docs/src/snippets/initScripts/multiVersionCacheRetention/groovy/gradleUserHome/init.d/gradle8/cache-settings.gradle
@@ -4,5 +4,6 @@ beforeSettings { settings ->
         snapshotWrappers.removeUnusedEntriesAfterDays = 10
         downloadedResources.removeUnusedEntriesAfterDays = 45
         createdResources.removeUnusedEntriesAfterDays = 10
+        buildCache.removeUnusedEntriesAfterDays = 5
     }
 }

--- a/platforms/documentation/docs/src/snippets/initScripts/multiVersionCacheRetention/kotlin/gradleUserHome/init.d/gradle8/cache-settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/initScripts/multiVersionCacheRetention/kotlin/gradleUserHome/init.d/gradle8/cache-settings.gradle.kts
@@ -4,5 +4,6 @@ beforeSettings {
         snapshotWrappers { setRemoveUnusedEntriesAfterDays(10) }
         downloadedResources { setRemoveUnusedEntriesAfterDays(45) }
         createdResources { setRemoveUnusedEntriesAfterDays(10) }
+        buildCache { setRemoveUnusedEntriesAfterDays(5) }
     }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/cache/CacheConfigurations.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/cache/CacheConfigurations.java
@@ -77,6 +77,21 @@ public interface CacheConfigurations {
     CacheResourceConfiguration getCreatedResources();
 
     /**
+     * Configures caching for entries in the local build cache.
+     * By default, build cache entries are removed after 7 days of not being used.
+     *
+     * @since 8.8
+     */
+    void buildCache(Action<? super CacheResourceConfiguration> cacheConfiguration);
+
+    /**
+     * Returns the cache configuration for local build cache.
+     *
+     * @since 8.8
+     */
+    CacheResourceConfiguration getBuildCache();
+
+    /**
      * Returns the cache cleanup settings that apply to all caches.
      */
     Property<Cleanup> getCleanup();

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheConfigurationsInternal.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheConfigurationsInternal.java
@@ -28,6 +28,7 @@ public interface CacheConfigurationsInternal extends CacheConfigurations {
     int DEFAULT_MAX_AGE_IN_DAYS_FOR_SNAPSHOT_DISTS = 7;
     int DEFAULT_MAX_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES = 30;
     int DEFAULT_MAX_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES = 7;
+    int DEFAULT_MAX_AGE_IN_DAYS_FOR_BUILD_CACHE_ENTRIES = 7;
 
     @Override
     CacheResourceConfigurationInternal getReleasedWrappers();
@@ -37,6 +38,8 @@ public interface CacheConfigurationsInternal extends CacheConfigurations {
     CacheResourceConfigurationInternal getDownloadedResources();
     @Override
     CacheResourceConfigurationInternal getCreatedResources();
+    @Override
+    CacheResourceConfigurationInternal getBuildCache();
 
     @Override
     Property<Cleanup> getCleanup();

--- a/subprojects/core-api/src/main/java/org/gradle/caching/local/DirectoryBuildCache.java
+++ b/subprojects/core-api/src/main/java/org/gradle/caching/local/DirectoryBuildCache.java
@@ -17,6 +17,7 @@
 package org.gradle.caching.local;
 
 import org.gradle.caching.configuration.AbstractBuildCache;
+import org.gradle.internal.deprecation.DeprecationLogger;
 
 import javax.annotation.Nullable;
 
@@ -71,11 +72,10 @@ public abstract class DirectoryBuildCache extends AbstractBuildCache {
         if (removeUnusedEntriesAfterDays < 1) {
             throw new IllegalArgumentException("Directory build cache needs to retain entries for at least a day.");
         }
-//        DeprecationLogger.deprecateProperty(this.getClass(), "removeEntriesAfterDays")
-//            .withAdvice("Use an init-script to configure cache cleanup")
-//            .willBeRemovedInGradle9()
-//            .withUpgradeGuideSection(8, "local_build_cache_retention_deprecated")
-//            .nagUser();
+        DeprecationLogger.deprecateProperty(DirectoryBuildCache.class, "removeEntriesAfterDays")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(8, "directory_build_cache_retention_deprecated")
+            .nagUser();
 
         this.removeUnusedEntriesAfterDays = removeUnusedEntriesAfterDays;
     }

--- a/subprojects/core-api/src/main/java/org/gradle/caching/local/DirectoryBuildCache.java
+++ b/subprojects/core-api/src/main/java/org/gradle/caching/local/DirectoryBuildCache.java
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
  */
 public abstract class DirectoryBuildCache extends AbstractBuildCache {
     private Object directory;
-    private int removeUnusedEntriesAfterDays = 7;
+    private int removeUnusedEntriesAfterDays = -1;
 
     /**
      * Returns the directory to use to store the build cache.
@@ -48,7 +48,8 @@ public abstract class DirectoryBuildCache extends AbstractBuildCache {
     }
 
     /**
-     * Returns the number of days after unused entries are garbage collected. Defaults to 7 days.
+     * Returns the number of days after unused entries are garbage collected.
+     * If not set, entries will be removed based on the value configured for {@link org.gradle.api.cache.CacheConfigurations#createdResources}.
      *
      * @since 4.6
      */
@@ -57,7 +58,8 @@ public abstract class DirectoryBuildCache extends AbstractBuildCache {
     }
 
     /**
-     * Sets the number of days after unused entries are garbage collected. Defaults to 7 days.
+     * Sets the number of days after unused entries are garbage collected.
+     * When set, this will take precedence over the value configured for {@link org.gradle.api.cache.CacheConfigurations#createdResources}.
      *
      * Must be greater than 1.
      *

--- a/subprojects/core-api/src/main/java/org/gradle/caching/local/DirectoryBuildCache.java
+++ b/subprojects/core-api/src/main/java/org/gradle/caching/local/DirectoryBuildCache.java
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
  */
 public abstract class DirectoryBuildCache extends AbstractBuildCache {
     private Object directory;
-    private int removeUnusedEntriesAfterDays = -1;
+    private int removeUnusedEntriesAfterDays = 7;
 
     /**
      * Returns the directory to use to store the build cache.
@@ -48,27 +48,35 @@ public abstract class DirectoryBuildCache extends AbstractBuildCache {
     }
 
     /**
-     * Returns the number of days after unused entries are garbage collected.
-     * If not set, entries will be removed based on the value configured for {@link org.gradle.api.cache.CacheConfigurations#createdResources}.
+     * Returns the number of days after unused entries are garbage collected. Defaults to 7 days.
      *
      * @since 4.6
+     * @deprecated
      */
+    @Deprecated
     public int getRemoveUnusedEntriesAfterDays() {
         return removeUnusedEntriesAfterDays;
     }
 
     /**
-     * Sets the number of days after unused entries are garbage collected.
-     * When set, this will take precedence over the value configured for {@link org.gradle.api.cache.CacheConfigurations#createdResources}.
+     * Sets the number of days after unused entries are garbage collected. Defaults to 7 days.
      *
      * Must be greater than 1.
      *
      * @since 4.6
+     * @deprecated
      */
+    @Deprecated
     public void setRemoveUnusedEntriesAfterDays(int removeUnusedEntriesAfterDays) {
         if (removeUnusedEntriesAfterDays < 1) {
             throw new IllegalArgumentException("Directory build cache needs to retain entries for at least a day.");
         }
+//        DeprecationLogger.deprecateProperty(this.getClass(), "removeEntriesAfterDays")
+//            .withAdvice("Use an init-script to configure cache cleanup")
+//            .willBeRemovedInGradle9()
+//            .withUpgradeGuideSection(8, "local_build_cache_retention_deprecated")
+//            .nagUser();
+
         this.removeUnusedEntriesAfterDays = removeUnusedEntriesAfterDays;
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsCompositeBuildTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsCompositeBuildTest.groovy
@@ -46,6 +46,7 @@ class CacheConfigurationsCompositeBuildTest extends AbstractIntegrationSpec impl
                     snapshotWrappers.removeUnusedEntriesAfterDays = 5
                     downloadedResources.removeUnusedEntriesAfterDays = 10
                     createdResources.removeUnusedEntriesAfterDays = 5
+                    buildCache.removeUnusedEntriesAfterDays = 15
                 }
             }
         """

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsContinuousIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsContinuousIntegrationTest.groovy
@@ -49,6 +49,7 @@ class CacheConfigurationsContinuousIntegrationTest extends AbstractContinuousInt
                     snapshotWrappers.removeUnusedEntriesAfterDays = 5
                     downloadedResources.removeUnusedEntriesAfterDays = 10
                     createdResources.removeUnusedEntriesAfterDays = 5
+                    buildCache.removeUnusedEntriesAfterDays = 15
                 }
             }
         """
@@ -59,6 +60,7 @@ class CacheConfigurationsContinuousIntegrationTest extends AbstractContinuousInt
                 snapshotWrappers { ${assertValueIsSameInDays(5)} }
                 downloadedResources { ${assertValueIsSameInDays(10)} }
                 createdResources { ${assertValueIsSameInDays(5)} }
+                buildCache { ${assertValueIsSameInDays(15)} }
             }
         """
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsIntegrationTest.groovy
@@ -24,6 +24,7 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
     private static final int MODIFIED_AGE_IN_DAY_FOR_SNAPSHOT_DISTS = CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_SNAPSHOT_DISTS + 1
     private static final int MODIFIED_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES = CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES + 1
     private static final int MODIFIED_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES = CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES + 1
+    private static final int MODIFIED_AGE_IN_DAYS_FOR_BUILD_CACHE_ENTRIES = CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_BUILD_CACHE_ENTRIES + 1
 
     def setup() {
         requireOwnGradleUserHomeDir()
@@ -41,6 +42,7 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
                     snapshotWrappers.removeUnusedEntriesAfterDays = ${MODIFIED_AGE_IN_DAY_FOR_SNAPSHOT_DISTS}
                     downloadedResources.removeUnusedEntriesAfterDays = ${MODIFIED_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES}
                     createdResources.removeUnusedEntriesAfterDays = ${MODIFIED_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES}
+                    buildCache.removeUnusedEntriesAfterDays = ${MODIFIED_AGE_IN_DAYS_FOR_BUILD_CACHE_ENTRIES}
                 }
             }
         """
@@ -51,6 +53,7 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
                 snapshotWrappers { ${assertValueIsSameInDays(MODIFIED_AGE_IN_DAY_FOR_SNAPSHOT_DISTS)} }
                 downloadedResources { ${assertValueIsSameInDays(MODIFIED_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES)} }
                 createdResources { ${assertValueIsSameInDays(MODIFIED_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES)} }
+                createdResources { ${assertValueIsSameInDays(MODIFIED_AGE_IN_DAYS_FOR_BUILD_CACHE_ENTRIES)} }
             }
         """
 
@@ -114,6 +117,7 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
         'snapshotWrappers.removeUnusedEntriesAfterDays'    | 'removeUnusedEntriesOlderThan' | "${MODIFIED_AGE_IN_DAY_FOR_SNAPSHOT_DISTS}"
         'downloadedResources.removeUnusedEntriesAfterDays' | 'removeUnusedEntriesOlderThan' | "${MODIFIED_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES}"
         'createdResources.removeUnusedEntriesAfterDays'    | 'removeUnusedEntriesOlderThan' | "${MODIFIED_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES}"
+        'buildCache.removeUnusedEntriesAfterDays'          | 'removeUnusedEntriesOlderThan' | "${MODIFIED_AGE_IN_DAYS_FOR_BUILD_CACHE_ENTRIES}"
     }
 
     static String modifyCacheConfiguration(String property, String value) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/cache/DefaultCacheConfigurations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/cache/DefaultCacheConfigurations.java
@@ -49,6 +49,7 @@ abstract public class DefaultCacheConfigurations implements CacheConfigurationsI
     private static final String SNAPSHOT_WRAPPERS = "snapshotWrappers";
     private static final String DOWNLOADED_RESOURCES = "downloadedResources";
     private static final String CREATED_RESOURCES = "createdResources";
+    private static final String BUILD_CACHE = "buildCache";
     static final String UNSAFE_MODIFICATION_ERROR = "The property '%s' was modified from an unsafe location (for instance a settings script or plugin).  " +
         "This property can only be changed in an init script, preferably stored in the init.d directory inside the Gradle user home directory. " +
         DOCUMENTATION_REGISTRY.getDocumentationRecommendationFor("information on this", "directory_layout", "dir:gradle_user_home:configure_cache_cleanup");
@@ -57,6 +58,7 @@ abstract public class DefaultCacheConfigurations implements CacheConfigurationsI
     private final CacheResourceConfigurationInternal snapshotWrappersConfiguration;
     private final CacheResourceConfigurationInternal downloadedResourcesConfiguration;
     private final CacheResourceConfigurationInternal createdResourcesConfiguration;
+    private final CacheResourceConfigurationInternal buildCacheConfiguration;
     private final Property<Cleanup> cleanup;
     private final Property<MarkingStrategy> markingStrategy;
     private final LegacyCacheCleanupEnablement legacyCacheCleanupEnablement;
@@ -69,6 +71,7 @@ abstract public class DefaultCacheConfigurations implements CacheConfigurationsI
         this.snapshotWrappersConfiguration = createResourceConfiguration(objectFactory, SNAPSHOT_WRAPPERS, DEFAULT_MAX_AGE_IN_DAYS_FOR_SNAPSHOT_DISTS);
         this.downloadedResourcesConfiguration = createResourceConfiguration(objectFactory, DOWNLOADED_RESOURCES, DEFAULT_MAX_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES);
         this.createdResourcesConfiguration = createResourceConfiguration(objectFactory, CREATED_RESOURCES, DEFAULT_MAX_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES);
+        this.buildCacheConfiguration = createResourceConfiguration(objectFactory, BUILD_CACHE, DEFAULT_MAX_AGE_IN_DAYS_FOR_BUILD_CACHE_ENTRIES);
         this.cleanup = new ContextualErrorMessageProperty<>(propertyHost, Cleanup.class, "cleanup").convention(createCleanupConvention());
         this.markingStrategy = new ContextualErrorMessageProperty<>(propertyHost, MarkingStrategy.class, "markingStrategy").convention(MarkingStrategy.CACHEDIR_TAG);
         this.legacyCacheCleanupEnablement = legacyCacheCleanupEnablement;
@@ -125,6 +128,16 @@ abstract public class DefaultCacheConfigurations implements CacheConfigurationsI
     }
 
     @Override
+    public void buildCache(Action<? super CacheResourceConfiguration> cacheConfiguration) {
+        cacheConfiguration.execute(buildCacheConfiguration);
+    }
+
+    @Override
+    public CacheResourceConfigurationInternal getBuildCache() {
+        return buildCacheConfiguration;
+    }
+
+    @Override
     public Property<Cleanup> getCleanup() {
         return cleanup;
     }
@@ -147,6 +160,7 @@ abstract public class DefaultCacheConfigurations implements CacheConfigurationsI
         persistentCacheConfigurations.getSnapshotWrappers().getRemoveUnusedEntriesOlderThan().value(getSnapshotWrappers().getRemoveUnusedEntriesOlderThan());
         persistentCacheConfigurations.getDownloadedResources().getRemoveUnusedEntriesOlderThan().value(getDownloadedResources().getRemoveUnusedEntriesOlderThan());
         persistentCacheConfigurations.getCreatedResources().getRemoveUnusedEntriesOlderThan().value(getCreatedResources().getRemoveUnusedEntriesOlderThan());
+        persistentCacheConfigurations.getBuildCache().getRemoveUnusedEntriesOlderThan().value(getBuildCache().getRemoveUnusedEntriesOlderThan());
         persistentCacheConfigurations.getCleanup().value(getCleanup());
         persistentCacheConfigurations.getMarkingStrategy().value(getMarkingStrategy());
     }
@@ -163,6 +177,7 @@ abstract public class DefaultCacheConfigurations implements CacheConfigurationsI
         snapshotWrappersConfiguration.getRemoveUnusedEntriesOlderThan().finalizeValue();
         downloadedResourcesConfiguration.getRemoveUnusedEntriesOlderThan().finalizeValue();
         createdResourcesConfiguration.getRemoveUnusedEntriesOlderThan().finalizeValue();
+        buildCacheConfiguration.getRemoveUnusedEntriesOlderThan().finalizeValue();
         getCleanup().finalizeValue();
         getMarkingStrategy().finalizeValue();
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
@@ -34,6 +34,7 @@ class DefaultCacheConfigurationsTest extends Specification {
         cacheConfigurations.downloadedResources.setRemoveUnusedEntriesAfterDays(2)
         cacheConfigurations.releasedWrappers.setRemoveUnusedEntriesAfterDays(2)
         cacheConfigurations.snapshotWrappers.setRemoveUnusedEntriesAfterDays(2)
+        cacheConfigurations.buildCache.setRemoveUnusedEntriesAfterDays(2)
         cacheConfigurations.cleanup.set(Cleanup.DISABLED)
 
         then:
@@ -69,6 +70,13 @@ class DefaultCacheConfigurationsTest extends Specification {
         then:
         e = thrown(IllegalStateException)
         assertCannotConfigureErrorIsThrown(e, "removeUnusedEntriesOlderThan")
+
+        when:
+        cacheConfigurations.buildCache.setRemoveUnusedEntriesAfterDays(1)
+
+        then:
+        e = thrown(IllegalStateException)
+        assertCannotConfigureErrorIsThrown(e, "removeUnusedEntriesOlderThan")
     }
 
     def "cannot modify cache configurations via property unless mutable (method: #method)"() {
@@ -80,6 +88,7 @@ class DefaultCacheConfigurationsTest extends Specification {
         cacheConfigurations.downloadedResources.removeUnusedEntriesOlderThan."${method}"(firstValue)
         cacheConfigurations.releasedWrappers.removeUnusedEntriesOlderThan."${method}"(firstValue)
         cacheConfigurations.snapshotWrappers.removeUnusedEntriesOlderThan."${method}"(firstValue)
+        cacheConfigurations.buildCache.removeUnusedEntriesOlderThan."${method}"(firstValue)
         cacheConfigurations.cleanup."${method}"(Cleanup.DISABLED)
         cacheConfigurations.markingStrategy."${method}"(MarkingStrategy.NONE)
 
@@ -112,6 +121,13 @@ class DefaultCacheConfigurationsTest extends Specification {
 
         when:
         cacheConfigurations.snapshotWrappers.removeUnusedEntriesOlderThan."${method}"(secondValue)
+
+        then:
+        e = thrown(IllegalStateException)
+        assertCannotConfigureErrorIsThrown(e, "removeUnusedEntriesOlderThan")
+
+        when:
+        cacheConfigurations.buildCache.removeUnusedEntriesOlderThan."${method}"(secondValue)
 
         then:
         e = thrown(IllegalStateException)
@@ -177,6 +193,12 @@ class DefaultCacheConfigurationsTest extends Specification {
 
         when:
         cacheConfigurations.snapshotWrappers.setRemoveUnusedEntriesAfterDays(0)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        when:
+        cacheConfigurations.buildCache.setRemoveUnusedEntriesAfterDays(0)
 
         then:
         thrown(IllegalArgumentException)

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/GradleUserHomeCleanupFixture.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/GradleUserHomeCleanupFixture.groovy
@@ -122,6 +122,10 @@ trait GradleUserHomeCleanupFixture implements VersionSpecificCacheCleanupFixture
         withCacheRetentionInDays(days, "downloadedResources")
     }
 
+    void withBuildCacheRetentionInDays(int days) {
+        withCacheRetentionInDays(days, "buildCache")
+    }
+
     void withCacheRetentionInDays(int days, String resources) {
         def initDir = new File(gradleUserHomeDir, "init.d")
         initDir.mkdirs()


### PR DESCRIPTION
Fixes #28505 

### Context
Reliable and predictable cleanup of Gradle User Home is important to users attempting to manage disk usage, both locally and on CI. This PR allows the cleanup of the local build cache to be configured via the [regular cache configuration mechanisms](https://docs.gradle.org/current/userguide/directory_layout.html#dir:gradle_user_home:configure_cache_cleanup).

