### PR TITLE
docs: Shows earlier hidden snippet needed for compilation

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/structuring/sharing_build_logic_between_subprojects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/structuring/sharing_build_logic_between_subprojects.adoc
@@ -324,6 +324,13 @@ include::sample[dir="snippets/multiproject/dependencies-java/kotlin",files="buil
 include::sample[dir="snippets/multiproject/dependencies-java/groovy",files="buildSrc/src/main/groovy/myproject.java-conventions.gradle[]"]
 ====
 
+For the convention plugin to compile, basic configuration needs to be applied in the build file of the `buildSrc` directory:
+
+====
+include::sample[dir="snippets/multiproject/dependencies-java/kotlin",files="buildSrc/build.gradle.kts[]"]
+include::sample[dir="snippets/multiproject/dependencies-java/groovy",files="buildSrc/build.gradle[]"]
+====
+
 The convention plugin is applied to the `api`, `shared`, and `person-service` subprojects:
 
 ====


### PR DESCRIPTION
Adds showing of snippet for buildSrc/build.gradle[.kts] in example for "Share logic using convention plugins". This snippet is required for the example to compile and its absence causes confusion when trying to follow the example.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
The existing example of ["Share logic using convention plugins"](https://docs.gradle.org/current/userguide/sharing_build_logic_between_subprojects.html#sec:convention_plugins) omits the needed configuration in the buildSrc/build.gradle[.kts] file. This makes the example hard to follow since the convention plugin will not compile without this configuration.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [n/a] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [n/a] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
