### PR TITLE
Upgrade wrapper to 8.8-20240325001802+0000

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-rc-4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.8-20240325001802+0000-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -55,7 +55,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/HEAD/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/HEAD/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
@@ -104,11 +104,15 @@ public class ProjectBuilderImpl {
     }
 
     public ProjectInternal createProject(String name, File inputProjectDir, @Nullable File gradleUserHomeDir) {
-
         final File projectDir = prepareProjectDir(inputProjectDir);
         File userHomeDir = gradleUserHomeDir == null ? new File(projectDir, "userHome") : FileUtils.canonicalize(gradleUserHomeDir);
         StartParameterInternal startParameter = new StartParameterInternal();
         startParameter.setGradleUserHomeDir(userHomeDir);
+
+        // ProjectBuilder tests are more lightweight and native services shouldn't be required, so we disable them by default.
+        // Additionally, when they are enabled they are put in the projectDir by default and that can cause issues with test cleanup on Windows.
+        // If needed, a test can still enable them by setting the org.gradle.native=true system property.
+        // This was also the default behavior before Gradle 8.8 by accident since org.gradle.native=false was always passed to the test executor.
         NativeServicesMode nativeServicesMode = System.getProperty(NativeServices.NATIVE_SERVICES_OPTION) != null
             ? NativeServicesMode.fromSystemProperties()
             : NativeServicesMode.DISABLED;

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
@@ -109,7 +109,10 @@ public class ProjectBuilderImpl {
         File userHomeDir = gradleUserHomeDir == null ? new File(projectDir, "userHome") : FileUtils.canonicalize(gradleUserHomeDir);
         StartParameterInternal startParameter = new StartParameterInternal();
         startParameter.setGradleUserHomeDir(userHomeDir);
-        NativeServices.initializeOnDaemon(userHomeDir, NativeServicesMode.fromSystemProperties());
+        NativeServicesMode nativeServicesMode = System.getProperty(NativeServices.NATIVE_SERVICES_OPTION) != null
+            ? NativeServicesMode.fromSystemProperties()
+            : NativeServicesMode.DISABLED;
+        NativeServices.initializeOnDaemon(userHomeDir, nativeServicesMode);
 
         final ServiceRegistry globalServices = getGlobalServices();
 


### PR DESCRIPTION
To dogfood native services and instrumentation changes.

~~Also we now initialize NativeServices when calling create project via TestUtil static methods.
This is done by making sure we call TestUtil constructor, where NativeServices initialization was added due to similar issues in the past see:
https://github.com/gradle/gradle/commit/19a5d4884e5f2e565659cbe376b12ff8d0b9e21d~~

> TestUtil initializes native services before using ProjectBuilder
This prevents the native services from being initialized into the test
temporary directory, which is problematic for 2 reasons:
> 1. The native services dll may be locked, preventing directory cleanup.
> 2. The directory may be cleaned up, meaning that native services is
   statically initialized against a non-existent directory.

Actually let's disable it by default and enable it if user specifies `org.gradle.native` property. When using ProjectBuilder you want to have lightweight tests. So we probably don't need to have NativeServices enabled. Also since ProjectBuilder puts native services to `<project build folder>/native` enabling it by default can cause problems when cleaning the test folder on Windows.

Relates to https://github.com/gradle/gradle/pull/28021
