### PR TITLE
Store transform outputs in a version-bound directory

### DIFF
--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/CacheVersionMapping.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/CacheVersionMapping.java
@@ -65,6 +65,10 @@ public class CacheVersionMapping {
             return changedTo(versions.get(versions.lastKey()) + 1, minGradleVersion);
         }
 
+        public Builder retiredIn(String gradleVersion) {
+            return changedTo(Integer.MAX_VALUE, gradleVersion);
+        }
+
         public Builder changedTo(int cacheVersion, String minGradleVersion) {
             GradleVersion parsedGradleVersion = GradleVersion.version(minGradleVersion);
             if (!versions.isEmpty()) {

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/CacheVersionMapping.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/CacheVersionMapping.java
@@ -65,6 +65,11 @@ public class CacheVersionMapping {
             return changedTo(versions.get(versions.lastKey()) + 1, minGradleVersion);
         }
 
+        /**
+         * Specify the Gradle version where this cache directory was retired.
+         * For this and any newer Gradle version, the cache directory is unused.
+         * This is indicated by setting the current cache version to Integer.MAX_VALUE (so it cannot be further incremented).
+         */
         public Builder retiredIn(String gradleVersion) {
             return changedTo(Integer.MAX_VALUE, gradleVersion);
         }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/ArtifactCacheUnusedVersionCleanupIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/ArtifactCacheUnusedVersionCleanupIntegrationTest.groovy
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.caching
+
+
+import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
+import org.gradle.cache.internal.GradleUserHomeCleanupFixture
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.cache.FileAccessTimeJournalFixture
+import org.gradle.test.fixtures.file.TestFile
+
+class ArtifactCacheUnusedVersionCleanupIntegrationTest extends AbstractIntegrationSpec implements FileAccessTimeJournalFixture, GradleUserHomeCleanupFixture {
+
+    TestFile oldModulesDir
+    TestFile oldMetadataDir
+    TestFile currentModulesDir
+    TestFile currentModulesMetadataDir
+
+    def setup() {
+        requireOwnGradleUserHomeDir("messes with caches")
+        oldModulesDir = userHomeCacheDir.createDir("${CacheLayout.MODULES.name}-1")
+        oldMetadataDir = userHomeCacheDir.file(CacheLayout.MODULES.key).createDir("${CacheLayout.META_DATA.name}-2.56")
+        currentModulesDir = userHomeCacheDir.file(CacheLayout.MODULES.key).createDir()
+        currentModulesMetadataDir = currentModulesDir.file(CacheLayout.META_DATA.key).createDir()
+        gcFile.createFile()
+    }
+
+    def "cleans up unused versions of caches when latest cache requires cleanup"() {
+        given:
+        gcFile.lastModified = daysAgo(2)
+
+        when:
+        succeeds("help")
+
+        then:
+        oldModulesDir.assertDoesNotExist()
+        oldMetadataDir.assertDoesNotExist()
+        currentModulesDir.assertExists()
+        currentModulesMetadataDir.assertExists()
+    }
+
+    def "cleans up unused versions of caches on cleanup always"() {
+        given:
+        alwaysCleanupCaches()
+
+        when:
+        succeeds("help")
+
+        then:
+        oldModulesDir.assertDoesNotExist()
+        oldMetadataDir.assertDoesNotExist()
+        currentModulesDir.assertExists()
+        currentModulesMetadataDir.assertExists()
+    }
+
+    def "does not cleanup unused versions of caches when cleanup disabled"(CleanupMethod method) {
+        given:
+        gcFile.lastModified = daysAgo(2)
+        disableCacheCleanup(method)
+
+        when:
+        method.maybeExpectDeprecationWarning(executer)
+        succeeds("help")
+
+        then:
+        oldModulesDir.assertExists()
+        oldMetadataDir.assertExists()
+        currentModulesDir.assertExists()
+        currentModulesMetadataDir.assertExists()
+
+        where:
+        method << CleanupMethod.values()
+    }
+
+    TestFile getGcFile() {
+        return currentModulesDir.file("gc.properties")
+    }
+
+    @Override
+    TestFile getGradleUserHomeDir() {
+        return executer.gradleUserHomeDir
+    }
+}

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCacheUnusedVersionCleanupIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCacheUnusedVersionCleanupIntegrationTest.groovy
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.transform
+
+import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
+import org.gradle.cache.internal.GradleUserHomeCleanupFixture
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.cache.FileAccessTimeJournalFixture
+import org.gradle.test.fixtures.file.TestFile
+
+class ArtifactTransformCacheUnusedVersionCleanupIntegrationTest extends AbstractIntegrationSpec implements FileAccessTimeJournalFixture, GradleUserHomeCleanupFixture {
+
+    TestFile transforms3Dir
+    TestFile transforms4Dir
+    TestFile currentTransformsDir
+    TestFile currentModulesDir
+
+
+    def setup() {
+        requireOwnGradleUserHomeDir("messes with caches")
+        transforms3Dir = userHomeCacheDir.createDir("${CacheLayout.TRANSFORMS.name}-3")
+        transforms4Dir = userHomeCacheDir.createDir("${CacheLayout.TRANSFORMS.name}-4")
+        currentTransformsDir = gradleVersionedCacheDir.file(CacheLayout.TRANSFORMS.name).createDir()
+        currentModulesDir = userHomeCacheDir.file(CacheLayout.MODULES.key).createDir()
+        modulesGcFile.createFile()
+    }
+
+    def "cleans up all old unused versions of transforms-X when current modules requires cleanup"() {
+        given:
+        modulesGcFile.lastModified = daysAgo(2)
+
+        when:
+        succeeds("help")
+
+        then:
+        transforms3Dir.assertDoesNotExist()
+        transforms4Dir.assertDoesNotExist()
+        currentTransformsDir.assertExists()
+        currentModulesDir.assertExists()
+    }
+
+    def "retains used versions of transforms-X when current modules requires cleanup"() {
+        given:
+        userHomeCacheDir.file("8.7").file("gc.properties").createFile()
+        modulesGcFile.lastModified = daysAgo(2)
+
+        when:
+        succeeds("help")
+
+        then:
+        transforms3Dir.assertDoesNotExist()
+        transforms4Dir.assertExists() // Transforms-4 is used by Gradle 8.7
+        currentTransformsDir.assertExists()
+        currentModulesDir.assertExists()
+    }
+
+    def "cleans up old unused versions of transforms-X when cleanup always configured"() {
+        given:
+        alwaysCleanupCaches()
+
+        when:
+        succeeds("help")
+
+        then:
+        transforms3Dir.assertDoesNotExist()
+        transforms4Dir.assertDoesNotExist()
+        currentTransformsDir.assertExists()
+        currentModulesDir.assertExists()
+    }
+
+    def "does not cleans up old unused versions of transforms-X when cleanup disabled"(CleanupMethod method) {
+        given:
+        modulesGcFile.lastModified = daysAgo(2)
+        disableCacheCleanup(method)
+
+        when:
+        method.maybeExpectDeprecationWarning(executer)
+        succeeds("help")
+
+        then:
+        transforms3Dir.assertExists()
+        transforms4Dir.assertExists()
+        currentTransformsDir.assertExists()
+        currentModulesDir.assertExists()
+
+        where:
+        method << CleanupMethod.values()
+    }
+
+    TestFile getModulesGcFile() {
+        return currentModulesDir.file("gc.properties")
+    }
+
+    @Override
+    TestFile getGradleUserHomeDir() {
+        return executer.gradleUserHomeDir
+    }
+}

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -2496,7 +2496,7 @@ resultsFile:
     }
 
     TestFile getCacheDir() {
-        return getUserHomeCacheDir().file(CacheLayout.TRANSFORMS.getKey())
+        return getGradleVersionedCacheDir().file(CacheLayout.TRANSFORMS.getName())
     }
 
     void writeLastTransformationAccessTimeToJournal(TestFile workspaceDir, long millis) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGradleUserHomeScopeServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGradleUserHomeScopeServices.java
@@ -20,6 +20,7 @@ import org.gradle.BuildAdapter;
 import org.gradle.BuildResult;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCachesProvider;
+import org.gradle.api.internal.artifacts.ivyservice.CacheLayout;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultArtifactCaches;
 import org.gradle.api.internal.artifacts.transform.ImmutableTransformWorkspaceServices;
 import org.gradle.api.internal.artifacts.transform.ToPlannedTransformStepConverter;
@@ -82,14 +83,13 @@ public class DependencyManagementGradleUserHomeScopeServices {
     }
 
     ImmutableTransformWorkspaceServices createTransformWorkspaceServices(
-        ArtifactCachesProvider artifactCaches,
-        UnscopedCacheBuilderFactory unscopedCacheBuilderFactory,
+        GlobalScopedCacheBuilderFactory cacheBuilderFactory,
         CrossBuildInMemoryCacheFactory crossBuildInMemoryCacheFactory,
         FileAccessTimeJournal fileAccessTimeJournal,
         CacheConfigurationsInternal cacheConfigurations
     ) {
-        CacheBuilder cacheBuilder = unscopedCacheBuilderFactory
-            .cache(artifactCaches.getWritableCacheMetadata().getTransformsStoreDirectory())
+        CacheBuilder cacheBuilder = cacheBuilderFactory
+            .createCacheBuilder(CacheLayout.TRANSFORMS.getName())
             .withDisplayName("Artifact transforms cache");
         CrossBuildInMemoryCache<UnitOfWork.Identity, ExecutionEngine.IdentityCacheResult<TransformExecutionResult.TransformWorkspaceResult>> identityCache = crossBuildInMemoryCacheFactory.newCacheRetainingDataFromPreviousBuild(result -> result.getResult().isSuccessful());
         CacheBasedImmutableWorkspaceProvider workspaceProvider = CacheBasedImmutableWorkspaceProvider.createWorkspaceProvider(cacheBuilder, fileAccessTimeJournal, cacheConfigurations);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCacheMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCacheMetadata.java
@@ -43,9 +43,4 @@ public interface ArtifactCacheMetadata {
      * @return Metadata store location
      */
     File getMetaDataStoreDirectory();
-
-    /**
-     * Returns the root directory for the transforms cache.
-     */
-    File getTransformsStoreDirectory();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -85,6 +85,7 @@ public enum CacheLayout {
         .changedTo(3, "6.8-rc-1")
         // Introduced move semantics
         .changedTo(4, "8.6-rc-1")
+        .retiredIn("8.8-rc-1")
     );
 
     private final String name;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheMetadata.java
@@ -27,13 +27,11 @@ public class DefaultArtifactCacheMetadata implements ArtifactCacheMetadata, Glob
 
     public static final CacheVersion CACHE_LAYOUT_VERSION = CacheLayout.META_DATA.getVersion();
     private final File cacheDir;
-    private final File transformsDir;
     private final File baseDir;
 
     public DefaultArtifactCacheMetadata(GlobalScopedCacheBuilderFactory cacheBuilderFactory) {
         this.baseDir = cacheBuilderFactory.getRootDir();
         this.cacheDir = cacheBuilderFactory.baseDirForCrossVersionCache(CacheLayout.MODULES.getKey());
-        this.transformsDir = cacheBuilderFactory.baseDirForCrossVersionCache(CacheLayout.TRANSFORMS.getKey());
     }
 
     public DefaultArtifactCacheMetadata(GlobalScopedCacheBuilderFactory cacheBuilderFactory, File baseDir) {
@@ -43,11 +41,6 @@ public class DefaultArtifactCacheMetadata implements ArtifactCacheMetadata, Glob
     @Override
     public File getCacheDir() {
         return cacheDir;
-    }
-
-    @Override
-    public File getTransformsStoreDirectory() {
-        return transformsDir;
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/WritableArtifactCacheLockingAccessCoordinator.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/WritableArtifactCacheLockingAccessCoordinator.java
@@ -77,6 +77,8 @@ public class WritableArtifactCacheLockingAccessCoordinator implements ArtifactCa
                     new LeastRecentlyUsedCacheCleanup(new SingleDepthFilesFinder(DefaultArtifactIdentifierFileStore.FILE_TREE_DEPTH_TO_TRACK_AND_CLEANUP), fileAccessTimeJournal, getMaxAgeTimestamp(cacheConfigurations)))
                 .add(cacheMetaData.getMetaDataStoreDirectory().getParentFile(),
                     UnusedVersionsCacheCleanup.create(CacheLayout.META_DATA.getName(), CacheLayout.META_DATA.getVersionMapping(), usedGradleVersions))
+                // Cleanup old unused 'transforms-X' directories too. Transforms are now cached in 'caches/<gradle-version>/transforms'.
+                .add(UnusedVersionsCacheCleanup.create(CacheLayout.TRANSFORMS.getName(), CacheLayout.TRANSFORMS.getVersionMapping(), usedGradleVersions))
                 .build();
     }
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -74,17 +74,4 @@ class CacheLayoutTest extends Specification {
         cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("7.7")).get() == CacheVersion.parse("2.101")
         cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("8.0")).get() == CacheVersion.parse("2.100")
     }
-
-    def "use transforms layout"() {
-        when:
-        CacheLayout cacheLayout = CacheLayout.TRANSFORMS
-
-        then:
-        cacheLayout.name == 'transforms'
-        cacheLayout.key == 'transforms-4'
-        cacheLayout.version == CacheVersion.parse("4")
-        cacheLayout.version.toString() == '4'
-        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/transforms-4')
-    }
-
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathInstrumentationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathInstrumentationIntegrationTest.groovy
@@ -643,6 +643,6 @@ class BuildScriptClasspathInstrumentationIntegrationTest extends AbstractIntegra
     }
 
     TestFile getCacheDir() {
-        return getUserHomeCacheDir().file(CacheLayout.TRANSFORMS.getKey())
+        return getGradleVersionedCacheDir().file(CacheLayout.TRANSFORMS.getName())
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathIntegrationSpec.groovy
@@ -543,7 +543,7 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implem
     }
 
     TestFile getArtifactTransformCacheDir() {
-        return userHomeCacheDir.file(CacheLayout.TRANSFORMS.key)
+        return getGradleVersionedCacheDir().file(CacheLayout.TRANSFORMS.getName())
     }
 
     /**

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/cache/CachingIntegrationFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/cache/CachingIntegrationFixture.groovy
@@ -20,6 +20,7 @@ import groovy.transform.SelfType
 import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.GradleVersion
 
 import static org.gradle.cache.internal.scopes.DefaultCacheScopeMapping.GLOBAL_CACHE_DIR_NAME
 
@@ -27,6 +28,10 @@ import static org.gradle.cache.internal.scopes.DefaultCacheScopeMapping.GLOBAL_C
 trait CachingIntegrationFixture {
     TestFile getUserHomeCacheDir() {
         return executer.gradleUserHomeDir.file(GLOBAL_CACHE_DIR_NAME)
+    }
+
+    TestFile getGradleVersionedCacheDir() {
+        return executer.gradleUserHomeDir.file(GLOBAL_CACHE_DIR_NAME, GradleVersion.current().getVersion())
     }
 
     TestFile getMetadataCacheDir() {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/mutator/ClearArtifactTransformCacheWithoutInstrumentedJarsMutator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/mutator/ClearArtifactTransformCacheWithoutInstrumentedJarsMutator.groovy
@@ -18,6 +18,7 @@ package org.gradle.performance.mutator
 
 import com.google.common.collect.Lists
 import groovy.io.FileType
+import org.apache.commons.io.FilenameUtils
 import org.apache.commons.io.file.PathUtils
 import org.gradle.profiler.BuildMutator
 import org.gradle.profiler.CompositeBuildMutator
@@ -52,8 +53,8 @@ class ClearArtifactTransformCacheWithoutInstrumentedJarsMutator extends Abstract
 
     ClearArtifactTransformCacheWithoutInstrumentedJarsMutator(File gradleUserHome, CleanupSchedule schedule, String cacheDirPattern) {
         super(schedule);
-        this.gradleUserHome = gradleUserHome;
-        this.cacheDirPattern = cacheDirPattern;
+        this.gradleUserHome = gradleUserHome
+        this.cacheDirPattern = cacheDirPattern
     }
 
     @Override
@@ -63,7 +64,8 @@ class ClearArtifactTransformCacheWithoutInstrumentedJarsMutator extends Abstract
         List<File> cacheDirsToClean = []
         gradleUserHome.eachFileRecurse(FileType.DIRECTORIES) {
             def relativePath = gradleUserHome.toPath().relativize(it.toPath())
-            if (relativePath.toString().matches(cacheDirPattern)) {
+            def normalizedPath = FilenameUtils.separatorsToUnix(relativePath.toString())
+            if (normalizedPath.toString().matches(cacheDirPattern)) {
                 cacheDirsToClean << it
             }
         }

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/mutator/ClearArtifactTransformCacheWithoutInstrumentedJarsMutatorTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/mutator/ClearArtifactTransformCacheWithoutInstrumentedJarsMutatorTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.performance.mutator
 
-import org.gradle.util.GradleVersion
 import spock.lang.Specification
 import spock.lang.TempDir
 
@@ -72,19 +71,23 @@ class ClearArtifactTransformCacheWithoutInstrumentedJarsMutatorTest extends Spec
 
     def "should cleanup all version-bound transform folders except the ones with instrumented jars"() {
         given:
-        def cachesDir = new File(gradleUserHome, "caches/${GradleVersion.current().version}")
-        createFile(new File(cachesDir, "transforms/first/transformed/instrumented/file"))
-        createFile(new File(cachesDir, "transforms/first/transformed/original/file"))
-        createFile(new File(cachesDir, "transforms/second/metadata.bin"))
-        createFile(new File(cachesDir, "transforms/second/transformed/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}"))
-        createFile(new File(cachesDir, "transforms/second/transformed/instrumented/file"))
-        createFile(new File(cachesDir, "transforms/second/transformed/original/file"))
-        createFile(new File(cachesDir, "transforms/third/metadata.bin"))
-        createFile(new File(cachesDir, "transforms/third/transformed/$ANALYSIS_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}"))
-        createFile(new File(cachesDir, "transforms/third/transformed/original/file"))
-        createFile(new File(cachesDir, "transforms/fourth/metadata.bin"))
-        createFile(new File(cachesDir, "transforms/fourth/transformed/$MERGE_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}"))
-        createFile(new File(cachesDir, "transforms/fourth/transformed/original/file"))
+        def cachesDir = new File(gradleUserHome, "caches")
+        createFile(new File(cachesDir, "8.7-rc-4/transforms/first/transformed/file"))
+        createFile(new File(cachesDir, "8.7-rc-4/transforms/first/metadata.bin"))
+        createFile(new File(cachesDir, "8.7-rc-4/transforms/first/transformed/instrumented/file"))
+        createFile(new File(cachesDir, "8.7-rc-4/transforms/second/transformed/original/file"))
+        createFile(new File(cachesDir, "8.8/transforms/first/transformed/instrumented/file"))
+        createFile(new File(cachesDir, "8.8/transforms/first/transformed/original/file"))
+        createFile(new File(cachesDir, "8.8/transforms/second/metadata.bin"))
+        createFile(new File(cachesDir, "8.8/transforms/second/transformed/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}"))
+        createFile(new File(cachesDir, "8.8/transforms/second/transformed/instrumented/file"))
+        createFile(new File(cachesDir, "8.8/transforms/second/transformed/original/file"))
+        createFile(new File(cachesDir, "8.8/transforms/third/metadata.bin"))
+        createFile(new File(cachesDir, "8.8/transforms/third/transformed/$ANALYSIS_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}"))
+        createFile(new File(cachesDir, "8.8/transforms/third/transformed/original/file"))
+        createFile(new File(cachesDir, "8.8/transforms/fourth/metadata.bin"))
+        createFile(new File(cachesDir, "8.8/transforms/fourth/transformed/$MERGE_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}"))
+        createFile(new File(cachesDir, "8.8/transforms/fourth/transformed/original/file"))
 
         def mutator = ClearArtifactTransformCacheWithoutInstrumentedJarsMutator.create(gradleUserHome, BUILD)
 
@@ -92,17 +95,18 @@ class ClearArtifactTransformCacheWithoutInstrumentedJarsMutatorTest extends Spec
         mutator.beforeBuild(null)
 
         then:
-        !new File(cachesDir, "transforms/first").exists()
-        new File(cachesDir, "transforms/second/metadata.bin").exists()
-        new File(cachesDir, "transforms/second/transformed/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}").exists()
-        new File(cachesDir, "transforms/second/transformed/instrumented/file").exists()
-        new File(cachesDir, "transforms/second/transformed/original/file").exists()
-        new File(cachesDir, "transforms/third/metadata.bin").exists()
-        new File(cachesDir, "transforms/third/transformed/$ANALYSIS_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}").exists()
-        new File(cachesDir, "transforms/third/transformed/original/file").exists()
-        new File(cachesDir, "transforms/fourth/metadata.bin").exists()
-        new File(cachesDir, "transforms/fourth/transformed/$MERGE_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}").exists()
-        new File(cachesDir, "transforms/fourth/transformed/original/file").exists()
+        !new File(cachesDir, "8.7-rc-4/transforms/").exists()
+        !new File(cachesDir, "8.8/transforms/first").exists()
+        new File(cachesDir, "8.8/transforms/second/metadata.bin").exists()
+        new File(cachesDir, "8.8/transforms/second/transformed/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}").exists()
+        new File(cachesDir, "8.8/transforms/second/transformed/instrumented/file").exists()
+        new File(cachesDir, "8.8/transforms/second/transformed/original/file").exists()
+        new File(cachesDir, "8.8/transforms/third/metadata.bin").exists()
+        new File(cachesDir, "8.8/transforms/third/transformed/$ANALYSIS_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}").exists()
+        new File(cachesDir, "8.8/transforms/third/transformed/original/file").exists()
+        new File(cachesDir, "8.8/transforms/fourth/metadata.bin").exists()
+        new File(cachesDir, "8.8/transforms/fourth/transformed/$MERGE_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}").exists()
+        new File(cachesDir, "8.8/transforms/fourth/transformed/original/file").exists()
     }
 
     private static void createFile(File file) {

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/mutator/ClearArtifactTransformCacheWithoutInstrumentedJarsMutatorTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/mutator/ClearArtifactTransformCacheWithoutInstrumentedJarsMutatorTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.performance.mutator
 
-
+import org.gradle.util.GradleVersion
 import spock.lang.Specification
 import spock.lang.TempDir
 
@@ -30,42 +30,79 @@ class ClearArtifactTransformCacheWithoutInstrumentedJarsMutatorTest extends Spec
     @TempDir
     File gradleUserHome
 
-    def "should cleanup all folders except the ones with instrumented jars"() {
+    def "should cleanup all transforms-X folders except the ones with instrumented jars"() {
         given:
-        createFile(new File(gradleUserHome, "caches/transforms-1/first/transformed/file"))
-        createFile(new File(gradleUserHome, "caches/transforms-1/first/metadata.bin"))
-        createFile(new File(gradleUserHome, "caches/transforms-1/first/transformed/instrumented/file"))
-        createFile(new File(gradleUserHome, "caches/transforms-1/second/transformed/original/file"))
-        createFile(new File(gradleUserHome, "caches/transforms-2/first/transformed/instrumented/file"))
-        createFile(new File(gradleUserHome, "caches/transforms-2/first/transformed/original/file"))
-        createFile(new File(gradleUserHome, "caches/transforms-2/second/metadata.bin"))
-        createFile(new File(gradleUserHome, "caches/transforms-2/second/transformed/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}"))
-        createFile(new File(gradleUserHome, "caches/transforms-2/second/transformed/instrumented/file"))
-        createFile(new File(gradleUserHome, "caches/transforms-2/second/transformed/original/file"))
-        createFile(new File(gradleUserHome, "caches/transforms-2/third/metadata.bin"))
-        createFile(new File(gradleUserHome, "caches/transforms-2/third/transformed/$ANALYSIS_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}"))
-        createFile(new File(gradleUserHome, "caches/transforms-2/third/transformed/original/file"))
-        createFile(new File(gradleUserHome, "caches/transforms-2/fourth/metadata.bin"))
-        createFile(new File(gradleUserHome, "caches/transforms-2/fourth/transformed/$MERGE_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}"))
-        createFile(new File(gradleUserHome, "caches/transforms-2/fourth/transformed/original/file"))
-        def mutator = new ClearArtifactTransformCacheWithoutInstrumentedJarsMutator(gradleUserHome, BUILD)
+        def cachesDir = new File(gradleUserHome, "caches")
+        createFile(new File(cachesDir, "transforms-1/first/transformed/file"))
+        createFile(new File(cachesDir, "transforms-1/first/metadata.bin"))
+        createFile(new File(cachesDir, "transforms-1/first/transformed/instrumented/file"))
+        createFile(new File(cachesDir, "transforms-1/second/transformed/original/file"))
+        createFile(new File(cachesDir, "transforms-2/first/transformed/instrumented/file"))
+        createFile(new File(cachesDir, "transforms-2/first/transformed/original/file"))
+        createFile(new File(cachesDir, "transforms-2/second/metadata.bin"))
+        createFile(new File(cachesDir, "transforms-2/second/transformed/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}"))
+        createFile(new File(cachesDir, "transforms-2/second/transformed/instrumented/file"))
+        createFile(new File(cachesDir, "transforms-2/second/transformed/original/file"))
+        createFile(new File(cachesDir, "transforms-2/third/metadata.bin"))
+        createFile(new File(cachesDir, "transforms-2/third/transformed/$ANALYSIS_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}"))
+        createFile(new File(cachesDir, "transforms-2/third/transformed/original/file"))
+        createFile(new File(cachesDir, "transforms-2/fourth/metadata.bin"))
+        createFile(new File(cachesDir, "transforms-2/fourth/transformed/$MERGE_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}"))
+        createFile(new File(cachesDir, "transforms-2/fourth/transformed/original/file"))
+
+        def mutator = ClearArtifactTransformCacheWithoutInstrumentedJarsMutator.create(gradleUserHome, BUILD)
 
         when:
         mutator.beforeBuild(null)
 
         then:
-        !new File(gradleUserHome, "caches/transforms-1/").exists()
-        !new File(gradleUserHome, "caches/transforms-2/first").exists()
-        new File(gradleUserHome, "caches/transforms-2/second/metadata.bin").exists()
-        new File(gradleUserHome, "caches/transforms-2/second/transformed/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}").exists()
-        new File(gradleUserHome, "caches/transforms-2/second/transformed/instrumented/file").exists()
-        new File(gradleUserHome, "caches/transforms-2/second/transformed/original/file").exists()
-        new File(gradleUserHome, "caches/transforms-2/third/metadata.bin").exists()
-        new File(gradleUserHome, "caches/transforms-2/third/transformed/$ANALYSIS_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}").exists()
-        new File(gradleUserHome, "caches/transforms-2/third/transformed/original/file").exists()
-        new File(gradleUserHome, "caches/transforms-2/fourth/metadata.bin").exists()
-        new File(gradleUserHome, "caches/transforms-2/fourth/transformed/$MERGE_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}").exists()
-        new File(gradleUserHome, "caches/transforms-2/fourth/transformed/original/file").exists()
+        !new File(cachesDir, "transforms-1/").exists()
+        !new File(cachesDir, "transforms-2/first").exists()
+        new File(cachesDir, "transforms-2/second/metadata.bin").exists()
+        new File(cachesDir, "transforms-2/second/transformed/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}").exists()
+        new File(cachesDir, "transforms-2/second/transformed/instrumented/file").exists()
+        new File(cachesDir, "transforms-2/second/transformed/original/file").exists()
+        new File(cachesDir, "transforms-2/third/metadata.bin").exists()
+        new File(cachesDir, "transforms-2/third/transformed/$ANALYSIS_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}").exists()
+        new File(cachesDir, "transforms-2/third/transformed/original/file").exists()
+        new File(cachesDir, "transforms-2/fourth/metadata.bin").exists()
+        new File(cachesDir, "transforms-2/fourth/transformed/$MERGE_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}").exists()
+        new File(cachesDir, "transforms-2/fourth/transformed/original/file").exists()
+    }
+
+    def "should cleanup all version-bound transform folders except the ones with instrumented jars"() {
+        given:
+        def cachesDir = new File(gradleUserHome, "caches/${GradleVersion.current().version}")
+        createFile(new File(cachesDir, "transforms/first/transformed/instrumented/file"))
+        createFile(new File(cachesDir, "transforms/first/transformed/original/file"))
+        createFile(new File(cachesDir, "transforms/second/metadata.bin"))
+        createFile(new File(cachesDir, "transforms/second/transformed/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}"))
+        createFile(new File(cachesDir, "transforms/second/transformed/instrumented/file"))
+        createFile(new File(cachesDir, "transforms/second/transformed/original/file"))
+        createFile(new File(cachesDir, "transforms/third/metadata.bin"))
+        createFile(new File(cachesDir, "transforms/third/transformed/$ANALYSIS_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}"))
+        createFile(new File(cachesDir, "transforms/third/transformed/original/file"))
+        createFile(new File(cachesDir, "transforms/fourth/metadata.bin"))
+        createFile(new File(cachesDir, "transforms/fourth/transformed/$MERGE_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}"))
+        createFile(new File(cachesDir, "transforms/fourth/transformed/original/file"))
+
+        def mutator = ClearArtifactTransformCacheWithoutInstrumentedJarsMutator.create(gradleUserHome, BUILD)
+
+        when:
+        mutator.beforeBuild(null)
+
+        then:
+        !new File(cachesDir, "transforms/first").exists()
+        new File(cachesDir, "transforms/second/metadata.bin").exists()
+        new File(cachesDir, "transforms/second/transformed/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}").exists()
+        new File(cachesDir, "transforms/second/transformed/instrumented/file").exists()
+        new File(cachesDir, "transforms/second/transformed/original/file").exists()
+        new File(cachesDir, "transforms/third/metadata.bin").exists()
+        new File(cachesDir, "transforms/third/transformed/$ANALYSIS_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}").exists()
+        new File(cachesDir, "transforms/third/transformed/original/file").exists()
+        new File(cachesDir, "transforms/fourth/metadata.bin").exists()
+        new File(cachesDir, "transforms/fourth/transformed/$MERGE_OUTPUT_DIR/${INSTRUMENTATION_CLASSPATH_MARKER.fileName}").exists()
+        new File(cachesDir, "transforms/fourth/transformed/original/file").exists()
     }
 
     private static void createFile(File file) {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -27,7 +27,6 @@ import org.gradle.profiler.BuildContext
 import org.gradle.profiler.BuildMutator
 import org.gradle.profiler.InvocationSettings
 import org.gradle.profiler.ScenarioContext
-import org.gradle.profiler.mutations.AbstractCleanupMutator
 import org.gradle.profiler.mutations.AbstractFileChangeMutator
 import spock.lang.Issue
 
@@ -37,6 +36,7 @@ import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
 import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.fixture.AndroidTestProject.LARGE_ANDROID_BUILD
 import static org.gradle.performance.results.OperatingSystem.LINUX
+import static org.gradle.profiler.mutations.AbstractCleanupMutator.CleanupSchedule.BUILD
 
 class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanceTest implements AndroidPerformanceTestFixture {
 
@@ -103,7 +103,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
         runner.cleanTasks = ["clean"]
         runner.useDaemon = false
         runner.addBuildMutator { invocationSettings ->
-            new ClearArtifactTransformCacheWithoutInstrumentedJarsMutator(invocationSettings.getGradleUserHome(), AbstractCleanupMutator.CleanupSchedule.BUILD)
+            ClearArtifactTransformCacheWithoutInstrumentedJarsMutator.create(invocationSettings.getGradleUserHome(), BUILD)
         }
         if (IncrementalAndroidTestProject.NOW_IN_ANDROID == testProject) {
             configureRunnerSpecificallyForNowInAndroid()


### PR DESCRIPTION
Fixes #28178 

### Context

Each transform output is implicitly tied to the Gradle version used to generate it. As such, it makes no sense to store these entries in a cross-version cache (like `caches/transforms-4`). Instead, these transform outputs are now stored in a version-bound cache directory: `caches/<gradle-version>/transforms`.

This change makes the transform cache directory easier to manage:
- It will only contain entries that are relevant to the Gradle version being used
- It will automatically be purged when the bound Gradle version is no longer used

As well as moving the transform outputs into a version-bound directory, this PR also ensures that old `caches/transforms-X` directories will be purged when they are no longer used by an active Gradle version.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
