### PR TITLE
Fix Scala incremental compilation of sourceSet dependent on changed Scala objects

### DIFF
--- a/platforms/jvm/scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
+++ b/platforms/jvm/scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
@@ -202,8 +202,8 @@ public abstract class AbstractScalaCompile extends AbstractCompile implements Ha
 
         File analysisFile = incrementalOptions.getAnalysisFile().getAsFile().get();
         File classpathBackupDir = incrementalOptions.getClassfileBackupDir().getAsFile().get();
-        Map<File, File> globalAnalysisMap = resolveAnalysisMappingsForOtherProjects();
-        spec.setAnalysisMap(globalAnalysisMap);
+        Map<File, File> analysisMap = resolveInputAnalysisMap();
+        spec.setAnalysisMap(analysisMap);
         spec.setAnalysisFile(analysisFile);
         spec.setClassfileBackupDir(classpathBackupDir);
 
@@ -220,8 +220,16 @@ public abstract class AbstractScalaCompile extends AbstractCompile implements Ha
             GFileUtils.writeFile(publishedCode.getAbsolutePath() + "\n" + analysisFile.getAbsolutePath(), analysisMapping);
         }
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("scala-incremental Analysis map: {}", globalAnalysisMap);
+            LOGGER.debug("scala-incremental Analysis map: {}", analysisMap);
         }
+    }
+
+
+    private Map<File, File> resolveInputAnalysisMap() {
+        Map<File, File> analysisMap = new HashMap<>();
+        analysisMap.putAll(resolveAnalysisMappingsForLocalSourceSets());
+        analysisMap.putAll(resolveAnalysisMappingsForOtherProjects());
+        return analysisMap;
     }
 
     private Map<File, File> resolveAnalysisMappingsForOtherProjects() {
@@ -238,6 +246,11 @@ public abstract class AbstractScalaCompile extends AbstractCompile implements Ha
             }
         }
 
+        return analysisMap;
+    }
+
+    private Map<File, File> resolveAnalysisMappingsForLocalSourceSets() {
+        Map<File, File> analysisMap = new HashMap<>();
         for (Task taskDependency : getTaskDependencies().getDependenciesForInternalUse(this)) {
             if (taskDependency instanceof AbstractScalaCompile) {
                 AbstractScalaCompile scalaCompileTask = (AbstractScalaCompile) taskDependency;

--- a/platforms/jvm/scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
+++ b/platforms/jvm/scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
@@ -238,7 +238,7 @@ public abstract class AbstractScalaCompile extends AbstractCompile implements Ha
             }
         }
 
-        for (Task taskDependency : getTaskDependencies().getDependencies(this)) {
+        for (Task taskDependency : getTaskDependencies().getDependenciesForInternalUse(this)) {
             if (taskDependency instanceof AbstractScalaCompile) {
                 AbstractScalaCompile scalaCompileTask = (AbstractScalaCompile) taskDependency;
                 File destinationDirectory = scalaCompileTask.getDestinationDirectory().getAsFile().get();

--- a/platforms/jvm/scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
+++ b/platforms/jvm/scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.io.Files;
 import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
+import org.gradle.api.Task;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileTree;
@@ -236,6 +237,16 @@ public abstract class AbstractScalaCompile extends AbstractCompile implements Ha
                 }
             }
         }
+
+        for (Task taskDependency : getTaskDependencies().getDependencies(this)) {
+            if (taskDependency instanceof AbstractScalaCompile) {
+                AbstractScalaCompile scalaCompileTask = (AbstractScalaCompile) taskDependency;
+                File destinationDirectory = scalaCompileTask.getDestinationDirectory().getAsFile().get();
+                File analysisFile = scalaCompileTask.getScalaCompileOptions().getIncrementalOptions().getAnalysisFile().getAsFile().get();
+                analysisMap.put(destinationDirectory, analysisFile);
+            }
+        }
+
         return analysisMap;
     }
 


### PR DESCRIPTION
Fixes #28536 

### Context
Currently incremental compilation that involves Scala objects in different sourceSets is broken.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
