### PR TITLE
Refactor: Rename CacheLayout.ROOT -> MODULES

### DIFF
--- a/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest.groovy
+++ b/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest.groovy
@@ -536,9 +536,9 @@ dependencies {
     String getActualXml(File file) {
         def gradleUserHomeDir = executer.getGradleUserHomeDir()
         def homeDir = gradleUserHomeDir.absolutePath.replace(File.separator, '/')
-        def pattern = Pattern.compile(Pattern.quote(homeDir) + "/caches/${CacheLayout.ROOT.getKey()}/${CacheLayout.FILE_STORE.getKey()}/([^/]+/[^/]+/[^/]+)/[a-z0-9]+/")
+        def pattern = Pattern.compile(Pattern.quote(homeDir) + "/caches/${CacheLayout.MODULES.getKey()}/${CacheLayout.FILE_STORE.getKey()}/([^/]+/[^/]+/[^/]+)/[a-z0-9]+/")
         def text = file.text.replaceAll(pattern, '@CACHE_DIR@/$1/@SHA1@/')
-        pattern = Pattern.compile("GRADLE_USER_HOME/${CacheLayout.ROOT.getKey()}/${CacheLayout.FILE_STORE.getKey()}/([^/]+/[^/]+/[^/]+)/[a-z0-9]+/")
+        pattern = Pattern.compile("GRADLE_USER_HOME/${CacheLayout.MODULES.getKey()}/${CacheLayout.FILE_STORE.getKey()}/([^/]+/[^/]+/[^/]+)/[a-z0-9]+/")
         text = text.replaceAll(pattern, 'GRADLE_USER_HOME/@CACHE@/$1/@SHA1@/')
 
         //remove trailing slashes for windows paths

--- a/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy
+++ b/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy
@@ -469,7 +469,7 @@ idea.project {
         def expectedXml = expectedFile.text
 
         def homeDir = executer.gradleUserHomeDir.absolutePath.replace(File.separator, '/')
-        def pattern = Pattern.compile(Pattern.quote(homeDir) + "/caches/${CacheLayout.ROOT.getKey()}/${CacheLayout.FILE_STORE.getKey()}/([^/]+/[^/]+/[^/]+)/[a-z0-9]+/")
+        def pattern = Pattern.compile(Pattern.quote(homeDir) + "/caches/${CacheLayout.MODULES.getKey()}/${CacheLayout.FILE_STORE.getKey()}/([^/]+/[^/]+/[^/]+)/[a-z0-9]+/")
         def actualXml = actualFile.text.replaceAll(pattern, '@CACHE_DIR@/$1/@SHA1@/')
 
         Diff diff = new Diff(expectedXml, actualXml)

--- a/platforms/ide/ide/src/testFixtures/groovy/org/gradle/plugins/ide/eclipse/EclipseClasspathFixture.groovy
+++ b/platforms/ide/ide/src/testFixtures/groovy/org/gradle/plugins/ide/eclipse/EclipseClasspathFixture.groovy
@@ -182,7 +182,7 @@ class EclipseClasspathFixture {
         }
 
         private String cachePath(String group, String module, String version) {
-            return Pattern.quote("${userHomeDir.path.replace(File.separator, '/')}") + "/caches/${CacheLayout.ROOT.getKey()}/${CacheLayout.FILE_STORE.getKey()}/" + Pattern.quote("${group}/${module}/${version}/") + "\\w+/"
+            return Pattern.quote("${userHomeDir.path.replace(File.separator, '/')}") + "/caches/${CacheLayout.MODULES.getKey()}/${CacheLayout.FILE_STORE.getKey()}/" + Pattern.quote("${group}/${module}/${version}/") + "\\w+/"
         }
 
         void assertHasNoSource() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/CacheResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/CacheResolveIntegrationTest.groovy
@@ -263,7 +263,7 @@ dependencies { implementation 'org.test:test:1.0' }
     }
 
     private String getCachePath() {
-        "caches/${CacheLayout.ROOT.key}/${CacheLayout.FILE_STORE.key}/"
+        "caches/${CacheLayout.MODULES.key}/${CacheLayout.FILE_STORE.key}/"
     }
 
     private void buildWithJavaLibraryAndMavenRepoArtifactOnly() {
@@ -309,7 +309,7 @@ public class Base {}
         def otherHome = executer.gradleUserHomeDir.parentFile.createDir('other-home')
         def otherCacheDir = otherHome.toPath().resolve(DefaultCacheScopeMapping.GLOBAL_CACHE_DIR_NAME)
         Files.createDirectory(otherCacheDir)
-        Files.move(getMetadataCacheDir().toPath(), otherCacheDir.resolve(CacheLayout.ROOT.key))
+        Files.move(getMetadataCacheDir().toPath(), otherCacheDir.resolve(CacheLayout.MODULES.key))
         executer.withGradleUserHomeDir(otherHome)
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/DefaultArtifactCacheLockingAccessCoordinatorIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/DefaultArtifactCacheLockingAccessCoordinatorIntegrationTest.groovy
@@ -457,10 +457,10 @@ class DefaultArtifactCacheLockingAccessCoordinatorIntegrationTest extends Abstra
         given:
         requireOwnGradleUserHomeDir() // messes with caches
         def oldCacheDirs = [
-            userHomeCacheDir.createDir("${CacheLayout.ROOT.name}-1"),
-            userHomeCacheDir.file(CacheLayout.ROOT.key).createDir("${CacheLayout.META_DATA.name}-2.56")
+                userHomeCacheDir.createDir("${CacheLayout.MODULES.name}-1"),
+                userHomeCacheDir.file(CacheLayout.MODULES.key).createDir("${CacheLayout.META_DATA.name}-2.56")
         ]
-        def currentMetaDataDir = userHomeCacheDir.file(CacheLayout.ROOT.key, CacheLayout.META_DATA.key).createDir()
+        def currentMetaDataDir = userHomeCacheDir.file(CacheLayout.MODULES.key, CacheLayout.META_DATA.key).createDir()
         gcFile.createFile().lastModified = daysAgo(2)
 
         when:
@@ -519,7 +519,7 @@ class DefaultArtifactCacheLockingAccessCoordinatorIntegrationTest extends Abstra
     }
 
     TestFile getCacheDir() {
-        return getUserHomeCacheDir().file(CacheLayout.ROOT.getKey())
+        return getUserHomeCacheDir().file(CacheLayout.MODULES.getKey())
     }
 
     void forceCleanup(File file) {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rocache/AbstractReadOnlyCacheDependencyResolutionTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rocache/AbstractReadOnlyCacheDependencyResolutionTest.groovy
@@ -177,7 +177,7 @@ abstract class AbstractReadOnlyCacheDependencyResolutionTest extends AbstractHtt
     private void copyToReadOnlyCache() {
         roCacheDir = temporaryFolder.createDir("read-only-cache")
         def cachePath = roCacheDir.toPath()
-        doCopy(metadataCacheDir, cachePath, CacheLayout.ROOT)
+        doCopy(metadataCacheDir, cachePath, CacheLayout.MODULES)
 
         roCacheDir
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rocache/ParentPomsReadOnlyCacheDependencyResolutionTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rocache/ParentPomsReadOnlyCacheDependencyResolutionTest.groovy
@@ -36,7 +36,7 @@ class ParentPomsReadOnlyCacheDependencyResolutionTest extends AbstractReadOnlyCa
         """
 
         when:
-        fileInReadReadOnlyCache("modules-${CacheLayout.ROOT.version}/files-${CacheLayout.FILE_STORE.version}/org.readonly/parent/1.0").eachFileRecurse { it.delete() }
+        fileInReadReadOnlyCache("modules-${CacheLayout.MODULES.version}/files-${CacheLayout.FILE_STORE.version}/org.readonly/parent/1.0").eachFileRecurse { it.delete() }
         withReadOnlyCache()
         other.allowAll()
         parent.allowAll()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rocache/StaticVersionsReadOnlyCacheDependencyResolutionTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rocache/StaticVersionsReadOnlyCacheDependencyResolutionTest.groovy
@@ -95,7 +95,7 @@ class StaticVersionsReadOnlyCacheDependencyResolutionTest extends AbstractReadOn
         """
 
         when:
-        fileInReadReadOnlyCache("modules-${CacheLayout.ROOT.version}/metadata-${CacheLayout.META_DATA.version}/${file}.bin").bytes = [0, 0, 0]
+        fileInReadReadOnlyCache("modules-${CacheLayout.MODULES.version}/metadata-${CacheLayout.META_DATA.version}/${file}.bin").bytes = [0, 0, 0]
         withReadOnlyCache()
 
         core.allowAll()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
@@ -1175,7 +1175,7 @@ group:projectB:2.2;release
         run '--stop'
         // bust the artifact cache because we don't want to fall into the smart behavior
         // of reusing metadata from cache for a different repository
-        getUserHomeCacheDir().file(CacheLayout.ROOT.getKey()).deleteDir()
+        getUserHomeCacheDir().file(CacheLayout.MODULES.getKey()).deleteDir()
         resetExpectations()
         // Changing the host makes Gradle consider that the 2 repositories are distinct
         buildFile.text = buildFile.text.replaceAll("(?m)http://localhost", "http://127.0.0.1")

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -36,12 +36,12 @@ import static org.gradle.cache.internal.CacheVersionMapping.introducedIn;
  */
 public enum CacheLayout {
 
-    ROOT(null, "modules", introducedIn("1.9-rc-1").incrementedIn("1.9-rc-2")),
+    MODULES(null, "modules", introducedIn("1.9-rc-1").incrementedIn("1.9-rc-2")),
 
     // If you update FILE_STORE, you may also need to update LocallyAvailableResourceFinderFactory
-    FILE_STORE(ROOT, "files", introducedIn("1.9-rc-1")),
+    FILE_STORE(MODULES, "files", introducedIn("1.9-rc-1")),
 
-    META_DATA(ROOT, "metadata",
+    META_DATA(MODULES, "metadata",
         // skipped versions were not used in a release
         introducedIn("1.9-rc-2")
         .changedTo(2, "1.11-rc-1")
@@ -78,7 +78,7 @@ public enum CacheLayout {
         .changedTo(106, "8.2-milestone-1")
     ),
 
-    RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),
+    RESOURCES(MODULES, "resources", introducedIn("1.9-rc-1")),
 
     TRANSFORMS(null, "transforms", introducedIn("3.5-rc-1")
         .changedTo(2, "5.1")

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheMetadata.java
@@ -32,7 +32,7 @@ public class DefaultArtifactCacheMetadata implements ArtifactCacheMetadata, Glob
 
     public DefaultArtifactCacheMetadata(GlobalScopedCacheBuilderFactory cacheBuilderFactory) {
         this.baseDir = cacheBuilderFactory.getRootDir();
-        this.cacheDir = cacheBuilderFactory.baseDirForCrossVersionCache(CacheLayout.ROOT.getKey());
+        this.cacheDir = cacheBuilderFactory.baseDirForCrossVersionCache(CacheLayout.MODULES.getKey());
         this.transformsDir = cacheBuilderFactory.baseDirForCrossVersionCache(CacheLayout.TRANSFORMS.getKey());
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCaches.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCaches.java
@@ -80,12 +80,12 @@ public class DefaultArtifactCaches implements ArtifactCachesProvider {
             LOGGER.warn("The " + READONLY_CACHE_ENV_VAR + " environment variable was set to " + cacheDir + " which doesn't exist!");
             return null;
         }
-        File root = CacheLayout.ROOT.getPath(cacheDir);
+        File root = CacheLayout.MODULES.getPath(cacheDir);
         if (!root.exists()) {
             String docLink = documentationRegistry.getDocumentationRecommendationFor("instructions on how to do this", "dependency_resolution", "sub:shared-readonly-cache");
             LOGGER.warn("The read-only dependency cache is disabled because of a configuration problem:");
             LOGGER.warn("Read-only cache is configured but the directory layout isn't expected. You must have a pre-populated " +
-                CacheLayout.ROOT.getKey() + " directory at " + root + " . " + docLink);
+                CacheLayout.MODULES.getKey() + " directory at " + root + " . " + docLink);
             return null;
         }
         return cacheDir;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/WritableArtifactCacheLockingAccessCoordinator.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/WritableArtifactCacheLockingAccessCoordinator.java
@@ -68,7 +68,7 @@ public class WritableArtifactCacheLockingAccessCoordinator implements ArtifactCa
 
     private CleanupAction createCleanupAction(ArtifactCacheMetadata cacheMetaData, FileAccessTimeJournal fileAccessTimeJournal, UsedGradleVersions usedGradleVersions, CacheConfigurationsInternal cacheConfigurations) {
         return CompositeCleanupAction.builder()
-                .add(UnusedVersionsCacheCleanup.create(CacheLayout.ROOT.getName(), CacheLayout.ROOT.getVersionMapping(), usedGradleVersions))
+                .add(UnusedVersionsCacheCleanup.create(CacheLayout.MODULES.getName(), CacheLayout.MODULES.getVersionMapping(), usedGradleVersions))
                 .add(cacheMetaData.getExternalResourcesStoreDirectory(),
                     UnusedVersionsCacheCleanup.create(CacheLayout.RESOURCES.getName(), CacheLayout.RESOURCES.getVersionMapping(), usedGradleVersions),
                     new LeastRecentlyUsedCacheCleanup(new SingleDepthFilesFinder(DefaultExternalResourceFileStore.FILE_TREE_DEPTH_TO_TRACK_AND_CLEANUP), fileAccessTimeJournal, getMaxAgeTimestamp(cacheConfigurations)))

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -23,7 +23,7 @@ class CacheLayoutTest extends Specification {
 
     def "use root layout"() {
         when:
-        CacheLayout cacheLayout = CacheLayout.ROOT
+        CacheLayout cacheLayout = CacheLayout.MODULES
 
         then:
         cacheLayout.name == 'modules'

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheLockingAccessCoordinatorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheLockingAccessCoordinatorTest.groovy
@@ -33,7 +33,7 @@ class DefaultArtifactCacheLockingAccessCoordinatorTest extends Specification {
     @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def cacheRepository = new DefaultUnscopedCacheBuilderFactory(new TestInMemoryCacheFactory())
-    def cacheDir = temporaryFolder.createDir(CacheLayout.ROOT.key)
+    def cacheDir = temporaryFolder.createDir(CacheLayout.MODULES.key)
     def resourcesDir = cacheDir.createDir(CacheLayout.RESOURCES.key)
     def filesDir = cacheDir.createDir(CacheLayout.FILE_STORE.key)
     def metaDataDir = cacheDir.createDir(CacheLayout.META_DATA.key)

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheMetadataTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheMetadataTest.groovy
@@ -29,7 +29,7 @@ class DefaultArtifactCacheMetadataTest extends Specification {
     def "calculates file store directory"() {
         given:
         TestFile testCacheDir = temporaryFolder.file("test/cache")
-        cache.baseDirForCrossVersionCache(CacheLayout.ROOT.key) >> testCacheDir
+        cache.baseDirForCrossVersionCache(CacheLayout.MODULES.key) >> testCacheDir
 
         when:
         def metaData = new DefaultArtifactCacheMetadata(cache)
@@ -42,7 +42,7 @@ class DefaultArtifactCacheMetadataTest extends Specification {
     def "calculates metadata store directory"() {
         given:
         TestFile testCacheDir = temporaryFolder.file("test/cache")
-        cache.baseDirForCrossVersionCache(CacheLayout.ROOT.key) >> testCacheDir
+        cache.baseDirForCrossVersionCache(CacheLayout.MODULES.key) >> testCacheDir
 
         when:
         def metaData = new DefaultArtifactCacheMetadata(cache)

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CacheProjectIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CacheProjectIntegrationTest.groovy
@@ -145,7 +145,7 @@ class CacheProjectIntegrationTest extends AbstractIntegrationTest {
     }
 
     private TestFile findDependencyCacheDir() {
-        def resolverArtifactCache = new TestFile(userHomeDir.file("caches/${CacheLayout.ROOT.getKey()}/${CacheLayout.FILE_STORE.getKey()}"))
+        def resolverArtifactCache = new TestFile(userHomeDir.file("caches/${CacheLayout.MODULES.getKey()}/${CacheLayout.FILE_STORE.getKey()}"))
         return resolverArtifactCache.file("commons-io/commons-io/")
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/cache/CachingIntegrationFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/cache/CachingIntegrationFixture.groovy
@@ -30,7 +30,7 @@ trait CachingIntegrationFixture {
     }
 
     TestFile getMetadataCacheDir() {
-        return userHomeCacheDir.file(CacheLayout.ROOT.key)
+        return userHomeCacheDir.file(CacheLayout.MODULES.key)
     }
 
     void markForArtifactCacheCleanup() {


### PR DESCRIPTION
### Context
`CacheLayout.ROOT` points to the `~/.gradle/caches/modules-2` directory.
Calling it `ROOT` doesn't make any sense.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
