### PR TITLE
Support enabling preview for Java compilation via task options

### DIFF
--- a/platforms/documentation/docs/src/docs/dsl/org.gradle.api.tasks.compile.CompileOptions.xml
+++ b/platforms/documentation/docs/src/docs/dsl/org.gradle.api.tasks.compile.CompileOptions.xml
@@ -69,6 +69,10 @@
                 <td><literal>null</literal></td>
             </tr>
             <tr>
+                <td>enablePreview</td>
+                <td><literal>false</literal></td>
+            </tr>
+            <tr>
                 <td>javaModuleVersion</td>
                 <td></td>
             </tr>

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileCompatibilityIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileCompatibilityIntegrationTest.groovy
@@ -555,6 +555,113 @@ class JavaCompileCompatibilityIntegrationTest extends AbstractIntegrationSpec im
         classJavaVersion(javaClassFile("Main.class")) == JavaVersion.VERSION_17
     }
 
+    def sourceUsingLanguageFeaturePreviewFromJava21() {
+        """
+            public class Main {
+                public static void main(String[] args) {
+                    String version = System.getProperty("java.version").toString();
+                    System.out.println("Main: java " + version);
+
+                    // Error to use '_' name since Java 9, and supported as "unnamed variable" in Java 21 as Preview
+                    int _ = version.length();
+                }
+            }
+        """
+    }
+
+    def "preview features are not allowed #description"() {
+        def jdk = AvailableJavaHomes.getJdk(JavaVersion.VERSION_21)
+
+        buildFile << """
+            apply plugin: "java"
+
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(${jdk.javaVersion.majorVersion})
+                }
+            }
+
+            compileJava {
+                $configureCompilation
+            }
+        """
+
+        file("src/main/java/Main.java") << sourceUsingLanguageFeaturePreviewFromJava21()
+
+        when:
+        withInstallations(jdk).fails(":compileJava")
+
+        then:
+        failure.assertHasErrorOutput("Main.java:8: error: unnamed variables are a preview feature")
+        failure.assertHasErrorOutput("(use --enable-preview to enable unnamed variables)")
+        javaClassFile("Main.class").assertDoesNotExist()
+
+        where:
+        description     | configureCompilation
+        "by default"    | ""
+        "when disabled" | "options.enablePreview = false"
+    }
+
+    def "preview features are allowed when enabled via #description"() {
+        def jdk = AvailableJavaHomes.getJdk(JavaVersion.VERSION_21)
+
+        buildFile << """
+            apply plugin: "java"
+
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(${jdk.javaVersion.majorVersion})
+                }
+            }
+
+            compileJava {
+                $configureCompilation
+            }
+        """
+
+        file("src/main/java/Main.java") << sourceUsingLanguageFeaturePreviewFromJava21()
+
+        when:
+        withInstallations(jdk).succeeds(":compileJava")
+
+        then:
+        executedAndNotSkipped(":compileJava")
+        errorOutput.contains("Main.java uses preview features of Java SE 21.")
+        classJavaVersion(javaClassFile("Main.class")) == JavaVersion.VERSION_21
+
+        where:
+        description          | configureCompilation
+        "compiler flag"      | "options.compilerArgs += '--enable-preview'"
+        "compilation option" | "options.enablePreview = true"
+    }
+
+    def "cannot mix enable-preview compiler flag and enabling the compilation option"() {
+        def jdk = AvailableJavaHomes.getJdk(JavaVersion.VERSION_21)
+
+        buildFile << """
+            apply plugin: "java"
+
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(${jdk.javaVersion.majorVersion})
+                }
+            }
+
+            compileJava {
+                options.enablePreview = true
+                options.compilerArgs += '--enable-preview'
+            }
+        """
+
+        file("src/main/java/Main.java") << sourceUsingLanguageFeaturePreviewFromJava21()
+
+        when:
+        withInstallations(jdk).fails(":compileJava")
+
+        then:
+        failureHasCause('Cannot specify --enable-preview via `CompileOptions.compilerArgs` when using `CompileOptions.enablePreview`.')
+    }
+
     private static String currentJavaVersion() {
         return Jvm.current().javaVersion.toString()
     }

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileCompatibilityIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileCompatibilityIntegrationTest.groovy
@@ -604,7 +604,7 @@ class JavaCompileCompatibilityIntegrationTest extends AbstractIntegrationSpec im
         "when disabled" | "options.enablePreview = false"
     }
 
-    def "preview features are allowed when enabled"() {
+    def "preview features are allowed when enabled via #description"() {
         def jdk = AvailableJavaHomes.getJdk21()
 
         buildFile << """
@@ -619,7 +619,7 @@ class JavaCompileCompatibilityIntegrationTest extends AbstractIntegrationSpec im
             }
 
             compileJava {
-                options.enablePreview = true
+                $configureCompilation
             }
         """
 
@@ -632,6 +632,11 @@ class JavaCompileCompatibilityIntegrationTest extends AbstractIntegrationSpec im
         executedAndNotSkipped(":compileJava")
         errorOutput.contains("Main.java uses preview features of Java SE 21.")
         classJavaVersion(javaClassFile("Main.class")) == JavaVersion.VERSION_21
+
+        where:
+        description          | configureCompilation
+        "compiler flag"      | "options.compilerArgs += '--enable-preview'"
+        "compilation option" | "options.enablePreview = true"
     }
 
     def "cannot mix enable-preview compiler flag and enabling the compilation option"() {

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileCompatibilityIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileCompatibilityIntegrationTest.groovy
@@ -570,10 +570,12 @@ class JavaCompileCompatibilityIntegrationTest extends AbstractIntegrationSpec im
     }
 
     def "preview features are not allowed #description"() {
-        def jdk = AvailableJavaHomes.getJdk(JavaVersion.VERSION_21)
+        def jdk = AvailableJavaHomes.getJdk21()
 
         buildFile << """
-            apply plugin: "java"
+            plugins {
+                id 'java'
+            }
 
             java {
                 toolchain {
@@ -602,11 +604,13 @@ class JavaCompileCompatibilityIntegrationTest extends AbstractIntegrationSpec im
         "when disabled" | "options.enablePreview = false"
     }
 
-    def "preview features are allowed when enabled via #description"() {
-        def jdk = AvailableJavaHomes.getJdk(JavaVersion.VERSION_21)
+    def "preview features are allowed when enabled"() {
+        def jdk = AvailableJavaHomes.getJdk21()
 
         buildFile << """
-            apply plugin: "java"
+            plugins {
+                id 'java'
+            }
 
             java {
                 toolchain {
@@ -615,7 +619,7 @@ class JavaCompileCompatibilityIntegrationTest extends AbstractIntegrationSpec im
             }
 
             compileJava {
-                $configureCompilation
+                options.enablePreview = true
             }
         """
 
@@ -628,18 +632,15 @@ class JavaCompileCompatibilityIntegrationTest extends AbstractIntegrationSpec im
         executedAndNotSkipped(":compileJava")
         errorOutput.contains("Main.java uses preview features of Java SE 21.")
         classJavaVersion(javaClassFile("Main.class")) == JavaVersion.VERSION_21
-
-        where:
-        description          | configureCompilation
-        "compiler flag"      | "options.compilerArgs += '--enable-preview'"
-        "compilation option" | "options.enablePreview = true"
     }
 
     def "cannot mix enable-preview compiler flag and enabling the compilation option"() {
-        def jdk = AvailableJavaHomes.getJdk(JavaVersion.VERSION_21)
+        def jdk = AvailableJavaHomes.getJdk21()
 
         buildFile << """
-            apply plugin: "java"
+            plugins {
+                id 'java'
+            }
 
             java {
                 toolchain {

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -120,6 +120,10 @@ public class JavaCompilerArgumentsBuilder {
             if ("--release".equals(arg) && spec.getRelease() != null) {
                 throw new InvalidUserDataException("Cannot specify --release via `CompileOptions.compilerArgs` when using `CompileOptions.release`.");
             }
+
+            if ("--enable-preview".equals(arg) && spec.getEnablePreview() != null) {
+                throw new InvalidUserDataException("Cannot specify --enable-preview via `CompileOptions.compilerArgs` when using `CompileOptions.enablePreview`.");
+            }
         }
     }
 
@@ -146,6 +150,10 @@ public class JavaCompilerArgumentsBuilder {
         }
         Integer release = spec.getRelease();
         final MinimalJavaCompileOptions compileOptions = spec.getCompileOptions();
+
+        if (spec.getEnablePreview() != null && spec.getEnablePreview()) {
+            args.add("--enable-preview");
+        }
 
         if (release != null) {
             args.add("--release");

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -310,9 +310,7 @@ public abstract class JavaCompile extends AbstractCompile implements HasCompileO
             spec.setTargetCompatibility(targetCompatibility);
         }
 
-        if (compileOptions.getEnablePreview().isPresent()) {
-            spec.setEnablePreview(compileOptions.getEnablePreview().get());
-        }
+        spec.setEnablePreview(compileOptions.getEnablePreview().get());
 
         spec.setCompileOptions(compileOptions);
     }

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -310,7 +310,9 @@ public abstract class JavaCompile extends AbstractCompile implements HasCompileO
             spec.setTargetCompatibility(targetCompatibility);
         }
 
-        spec.setEnablePreview(compileOptions.getEnablePreview().get());
+        if (compileOptions.getEnablePreview().isPresent()) {
+            spec.setEnablePreview(compileOptions.getEnablePreview().get());
+        }
 
         spec.setCompileOptions(compileOptions);
     }

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -309,6 +309,11 @@ public abstract class JavaCompile extends AbstractCompile implements HasCompileO
             spec.setSourceCompatibility(sourceCompatibility);
             spec.setTargetCompatibility(targetCompatibility);
         }
+
+        if (compileOptions.getEnablePreview().isPresent()) {
+            spec.setEnablePreview(compileOptions.getEnablePreview().get());
+        }
+
         spec.setCompileOptions(compileOptions);
     }
 

--- a/platforms/jvm/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJvmLanguageCompileSpec.java
+++ b/platforms/jvm/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJvmLanguageCompileSpec.java
@@ -33,6 +33,8 @@ public class DefaultJvmLanguageCompileSpec implements JvmLanguageCompileSpec, Se
     private String sourceCompatibility;
     private String targetCompatibility;
     private List<File> sourceRoots;
+    @Nullable
+    private Boolean enablePreview;
 
     @Override
     public File getWorkingDir() {
@@ -128,5 +130,16 @@ public class DefaultJvmLanguageCompileSpec implements JvmLanguageCompileSpec, Se
     @Override
     public void setSourcesRoots(List<File> sourceRoots) {
         this.sourceRoots = sourceRoots;
+    }
+
+    @Override
+    @Nullable
+    public Boolean getEnablePreview() {
+        return enablePreview;
+    }
+
+    @Override
+    public void setEnablePreview(@Nullable Boolean enablePreview) {
+        this.enablePreview = enablePreview;
     }
 }

--- a/platforms/jvm/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/JvmLanguageCompileSpec.java
+++ b/platforms/jvm/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/JvmLanguageCompileSpec.java
@@ -61,4 +61,10 @@ public interface JvmLanguageCompileSpec extends CompileSpec {
     List<File> getSourceRoots();
 
     void setSourcesRoots(List<File> sourcesRoots);
+
+    @Nullable
+    Boolean getEnablePreview();
+
+    void setEnablePreview(@Nullable Boolean enablePreview);
+
 }

--- a/platforms/jvm/language-jvm/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/platforms/jvm/language-jvm/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -512,7 +512,7 @@ public abstract class CompileOptions extends AbstractOptions {
     /**
      * Configures whether Preview Features should be enabled for the compilation ({@code --enable-preview} compiler flag).
      *
-     * @since 8.9
+     * @since 8.10
      */
     @Incubating
     @Optional

--- a/platforms/jvm/language-jvm/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/platforms/jvm/language-jvm/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -112,7 +112,7 @@ public abstract class CompileOptions extends AbstractOptions {
         this.generatedSourceOutputDirectory = objectFactory.directoryProperty();
         this.headerOutputDirectory = objectFactory.directoryProperty();
         this.release = objectFactory.property(Integer.class);
-        this.enablePreview = objectFactory.property(Boolean.class).convention(false);
+        this.enablePreview = objectFactory.property(Boolean.class);
         this.incrementalAfterFailure = objectFactory.property(Boolean.class);
         this.forkOptions = objectFactory.newInstance(ForkOptions.class);
         this.debugOptions = new DebugOptions();
@@ -515,6 +515,7 @@ public abstract class CompileOptions extends AbstractOptions {
      * @since 8.9
      */
     @Incubating
+    @Optional
     @Input
     public Property<Boolean> getEnablePreview() {
         return enablePreview;

--- a/platforms/jvm/language-jvm/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/platforms/jvm/language-jvm/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -99,6 +99,7 @@ public abstract class CompileOptions extends AbstractOptions {
     private final Property<String> javaModuleVersion;
     private final Property<String> javaModuleMainClass;
     private final Property<Integer> release;
+    private final Property<Boolean> enablePreview;
 
     private final DirectoryProperty generatedSourceOutputDirectory;
 
@@ -111,6 +112,7 @@ public abstract class CompileOptions extends AbstractOptions {
         this.generatedSourceOutputDirectory = objectFactory.directoryProperty();
         this.headerOutputDirectory = objectFactory.directoryProperty();
         this.release = objectFactory.property(Integer.class);
+        this.enablePreview = objectFactory.property(Boolean.class);
         this.incrementalAfterFailure = objectFactory.property(Boolean.class);
         this.forkOptions = objectFactory.newInstance(ForkOptions.class);
         this.debugOptions = new DebugOptions();
@@ -507,6 +509,17 @@ public abstract class CompileOptions extends AbstractOptions {
         return release;
     }
 
+    /**
+     * Configures whether Preview Features should be enabled for the compilation ({@code --enable-preview} compiler flag).
+     *
+     * @since 8.9
+     */
+    @Incubating
+    @Input
+    @Optional
+    public Property<Boolean> getEnablePreview() {
+        return enablePreview;
+    }
 
     /**
      * Set the version of the Java module.

--- a/platforms/jvm/language-jvm/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/platforms/jvm/language-jvm/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -112,7 +112,7 @@ public abstract class CompileOptions extends AbstractOptions {
         this.generatedSourceOutputDirectory = objectFactory.directoryProperty();
         this.headerOutputDirectory = objectFactory.directoryProperty();
         this.release = objectFactory.property(Integer.class);
-        this.enablePreview = objectFactory.property(Boolean.class);
+        this.enablePreview = objectFactory.property(Boolean.class).convention(false);
         this.incrementalAfterFailure = objectFactory.property(Boolean.class);
         this.forkOptions = objectFactory.newInstance(ForkOptions.class);
         this.debugOptions = new DebugOptions();
@@ -516,7 +516,6 @@ public abstract class CompileOptions extends AbstractOptions {
      */
     @Incubating
     @Input
-    @Optional
     public Property<Boolean> getEnablePreview() {
         return enablePreview;
     }

--- a/platforms/jvm/language-jvm/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/platforms/jvm/language-jvm/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -329,12 +329,12 @@ public abstract class CompileOptions extends AbstractOptions {
     /**
      * Returns any additional arguments to be passed to the compiler.
      * Defaults to the empty list.
-     *
+     * <p>
      * Compiler arguments not supported by the DSL can be added here.
-     *
-     * For example, it is possible to pass the {@code --enable-preview} option that was added in newer Java versions:
-     * <pre><code>compilerArgs.add("--enable-preview")</code></pre>
-     *
+     * <p>
+     * For example, it is possible to pass the {@code -Werror} option:
+     * <pre><code>compilerArgs.add("-Werror")</code></pre>
+     * <p>
      * Note that if {@code --release} is added then {@code -target} and {@code -source}
      * are ignored.
      */

--- a/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -149,6 +149,7 @@ public abstract class JavaBasePlugin implements Plugin<Project> {
 
         DefaultJavaPluginExtension javaPluginExtension = addExtensions(project);
 
+        // TODO: configure test and javadoc tasks
         configureCompileDefaults(project, javaPluginExtension);
         configureSourceSetDefaults(project, javaPluginExtension);
         configureJavaDoc(project, javaPluginExtension);

--- a/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -149,7 +149,6 @@ public abstract class JavaBasePlugin implements Plugin<Project> {
 
         DefaultJavaPluginExtension javaPluginExtension = addExtensions(project);
 
-        // TODO: configure test and javadoc tasks
         configureCompileDefaults(project, javaPluginExtension);
         configureSourceSetDefaults(project, javaPluginExtension);
         configureJavaDoc(project, javaPluginExtension);


### PR DESCRIPTION
Contributes towards #28540

Provides a new Java compilation option property to configure Preview Features:
```
tasks.withType<JavaCompile>().configureEach {
    options.enablePreview = true
}
```