### PR TITLE
Add PMD 7.0.0 test coverage

### DIFF
--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/AbstractPmdPluginVersionIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/AbstractPmdPluginVersionIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.plugins.quality.pmd
 
+import org.gradle.api.plugins.quality.PmdPlugin
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.quality.integtest.fixtures.PmdCoverage
@@ -25,15 +26,10 @@ import org.gradle.util.internal.VersionNumber
 
 @TargetCoverage({ PmdCoverage.getSupportedVersionsByJdk() })
 class AbstractPmdPluginVersionIntegrationTest extends MultiVersionIntegrationSpec {
-    String calculateDefaultDependencyNotation() {
-        if (versionNumber < VersionNumber.version(5)) {
-            return "pmd:pmd:$version"
-        } else if (versionNumber < VersionNumber.parse("5.2.0")) {
-            return "net.sourceforge.pmd:pmd:$version"
-        }
-        return "net.sourceforge.pmd:pmd-java:$version"
-    }
 
+    Set<String> calculateDefaultDependencyNotation() {
+        return PmdPlugin.calculateDefaultDependencyNotation(versionNumber.toString())
+    }
     /**
      * Checks if the current PMD version supports the current Java version, if not we set the sourceCompatibility to the max Java version supported by the current PMD version.
      */
@@ -52,7 +48,7 @@ class AbstractPmdPluginVersionIntegrationTest extends MultiVersionIntegrationSpe
             "java.sourceCompatibility = 13"
         } else if (versionNumber < VersionNumber.parse('6.48.0') && TestPrecondition.satisfied(UnitTestPreconditions.Jdk19OrLater)) {
             "java.sourceCompatibility = 18"
-        } else if (versionNumber < VersionNumber.parse('7.0.0-rc4') && TestPrecondition.satisfied(UnitTestPreconditions.Jdk21OrLater)) {
+        } else if (versionNumber < VersionNumber.parse('7.0.0') && TestPrecondition.satisfied(UnitTestPreconditions.Jdk21OrLater)) {
             "java.sourceCompatibility = 20"
         } else {
             "" // do not set a source compatibility for the DEFAULT_PMD_VERSION running on latest Java, this way we will catch if it breaks with a new Java version

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdCustomRulesIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdCustomRulesIntegrationTest.groovy
@@ -32,10 +32,7 @@ class PmdCustomRulesIntegrationTest extends AbstractPmdPluginVersionIntegrationT
 
             pmd {
                 $customRuleSetConfig
-            }
-
-            dependencies {
-                implementation "${calculateDefaultDependencyNotation()}"
+                toolVersion = '$version'
             }
         """
 
@@ -59,14 +56,13 @@ class PmdCustomRulesIntegrationTest extends AbstractPmdPluginVersionIntegrationT
                 id "pmd"
                 id "java-library"
             }
+            pmd {
+                toolVersion = '$version'
+            }
 
             ${requiredSourceCompatibility()}
 
             ${mavenCentralRepository()}
-
-            dependencies {
-                implementation "${calculateDefaultDependencyNotation()}"
-            }
         """
 
         file("src/main/java/org/gradle/ruleusing/Class1.java") << breakingDefaultRulesCode()
@@ -83,7 +79,7 @@ class PmdCustomRulesIntegrationTest extends AbstractPmdPluginVersionIntegrationT
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xsi:schemaLocation="http://pmd.sf.net/ruleset/2.0.0 http://pmd.sf.net/ruleset_2_0_0.xsd"
                 xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_2_0_0.xsd">
-
+                <description>some description</description>
                 <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod"/>
 
             </ruleset>

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginSubtypeParamIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginSubtypeParamIntegrationTest.groovy
@@ -33,7 +33,6 @@ class PmdPluginSubtypeParamIntegrationTest extends AbstractPmdPluginVersionInteg
             ${mavenCentralRepository()}
 
             dependencies {
-                pmd "${calculateDefaultDependencyNotation()}"
                 implementation 'ch.qos.logback.contrib:logback-json-core:0.1.4'
             }
         """
@@ -41,6 +40,7 @@ class PmdPluginSubtypeParamIntegrationTest extends AbstractPmdPluginVersionInteg
         if (versionNumber < VersionNumber.version(6)) {
             buildFile << """
                 pmd {
+                    toolVersion = '$version'
                     ruleSets = ["java-unusedcode"]
                     incrementalAnalysis = false
                 }
@@ -48,6 +48,7 @@ class PmdPluginSubtypeParamIntegrationTest extends AbstractPmdPluginVersionInteg
         } else {
             buildFile << """
                 pmd {
+                    toolVersion = '$version'
                     ruleSetConfig = resources.text.fromString('''<?xml version="1.0"?>
                         <ruleset name="Unused Code">
                             <description>Copy of https://github.com/pmd/pmd/blob/master/pmd-java/src/main/resources/rulesets/java/unusedcode.xml without deprecations.</description>

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginToolchainsIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginToolchainsIntegrationTest.groovy
@@ -91,7 +91,9 @@ class PmdPluginToolchainsIntegrationTest extends AbstractPmdPluginVersionIntegra
             configuration.exclude(excludeProperties("org.slf4j", "log4j-over-slf4j"))
             configuration.exclude(excludeProperties("commons-logging", "commons-logging"))
             configuration.exclude(excludeProperties("log4j", "log4j"))
-            dependencies.add("pmd", dependencies.create("${calculateDefaultDependencyNotation()}"))
+            ${calculateDefaultDependencyNotation().collect { dependency ->
+            """dependencies.add("pmd", dependencies.create("$dependency"))"""
+        }.join('\n')}
             FileCollection pmdFileCollection = configuration
 
             tasks.register("myPmd", Pmd) {
@@ -128,10 +130,6 @@ class PmdPluginToolchainsIntegrationTest extends AbstractPmdPluginVersionIntegra
                 id 'pmd'
             }
 
-            dependencies {
-                pmd "${calculateDefaultDependencyNotation()}"
-            }
-
             ${mavenCentralRepository()}
         """
 
@@ -139,6 +137,13 @@ class PmdPluginToolchainsIntegrationTest extends AbstractPmdPluginVersionIntegra
             buildFile << """
                 pmd {
                     incrementalAnalysis = false
+                    toolVersion = '$version'
+                }
+            """
+        } else {
+            buildFile << """
+                pmd {
+                    toolVersion = '$version'
                 }
             """
         }

--- a/platforms/jvm/code-quality/src/testFixtures/groovy/org/gradle/quality/integtest/fixtures/PmdCoverage.groovy
+++ b/platforms/jvm/code-quality/src/testFixtures/groovy/org/gradle/quality/integtest/fixtures/PmdCoverage.groovy
@@ -20,7 +20,7 @@ package org.gradle.quality.integtest.fixtures
 import org.gradle.api.plugins.quality.PmdPlugin
 
 class PmdCoverage {
-    private final static List<String> ALL = [PmdPlugin.DEFAULT_PMD_VERSION, '4.3', '5.0.5', '5.1.1', '5.3.3', '6.0.0' /*Java 9*/, '6.13.0' /*Java 12*/].asImmutable()
+    private final static List<String> ALL = [PmdPlugin.DEFAULT_PMD_VERSION, '4.3', '5.0.5', '5.1.1', '5.3.3', '6.0.0' /*Java 9*/, '6.13.0' /*Java 12*/, '7.0.0'].asImmutable()
 
     static List<String> getSupportedVersionsByJdk() {
         ALL


### PR DESCRIPTION
Resolves [this comment](https://github.com/gradle/gradle/issues/24502#issuecomment-1555399340):

>  https://github.com/gradle/gradle/pull/25122 resolves the dependency issue noted in the original post.
>
> In order to resolve this issue fully and for Gradle to officially support PMD 7.0, org.gradle.quality.integtest.fixtures.PmdCoverage would need to be updated to add an entry for 7.0.0-rc2 (or the most recent version) and verify all tests succeed.


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
