### PR TITLE
Fix Declarative DSL runtime setting properties in Kotlin types

### DIFF
--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/DeclarativeReflectionToObjectConverter.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/DeclarativeReflectionToObjectConverter.kt
@@ -168,8 +168,8 @@ class DeclarativeReflectionToObjectConverter(
             ?: error("tried to access a property ${dataProperty.name} on a null receiver")
         val receiverKClass = receiverInstance::class
         return when (val property = propertyResolver.resolvePropertyRead(receiverKClass, dataProperty.name)) {
-            is RuntimePropertyResolver.Resolution.Resolved -> property.property.getValue(receiverInstance)
-            else -> error("cannot get property ${dataProperty.name} from the receiver class $receiverKClass")
+            is RuntimePropertyResolver.ReadResolution.ResolvedRead -> property.getter.getValue(receiverInstance)
+            RuntimePropertyResolver.ReadResolution.UnresolvedRead -> error("cannot get property ${dataProperty.name} from the receiver class $receiverKClass")
         }
     }
 
@@ -179,8 +179,8 @@ class DeclarativeReflectionToObjectConverter(
             ?: error("tried to access a property ${dataProperty.name} on a null receiver")
         val receiverKClass = receiverInstance::class
         when (val property = propertyResolver.resolvePropertyWrite(receiverKClass, dataProperty.name)) {
-            is RuntimePropertyResolver.Resolution.Resolved -> property.property.setValue(receiverInstance, value)
-            RuntimePropertyResolver.Resolution.Unresolved -> error("cannot set property ${dataProperty.name} in the receiver class $receiverKClass")
+            is RuntimePropertyResolver.WriteResolution.ResolvedWrite -> property.setter.setValue(receiverInstance, value)
+            RuntimePropertyResolver.WriteResolution.UnresolvedWrite -> error("cannot set property ${dataProperty.name} in the receiver class $receiverKClass")
         }
     }
 }

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/DeclarativeRuntimeProperty.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/DeclarativeRuntimeProperty.kt
@@ -17,7 +17,11 @@
 package org.gradle.internal.declarativedsl.mappingToJvm
 
 
-interface DeclarativeRuntimeProperty {
+fun interface DeclarativeRuntimePropertyGetter {
     fun getValue(receiver: Any): Any?
+}
+
+
+fun interface DeclarativeRuntimePropertySetter {
     fun setValue(receiver: Any, value: Any?)
 }

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/TypeSafeProjectAccessorsSchemaBuildingComponent.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/TypeSafeProjectAccessorsSchemaBuildingComponent.kt
@@ -22,7 +22,6 @@ import org.gradle.internal.declarativedsl.analysis.DataProperty
 import org.gradle.internal.declarativedsl.analysis.DataTypeRef
 import org.gradle.internal.declarativedsl.analysis.FqName
 import org.gradle.internal.declarativedsl.evaluationSchema.EvaluationSchemaComponent
-import org.gradle.internal.declarativedsl.mappingToJvm.DeclarativeRuntimeProperty
 import org.gradle.internal.declarativedsl.mappingToJvm.RuntimePropertyResolver
 import org.gradle.internal.declarativedsl.schemaBuilder.CollectedPropertyInformation
 import org.gradle.internal.declarativedsl.schemaBuilder.DefaultPropertyExtractor
@@ -87,17 +86,12 @@ class TypesafeProjectAccessorsComponent(targetScope: ClassLoaderScope) : Evaluat
 
 private
 class ProjectPropertyAccessorRuntimeResolver : RuntimePropertyResolver {
-    override fun resolvePropertyRead(receiverClass: KClass<*>, name: String): RuntimePropertyResolver.Resolution {
+    override fun resolvePropertyRead(receiverClass: KClass<*>, name: String): RuntimePropertyResolver.ReadResolution =
         if (receiverClass.isSubclassOf(Project::class) && name == "projects") {
-            return RuntimePropertyResolver.Resolution.Resolved(object : DeclarativeRuntimeProperty {
-                override fun getValue(receiver: Any) = (receiver as Project).extensions.getByName("projects")
-                override fun setValue(receiver: Any, value: Any?): Unit = throw UnsupportedOperationException()
-            })
-        }
-        return RuntimePropertyResolver.Resolution.Unresolved
-    }
+            RuntimePropertyResolver.ReadResolution.ResolvedRead { receiver -> (receiver as Project).extensions.getByName("projects") }
+        } else RuntimePropertyResolver.ReadResolution.UnresolvedRead
 
-    override fun resolvePropertyWrite(receiverClass: KClass<*>, name: String): RuntimePropertyResolver.Resolution = RuntimePropertyResolver.Resolution.Unresolved
+    override fun resolvePropertyWrite(receiverClass: KClass<*>, name: String) = RuntimePropertyResolver.WriteResolution.UnresolvedWrite
 }
 
 


### PR DESCRIPTION
If Kotlin reflection cannot find the property or the setter method, try to look up the setter via Java reflection.

Also, refactor some code around `DeclarativeRuntimeProperty`.

<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle-private/issues/4160
