### PR TITLE
Add option to customize definition of upgraded methods

### DIFF
--- a/platforms/core-runtime/internal-instrumentation-api/src/main/java/org/gradle/internal/instrumentation/api/annotations/UpgradedAccessor.java
+++ b/platforms/core-runtime/internal-instrumentation-api/src/main/java/org/gradle/internal/instrumentation/api/annotations/UpgradedAccessor.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.instrumentation.api.annotations;
+
+import org.gradle.internal.instrumentation.api.annotations.UpgradedProperty.DefaultValue;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.ANNOTATION_TYPE})
+public @interface UpgradedAccessor {
+
+    enum AccessorType {
+        GETTER,
+        SETTER
+    }
+
+    AccessorType value();
+
+    String methodName();
+
+    Class<?> originalType() default DefaultValue.class;
+
+    /**
+     * Applies only to setters
+     */
+    boolean fluentSetter() default false;
+}

--- a/platforms/core-runtime/internal-instrumentation-api/src/main/java/org/gradle/internal/instrumentation/api/annotations/UpgradedProperty.java
+++ b/platforms/core-runtime/internal-instrumentation-api/src/main/java/org/gradle/internal/instrumentation/api/annotations/UpgradedProperty.java
@@ -41,6 +41,8 @@ public @interface UpgradedProperty {
 
     boolean fluentSetter() default false;
 
+    UpgradedAccessor[] originalAccessors() default {};
+
     interface DefaultValue {
     }
 }

--- a/platforms/core-runtime/internal-instrumentation-processor/build.gradle.kts
+++ b/platforms/core-runtime/internal-instrumentation-processor/build.gradle.kts
@@ -26,6 +26,7 @@ errorprone {
         "ReturnValueIgnored", // 3 occurrences
         "ShortCircuitBoolean", // 1 occurrences
         "StringCaseLocaleUsage", // 2 occurrences
+        "ImmutableEnumChecker" // 1 occurrences
     )
 }
 
@@ -41,8 +42,6 @@ dependencies {
     implementation(libs.jacksonDatabind)
 
     implementation(project(":base-services"))
-    implementation(project(":core-api"))
-    implementation(project(":model-core"))
 
     testCompileOnly(libs.jetbrainsAnnotations)
 

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
@@ -51,6 +51,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -63,9 +64,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.gradle.internal.instrumentation.api.types.BytecodeInterceptorType.BYTECODE_UPGRADE;
+import static org.gradle.internal.instrumentation.api.annotations.UpgradedAccessor.AccessorType;
 import static org.gradle.internal.instrumentation.api.declarations.InterceptorDeclaration.GROOVY_INTERCEPTORS_GENERATED_CLASS_NAME_FOR_PROPERTY_UPGRADES;
 import static org.gradle.internal.instrumentation.api.declarations.InterceptorDeclaration.JVM_BYTECODE_GENERATED_CLASS_NAME_FOR_PROPERTY_UPGRADES;
+import static org.gradle.internal.instrumentation.api.types.BytecodeInterceptorType.BYTECODE_UPGRADE;
 import static org.gradle.internal.instrumentation.model.CallableKindInfo.GROOVY_PROPERTY_GETTER;
 import static org.gradle.internal.instrumentation.model.CallableKindInfo.INSTANCE_METHOD;
 import static org.gradle.internal.instrumentation.model.ParameterKindInfo.METHOD_PARAMETER;
@@ -79,9 +81,11 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
     private static final Type DEFAULT_TYPE = Type.getType(UpgradedProperty.DefaultValue.class);
 
     private final String projectName;
+    private final Elements elements;
 
     public PropertyUpgradeAnnotatedMethodReader(ProcessingEnvironment processingEnv) {
         this.projectName = getProjectName(processingEnv);
+        this.elements = processingEnv.getElementUtils();
     }
 
     private static String getProjectName(ProcessingEnvironment processingEnv) {
@@ -117,19 +121,84 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
         }
 
         try {
-            String propertyName = getPropertyName(method);
-            Type originalType = extractOriginalType(method, annotation.get());
             AnnotationMirror annotationMirror = annotation.get();
-            boolean isFluentSetter = AnnotationUtils.findAnnotationValue(annotationMirror, "fluentSetter")
-                .map(v -> (Boolean) v.getValue())
-                .orElse(false);
-            CallInterceptionRequest groovyPropertyRequest = createGroovyPropertyInterceptionRequest(propertyName, method, originalType);
-            CallInterceptionRequest jvmGetterRequest = createJvmGetterInterceptionRequest(propertyName, method, originalType);
-            CallInterceptionRequest jvmSetterRequest = createJvmSetterInterceptionRequest(propertyName, method, originalType, isFluentSetter);
-            return Arrays.asList(new Success(groovyPropertyRequest), new Success(jvmGetterRequest), new Success(jvmSetterRequest));
+            List<AccessorSpec> accessorSpecs = readAccessorSpecsFromUpgradedProperty(method, annotationMirror);
+            List<CallInterceptionRequest> requests = new ArrayList<>();
+            for (AccessorSpec accessorSpec : accessorSpecs) {
+                switch (accessorSpec.accessorType) {
+                    case GETTER:
+                        CallInterceptionRequest groovyPropertyRequest = createGroovyPropertyInterceptionRequest(accessorSpec, method);
+                        CallInterceptionRequest jvmGetterRequest = createJvmGetterInterceptionRequest(accessorSpec, method);
+                        requests.add(groovyPropertyRequest);
+                        requests.add(jvmGetterRequest);
+                        break;
+                    case SETTER:
+                        CallInterceptionRequest jvmSetterRequest = createJvmSetterInterceptionRequest(accessorSpec, method);
+                        requests.add(jvmSetterRequest);
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Unsupported accessor type: " + accessorSpec.accessorType);
+                }
+            }
+            return requests.stream()
+                .map(Success::new)
+                .collect(Collectors.toList());
         } catch (AnnotationReadFailure failure) {
             return Collections.singletonList(new InvalidRequest(failure.reason));
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<AccessorSpec> readAccessorSpecsFromUpgradedProperty(ExecutableElement method, AnnotationMirror annotationMirror) {
+        List<AnnotationMirror> originalAccessors = AnnotationUtils.findAnnotationValue(annotationMirror, "originalAccessors")
+            .map(v -> (List<AnnotationMirror>) v.getValue())
+            .orElse(Collections.emptyList());
+        if (!originalAccessors.isEmpty()) {
+            return originalAccessors.stream()
+                .map(annotation -> getAccessorSpec(method, annotation))
+                .collect(Collectors.toList());
+        }
+        return Arrays.asList(
+            getAccessorSpec(method, AccessorType.GETTER, annotationMirror),
+            getAccessorSpec(method, AccessorType.SETTER, annotationMirror)
+        );
+    }
+
+    private AccessorSpec getAccessorSpec(ExecutableElement method, AnnotationMirror annotation) {
+        String methodName = AnnotationUtils.findAnnotationValue(annotation, "methodName")
+            .map(v -> (String) v.getValue())
+            .orElseThrow(() -> new AnnotationReadFailure("Missing 'methodName' attribute in @UpgradedAccessor"));
+        AccessorType accessorType = AnnotationUtils.findAnnotationValue(annotation, "value")
+            .map(v -> (AccessorType) v.getValue())
+            .orElseThrow(() -> new AnnotationReadFailure("Missing 'value' attribute in @UpgradedAccessor"));
+        Type originalType = extractOriginalType(method, annotation);
+        return getAccessorSpec(accessorType, methodName, originalType, annotation);
+    }
+
+    private AccessorSpec getAccessorSpec(ExecutableElement method, AccessorType accessorType, AnnotationMirror annotation) {
+        String propertyName = getPropertyName(method);
+        Type originalType = extractOriginalType(method, annotation);
+        String methodName;
+        switch (accessorType) {
+            case GETTER:
+                String capitalize = propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1);
+                methodName = originalType.equals(Type.BOOLEAN_TYPE) ? "is" + capitalize : "get" + capitalize;
+                break;
+            case SETTER:
+                methodName = method.getSimpleName().toString().replaceFirst("get", "set");
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported accessor type: " + accessorType);
+        }
+        return getAccessorSpec(accessorType, methodName, originalType, annotation);
+    }
+
+    private AccessorSpec getAccessorSpec(AccessorType accessorType, String methodName, Type originalType, AnnotationMirror annotation) {
+        boolean isFluentSetter = AnnotationUtils.findAnnotationValueWithDefaults(elements, annotation, "fluentSetter")
+            .map(v -> (Boolean) v.getValue())
+            .orElseThrow(() -> new AnnotationReadFailure("Missing 'fluentSetter' attribute"));
+        String propertyName = getPropertyName(methodName);
+        return new AccessorSpec(accessorType, propertyName, methodName, originalType, isFluentSetter);
     }
 
     private static Type extractOriginalType(ExecutableElement method, AnnotationMirror annotation) {
@@ -162,21 +231,22 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
         }
     }
 
-    private CallInterceptionRequest createGroovyPropertyInterceptionRequest(String propertyName, ExecutableElement method, Type originalType) {
+    private CallInterceptionRequest createGroovyPropertyInterceptionRequest(AccessorSpec accessor, ExecutableElement method) {
         String interceptorsClassName = getGroovyInterceptorsClassName();
         List<RequestExtra> extras = Arrays.asList(new RequestExtra.OriginatingElement(method), new RequestExtra.InterceptGroovyCalls(interceptorsClassName, BYTECODE_UPGRADE));
         List<ParameterInfo> parameters = Collections.singletonList(new ParameterInfoImpl("receiver", extractType(method.getEnclosingElement().asType()), RECEIVER));
+        Type originalType = accessor.originalType;
         return new CallInterceptionRequestImpl(
-            extractCallableInfo(GROOVY_PROPERTY_GETTER, method, originalType, propertyName, parameters),
+            extractCallableInfo(GROOVY_PROPERTY_GETTER, method, originalType, accessor.propertyName, parameters),
             extractImplementationInfo(method, originalType, "get", Collections.emptyList()),
             extras
         );
     }
 
-    private CallInterceptionRequest createJvmGetterInterceptionRequest(String propertyName, ExecutableElement method, Type originalType) {
-        List<RequestExtra> extras = getJvmRequestExtras(propertyName, method, false);
-        String capitalize = propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1);
-        String callableName = originalType.equals(Type.BOOLEAN_TYPE) ? "is" + capitalize : "get" + capitalize;
+    private CallInterceptionRequest createJvmGetterInterceptionRequest(AccessorSpec accessor, ExecutableElement method) {
+        List<RequestExtra> extras = getJvmRequestExtras(accessor.propertyName, method, false);
+        String callableName = accessor.methodName;
+        Type originalType = accessor.originalType;
         return new CallInterceptionRequestImpl(
             extractCallableInfo(INSTANCE_METHOD, method, originalType, callableName, Collections.emptyList()),
             extractImplementationInfo(method, originalType, "get", Collections.emptyList()),
@@ -184,9 +254,12 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
         );
     }
 
-    private CallInterceptionRequest createJvmSetterInterceptionRequest(String propertyName, ExecutableElement method, Type originalType, boolean isFluentSetter) {
+    private CallInterceptionRequest createJvmSetterInterceptionRequest(AccessorSpec accessor, ExecutableElement method) {
+        boolean isFluentSetter = accessor.isFluentSetter;
+        String propertyName = accessor.propertyName;
+        Type originalType = accessor.originalType;
         Type returnType = isFluentSetter ? extractType(method.getEnclosingElement().asType()) : Type.VOID_TYPE;
-        String callableName = method.getSimpleName().toString().replaceFirst("get", "set");
+        String callableName = accessor.methodName;
         List<ParameterInfo> parameters = Collections.singletonList(new ParameterInfoImpl("arg0", originalType, METHOD_PARAMETER));
         List<RequestExtra> extras = getJvmRequestExtras(propertyName, method, isFluentSetter);
         return new CallInterceptionRequestImpl(
@@ -238,9 +311,17 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
     }
 
     private static String getPropertyName(ExecutableElement method) {
-        String methodName = method.getSimpleName().toString();
-        String property = methodName.startsWith("get") ? methodName.substring(3) : methodName;
-        return Character.toLowerCase(property.charAt(0)) + property.substring(1);
+        return getPropertyName(method.getSimpleName().toString());
+    }
+
+    private static String getPropertyName(String methodName) {
+        if (methodName.startsWith("is") && methodName.length() > 2 && Character.isUpperCase(methodName.charAt(2))) {
+            return Character.toLowerCase(methodName.charAt(2)) + methodName.substring(3);
+        } else if ((methodName.startsWith("get") || methodName.startsWith("set")) && methodName.length() > 3 && Character.isUpperCase(methodName.charAt(3))) {
+            return Character.toLowerCase(methodName.charAt(3)) + methodName.substring(4);
+        } else {
+            return methodName;
+        }
     }
 
     // TODO Consolidate with AnnotationCallInterceptionRequestReaderImpl#Failure
@@ -249,6 +330,22 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
 
         private AnnotationReadFailure(String reason) {
             this.reason = reason;
+        }
+    }
+
+    private static class AccessorSpec {
+        private final String propertyName;
+        private final AccessorType accessorType;
+        private final String methodName;
+        private final Type originalType;
+        private final boolean isFluentSetter;
+
+        private AccessorSpec(AccessorType accessorType, String propertyName, String methodName, Type originalType, boolean isFluentSetter) {
+            this.propertyName = propertyName;
+            this.accessorType = accessorType;
+            this.methodName = methodName;
+            this.originalType = originalType;
+            this.isFluentSetter = isFluentSetter;
         }
     }
 }

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
@@ -120,10 +120,6 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
             for (AccessorSpec accessorSpec : accessorSpecs) {
                 switch (accessorSpec.accessorType) {
                     case GETTER:
-                        if (isProviderOrProperty(accessorSpec.originalType)) {
-                            // We don't support Provider or Property as original type for a getter accessor
-                            return Collections.singletonList(new InvalidRequest(String.format("`Provider` or `Property` type is not supported as original type for a GETTER accessor. Method: %s.%s", method.getEnclosingElement(), method)));
-                        }
                         CallInterceptionRequest groovyPropertyRequest = createGroovyPropertyInterceptionRequest(accessorSpec, method);
                         CallInterceptionRequest jvmGetterRequest = createJvmGetterInterceptionRequest(accessorSpec, method);
                         requests.add(groovyPropertyRequest);
@@ -143,10 +139,6 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
         } catch (AnnotationReadFailure failure) {
             return Collections.singletonList(new InvalidRequest(failure.reason));
         }
-    }
-
-    static boolean isProviderOrProperty(Type type) {
-        return GradleLazyType.PROVIDER.asType().equals(type);
     }
 
     @SuppressWarnings("unchecked")
@@ -229,7 +221,6 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
             case MAP_PROPERTY:
                 return Type.getType(Map.class);
             case PROPERTY:
-            case PROVIDER:
                 return extractType(((DeclaredType) typeMirror).getTypeArguments().get(0));
             default:
                 throw new AnnotationReadFailure(String.format("Cannot extract original type for method '%s.%s: %s'. Use explicit @UpgradedProperty#originalType instead.", method.getEnclosingElement(), method, typeMirror));

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
@@ -169,7 +169,7 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
             .map(v -> (String) v.getValue())
             .orElseThrow(() -> new AnnotationReadFailure("Missing 'methodName' attribute in @UpgradedAccessor"));
         AccessorType accessorType = AnnotationUtils.findAnnotationValue(annotation, "value")
-            .map(v -> (AccessorType) v.getValue())
+            .map(v -> AccessorType.valueOf(v.getValue().toString()))
             .orElseThrow(() -> new AnnotationReadFailure("Missing 'value' attribute in @UpgradedAccessor"));
         Type originalType = extractOriginalType(method, annotation);
         return getAccessorSpec(accessorType, methodName, originalType, annotation);

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
@@ -249,7 +249,7 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
         Type originalType = accessor.originalType;
         return new CallInterceptionRequestImpl(
             extractCallableInfo(GROOVY_PROPERTY_GETTER, method, originalType, accessor.propertyName, parameters),
-            extractImplementationInfo(method, originalType, "get", Collections.emptyList()),
+            extractImplementationInfo(method, originalType, accessor.methodName, "get", Collections.emptyList()),
             extras
         );
     }
@@ -260,7 +260,7 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
         Type originalType = accessor.originalType;
         return new CallInterceptionRequestImpl(
             extractCallableInfo(INSTANCE_METHOD, method, originalType, callableName, Collections.emptyList()),
-            extractImplementationInfo(method, originalType, "get", Collections.emptyList()),
+            extractImplementationInfo(method, originalType, accessor.methodName, "get", Collections.emptyList()),
             extras
         );
     }
@@ -275,7 +275,7 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
         List<RequestExtra> extras = getJvmRequestExtras(propertyName, method, isFluentSetter);
         return new CallInterceptionRequestImpl(
             extractCallableInfo(INSTANCE_METHOD, method, returnType, callableName, parameters),
-            extractImplementationInfo(method, returnType, "set", parameters),
+            extractImplementationInfo(method, returnType, accessor.methodName, "set", parameters),
             extras
         );
     }
@@ -299,10 +299,10 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
         return new CallableInfoImpl(kindInfo, owner, callableName, returnTypeInfo, parameters);
     }
 
-    private static ImplementationInfoImpl extractImplementationInfo(ExecutableElement method, Type returnType, String methodPrefix, List<ParameterInfo> parameters) {
+    private static ImplementationInfoImpl extractImplementationInfo(ExecutableElement method, Type returnType, String interceptedMethodName, String methodPrefix, List<ParameterInfo> parameters) {
         Type owner = extractType(method.getEnclosingElement().asType());
         Type implementationOwner = Type.getObjectType(getGeneratedClassName(method.getEnclosingElement()));
-        String implementationName = "access_" + methodPrefix + "_" + getPropertyName(method);
+        String implementationName = "access_" + methodPrefix + "_" + interceptedMethodName;
         String implementationDescriptor = Type.getMethodDescriptor(returnType, toArray(owner, parameters));
         return new ImplementationInfoImpl(implementationOwner, implementationName, implementationDescriptor);
     }

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeClassSourceGenerator.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeClassSourceGenerator.java
@@ -142,7 +142,7 @@ public class PropertyUpgradeClassSourceGenerator extends RequestGroupingInstrume
             case FILE_SYSTEM_LOCATION_PROPERTY:
                 if (isProviderOrProperty(parameterType)) {
                     // expect `Provider<File> arg0`
-                    return ".fileProvider((Provider) arg0)";
+                    return ".fileProvider(arg0)";
                 } else {
                     // expect `File arg0`
                     return ".fileValue(arg0)";

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeClassSourceGenerator.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeClassSourceGenerator.java
@@ -21,14 +21,11 @@ import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.TypeSpec;
-import org.gradle.api.internal.provider.views.ListPropertyListView;
-import org.gradle.api.internal.provider.views.MapPropertyMapView;
-import org.gradle.api.internal.provider.views.SetPropertySetView;
-import org.gradle.internal.instrumentation.extensions.property.PropertyUpgradeRequestExtra.UpgradedPropertyType;
 import org.gradle.internal.instrumentation.model.CallInterceptionRequest;
 import org.gradle.internal.instrumentation.model.CallableInfo;
 import org.gradle.internal.instrumentation.model.CallableReturnTypeInfo;
 import org.gradle.internal.instrumentation.model.ImplementationInfo;
+import org.gradle.internal.instrumentation.processor.codegen.GradleLazyType;
 import org.gradle.internal.instrumentation.processor.codegen.HasFailures;
 import org.gradle.internal.instrumentation.processor.codegen.RequestGroupingInstrumentationClassSourceGenerator;
 import org.gradle.internal.instrumentation.processor.codegen.TypeUtils;
@@ -41,6 +38,9 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static org.gradle.internal.instrumentation.extensions.property.PropertyUpgradeAnnotatedMethodReader.isProviderOrProperty;
+import static org.gradle.internal.instrumentation.processor.codegen.GradleReferencedType.LIST_PROPERTY_LIST_VIEW;
+import static org.gradle.internal.instrumentation.processor.codegen.GradleReferencedType.MAP_PROPERTY_MAP_VIEW;
+import static org.gradle.internal.instrumentation.processor.codegen.GradleReferencedType.SET_PROPERTY_SET_VIEW;
 import static org.gradle.internal.instrumentation.processor.codegen.TypeUtils.typeName;
 
 public class PropertyUpgradeClassSourceGenerator extends RequestGroupingInstrumentationClassSourceGenerator {
@@ -62,39 +62,56 @@ public class PropertyUpgradeClassSourceGenerator extends RequestGroupingInstrume
         Consumer<? super HasFailures.FailureInfo> onFailure
     ) {
         List<MethodSpec> methods = requestsClassGroup.stream()
-            .map(request -> mapToMethodSpec(request, onProcessedRequest))
+            .map(request -> mapToMethodSpec(request, onProcessedRequest, onFailure))
             .collect(Collectors.toList());
         return builder -> builder.addModifiers(Modifier.PUBLIC).addMethods(methods);
     }
 
-    private static MethodSpec mapToMethodSpec(CallInterceptionRequest request, Consumer<? super CallInterceptionRequest> onProcessedRequest) {
+    private static MethodSpec mapToMethodSpec(CallInterceptionRequest request, Consumer<? super CallInterceptionRequest> onProcessedRequest, Consumer<? super HasFailures.FailureInfo> onFailure) {
         PropertyUpgradeRequestExtra implementationExtra = request.getRequestExtras()
             .getByType(PropertyUpgradeRequestExtra.class)
             .orElseThrow(() -> new RuntimeException(PropertyUpgradeRequestExtra.class.getSimpleName() + " should be present at this stage!"));
 
-        CallableInfo callable = request.getInterceptedCallable();
-        ImplementationInfo implementation = request.getImplementationInfo();
-        List<ParameterSpec> parameters = callable.getParameters().stream()
-            .map(parameter -> ParameterSpec.builder(typeName(parameter.getParameterType()), parameter.getName()).build())
-            .collect(Collectors.toList());
-        onProcessedRequest.accept(request);
-        return MethodSpec.methodBuilder(implementation.getName())
-            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-            .addParameter(typeName(callable.getOwner().getType()), SELF_PARAMETER_NAME)
-            .addParameters(parameters)
-            .addCode(generateMethodBody(implementation, callable, implementationExtra))
-            .returns(typeName(callable.getReturnType().getType()))
-            .addAnnotations(getAnnotations(implementationExtra, callable))
-            .build();
+        try {
+            CallableInfo callable = request.getInterceptedCallable();
+            ImplementationInfo implementation = request.getImplementationInfo();
+            List<ParameterSpec> parameters = callable.getParameters().stream()
+                .map(parameter -> ParameterSpec.builder(typeName(parameter.getParameterType()), parameter.getName()).build())
+                .collect(Collectors.toList());
+            MethodSpec spec = MethodSpec.methodBuilder(implementation.getName())
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .addParameter(typeName(callable.getOwner().getType()), SELF_PARAMETER_NAME)
+                .addParameters(parameters)
+                .addCode(generateMethodBody(implementation, callable, implementationExtra))
+                .returns(typeName(callable.getReturnType().getType()))
+                .addAnnotations(getAnnotations(implementationExtra, callable))
+                .build();
+            onProcessedRequest.accept(request);
+            return spec;
+        } catch (Exception e) {
+            onFailure.accept(new HasFailures.FailureInfo(request, e.getMessage()));
+            throw e;
+        }
+
     }
 
     private static List<AnnotationSpec> getAnnotations(PropertyUpgradeRequestExtra implementationExtra, CallableInfo callable) {
-        if (implementationExtra.getUpgradedPropertyType().isMultiValueProperty() || hasAParameterWithGenerics(callable)) {
-            return Collections.singletonList(AnnotationSpec.builder(SuppressWarnings.class)
-                .addMember("value", "$L", "{\"unchecked\", \"rawtypes\"}")
-                .build());
+        switch (implementationExtra.getUpgradedPropertyType()) {
+            case LIST_PROPERTY:
+            case SET_PROPERTY:
+            case MAP_PROPERTY:
+                return Collections.singletonList(AnnotationSpec.builder(SuppressWarnings.class)
+                    .addMember("value", "$L", "{\"unchecked\", \"rawtypes\"}")
+                    .build());
+            default:
+                if (hasAParameterWithGenerics(callable)) {
+                    return Collections.singletonList(AnnotationSpec.builder(SuppressWarnings.class)
+                        .addMember("value", "$L", "{\"unchecked\", \"rawtypes\"}")
+                        .build());
+                } else {
+                    return Collections.emptyList();
+                }
         }
-        return Collections.emptyList();
     }
 
     private static boolean hasAParameterWithGenerics(CallableInfo callable) {
@@ -105,8 +122,8 @@ public class PropertyUpgradeClassSourceGenerator extends RequestGroupingInstrume
     private static CodeBlock generateMethodBody(ImplementationInfo implementation, CallableInfo callableInfo, PropertyUpgradeRequestExtra implementationExtra) {
         String propertyGetterName = implementationExtra.getInterceptedPropertyAccessorName();
         boolean isSetter = implementation.getName().startsWith("access_set_");
-        UpgradedPropertyType upgradedPropertyType = implementationExtra.getUpgradedPropertyType();
         CallableReturnTypeInfo returnType = callableInfo.getReturnType();
+        GradleLazyType upgradedPropertyType = implementationExtra.getUpgradedPropertyType();
         if (isSetter) {
             Type parameterType = callableInfo.getParameters().get(0).getParameterType();
             String setCall = getSetCall(upgradedPropertyType, parameterType);
@@ -120,26 +137,32 @@ public class PropertyUpgradeClassSourceGenerator extends RequestGroupingInstrume
         }
     }
 
-    private static CodeBlock getGetCall(String propertyGetterName, CallableReturnTypeInfo returnType, UpgradedPropertyType upgradedPropertyType) {
+    private static CodeBlock getGetCall(String propertyGetterName, CallableReturnTypeInfo returnType, GradleLazyType upgradedPropertyType) {
         switch (upgradedPropertyType) {
-            case FILE_SYSTEM_LOCATION_PROPERTY:
+            case REGULAR_FILE_PROPERTY:
+            case DIRECTORY_PROPERTY:
                 return CodeBlock.of("return $N.$N().getAsFile().getOrNull();", SELF_PARAMETER_NAME, propertyGetterName);
             case CONFIGURABLE_FILE_COLLECTION:
+            case FILE_COLLECTION:
                 return CodeBlock.of("return $N.$N();", SELF_PARAMETER_NAME, propertyGetterName);
             case LIST_PROPERTY:
-                return CodeBlock.of("return new $T<>($N.$N());", ListPropertyListView.class, SELF_PARAMETER_NAME, propertyGetterName);
+                return CodeBlock.of("return new $T<>($N.$N());", LIST_PROPERTY_LIST_VIEW.asTypeName(), SELF_PARAMETER_NAME, propertyGetterName);
             case SET_PROPERTY:
-                return CodeBlock.of("return new $T<>($N.$N());", SetPropertySetView.class, SELF_PARAMETER_NAME, propertyGetterName);
+                return CodeBlock.of("return new $T<>($N.$N());", SET_PROPERTY_SET_VIEW.asTypeName(), SELF_PARAMETER_NAME, propertyGetterName);
             case MAP_PROPERTY:
-                return CodeBlock.of("return new $T<>($N.$N());", MapPropertyMapView.class, SELF_PARAMETER_NAME, propertyGetterName);
-            default:
+                return CodeBlock.of("return new $T<>($N.$N());", MAP_PROPERTY_MAP_VIEW.asTypeName(), SELF_PARAMETER_NAME, propertyGetterName);
+            case PROPERTY:
+            case PROVIDER:
                 return CodeBlock.of("return $N.$N().getOrElse($L);", SELF_PARAMETER_NAME, propertyGetterName, TypeUtils.getDefaultValue(returnType.getType()));
+            default:
+                throw new UnsupportedOperationException("Generating get call for type: " + upgradedPropertyType.asType() + " is not supported");
         }
     }
 
-    private static String getSetCall(UpgradedPropertyType upgradedPropertyType, Type parameterType) {
+    private static String getSetCall(GradleLazyType upgradedPropertyType, Type parameterType) {
         switch (upgradedPropertyType) {
-            case FILE_SYSTEM_LOCATION_PROPERTY:
+            case REGULAR_FILE_PROPERTY:
+            case DIRECTORY_PROPERTY:
                 if (isProviderOrProperty(parameterType)) {
                     // expect `Provider<File> arg0`
                     return ".fileProvider(arg0)";
@@ -149,12 +172,17 @@ public class PropertyUpgradeClassSourceGenerator extends RequestGroupingInstrume
                 }
             case CONFIGURABLE_FILE_COLLECTION:
                 return ".setFrom(arg0)";
-            default:
+            case LIST_PROPERTY:
+            case SET_PROPERTY:
+            case MAP_PROPERTY:
+            case PROPERTY:
                 if (isProviderOrProperty(parameterType)) {
                     return ".set((Provider) arg0)";
                 } else {
                     return ".set(arg0)";
                 }
+            default:
+                throw new UnsupportedOperationException("Generating set call for type: " + upgradedPropertyType.asType() + " is not supported");
         }
     }
 }

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeClassSourceGenerator.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeClassSourceGenerator.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import static org.gradle.internal.instrumentation.processor.codegen.GradleReferencedType.GENERATED_ANNOTATION;
 import static org.gradle.internal.instrumentation.processor.codegen.GradleReferencedType.LIST_PROPERTY_LIST_VIEW;
 import static org.gradle.internal.instrumentation.processor.codegen.GradleReferencedType.MAP_PROPERTY_MAP_VIEW;
 import static org.gradle.internal.instrumentation.processor.codegen.GradleReferencedType.SET_PROPERTY_SET_VIEW;
@@ -62,7 +63,11 @@ public class PropertyUpgradeClassSourceGenerator extends RequestGroupingInstrume
         List<MethodSpec> methods = requestsClassGroup.stream()
             .map(request -> mapToMethodSpec(request, onProcessedRequest, onFailure))
             .collect(Collectors.toList());
-        return builder -> builder.addModifiers(Modifier.PUBLIC).addMethods(methods);
+
+        return builder -> builder
+            .addAnnotation(GENERATED_ANNOTATION.asClassName())
+            .addModifiers(Modifier.PUBLIC)
+            .addMethods(methods);
     }
 
     private static MethodSpec mapToMethodSpec(CallInterceptionRequest request, Consumer<? super CallInterceptionRequest> onProcessedRequest, Consumer<? super HasFailures.FailureInfo> onFailure) {

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeRequestExtra.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeRequestExtra.java
@@ -16,58 +16,17 @@
 
 package org.gradle.internal.instrumentation.extensions.property;
 
-import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.file.DirectoryProperty;
-import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.provider.ListProperty;
-import org.gradle.api.provider.MapProperty;
-import org.gradle.api.provider.SetProperty;
 import org.gradle.internal.instrumentation.model.RequestExtra;
-import org.objectweb.asm.Type;
+import org.gradle.internal.instrumentation.processor.codegen.GradleLazyType;
 
 class PropertyUpgradeRequestExtra implements RequestExtra {
-
-    enum UpgradedPropertyType {
-        LIST_PROPERTY(true),
-        SET_PROPERTY(true),
-        MAP_PROPERTY(true),
-        PROPERTY(false),
-        FILE_SYSTEM_LOCATION_PROPERTY(false),
-        CONFIGURABLE_FILE_COLLECTION(false);
-
-        private final boolean isMultiValueProperty;
-
-        UpgradedPropertyType(boolean isMultiValueProperty) {
-            this.isMultiValueProperty = isMultiValueProperty;
-        }
-
-        public boolean isMultiValueProperty() {
-            return isMultiValueProperty;
-        }
-
-        public static UpgradedPropertyType from(Type type) {
-            if (type.getClassName().equals(DirectoryProperty.class.getName()) || type.getClassName().equals(RegularFileProperty.class.getName())) {
-                return FILE_SYSTEM_LOCATION_PROPERTY;
-            } else if (type.getClassName().equals(ConfigurableFileCollection.class.getName())) {
-                return CONFIGURABLE_FILE_COLLECTION;
-            } else if (type.getClassName().equals(MapProperty.class.getName())) {
-                return MAP_PROPERTY;
-            } else if (type.getClassName().equals(SetProperty.class.getName())) {
-                return SET_PROPERTY;
-            } else if (type.getClassName().equals(ListProperty.class.getName())) {
-                return LIST_PROPERTY;
-            } else {
-                return PROPERTY;
-            }
-        }
-    }
 
     private final String propertyName;
     private final boolean isFluentSetter;
     private final String implementationClassName;
     private final String interceptedPropertyAccessorName;
     private final String interceptedPropertyAccessorDescriptor;
-    private final UpgradedPropertyType upgradedPropertyType;
+    private final GradleLazyType upgradedPropertyType;
 
     public PropertyUpgradeRequestExtra(
         String propertyName,
@@ -75,7 +34,7 @@ class PropertyUpgradeRequestExtra implements RequestExtra {
         String implementationClassName,
         String interceptedPropertyAccessorName,
         String interceptedPropertyAccessorDescriptor,
-        UpgradedPropertyType upgradedPropertyType
+        GradleLazyType upgradedPropertyType
     ) {
         this.propertyName = propertyName;
         this.isFluentSetter = isFluentSetter;
@@ -101,7 +60,7 @@ class PropertyUpgradeRequestExtra implements RequestExtra {
         return interceptedPropertyAccessorDescriptor;
     }
 
-    public UpgradedPropertyType getUpgradedPropertyType() {
+    public GradleLazyType getUpgradedPropertyType() {
         return upgradedPropertyType;
     }
 

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/GradleLazyType.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/GradleLazyType.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.instrumentation.processor.codegen;
+
+import com.squareup.javapoet.TypeName;
+import org.objectweb.asm.Type;
+
+public enum GradleLazyType {
+    CONFIGURABLE_FILE_COLLECTION("org.gradle.api.file.ConfigurableFileCollection"),
+    FILE_COLLECTION("org.gradle.api.file.FileCollection"),
+    DIRECTORY_PROPERTY("org.gradle.api.file.DirectoryProperty"),
+    REGULAR_FILE_PROPERTY("org.gradle.api.file.RegularFileProperty"),
+    LIST_PROPERTY("org.gradle.api.provider.ListProperty"),
+    SET_PROPERTY("org.gradle.api.provider.SetProperty"),
+    MAP_PROPERTY("org.gradle.api.provider.MapProperty"),
+    PROPERTY("org.gradle.api.provider.Property"),
+    PROVIDER("org.gradle.api.provider.Provider"),
+    UNSUPPORTED((Type) null) {
+        @Override
+        public Type asType() {
+            throw new UnsupportedOperationException("Unsupported type");
+        }
+    };
+
+    private final Type type;
+
+    GradleLazyType(String name) {
+        this(Type.getType("L" + name.replace('.', '/') + ";"));
+    }
+
+    GradleLazyType(Type type) {
+        this.type = type;
+    }
+
+    public Type asType() {
+        return type;
+    }
+
+    public TypeName asTypeName() {
+        return TypeUtils.typeName(type);
+    }
+
+    public static boolean isAnyOf(Type type) {
+        for (GradleLazyType gradleType : values()) {
+            if (gradleType.type != null && gradleType.type.equals(type)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static GradleLazyType from(Type type) {
+        for (GradleLazyType gradleType : values()) {
+            if (gradleType.type != null && gradleType.type.equals(type)) {
+                return gradleType;
+            }
+        }
+        throw new UnsupportedOperationException("Unknown lazy type: " + type.getClassName());
+    }
+
+    public static GradleLazyType from(String name) {
+        for (GradleLazyType gradleType : values()) {
+            if (gradleType.type != null && gradleType.type.getClassName().equals(name)) {
+                return gradleType;
+            }
+        }
+        throw new UnsupportedOperationException("Unknown lazy type: " + name);
+    }
+}

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/GradleLazyType.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/GradleLazyType.java
@@ -28,7 +28,6 @@ public enum GradleLazyType {
     SET_PROPERTY("org.gradle.api.provider.SetProperty"),
     MAP_PROPERTY("org.gradle.api.provider.MapProperty"),
     PROPERTY("org.gradle.api.provider.Property"),
-    PROVIDER("org.gradle.api.provider.Provider"),
     UNSUPPORTED((Type) null) {
         @Override
         public Type asType() {

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/GradleReferencedType.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/GradleReferencedType.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.instrumentation.processor.codegen;
+
+import com.squareup.javapoet.TypeName;
+import org.objectweb.asm.Type;
+
+/**
+ * Used since we don't want to depend on Gradle types directly, since that way we have to depend on Gradle projects like core-api.
+ * And we don't want to depend on Gradle projects since that way we can't apply this annotation processor to them.
+ */
+public enum GradleReferencedType {
+    METHOD_VISITOR_SCOPE("org.gradle.model.internal.asm.MethodVisitorScope"),
+    LIST_PROPERTY_LIST_VIEW("org.gradle.api.internal.provider.views.ListPropertyListView"),
+    SET_PROPERTY_SET_VIEW("org.gradle.api.internal.provider.views.SetPropertySetView"),
+    MAP_PROPERTY_MAP_VIEW("org.gradle.api.internal.provider.views.MapPropertyMapView");
+
+    private final Type type;
+
+    GradleReferencedType(String name) {
+        this.type = Type.getType("L" + name.replace('.', '/') + ";");
+    }
+
+    public Type asType() {
+        return type;
+    }
+
+    public TypeName asTypeName() {
+        return TypeUtils.typeName(type);
+    }
+}

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/GradleReferencedType.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/GradleReferencedType.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.instrumentation.processor.codegen;
 
+import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.TypeName;
 import org.objectweb.asm.Type;
 
@@ -25,6 +26,7 @@ import org.objectweb.asm.Type;
  */
 public enum GradleReferencedType {
     METHOD_VISITOR_SCOPE("org.gradle.model.internal.asm.MethodVisitorScope"),
+    GENERATED_ANNOTATION("org.gradle.api.Generated"),
     LIST_PROPERTY_LIST_VIEW("org.gradle.api.internal.provider.views.ListPropertyListView"),
     SET_PROPERTY_SET_VIEW("org.gradle.api.internal.provider.views.SetPropertySetView"),
     MAP_PROPERTY_MAP_VIEW("org.gradle.api.internal.provider.views.MapPropertyMapView");
@@ -40,6 +42,10 @@ public enum GradleReferencedType {
     }
 
     public TypeName asTypeName() {
-        return TypeUtils.typeName(type);
+        return asClassName();
+    }
+
+    public ClassName asClassName() {
+        return TypeUtils.className(type);
     }
 }

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/SignatureUtils.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/SignatureUtils.java
@@ -16,10 +16,19 @@
 
 package org.gradle.internal.instrumentation.processor.codegen;
 
+import com.squareup.javapoet.AnnotationSpec;
 import org.gradle.internal.instrumentation.model.CallableInfo;
 import org.gradle.internal.instrumentation.model.ParameterKindInfo;
 
 public class SignatureUtils {
+
+    /**
+     * Suppress some error prone warnings that are not important and would complicate the logic for code generation.
+     */
+    public static final AnnotationSpec SUPPRESS_ERROR_PRONE = AnnotationSpec.builder(SuppressWarnings.class)
+        .addMember("value", "$L", "{\"NotJavadoc\", \"UnusedMethod\", \"UnusedVariable\"}")
+        .build();
+
     public static boolean hasCallerClassName(CallableInfo callableInfo) {
         return callableInfo.getParameters().stream().anyMatch(it -> it.getKind() == ParameterKindInfo.CALLER_CLASS_NAME);
     }

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/SignatureUtils.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/SignatureUtils.java
@@ -16,18 +16,10 @@
 
 package org.gradle.internal.instrumentation.processor.codegen;
 
-import com.squareup.javapoet.AnnotationSpec;
 import org.gradle.internal.instrumentation.model.CallableInfo;
 import org.gradle.internal.instrumentation.model.ParameterKindInfo;
 
 public class SignatureUtils {
-
-    /**
-     * Suppress some error prone warnings that are not important and would complicate the logic for code generation.
-     */
-    public static final AnnotationSpec SUPPRESS_ERROR_PRONE = AnnotationSpec.builder(SuppressWarnings.class)
-        .addMember("value", "$L", "{\"NotJavadoc\", \"UnusedMethod\", \"UnusedVariable\"}")
-        .build();
 
     public static boolean hasCallerClassName(CallableInfo callableInfo) {
         return callableInfo.getParameters().stream().anyMatch(it -> it.getKind() == ParameterKindInfo.CALLER_CLASS_NAME);

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/TypeUtils.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/TypeUtils.java
@@ -79,6 +79,10 @@ public class TypeUtils {
         if (type.getSort() == Type.ARRAY) {
             return ArrayTypeName.of(typeName(type.getElementType()));
         }
+        return className(type);
+    }
+
+    public static ClassName className(Type type) {
         return ClassName.bestGuess(type.getClassName().replace("$", "."));
     }
 }

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/groovy/InterceptGroovyCallsGenerator.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/groovy/InterceptGroovyCallsGenerator.java
@@ -51,10 +51,10 @@ import java.util.stream.Collectors;
 
 import static org.gradle.internal.instrumentation.model.CallableKindInfo.GROOVY_PROPERTY_GETTER;
 import static org.gradle.internal.instrumentation.model.CallableKindInfo.GROOVY_PROPERTY_SETTER;
+import static org.gradle.internal.instrumentation.processor.codegen.GradleReferencedType.GENERATED_ANNOTATION;
 import static org.gradle.internal.instrumentation.processor.codegen.JavadocUtils.callableKindForJavadoc;
 import static org.gradle.internal.instrumentation.processor.codegen.JavadocUtils.interceptedCallableLink;
 import static org.gradle.internal.instrumentation.processor.codegen.JavadocUtils.interceptorImplementationLink;
-import static org.gradle.internal.instrumentation.processor.codegen.SignatureUtils.SUPPRESS_ERROR_PRONE;
 
 public class InterceptGroovyCallsGenerator extends RequestGroupingInstrumentationClassSourceGenerator {
     @Override
@@ -111,7 +111,7 @@ public class InterceptGroovyCallsGenerator extends RequestGroupingInstrumentatio
 
     private static TypeSpec.Builder generateInterceptorClass(String className, BytecodeInterceptorType interceptorType, CodeBlock scopes, List<CallInterceptionRequest> requests) {
         TypeSpec.Builder generatedClass = TypeSpec.classBuilder(className)
-            .addAnnotation(SUPPRESS_ERROR_PRONE)
+            .addAnnotation(GENERATED_ANNOTATION.asClassName())
             .superclass(CALL_INTERCEPTOR_CLASS)
             .addSuperinterface(SIGNATURE_AWARE_CALL_INTERCEPTOR_CLASS)
             .addSuperinterface(interceptorType.getInterceptorMarkerInterface())

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/groovy/InterceptGroovyCallsGenerator.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/groovy/InterceptGroovyCallsGenerator.java
@@ -54,6 +54,7 @@ import static org.gradle.internal.instrumentation.model.CallableKindInfo.GROOVY_
 import static org.gradle.internal.instrumentation.processor.codegen.JavadocUtils.callableKindForJavadoc;
 import static org.gradle.internal.instrumentation.processor.codegen.JavadocUtils.interceptedCallableLink;
 import static org.gradle.internal.instrumentation.processor.codegen.JavadocUtils.interceptorImplementationLink;
+import static org.gradle.internal.instrumentation.processor.codegen.SignatureUtils.SUPPRESS_ERROR_PRONE;
 
 public class InterceptGroovyCallsGenerator extends RequestGroupingInstrumentationClassSourceGenerator {
     @Override
@@ -110,6 +111,7 @@ public class InterceptGroovyCallsGenerator extends RequestGroupingInstrumentatio
 
     private static TypeSpec.Builder generateInterceptorClass(String className, BytecodeInterceptorType interceptorType, CodeBlock scopes, List<CallInterceptionRequest> requests) {
         TypeSpec.Builder generatedClass = TypeSpec.classBuilder(className)
+            .addAnnotation(SUPPRESS_ERROR_PRONE)
             .superclass(CALL_INTERCEPTOR_CLASS)
             .addSuperinterface(SIGNATURE_AWARE_CALL_INTERCEPTOR_CLASS)
             .addSuperinterface(interceptorType.getInterceptorMarkerInterface())

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/jvmbytecode/InterceptJvmCallsGenerator.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/jvmbytecode/InterceptJvmCallsGenerator.java
@@ -38,7 +38,6 @@ import org.gradle.internal.instrumentation.model.RequestExtra;
 import org.gradle.internal.instrumentation.processor.codegen.HasFailures.FailureInfo;
 import org.gradle.internal.instrumentation.processor.codegen.JavadocUtils;
 import org.gradle.internal.instrumentation.processor.codegen.RequestGroupingInstrumentationClassSourceGenerator;
-import org.gradle.model.internal.asm.MethodVisitorScope;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -59,6 +58,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.gradle.internal.instrumentation.processor.codegen.GradleReferencedType.METHOD_VISITOR_SCOPE;
 import static org.gradle.internal.instrumentation.processor.codegen.SignatureUtils.SUPPRESS_ERROR_PRONE;
 import static org.gradle.internal.instrumentation.processor.codegen.SignatureUtils.hasCallerClassName;
 import static org.gradle.internal.instrumentation.processor.codegen.SignatureUtils.hasInjectVisitorContext;
@@ -107,7 +107,7 @@ public class InterceptJvmCallsGenerator extends RequestGroupingInstrumentationCl
                 .addField(METHOD_VISITOR_FIELD)
                 .addField(METADATA_FIELD)
                 .addField(CONTEXT_FIELD)
-                .superclass(MethodVisitorScope.class)
+                .superclass(METHOD_VISITOR_SCOPE.asTypeName())
                 // actual content:
                 .addMethod(visitMethodInsnBuilder.build())
                 .addFields(typeFieldByOwner.values())

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/jvmbytecode/InterceptJvmCallsGenerator.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/jvmbytecode/InterceptJvmCallsGenerator.java
@@ -24,10 +24,10 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeSpec;
 import org.gradle.internal.instrumentation.api.annotations.CallableKind;
 import org.gradle.internal.instrumentation.api.annotations.ParameterKind;
-import org.gradle.internal.instrumentation.api.types.BytecodeInterceptorFilter;
-import org.gradle.internal.instrumentation.api.types.BytecodeInterceptorType;
 import org.gradle.internal.instrumentation.api.jvmbytecode.JvmBytecodeCallInterceptor;
 import org.gradle.internal.instrumentation.api.metadata.InstrumentationMetadata;
+import org.gradle.internal.instrumentation.api.types.BytecodeInterceptorFilter;
+import org.gradle.internal.instrumentation.api.types.BytecodeInterceptorType;
 import org.gradle.internal.instrumentation.model.CallInterceptionRequest;
 import org.gradle.internal.instrumentation.model.CallableInfo;
 import org.gradle.internal.instrumentation.model.CallableKindInfo;
@@ -59,12 +59,14 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.gradle.internal.instrumentation.processor.codegen.SignatureUtils.SUPPRESS_ERROR_PRONE;
 import static org.gradle.internal.instrumentation.processor.codegen.SignatureUtils.hasCallerClassName;
 import static org.gradle.internal.instrumentation.processor.codegen.SignatureUtils.hasInjectVisitorContext;
 import static org.gradle.internal.instrumentation.processor.codegen.TypeUtils.typeName;
 import static org.gradle.util.internal.TextUtil.camelToKebabCase;
 
 public class InterceptJvmCallsGenerator extends RequestGroupingInstrumentationClassSourceGenerator {
+
     @Override
     protected String classNameForRequest(CallInterceptionRequest request) {
         return request.getRequestExtras().getByType(RequestExtra.InterceptJvmCalls.class)
@@ -90,8 +92,11 @@ public class InterceptJvmCallsGenerator extends RequestGroupingInstrumentationCl
         );
         TypeSpec factoryClass = generateFactoryClass(className, interceptorType);
 
+        // Suppress some error prone warnings that are not important and would complicate the logic for code generation.
+
         return builder ->
             builder.addMethod(constructor)
+                .addAnnotation(SUPPRESS_ERROR_PRONE)
                 .addModifiers(Modifier.PUBLIC)
                 // generic stuff not related to the content:
                 .addSuperinterface(JvmBytecodeCallInterceptor.class)

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/jvmbytecode/InterceptJvmCallsGenerator.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/jvmbytecode/InterceptJvmCallsGenerator.java
@@ -58,8 +58,8 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.gradle.internal.instrumentation.processor.codegen.GradleReferencedType.GENERATED_ANNOTATION;
 import static org.gradle.internal.instrumentation.processor.codegen.GradleReferencedType.METHOD_VISITOR_SCOPE;
-import static org.gradle.internal.instrumentation.processor.codegen.SignatureUtils.SUPPRESS_ERROR_PRONE;
 import static org.gradle.internal.instrumentation.processor.codegen.SignatureUtils.hasCallerClassName;
 import static org.gradle.internal.instrumentation.processor.codegen.SignatureUtils.hasInjectVisitorContext;
 import static org.gradle.internal.instrumentation.processor.codegen.TypeUtils.typeName;
@@ -96,7 +96,7 @@ public class InterceptJvmCallsGenerator extends RequestGroupingInstrumentationCl
 
         return builder ->
             builder.addMethod(constructor)
-                .addAnnotation(SUPPRESS_ERROR_PRONE)
+                .addAnnotation(GENERATED_ANNOTATION.asClassName())
                 .addModifiers(Modifier.PUBLIC)
                 // generic stuff not related to the content:
                 .addSuperinterface(JvmBytecodeCallInterceptor.class)

--- a/platforms/core-runtime/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeCodeGenTest.groovy
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeCodeGenTest.groovy
@@ -195,6 +195,55 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
         "ConfigurableFileCollection"  | "FileCollection" | "self.getProperty()"                             | ".setFrom(arg0)"   | [FileCollection]
     }
 
+    def "should auto generate adapter for upgraded setter property with Provider argument for #upgradedType"() {
+        given:
+        def givenSource = source """
+            package org.gradle.test;
+
+            import org.gradle.api.provider.*;
+            import org.gradle.api.file.*;
+            import org.gradle.internal.instrumentation.api.annotations.VisitForInstrumentation;
+            import org.gradle.internal.instrumentation.api.annotations.UpgradedProperty;
+            import org.gradle.internal.instrumentation.api.annotations.UpgradedAccessor;
+            import org.gradle.internal.instrumentation.api.annotations.UpgradedAccessor.AccessorType;
+
+            public abstract class Task {
+                @UpgradedProperty(originalAccessors = {
+                    @UpgradedAccessor(value = AccessorType.SETTER, methodName = "setProperty", originalType = Provider.class)
+                })
+                public abstract $upgradedType getProperty();
+            }
+        """
+
+        when:
+        Compilation compilation = compile(givenSource)
+
+        then:
+        def generatedClass = source """
+            package $GENERATED_CLASSES_PACKAGE_NAME;
+            import java.lang.SuppressWarnings;
+            import org.gradle.api.provider.Provider;
+            import org.gradle.test.Task;
+
+            public class Task_Adapter {
+                @SuppressWarnings({"unchecked", "rawtypes"})
+                public static void access_set_property(Task self, Provider arg0) {
+                    self.getProperty()$setCall;
+                }
+            }
+        """
+        assertThat(compilation).succeededWithoutWarnings()
+        assertThat(compilation)
+            .generatedSourceFile(fqName(generatedClass))
+            .hasSourceEquivalentTo(generatedClass)
+
+        where:
+        upgradedType          | setCall
+        "Property<String>"    | ".set((Provider) arg0)"
+        "RegularFileProperty" | ".fileProvider((Provider) arg0)"
+        "DirectoryProperty"   | ".fileProvider((Provider) arg0)"
+    }
+
     def "should correctly generate interceptor when property name contains get"() {
         given:
         def givenSource = source"""
@@ -299,7 +348,9 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
             public abstract class Task {
                 @UpgradedProperty(originalAccessors = {
                     @UpgradedAccessor(value = AccessorType.GETTER, methodName = "getDestinationDir"),
-                    @UpgradedAccessor(value = AccessorType.SETTER, methodName = "setDestinationDir")
+                    @UpgradedAccessor(value = AccessorType.SETTER, methodName = "setDestinationDir"),
+                    // @UpgradedAccessor(value = AccessorType.SETTER, methodName = "destinationDir", originalType = File.class),
+                    @UpgradedAccessor(value = AccessorType.SETTER, methodName = "setDestinationDir", originalType = Provider.class)
                 })
                 public abstract DirectoryProperty getDestinationDirectory();
             }
@@ -322,6 +373,10 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
                         }
                         if (name.equals("setDestinationDir") && descriptor.equals("(Ljava/io/File;)V") && (opcode == Opcodes.INVOKEVIRTUAL || opcode == Opcodes.INVOKEINTERFACE)) {
                             _INVOKESTATIC(TASK__ADAPTER_TYPE, "access_set_destinationDirectory", "(Lorg/gradle/test/Task;Ljava/io/File;)V");
+                            return true;
+                        }
+                        if (name.equals("setDestinationDir") && descriptor.equals("(Lorg/gradle/api/provider/Provider;)V") && (opcode == Opcodes.INVOKEVIRTUAL || opcode == Opcodes.INVOKEINTERFACE)) {
+                            _INVOKESTATIC(TASK__ADAPTER_TYPE, "access_set_destinationDirectory", "(Lorg/gradle/test/Task;Lorg/gradle/api/provider/Provider;)V");
                             return true;
                         }
                     }

--- a/platforms/core-runtime/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeCodeGenTest.groovy
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeCodeGenTest.groovy
@@ -94,6 +94,7 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
         then:
         def generatedClass = source """
             package $GENERATED_CLASSES_PACKAGE_NAME;
+            @SuppressWarnings({"NotJavadoc", "UnusedMethod", "UnusedVariable"})
             public class InterceptorDeclaration_PropertyUpgradesJvmBytecode_TestProject extends MethodVisitorScope implements JvmBytecodeCallInterceptor, org.gradle.internal.instrumentation.api.types.BytecodeInterceptor.BytecodeUpgradeInterceptor {
                 @Override
                 public boolean visitMethodInsn(String className, int opcode, String owner, String name,
@@ -241,8 +242,8 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
         where:
         upgradedType          | setCall
         "Property<String>"    | ".set((Provider) arg0)"
-        "RegularFileProperty" | ".fileProvider((Provider) arg0)"
-        "DirectoryProperty"   | ".fileProvider((Provider) arg0)"
+        "RegularFileProperty" | ".fileProvider(arg0)"
+        "DirectoryProperty"   | ".fileProvider(arg0)"
     }
 
     def "should correctly generate interceptor when property name contains get"() {
@@ -267,6 +268,7 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
         then:
         def generatedClass = source """
             package $GENERATED_CLASSES_PACKAGE_NAME;
+            @SuppressWarnings({"NotJavadoc", "UnusedMethod", "UnusedVariable"})
             public class InterceptorDeclaration_PropertyUpgradesJvmBytecode_TestProject extends MethodVisitorScope implements JvmBytecodeCallInterceptor, org.gradle.internal.instrumentation.api.types.BytecodeInterceptor.BytecodeUpgradeInterceptor {
                 @Override
                 public boolean visitMethodInsn(String className, int opcode, String owner, String name,
@@ -363,6 +365,7 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
         then:
         def generatedClass = source """
             package $GENERATED_CLASSES_PACKAGE_NAME;
+            @SuppressWarnings({"NotJavadoc", "UnusedMethod", "UnusedVariable"})
             public class InterceptorDeclaration_PropertyUpgradesJvmBytecode_TestProject extends MethodVisitorScope implements JvmBytecodeCallInterceptor, org.gradle.internal.instrumentation.api.types.BytecodeInterceptor.BytecodeUpgradeInterceptor {
                 @Override
                 public boolean visitMethodInsn(String className, int opcode, String owner, String name,

--- a/platforms/core-runtime/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeCodeGenTest.groovy
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeCodeGenTest.groovy
@@ -56,6 +56,7 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
             package $GENERATED_CLASSES_PACKAGE_NAME;
             import org.gradle.test.Task;
 
+            @Generated
             public class Task_Adapter {
                 public static int access_get_getMaxErrors(Task self) {
                     return self.getMaxErrors().getOrElse(0);
@@ -69,7 +70,7 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
         assertThat(compilation).succeededWithoutWarnings()
         assertThat(compilation)
             .generatedSourceFile(fqName(generatedClass))
-            .hasSourceEquivalentTo(generatedClass)
+            .containsElementsIn(generatedClass)
     }
 
     def "should auto generate adapter for upgraded property with boolean"() {
@@ -94,7 +95,8 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
         then:
         def generatedClass = source """
             package $GENERATED_CLASSES_PACKAGE_NAME;
-            @SuppressWarnings({"NotJavadoc", "UnusedMethod", "UnusedVariable"})
+
+            @Generated
             public class InterceptorDeclaration_PropertyUpgradesJvmBytecode_TestProject extends MethodVisitorScope implements JvmBytecodeCallInterceptor, org.gradle.internal.instrumentation.api.types.BytecodeInterceptor.BytecodeUpgradeInterceptor {
                 @Override
                 public boolean visitMethodInsn(String className, int opcode, String owner, String name,
@@ -117,6 +119,7 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
             package $GENERATED_CLASSES_PACKAGE_NAME;
             import org.gradle.test.Task;
 
+            @Generated
             public class Task_Adapter {
                 public static boolean access_get_isIncremental(Task self) {
                     return self.getIncremental().getOrElse(false);
@@ -134,7 +137,7 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
             .containsElementsIn(generatedClass)
         assertThat(compilation)
             .generatedSourceFile(fqName(adapterClass))
-            .hasSourceEquivalentTo(adapterClass)
+            .containsElementsIn(adapterClass)
     }
 
     def "should auto generate adapter for upgraded property with type #upgradedType"() {
@@ -165,6 +168,7 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
             ${imports.collect { "import $it.name;" }.join("\n")}
             import org.gradle.test.Task;
 
+            @Generated
             public class Task_Adapter {
                 ${hasSuppressWarnings ? '@SuppressWarnings({"unchecked", "rawtypes"})' : ''}
                 public static $originalType access_get_${getterPrefix}Property(Task self) {
@@ -180,7 +184,7 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
         assertThat(compilation).succeededWithoutWarnings()
         assertThat(compilation)
             .generatedSourceFile(fqName(generatedClass))
-            .hasSourceEquivalentTo(generatedClass)
+            .containsElementsIn(generatedClass)
 
         where:
         upgradedType                  | originalType     | getCall                                          | setCall            | imports
@@ -219,7 +223,8 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
         then:
         def generatedClass = source """
             package $GENERATED_CLASSES_PACKAGE_NAME;
-            @SuppressWarnings({"NotJavadoc", "UnusedMethod", "UnusedVariable"})
+
+            @Generated
             public class InterceptorDeclaration_PropertyUpgradesJvmBytecode_TestProject extends MethodVisitorScope implements JvmBytecodeCallInterceptor, org.gradle.internal.instrumentation.api.types.BytecodeInterceptor.BytecodeUpgradeInterceptor {
                 @Override
                 public boolean visitMethodInsn(String className, int opcode, String owner, String name,
@@ -315,7 +320,8 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
         then:
         def generatedClass = source """
             package $GENERATED_CLASSES_PACKAGE_NAME;
-            @SuppressWarnings({"NotJavadoc", "UnusedMethod", "UnusedVariable"})
+
+            @Generated
             public class InterceptorDeclaration_PropertyUpgradesJvmBytecode_TestProject extends MethodVisitorScope implements JvmBytecodeCallInterceptor, org.gradle.internal.instrumentation.api.types.BytecodeInterceptor.BytecodeUpgradeInterceptor {
                 @Override
                 public boolean visitMethodInsn(String className, int opcode, String owner, String name,

--- a/platforms/core-runtime/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeCodeGenTest.groovy
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeCodeGenTest.groovy
@@ -57,11 +57,11 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
             import org.gradle.test.Task;
 
             public class Task_Adapter {
-                public static int access_get_maxErrors(Task self) {
+                public static int access_get_getMaxErrors(Task self) {
                     return self.getMaxErrors().getOrElse(0);
                 }
 
-                public static void access_set_maxErrors(Task self, int arg0) {
+                public static void access_set_setMaxErrors(Task self, int arg0) {
                     self.getMaxErrors().set(arg0);
                 }
             }
@@ -100,11 +100,11 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
                                                String descriptor, boolean isInterface, Supplier<MethodNode> readMethodNode) {
                     if (metadata.isInstanceOf(owner, "org/gradle/test/Task")) {
                          if (name.equals("isIncremental") && descriptor.equals("()Z") && (opcode == Opcodes.INVOKEVIRTUAL || opcode == Opcodes.INVOKEINTERFACE)) {
-                             _INVOKESTATIC(TASK__ADAPTER_TYPE, "access_get_incremental", "(Lorg/gradle/test/Task;)Z");
+                             _INVOKESTATIC(TASK__ADAPTER_TYPE, "access_get_isIncremental", "(Lorg/gradle/test/Task;)Z");
                              return true;
                          }
                         if (name.equals("setIncremental") && descriptor.equals("(Z)Lorg/gradle/test/Task;") && (opcode == Opcodes.INVOKEVIRTUAL || opcode == Opcodes.INVOKEINTERFACE)) {
-                             _INVOKESTATIC(TASK__ADAPTER_TYPE, "access_set_incremental", "(Lorg/gradle/test/Task;Z)Lorg/gradle/test/Task;");
+                             _INVOKESTATIC(TASK__ADAPTER_TYPE, "access_set_setIncremental", "(Lorg/gradle/test/Task;Z)Lorg/gradle/test/Task;");
                              return true;
                          }
                     }
@@ -117,11 +117,11 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
             import org.gradle.test.Task;
 
             public class Task_Adapter {
-                public static boolean access_get_incremental(Task self) {
+                public static boolean access_get_isIncremental(Task self) {
                     return self.getIncremental().getOrElse(false);
                 }
 
-                public static Task access_set_incremental(Task self, boolean arg0) {
+                public static Task access_set_setIncremental(Task self, boolean arg0) {
                     self.getIncremental().set(arg0);
                     return self;
                 }
@@ -158,6 +158,7 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
 
         then:
         boolean hasSuppressWarnings = originalType in ["List", "Map", "Set"]
+        String getterPrefix = originalType == "boolean" ? "is" : "get"
         def generatedClass = source """
             package $GENERATED_CLASSES_PACKAGE_NAME;
             ${imports.collect { "import $it.name;" }.join("\n")}
@@ -165,12 +166,12 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
 
             public class Task_Adapter {
                 ${hasSuppressWarnings ? '@SuppressWarnings({"unchecked", "rawtypes"})' : ''}
-                public static $originalType access_get_property(Task self) {
+                public static $originalType access_get_${getterPrefix}Property(Task self) {
                     return $getCall;
                 }
 
                 ${hasSuppressWarnings ? '@SuppressWarnings({"unchecked", "rawtypes"})' : ''}
-                public static void access_set_property(Task self, $originalType arg0) {
+                public static void access_set_setProperty(Task self, $originalType arg0) {
                     self.getProperty()$setCall;
                 }
             }
@@ -227,7 +228,7 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
 
             public class Task_Adapter {
                 @SuppressWarnings({"unchecked", "rawtypes"})
-                public static void access_set_property(Task self, Provider arg0) {
+                public static void access_set_setProperty(Task self, Provider arg0) {
                     self.getProperty()$setCall;
                 }
             }
@@ -272,11 +273,11 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
                                                String descriptor, boolean isInterface, Supplier<MethodNode> readMethodNode) {
                     if (metadata.isInstanceOf(owner, "org/gradle/test/Task")) {
                          if (name.equals("getTargetCompatibility") && descriptor.equals("()Ljava/lang/String;") && (opcode == Opcodes.INVOKEVIRTUAL || opcode == Opcodes.INVOKEINTERFACE)) {
-                             _INVOKESTATIC(TASK__ADAPTER_TYPE, "access_get_targetCompatibility", "(Lorg/gradle/test/Task;)Ljava/lang/String;");
+                             _INVOKESTATIC(TASK__ADAPTER_TYPE, "access_get_getTargetCompatibility", "(Lorg/gradle/test/Task;)Ljava/lang/String;");
                              return true;
                          }
                          if (name.equals("setTargetCompatibility") && descriptor.equals("(Ljava/lang/String;)V") && (opcode == Opcodes.INVOKEVIRTUAL || opcode == Opcodes.INVOKEINTERFACE)) {
-                           _INVOKESTATIC(TASK__ADAPTER_TYPE, "access_set_targetCompatibility", "(Lorg/gradle/test/Task;Ljava/lang/String;)V");
+                           _INVOKESTATIC(TASK__ADAPTER_TYPE, "access_set_setTargetCompatibility", "(Lorg/gradle/test/Task;Ljava/lang/String;)V");
                            return true;
                        }
                     }
@@ -349,7 +350,7 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
                 @UpgradedProperty(originalAccessors = {
                     @UpgradedAccessor(value = AccessorType.GETTER, methodName = "getDestinationDir"),
                     @UpgradedAccessor(value = AccessorType.SETTER, methodName = "setDestinationDir"),
-                    // @UpgradedAccessor(value = AccessorType.SETTER, methodName = "destinationDir", originalType = File.class),
+                    @UpgradedAccessor(value = AccessorType.SETTER, methodName = "destinationDir", originalType = File.class),
                     @UpgradedAccessor(value = AccessorType.SETTER, methodName = "setDestinationDir", originalType = Provider.class)
                 })
                 public abstract DirectoryProperty getDestinationDirectory();
@@ -368,15 +369,19 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
                                                String descriptor, boolean isInterface, Supplier<MethodNode> readMethodNode) {
                     if (metadata.isInstanceOf(owner, "org/gradle/test/Task")) {
                         if (name.equals("getDestinationDir") && descriptor.equals("()Ljava/io/File;") && (opcode == Opcodes.INVOKEVIRTUAL || opcode == Opcodes.INVOKEINTERFACE)) {
-                            _INVOKESTATIC(TASK__ADAPTER_TYPE, "access_get_destinationDirectory", "(Lorg/gradle/test/Task;)Ljava/io/File;");
+                            _INVOKESTATIC(TASK__ADAPTER_TYPE, "access_get_getDestinationDir", "(Lorg/gradle/test/Task;)Ljava/io/File;");
                             return true;
                         }
                         if (name.equals("setDestinationDir") && descriptor.equals("(Ljava/io/File;)V") && (opcode == Opcodes.INVOKEVIRTUAL || opcode == Opcodes.INVOKEINTERFACE)) {
-                            _INVOKESTATIC(TASK__ADAPTER_TYPE, "access_set_destinationDirectory", "(Lorg/gradle/test/Task;Ljava/io/File;)V");
+                            _INVOKESTATIC(TASK__ADAPTER_TYPE, "access_set_setDestinationDir", "(Lorg/gradle/test/Task;Ljava/io/File;)V");
+                            return true;
+                        }
+                        if (name.equals("destinationDir") && descriptor.equals("(Ljava/io/File;)V") && (opcode == Opcodes.INVOKEVIRTUAL || opcode == Opcodes.INVOKEINTERFACE)) {
+                            _INVOKESTATIC(TASK__ADAPTER_TYPE, "access_set_destinationDir", "(Lorg/gradle/test/Task;Ljava/io/File;)V");
                             return true;
                         }
                         if (name.equals("setDestinationDir") && descriptor.equals("(Lorg/gradle/api/provider/Provider;)V") && (opcode == Opcodes.INVOKEVIRTUAL || opcode == Opcodes.INVOKEINTERFACE)) {
-                            _INVOKESTATIC(TASK__ADAPTER_TYPE, "access_set_destinationDirectory", "(Lorg/gradle/test/Task;Lorg/gradle/api/provider/Provider;)V");
+                            _INVOKESTATIC(TASK__ADAPTER_TYPE, "access_set_setDestinationDir", "(Lorg/gradle/test/Task;Lorg/gradle/api/provider/Provider;)V");
                             return true;
                         }
                     }

--- a/platforms/core-runtime/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/processor/codegen/jvmbytecode/InterceptJvmCallsGeneratorTest.groovy
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/processor/codegen/jvmbytecode/InterceptJvmCallsGeneratorTest.groovy
@@ -51,6 +51,7 @@ class InterceptJvmCallsGeneratorTest extends InstrumentationCodeGenTest {
         then:
         def expectedJvmInterceptors = source """
             package my;
+            @SuppressWarnings({"NotJavadoc", "UnusedMethod", "UnusedVariable"})
             public class InterceptorDeclaration_JvmBytecodeImpl extends MethodVisitorScope implements JvmBytecodeCallInterceptor, org.gradle.internal.instrumentation.api.types.BytecodeInterceptor.InstrumentationInterceptor {
                 @Override
                 public boolean visitMethodInsn(String className, int opcode, String owner, String name,
@@ -126,6 +127,7 @@ class InterceptJvmCallsGeneratorTest extends InstrumentationCodeGenTest {
         def factoryCapability = type.getInterceptorFactoryMarkerInterface().getCanonicalName()
         def expectedJvmInterceptors = source """
             package my;
+            @SuppressWarnings({"NotJavadoc", "UnusedMethod", "UnusedVariable"})
             public class InterceptorDeclaration_JvmBytecodeImpl extends MethodVisitorScope implements JvmBytecodeCallInterceptor, $capability {
 
                 public static class Factory implements JvmBytecodeCallInterceptor.Factory, $factoryCapability {
@@ -182,6 +184,7 @@ class InterceptJvmCallsGeneratorTest extends InstrumentationCodeGenTest {
         then:
         def expectedJvmInterceptors = source """
             package my;
+            @SuppressWarnings({"NotJavadoc", "UnusedMethod", "UnusedVariable"})
             public class InterceptorDeclaration_JvmBytecodeImpl extends MethodVisitorScope implements JvmBytecodeCallInterceptor, org.gradle.internal.instrumentation.api.types.BytecodeInterceptor.InstrumentationInterceptor {
                 @Override
                 public boolean visitMethodInsn(String className, int opcode, String owner, String name,
@@ -232,6 +235,7 @@ class InterceptJvmCallsGeneratorTest extends InstrumentationCodeGenTest {
         then:
         def expectedJvmInterceptors = source """
             package my;
+            @SuppressWarnings({"NotJavadoc", "UnusedMethod", "UnusedVariable"})
             public class InterceptorDeclaration_JvmBytecodeImpl extends MethodVisitorScope implements JvmBytecodeCallInterceptor, org.gradle.internal.instrumentation.api.types.BytecodeInterceptor.InstrumentationInterceptor {
                 @Override
                 public boolean visitMethodInsn(String className, int opcode, String owner, String name,

--- a/platforms/core-runtime/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/processor/codegen/jvmbytecode/InterceptJvmCallsGeneratorTest.groovy
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/processor/codegen/jvmbytecode/InterceptJvmCallsGeneratorTest.groovy
@@ -51,7 +51,8 @@ class InterceptJvmCallsGeneratorTest extends InstrumentationCodeGenTest {
         then:
         def expectedJvmInterceptors = source """
             package my;
-            @SuppressWarnings({"NotJavadoc", "UnusedMethod", "UnusedVariable"})
+
+            @Generated
             public class InterceptorDeclaration_JvmBytecodeImpl extends MethodVisitorScope implements JvmBytecodeCallInterceptor, org.gradle.internal.instrumentation.api.types.BytecodeInterceptor.InstrumentationInterceptor {
                 @Override
                 public boolean visitMethodInsn(String className, int opcode, String owner, String name,
@@ -127,7 +128,8 @@ class InterceptJvmCallsGeneratorTest extends InstrumentationCodeGenTest {
         def factoryCapability = type.getInterceptorFactoryMarkerInterface().getCanonicalName()
         def expectedJvmInterceptors = source """
             package my;
-            @SuppressWarnings({"NotJavadoc", "UnusedMethod", "UnusedVariable"})
+
+            @Generated
             public class InterceptorDeclaration_JvmBytecodeImpl extends MethodVisitorScope implements JvmBytecodeCallInterceptor, $capability {
 
                 public static class Factory implements JvmBytecodeCallInterceptor.Factory, $factoryCapability {
@@ -184,7 +186,8 @@ class InterceptJvmCallsGeneratorTest extends InstrumentationCodeGenTest {
         then:
         def expectedJvmInterceptors = source """
             package my;
-            @SuppressWarnings({"NotJavadoc", "UnusedMethod", "UnusedVariable"})
+
+            @Generated
             public class InterceptorDeclaration_JvmBytecodeImpl extends MethodVisitorScope implements JvmBytecodeCallInterceptor, org.gradle.internal.instrumentation.api.types.BytecodeInterceptor.InstrumentationInterceptor {
                 @Override
                 public boolean visitMethodInsn(String className, int opcode, String owner, String name,
@@ -235,7 +238,8 @@ class InterceptJvmCallsGeneratorTest extends InstrumentationCodeGenTest {
         then:
         def expectedJvmInterceptors = source """
             package my;
-            @SuppressWarnings({"NotJavadoc", "UnusedMethod", "UnusedVariable"})
+
+            @Generated
             public class InterceptorDeclaration_JvmBytecodeImpl extends MethodVisitorScope implements JvmBytecodeCallInterceptor, org.gradle.internal.instrumentation.api.types.BytecodeInterceptor.InstrumentationInterceptor {
                 @Override
                 public boolean visitMethodInsn(String className, int opcode, String owner, String name,


### PR DESCRIPTION
This PR adds option to more precisily define what methods are upgraded.

So for example methods:
```
class AbstractCompile {
  File getDestinationDir();
  void setDestinationDir(File destinationDir)
  void setDestinationDir(Provider<File> destinationDir)
}
```

Were replaced with:
```
DirectoryProperty getDestinationDirectory()
```

We can now express that as:
```
@UpgradedProperty(originalAccessors = {
    @UpgradedAccessor(value = AccessorType.GETTER, methodName = "getDestinationDir"),
    @UpgradedAccessor(value = AccessorType.SETTER, methodName = "setDestinationDir"),
    @UpgradedAccessor(value = AccessorType.SETTER, methodName = "setDestinationDir", originalType = Provider.class),
})
DirectoryProperty getDestinationDirectory()
```

Another example is case where we don't have a getter, e.g.:
```
class JavaExecSpec { 
  JavaExecSpec setMain(@Nullable String main)
}
```
that was replaced by `Property<String> getMainClass()`, we can express that as:
```
@UpgradedProperty(originalAccessors = {
    @UpgradedAccessor(value = AccessorType.SETTER, methodName = "setMain", fluentSetter = true)
})
Property<String> getMainClass()
```

