### PR TITLE
Make it possible to override POM name and description using conventions

### DIFF
--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -177,7 +177,7 @@ tasks.test {
 
 #### Setting custom POM values in Maven publications for plugins
 
-The following example demonstrates how to set custom POM values per-publication:
+The maven-publish plugin provides a way to set custom POM values for a Gradle plugin publication, as demonstrated in the following example:
 
 ```groovy
 gradlePlugin {

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -199,7 +199,7 @@ publishing {
 }
 ```
 
-Previously, this was not working as expected and the published POM would contain the name and description values configured via `plugins` block.
+Previously, this was not working as expected and the published POM would contain the name and description values configured via the `plugins` block.
 
 Now, any values configured in the `pom` block will take priority if present, and be written to the published POM for that publication:
 

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -174,6 +174,47 @@ tasks.test {
     }
 }
 ```
+
+#### Setting custom POM values in Maven publications for plugins
+
+The following example demonstrates how to set custom POM values per-publication:
+
+```groovy
+gradlePlugin {
+    plugins {
+        register("some.plugin") {
+            name = "SomePluginName"
+            description = "SomePluginDesc"
+        }
+    }
+}
+
+publishing {
+    publications.withType<MavenPublication> {
+        pom {
+            name = "CustomPublicationName"
+            description = "CustomPublicationDesc"
+        }
+    }
+}
+```
+
+Previously, this was not working as expected and the published POM would contain the name and description values configured via `plugins` block.
+
+Now, any values configured in the `pom` block will take priority if present, and be written to the published POM for that publication:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <name>CustomPublicationName</name>
+  <description>CustomPublicationDesc</description>
+  ...
+</project>
+
+```
+
+This fixes https://github.com/gradle/gradle/issues/12259.
+
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ADD RELEASE FEATURES ABOVE
 ==========================================================

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginPluginPublishingIntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginPluginPublishingIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.plugin.devel.plugins
 
-import groovy.xml.XmlSlurper
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Issue
 
@@ -262,26 +261,6 @@ class JavaGradlePluginPluginPublishingIntegrationTest extends AbstractIntegratio
     }
 
     @Issue("https://github.com/gradle/gradle/issues/12259")
-    def "when publishing to maven then name and description from plugin block are used by convention when writing pom"() {
-        given:
-        plugin('foo', 'com.example.foo', 'pluginName', 'pluginDesc')
-        publishToMaven()
-
-        when:
-        succeeds 'publish'
-
-        then:
-        mavenRepo.module('com.example', 'plugins', '1.0').assertPublished()
-
-        def module = mavenRepo.module('com.example.foo', 'com.example.foo' + PLUGIN_MARKER_SUFFIX, '1.0')
-        module.assertPublished()
-
-        def xml = new XmlSlurper().parseText(module.getPomFile().text)
-        xml.name.text() == 'pluginName'
-        xml.description.text() == 'pluginDesc'
-    }
-
-    @Issue("https://github.com/gradle/gradle/issues/12259")
     def "when publishing to maven then name and description from plugin block can be overriden by the publishing block when writing pom"() {
         given:
         plugin('foo', 'com.example.foo', 'pluginName', 'pluginDesc')
@@ -308,9 +287,8 @@ class JavaGradlePluginPluginPublishingIntegrationTest extends AbstractIntegratio
         def module = mavenRepo.module('com.example.foo', 'com.example.foo' + PLUGIN_MARKER_SUFFIX, '1.0')
         module.assertPublished()
 
-        def xml = new XmlSlurper().parseText(module.getPomFile().text)
-        xml.name.text() == 'publishingName'
-        xml.description.text() == 'publishingDesc'
+        module.parsedPom.name == 'publishingName'
+        module.parsedPom.description == 'publishingDesc'
     }
 
     @Issue("https://github.com/gradle/gradle/issues/12259")
@@ -340,9 +318,8 @@ class JavaGradlePluginPluginPublishingIntegrationTest extends AbstractIntegratio
         def module = mavenRepo.module('com.example.foo', 'com.example.foo' + PLUGIN_MARKER_SUFFIX, '1.0')
         module.assertPublished()
 
-        def xml = new XmlSlurper().parseText(module.getPomFile().text)
-        xml.name.text() == 'publishingName'
-        xml.description.text() == 'publishingDesc'
+        module.parsedPom.name == 'publishingName'
+        module.parsedPom.description == 'publishingDesc'
     }
 
     def publishToMaven() {

--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/MavenPluginPublishPlugin.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/MavenPluginPublishPlugin.java
@@ -110,7 +110,13 @@ abstract class MavenPluginPublishPlugin implements Plugin<Project> {
                 version.setTextContent(versionProvider.get());
             }
         });
-        publication.getPom().getName().set(declaration.getDisplayName());
-        publication.getPom().getDescription().set(declaration.getDescription());
+        String displayName = declaration.getDisplayName();
+        if (displayName != null) {
+            publication.getPom().getName().set(displayName);
+        }
+        String description = declaration.getDescription();
+        if (description != null && !description.isEmpty()) {
+            publication.getPom().getDescription().set(description);
+        }
     }
 }

--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/MavenPluginPublishPlugin.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/MavenPluginPublishPlugin.java
@@ -110,13 +110,8 @@ abstract class MavenPluginPublishPlugin implements Plugin<Project> {
                 version.setTextContent(versionProvider.get());
             }
         });
-        String displayName = declaration.getDisplayName();
-        if (displayName != null) {
-            publication.getPom().getName().set(displayName);
-        }
-        String description = declaration.getDescription();
-        if (description != null && !description.isEmpty()) {
-            publication.getPom().getDescription().set(description);
-        }
+
+        publication.getPom().getName().convention(declaration.getDisplayName());
+        publication.getPom().getDescription().convention(declaration.getDescription());
     }
 }


### PR DESCRIPTION
Allows a "custom pom declaration" via the `publishing.publication` block to override the name and description values set in the `gradlePlugin.plugins` block. 

Fixes: #12259.  Supercedes #27468.