### PR TITLE
Fix error markers in CC reports

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblemsSummary.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblemsSummary.kt
@@ -41,7 +41,7 @@ const val maxCauses = 5
 
 internal
 enum class ProblemSeverity {
-    Warn,
+    Info,
     Failure,
 
     /**

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/DecoratedPropertyProblem.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/DecoratedPropertyProblem.kt
@@ -34,8 +34,12 @@ data class DecoratedPropertyProblem(
 internal
 data class DecoratedFailure(
     val summary: StructuredMessage?,
-    val parts: List<StackTracePart>
-)
+    val parts: List<StackTracePart>?
+) {
+    companion object {
+        val MARKER = DecoratedFailure(null, null)
+    }
+}
 
 
 internal

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/JsonModelWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/JsonModelWriter.kt
@@ -137,6 +137,7 @@ class JsonModelWriter(val writer: Writer) {
                         comma()
                         property("declaringType", firstTypeFrom(trace.trace).name)
                     }
+
                     PropertyKind.PropertyUsage -> {
                         property("kind", trace.kind.name)
                         comma()
@@ -144,6 +145,7 @@ class JsonModelWriter(val writer: Writer) {
                         comma()
                         property("from", projectPathFrom(trace.trace))
                     }
+
                     else -> {
                         property("kind", trace.kind.name)
                         comma()
@@ -153,11 +155,13 @@ class JsonModelWriter(val writer: Writer) {
                     }
                 }
             }
+
             is PropertyTrace.SystemProperty -> {
                 property("kind", "SystemProperty")
                 comma()
                 property("name", trace.name)
             }
+
             is PropertyTrace.Task -> {
                 property("kind", "Task")
                 comma()
@@ -165,29 +169,35 @@ class JsonModelWriter(val writer: Writer) {
                 comma()
                 property("type", trace.type.name)
             }
+
             is PropertyTrace.Bean -> {
                 property("kind", "Bean")
                 comma()
                 property("type", trace.type.name)
             }
+
             is PropertyTrace.Project -> {
                 property("kind", "Project")
                 comma()
                 property("path", trace.path)
             }
+
             is PropertyTrace.BuildLogic -> {
                 property("kind", "BuildLogic")
                 comma()
                 property("location", trace.source.displayName)
             }
+
             is PropertyTrace.BuildLogicClass -> {
                 property("kind", "BuildLogicClass")
                 comma()
                 property("type", trace.name)
             }
+
             PropertyTrace.Gradle -> {
                 property("kind", "Gradle")
             }
+
             PropertyTrace.Unknown -> {
                 property("kind", "Unknown")
             }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/JsonModelWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/JsonModelWriter.kt
@@ -87,17 +87,22 @@ class JsonModelWriter(val writer: Writer) {
 
     private
     fun writeError(failure: DecoratedFailure) {
+        val summary = failure.summary
+        val parts = failure.parts
         property("error") {
             jsonObject {
-                failure.summary?.let {
+                if (summary != null) {
                     property("summary") {
-                        writeStructuredMessage(it)
+                        writeStructuredMessage(summary)
                     }
-                    comma()
                 }
-                property("parts") {
-                    jsonObjectList(failure.parts) { (isInternal, text) ->
-                        property(if (isInternal) "internalText" else "text", text)
+
+                if (parts != null) {
+                    if (summary != null) comma()
+                    property("parts") {
+                        jsonObjectList(parts) { (isInternal, text) ->
+                            property(if (isInternal) "internalText" else "text", text)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
CC report incorrectly shows some problems as warnings instead of errors, because an error (exception stacktrace) was omitted. This could happen due to stacktrace collection limits.

In order to fix this, an error marker is included in the problem diagnostic that is communicated to the CC report.

Requires upgrade of the CC report dependency that can handle error markers.