### PR TITLE
Document support for `Externalizable` in the configuration cache

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/jos/JavaObjectSerializationCodec.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/jos/JavaObjectSerializationCodec.kt
@@ -47,8 +47,8 @@ import java.lang.reflect.Modifier.isStatic
  * Allows objects that support the [Java Object Serialization](https://docs.oracle.com/javase/8/docs/platform/serialization/spec/serialTOC.html)
  * protocol to be stored in the configuration cache.
  *
- * The implementation is currently limited to serializable classes that implement the [java.io.Serializable] interface
- * and define one of the following combination of methods:
+ * The implementation is currently limited to serializable classes that
+ * either implement the [java.io.Externalizable] interface, or implement the [java.io.Serializable] interface and define one of the following combination of methods:
  * - a `writeObject` method combined with a `readObject` method to control exactly which information to store;
  * - a `writeObject` method with no corresponding `readObject`; `writeObject` must eventually call [ObjectOutputStream.defaultWriteObject];
  * - a `readObject` method with no corresponding `writeObject`; `readObject` must eventually call [ObjectInputStream.defaultReadObject];
@@ -56,7 +56,6 @@ import java.lang.reflect.Modifier.isStatic
  * - a `readResolve` method to allow the class to nominate a replacement for the object just read;
  *
  * The following _Java Object Serialization_ features are **not** supported:
- * - serializable classes implementing the [java.io.Externalizable] interface; objects of such classes are discarded by the configuration cache during serialization and reported as problems;
  * - the `serialPersistentFields` member to explicitly declare which fields are serializable; the member, if present, is ignored; the configuration cache considers all but `transient` fields serializable;
  * - the following methods of [ObjectOutputStream] are not supported and will throw [UnsupportedOperationException]:
  *    - `reset()`, `writeFields()`, `putFields()`, `writeChars(String)`, `writeBytes(String)` and `writeUnshared(Any?)`.

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -54,7 +54,9 @@ vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv -->
 
 ### Configuration cache improvements
 
-[Java Record classes](https://docs.oracle.com/en/java/javase/21/language/records.html) are now supported in the configuration cache.
+The configuration cache now supports:
+* [Java Record classes](https://docs.oracle.com/en/java/javase/21/language/records.html)
+* [java.io.Externalizable instances](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/io/Externalizable.html)
 
 #### Ability to set conventions on file collections
 

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/configuration_cache.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/configuration_cache.adoc
@@ -1179,7 +1179,8 @@ See link:{gradle-issues}20969[gradle/gradle#20969].
 
 Gradle allows objects that support the link:https://docs.oracle.com/javase/8/docs/platform/serialization/spec/serialTOC.html[Java Object Serialization] protocol to be stored in the configuration cache.
 
-The implementation is currently limited to serializable classes that implement the `java.io.Serializable` interface and define one of the following combination of methods:
+The implementation is currently limited to serializable classes that
+either implement the `java.io.Externalizable` interface, or implement the `java.io.Serializable` interface and define one of the following combination of methods:
 
 - a `writeObject` method combined with a `readObject` method to control exactly which information to store;
 - a `writeObject` method with no corresponding `readObject`; `writeObject` must eventually call `ObjectOutputStream.defaultWriteObject`;
@@ -1189,7 +1190,6 @@ The implementation is currently limited to serializable classes that implement t
 
 The following _Java Object Serialization_ features are **not** supported:
 
-- serializable classes implementing the `java.io.Externalizable` interface; objects of such classes are discarded by the configuration cache during serialization and reported as problems;
 - the `serialPersistentFields` member to explicitly declare which fields are serializable; the member, if present, is ignored; the configuration cache considers all but `transient` fields serializable;
 - the following methods of `ObjectOutputStream` are not supported and will throw `UnsupportedOperationException`:
 ** `reset()`, `writeFields()`, `putFields()`, `writeChars(String)`, `writeBytes(String)` and `writeUnshared(Any?)`.


### PR DESCRIPTION
Fixes: #28461