### PR TITLE
Build name and errors without stacktrace in CC report

### DIFF
--- a/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
+++ b/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
@@ -21,7 +21,7 @@ import gradlebuild.modules.model.License
 abstract class ExternalModulesExtension(isBundleGroovy4: Boolean) {
 
     val groovyVersion = if (isBundleGroovy4) "4.0.7" else "3.0.17"
-    val configurationCacheReportVersion = "1.4"
+    val configurationCacheReportVersion = "1.5"
     val kotlinVersion = "1.9.22"
 
     fun futureKotlin(module: String) = "org.jetbrains.kotlin:kotlin-$module:$kotlinVersion"

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblems.kt
@@ -178,7 +178,7 @@ class ConfigurationCacheProblems(
         val outputDirectory = outputDirectoryFor(reportDir)
         val cacheActionText = cacheAction.summaryText()
         val requestedTasks = startParameter.requestedTasksOrDefault()
-        val buildDisplayName = buildName ?: "a build"
+        val buildDisplayName = buildName
         val htmlReportFile = report.writeReportFileTo(outputDirectory, buildDisplayName, cacheActionText, requestedTasks, summary.problemCount)
         if (htmlReportFile == null) {
             // there was nothing to report (no problems, no build configuration inputs)
@@ -206,7 +206,7 @@ class ConfigurationCacheProblems(
 
     private
     fun ConfigurationCacheStartParameter.requestedTasksOrDefault() =
-        requestedTaskNames.takeIf { it.isNotEmpty() }?.joinToString(" ") ?: "default tasks"
+        requestedTaskNames.takeIf { it.isNotEmpty() }?.joinToString(" ")
 
     private
     fun outputDirectoryFor(buildDir: File): File =

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblems.kt
@@ -17,6 +17,8 @@
 package org.gradle.configurationcache.problems
 
 import com.google.common.collect.Sets.newConcurrentHashSet
+import org.gradle.api.initialization.Settings
+import org.gradle.api.internal.SettingsInternal
 import org.gradle.api.logging.Logging
 import org.gradle.configurationcache.ConfigurationCacheAction
 import org.gradle.configurationcache.ConfigurationCacheAction.LOAD
@@ -27,6 +29,7 @@ import org.gradle.configurationcache.ConfigurationCacheProblemsException
 import org.gradle.configurationcache.TooManyConfigurationCacheProblemsException
 import org.gradle.configurationcache.initialization.ConfigurationCacheStartParameter
 import org.gradle.initialization.RootBuildLifecycleListener
+import org.gradle.internal.InternalBuildAdapter
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.service.scopes.Scope
 import org.gradle.internal.service.scopes.ServiceScope
@@ -56,7 +59,13 @@ class ConfigurationCacheProblems(
     val summarizer = ConfigurationCacheProblemsSummary()
 
     private
+    val buildNameHandler = BuildNameHandler()
+
+    private
     val postBuildHandler = PostBuildProblemsHandler()
+
+    private
+    var buildName: String? = null
 
     private
     var isFailOnProblems = startParameter.failOnProblems
@@ -89,10 +98,12 @@ class ConfigurationCacheProblems(
         }
 
     init {
+        listenerManager.addListener(buildNameHandler)
         listenerManager.addListener(postBuildHandler)
     }
 
     override fun close() {
+        listenerManager.removeListener(buildNameHandler)
         listenerManager.removeListener(postBuildHandler)
     }
 
@@ -167,7 +178,8 @@ class ConfigurationCacheProblems(
         val outputDirectory = outputDirectoryFor(reportDir)
         val cacheActionText = cacheAction.summaryText()
         val requestedTasks = startParameter.requestedTasksOrDefault()
-        val htmlReportFile = report.writeReportFileTo(outputDirectory, cacheActionText, requestedTasks, summary.problemCount)
+        val buildDisplayName = buildName ?: "a build"
+        val htmlReportFile = report.writeReportFileTo(outputDirectory, buildDisplayName, cacheActionText, requestedTasks, summary.problemCount)
         if (htmlReportFile == null) {
             // there was nothing to report (no problems, no build configuration inputs)
             require(hasNoProblems)
@@ -199,6 +211,15 @@ class ConfigurationCacheProblems(
     private
     fun outputDirectoryFor(buildDir: File): File =
         buildDir.resolve("reports/configuration-cache/$cacheKey")
+
+    private
+    inner class BuildNameHandler : InternalBuildAdapter() {
+        override fun settingsEvaluated(settings: Settings) {
+            if ((settings as SettingsInternal).gradle.isRootBuild) {
+                buildName = settings.rootProject.name
+            }
+        }
+    }
 
     private
     inner class PostBuildProblemsHandler : RootBuildLifecycleListener {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblemsSummary.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblemsSummary.kt
@@ -41,7 +41,7 @@ const val maxCauses = 5
 
 internal
 enum class ProblemSeverity {
-    Warn,
+    Info,
     Failure,
 
     /**

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheReport.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheReport.kt
@@ -65,6 +65,7 @@ class ConfigurationCacheReport(
          */
         open fun commitReportTo(
             outputDirectory: File,
+            buildDisplayName: String,
             cacheAction: String,
             requestedTasks: String,
             totalProblemCount: Int
@@ -87,6 +88,7 @@ class ConfigurationCacheReport(
              */
             override fun commitReportTo(
                 outputDirectory: File,
+                buildDisplayName: String,
                 cacheAction: String,
                 requestedTasks: String,
                 totalProblemCount: Int
@@ -131,11 +133,18 @@ class ConfigurationCacheReport(
                 return this
             }
 
-            override fun commitReportTo(outputDirectory: File, cacheAction: String, requestedTasks: String, totalProblemCount: Int): Pair<State, File?> {
+            override fun commitReportTo(
+                outputDirectory: File,
+                buildDisplayName: String,
+                cacheAction: String,
+                requestedTasks: String,
+                totalProblemCount: Int
+            ): Pair<State, File?> {
+
                 val reportFile = try {
                     executor
                         .submit(Callable {
-                            closeHtmlReport(cacheAction, requestedTasks, totalProblemCount)
+                            closeHtmlReport(buildDisplayName, cacheAction, requestedTasks, totalProblemCount)
                             moveSpoolFileTo(outputDirectory)
                         })
                         .get(30, TimeUnit.SECONDS)
@@ -158,8 +167,8 @@ class ConfigurationCacheReport(
             }
 
             private
-            fun closeHtmlReport(cacheAction: String, requestedTasks: String, totalProblemCount: Int) {
-                writer.endHtmlReport(cacheAction, requestedTasks, totalProblemCount)
+            fun closeHtmlReport(buildDisplayName: String, cacheAction: String, requestedTasks: String, totalProblemCount: Int) {
+                writer.endHtmlReport(buildDisplayName, cacheAction, requestedTasks, totalProblemCount)
                 writer.close()
             }
 
@@ -280,10 +289,10 @@ class ConfigurationCacheReport(
      * see [HtmlReportWriter].
      */
     internal
-    fun writeReportFileTo(outputDirectory: File, cacheAction: String, requestedTasks: String, totalProblemCount: Int): File? {
+    fun writeReportFileTo(outputDirectory: File, buildDisplayName: String, cacheAction: String, requestedTasks: String, totalProblemCount: Int): File? {
         var reportFile: File?
         modifyState {
-            val (newState, outputFile) = commitReportTo(outputDirectory, cacheAction, requestedTasks, totalProblemCount)
+            val (newState, outputFile) = commitReportTo(outputDirectory, buildDisplayName, cacheAction, requestedTasks, totalProblemCount)
             reportFile = outputFile
             newState
         }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheReport.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheReport.kt
@@ -65,9 +65,9 @@ class ConfigurationCacheReport(
          */
         open fun commitReportTo(
             outputDirectory: File,
-            buildDisplayName: String,
+            buildDisplayName: String?,
             cacheAction: String,
-            requestedTasks: String,
+            requestedTasks: String?,
             totalProblemCount: Int
         ): Pair<State, File?> =
             illegalState()
@@ -88,9 +88,9 @@ class ConfigurationCacheReport(
              */
             override fun commitReportTo(
                 outputDirectory: File,
-                buildDisplayName: String,
+                buildDisplayName: String?,
                 cacheAction: String,
-                requestedTasks: String,
+                requestedTasks: String?,
                 totalProblemCount: Int
             ): Pair<State, File?> =
                 this to null
@@ -135,9 +135,9 @@ class ConfigurationCacheReport(
 
             override fun commitReportTo(
                 outputDirectory: File,
-                buildDisplayName: String,
+                buildDisplayName: String?,
                 cacheAction: String,
-                requestedTasks: String,
+                requestedTasks: String?,
                 totalProblemCount: Int
             ): Pair<State, File?> {
 
@@ -167,7 +167,7 @@ class ConfigurationCacheReport(
             }
 
             private
-            fun closeHtmlReport(buildDisplayName: String, cacheAction: String, requestedTasks: String, totalProblemCount: Int) {
+            fun closeHtmlReport(buildDisplayName: String?, cacheAction: String, requestedTasks: String?, totalProblemCount: Int) {
                 writer.endHtmlReport(buildDisplayName, cacheAction, requestedTasks, totalProblemCount)
                 writer.close()
             }
@@ -289,7 +289,7 @@ class ConfigurationCacheReport(
      * see [HtmlReportWriter].
      */
     internal
-    fun writeReportFileTo(outputDirectory: File, buildDisplayName: String, cacheAction: String, requestedTasks: String, totalProblemCount: Int): File? {
+    fun writeReportFileTo(outputDirectory: File, buildDisplayName: String?, cacheAction: String, requestedTasks: String?, totalProblemCount: Int): File? {
         var reportFile: File?
         modifyState {
             val (newState, outputFile) = commitReportTo(outputDirectory, buildDisplayName, cacheAction, requestedTasks, totalProblemCount)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/DecoratedPropertyProblem.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/DecoratedPropertyProblem.kt
@@ -34,8 +34,12 @@ data class DecoratedPropertyProblem(
 internal
 data class DecoratedFailure(
     val summary: StructuredMessage?,
-    val parts: List<StackTracePart>
-)
+    val parts: List<StackTracePart>?
+) {
+    companion object {
+        val MARKER = DecoratedFailure(null, null)
+    }
+}
 
 
 internal

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/HtmlReportWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/HtmlReportWriter.kt
@@ -40,7 +40,7 @@ class HtmlReportWriter(val writer: Writer) {
         jsonModelWriter.beginModel()
     }
 
-    fun endHtmlReport(buildDisplayName: String, cacheAction: String, requestedTasks: String, totalProblemCount: Int) {
+    fun endHtmlReport(buildDisplayName: String?, cacheAction: String, requestedTasks: String?, totalProblemCount: Int) {
         jsonModelWriter.endModel(buildDisplayName, cacheAction, requestedTasks, totalProblemCount)
         endReportData()
         writer.append(htmlTemplate.second)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/HtmlReportWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/HtmlReportWriter.kt
@@ -40,8 +40,8 @@ class HtmlReportWriter(val writer: Writer) {
         jsonModelWriter.beginModel()
     }
 
-    fun endHtmlReport(cacheAction: String, requestedTasks: String, totalProblemCount: Int) {
-        jsonModelWriter.endModel(cacheAction, requestedTasks, totalProblemCount)
+    fun endHtmlReport(buildDisplayName: String, cacheAction: String, requestedTasks: String, totalProblemCount: Int) {
+        jsonModelWriter.endModel(buildDisplayName, cacheAction, requestedTasks, totalProblemCount)
         endReportData()
         writer.append(htmlTemplate.second)
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/JsonModelWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/JsonModelWriter.kt
@@ -45,19 +45,23 @@ class JsonModelWriter(val writer: Writer) {
         beginArray()
     }
 
-    fun endModel(buildDisplayName: String, cacheAction: String, requestedTasks: String, totalProblemCount: Int) {
+    fun endModel(buildDisplayName: String?, cacheAction: String, requestedTasks: String?, totalProblemCount: Int) {
         endArray()
 
         comma()
         property("totalProblemCount") {
             write(totalProblemCount.toString())
         }
-        comma()
-        property("buildName", buildDisplayName)
+        if (buildDisplayName != null) {
+            comma()
+            property("buildName", buildDisplayName)
+        }
+        if (requestedTasks != null) {
+            comma()
+            property("requestedTasks", requestedTasks)
+        }
         comma()
         property("cacheAction", cacheAction)
-        comma()
-        property("requestedTasks", requestedTasks)
         comma()
         property("documentationLink", documentationRegistry.getDocumentationFor("configuration_cache"))
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/JsonModelWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/JsonModelWriter.kt
@@ -137,6 +137,7 @@ class JsonModelWriter(val writer: Writer) {
                         comma()
                         property("declaringType", firstTypeFrom(trace.trace).name)
                     }
+
                     PropertyKind.PropertyUsage -> {
                         property("kind", trace.kind.name)
                         comma()
@@ -144,6 +145,7 @@ class JsonModelWriter(val writer: Writer) {
                         comma()
                         property("from", projectPathFrom(trace.trace))
                     }
+
                     else -> {
                         property("kind", trace.kind.name)
                         comma()
@@ -153,11 +155,13 @@ class JsonModelWriter(val writer: Writer) {
                     }
                 }
             }
+
             is PropertyTrace.SystemProperty -> {
                 property("kind", "SystemProperty")
                 comma()
                 property("name", trace.name)
             }
+
             is PropertyTrace.Task -> {
                 property("kind", "Task")
                 comma()
@@ -165,29 +169,35 @@ class JsonModelWriter(val writer: Writer) {
                 comma()
                 property("type", trace.type.name)
             }
+
             is PropertyTrace.Bean -> {
                 property("kind", "Bean")
                 comma()
                 property("type", trace.type.name)
             }
+
             is PropertyTrace.Project -> {
                 property("kind", "Project")
                 comma()
                 property("path", trace.path)
             }
+
             is PropertyTrace.BuildLogic -> {
                 property("kind", "BuildLogic")
                 comma()
                 property("location", trace.source.displayName)
             }
+
             is PropertyTrace.BuildLogicClass -> {
                 property("kind", "BuildLogicClass")
                 comma()
                 property("type", trace.name)
             }
+
             PropertyTrace.Gradle -> {
                 property("kind", "Gradle")
             }
+
             PropertyTrace.Unknown -> {
                 property("kind", "Unknown")
             }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/JsonModelWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/JsonModelWriter.kt
@@ -87,17 +87,22 @@ class JsonModelWriter(val writer: Writer) {
 
     private
     fun writeError(failure: DecoratedFailure) {
+        val summary = failure.summary
+        val parts = failure.parts
         property("error") {
             jsonObject {
-                failure.summary?.let {
+                if (summary != null) {
                     property("summary") {
-                        writeStructuredMessage(it)
+                        writeStructuredMessage(summary)
                     }
-                    comma()
                 }
-                property("parts") {
-                    jsonObjectList(failure.parts) { (isInternal, text) ->
-                        property(if (isInternal) "internalText" else "text", text)
+
+                if (parts != null) {
+                    if (summary != null) comma()
+                    property("parts") {
+                        jsonObjectList(parts) { (isInternal, text) ->
+                            property(if (isInternal) "internalText" else "text", text)
+                        }
                     }
                 }
             }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/JsonModelWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/JsonModelWriter.kt
@@ -45,13 +45,15 @@ class JsonModelWriter(val writer: Writer) {
         beginArray()
     }
 
-    fun endModel(cacheAction: String, requestedTasks: String, totalProblemCount: Int) {
+    fun endModel(buildDisplayName: String, cacheAction: String, requestedTasks: String, totalProblemCount: Int) {
         endArray()
 
         comma()
         property("totalProblemCount") {
             write(totalProblemCount.toString())
         }
+        comma()
+        property("buildName", buildDisplayName)
         comma()
         property("cacheAction", cacheAction)
         comma()

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/configurationcache/problems/JsonModelWriterTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/configurationcache/problems/JsonModelWriterTest.kt
@@ -38,7 +38,7 @@ class JsonModelWriterTest {
                         StructuredMessage.build { reference("") }
                     )
                 )
-                endModel("", "", 0)
+                endModel("", "", "", 0)
             },
             hasEntry(
                 "diagnostics",

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsFixture.groovy
@@ -414,7 +414,7 @@ final class ConfigurationCacheProblemsFixture {
     }
 
     protected static int numberOfProblemsWithStacktraceIn(jsModel) {
-        return (jsModel.diagnostics as List<Object>).count { it['error'] != null }
+        return (jsModel.diagnostics as List<Object>).count { it['error']?.getAt('parts') != null }
     }
 
     private static ProblemsSummary extractSummary(String text) {


### PR DESCRIPTION
- Allows displaying build name in the report to tell reports apart
- Ensures that errors that don't have stacktraces are still indicated with an error icon

![image](https://github.com/gradle/gradle/assets/2759152/3580c0dc-8bde-4ad8-9fbb-72c1236b9239)
