### PR TITLE
Improve error message when the classpath configuration fails to resolve

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/TaskDependencyResolveContext.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/TaskDependencyResolveContext.java
@@ -17,12 +17,13 @@
 package org.gradle.api.internal.tasks;
 
 import org.gradle.api.Action;
+import org.gradle.api.Named;
 import org.gradle.api.Task;
 import org.gradle.api.internal.artifacts.transform.TransformNodeDependency;
 
 import javax.annotation.Nullable;
 
-public interface TaskDependencyResolveContext extends Action<Task> {
+public interface TaskDependencyResolveContext extends Action<Task>, Named {
     @Override
     default void execute(Task task) {
         add(task);
@@ -59,4 +60,10 @@ public interface TaskDependencyResolveContext extends Action<Task> {
      */
     @Nullable
     Task getTask();
+
+
+    @Override
+    default String getName() {
+        return "task dependencies";
+    }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/plugin/devel/variants/TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/plugin/devel/variants/TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest.groovy
@@ -256,12 +256,11 @@ class TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest extends Abst
         fails 'greet', "--stacktrace"
 
         then:
-        failure.assertHasErrorOutput("""> Could not determine the dependencies of null.
-   > Could not resolve all task dependencies for configuration ':classpath'.
-      > Could not resolve project :producer.
-        Required by:
-            project :
-         > Dependency requires at least JVM runtime version ${higherVersion.javaVersion.majorVersion}. This build uses a Java ${lowerVersion.javaVersion.majorVersion} JVM.""")
+        failure.assertHasErrorOutput("""> Could not resolve all dependencies for configuration ':classpath'.
+   > Could not resolve project :producer.
+     Required by:
+         project :
+      > Dependency requires at least JVM runtime version ${higherVersion.javaVersion.majorVersion}. This build uses a Java ${lowerVersion.javaVersion.majorVersion} JVM.""")
         failure.assertHasErrorOutput("Caused by: " + VariantSelectionException.class.getName())
         failure.assertHasResolution("Run this build using a Java ${higherVersion.javaVersion.majorVersion} or newer JVM.")
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionBackedFileCollection.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionBackedFileCollection.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.api.internal.tasks.FailureCollectingTaskDependencyResolveContext;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+import org.gradle.internal.component.resolution.failure.exception.ArtifactVariantSelectionException;
 import org.gradle.internal.logging.text.TreeFormatter;
 
 public class ResolutionBackedFileCollection extends AbstractFileCollection {
@@ -57,7 +58,7 @@ public class ResolutionBackedFileCollection extends AbstractFileCollection {
         FailureCollectingTaskDependencyResolveContext collectingContext = new FailureCollectingTaskDependencyResolveContext(context);
         selected.visitDependencies(collectingContext);
         if (!lenient) {
-            resolutionHost.mapFailure("task dependencies", collectingContext.getFailures()).ifPresent(context::visitFailure);
+            resolutionHost.mapFailure(context.getName(), collectingContext.getFailures()).ifPresent(context::visitFailure);
         }
     }
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -374,7 +374,7 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
 
         then:
         def t = thrown(GradleException)
-        t.cause == failure
+        t == failure
         configuration.getState() == RESOLVED_WITH_FAILURES
     }
 


### PR DESCRIPTION
- Remove useless "Could not determine the dependencies of null." line.
- Instead of saying "Could not resolve all task dependencies" say "Could not resolve all dependencies".

Followup to https://github.com/gradle/gradle/pull/27858.

Previous error:
```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'unified-prototype'.
> Could not determine the dependencies of null.
   > Could not resolve all task dependencies for configuration ':classpath'.
      > Could not resolve project :unified-plugin:plugin-android.
        Required by:
            project :
         > Dependency requires at least JVM runtime version 17. This build uses a Java 11 JVM.

* Try:
> Run this build using a Java 17 or newer JVM.
```

New error:
```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'unified-prototype'.
> Could not resolve all dependencies for configuration ':classpath'.
   > Could not resolve project :unified-plugin:plugin-android.
     Required by:
         project :
      > Dependency requires at least JVM runtime version 17. This build uses a Java 11 JVM.

* Try:
> Run this build using a Java 17 or newer JVM.
```