### PR TITLE
Let Kotlin DSL accessors generation skip empty jars

### DIFF
--- a/build-logic/kotlin-dsl-shared-runtime/src/main/kotlin/org/gradle/kotlin/dsl/internal/sharedruntime/support/ClassBytesRepository.kt
+++ b/build-logic/kotlin-dsl-shared-runtime/src/main/kotlin/org/gradle/kotlin/dsl/internal/sharedruntime/support/ClassBytesRepository.kt
@@ -39,15 +39,18 @@ typealias ClassBytesIndex = (String) -> ClassBytesSupplier?
  */
 class ClassBytesRepository(
     platformClassLoader: ClassLoader,
-    private val classPathFiles: List<File>,
+    classPathFiles: List<File>,
     classPathDependencies: List<File> = emptyList(),
 ) : Closeable {
+
+    private
+    val relevantClassPathFiles = classPathFiles.filter { it.isDirectory || (it.isFile && it.length() > 0) }
 
     private
     val openJars = mutableMapOf<File, JarFile>()
 
     private
-    val classBytesIndex = (classPathFiles + classPathDependencies + platformClassLoader).map { classBytesIndexFor(it) }
+    val classBytesIndex = (relevantClassPathFiles + classPathDependencies + platformClassLoader).map { classBytesIndexFor(it) }
 
     /**
      * Class file bytes for Kotlin source name, if found.
@@ -59,7 +62,7 @@ class ClassBytesRepository(
      * All found class files bytes by Kotlin source name.
      */
     fun allClassesBytesBySourceName(): Sequence<Pair<String, ClassBytesSupplier>> =
-        classPathFiles.asSequence()
+        relevantClassPathFiles.asSequence()
             .flatMap { sourceNamesFrom(it) }
             .mapNotNull { sourceName ->
                 classBytesSupplierForSourceName(sourceName)?.let { sourceName to it }

--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepositoryTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepositoryTest.kt
@@ -183,6 +183,23 @@ class ClassBytesRepositoryTest : AbstractKotlinIntegrationTest() {
         }
     }
 
+    @Test
+    fun `ignores empty jars`() {
+        val entries = listOf(
+            withClassJar("some.jar", DeepThought::class.java),
+            withFile("empty.jar")
+        )
+        ClassBytesRepository(
+            platformClassLoader = ClassLoaderUtils.getPlatformClassLoader(),
+            classPathFiles = entries
+        ).use { repository ->
+            assertThat(
+                repository.allSourceNames,
+                equalTo(listOf(canonicalNameOf<DeepThought>()))
+            )
+        }
+    }
+
     private
     val ClassBytesRepository.allSourceNames: List<String>
         get() = allClassesBytesBySourceName().map { it.first }.toList()


### PR DESCRIPTION
* Fixes https://github.com/gradle/gradle/issues/26542

I stumbled upon this problem with some build logic dependencies and discovered it was already reported. This PR makes Kotlin DSL `ClassBytesRepository` simply ignore empty JAR files instead of needlessly failing.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
