### PR TITLE
`unset()` should restore property to initial state if no convention set

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -28,7 +28,6 @@ import org.gradle.api.internal.provider.Collectors.ElementsFromCollectionProvide
 import org.gradle.api.internal.provider.Collectors.SingleElement;
 import org.gradle.api.provider.HasMultipleValues;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.provider.SupportsConvention;
 import org.gradle.internal.Cast;
 import org.gradle.util.internal.TextUtil;
 
@@ -278,20 +277,10 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         setSupplier(new CollectingSupplier(new ElementsFromCollectionProvider<>(p)));
     }
 
-    @Override
-    public SupportsConvention unset() {
-        assertCanMutate();
-        unsetValue();
-        return this;
-    }
-
-    private void unsetValue() {
-        super.unset();
-    }
-
     private void unsetValueAndDefault() {
+        // assign no-value default before restoring to it
         defaultValue = noValueSupplier();
-        unsetValue();
+        unset();
     }
 
     @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -84,7 +84,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
     private final Class<T> elementType;
     private final Supplier<ImmutableCollection.Builder<T>> collectionFactory;
     private final ValueCollector<T> valueCollector;
-    private CollectionSupplier<T, C> defaultValue = emptySupplier();
+    private CollectionSupplier<T, C> defaultValue;
 
     AbstractCollectionProperty(PropertyHost host, Class<? extends Collection> collectionType, Class<T> elementType, Supplier<ImmutableCollection.Builder<T>> collectionFactory) {
         super(host);
@@ -92,7 +92,17 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         this.elementType = elementType;
         this.collectionFactory = collectionFactory;
         valueCollector = new ValidatingValueCollector<>(collectionType, elementType, ValueSanitizers.forType(elementType));
+        init();
+    }
+
+    private void init() {
+        defaultValue = emptySupplier();
         init(defaultValue, noValueSupplier());
+    }
+
+    @Override
+    protected CollectionSupplier<T, C> getDefaultValue() {
+        return defaultValue;
     }
 
     @Override
@@ -270,15 +280,16 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
 
     @Override
     public SupportsConvention unset() {
+        assertCanMutate();
         doUnset(false);
         return this;
     }
 
     private void doUnset(boolean changeDefault) {
-        super.unset();
         if (changeDefault) {
             defaultValue = noValueSupplier();
         }
+        super.unset();
     }
 
     @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -254,7 +254,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
     @Override
     public void set(@Nullable final Iterable<? extends T> elements) {
         if (elements == null) {
-            doUnset(true);
+            unsetValueAndDefault();
         } else {
             setSupplier(new CollectingSupplier(new ElementsFromCollection<>(elements)));
         }
@@ -281,15 +281,17 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
     @Override
     public SupportsConvention unset() {
         assertCanMutate();
-        doUnset(false);
+        unsetValue();
         return this;
     }
 
-    private void doUnset(boolean changeDefault) {
-        if (changeDefault) {
-            defaultValue = noValueSupplier();
-        }
+    private void unsetValue() {
         super.unset();
+    }
+
+    private void unsetValueAndDefault() {
+        defaultValue = noValueSupplier();
+        unsetValue();
     }
 
     @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -301,7 +301,14 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
      */
     protected void discardValue() {
         assertCanMutate();
-        value = state.implicitValue();
+        if (isDefaultConvention()) {
+            // special case: discarding value without a convention restores the initial state
+            state.implicitValue(getDefaultConvention());
+            value = getDefaultValue();
+        } else {
+            // otherwise, the convention will become the new value
+            value = state.implicitValue(state.convention());
+        }
     }
 
     /**
@@ -350,6 +357,8 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
         }
         return this;
     }
+
+    protected abstract S getDefaultValue();
 
     protected abstract S getDefaultConvention();
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -158,7 +158,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
     @SuppressWarnings("unchecked")
     public void set(@Nullable Map<? extends K, ? extends V> entries) {
         if (entries == null) {
-            doUnset(true);
+            unsetValueAndDefault();
         } else {
             setSupplier(new CollectingSupplier(new MapCollectors.EntriesFromMap<>(entries), false));
         }
@@ -296,15 +296,17 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
     @Override
     public MapProperty<K, V> unset() {
         assertCanMutate();
-        doUnset(false);
+        unsetValue();
         return this;
     }
 
-    private void doUnset(boolean changeDefault) {
-        if (changeDefault) {
-            defaultValue = noValueSupplier();
-        }
+    private void unsetValue() {
         super.unset();
+    }
+
+    private void unsetValueAndDefault() {
+        defaultValue = noValueSupplier();
+        unsetValue();
     }
 
     public void fromState(ExecutionTimeValue<? extends Map<? extends K, ? extends V>> value) {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -29,6 +29,7 @@ import org.gradle.api.internal.provider.MapCollectors.EntryWithValueFromProvider
 import org.gradle.api.internal.provider.MapCollectors.SingleEntry;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Provider;
+import org.gradle.internal.Cast;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -295,18 +296,13 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
 
     @Override
     public MapProperty<K, V> unset() {
-        assertCanMutate();
-        unsetValue();
-        return this;
-    }
-
-    private void unsetValue() {
-        super.unset();
+        return Cast.uncheckedNonnullCast(super.unset());
     }
 
     private void unsetValueAndDefault() {
+        // assign no-value default before restoring to it
         defaultValue = noValueSupplier();
-        unsetValue();
+        unset();
     }
 
     public void fromState(ExecutionTimeValue<? extends Map<? extends K, ? extends V>> value) {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -71,7 +71,17 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         this.valueType = valueType;
         keyCollector = new ValidatingValueCollector<>(Set.class, keyType, ValueSanitizers.forType(keyType));
         entryCollector = new ValidatingMapEntryCollector<>(keyType, valueType, ValueSanitizers.forType(keyType), ValueSanitizers.forType(valueType));
-        init(defaultValue, getDefaultConvention());
+        init();
+    }
+
+    private void init() {
+        defaultValue = emptySupplier();
+        init(defaultValue, noValueSupplier());
+    }
+
+    @Override
+    public MapSupplier<K, V> getDefaultValue() {
+        return defaultValue;
     }
 
     @Override
@@ -285,15 +295,16 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
 
     @Override
     public MapProperty<K, V> unset() {
+        assertCanMutate();
         doUnset(false);
         return this;
     }
 
     private void doUnset(boolean changeDefault) {
-        super.unset();
         if (changeDefault) {
             defaultValue = noValueSupplier();
         }
+        super.unset();
     }
 
     public void fromState(ExecutionTimeValue<? extends Map<? extends K, ? extends V>> value) {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -39,7 +39,12 @@ public class DefaultProperty<T> extends AbstractProperty<T, ProviderInternal<? e
         super(propertyHost);
         this.type = type;
         this.sanitizer = ValueSanitizers.forType(type);
-        init(Providers.notDefined());
+        init(getDefaultValue());
+    }
+
+    @Override
+    protected ProviderInternal<? extends T> getDefaultValue() {
+        return Providers.notDefined();
     }
 
     @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueState.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueState.java
@@ -293,9 +293,8 @@ public abstract class ValueState<S> {
 
         @Override
         public S implicitValue(S newConvention) {
-            explicitValue = false;
             setConvention(newConvention);
-            return shallowCopy(convention);
+            return implicitValue();
         }
 
         @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueState.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueState.java
@@ -115,6 +115,8 @@ public abstract class ValueState<S> {
     /**
      * Marks this value state as being non-explicit. Returns the convention, if any.
      */
+    public abstract S implicitValue(S convention);
+
     public abstract S implicitValue();
 
     public abstract boolean maybeFinalizeOnRead(Describable displayName, @Nullable ModelObject producer, ValueSupplier.ValueConsumer consumer);
@@ -290,6 +292,13 @@ public abstract class ValueState<S> {
         }
 
         @Override
+        public S implicitValue(S newConvention) {
+            explicitValue = false;
+            setConvention(newConvention);
+            return shallowCopy(convention);
+        }
+
+        @Override
         public S applyConvention(S value, S convention) {
             this.convention = convention;
             if (!explicitValue) {
@@ -377,6 +386,11 @@ public abstract class ValueState<S> {
 
         @Override
         public S implicitValue() {
+            throw unexpected();
+        }
+
+        @Override
+        public S implicitValue(S defaultValue) {
             throw unexpected();
         }
 

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
@@ -38,7 +38,7 @@ abstract class CollectionPropertySpec<C extends Collection<String>> extends Prop
     @Override
     AbstractCollectionProperty<String, C> propertyWithNoValue() {
         def p = property()
-        p.unset()
+        p.set((List) null)
         return p
     }
 
@@ -1591,6 +1591,20 @@ The value of this property is derived from: <source>""")
     def "property is empty when setToConventionIfUnset if convention not set yet"() {
         when:
         property.setToConventionIfUnset()
+
+        then:
+        assertValueIs([])
+        !property.explicit
+    }
+
+    def "property is restored to initial state after unset"() {
+        expect:
+        assertValueIs([])
+        !property.explicit
+
+        when:
+        property.add('1')
+        property.unset()
 
         then:
         assertValueIs([])

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
@@ -78,9 +78,11 @@ abstract class CollectionPropertySpec<C extends Collection<String>> extends Prop
 
     def property = property()
 
-    protected void assertValueIs(Collection<String> expected, PropertyInternal<?> property = this.property) {
-        assert property.present
-        def actual = property.get()
+    protected void assertValueIs(C expected, PropertyInternal<?> property = this.property) {
+        assertPropertyValueIs(expected, property)
+    }
+
+    protected void assertEqualValues(C expected, C actual) {
         assert actual instanceof ImmutableCollection
         assert immutableCollectionType.isInstance(actual)
         assertCollectionIs(actual, expected)
@@ -1591,20 +1593,6 @@ The value of this property is derived from: <source>""")
     def "property is empty when setToConventionIfUnset if convention not set yet"() {
         when:
         property.setToConventionIfUnset()
-
-        then:
-        assertValueIs([])
-        !property.explicit
-    }
-
-    def "property is restored to initial state after unset"() {
-        expect:
-        assertValueIs([])
-        !property.explicit
-
-        when:
-        property.add('1')
-        property.unset()
 
         then:
         assertValueIs([])

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
@@ -1977,4 +1977,18 @@ The value of this property is derived from: <source>""")
         // The following case abuses Groovy lax type-checking to put an invalid value into the property.
         "[k: (Object) provider {v}]" | { property().value(k: Providers.of("v")) }              || "Map(String->String, {k=fixed(class ${String.name}, v)})"
     }
+
+    def "property is restored to initial state after unset"() {
+        expect:
+        assertValueIs([:])
+        !property.explicit
+
+        when:
+        property.put('k1', 'v1')
+        property.unset()
+
+        then:
+        assertValueIs([:])
+        !property.explicit
+    }
 }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
@@ -1487,7 +1487,7 @@ The value of this property is derived from: <source>""")
         def execTimeValue = property.calculateExecutionTimeValue()
 
         then:
-        assertMapIs([b: '2', c: '3', d: '4'], execTimeValue.toValue().get())
+        assertEqualValues([b: '2', c: '3', d: '4'], execTimeValue.toValue().get())
     }
 
     def "execution time value is missing if any undefined-safe operations are performed in the tail"() {
@@ -1651,14 +1651,11 @@ The value of this property is derived from: <source>""")
         return brokenSupplier(String)
     }
 
-    private void assertValueIs(Map<String, String> expected, MapProperty<String, String> property = this.property) {
-        assert property.present
-        def actual = property.get()
-        assertImmutable(actual)
-        assertMapIs(expected, actual)
+    protected void assertValueIs(Map<String, String> expected, MapProperty<String, String> property = this.property) {
+        assertPropertyValueIs(expected, property)
     }
 
-    protected void assertMapIs(Map<String, String> expected, Map<String, String> actual) {
+    protected void assertEqualValues(Map<String, String> expected, Map<String, String> actual) {
         actual.each {
             assert it.key instanceof String
             assert it.value instanceof String
@@ -1976,19 +1973,5 @@ The value of this property is derived from: <source>""")
 
         // The following case abuses Groovy lax type-checking to put an invalid value into the property.
         "[k: (Object) provider {v}]" | { property().value(k: Providers.of("v")) }              || "Map(String->String, {k=fixed(class ${String.name}, v)})"
-    }
-
-    def "property is restored to initial state after unset"() {
-        expect:
-        assertValueIs([:])
-        !property.explicit
-
-        when:
-        property.put('k1', 'v1')
-        property.unset()
-
-        then:
-        assertValueIs([:])
-        !property.explicit
     }
 }

--- a/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
@@ -64,6 +64,16 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
 
     def host = Mock(PropertyHost)
 
+    protected void assertPropertyValueIs(T expected, PropertyInternal<?> property) {
+        assert property.present
+        T actual = property.get()
+        assertEqualValues(expected, actual)
+    }
+
+    protected void assertEqualValues(T expected, T actual) {
+        assert actual == expected
+    }
+
     def "cannot get value when it has none"() {
         given:
         def property = propertyWithNoValue()
@@ -194,6 +204,25 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         property.getOrNull() == someValue()
         property.getOrElse(someOtherValue()) == someValue()
         property.getOrElse(null) == someValue()
+    }
+
+
+    def "property is restored to initial state after unset"() {
+        given:
+        def property = propertyWithNoValue()
+        property.set(someValue())
+
+        expect:
+        assertPropertyValueIs(someValue(), property)
+        property.explicit
+
+        when:
+        property.unset()
+
+        then:
+        !property.present
+        property.getOrNull() == null
+        property.getOrElse(someOtherValue()) == someOtherValue()
     }
 
     def "fails when untyped value is set using incompatible type"() {


### PR DESCRIPTION

```gradle
// build.gradle
task demo {
    def list = objects.listProperty(Integer)
    doLast {    
        assert list.orNull == []
        
        // the initial state above is impossible to recreate if you make any changes
        list.add(1)
        assert list.orNull == [1]

        list.set([]) // `unset()` would cause the assertion below to fail  
        assert list.orNull == []

        // conventions don't kick in anymore
        list.convention([1, 2, 3])
        assert list.orNull == [1, 2, 3]
    }
}
```