### PR TITLE
Auto apply Develocity plugin v3.17

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheEnterprisePluginIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheEnterprisePluginIntegrationTest.groovy
@@ -93,15 +93,15 @@ class ConfigurationCacheEnterprisePluginIntegrationTest extends AbstractConfigur
     }
 
     @Issue("https://github.com/gradle/gradle/issues/19047")
-    def "precompiled script plugin can use lambda expression with enterprise plugin"() {
+    def "precompiled script plugin can use lambda expression with develocity plugin"() {
         given:
         createDir('ge-conventions') {
             file('src/main/kotlin/ge-conventions.settings.gradle.kts') << '''
                 plugins {
-                    com.gradle.enterprise
+                    com.gradle.develocity
                 }
 
-                gradleEnterprise {
+                develocity {
                     buildScan.obfuscation.hostname {
                         // lambda expression
                         "unset"
@@ -136,7 +136,7 @@ class ConfigurationCacheEnterprisePluginIntegrationTest extends AbstractConfigur
     static String getGeConventionsConfig() {
         """
             dependencies {
-                implementation("com.gradle:gradle-enterprise-gradle-plugin:${AutoAppliedGradleEnterprisePlugin.VERSION}")
+                implementation("com.gradle:develocity-gradle-plugin:${AutoAppliedGradleEnterprisePlugin.VERSION}")
             }
             ${KotlinDslTestUtil.kotlinDslBuildSrcConfig}
             repositories.gradlePluginPortal()

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecExtensions.kt
@@ -25,15 +25,15 @@ import org.gradle.plugin.use.PluginDependencySpec
  *
  * Visit the [Develocity Plugin User Manual](https://docs.gradle.com/enterprise/gradle-plugin/) for additional information.
  *
- * By default, the applied plugin version will be "3.16.2", which is the last version of the Gradle Enterprise plugin.
- * To apply later versions, use `develocity` plugin instead.
+ * By default, the applied plugin version will be the same as the one used by the `--scan` command line option.
  *
  * You can also use e.g. `` `gradle-enterprise` version "3.0" `` to request a different version.
  *
  * @since 6.0
  */
+@Deprecated("use `develocity` instead", replaceWith = ReplaceWith("`develocity`"))
 val PluginDependenciesSpec.`gradle-enterprise`: PluginDependencySpec
-    get() = this.id(AutoAppliedGradleEnterprisePlugin.GRADLE_ENTERPRISE_PLUGIN_ID.id).version(AutoAppliedGradleEnterprisePlugin.LAST_GRADLE_ENTERPRISE_PLUGIN_VERSION)
+    get() = this.id(AutoAppliedGradleEnterprisePlugin.GRADLE_ENTERPRISE_PLUGIN_ID.id).version(AutoAppliedGradleEnterprisePlugin.VERSION)
 
 
 /**

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecExtensions.kt
@@ -15,6 +15,7 @@
  */
 package org.gradle.kotlin.dsl
 
+import org.gradle.api.Incubating
 import org.gradle.plugin.management.internal.autoapply.AutoAppliedGradleEnterprisePlugin
 import org.gradle.plugin.use.PluginDependenciesSpec
 import org.gradle.plugin.use.PluginDependencySpec
@@ -31,7 +32,6 @@ import org.gradle.plugin.use.PluginDependencySpec
  *
  * @since 6.0
  */
-@Deprecated("use `develocity` instead", replaceWith = ReplaceWith("`develocity`"))
 val PluginDependenciesSpec.`gradle-enterprise`: PluginDependencySpec
     get() = this.id(AutoAppliedGradleEnterprisePlugin.GRADLE_ENTERPRISE_PLUGIN_ID.id).version(AutoAppliedGradleEnterprisePlugin.VERSION)
 
@@ -45,7 +45,8 @@ val PluginDependenciesSpec.`gradle-enterprise`: PluginDependencySpec
  *
  * You can also use e.g. `` `develocity` version "3.17" `` to request a different version.
  *
- * @since 8.7
+ * @since 8.8
  */
-val PluginDependenciesSpec.`develocity`: PluginDependencySpec
+@get:Incubating
+val PluginDependenciesSpec.develocity: PluginDependencySpec
     get() = this.id(AutoAppliedGradleEnterprisePlugin.ID.id).version(AutoAppliedGradleEnterprisePlugin.VERSION)

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecExtensions.kt
@@ -25,11 +25,27 @@ import org.gradle.plugin.use.PluginDependencySpec
  *
  * Visit the [Build Scan Plugin User Manual](https://docs.gradle.com/build-scan-plugin/) for additional information.
  *
- * By default, the applied plugin version will be the same as the one used by the `--scan` command line option.
+ * By default, the applied plugin version will be "3.16.2", which is the last version of the Gradle Enterprise plugin.
+ * To apply later versions, use `develocity` plugin instead.
  *
  * You can also use e.g. `` `gradle-enterprise` version "3.0" `` to request a different version.
  *
  * @since 6.0
  */
 val PluginDependenciesSpec.`gradle-enterprise`: PluginDependencySpec
+    get() = this.id(AutoAppliedGradleEnterprisePlugin.GRADLE_ENTERPRISE_PLUGIN_ID.id).version(AutoAppliedGradleEnterprisePlugin.LAST_GRADLE_ENTERPRISE_PLUGIN_VERSION)
+
+
+/**
+ * The `develocity` plugin.
+ *
+ * Visit the [Build Scan Plugin User Manual](https://docs.gradle.com/enterprise/gradle-plugin/) for additional information.
+ *
+ * By default, the applied plugin version will be the same as the one used by the `--scan` command line option.
+ *
+ * You can also use e.g. `` `develocity` version "3.17" `` to request a different version.
+ *
+ * @since 8.7
+ */
+val PluginDependenciesSpec.`develocity`: PluginDependencySpec
     get() = this.id(AutoAppliedGradleEnterprisePlugin.ID.id).version(AutoAppliedGradleEnterprisePlugin.VERSION)

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecExtensions.kt
@@ -23,7 +23,7 @@ import org.gradle.plugin.use.PluginDependencySpec
 /**
  * The `gradle-enterprise` plugin.
  *
- * Visit the [Build Scan Plugin User Manual](https://docs.gradle.com/build-scan-plugin/) for additional information.
+ * Visit the [Develocity Plugin User Manual](https://docs.gradle.com/enterprise/gradle-plugin/) for additional information.
  *
  * By default, the applied plugin version will be "3.16.2", which is the last version of the Gradle Enterprise plugin.
  * To apply later versions, use `develocity` plugin instead.
@@ -39,7 +39,7 @@ val PluginDependenciesSpec.`gradle-enterprise`: PluginDependencySpec
 /**
  * The `develocity` plugin.
  *
- * Visit the [Build Scan Plugin User Manual](https://docs.gradle.com/enterprise/gradle-plugin/) for additional information.
+ * Visit the [Develocity Plugin User Manual](https://docs.gradle.com/enterprise/gradle-plugin/) for additional information.
  *
  * By default, the applied plugin version will be the same as the one used by the `--scan` command line option.
  *

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecScopeTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecScopeTest.kt
@@ -46,7 +46,7 @@ class PluginDependenciesSpecScopeTest {
 
     @Test
     fun `given gradle-enterprise plugin accessor, it should create a single request matching the auto-applied plugin version`() {
-        expecting(plugin(id = "com.gradle.enterprise", version = AutoAppliedGradleEnterprisePlugin.VERSION)) {
+        expecting(plugin(id = "com.gradle.enterprise", version = AutoAppliedGradleEnterprisePlugin.LAST_GRADLE_ENTERPRISE_PLUGIN_VERSION)) {
             `gradle-enterprise`
         }
     }
@@ -55,6 +55,20 @@ class PluginDependenciesSpecScopeTest {
     fun `given gradle-enterprise plugin accessor with version, it should create a single request with given version`() {
         expecting(plugin(id = "com.gradle.enterprise", version = "1.7.1")) {
             `gradle-enterprise` version "1.7.1"
+        }
+    }
+
+    @Test
+    fun `given develocity plugin accessor, it should create a single request matching the auto-applied plugin version`() {
+        expecting(plugin(id = "com.gradle.develocity", version = AutoAppliedGradleEnterprisePlugin.VERSION)) {
+            `develocity`
+        }
+    }
+
+    @Test
+    fun `given develocity plugin accessor with version, it should create a single request with given version`() {
+        expecting(plugin(id = "com.gradle.develocity", version = "1.7.1")) {
+            `develocity` version "1.7.1"
         }
     }
 

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecScopeTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecScopeTest.kt
@@ -46,7 +46,7 @@ class PluginDependenciesSpecScopeTest {
 
     @Test
     fun `given gradle-enterprise plugin accessor, it should create a single request matching the auto-applied plugin version`() {
-        expecting(plugin(id = "com.gradle.enterprise", version = AutoAppliedGradleEnterprisePlugin.LAST_GRADLE_ENTERPRISE_PLUGIN_VERSION)) {
+        expecting(plugin(id = "com.gradle.enterprise", version = AutoAppliedGradleEnterprisePlugin.VERSION)) {
             `gradle-enterprise`
         }
     }

--- a/platforms/documentation/docs/src/docs/userguide/reference/ci-systems/github-actions.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/ci-systems/github-actions.adoc
@@ -150,7 +150,7 @@ image::ci-systems/github-actions-workflows.png[View workflow executions]
 
 === See the results for GitHub Actions workflow run
 
-Clicking on the link for a workflow run will show the details of the workflow run, 
+Clicking on the link for a workflow run will show the details of the workflow run,
 including a summary of all Gradle builds with links to any Build Scan published.
 
 TIP: Configuring link:https://scans.gradle.com/[build scans] is especially helpful on cloud CI systems like GitHub Actions because it has additional environment and test results information that are difficult to obtain otherwise.
@@ -179,10 +179,10 @@ image::ci-systems/github-actions-cache-details.png[View cache entry details]
 link:https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-supply-chain-security[GitHub supply chain security] features will detect and alert about any dependencies that have known vulnerabilities.
 In order to do this, GitHub requires a complete dependency graph for your project.
 
-NOTE: Ensure that you have both link:https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/configuring-the-dependency-graph[Dependency graph] 
+NOTE: Ensure that you have both link:https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/configuring-the-dependency-graph[Dependency graph]
 and link:https://docs.github.com/en/code-security/dependabot/dependabot-alerts/configuring-dependabot-alerts#managing-dependabot-alerts-for-your-repository[Dependabot alerts] enabled for your repository.
 
-The link:https://github.com/gradle/actions/tree/main/dependency-submission[dependency-submission] action for Gradle provides the simplest way to generate a dependency graph for your project. 
+The link:https://github.com/gradle/actions/tree/main/dependency-submission[dependency-submission] action for Gradle provides the simplest way to generate a dependency graph for your project.
 This action will attempt to detect and upload a list of all dependencies used by your build.
 
 We recommend a separate GitHub Actions workflow for dependency submission. Create a GitHub Actions workflow by adding a `.github/workflows/<workflow-name>.yml` file to your repository.
@@ -245,7 +245,7 @@ image::ci-systems/github-actions-dependency-alerts.png[View dependency alerts]
 In some cases, resolving a vulnerability is as easy as updating a dependency declaration in your project.
 In other cases, when the dependency is transitive or is part of a plugin classpath, the solution is not so simple.
 
-Please refer to the link:https://github.com/gradle/actions/blob/main/docs/dependency-submission.md[dependency-submission] documentation, 
+Please refer to the link:https://github.com/gradle/actions/blob/main/docs/dependency-submission.md[dependency-submission] documentation,
 together with the link:https://github.com/gradle/github-dependency-submission-demo[github-dependency-submission-demo] repository to learn more.
 
 == Further reading

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/DevelocityPluginCheckInFixture.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/DevelocityPluginCheckInFixture.groovy
@@ -28,10 +28,10 @@ class DevelocityPluginCheckInFixture extends BaseBuildScanPluginCheckInFixture {
             projectDir,
             mavenRepo,
             pluginBuildExecuter,
-            AutoAppliedGradleEnterprisePlugin.DEVELOCITY_PLUGIN_ID.id,
+            AutoAppliedGradleEnterprisePlugin.ID.id,
             'com.gradle.develocity.agent.gradle',
             'DevelocityPlugin',
-            AutoAppliedGradleEnterprisePlugin.DEVELOCITY_PLUGIN_ARTIFACT_NAME
+            AutoAppliedGradleEnterprisePlugin.NAME
         )
     }
 

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginBuildOperationNotificationsIntegrationTest.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginBuildOperationNotificationsIntegrationTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
 class GradleEnterprisePluginBuildOperationNotificationsIntegrationTest extends AbstractIntegrationSpec {
 
-    def plugin = new GradleEnterprisePluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
+    def plugin = new DevelocityPluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
 
     def setup() {
         settingsFile << plugin.pluginManagement() << plugin.plugins()

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginBuildStateIntegrationTest.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginBuildStateIntegrationTest.groovy
@@ -26,7 +26,7 @@ import org.gradle.internal.time.Clock
 
 class GradleEnterprisePluginBuildStateIntegrationTest extends AbstractIntegrationSpec {
 
-    def plugin = new GradleEnterprisePluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
+    def plugin = new DevelocityPluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
 
     def setup() {
         settingsFile << plugin.pluginManagement() << plugin.plugins()

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInFixture.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInFixture.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInFixture.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInFixture.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,10 +28,10 @@ class GradleEnterprisePluginCheckInFixture extends BaseBuildScanPluginCheckInFix
             projectDir,
             mavenRepo,
             pluginBuildExecuter,
-            AutoAppliedGradleEnterprisePlugin.ID.id,
+            AutoAppliedGradleEnterprisePlugin.GRADLE_ENTERPRISE_PLUGIN_ID.id,
             'com.gradle.enterprise.gradleplugin',
             'GradleEnterprisePlugin',
-            AutoAppliedGradleEnterprisePlugin.NAME
+            AutoAppliedGradleEnterprisePlugin.GRADLE_ENTERPRISE_PLUGIN_ARTIFACT_NAME
         )
     }
 

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInIntegrationTest.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInIntegrationTest.groovy
@@ -32,7 +32,7 @@ import static org.gradle.internal.enterprise.impl.DefaultGradleEnterprisePluginC
 
 class GradleEnterprisePluginCheckInIntegrationTest extends AbstractIntegrationSpec {
 
-    def plugin = new GradleEnterprisePluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
+    def plugin = new DevelocityPluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
 
     def setup() {
         settingsFile << plugin.pluginManagement()
@@ -116,7 +116,7 @@ class GradleEnterprisePluginCheckInIntegrationTest extends AbstractIntegrationSp
         output.contains("present: ${applied}")
 
         and:
-        output.contains("gradleEnterprisePlugin.checkIn.unsupported.reasonMessage = $UNSUPPORTED_PLUGIN_DUE_TO_CONFIGURATION_CACHING_MESSAGE") != applied
+        output.contains("develocityPlugin.checkIn.unsupported.reasonMessage = $UNSUPPORTED_PLUGIN_DUE_TO_CONFIGURATION_CACHING_MESSAGE") != applied
 
         where:
         pluginVersion                               | applied
@@ -141,7 +141,7 @@ class GradleEnterprisePluginCheckInIntegrationTest extends AbstractIntegrationSp
         output.contains("present: ${applied}")
 
         and:
-        output.contains("gradleEnterprisePlugin.checkIn.unsupported.reasonMessage = $UNSUPPORTED_PLUGIN_DUE_TO_ISOLATED_PROJECTS_MESSAGE") != applied
+        output.contains("develocityPlugin.checkIn.unsupported.reasonMessage = $UNSUPPORTED_PLUGIN_DUE_TO_ISOLATED_PROJECTS_MESSAGE") != applied
 
         where:
         pluginVersion                           | applied

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginConfigIntegrationTest.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginConfigIntegrationTest.groovy
@@ -31,7 +31,7 @@ import static org.gradle.internal.enterprise.GradleEnterprisePluginConfig.BuildS
 
 class GradleEnterprisePluginConfigIntegrationTest extends AbstractIntegrationSpec {
 
-    def plugin = new GradleEnterprisePluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
+    def plugin = new DevelocityPluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
 
     def setup() {
         settingsFile << plugin.pluginManagement()
@@ -95,7 +95,7 @@ class GradleEnterprisePluginConfigIntegrationTest extends AbstractIntegrationSpe
                 }
             }
 
-            apply plugin: 'com.gradle.enterprise'
+            apply plugin: 'com.gradle.develocity'
         """
 
         when:
@@ -106,13 +106,13 @@ class GradleEnterprisePluginConfigIntegrationTest extends AbstractIntegrationSpe
 
         where:
         groupId                                 | artifactId
-        'com.gradle'                            | 'gradle-enterprise-gradle-plugin'
+        'com.gradle'                            | 'develocity-gradle-plugin'
         AutoAppliedGradleEnterprisePlugin.ID.id | "${AutoAppliedGradleEnterprisePlugin.ID.id}.gradle.plugin"
     }
 
     def "is auto-applied when --scan is used despite init script"() {
         given:
-        def pluginArtifactId = "com.gradle:gradle-enterprise-gradle-plugin:${plugin.runtimeVersion}"
+        def pluginArtifactId = "com.gradle:develocity-gradle-plugin:${plugin.runtimeVersion}"
         def initScript = file("build-scan-init.gradle") << """
             initscript {
                 repositories {
@@ -143,7 +143,7 @@ class GradleEnterprisePluginConfigIntegrationTest extends AbstractIntegrationSpe
     @ToBeImplemented("https://github.com/gradle/gradle/issues/24884")
     def "is not auto-applied when --scan is used and applied via init script in beforeSettings"() {
         given:
-        def pluginArtifactId = "com.gradle:gradle-enterprise-gradle-plugin:${plugin.runtimeVersion}"
+        def pluginArtifactId = "com.gradle:develocity-gradle-plugin:${plugin.runtimeVersion}"
         def initScript = file("build-scan-init.gradle") << """
             initscript {
                 repositories {
@@ -155,14 +155,14 @@ class GradleEnterprisePluginConfigIntegrationTest extends AbstractIntegrationSpe
             }
             gradle.beforeSettings { settings ->
                 settings.buildscript.repositories { maven { url '${mavenRepo.uri}' } }
-                settings.buildscript.dependencies.classpath("com.gradle:gradle-enterprise-gradle-plugin:${plugin.runtimeVersion}")
+                settings.buildscript.dependencies.classpath("com.gradle:develocity-gradle-plugin:${plugin.runtimeVersion}")
             }
             gradle.settingsEvaluated { settings ->
                 if (settings.pluginManager.hasPlugin('${plugin.id}')) {
                     logger.lifecycle("${plugin.id} is already applied")
                 } else {
                     logger.lifecycle("Applying ${plugin.id} via init script")
-                    settings.pluginManager.apply("com.gradle.enterprise")
+                    settings.pluginManager.apply("com.gradle.develocity")
                 }
             }
         """

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginConfigurationCachingIntegrationTest.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginConfigurationCachingIntegrationTest.groovy
@@ -33,7 +33,7 @@ import static org.gradle.internal.enterprise.GradleEnterprisePluginConfig.BuildS
 @Requires(IntegTestPreconditions.NotConfigCached)
 class GradleEnterprisePluginConfigurationCachingIntegrationTest extends AbstractIntegrationSpec {
 
-    def plugin = new GradleEnterprisePluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
+    def plugin = new DevelocityPluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
 
     def setup() {
         settingsFile << plugin.pluginManagement() << plugin.plugins()

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginEndOfBuildCallbackIntegrationTest.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginEndOfBuildCallbackIntegrationTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
 class GradleEnterprisePluginEndOfBuildCallbackIntegrationTest extends AbstractIntegrationSpec {
 
-    def plugin = new GradleEnterprisePluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
+    def plugin = new DevelocityPluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
 
     def setup() {
         settingsFile << plugin.pluginManagement() << plugin.plugins()

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginRequiredServicesIntegrationTest.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginRequiredServicesIntegrationTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.internal.logging.text.StyledTextOutputFactory
 
 class GradleEnterprisePluginRequiredServicesIntegrationTest extends AbstractIntegrationSpec {
 
-    def plugin = new GradleEnterprisePluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
+    def plugin = new DevelocityPluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
 
     def setup() {
         settingsFile << plugin.pluginManagement() << plugin.plugins()

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/core/BuildScanAutoApplyClasspathIntegrationTest.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/core/BuildScanAutoApplyClasspathIntegrationTest.groovy
@@ -18,8 +18,8 @@ package org.gradle.internal.enterprise.core
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.internal.enterprise.BaseBuildScanPluginCheckInFixture
-import org.gradle.internal.enterprise.DevelocityPluginCheckInFixture
 import org.gradle.internal.enterprise.GradleEnterprisePluginCheckInFixture
+import org.gradle.internal.enterprise.DevelocityPluginCheckInFixture
 import org.gradle.internal.enterprise.impl.DefaultGradleEnterprisePluginCheckInService
 import org.gradle.util.internal.VersionNumber
 
@@ -27,13 +27,13 @@ abstract class BuildScanAutoApplyClasspathIntegrationTest extends AbstractIntegr
 
     private static final VersionNumber PLUGIN_MINIMUM_NON_DEPRECATED_VERSION = DefaultGradleEnterprisePluginCheckInService.MINIMUM_SUPPORTED_PLUGIN_VERSION_SINCE_GRADLE_9
 
-    protected final GradleEnterprisePluginCheckInFixture autoAppliedPluginFixture = new GradleEnterprisePluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
+    protected final DevelocityPluginCheckInFixture autoAppliedPluginFixture = new DevelocityPluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
 
     abstract BaseBuildScanPluginCheckInFixture getTransitivePluginFixture()
 
     abstract void assertNotAutoApplied(String output)
 
-    static class GradleEnterpriseAutoApplyClasspathIntegrationTest extends BuildScanAutoApplyClasspathIntegrationTest {
+    static class DevelocityAutoApplyClasspathIntegrationTest extends BuildScanAutoApplyClasspathIntegrationTest {
 
         @Override
         BaseBuildScanPluginCheckInFixture getTransitivePluginFixture() {
@@ -42,24 +42,24 @@ abstract class BuildScanAutoApplyClasspathIntegrationTest extends AbstractIntegr
 
         @Override
         void assertNotAutoApplied(String output) {
-            // GE plugin is transitively applied, but not via auto-application mechanism
+            // Develocity plugin is transitively applied, but not via auto-application mechanism
             autoAppliedPluginFixture.assertAutoApplied(output, false)
         }
     }
 
-    static class DevelocityAutoApplyClasspathIntegrationTest extends BuildScanAutoApplyClasspathIntegrationTest {
+    static class GradleEnterpriseAutoApplyClasspathIntegrationTest extends BuildScanAutoApplyClasspathIntegrationTest {
 
-        private final DevelocityPluginCheckInFixture develocityFixture = new DevelocityPluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
+        private final GradleEnterprisePluginCheckInFixture gradleEnterpriseFixture = new GradleEnterprisePluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
 
         @Override
         BaseBuildScanPluginCheckInFixture getTransitivePluginFixture() {
-            // GE plugin is auto-applied but the Develocity plugin is a transitive dependency
-            develocityFixture
+            // Develocity plugin is auto-applied but the Gradle Enterprise plugin is a transitive dependency
+            gradleEnterpriseFixture
         }
 
         @Override
         void assertNotAutoApplied(String output) {
-            // GE plugin is applied neither as a transitive dependency, nor via auto-application mechanism as Develocity plugin is present
+            // Develocity plugin is applied neither as a transitive dependency, nor via auto-application mechanism as Gradle Enterprise plugin is present
             autoAppliedPluginFixture.notApplied(output)
         }
     }
@@ -82,7 +82,7 @@ abstract class BuildScanAutoApplyClasspathIntegrationTest extends AbstractIntegr
 
             gradlePlugin {
                 plugins {
-                    enterprise {
+                    develocity {
                         id = 'my.plugin'
                         implementationClass = 'org.gradle.reproducer.MyPlugin'
                     }

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/core/BuildScanAutoApplyIntegrationTest.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/core/BuildScanAutoApplyIntegrationTest.groovy
@@ -18,8 +18,8 @@ package org.gradle.internal.enterprise.core
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-import org.gradle.internal.enterprise.DevelocityPluginCheckInFixture
 import org.gradle.internal.enterprise.GradleEnterprisePluginCheckInFixture
+import org.gradle.internal.enterprise.DevelocityPluginCheckInFixture
 import org.gradle.internal.enterprise.impl.DefaultGradleEnterprisePluginCheckInService
 import org.gradle.internal.enterprise.impl.legacy.LegacyGradleEnterprisePluginCheckInService
 import org.gradle.plugin.management.internal.autoapply.AutoAppliedGradleEnterprisePlugin
@@ -36,8 +36,8 @@ class BuildScanAutoApplyIntegrationTest extends AbstractIntegrationSpec {
 
     private static final VersionNumber PLUGIN_MINIMUM_NON_DEPRECATED_VERSION = DefaultGradleEnterprisePluginCheckInService.MINIMUM_SUPPORTED_PLUGIN_VERSION_SINCE_GRADLE_9
 
-    private final GradleEnterprisePluginCheckInFixture fixture = new GradleEnterprisePluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
-    private final DevelocityPluginCheckInFixture develocityFixture = new DevelocityPluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
+    private final DevelocityPluginCheckInFixture fixture = new DevelocityPluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
+    private final GradleEnterprisePluginCheckInFixture gradleEnterpriseFixture = new GradleEnterprisePluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
 
     def setup() {
         buildFile << """
@@ -148,7 +148,7 @@ class BuildScanAutoApplyIntegrationTest extends AbstractIntegrationSpec {
                     maven { url '${mavenRepo.uri}' }
                 }
                 dependencies {
-                    classpath '${"com.gradle:gradle-enterprise-gradle-plugin:$version"}'
+                    classpath '${"com.gradle:develocity-gradle-plugin:$version"}'
                 }
             }
             apply plugin: '$fixture.id'
@@ -183,7 +183,7 @@ class BuildScanAutoApplyIntegrationTest extends AbstractIntegrationSpec {
                 }
 
                 dependencies {
-                    classpath '${"com.gradle:gradle-enterprise-gradle-plugin:$version"}'
+                    classpath '${"com.gradle:develocity-gradle-plugin:$version"}'
                 }
             }
 
@@ -324,10 +324,10 @@ class BuildScanAutoApplyIntegrationTest extends AbstractIntegrationSpec {
         fixture.issuedNoPluginWarningCount(output, 1)
     }
 
-    def "does not auto-apply plugin when Develocity plugin is applied using plugin ID"() {
+    def "does not auto-apply plugin when Gradle Enterprise plugin is applied using plugin ID"() {
         when:
-        develocityFixture.publishDummyPlugin(executer)
-        settingsFile << develocityFixture.plugins()
+        gradleEnterpriseFixture.publishDummyPlugin(executer)
+        settingsFile << gradleEnterpriseFixture.plugins()
 
         and:
         runBuildWithScanRequest()
@@ -336,19 +336,19 @@ class BuildScanAutoApplyIntegrationTest extends AbstractIntegrationSpec {
         pluginNotApplied()
     }
 
-    def "does not auto-apply plugin when Develocity plugin is applied using plugin class name"() {
+    def "does not auto-apply plugin when Gradle Enterprise plugin is applied using plugin class name"() {
         when:
-        develocityFixture.publishDummyPlugin(executer)
+        gradleEnterpriseFixture.publishDummyPlugin(executer)
         settingsFile.text = """
             buildscript {
                 repositories {
                     maven { url '${mavenRepo.uri}' }
                 }
                 dependencies {
-                    classpath '${"com.gradle:develocity-gradle-plugin:${develocityFixture.runtimeVersion}"}'
+                    classpath '${"com.gradle:gradle-enterprise-gradle-plugin:${gradleEnterpriseFixture.runtimeVersion}"}'
                 }
             }
-            apply plugin: $develocityFixture.className
+            apply plugin: $gradleEnterpriseFixture.className
         """
 
         and:
@@ -358,12 +358,12 @@ class BuildScanAutoApplyIntegrationTest extends AbstractIntegrationSpec {
         pluginNotApplied()
     }
 
-    def "does not auto-apply plugin when Develocity plugin explicitly requested and not applied"() {
+    def "does not auto-apply plugin when Gradle Enterprise plugin explicitly requested and not applied"() {
         when:
-        develocityFixture.publishDummyPlugin(executer)
+        gradleEnterpriseFixture.publishDummyPlugin(executer)
         settingsFile << """
             plugins {
-                id '$develocityFixture.id' version '${develocityFixture.artifactVersion}' apply false
+                id '$gradleEnterpriseFixture.id' version '${gradleEnterpriseFixture.artifactVersion}' apply false
             }
         """
 
@@ -374,9 +374,9 @@ class BuildScanAutoApplyIntegrationTest extends AbstractIntegrationSpec {
         pluginNotApplied()
     }
 
-    def "does not auto-apply plugin when Develocity plugin is added to initscript classpath"() {
+    def "does not auto-apply plugin when Gradle Enterprise plugin is added to initscript classpath"() {
         when:
-        develocityFixture.publishDummyPlugin(executer)
+        gradleEnterpriseFixture.publishDummyPlugin(executer)
         file('init.gradle') << """
             initscript {
                 repositories {
@@ -384,12 +384,12 @@ class BuildScanAutoApplyIntegrationTest extends AbstractIntegrationSpec {
                 }
 
                 dependencies {
-                    classpath '${"com.gradle:develocity-gradle-plugin:${develocityFixture.runtimeVersion}"}'
+                    classpath '${"com.gradle:gradle-enterprise-gradle-plugin:${gradleEnterpriseFixture.runtimeVersion}"}'
                 }
             }
 
             beforeSettings {
-                it.apply plugin: $develocityFixture.className
+                it.apply plugin: $gradleEnterpriseFixture.className
             }
         """
 

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/core/BuildScanAutoApplyKotlinIntegrationTest.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/core/BuildScanAutoApplyKotlinIntegrationTest.groovy
@@ -17,13 +17,13 @@
 package org.gradle.internal.enterprise.core
 
 import org.gradle.integtests.fixtures.KotlinScriptIntegrationTest
-import org.gradle.internal.enterprise.GradleEnterprisePluginCheckInFixture
+import org.gradle.internal.enterprise.DevelocityPluginCheckInFixture
 
 import static org.gradle.initialization.StartParameterBuildOptions.BuildScanOption
 
 class BuildScanAutoApplyKotlinIntegrationTest extends KotlinScriptIntegrationTest {
 
-    private final GradleEnterprisePluginCheckInFixture fixture = new GradleEnterprisePluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
+    private final DevelocityPluginCheckInFixture fixture = new DevelocityPluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
 
     def "can automatically apply plugin when --scan is provided on command-line"() {
         given:

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/core/BuildScanBuildFailureHintIntegrationTest.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/core/BuildScanBuildFailureHintIntegrationTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.internal.enterprise.core
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.internal.enterprise.GradleEnterprisePluginCheckInFixture
+import org.gradle.internal.enterprise.DevelocityPluginCheckInFixture
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 import spock.lang.Issue
@@ -35,7 +35,7 @@ class BuildScanBuildFailureHintIntegrationTest extends AbstractIntegrationSpec {
     private static final List<String> DUMMY_TASK_ONLY = [DUMMY_TASK_NAME]
     private static final List<String> DUMMY_TASK_AND_BUILD_SCAN = [DUMMY_TASK_NAME, "--$BuildScanOption.LONG_OPTION"]
 
-    def fixture = new GradleEnterprisePluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
+    def fixture = new DevelocityPluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
 
     def setup() {
         settingsFile << fixture.pluginManagement()

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/legacy/GradleEnterprisePluginLegacyContactPointFixture.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/legacy/GradleEnterprisePluginLegacyContactPointFixture.groovy
@@ -111,7 +111,7 @@ class GradleEnterprisePluginLegacyContactPointFixture {
             println '$BUILD_SCAN_PLUGIN_APPLIED_MESSAGE'
         """, BUILD_SCAN_PLUGIN_ID, BUILD_SCAN_PLUGIN_CLASS_SIMPLE_NAME)
 
-        builder.publishAs("com.gradle:gradle-enterprise-gradle-plugin:${artifactVersion}", mavenRepo, pluginBuildExecuter)
+        builder.publishAs("com.gradle:develocity-gradle-plugin:${artifactVersion}", mavenRepo, pluginBuildExecuter)
     }
 
     void assertDisabled(String output, boolean disabled) {

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/GradleEnterpriseAutoAppliedPluginRegistry.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/GradleEnterpriseAutoAppliedPluginRegistry.java
@@ -50,17 +50,17 @@ public class GradleEnterpriseAutoAppliedPluginRegistry implements AutoAppliedPlu
         if (((StartParameterInternal) target.getStartParameter()).isUseEmptySettings() || !shouldApplyGradleEnterprisePlugin(target)) {
             return PluginRequests.EMPTY;
         } else {
-            return PluginRequests.of(createGradleEnterprisePluginRequest());
+            return PluginRequests.of(createDevelocityPluginRequest());
         }
     }
 
-    private boolean shouldApplyGradleEnterprisePlugin(Settings settings) {
+    private static boolean shouldApplyGradleEnterprisePlugin(Settings settings) {
         Gradle gradle = settings.getGradle();
         StartParameter startParameter = gradle.getStartParameter();
         return startParameter.isBuildScan() && gradle.getParent() == null;
     }
 
-    private PluginRequestInternal createGradleEnterprisePluginRequest() {
+    private static PluginRequestInternal createDevelocityPluginRequest() {
         ModuleIdentifier moduleIdentifier = DefaultModuleIdentifier.newId(AutoAppliedGradleEnterprisePlugin.GROUP, AutoAppliedGradleEnterprisePlugin.NAME);
         ModuleVersionSelector artifact = DefaultModuleVersionSelector.newSelector(moduleIdentifier, AutoAppliedGradleEnterprisePlugin.VERSION);
         return new DefaultPluginRequest(
@@ -72,14 +72,14 @@ public class GradleEnterpriseAutoAppliedPluginRegistry implements AutoAppliedPlu
             AutoAppliedGradleEnterprisePlugin.VERSION,
             artifact,
             null,
-            develocityPluginCoordinates()
+            gradleEnterprisePluginCoordinates()
         );
     }
 
-    private static PluginCoordinates develocityPluginCoordinates() {
-        ModuleIdentifier moduleIdentifier = DefaultModuleIdentifier.newId(AutoAppliedGradleEnterprisePlugin.GROUP, AutoAppliedGradleEnterprisePlugin.DEVELOCITY_PLUGIN_ARTIFACT_NAME);
+    private static PluginCoordinates gradleEnterprisePluginCoordinates() {
+        ModuleIdentifier moduleIdentifier = DefaultModuleIdentifier.newId(AutoAppliedGradleEnterprisePlugin.GROUP, AutoAppliedGradleEnterprisePlugin.GRADLE_ENTERPRISE_PLUGIN_ARTIFACT_NAME);
         ModuleVersionSelector artifact = DefaultModuleVersionSelector.newSelector(moduleIdentifier, AutoAppliedGradleEnterprisePlugin.VERSION);
-        return new PluginCoordinates(AutoAppliedGradleEnterprisePlugin.DEVELOCITY_PLUGIN_ID, artifact);
+        return new PluginCoordinates(AutoAppliedGradleEnterprisePlugin.GRADLE_ENTERPRISE_PLUGIN_ID, artifact);
     }
 
     private static String getScriptDisplayName() {

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedGradleEnterprisePlugin.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedGradleEnterprisePlugin.java
@@ -30,10 +30,12 @@ public final class AutoAppliedGradleEnterprisePlugin {
     public static final String NAME = "develocity-gradle-plugin";
     public static final String VERSION = "3.17";
 
-    public static final String GRADLE_ENTERPRISE_PLUGIN_ARTIFACT_NAME = "gradle-enterprise-gradle-plugin";
 
     public static final PluginId ID = new DefaultPluginId("com.gradle.develocity");
     public static final PluginId BUILD_SCAN_PLUGIN_ID = new DefaultPluginId("com.gradle.build-scan");
+
     public static final PluginId GRADLE_ENTERPRISE_PLUGIN_ID = new DefaultPluginId("com.gradle.enterprise");
+    public static final String GRADLE_ENTERPRISE_PLUGIN_ARTIFACT_NAME = "gradle-enterprise-gradle-plugin";
+    public static final String LAST_GRADLE_ENTERPRISE_PLUGIN_VERSION = "3.16.2";
 
 }

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedGradleEnterprisePlugin.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedGradleEnterprisePlugin.java
@@ -36,6 +36,5 @@ public final class AutoAppliedGradleEnterprisePlugin {
 
     public static final PluginId GRADLE_ENTERPRISE_PLUGIN_ID = new DefaultPluginId("com.gradle.enterprise");
     public static final String GRADLE_ENTERPRISE_PLUGIN_ARTIFACT_NAME = "gradle-enterprise-gradle-plugin";
-    public static final String LAST_GRADLE_ENTERPRISE_PLUGIN_VERSION = "3.16.2";
 
 }

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedGradleEnterprisePlugin.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedGradleEnterprisePlugin.java
@@ -27,13 +27,13 @@ import org.gradle.plugin.use.internal.DefaultPluginId;
 public final class AutoAppliedGradleEnterprisePlugin {
 
     public static final String GROUP = "com.gradle";
-    public static final String NAME = "gradle-enterprise-gradle-plugin";
-    public static final String VERSION = "3.16.2";
+    public static final String NAME = "develocity-gradle-plugin";
+    public static final String VERSION = "3.17";
 
-    public static final String DEVELOCITY_PLUGIN_ARTIFACT_NAME = "develocity-gradle-plugin";
+    public static final String GRADLE_ENTERPRISE_PLUGIN_ARTIFACT_NAME = "gradle-enterprise-gradle-plugin";
 
-    public static final PluginId ID = new DefaultPluginId("com.gradle.enterprise");
+    public static final PluginId ID = new DefaultPluginId("com.gradle.develocity");
     public static final PluginId BUILD_SCAN_PLUGIN_ID = new DefaultPluginId("com.gradle.build-scan");
-    public static final PluginId DEVELOCITY_PLUGIN_ID = new DefaultPluginId("com.gradle.develocity");
+    public static final PluginId GRADLE_ENTERPRISE_PLUGIN_ID = new DefaultPluginId("com.gradle.enterprise");
 
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/internal/scan/config/fixtures/ApplyGradleEnterprisePluginFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/internal/scan/config/fixtures/ApplyGradleEnterprisePluginFixture.groovy
@@ -30,7 +30,7 @@ class ApplyGradleEnterprisePluginFixture {
 
     static void applyEnterprisePlugin(File settingsFile) {
         def settingsText = settingsFile.text
-        def matcher = settingsText =~ /id[ (]["']com.gradle.enterprise["'][)]? version[ (]["'](.*)["'][)]?/
+        def matcher = settingsText =~ /id[ (]["']com.gradle.develocity["'][)]? version[ (]["'](.*)["'][)]?/
         if (matcher.find()) {
             settingsFile.text = settingsText.substring(0, matcher.start(1)) + VERSION + settingsText.substring(matcher.end(1))
         } else {

--- a/testing/internal-integ-testing/src/test/groovy/org/gradle/internal/scan/config/fixtures/ApplyGradleEnterprisePluginFixtureTest.groovy
+++ b/testing/internal-integ-testing/src/test/groovy/org/gradle/internal/scan/config/fixtures/ApplyGradleEnterprisePluginFixtureTest.groovy
@@ -34,7 +34,7 @@ class ApplyGradleEnterprisePluginFixtureTest extends Specification {
 
         then:
         file.text =="""plugins {
-            |    id("com.gradle.enterprise") version("${VERSION}")
+            |    id("com.gradle.develocity") version("${VERSION}")
             |}
             |
             |includeBuild '../lib'""".stripMargin()
@@ -64,7 +64,7 @@ class ApplyGradleEnterprisePluginFixtureTest extends Specification {
             |}
             |
             |plugins {
-            |    id("com.gradle.enterprise") version("${VERSION}")
+            |    id("com.gradle.develocity") version("${VERSION}")
             |}
             |
             |includeBuild '../lib'""".stripMargin()

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
@@ -28,7 +28,7 @@ import org.gradle.util.internal.VersionNumber
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.ConcurrentHashMap
 
-// https://plugins.gradle.org/plugin/com.gradle.enterprise
+// https://plugins.gradle.org/plugin/com.gradle.develocity
 class BuildScanPluginSmokeTest extends AbstractSmokeTest {
 
     enum CI {
@@ -155,6 +155,7 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
     private static final VersionNumber FIRST_VERSION_CALLING_BUILD_PATH = VersionNumber.parse("3.13.1")
     private static final VersionNumber FIRST_VERSION_BUNDLING_TEST_RETRY_PLUGIN = VersionNumber.parse("3.12")
     private static final VersionNumber FIRST_VERSION_SUPPORTING_SAFE_MODE = VersionNumber.parse("3.15")
+    private static final VersionNumber FIRST_VERSION_UNDER_DEVELOCITY_BRAND = VersionNumber.parse("3.17")
 
     private static final List<String> SUPPORTED_WITH_GRADLE_8_CONFIGURATION_CACHE = SUPPORTED
         .findAll { FIRST_VERSION_SUPPORTING_GRADLE_8_CONFIGURATION_CACHE <= VersionNumber.parse(it) }
@@ -307,6 +308,11 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
 
         expect:
         scanRunner("--init-script", initScript)
+            .maybeExpectLegacyDeprecationWarningIf(FIRST_VERSION_UNDER_DEVELOCITY_BRAND <= versionNumber,
+                "WARNING: The following functionality has been deprecated and will be removed in the next major release of the Develocity Gradle plugin:")
+            .maybeExpectLegacyDeprecationWarningIf(FIRST_VERSION_UNDER_DEVELOCITY_BRAND <= versionNumber,
+                "WARNING: The following functionality has been deprecated and will be removed in the next major release of the Develocity Gradle plugin. " +
+                    "For assistance with migration, see https://gradle.com/help/gradle-plugin-develocity-migration.")
             .expectLegacyDeprecationWarningIf(FIRST_VERSION_SUPPORTING_CHECK_IN_SERVICE <= versionNumber && versionNumber < FIRST_VERSION_CALLING_BUILD_PATH,
                 "Develocity plugin $pluginVersion has been deprecated. " +
                     "Starting with Gradle 9.0, only Develocity plugin 3.13.1 or newer is supported. " +

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
@@ -140,6 +140,7 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
         "3.16",
         "3.16.1",
         "3.16.2",
+        "3.17",
     ]
 
     // Current injection scripts support Develocity plugin 3.3 and above
@@ -338,8 +339,22 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
     }
 
     void usePluginVersion(String version) {
+        def develocityPlugin = VersionNumber.parse(version) >= VersionNumber.parse("3.17")
         def gradleEnterprisePlugin = VersionNumber.parse(version) >= VersionNumber.parse("3.0")
-        if (gradleEnterprisePlugin) {
+        if (develocityPlugin) {
+            settingsFile << """
+                plugins {
+                    id "com.gradle.develocity" version "$version"
+                }
+
+                develocity {
+                    buildScan {
+                        termsOfUseUrl = 'https://gradle.com/help/legal-terms-of-use'
+                        termsOfUseAgree = 'yes'
+                    }
+                }
+            """
+        } else if (gradleEnterprisePlugin) {
             settingsFile << """
                 plugins {
                     id "com.gradle.enterprise" version "$version"


### PR DESCRIPTION
### Context
This is the first PR related to the post-release activities for Develocity plugin 3.17 release. It makes sure that smoke tests run against the latest public version, and also updates the auto-application logic to apply the `com.gradle.develocity` plugin instead of `com.gradle.enterprise`.

_Note_: I did not rename all occurrences of "GE" or "Gradle Enterprise" to Develocity. I think it would be the best if the GBT team tackles this when they see need.