### PR TITLE
Use only type hierarchy as an input to MergeInstrumentationAnalysisTransform

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptClassPathResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptClassPathResolver.java
@@ -57,7 +57,6 @@ import static org.gradle.api.internal.initialization.DefaultScriptClassPathResol
 import static org.gradle.api.internal.initialization.DefaultScriptClassPathResolver.InstrumentationPhase.INSTRUMENTED_AND_UPGRADED;
 import static org.gradle.api.internal.initialization.DefaultScriptClassPathResolver.InstrumentationPhase.INSTRUMENTED_ONLY;
 import static org.gradle.api.internal.initialization.DefaultScriptClassPathResolver.InstrumentationPhase.NOT_INSTRUMENTED;
-import static org.gradle.api.internal.initialization.transform.utils.InstrumentationTransformUtils.ANALYSIS_FILE_NAME;
 
 public class DefaultScriptClassPathResolver implements ScriptClassPathResolver {
 
@@ -133,7 +132,7 @@ public class DefaultScriptClassPathResolver implements ScriptClassPathResolver {
         CacheInstrumentationDataBuildService buildService = resolutionContext.getBuildService().get();
         try (ResolutionScope resolutionScope = buildService.newResolutionScope(contextId)) {
             ArtifactView originalDependencies = getOriginalDependencies(classpathConfiguration);
-            resolutionScope.setAnalysisResult(getAnalysisResult(classpathConfiguration));
+            resolutionScope.setTypeHierarchyAnalysisResult(getAnalysisResult(classpathConfiguration));
             resolutionScope.setOriginalClasspath(originalDependencies.getFiles());
             ArtifactCollection instrumentedExternalDependencies = getInstrumentedExternalDependencies(classpathConfiguration);
             ArtifactCollection instrumentedProjectDependencies = getInstrumentedProjectDependencies(classpathConfiguration);
@@ -152,7 +151,7 @@ public class DefaultScriptClassPathResolver implements ScriptClassPathResolver {
             // We have to analyze external and project dependencies to get full hierarchies, since
             // for example user could use dependency substitution to replace external dependency with project dependency.
             config.componentFilter(componentId -> !isGradleApi(componentId));
-        }).getFiles().filter(file -> file.getName().equals(ANALYSIS_FILE_NAME));
+        }).getFiles();
     }
 
     private static ArtifactView getOriginalDependencies(Configuration classpathConfiguration) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptClassPathResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptClassPathResolver.java
@@ -53,6 +53,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.gradle.api.attributes.LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE;
 import static org.gradle.api.internal.initialization.DefaultScriptClassPathResolver.InstrumentationPhase.ANALYZED_ARTIFACT;
 import static org.gradle.api.internal.initialization.DefaultScriptClassPathResolver.InstrumentationPhase.INSTRUMENTED_AND_UPGRADED;
 import static org.gradle.api.internal.initialization.DefaultScriptClassPathResolver.InstrumentationPhase.INSTRUMENTED_ONLY;
@@ -113,7 +114,7 @@ public class DefaultScriptClassPathResolver implements ScriptClassPathResolver {
         AttributeContainer attributes = configuration.getAttributes();
         attributes.attribute(Usage.USAGE_ATTRIBUTE, instantiator.named(Usage.class, Usage.JAVA_RUNTIME));
         attributes.attribute(Category.CATEGORY_ATTRIBUTE, instantiator.named(Category.class, Category.LIBRARY));
-        attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, instantiator.named(LibraryElements.class, LibraryElements.JAR));
+        attributes.attribute(LIBRARY_ELEMENTS_ATTRIBUTE, instantiator.named(LibraryElements.class, LibraryElements.JAR));
         attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, instantiator.named(Bundling.class, Bundling.EXTERNAL));
         attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.parseInt(JavaVersion.current().getMajorVersion()));
         attributes.attribute(GradlePluginApiVersion.GRADLE_PLUGIN_API_VERSION_ATTRIBUTE, instantiator.named(GradlePluginApiVersion.class, GradleVersion.current().getVersion()));
@@ -145,9 +146,12 @@ public class DefaultScriptClassPathResolver implements ScriptClassPathResolver {
         }
     }
 
-    private static FileCollection getAnalysisResult(Configuration classpathConfiguration) {
+    private FileCollection getAnalysisResult(Configuration classpathConfiguration) {
         return classpathConfiguration.getIncoming().artifactView((Action<? super ArtifactView.ViewConfiguration>) config -> {
-            config.attributes(it -> it.attribute(INSTRUMENTED_ATTRIBUTE, ANALYZED_ARTIFACT.value));
+            config.attributes(attributes -> {
+                attributes.attribute(INSTRUMENTED_ATTRIBUTE, ANALYZED_ARTIFACT.value);
+                attributes.attribute(LIBRARY_ELEMENTS_ATTRIBUTE, instantiator.named(LibraryElements.class, LibraryElements.CLASSES));
+            });
             // We have to analyze external and project dependencies to get full hierarchies, since
             // for example user could use dependency substitution to replace external dependency with project dependency.
             config.componentFilter(componentId -> !isGradleApi(componentId));

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/ExternalDependencyInstrumentingArtifactTransform.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/ExternalDependencyInstrumentingArtifactTransform.java
@@ -42,7 +42,7 @@ public abstract class ExternalDependencyInstrumentingArtifactTransform extends B
         File input = getInput().get().getAsFile();
         InstrumentationInputType inputType = getInputType(input);
         switch (inputType) {
-            case ANALYSIS_DATA:
+            case DEPENDENCY_ANALYSIS_DATA:
                 doOutputTransformedFile(input, outputs);
                 return;
             case ORIGINAL_ARTIFACT:
@@ -53,6 +53,8 @@ public abstract class ExternalDependencyInstrumentingArtifactTransform extends B
             case INSTRUMENTATION_MARKER:
                 // We don't need to do anything with the marker file
                 return;
+            case TYPE_HIERARCHY_ANALYSIS_DATA:
+                // Type hierarchy analysis should never be an input to this transform
             default:
                 throw new IllegalStateException("Unexpected input type: " + inputType);
         }
@@ -67,7 +69,7 @@ public abstract class ExternalDependencyInstrumentingArtifactTransform extends B
 
     private InstrumentationArtifactMetadata readArtifactMetadata(File input) {
         InstrumentationAnalysisSerializer serializer = new InstrumentationAnalysisSerializer(internalServices.get().getStringInterner());
-        return serializer.readOnlyMetadata(input);
+        return serializer.readMetadataOnly(input);
     }
 
     @Override
@@ -78,7 +80,7 @@ public abstract class ExternalDependencyInstrumentingArtifactTransform extends B
                 return PropertiesBackedInstrumentationTypeRegistry.of(() -> {
                     File analysisFile = getInput().get().getAsFile();
                     InstrumentationAnalysisSerializer serializer = new InstrumentationAnalysisSerializer(internalServices.get().getStringInterner());
-                    return serializer.readOnlyTypeHierarchy(analysisFile);
+                    return serializer.readDependencyAnalysis(analysisFile).getDependencies();
                 });
             }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/InstrumentationDependencyAnalysis.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/InstrumentationDependencyAnalysis.java
@@ -19,19 +19,16 @@ package org.gradle.api.internal.initialization.transform;
 import java.util.Map;
 import java.util.Set;
 
-public class InstrumentationArtifactAnalysis {
+public class InstrumentationDependencyAnalysis {
 
     private final InstrumentationArtifactMetadata metadata;
-    private final Map<String, Set<String>> typeHierarchy;
-    private final Set<String> dependencies;
+    private final Map<String, Set<String>> dependencies;
 
-    public InstrumentationArtifactAnalysis(
+    public InstrumentationDependencyAnalysis(
         InstrumentationArtifactMetadata metadata,
-        Map<String, Set<String>> typeHierarchy,
-        Set<String> dependencies
+        Map<String, Set<String>> dependencies
     ) {
         this.metadata = metadata;
-        this.typeHierarchy = typeHierarchy;
         this.dependencies = dependencies;
     }
 
@@ -39,11 +36,7 @@ public class InstrumentationArtifactAnalysis {
         return metadata;
     }
 
-    public Map<String, Set<String>> getTypeHierarchy() {
-        return typeHierarchy;
-    }
-
-    public Set<String> getDependencies() {
+    public Map<String, Set<String>> getDependencies() {
         return dependencies;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/MergeInstrumentationAnalysisTransform.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/MergeInstrumentationAnalysisTransform.java
@@ -78,7 +78,7 @@ public abstract class MergeInstrumentationAnalysisTransform implements Transform
          */
         @InputFiles
         @PathSensitive(PathSensitivity.NAME_ONLY)
-        ConfigurableFileCollection getAnalysisResult();
+        ConfigurableFileCollection getTypeHierarchyAnalysis();
     }
 
     @Inject

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/MergeInstrumentationAnalysisTransform.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/MergeInstrumentationAnalysisTransform.java
@@ -38,13 +38,12 @@ import org.gradle.work.DisableCachingByDefault;
 
 import javax.inject.Inject;
 import java.io.File;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
-import static org.gradle.api.internal.initialization.transform.utils.InstrumentationTransformUtils.ANALYSIS_FILE_NAME;
+import static org.gradle.api.internal.initialization.transform.utils.InstrumentationTransformUtils.DEPENDENCY_ANALYSIS_FILE_NAME;
 import static org.gradle.api.internal.initialization.transform.utils.InstrumentationTransformUtils.MERGE_OUTPUT_DIR;
 import static org.gradle.api.internal.initialization.transform.utils.InstrumentationTransformUtils.createInstrumentationClasspathMarker;
 import static org.gradle.api.internal.initialization.transform.utils.InstrumentationTransformUtils.getInputType;
@@ -97,14 +96,15 @@ public abstract class MergeInstrumentationAnalysisTransform implements Transform
         File input = getInput().get().getAsFile();
         InstrumentationInputType inputType = getInputType(input);
         switch (inputType) {
-            case ANALYSIS_DATA:
+            case DEPENDENCY_ANALYSIS_DATA:
                 doMergeAndOutputAnalysis(input, outputs);
                 return;
             case ORIGINAL_ARTIFACT:
                 outputOriginalArtifact(outputs, input);
                 return;
             case INSTRUMENTATION_MARKER:
-                // We don't need to do anything with the marker file
+            case TYPE_HIERARCHY_ANALYSIS_DATA:
+                // We don't need to do anything with the marker file and type hierarchy
                 return;
             default:
                 throw new IllegalStateException("Unexpected input type: " + inputType);
@@ -116,9 +116,9 @@ public abstract class MergeInstrumentationAnalysisTransform implements Transform
         InstrumentationAnalysisSerializer serializer = new InstrumentationAnalysisSerializer(services.getStringInterner());
         InstrumentationTypeRegistry registry = getInstrumentationTypeRegistry();
 
-        InstrumentationArtifactAnalysis analysisData = serializer.readAnalysis(input);
+        InstrumentationDependencyAnalysis data = serializer.readDependencyAnalysis(input);
         Map<String, Set<String>> dependenciesSuperTypes = new TreeMap<>();
-        for (String className : analysisData.getDependencies()) {
+        for (String className : data.getDependencies().keySet()) {
             Set<String> superTypes = registry.getSuperTypes(className);
             if (!superTypes.isEmpty()) {
                 dependenciesSuperTypes.put(className, new TreeSet<>(superTypes));
@@ -126,8 +126,8 @@ public abstract class MergeInstrumentationAnalysisTransform implements Transform
         }
 
         createInstrumentationClasspathMarker(outputs);
-        File output = outputs.file(MERGE_OUTPUT_DIR + "/" + ANALYSIS_FILE_NAME);
-        serializer.writeAnalysis(output, analysisData.getMetadata(), dependenciesSuperTypes, Collections.emptySet());
+        File output = outputs.file(MERGE_OUTPUT_DIR + "/" + DEPENDENCY_ANALYSIS_FILE_NAME);
+        serializer.writeDependencyAnalysis(output, data.getMetadata(), dependenciesSuperTypes);
     }
 
     private InstrumentationTypeRegistry getInstrumentationTypeRegistry() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/registration/InstrumentationTransformRegisterer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/registration/InstrumentationTransformRegisterer.java
@@ -85,7 +85,7 @@ public class InstrumentationTransformRegisterer {
                 spec.parameters(params -> {
                     params.getBuildService().set(service);
                     params.getContextId().set(contextId);
-                    params.getAnalysisResult().setFrom(service.map(it -> it.getAnalysisResult(contextId)));
+                    params.getTypeHierarchyAnalysis().setFrom(service.map(it -> it.getTypeHierarchyAnalysis(contextId)));
                 });
             }
         );

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/services/CacheInstrumentationDataBuildService.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/services/CacheInstrumentationDataBuildService.java
@@ -85,7 +85,7 @@ public abstract class CacheInstrumentationDataBuildService implements BuildServi
         return getResolutionData(contextId).getArtifactHash(file);
     }
 
-    public FileCollection getAnalysisResult(long contextId) {
+    public FileCollection getTypeHierarchyAnalysis(long contextId) {
         return getResolutionData(contextId).getTypeHierarchyAnalysisResult();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/services/CacheInstrumentationDataBuildService.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/services/CacheInstrumentationDataBuildService.java
@@ -86,7 +86,7 @@ public abstract class CacheInstrumentationDataBuildService implements BuildServi
     }
 
     public FileCollection getAnalysisResult(long contextId) {
-        return getResolutionData(contextId).getAnalysisResult();
+        return getResolutionData(contextId).getTypeHierarchyAnalysisResult();
     }
 
     private ResolutionData getResolutionData(long contextId) {
@@ -100,8 +100,9 @@ public abstract class CacheInstrumentationDataBuildService implements BuildServi
         });
         return new ResolutionScope() {
             @Override
-            public void setAnalysisResult(FileCollection analysisResult) {
-                resolutionData.getAnalysisResult().setFrom(analysisResult);
+            public void setTypeHierarchyAnalysisResult(FileCollection analysisResult) {
+                FileCollection typeHierarchyAnalysisResult = analysisResult.filter(InstrumentationTransformUtils::isTypeHierarchyAnalysisFile);
+                resolutionData.getTypeHierarchyAnalysisResult().setFrom(typeHierarchyAnalysisResult);
             }
 
             @Override
@@ -118,7 +119,7 @@ public abstract class CacheInstrumentationDataBuildService implements BuildServi
 
     public interface ResolutionScope extends AutoCloseable {
 
-        void setAnalysisResult(FileCollection analysisResult);
+        void setTypeHierarchyAnalysisResult(FileCollection analysisResult);
         void setOriginalClasspath(FileCollection originalClasspath);
 
         @Override
@@ -147,22 +148,21 @@ public abstract class CacheInstrumentationDataBuildService implements BuildServi
             });
             this.instrumentationTypeRegistry = Lazy.locking().of(() -> {
                 InstrumentationTypeRegistry gradleCoreInstrumentationTypeRegistry = internalServices.getGradleCoreInstrumentationTypeRegistry();
-                Map<String, Set<String>> directSuperTypes = readDirectSuperTypes();
+                Map<String, Set<String>> directSuperTypes = mergeTypeHierarchyAnalysis();
                 return new ExternalPluginsInstrumentationTypeRegistry(directSuperTypes, gradleCoreInstrumentationTypeRegistry);
             });
             this.internalServices = internalServices;
         }
 
-        abstract ConfigurableFileCollection getAnalysisResult();
-        abstract ConfigurableFileCollection getOriginalClasspath();
-
-        private Map<String, Set<String>> readDirectSuperTypes() {
+        private Map<String, Set<String>> mergeTypeHierarchyAnalysis() {
             InstrumentationAnalysisSerializer serializer = new InstrumentationAnalysisSerializer(internalServices.getStringInterner());
-            return getAnalysisResult().getFiles().stream()
-                .filter(InstrumentationTransformUtils::isAnalysisFile)
-                .flatMap(file -> serializer.readOnlyTypeHierarchy(file).entrySet().stream())
+            return getTypeHierarchyAnalysisResult().getFiles().stream()
+                .flatMap(file -> serializer.readTypeHierarchyAnalysis(file).entrySet().stream())
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, Sets::union));
         }
+
+        abstract ConfigurableFileCollection getTypeHierarchyAnalysisResult();
+        abstract ConfigurableFileCollection getOriginalClasspath();
 
         private InstrumentationTypeRegistry getInstrumentationTypeRegistry() {
             return instrumentationTypeRegistry.get();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/utils/InstrumentationTransformUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/transform/utils/InstrumentationTransformUtils.java
@@ -27,27 +27,35 @@ import static org.gradle.internal.classpath.TransformedClassPath.FileMarker.INST
 public class InstrumentationTransformUtils {
 
     public enum InstrumentationInputType {
-        ANALYSIS_DATA,
+        DEPENDENCY_ANALYSIS_DATA,
+        TYPE_HIERARCHY_ANALYSIS_DATA,
         INSTRUMENTATION_MARKER,
         ORIGINAL_ARTIFACT
     }
 
     public static final String ANALYSIS_OUTPUT_DIR = "analysis";
     public static final String MERGE_OUTPUT_DIR = "merge";
-    public static final String ANALYSIS_FILE_NAME = "instrumentation-analysis.bin";
+    public static final String TYPE_HIERARCHY_ANALYSIS_FILE_NAME = "instrumentation-hierarchy.bin";
+    public static final String DEPENDENCY_ANALYSIS_FILE_NAME = "instrumentation-dependencies.bin";
 
     public static InstrumentationInputType getInputType(File input) {
-        if (isAnalysisFile(input)) {
-            return InstrumentationInputType.ANALYSIS_DATA;
-        } else if (isInstrumentationMarkerFile(input)) {
+        if (isInstrumentationMarkerFile(input)) {
             return InstrumentationInputType.INSTRUMENTATION_MARKER;
+        } else if (isDependencyAnalysisFile(input)) {
+            return InstrumentationInputType.DEPENDENCY_ANALYSIS_DATA;
+        } else if (isTypeHierarchyAnalysisFile(input)) {
+            return InstrumentationInputType.TYPE_HIERARCHY_ANALYSIS_DATA;
         } else {
             return InstrumentationInputType.ORIGINAL_ARTIFACT;
         }
     }
 
-    public static boolean isAnalysisFile(File input) {
-        return input.getName().equals(ANALYSIS_FILE_NAME);
+    public static boolean isDependencyAnalysisFile(File input) {
+        return input.getName().equals(DEPENDENCY_ANALYSIS_FILE_NAME);
+    }
+
+    public static boolean isTypeHierarchyAnalysisFile(File input) {
+        return input.getName().equals(TYPE_HIERARCHY_ANALYSIS_FILE_NAME);
     }
 
     public static boolean isInstrumentationMarkerFile(File input) {


### PR DESCRIPTION
Before if any local build-logic project was recompiled we re-run "merge analysis" step for whole classpath. So for all jars.
With this change "merge analysis" step is run only if type hiearachy changes.

This reduces newly generated files after:
```
git clean -ffdx && ./gradlew help --no-configuration-cache --no-build-cache
```

for `gradle/gradle` project in `caches/<version>/transforms/` from ~20000 to ~300. Gradle 8.7 produces 18 new files in transforms cache, but might also produce files in other directories.

~~Another improvement could be, that we would use `@Classpath` for "analyze artifact" step: that brings newly created files to ~200. But might have some performance penalty, so I am a bit reluctant to add. I would vote to try that option if improvement above really won't be sufficient.~~

Actually, using classes variant reduces the newly created files to ~200.

Mostly fixes https://github.com/gradle/gradle-private/issues/4162