### PR TITLE
Upgrade Develocity plugin to 3.17

### DIFF
--- a/build-logic-commons/build-platform/build.gradle.kts
+++ b/build-logic-commons/build-platform/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     constraints {
         api("org.gradle.guides:gradle-guides-plugin:0.23")
         api("org.apache.ant:ant:1.10.13") // Bump the version brought in transitively by gradle-guides-plugin
-        api("com.gradle:gradle-enterprise-gradle-plugin:3.16.2") // Sync with `settings.gradle.kts`
+        api("com.gradle:develocity-gradle-plugin:3.17") // Sync with `settings.gradle.kts`
         api("com.gradle.publish:plugin-publish-plugin:1.2.1")
         api("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:1.0.1")
         api("me.champeau.gradle:japicmp-gradle-plugin:0.4.1")

--- a/build-logic-commons/gradle-plugin/build.gradle.kts
+++ b/build-logic-commons/gradle-plugin/build.gradle.kts
@@ -14,7 +14,7 @@ java {
 }
 
 dependencies {
-    compileOnly("com.gradle:gradle-enterprise-gradle-plugin:3.16.2")
+    compileOnly("com.gradle:develocity-gradle-plugin:3.17")
 
     api(platform(project(":build-platform")))
 

--- a/build-logic/buildquality/build.gradle.kts
+++ b/build-logic/buildquality/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     implementation(kotlin("compiler-embeddable") as String) {
         because("Required by IncubatingApiReportTask")
     }
-    implementation("com.gradle:gradle-enterprise-gradle-plugin") {
+    implementation("com.gradle:develocity-gradle-plugin") {
         because("Arch-test plugin configures the PTS extension")
     }
 

--- a/build-logic/buildquality/src/main/kotlin/gradlebuild.arch-test.gradle.kts
+++ b/build-logic/buildquality/src/main/kotlin/gradlebuild.arch-test.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import com.gradle.enterprise.gradleplugin.testselection.PredictiveTestSelectionExtension
+import com.gradle.develocity.agent.gradle.test.DevelocityTestConfiguration
 import gradlebuild.archtest.PackageCyclesExtension
 
 plugins {
@@ -61,9 +61,9 @@ testing {
                         testClassesDirs += sharedArchTestClasses.filter { it.isDirectory }
                         classpath += sourceSets.main.get().output.classesDirs
                         systemProperty("package.cycle.exclude.patterns", packageCyclesExtension.excludePatterns.get().joinToString(","))
-                        extensions.findByType<PredictiveTestSelectionExtension>()?.apply {
+                        extensions.findByType<DevelocityTestConfiguration>()?.apply {
                             // PTS doesn't work well with architecture tests which scan all classes
-                            enabled = false
+                            predictiveTestSelection.enabled = false
                         }
                     }
                 }

--- a/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
+++ b/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
@@ -62,7 +62,7 @@ abstract class ExternalModulesExtension(isBundleGroovy4: Boolean) {
     val googleHttpClientApacheV2 = "com.google.http-client:google-http-client-apache-v2"
     val googleOauthClient = "com.google.oauth-client:google-oauth-client"
     val gradleProfiler = "org.gradle.profiler:gradle-profiler"
-    val gradleEnterpriseTestAnnotation = "com.gradle:gradle-enterprise-testing-annotations"
+    val develocityTestAnnotation = "com.gradle:develocity-testing-annotations"
     val groovyGroup = if (isBundleGroovy4) "org.apache.groovy" else "org.codehaus.groovy"
     val groovy = "$groovyGroup:groovy"
     val groovyAnt = "$groovyGroup:groovy-ant"

--- a/build-logic/jvm/build.gradle.kts
+++ b/build-logic/jvm/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     implementation("org.ow2.asm:asm")
     implementation("org.ow2.asm:asm-commons")
     implementation("com.google.code.gson:gson")
-    implementation("com.gradle:gradle-enterprise-gradle-plugin")
+    implementation("com.gradle:develocity-gradle-plugin")
 
     implementation("com.thoughtworks.qdox:qdox") {
         because("ParameterNamesIndex")

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -129,7 +129,7 @@ fun addDependencies() {
         testImplementation(libs.spock)
         testImplementation(libs.junit5Vintage)
         testImplementation(libs.spockJUnit4)
-        testImplementation(libs.gradleEnterpriseTestAnnotation)
+        testImplementation(libs.develocityTestAnnotation)
         testRuntimeOnly(libs.bytebuddy)
         testRuntimeOnly(libs.objenesis)
 
@@ -278,15 +278,6 @@ fun configureTests() {
                 }
                 maxRemoteExecutors = if (project.isPerformanceProject()) 0 else project.maxTestDistributionRemoteExecutors
                 maxLocalExecutors = project.maxTestDistributionLocalExecutors
-
-                // Test distribution annotation-class filters
-                // See: https://docs.gradle.com/enterprise/test-distribution/#gradle_executor_restrictions_class_matcher
-                localOnly {
-                    includeAnnotationClasses.addAll("com.gradle.enterprise.testing.annotations.LocalOnly")
-                }
-                remoteOnly {
-                    includeAnnotationClasses.addAll("com.gradle.enterprise.testing.annotations.RemoteOnly")
-                }
 
                 if (BuildEnvironment.isCiServer) {
                     when {

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-import com.gradle.enterprise.gradleplugin.testdistribution.TestDistributionExtension
-import com.gradle.enterprise.gradleplugin.testdistribution.internal.TestDistributionExtensionInternal
-import com.gradle.enterprise.gradleplugin.testretry.retry
-import com.gradle.enterprise.gradleplugin.testselection.PredictiveTestSelectionExtension
-import com.gradle.enterprise.gradleplugin.testselection.internal.PredictiveTestSelectionExtensionInternal
+import com.gradle.develocity.agent.gradle.internal.test.PredictiveTestSelectionConfigurationInternal
+import com.gradle.develocity.agent.gradle.internal.test.TestDistributionConfigurationInternal
+import com.gradle.develocity.agent.gradle.test.DevelocityTestConfiguration
 import gradlebuild.basics.BuildEnvironment
 import gradlebuild.basics.FlakyTestStrategy
 import gradlebuild.basics.accessors.kotlinMainSourceSet
@@ -255,7 +253,7 @@ fun configureTests() {
 
         if (BuildEnvironment.isCiServer) {
             configureRerun()
-            retry {
+            develocity.testRetry {
                 maxRetries.convention(determineMaxRetries())
                 maxFailures = determineMaxFailures()
             }
@@ -268,8 +266,8 @@ fun configureTests() {
         configureSpock()
         configureFlakyTest()
 
-        extensions.findByType<TestDistributionExtension>()?.apply {
-            this as TestDistributionExtensionInternal
+        extensions.findByType<DevelocityTestConfiguration>()?.testDistribution {
+            this as TestDistributionConfigurationInternal
             // Dogfooding TD against ge-td-dogfooding in order to test new features and benefit from bug fixes before they are released
             server = uri("https://ge-td-dogfooding.grdev.net")
 
@@ -278,8 +276,8 @@ fun configureTests() {
                 project.maxTestDistributionPartitionSecond?.apply {
                     preferredMaxDuration = Duration.ofSeconds(this)
                 }
-                distribution.maxRemoteExecutors = if (project.isPerformanceProject()) 0 else project.maxTestDistributionRemoteExecutors
-                distribution.maxLocalExecutors = project.maxTestDistributionLocalExecutors
+                maxRemoteExecutors = if (project.isPerformanceProject()) 0 else project.maxTestDistributionRemoteExecutors
+                maxLocalExecutors = project.maxTestDistributionLocalExecutors
 
                 // Test distribution annotation-class filters
                 // See: https://docs.gradle.com/enterprise/test-distribution/#gradle_executor_restrictions_class_matcher
@@ -306,8 +304,8 @@ fun configureTests() {
             // GitHub actions for contributor PRs uses public build scan instance
             // in this case we need to explicitly configure the PTS server
             // Don't move this line into the lambda as it may cause config cache problems
-            extensions.findByType<PredictiveTestSelectionExtension>()?.apply {
-                this as PredictiveTestSelectionExtensionInternal
+            extensions.findByType<DevelocityTestConfiguration>()?.predictiveTestSelection {
+                this as PredictiveTestSelectionConfigurationInternal
                 server = uri("https://ge.gradle.org")
                 enabled.convention(project.predictiveTestSelectionEnabled)
             }

--- a/build-logic/performance-testing/build.gradle.kts
+++ b/build-logic/performance-testing/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     implementation("commons-io:commons-io")
     implementation("javax.activation:activation")
     implementation("javax.xml.bind:jaxb-api")
-    implementation("com.gradle:gradle-enterprise-gradle-plugin")
+    implementation("com.gradle:develocity-gradle-plugin")
 
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("junit:junit")

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -17,7 +17,7 @@
 package gradlebuild.performance
 
 import com.google.common.annotations.VisibleForTesting
-import com.gradle.enterprise.gradleplugin.testretry.TestRetryExtension
+import com.gradle.develocity.agent.gradle.test.DevelocityTestConfiguration
 import gradlebuild.basics.accessors.groovy
 import gradlebuild.basics.buildBranch
 import gradlebuild.basics.buildCommitId
@@ -246,7 +246,7 @@ class PerformanceTestPlugin : Plugin<Project> {
             outputs.cacheIf { false }
             outputs.file(outputJson)
 
-            predictiveSelection.enabled = false
+            develocity.predictiveTestSelection.enabled = false
         }
 
     private
@@ -397,7 +397,7 @@ class PerformanceTestExtension(
                 mustRunAfter(currentlyRegisteredTestProjects)
                 testSpecificConfigurator(this)
 
-                extensions.findByType<TestRetryExtension>()?.maxRetries = 0
+                extensions.findByType<DevelocityTestConfiguration>()?.testRetry?.maxRetries = 0
             }
         )
 
@@ -408,7 +408,7 @@ class PerformanceTestExtension(
                 description = "Runs performance tests on $testProject - supposed to be used on CI"
                 channel = "commits$channelSuffix"
 
-                extensions.findByType<TestRetryExtension>()?.maxRetries = 1
+                extensions.findByType<DevelocityTestConfiguration>()?.testRetry?.maxRetries = 1
 
                 if (project.includePerformanceTestScenarios) {
                     val scenariosFromFile = project.loadScenariosFromFile(testProject)

--- a/build-logic/profiling/build.gradle.kts
+++ b/build-logic/profiling/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 description = "Provides plugins that configure profiling tools (jmh and build scans)"
 
 dependencies {
-    implementation("com.gradle:gradle-enterprise-gradle-plugin")
+    implementation("com.gradle:develocity-gradle-plugin")
 
     implementation("gradlebuild:basics")
     implementation("gradlebuild:module-identity")

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -32,7 +32,7 @@ dependencyResolutionManagement {
             url = uri("https://repo.gradle.org/gradle/enterprise-libs-release-candidates")
             content {
                 val rcAndMilestonesPattern = "\\d{1,2}?\\.\\d{1,2}?(\\.\\d{1,2}?)?-((rc-\\d{1,2}?)|(milestone-\\d{1,2}?))"
-                includeVersionByRegex("com.gradle", "gradle-enterprise-gradle-plugin", rcAndMilestonesPattern)
+                includeVersionByRegex("com.gradle", "develocity-gradle-plugin", rcAndMilestonesPattern)
             }
         }
         maven {

--- a/platforms/build-infrastructure/precondition-tester/build.gradle.kts
+++ b/platforms/build-infrastructure/precondition-tester/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.gradle.enterprise.gradleplugin.testselection.PredictiveTestSelectionExtension
+import com.gradle.develocity.agent.gradle.test.DevelocityTestConfiguration
 import gradlebuild.integrationtests.tasks.DistributionTest
 
 /*
@@ -77,8 +77,8 @@ fun Test.setupPreconditionTesting() {
     classpath += sourceSets.test.get().output
 
     // These tests should not be impacted by the predictive selection
-    extensions.findByType<PredictiveTestSelectionExtension>()?.apply {
-        enabled = false
+    extensions.findByType<DevelocityTestConfiguration>()?.apply {
+        predictiveTestSelection.enabled = false
     }
 
     // These tests should always run

--- a/platforms/build-infrastructure/precondition-tester/src/test/groovy/org/gradle/test/precondition/LocalPreconditionProbingTest.groovy
+++ b/platforms/build-infrastructure/precondition-tester/src/test/groovy/org/gradle/test/precondition/LocalPreconditionProbingTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.test.precondition
 
-import com.gradle.enterprise.testing.annotations.LocalOnly
+import com.gradle.develocity.testing.annotations.LocalOnly
 
 @LocalOnly
 class LocalPreconditionProbingTest extends PreconditionProbingTest {

--- a/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/BuildOperationsFileSystemWatchingIntegrationTest.groovy
+++ b/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/BuildOperationsFileSystemWatchingIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.watch
 
-import com.gradle.enterprise.testing.annotations.LocalOnly
+import com.gradle.develocity.testing.annotations.LocalOnly
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.internal.watch.vfs.BuildFinishedFileSystemWatchingBuildOperationType
 import org.gradle.internal.watch.vfs.BuildStartedFileSystemWatchingBuildOperationType

--- a/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/ChangesBetweenBuildsFileSystemWatchingIntegrationTest.groovy
+++ b/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/ChangesBetweenBuildsFileSystemWatchingIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.watch
 
-import com.gradle.enterprise.testing.annotations.LocalOnly
+import com.gradle.develocity.testing.annotations.LocalOnly
 import org.gradle.integtests.fixtures.TestBuildCache
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.internal.watch.registry.impl.WatchableHierarchies

--- a/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/ChangesByGradleFileWatchingIntegrationTest.groovy
+++ b/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/ChangesByGradleFileWatchingIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.watch
 
-import com.gradle.enterprise.testing.annotations.LocalOnly
+import com.gradle.develocity.testing.annotations.LocalOnly
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
 
 @LocalOnly

--- a/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/ChangesDuringTheBuildFileSystemWatchingIntegrationTest.groovy
+++ b/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/ChangesDuringTheBuildFileSystemWatchingIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.watch
 
-import com.gradle.enterprise.testing.annotations.LocalOnly
+import com.gradle.develocity.testing.annotations.LocalOnly
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule

--- a/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/ContinuousBuildFileWatchingIntegrationTest.groovy
+++ b/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/ContinuousBuildFileWatchingIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.watch
 
-import com.gradle.enterprise.testing.annotations.LocalOnly
+import com.gradle.develocity.testing.annotations.LocalOnly
 import org.gradle.integtests.fixtures.AbstractContinuousIntegrationTest
 import org.gradle.integtests.fixtures.FileSystemWatchingFixture
 import org.gradle.integtests.fixtures.FileSystemWatchingHelper

--- a/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/EnableFileSystemWatchingIntegrationTest.groovy
+++ b/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/EnableFileSystemWatchingIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.watch
 
-import com.gradle.enterprise.testing.annotations.LocalOnly
+import com.gradle.develocity.testing.annotations.LocalOnly
 import org.gradle.initialization.StartParameterBuildOptions
 import org.gradle.internal.watch.registry.WatchMode
 

--- a/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/FileSystemWatchingSettingsFinalizedBuildOperationIntegrationTest.groovy
+++ b/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/FileSystemWatchingSettingsFinalizedBuildOperationIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.watch
 
-import com.gradle.enterprise.testing.annotations.LocalOnly
+import com.gradle.develocity.testing.annotations.LocalOnly
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.internal.watch.options.FileSystemWatchingSettingsFinalizedProgressDetails
 

--- a/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/LoggingFileSystemWatchingIntegrationTest.groovy
+++ b/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/LoggingFileSystemWatchingIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.watch
 
-import com.gradle.enterprise.testing.annotations.LocalOnly
+import com.gradle.develocity.testing.annotations.LocalOnly
 import net.rubygrapefruit.platform.internal.jni.NativeLogger
 import org.gradle.initialization.StartParameterBuildOptions
 import org.gradle.integtests.fixtures.daemon.DaemonFixture

--- a/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/NoDaemonFilesystemWatchingIntegrationTest.groovy
+++ b/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/NoDaemonFilesystemWatchingIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.watch
 
-import com.gradle.enterprise.testing.annotations.LocalOnly
+import com.gradle.develocity.testing.annotations.LocalOnly
 import org.gradle.initialization.StartParameterBuildOptions
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.FileSystemWatchingFixture

--- a/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/SymlinkFileSystemWatchingIntegrationTest.groovy
+++ b/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/SymlinkFileSystemWatchingIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.watch
 
-import com.gradle.enterprise.testing.annotations.LocalOnly
+import com.gradle.develocity.testing.annotations.LocalOnly
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 import spock.lang.Issue

--- a/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
+++ b/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.internal.watch
 
 import com.google.common.collect.ImmutableSet
-import com.gradle.enterprise.testing.annotations.LocalOnly
+import com.gradle.develocity.testing.annotations.LocalOnly
 import org.apache.commons.io.FileUtils
 import org.gradle.cache.GlobalCacheLocations
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter

--- a/platforms/core-runtime/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperChecksumVerificationTest.groovy
+++ b/platforms/core-runtime/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperChecksumVerificationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.integtests
 
-import com.gradle.enterprise.testing.annotations.LocalOnly
+import com.gradle.develocity.testing.annotations.LocalOnly
 import org.gradle.integtests.fixtures.executer.GradleDistribution
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 import org.gradle.test.fixtures.server.http.BlockingHttpServer

--- a/platforms/core-runtime/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpsIntegrationTest.groovy
+++ b/platforms/core-runtime/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpsIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.integtests
 
-import com.gradle.enterprise.testing.annotations.LocalOnly
+import com.gradle.develocity.testing.annotations.LocalOnly
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.test.fixtures.keystore.TestKeyStore

--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerFileSystemWatchingIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerFileSystemWatchingIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.testkit.runner
 
-import com.gradle.enterprise.testing.annotations.LocalOnly
+import com.gradle.develocity.testing.annotations.LocalOnly
 import org.gradle.initialization.StartParameterBuildOptions
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,9 +7,9 @@ pluginManagement {
             content {
                 val rcAndMilestonesPattern = "\\d{1,2}?\\.\\d{1,2}?(\\.\\d{1,2}?)?-((rc-\\d{1,2}?)|(milestone-\\d{1,2}?))"
                 // GE plugin marker artifact
-                includeVersionByRegex("com.gradle.enterprise", "com.gradle.enterprise.gradle.plugin", rcAndMilestonesPattern)
+                includeVersionByRegex("com.gradle.develocity", "com.gradle.develocity.gradle.plugin", rcAndMilestonesPattern)
                 // GE plugin jar
-                includeVersionByRegex("com.gradle", "gradle-enterprise-gradle-plugin", rcAndMilestonesPattern)
+                includeVersionByRegex("com.gradle", "develocity-gradle-plugin", rcAndMilestonesPattern)
             }
         }
         maven {
@@ -24,7 +24,7 @@ pluginManagement {
 }
 
 plugins {
-    id("com.gradle.enterprise").version("3.16.2") // Sync with `build-logic-commons/build-platform/build.gradle.kts`
+    id("com.gradle.develocity").version("3.17") // Sync with `build-logic-commons/build-platform/build.gradle.kts`
     id("io.github.gradle.gradle-enterprise-conventions-plugin").version("0.7.6")
     id("org.gradle.toolchains.foojay-resolver-convention") version("0.8.0")
 //    id("net.ltgt.errorprone").version("3.1.0")

--- a/subprojects/architecture-test/build.gradle.kts
+++ b/subprojects/architecture-test/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.gradle.enterprise.gradleplugin.testselection.PredictiveTestSelectionExtension
+import com.gradle.develocity.agent.gradle.test.DevelocityTestConfiguration
 import gradlebuild.basics.FlakyTestStrategy
 import gradlebuild.basics.PublicApi
 import gradlebuild.basics.PublicKotlinDslApi
@@ -71,9 +71,9 @@ tasks {
         dependsOn(verifyAcceptedApiChangesOrdering)
         enabled = flakyTestStrategy != FlakyTestStrategy.ONLY
 
-        extensions.findByType<PredictiveTestSelectionExtension>()?.apply {
+        extensions.findByType<DevelocityTestConfiguration>()?.apply {
             // PTS doesn't work well with architecture tests which scan all classes
-            enabled = false
+            predictiveTestSelection.enabled = false
         }
 
         finalizedBy(reorderRuleStore)

--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -73,7 +73,7 @@ dependencies {
         api(libs.commonsMath)           { version { strictly("3.6.1") }}
         api(libs.eclipseSisuPlexus)     { version { strictly("0.3.5"); because("transitive dependency of Maven modules to process POM metadata") }}
         api(libs.gradleProfiler)        { version { strictly("0.21.0-alpha-3") }}
-        api(libs.gradleEnterpriseTestAnnotation) { version { strictly("1.0") }}
+        api(libs.develocityTestAnnotation) { version { strictly("2.0.1") }}
         api(libs.gcs)                   { version { strictly("v1-rev20220705-1.32.1") }}
         api(libs.googleApiClient)       { version { strictly("1.34.0"); because("our GCS version requires 1.34.0") }}
         api(libs.guava)                 { version { strictly("32.1.2-jre"); because("our Google API Client version requires at least 31.1-jre")  }}

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/internal/deployment/JavaApplicationDeploymentIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/internal/deployment/JavaApplicationDeploymentIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.deployment
 
-import com.gradle.enterprise.testing.annotations.LocalOnly
+import com.gradle.develocity.testing.annotations.LocalOnly
 import org.gradle.integtests.fixtures.AbstractContinuousIntegrationTest
 import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.gradle.test.fixtures.file.TestFile

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractKotlinPluginAndroidSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractKotlinPluginAndroidSmokeTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.smoketests
 
-import com.gradle.enterprise.testing.annotations.LocalOnly
+import com.gradle.develocity.testing.annotations.LocalOnly
 import org.gradle.integtests.fixtures.android.AndroidHome
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.dsl.GradleDsl


### PR DESCRIPTION
### Context
Update the version of the Develocity plugin used in the `gradle` build. I also fix the usage of the deprecated APIs. Additionally, I upgrade the `develocity-testing-annotations` to the latest released version.