### PR TITLE
Remove the requirement that DependencyCollector getters are named after Configurations

### DIFF
--- a/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/project/DeclarativeDSLCustomDependenciesExtensionsSpec.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/project/DeclarativeDSLCustomDependenciesExtensionsSpec.groovy
@@ -59,6 +59,42 @@ class DeclarativeDSLCustomDependenciesExtensionsSpec extends AbstractIntegration
         outputContains("org.apache.commons:commons-lang3:3.12.0")
     }
 
+    def 'can NOT configure an extension using DependencyCollector in declarative DSL if extension does NOT extend Dependencies'() {
+        given: "a plugin that creates a custom extension using a DependencyCollector on an extension that does NOT extend Dependencies"
+        file("buildSrc/src/main/java/com/example/restricted/DependenciesExtension.java") << defineDependenciesExtension(false)
+        file("buildSrc/src/main/java/com/example/restricted/LibraryExtension.java") << defineLibraryExtension()
+        file("buildSrc/src/main/java/com/example/restricted/RestrictedPlugin.java") << """
+            package com.example.restricted;
+
+            import org.gradle.api.Plugin;
+            import org.gradle.api.Project;
+            import org.gradle.api.artifacts.DependencyScopeConfiguration;
+
+            public class RestrictedPlugin implements Plugin<Project> {
+                @Override
+                public void apply(Project project) {
+                    // no plugin application, must create configurations manually
+                    DependencyScopeConfiguration api = project.getConfigurations().dependencyScope("api").get();
+                    DependencyScopeConfiguration implementation = project.getConfigurations().dependencyScope("implementation").get();
+
+                    // create and wire the custom dependencies extension's dependencies to these global configurations
+                    LibraryExtension restricted = project.getExtensions().create("library", LibraryExtension.class);
+                    api.fromDependencyCollector(restricted.getDependencies().getApi());
+                    implementation.fromDependencyCollector(restricted.getDependencies().getImplementation());
+                }
+            }
+        """
+        file("buildSrc/build.gradle") << defineRestrictedPluginBuild()
+
+        and: "a build script that adds dependencies using the custom extension"
+        file("build.gradle.something") << defineDeclarativeDSLBuildScript()
+        file("settings.gradle") << defineSettings()
+
+        expect: "the build fails"
+        fails("dependencies", "--configuration", "api")
+        failure.assertHasCause("Failed to interpret the declarative DSL file '${testDirectory.file("build.gradle.something").path}'")
+    }
+
     def 'can configure an extension using DependencyCollector in declarative DSL and build a java plugin'() {
         given: "a plugin that creates a custom extension using a DependencyCollector and applies the java library plugin"
         file("buildSrc/src/main/java/com/example/restricted/DependenciesExtension.java") << defineDependenciesExtension()
@@ -95,18 +131,16 @@ class DeclarativeDSLCustomDependenciesExtensionsSpec extends AbstractIntegration
         file("build/libs/example.jar").exists()
     }
 
-    private String defineDependenciesExtension() {
+    private String defineDependenciesExtension(boolean extendDependencies = true) {
         return """
             package com.example.restricted;
 
             import org.gradle.api.artifacts.dsl.DependencyCollector;
-            import org.gradle.api.artifacts.dsl.GradleDependencies;
-            import org.gradle.api.plugins.jvm.PlatformDependencyModifiers;
-            import org.gradle.api.plugins.jvm.TestFixturesDependencyModifiers;
+            import org.gradle.api.artifacts.dsl.Dependencies;
             import org.gradle.declarative.dsl.model.annotations.Restricted;
 
             @Restricted
-            public interface DependenciesExtension extends PlatformDependencyModifiers, TestFixturesDependencyModifiers, GradleDependencies {
+            public interface DependenciesExtension ${(extendDependencies) ? "extends Dependencies" : "" } {
                 DependencyCollector getApi();
                 DependencyCollector getImplementation();
             }

--- a/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/project/DeclarativeDSLCustomDependenciesExtensionsSpec.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/project/DeclarativeDSLCustomDependenciesExtensionsSpec.groovy
@@ -59,6 +59,69 @@ class DeclarativeDSLCustomDependenciesExtensionsSpec extends AbstractIntegration
         outputContains("org.apache.commons:commons-lang3:3.12.0")
     }
 
+    def 'can configure an extension using DependencyCollector in declarative DSL with a getter name NOT associated with an expected configuration name'() {
+        given: "a plugin that creates a custom extension using a DependencyCollector"
+        file("buildSrc/src/main/java/com/example/restricted/DependenciesExtension.java") << """
+            package com.example.restricted;
+
+            import org.gradle.api.artifacts.dsl.DependencyCollector;
+            import org.gradle.api.artifacts.dsl.Dependencies;
+            import org.gradle.declarative.dsl.model.annotations.Restricted;
+
+            @Restricted
+            public interface DependenciesExtension extends Dependencies {
+                DependencyCollector getSomething();
+                DependencyCollector getSomethingElse();
+            }
+        """
+        file("buildSrc/src/main/java/com/example/restricted/LibraryExtension.java") << defineLibraryExtension()
+        file("buildSrc/src/main/java/com/example/restricted/RestrictedPlugin.java") << """
+            package com.example.restricted;
+
+            import org.gradle.api.Plugin;
+            import org.gradle.api.Project;
+            import org.gradle.api.artifacts.DependencyScopeConfiguration;
+
+            public class RestrictedPlugin implements Plugin<Project> {
+                @Override
+                public void apply(Project project) {
+                    // no plugin application, must create configurations manually
+                    DependencyScopeConfiguration myConf = project.getConfigurations().dependencyScope("myConf").get();
+                    DependencyScopeConfiguration myOtherConf = project.getConfigurations().dependencyScope("myOtherConf").get();
+
+                    // create and wire the custom dependencies extension's dependencies to these global configurations
+                    LibraryExtension restricted = project.getExtensions().create("library", LibraryExtension.class);
+                    myConf.fromDependencyCollector(restricted.getDependencies().getSomething());
+                    myOtherConf.fromDependencyCollector(restricted.getDependencies().getSomethingElse());
+                }
+            }
+        """
+        file("buildSrc/build.gradle") << defineRestrictedPluginBuild()
+
+        and: "a build script that adds dependencies using the custom extension"
+        file("build.gradle.something") << """
+            plugins {
+                id("com.example.restricted")
+            }
+
+            library {
+                dependencies {
+                    something("com.google.guava:guava:30.1.1-jre")
+                    somethingElse("org.apache.commons:commons-lang3:3.12.0")
+                }
+            }
+        """
+        file("settings.gradle") << defineSettings()
+
+        expect: "a dependency has been added to the something configuration"
+        succeeds("dependencies", "--configuration", "myConf")
+        outputContains("com.google.guava:guava:30.1.1-jre")
+
+        and: "a dependency has been added to the somethingElse configuration"
+        succeeds("dependencies", "--configuration", "myOtherConf")
+        outputContains("org.apache.commons:commons-lang3:3.12.0")
+    }
+
     def 'can NOT configure an extension using DependencyCollector in declarative DSL if extension does NOT extend Dependencies'() {
         given: "a plugin that creates a custom extension using a DependencyCollector on an extension that does NOT extend Dependencies"
         file("buildSrc/src/main/java/com/example/restricted/DependenciesExtension.java") << defineDependenciesExtension(false)

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/dependencyConfigurationSchema.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/dependencyConfigurationSchema.kt
@@ -63,12 +63,12 @@ class DependencyConfigurationsComponent(
 
     override fun functionExtractors(): List<FunctionExtractor> = listOf(
         DependencyFunctionsExtractor(configurations),
-        ImplicitDependencyCollectorFunctionExtractor(configurations)
+        ImplicitDependencyCollectorFunctionExtractor()
     )
 
     override fun runtimeFunctionResolvers(): List<RuntimeFunctionResolver> = listOf(
         RuntimeDependencyFunctionResolver(configurations),
-        ImplicitDependencyCollectorFunctionResolver(configurations)
+        ImplicitDependencyCollectorFunctionResolver()
     )
 }
 
@@ -100,7 +100,7 @@ class DependencyFunctionsExtractor(val configurations: DependencyConfigurations)
 
 
 private
-class ImplicitDependencyCollectorFunctionExtractor(val configurations: DependencyConfigurations) : FunctionExtractor {
+class ImplicitDependencyCollectorFunctionExtractor : FunctionExtractor {
     override fun memberFunctions(kClass: KClass<*>, preIndex: DataSchemaBuilder.PreIndex): Iterable<SchemaMemberFunction> = kClass.memberFunctions
         .filter { function -> hasDependencyCollectorGetterSignature(kClass, function) }
         .map { function -> function.name.removePrefix("get").replaceFirstChar { it.lowercase(Locale.getDefault()) } }
@@ -149,44 +149,39 @@ class RuntimeDependencyFunctionResolver(configurations: DependencyConfigurations
 
 
 private
-class ImplicitDependencyCollectorFunctionResolver(configurations: DependencyConfigurations) : RuntimeFunctionResolver {
-    private
-    val configurationNames = configurations.configurationNames.toSet()
-
+class ImplicitDependencyCollectorFunctionResolver : RuntimeFunctionResolver {
     override fun resolve(receiverClass: KClass<*>, name: String, parameterValueBinding: ParameterValueBinding): RuntimeFunctionResolver.Resolution {
-        if (name in configurationNames) {
-            val getterFunction = getDependencyCollectorGetter(receiverClass, name)
-            if (getterFunction != null) {
-                if (parameterValueBinding.bindingMap.containsKey(gavDependencyParam)) {
-                    return RuntimeFunctionResolver.Resolution.Resolved(object : DeclarativeRuntimeFunction {
-                        override fun callBy(receiver: Any, binding: Map<DataParameter, Any?>, hasLambda: Boolean): DeclarativeRuntimeFunction.InvocationResult {
-                            val dependencyNotation = binding.values.single().toString()
-                            val collector: DependencyCollector = getterFunction.call(receiver) as DependencyCollector
-                            collector.add(dependencyNotation)
-                            return DeclarativeRuntimeFunction.InvocationResult(Unit, null)
-                        }
-                    })
-                } else if (parameterValueBinding.bindingMap.containsKey(projectDependencyParam)) {
-                    return RuntimeFunctionResolver.Resolution.Resolved(object : DeclarativeRuntimeFunction {
-                        override fun callBy(receiver: Any, binding: Map<DataParameter, Any?>, hasLambda: Boolean): DeclarativeRuntimeFunction.InvocationResult {
-                            val dependencyNotation = binding.values.single() as ProjectDependency
-                            val collector: DependencyCollector = getterFunction.call(receiver) as DependencyCollector
-                            collector.add(dependencyNotation)
-                            return DeclarativeRuntimeFunction.InvocationResult(Unit, null)
-                        }
-                    })
-                } else {
-                    throw IllegalStateException("Unexpected parameter binding contents: ${parameterValueBinding.bindingMap.keys} for function: $name in: $receiverClass")
-                }
+        val getterFunction = getDependencyCollectorGetter(receiverClass, name)
+        if (getterFunction != null) {
+            if (parameterValueBinding.bindingMap.containsKey(gavDependencyParam)) {
+                return RuntimeFunctionResolver.Resolution.Resolved(object : DeclarativeRuntimeFunction {
+                    override fun callBy(receiver: Any, binding: Map<DataParameter, Any?>, hasLambda: Boolean): DeclarativeRuntimeFunction.InvocationResult {
+                        val dependencyNotation = binding.values.single().toString()
+                        val collector: DependencyCollector = getterFunction.call(receiver) as DependencyCollector
+                        collector.add(dependencyNotation)
+                        return DeclarativeRuntimeFunction.InvocationResult(Unit, null)
+                    }
+                })
+            } else if (parameterValueBinding.bindingMap.containsKey(projectDependencyParam)) {
+                return RuntimeFunctionResolver.Resolution.Resolved(object : DeclarativeRuntimeFunction {
+                    override fun callBy(receiver: Any, binding: Map<DataParameter, Any?>, hasLambda: Boolean): DeclarativeRuntimeFunction.InvocationResult {
+                        val dependencyNotation = binding.values.single() as ProjectDependency
+                        val collector: DependencyCollector = getterFunction.call(receiver) as DependencyCollector
+                        collector.add(dependencyNotation)
+                        return DeclarativeRuntimeFunction.InvocationResult(Unit, null)
+                    }
+                })
+            } else {
+                throw IllegalStateException("Unexpected parameter binding contents: ${parameterValueBinding.bindingMap.keys} for function: $name in: $receiverClass")
             }
         }
         return RuntimeFunctionResolver.Resolution.Unresolved
     }
 
     private
-    fun getDependencyCollectorGetter(receiverClass: KClass<*>, configurationName: String): KFunction<*>? = receiverClass.functions
+    fun getDependencyCollectorGetter(receiverClass: KClass<*>, name: String): KFunction<*>? = receiverClass.functions
         .filter { hasDependencyCollectorGetterSignature(receiverClass, it) }
-        .firstOrNull { function -> function.name == "get${configurationName.replaceFirstChar { it.uppercase(Locale.getDefault()) }}" }
+        .firstOrNull { function -> function.name == "get${name.replaceFirstChar { it.uppercase(Locale.getDefault()) }}" }
 }
 
 

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/dependencyConfigurationSchema.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/dependencyConfigurationSchema.kt
@@ -31,6 +31,7 @@ import org.gradle.internal.declarativedsl.schemaBuilder.FunctionExtractor
 import org.gradle.internal.declarativedsl.schemaBuilder.toDataTypeRef
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.artifacts.dsl.Dependencies
 import org.gradle.api.artifacts.dsl.DependencyCollector
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.internal.declarativedsl.analysis.FunctionSemantics.ConfigureSemantics.ConfigureBlockRequirement.NOT_ALLOWED
@@ -101,9 +102,8 @@ class DependencyFunctionsExtractor(val configurations: DependencyConfigurations)
 private
 class ImplicitDependencyCollectorFunctionExtractor(val configurations: DependencyConfigurations) : FunctionExtractor {
     override fun memberFunctions(kClass: KClass<*>, preIndex: DataSchemaBuilder.PreIndex): Iterable<SchemaMemberFunction> = kClass.memberFunctions
-        .filter { function -> hasDependencyCollectorGetterSignature(function) }
+        .filter { function -> hasDependencyCollectorGetterSignature(kClass, function) }
         .map { function -> function.name.removePrefix("get").replaceFirstChar { it.lowercase(Locale.getDefault()) } }
-        .filter { confName -> confName in configurations.configurationNames }
         .flatMap { confName ->
             listOf(
                 DataMemberFunction(
@@ -185,14 +185,17 @@ class ImplicitDependencyCollectorFunctionResolver(configurations: DependencyConf
 
     private
     fun getDependencyCollectorGetter(receiverClass: KClass<*>, configurationName: String): KFunction<*>? = receiverClass.functions
-        .filter { hasDependencyCollectorGetterSignature(it) }
+        .filter { hasDependencyCollectorGetterSignature(receiverClass, it) }
         .firstOrNull { function -> function.name == "get${configurationName.replaceFirstChar { it.uppercase(Locale.getDefault()) }}" }
 }
 
 
 @OptIn(ExperimentalStdlibApi::class) // For javaType
 private
-fun hasDependencyCollectorGetterSignature(function: KFunction<*>): Boolean {
+fun hasDependencyCollectorGetterSignature(receiverClass: KClass<*>, function: KFunction<*>): Boolean {
+    if (!hasDependenciesSuperType(receiverClass)) {
+        return false
+    }
     val returnType: Type = try {
         function.returnType.javaType
     } catch (e: Throwable) { // Sometimes reflection fails with an error when the return type is unusual, if it failed then it's not a getter of interest
@@ -200,6 +203,10 @@ fun hasDependencyCollectorGetterSignature(function: KFunction<*>): Boolean {
     }
     return function.name.startsWith("get") && returnType == DependencyCollector::class.java && function.parameters.size == 1
 }
+
+
+private
+fun hasDependenciesSuperType(type: KClass<*>) = type.isSubclassOf(Dependencies::class)
 
 
 private


### PR DESCRIPTION
This is more correct as it is not required to name them after Configurations.  Instead, check if the type they are implemented on extends Dependencies.