### PR TITLE
Document supported ways for setting conventions on lazy properties

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/lazy_configuration.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/lazy_configuration.adoc
@@ -323,27 +323,55 @@ include::{snippetsPath}/providers/propertyConvention/tests/propertyConvention.ou
 
 === Where to apply conventions from?
 
-In general, you want to apply convention to a property at configuration time (i.e., before execution), so task actions are not appropriate.
-Still, there many appropriate locations for setting a convention on a property.
+There are several appropriate locations for setting a convention on a property at configuration time (i.e., before execution).
+
+====
+include::sample[dir="snippets/providers/propertyConventionCallsites/kotlin",files="build.gradle.kts[tags=convention-callsites]"]
+include::sample[dir="snippets/providers/propertyConventionCallsites/groovy",files="build.gradle[tags=convention-callsites]"]
+====
 
 ==== From a plugin's `apply()` method
 
-Plugin authors may configure a convention on a lazy property from a plugin's `apply()` method, while performing preliminary configuration of the property-owning task.
+Plugin authors may configure a convention on a lazy property from a plugin's `apply()` method, while performing preliminary configuration of the task or extension defining the property.
+This works well for regular plugins (meant to be distributed and used in the wild), and internal <<sharing_build_logic_between_subprojects.adoc#sec:convention_plugins,convention plugins>> (which often configure properties defined by third party plugins in a uniform way for the entire build).
+
+====
+include::sample[dir="snippets/providers/propertyConventionCallsites/kotlin",files="build.gradle.kts[tags=convention-callsites-from-plugin]"]
+include::sample[dir="snippets/providers/propertyConventionCallsites/groovy",files="build.gradle[tags=convention-callsites-from-plugin]"]
+====
 
 ==== From a build script
 
-Build engineers may configure a convention on a lazy property from shared build logic that is configuring tasks in a standard way for the entire build.
-Note that for project-specific values, instead of conventions, you should prefer setting explicit values (using `Property.value(...)` or `ConfigurableFileCollection.setFrom(...)`, for instance).
+Build engineers may configure a convention on a lazy property from shared build logic that is configuring tasks (for instance, from third-party plugins) in a standard way for the entire build.
 
-==== From the task constructor
+====
+include::sample[dir="snippets/providers/propertyConventionCallsites/kotlin",files="build.gradle.kts[tags=convention-callsites-from-buildscript]"]
+include::sample[dir="snippets/providers/propertyConventionCallsites/groovy",files="build.gradle[tags=convention-callsites-from-buildscript]"]
+====
 
-A task author may configure a convention on a lazy property from the task constructor. 
+Note that for project-specific values, instead of conventions, you should prefer setting explicit values (using `Property.set(...)` or `ConfigurableFileCollection.setFrom(...)`, for instance),
+as conventions are only meant to define defaults.
+
+==== From the task initialization
+
+A task author may configure a convention on a lazy property from the task constructor or (if in Kotlin) initializer block.
 This approach works for properties with trivial defaults, but it is not appropriate if additional context (external to the task implementation) is required in order to set a suitable default.
+
+====
+include::sample[dir="snippets/providers/propertyConventionCallsites/kotlin",files="build.gradle.kts[tags=convention-callsites-from-constructor]"]
+include::sample[dir="snippets/providers/propertyConventionCallsites/groovy",files="build.gradle[tags=convention-callsites-from-constructor]"]
+====
 
 ==== Next to the property declaration
 
 You may configure a convention on a lazy property next to the place where the property is declared.
 Note this option is not available for <<custom_gradle_types.adoc#managed_properties,managed properties>>, and has the same caveats as configuring a convention from the task constructor.
+
+====
+include::sample[dir="snippets/providers/propertyConventionCallsites/kotlin",files="build.gradle.kts[tags=convention-callsites-from-declaration]"]
+include::sample[dir="snippets/providers/propertyConventionCallsites/groovy",files="build.gradle[tags=convention-callsites-from-declaration]"]
+====
+
 
 [[unmodifiable_property]]
 == Making a property unmodifiable

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/lazy_configuration.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/lazy_configuration.adoc
@@ -323,8 +323,8 @@ include::{snippetsPath}/providers/propertyConvention/tests/propertyConvention.ou
 
 === Where to apply conventions from?
 
-In general, you want to apply convention to a property at configuration time, before tasks execute, so task actions are not appropriate.
-Still, there are multiple options for appropriate locations for setting a convention on a property.
+In general, you want to apply convention to a property at configuration time (i.e., before execution), so task actions are not appropriate.
+Still, there many appropriate locations for setting a convention on a property.
 
 ==== From a plugin's `apply()` method
 
@@ -337,8 +337,8 @@ Note that for project-specific values, instead of conventions, you should prefer
 
 ==== From the task constructor
 
-A task author may configure a convention on a lazy property from the task constructor. This approach works for properties with trivial defaults,
-but it is not appropriate if additional context (external to the task implementation) is required in order to set a suitable default.
+A task author may configure a convention on a lazy property from the task constructor. 
+This approach works for properties with trivial defaults, but it is not appropriate if additional context (external to the task implementation) is required in order to set a suitable default.
 
 ==== Next to the property declaration
 

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/lazy_configuration.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/lazy_configuration.adoc
@@ -321,6 +321,30 @@ $ gradle show
 include::{snippetsPath}/providers/propertyConvention/tests/propertyConvention.out[]
 ----
 
+=== Where to apply conventions from?
+
+In general, you want to apply convention to a property at configuration time, before tasks execute, so task actions are not appropriate.
+Still, there are multiple options for appropriate locations for setting a convention on a property.
+
+==== From a plugin's `apply()` method
+
+Plugin authors may configure a convention on a lazy property from a plugin's `apply()` method, while performing preliminary configuration of the property-owning task.
+
+==== From a build script
+
+Build engineers may configure a convention on a lazy property from shared build logic that is configuring tasks in a standard way for the entire build.
+Note that for project-specific values, instead of conventions, you should prefer setting explicit values (using `Property.value(...)` or `ConfigurableFileCollection.setFrom(...)`, for instance).
+
+==== From the task constructor
+
+A task author may configure a convention on a lazy property from the task constructor. This approach works for properties with trivial defaults,
+but it is not appropriate if additional context (external to the task implementation) is required in order to set a suitable default.
+
+==== Next to the property declaration
+
+You may configure a convention on a lazy property next to the place where the property is declared.
+Note this option is not available for <<custom_gradle_types.adoc#managed_properties,managed properties>>, and has the same caveats as configuring a convention from the task constructor.
+
 [[unmodifiable_property]]
 == Making a property unmodifiable
 

--- a/platforms/documentation/docs/src/snippets/providers/propertyConventionCallsites/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/providers/propertyConventionCallsites/groovy/build.gradle
@@ -1,0 +1,49 @@
+// tag::convention-callsites[]
+
+abstract class GreetingTask extends DefaultTask {
+    // tag::convention-callsites-from-declaration[]
+    // setting convention from declaration
+    @Input
+    final Property<String> greeter = project.objects.property(String).convention("person1")
+    // end::convention-callsites-from-declaration[]
+
+    // tag::convention-callsites-from-constructor[]
+    // setting convention from constructor
+    @Input
+    abstract Property<String> getGuest()
+
+    GreetingTask() {
+        guest.convention("person2")
+    }
+    // end::convention-callsites-from-constructor[]
+
+    @TaskAction
+    void greet() {
+        println("hello, ${guest.get()}, from ${greeter.get()}")
+    }
+}
+
+// tag::convention-callsites-from-plugin[]
+// setting convention when registering a task from plugin
+class GreetingPlugin implements Plugin<Project> {
+    void apply(Project project) {
+        project.getTasks().register("hello", GreetingTask) {
+            greeter.convention("Greeter")
+        }
+    }
+}
+// end::convention-callsites-from-plugin[]
+
+apply plugin: GreetingPlugin
+
+// tag::convention-callsites-from-buildscript[]
+tasks.withType(GreetingTask).configureEach {
+    // setting convention from build script
+    guest.convention("Guest")
+}
+// end::convention-callsites-from-buildscript[]
+
+// end::convention-callsites[]
+
+
+

--- a/platforms/documentation/docs/src/snippets/providers/propertyConventionCallsites/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/providers/propertyConventionCallsites/groovy/build.gradle
@@ -1,28 +1,5 @@
 // tag::convention-callsites[]
 
-abstract class GreetingTask extends DefaultTask {
-    // tag::convention-callsites-from-declaration[]
-    // setting convention from declaration
-    @Input
-    final Property<String> greeter = project.objects.property(String).convention("person1")
-    // end::convention-callsites-from-declaration[]
-
-    // tag::convention-callsites-from-constructor[]
-    // setting convention from constructor
-    @Input
-    abstract Property<String> getGuest()
-
-    GreetingTask() {
-        guest.convention("person2")
-    }
-    // end::convention-callsites-from-constructor[]
-
-    @TaskAction
-    void greet() {
-        println("hello, ${guest.get()}, from ${greeter.get()}")
-    }
-}
-
 // tag::convention-callsites-from-plugin[]
 // setting convention when registering a task from plugin
 class GreetingPlugin implements Plugin<Project> {
@@ -42,6 +19,29 @@ tasks.withType(GreetingTask).configureEach {
     guest.convention("Guest")
 }
 // end::convention-callsites-from-buildscript[]
+
+abstract class GreetingTask extends DefaultTask {
+    // tag::convention-callsites-from-constructor[]
+    // setting convention from constructor
+    @Input
+    abstract Property<String> getGuest()
+
+    GreetingTask() {
+        guest.convention("person2")
+    }
+    // end::convention-callsites-from-constructor[]
+
+    // tag::convention-callsites-from-declaration[]
+    // setting convention from declaration
+    @Input
+    final Property<String> greeter = project.objects.property(String).convention("person1")
+    // end::convention-callsites-from-declaration[]
+
+    @TaskAction
+    void greet() {
+        println("hello, ${guest.get()}, from ${greeter.get()}")
+    }
+}
 
 // end::convention-callsites[]
 

--- a/platforms/documentation/docs/src/snippets/providers/propertyConventionCallsites/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/providers/propertyConventionCallsites/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'property-convention-callsites'

--- a/platforms/documentation/docs/src/snippets/providers/propertyConventionCallsites/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/providers/propertyConventionCallsites/kotlin/build.gradle.kts
@@ -1,28 +1,5 @@
 // tag::convention-callsites[]
 
-abstract class GreetingTask : DefaultTask() {
-    // tag::convention-callsites-from-declaration[]
-    // setting convention from declaration
-    @Input
-    val greeter = project.objects.property<String>().convention("person1")
-    // end::convention-callsites-from-declaration[]
-
-    // tag::convention-callsites-from-constructor[]
-    // setting convention from constructor
-    @get:Input
-    abstract val guest: Property<String>
-
-    init {
-        guest.convention("person2")
-    }
-    // end::convention-callsites-from-constructor[]
-
-    @TaskAction
-    fun greet() {
-        println("hello, ${guest.get()}, from ${greeter.get()}")
-    }
-}
-
 // tag::convention-callsites-from-plugin[]
 // setting convention when registering a task from plugin
 class GreetingPlugin : Plugin<Project> {
@@ -42,6 +19,29 @@ tasks.withType<GreetingTask>().configureEach {
     guest.convention("Guest")
 }
 // end::convention-callsites-from-buildscript[]
+
+abstract class GreetingTask : DefaultTask() {
+    // tag::convention-callsites-from-constructor[]
+    // setting convention from constructor
+    @get:Input
+    abstract val guest: Property<String>
+
+    init {
+        guest.convention("person2")
+    }
+    // end::convention-callsites-from-constructor[]
+
+    // tag::convention-callsites-from-declaration[]
+    // setting convention from declaration
+    @Input
+    val greeter = project.objects.property<String>().convention("person1")
+    // end::convention-callsites-from-declaration[]
+
+    @TaskAction
+    fun greet() {
+        println("hello, ${guest.get()}, from ${greeter.get()}")
+    }
+}
 
 // end::convention-callsites[]
 

--- a/platforms/documentation/docs/src/snippets/providers/propertyConventionCallsites/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/providers/propertyConventionCallsites/kotlin/build.gradle.kts
@@ -1,0 +1,49 @@
+// tag::convention-callsites[]
+
+abstract class GreetingTask : DefaultTask() {
+    // tag::convention-callsites-from-declaration[]
+    // setting convention from declaration
+    @Input
+    val greeter = project.objects.property<String>().convention("person1")
+    // end::convention-callsites-from-declaration[]
+
+    // tag::convention-callsites-from-constructor[]
+    // setting convention from constructor
+    @get:Input
+    abstract val guest: Property<String>
+
+    init {
+        guest.convention("person2")
+    }
+    // end::convention-callsites-from-constructor[]
+
+    @TaskAction
+    fun greet() {
+        println("hello, ${guest.get()}, from ${greeter.get()}")
+    }
+}
+
+// tag::convention-callsites-from-plugin[]
+// setting convention when registering a task from plugin
+class GreetingPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        project.getTasks().register<GreetingTask>("hello") {
+            greeter.convention("Greeter")
+        }
+    }
+}
+// end::convention-callsites-from-plugin[]
+
+// tag::convention-callsites-from-buildscript[]
+apply<GreetingPlugin>()
+
+tasks.withType<GreetingTask>().configureEach {
+    // setting convention from build script
+    guest.convention("Guest")
+}
+// end::convention-callsites-from-buildscript[]
+
+// end::convention-callsites[]
+
+
+

--- a/platforms/documentation/docs/src/snippets/providers/propertyConventionCallsites/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/providers/propertyConventionCallsites/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "property-convention-callsites"

--- a/platforms/documentation/docs/src/snippets/providers/propertyConventionCallsites/tests/propertyConventionCallsites.out
+++ b/platforms/documentation/docs/src/snippets/providers/propertyConventionCallsites/tests/propertyConventionCallsites.out
@@ -1,3 +1,4 @@
+
 > Task :hello
 hello, Guest, from Greeter
 

--- a/platforms/documentation/docs/src/snippets/providers/propertyConventionCallsites/tests/propertyConventionCallsites.out
+++ b/platforms/documentation/docs/src/snippets/providers/propertyConventionCallsites/tests/propertyConventionCallsites.out
@@ -1,0 +1,5 @@
+> Task :hello
+hello, Guest, from Greeter
+
+BUILD SUCCESSFUL in 0s
+1 actionable task: 1 executed

--- a/platforms/documentation/docs/src/snippets/providers/propertyConventionCallsites/tests/propertyConventionCallsites.sample.conf
+++ b/platforms/documentation/docs/src/snippets/providers/propertyConventionCallsites/tests/propertyConventionCallsites.sample.conf
@@ -1,0 +1,6 @@
+# tag::cli[]
+# gradle show
+# end::cli[]
+executable: gradle
+args: hello
+expected-output-file: propertyConventionCallsites.out


### PR DESCRIPTION

Fixes: #24773

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
