### PR TITLE
Restore providing convention for Wrapper.validateDistributionUrl

### DIFF
--- a/platforms/software/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -103,6 +103,10 @@ public abstract class Wrapper extends DefaultTask {
     private boolean distributionUrlConfigured = false;
     private final boolean isOffline = getProject().getGradle().getStartParameter().isOffline();
 
+    public Wrapper() {
+        getValidateDistributionUrl().convention(WrapperDefaults.VALIDATE_DISTRIBUTION_URL);
+    }
+
     @TaskAction
     void generate() {
         File jarFileDestination = getJarFile();

--- a/platforms/software/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
+++ b/platforms/software/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.api.tasks.wrapper
 import org.gradle.api.tasks.AbstractTaskTest
 import org.gradle.api.tasks.TaskPropertyTestUtils
 import org.gradle.api.tasks.wrapper.internal.DefaultWrapperVersionsResources
-import org.gradle.api.tasks.wrapper.internal.WrapperDefaults
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.GradleVersion
 import org.gradle.util.internal.GUtil
@@ -57,7 +56,6 @@ class WrapperTest extends AbstractTaskTest {
         new File(getProject().getProjectDir(), TARGET_WRAPPER_FINAL).mkdirs()
         wrapper.setDistributionPath("somepath")
         wrapper.setDistributionSha256Sum("somehash")
-        wrapper.validateDistributionUrl.convention(WrapperDefaults.VALIDATE_DISTRIBUTION_URL)
     }
 
     Wrapper getTask() {


### PR DESCRIPTION
The breaking change was introduced in https://github.com/gradle/gradle/pull/27408