### PR TITLE
Increase heap size for daemon

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx2500m -XX:MaxMetaspaceSize=768m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2800m -XX:MaxMetaspaceSize=768m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true


### PR DESCRIPTION
This is to mitigate the OOM we recently observed in AllVersionsCross tests: https://github.com/gradle/gradle-private/issues/4168

I managed to capture a heap dump for the OOMed build. I don't see obvious memory leaks (like the memory used by last build invocation not reclaimed). 

![image](https://github.com/gradle/gradle/assets/12689835/4167bc88-0465-422c-97d3-d96e0414a90a)

Instead, I noticed a huge `CachingDirectedGraphWalker`, which seems valid.

![image](https://github.com/gradle/gradle/assets/12689835/b01f44f6-2946-4f11-be32-e3430c5773e8)

My feeling is that the single Gradle build now uses too much memory and finally kicks the last brick.

I tried too run AllVersionsCrossVersion Linux and Windows builds on my branch and it seems no issue:

https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_AllVersionsCrossVersion_11_Trigger?mode=builds#all-projects

https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_AllVersionsCrossVersion_10_Trigger?mode=builds#all-projects