### PR TITLE
Validate unscoped services without a scoped interface

### DIFF
--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/AnnotatedServiceLifecycleHandler.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/AnnotatedServiceLifecycleHandler.java
@@ -26,6 +26,10 @@ import java.util.List;
 public interface AnnotatedServiceLifecycleHandler {
     List<Class<? extends Annotation>> getAnnotations();
 
+    /**
+     * When not null, all services are considered to have the implicit annotation
+     * and the handler should be notified about all registrations.
+     */
     @Nullable
     Class<? extends Annotation> getImplicitAnnotation();
 

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/AnnotatedServiceLifecycleHandler.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/AnnotatedServiceLifecycleHandler.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.service;
 
+import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
 import java.util.List;
 
@@ -24,6 +25,9 @@ import java.util.List;
  */
 public interface AnnotatedServiceLifecycleHandler {
     List<Class<? extends Annotation>> getAnnotations();
+
+    @Nullable
+    Class<? extends Annotation> getImplicitAnnotation();
 
     /**
      * Called when a service with the given annotation is registered.

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -512,11 +512,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
             collectProvidersForClassHierarchy(inspector, serviceProvider.serviceClass, serviceProvider);
             services.add(serviceProvider);
             for (AnnotatedServiceLifecycleHandler annotationHandler : lifecycleHandlers) {
-                for (Class<? extends Annotation> annotation : annotationHandler.getAnnotations()) {
-                    if (inspector.hasAnnotation(serviceProvider.serviceClass, annotation)) {
-                        annotationHandler.whenRegistered(annotation, new RegistrationWrapper(serviceProvider));
-                    }
-                }
+                notifyAnnotationHandler(annotationHandler, serviceProvider);
             }
         }
 
@@ -564,6 +560,14 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
         void annotationHandlerCreated(AnnotatedServiceLifecycleHandler annotationHandler) {
             lifecycleHandlers.add(annotationHandler);
             for (SingletonService candidate : services) {
+                notifyAnnotationHandler(annotationHandler, candidate);
+            }
+        }
+
+        private void notifyAnnotationHandler(AnnotatedServiceLifecycleHandler annotationHandler, SingletonService candidate) {
+            if (annotationHandler.getImplicitAnnotation() != null) {
+                annotationHandler.whenRegistered(annotationHandler.getImplicitAnnotation(), new RegistrationWrapper(candidate));
+            } else {
                 for (Class<? extends Annotation> annotation : annotationHandler.getAnnotations()) {
                     if (inspector.hasAnnotation(candidate.serviceClass, annotation)) {
                         annotationHandler.whenRegistered(annotation, new RegistrationWrapper(candidate));

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/ServiceScopeValidator.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/ServiceScopeValidator.java
@@ -58,11 +58,20 @@ class ServiceScopeValidator implements AnnotatedServiceLifecycleHandler {
     }
 
     @Override
+    public Class<? extends Annotation> getImplicitAnnotation() {
+        return ServiceScope.class;
+    }
+
+    @Override
     public void whenRegistered(Class<? extends Annotation> annotation, Registration registration) {
         validateScope(registration.getDeclaredType());
     }
 
     private void validateScope(Class<?> serviceType) {
+        if (ServiceScopeValidator.class.isAssignableFrom(serviceType)) {
+            return;
+        }
+
         Class<? extends Scope>[] serviceScopes = scopeOf(serviceType);
 
         if (serviceScopes == null) {

--- a/platforms/core-runtime/base-services/src/test/groovy/org/gradle/internal/service/ScopedServiceRegistryTest.groovy
+++ b/platforms/core-runtime/base-services/src/test/groovy/org/gradle/internal/service/ScopedServiceRegistryTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.internal.service
 
 import org.gradle.internal.service.scopes.Scope
 import org.gradle.internal.service.scopes.ServiceScope
-import org.gradle.util.internal.ToBeImplemented
 import spock.lang.Specification
 
 class ScopedServiceRegistryTest extends Specification {
@@ -135,7 +134,6 @@ class ScopedServiceRegistryTest extends Specification {
         'provider' | { ScopedServiceRegistry it -> it.addProvider(new BuildTreeScopedServiceInterfaceUnscopedImplProvider()) }
     }
 
-    @ToBeImplemented
     def "fails when registering an unscoped service via #method in strict mode"() {
         given:
         def registry = strictScopedRegistry(Scope.BuildTree)
@@ -144,10 +142,8 @@ class ScopedServiceRegistryTest extends Specification {
         registration(registry)
 
         then:
-        noExceptionThrown()
-        // TODO: support validation of not annotated services
-//        def exception = thrown(IllegalArgumentException)
-//        exception.message.contains("The service implementation '${UnscopedService.name}' is registered in the 'BuildTree' scope but does not declare it explicitly.")
+        def exception = thrown(IllegalArgumentException)
+        exception.message.contains("The service '${UnscopedService.name}' is registered in the 'BuildTree' scope but does not declare it. Add the '@ServiceScope()' annotation on '${UnscopedService.simpleName}' with the 'BuildTree' scope.")
 
         where:
         method     | registration

--- a/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/event/DefaultListenerManager.java
+++ b/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/event/DefaultListenerManager.java
@@ -28,6 +28,7 @@ import org.gradle.internal.service.scopes.ListenerService;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.StatefulListener;
 
+import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -64,6 +65,12 @@ public class DefaultListenerManager implements ListenerManager, AnnotatedService
     @Override
     public List<Class<? extends Annotation>> getAnnotations() {
         return ANNOTATIONS;
+    }
+
+    @Nullable
+    @Override
+    public Class<? extends Annotation> getImplicitAnnotation() {
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Follow-up for https://github.com/gradle/gradle/pull/28682

Covers an additional case of strict service scoping validation when a class registered as a service is not annotated with `@ServiceScope` but also none of its super-interfaces. Previously, such services bypassed the scope validation logic.