### PR TITLE
Fix cause for non-closed build operations

### DIFF
--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/resources/DefaultResourceLockCoordinationService.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/resources/DefaultResourceLockCoordinationService.java
@@ -109,10 +109,16 @@ public class DefaultResourceLockCoordinationService implements ResourceLockCoord
                             maybeNotifyStateChange(resourceLockState);
                             resourceLockState.reset();
                             finishOperation(previous);
-                            try {
-                                lock.wait();
-                            } catch (InterruptedException e) {
-                                throw UncheckedException.throwAsUncheckedException(e);
+                            while (true) {
+                                try {
+                                    lock.wait();
+                                    break;
+                                } catch (InterruptedException e) {
+                                    // Interrupting the state lock thread means something changed,
+                                    // so let's retry obtaining the lock.
+                                    // Clear the interrupted flag.
+                                    boolean ignored = Thread.interrupted();
+                                }
                             }
                             startOperation(resourceLockState);
                             break;

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/resources/DefaultResourceLockCoordinationService.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/resources/DefaultResourceLockCoordinationService.java
@@ -99,7 +99,6 @@ public class DefaultResourceLockCoordinationService implements ResourceLockCoord
         synchronized (lock) {
             DefaultResourceLockState resourceLockState = new DefaultResourceLockState();
             DefaultResourceLockState previous = startOperation(resourceLockState);
-            boolean operationFinished = false;
             try {
                 while (true) {
                     ResourceLockState.Disposition disposition;
@@ -109,14 +108,12 @@ public class DefaultResourceLockCoordinationService implements ResourceLockCoord
                             resourceLockState.releaseLocks();
                             maybeNotifyStateChange(resourceLockState);
                             resourceLockState.reset();
-                            operationFinished = true;
                             finishOperation(previous);
                             try {
                                 lock.wait();
                             } catch (InterruptedException e) {
                                 throw UncheckedException.throwAsUncheckedException(e);
                             }
-                            operationFinished = false;
                             startOperation(resourceLockState);
                             break;
                         case FINISHED:
@@ -133,9 +130,7 @@ public class DefaultResourceLockCoordinationService implements ResourceLockCoord
                 resourceLockState.releaseLocks();
                 throw UncheckedException.throwAsUncheckedException(t);
             } finally {
-                if (!operationFinished) {
-                    finishOperation(previous);
-                }
+                finishOperation(previous);
             }
         }
     }

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/resources/DefaultResourceLockCoordinationService.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/resources/DefaultResourceLockCoordinationService.java
@@ -109,16 +109,13 @@ public class DefaultResourceLockCoordinationService implements ResourceLockCoord
                             maybeNotifyStateChange(resourceLockState);
                             resourceLockState.reset();
                             finishOperation(previous);
-                            while (true) {
-                                try {
-                                    lock.wait();
-                                    break;
-                                } catch (InterruptedException e) {
-                                    // Interrupting the state lock thread means something changed,
-                                    // so let's retry obtaining the lock.
-                                    // Clear the interrupted flag.
-                                    boolean ignored = Thread.interrupted();
-                                }
+                            try {
+                                lock.wait();
+                            } catch (InterruptedException e) {
+                                // Interrupting the state lock thread means something changed,
+                                // so let's retry obtaining the lock.
+                                // Clear the interrupted flag.
+                                boolean ignored = Thread.interrupted();
                             }
                             startOperation(resourceLockState);
                             break;

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/CancellationBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/CancellationBuildOperationIntegrationTest.groovy
@@ -62,19 +62,17 @@ class CancellationBuildOperationIntegrationTest extends AbstractIntegrationSpec 
         }
 
         when:
-        // Need to try a few times, the build doesn't always fail as expected
-        for (int i in 0..5) {
-            fails('parallelTask', '--parallel', ':interrupting', "--console=plain", "--max-workers=${(parallelTaskCount / 2) + 2 as int}", '--continue')
-            if (!operations.danglingChildren.empty) {
-                break
-            }
-        }
-
+        fails('parallelTask', '--parallel', ':interrupting', "--console=plain", "--max-workers=${(parallelTaskCount / 2) + 2 as int}", '--continue')
 
         then:
-        // Should be fixed: There shouldn't be any dangling build operations
-        !operations.danglingChildren.empty
-        failure.assertHasDescription("Another thread holds the state lock.")
-        failure.assertThatDescription(anyOf(equalTo("Not all work has completed."), equalTo("Some project locks have not been unlocked.")))
+        operations.danglingChildren.empty
+        failure.assertThatAllDescriptions(anyOf(
+            equalTo("Execution failed for task ':interrupting'."),
+            equalTo("Execution failed for task ':a0:parallelTask'."),
+            equalTo("Execution failed for task ':a1:parallelTask'."),
+            equalTo("Execution failed for task ':a2:parallelTask'."),
+            equalTo("Execution failed for task ':a3:parallelTask'."),
+            equalTo("Execution failed for task ':a4:parallelTask'.")
+        ))
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/CancellationBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/CancellationBuildOperationIntegrationTest.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.process.internal
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.BuildOperationsFixture
+
+import static org.hamcrest.CoreMatchers.anyOf
+import static org.hamcrest.CoreMatchers.equalTo
+
+class CancellationBuildOperationIntegrationTest extends AbstractIntegrationSpec {
+
+    BuildOperationsFixture operations = new BuildOperationsFixture(executer, temporaryFolder)
+
+    def "task operations are closed even when interrupting the execution workers"() {
+        def parallelTaskCount = 5
+        buildFile << """
+          ext.workerThreads = new HashSet<>()
+          ext.latch = new java.util.concurrent.CountDownLatch(${parallelTaskCount} )
+          tasks.register('interrupting') {
+            doFirst {
+              rootProject.ext.latch.await()
+              rootProject.ext.workerThreads.each {
+                if (it.name.contains('included builds')) {
+                  it.interrupt()
+                }
+              }
+            }
+          }
+        """
+        parallelTaskCount.times { project ->
+            settingsFile << """include 'a$project'\n"""
+            file("a$project/build.gradle") << """
+                tasks.register('parallelTask') {
+                    doFirst {
+                        println 'executing a parallelTask in thread ' + Thread.currentThread()
+                        rootProject.ext.workerThreads << Thread.currentThread()
+                        rootProject.ext.latch.countDown()
+                        Thread.sleep(1000)
+                    }
+                }
+            """
+        }
+
+        when:
+        // Need to try a few times, the build doesn't always fail as expected
+        for (int i in 0..5) {
+            fails('parallelTask', '--parallel', ':interrupting', "--console=plain", "--max-workers=${(parallelTaskCount / 2) + 2 as int}", '--continue')
+            if (!operations.danglingChildren.empty) {
+                break
+            }
+        }
+
+
+        then:
+        // Should be fixed: There shouldn't be any dangling build operations
+        !operations.danglingChildren.empty
+        failure.assertHasDescription("Another thread holds the state lock.")
+        failure.assertThatDescription(anyOf(equalTo("Not all work has completed."), equalTo("Some project locks have not been unlocked.")))
+    }
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/CancellationBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/CancellationBuildOperationIntegrationTest.groovy
@@ -18,6 +18,8 @@ package org.gradle.process.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.IntegTestPreconditions
 
 import static org.hamcrest.CoreMatchers.anyOf
 import static org.hamcrest.CoreMatchers.equalTo
@@ -26,6 +28,7 @@ class CancellationBuildOperationIntegrationTest extends AbstractIntegrationSpec 
 
     BuildOperationsFixture operations = new BuildOperationsFixture(executer, temporaryFolder)
 
+    @Requires(IntegTestPreconditions.NotEmbeddedExecutor)
     def "task operations are closed even when interrupting the execution workers"() {
         def parallelTaskCount = 5
         buildFile << """
@@ -39,6 +42,8 @@ class CancellationBuildOperationIntegrationTest extends AbstractIntegrationSpec 
                   it.interrupt()
                 }
               }
+              // We fail this task so the build fails consistently
+              throw new RuntimeException("Interrupting done")
             }
           }
         """

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/CancellationBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/CancellationBuildOperationIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.process.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
@@ -33,6 +34,7 @@ class CancellationBuildOperationIntegrationTest extends AbstractIntegrationSpec 
     BuildOperationsFixture operations = new BuildOperationsFixture(executer, temporaryFolder)
 
     @Requires(IntegTestPreconditions.NotEmbeddedExecutor)
+    @UnsupportedWithConfigurationCache(because = "captures worker threads in shared state")
     def "task operations are closed even when interrupting the execution workers"() {
         server.start()
         executer.withStackTraceChecksDisabled()

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationTrace.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationTrace.java
@@ -189,7 +189,7 @@ public class BuildOperationTrace implements Stoppable {
                 }
 
                 if (outputTree) {
-                    List<BuildOperationRecord> roots = readLogToTreeRoots(logFile(basePath), true);
+                    List<BuildOperationRecord> roots = readLogToTreeRoots(logFile(basePath), false);
                     writeDetailTree(roots);
                     writeSummaryTree(roots);
                 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationsFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationsFixture.groovy
@@ -48,6 +48,10 @@ class BuildOperationsFixture extends BuildOperationTreeQueries {
         getTree().roots
     }
 
+    List<BuildOperationRecord> getDanglingChildren() {
+        new BuildOperationTreeFixture(BuildOperationTrace.readPartialTree(path)).roots.findAll { it.parentId != null }
+    }
+
     @Override
     @SuppressWarnings("GrUnnecessaryPublicModifier")
     public <T extends BuildOperationType<?, ?>> BuildOperationRecord root(Class<T> type, Spec<? super BuildOperationRecord> predicate = Specs.satisfyAll()) {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ErrorsOnStdoutScrapingExecutionFailure.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ErrorsOnStdoutScrapingExecutionFailure.java
@@ -76,6 +76,12 @@ public class ErrorsOnStdoutScrapingExecutionFailure extends ErrorsOnStdoutScrapi
     }
 
     @Override
+    public ExecutionFailure assertThatAllDescriptions(Matcher<? super String> matcher) {
+        delegate.assertThatDescription(matcher);
+        return this;
+    }
+
+    @Override
     public ExecutionFailure assertHasFailure(String description, Consumer<? super Failure> action) {
         delegate.assertHasFailure(description, action);
         return this;

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExecutionFailure.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExecutionFailure.java
@@ -83,6 +83,13 @@ public interface ExecutionFailure extends ExecutionResult {
     ExecutionFailure assertThatDescription(Matcher<? super String> matcher);
 
     /**
+     * Asserts that there all failures match the given description (ie the bit after '* What went wrong').
+     *
+     * <p>Error messages are normalized to use new-line char as line separator.
+     */
+    ExecutionFailure assertThatAllDescriptions(Matcher<? super String> matcher);
+
+    /**
      * Asserts that the reported failure has exactly the given resolutions (ie the bit after '* Try').
      */
     ExecutionFailure assertHasResolutions(String... resolutions);

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -803,8 +803,14 @@ public class InProcessGradleExecuter extends DaemonGradleExecuter {
         @Override
         public ExecutionFailure assertThatDescription(Matcher<? super String> matcher) {
             outputFailure.assertThatDescription(matcher);
-            assertHasFailure(matcher, f -> {
-            });
+            assertHasFailure(matcher, f -> {});
+            return this;
+        }
+
+        @Override
+        public ExecutionFailure assertThatAllDescriptions(Matcher<? super String> matcher) {
+            outputFailure.assertThatAllDescriptions(matcher);
+            assertHasFailure(matcher, f -> {});
             return this;
         }
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionFailure.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionFailure.java
@@ -292,7 +292,13 @@ public class OutputScrapingExecutionFailure extends OutputScrapingExecutionResul
         super.assertResultVisited();
         // Ensure that exceptions are not unintentionally introduced.
         if (problems.size() > 1 && !problemsNotChecked.isEmpty()) {
-            throw new AssertionFailedError("The build failed with multiple exceptions, however not all exceptions where checked during the test. This can be done using assertHasFailures(n), assertHasDescription() or assertHasCause() or one of the variants of these methods.");
+            String nonCheckedProblems = problemsNotChecked.stream().map(p -> "- " + p.description).collect(joining("\n"));
+            throw new AssertionFailedError(String.format(
+                "The build failed with multiple exceptions, however not all exceptions where checked during the test. " +
+                    "This can be done using assertHasFailures(n), assertHasDescription() or assertHasCause() or one of the variants of these methods.%n" +
+                    "Unchecked problems:%n%s",
+                nonCheckedProblems
+            ));
         }
     }
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionFailure.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionFailure.java
@@ -258,6 +258,22 @@ public class OutputScrapingExecutionFailure extends OutputScrapingExecutionResul
     }
 
     @Override
+    public ExecutionFailure assertThatAllDescriptions(Matcher<? super String> matcher) {
+        Set<String> unmatched = new LinkedHashSet<>();
+        for (Problem problem : problems) {
+            if (matcher.matches(problem.description)) {
+                problemsNotChecked.remove(problem);
+            } else {
+                unmatched.add(problem.description);
+            }
+        }
+        if (!unmatched.isEmpty()) {
+            failureOnUnexpectedOutput(String.format("Not all failure descriptions match\nExpected: All failure descriptions are %s\n     but: unmatched failure descriptions %s", matcher, unmatched));
+        }
+        return this;
+    }
+
+    @Override
     public ExecutionFailure assertHasFailure(String description, Consumer<? super Failure> action) {
         assertHasFailure(startsWith(description), action);
         return this;


### PR DESCRIPTION
In rare circumstances (currently, the only case found is when canceling a Gradle build, but this is not even always happening), some Gradle build operations can be finished while some of their children's build operations are not finished.

This is eventually a bug in Gradle that doesn't handle the cancellation properly and leaves some build operations around.

This breaks Develocity assumptions, such as the fact that a TaskStarted event always has a corresponding TaskFinished event.

The problem occurs when an interrupted task executes on a Thread from the 'included builds' pool.

What we saw in the wild is something like this:

1. A task starts executing and we give the cancellation token a callback to interrupt the thread running the task.
    https://github.com/gradle/gradle/blob/1d48a3a847929a832e89ef8c7a366d98497dc389/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/CancelExecutionStep.java#L37-L42
2. The task starts running its actions, and uses the worker API to queue its actual work, exiting the task action.
    https://github.com/gradle/gradle/blob/ad4406e7e791231c017513bbb3b30d2df599277b/platforms/jvm/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Checkstyle.java#L137-L148
3. Gradle releases the project lock and offers itself to run other work while it is waiting for the worker action to finish. The current thread starts querying the execution plan for more work and ends up not obtaining necessary resources, e.g. enough workers, to do so. So it waits in `DefaultResourceLockCoordinationService.withStateLock()`. https://github.com/gradle/gradle/blob/cd7a7c7023c701c11d64ffe32582dadd63700413/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/resources/DefaultResourceLockCoordinationService.java#L107-L118
4. The user decides to cancel the build. That causes the cancellation token to interrupt the thread in `withStateLock()`. The `InterruptedException` causes the `withStateLock()` to exit without actually completing the work. That terminates the build in an unordered manner, even causing the build finished hook to be called twice and leaving build operations unclosed.

This PR resolves this problem by having `DefaultResourceLockCoordinationService.withStateLock()` retry acquiring the lock and doing the (quick) work it was supposed to do, allowing the build to exit gracefully.