### PR TITLE
Use Dependencies.project function for project dependencies

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/Dependencies.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/Dependencies.java
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderConvertible;
+import org.gradle.declarative.dsl.model.annotations.Restricted;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -87,6 +88,7 @@ public interface Dependencies {
      *
      * @see org.gradle.api.Project#project(String)
      */
+    @Restricted
     default ProjectDependency project(String projectPath) {
         return getDependencyFactory().create(getProject().project(projectPath));
     }


### PR DESCRIPTION
- Allows the `project()` method in `Dependencies` to be found by the declarative DSL.
- Adds a test to ensure `project()` continues to work.