### PR TITLE
Document usage of @OutputFile when file might be deleted

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/Destroys.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/Destroys.java
@@ -31,6 +31,8 @@ import java.lang.annotation.Target;
  * that other tasks that either create or consume this file (by specifying the file or directory as an input
  * or output) cannot execute concurrently with a task that destroys this file.</p>
  *
+ * To mark a file that might created or deleted use (@see org.gradle.api.tasks.OutputFile) instead
+ *
  * @since 4.0
  */
 @Documented

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/OutputFile.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/OutputFile.java
@@ -28,6 +28,9 @@ import java.lang.annotation.*;
  *
  * <p>This will cause the task to be considered out-of-date when the file path or contents
  * are different to when the task was last run.</p>
+ *
+ *  To mark a file that might created or deleted by a task, use this.
+ *
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
https://github.com/gradle/gradle/issues/28231

### Context

It clarifies a point of confusion. Before this PR, it is undocumented what do to if a task conditionally creates or destroys a file.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
