### PR TITLE
Expose listener manager service via an interface

### DIFF
--- a/platforms/core-execution/worker-processes/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
+++ b/platforms/core-execution/worker-processes/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
@@ -23,6 +23,7 @@ import org.gradle.internal.concurrent.DefaultExecutorFactory;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.event.DefaultListenerManager;
 import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.event.ScopedListenerManager;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
 import org.gradle.internal.nativeintegration.services.NativeServices;
@@ -191,7 +192,7 @@ public class SystemApplicationClassLoaderWorker implements Callable<Void> {
             });
         }
 
-        DefaultListenerManager createListenerManager() {
+        ScopedListenerManager createListenerManager() {
             return new DefaultListenerManager(Global.class);
         }
 

--- a/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/event/DefaultListenerManager.java
+++ b/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/event/DefaultListenerManager.java
@@ -22,7 +22,6 @@ import org.gradle.internal.dispatch.Dispatch;
 import org.gradle.internal.dispatch.MethodInvocation;
 import org.gradle.internal.dispatch.ProxyDispatchAdapter;
 import org.gradle.internal.dispatch.ReflectionDispatch;
-import org.gradle.internal.service.AnnotatedServiceLifecycleHandler;
 import org.gradle.internal.service.scopes.EventScope;
 import org.gradle.internal.service.scopes.ListenerService;
 import org.gradle.internal.service.scopes.Scope;
@@ -42,7 +41,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 
-public class DefaultListenerManager implements ListenerManager, AnnotatedServiceLifecycleHandler {
+public class DefaultListenerManager implements ScopedListenerManager {
     private static final List<Class<? extends Annotation>> ANNOTATIONS = ImmutableList.of(StatefulListener.class, ListenerService.class);
     private final Map<Object, ListenerDetails> allListeners = new LinkedHashMap<Object, ListenerDetails>();
     private final Map<Object, ListenerDetails> allLoggers = new LinkedHashMap<Object, ListenerDetails>();
@@ -193,13 +192,7 @@ public class DefaultListenerManager implements ListenerManager, AnnotatedService
         }
     }
 
-    /**
-     * Creates a child {@code ListenerManager}. All events broadcast in the child will be received by the listeners
-     * registered in the parent. However, the reverse is not true: events broadcast in the parent are not received
-     * by the listeners in the children. The child inherits the loggers of its parent, though these can be replaced.
-     *
-     * @return The child
-     */
+    @Override
     public DefaultListenerManager createChild(Class<? extends Scope> scope) {
         return new DefaultListenerManager(scope, this);
     }

--- a/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/event/ScopedListenerManager.java
+++ b/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/event/ScopedListenerManager.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.event;
+
+import org.gradle.api.NonNullApi;
+import org.gradle.internal.service.AnnotatedServiceLifecycleHandler;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+
+@NonNullApi
+@ServiceScope({Scope.Global.class, Scope.UserHome.class, Scope.BuildSession.class, Scope.BuildTree.class, Scope.Build.class})
+public interface ScopedListenerManager extends ListenerManager, AnnotatedServiceLifecycleHandler {
+
+    /**
+     * Creates a child {@code ListenerManager}.
+     * <p>
+     * All events broadcast in the child will be received by the listeners registered in the parent.
+     * However, the reverse is not true:
+     * events broadcast in the parent are not received by the listeners in the children.
+     * The child inherits the loggers of its parent, though these can be replaced.
+     *
+     * @return The child
+     */
+    ScopedListenerManager createChild(Class<? extends Scope> scope);
+
+}

--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/PropertyValidationAccess.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/PropertyValidationAccess.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.tasks.properties.annotations.OutputPropertyRoleAn
 import org.gradle.api.tasks.Nested;
 import org.gradle.cache.internal.DefaultCrossBuildInMemoryCacheFactory;
 import org.gradle.internal.event.DefaultListenerManager;
+import org.gradle.internal.event.ScopedListenerManager;
 import org.gradle.internal.instantiation.generator.DefaultInstantiatorFactory;
 import org.gradle.internal.properties.annotations.NestedValidationUtil;
 import org.gradle.internal.properties.annotations.PropertyMetadata;
@@ -59,7 +60,7 @@ public class PropertyValidationAccess {
         builder.provider(new Object() {
             @SuppressWarnings("unused")
             void configure(ServiceRegistration registration) {
-                registration.add(DefaultListenerManager.class, new DefaultListenerManager(Global.class));
+                registration.add(ScopedListenerManager.class, new DefaultListenerManager(Global.class));
                 registration.add(DefaultCrossBuildInMemoryCacheFactory.class);
                 // TODO: do we need any factories here?
                 registration.add(DefaultManagedFactoryRegistry.class, new DefaultManagedFactoryRegistry());

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
@@ -53,8 +53,8 @@ import org.gradle.internal.buildoption.DefaultFeatureFlags;
 import org.gradle.internal.buildoption.DefaultInternalOptions;
 import org.gradle.internal.buildoption.InternalOptions;
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
-import org.gradle.internal.event.DefaultListenerManager;
 import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.event.ScopedListenerManager;
 import org.gradle.internal.id.ConfigurationCacheableIdFactory;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.problems.DefaultProblemDiagnosticsFactory;
@@ -130,7 +130,7 @@ public class BuildTreeScopeServices {
         return objectFactory.newInstance(DefaultTaskSelector.class, new TaskNameResolver(), projectConfigurer);
     }
 
-    protected DefaultListenerManager createListenerManager(DefaultListenerManager parent) {
+    protected ScopedListenerManager createListenerManager(ScopedListenerManager parent) {
         return parent.createChild(Scope.BuildTree.class);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BasicGlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BasicGlobalScopeServices.java
@@ -40,6 +40,7 @@ import org.gradle.internal.concurrent.DefaultExecutorFactory;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.event.DefaultListenerManager;
 import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.event.ScopedListenerManager;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.jvm.inspection.CachingJvmMetadataDetector;
 import org.gradle.internal.jvm.inspection.DefaultJvmMetadataDetector;
@@ -134,7 +135,7 @@ public class BasicGlobalScopeServices {
         return PatternSets.getPatternSetFactory(patternSpecFactory);
     }
 
-    DefaultListenerManager createListenerManager() {
+    ScopedListenerManager createListenerManager() {
         return new DefaultListenerManager(Global.class);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -186,8 +186,8 @@ import org.gradle.internal.classpath.transforms.ClasspathElementTransformFactory
 import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.composite.DefaultBuildIncluder;
 import org.gradle.internal.concurrent.ExecutorFactory;
-import org.gradle.internal.event.DefaultListenerManager;
 import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.event.ScopedListenerManager;
 import org.gradle.internal.execution.ExecutionEngine;
 import org.gradle.internal.execution.InputFingerprinter;
 import org.gradle.internal.execution.WorkExecutionTracker;
@@ -344,7 +344,7 @@ public class BuildScopeServices extends ScopedServiceRegistry {
         return new DefaultTextFileResourceLoader(resolver);
     }
 
-    protected DefaultListenerManager createListenerManager(DefaultListenerManager listenerManager) {
+    protected ScopedListenerManager createListenerManager(ScopedListenerManager listenerManager) {
         return listenerManager.createChild(Scope.Build.class);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
@@ -69,8 +69,8 @@ import org.gradle.internal.classpath.transforms.ClasspathElementTransformFactory
 import org.gradle.internal.classpath.transforms.ClasspathElementTransformFactoryForLegacy;
 import org.gradle.internal.classpath.types.GradleCoreInstrumentationTypeRegistry;
 import org.gradle.internal.concurrent.ExecutorFactory;
-import org.gradle.internal.event.DefaultListenerManager;
 import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.event.ScopedListenerManager;
 import org.gradle.internal.execution.timeout.TimeoutHandler;
 import org.gradle.internal.execution.timeout.impl.DefaultTimeoutHandler;
 import org.gradle.internal.file.FileAccessTimeJournal;
@@ -137,7 +137,7 @@ public class GradleUserHomeScopeServices extends WorkerSharedUserHomeScopeServic
         return new DefaultGlobalScopedCacheBuilderFactory(globalCacheDir.getDir(), unscopedCacheBuilderFactory);
     }
 
-    DefaultListenerManager createListenerManager(DefaultListenerManager parent) {
+    ScopedListenerManager createListenerManager(ScopedListenerManager parent) {
         return parent.createChild(Scope.UserHome.class);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/session/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/session/BuildSessionScopeServices.java
@@ -53,8 +53,8 @@ import org.gradle.initialization.layout.ProjectCacheDir;
 import org.gradle.internal.build.BuildLayoutValidator;
 import org.gradle.internal.buildevents.BuildStartedTime;
 import org.gradle.internal.classpath.ClassPath;
-import org.gradle.internal.event.DefaultListenerManager;
 import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.event.ScopedListenerManager;
 import org.gradle.internal.file.Deleter;
 import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.hash.DefaultChecksumService;
@@ -129,7 +129,7 @@ public class BuildSessionScopeServices extends WorkerSharedBuildSessionScopeServ
         return new DefaultDeploymentRegistry(pendingChangesManager, buildOperationRunner, objectFactory);
     }
 
-    DefaultListenerManager createListenerManager(DefaultListenerManager parent) {
+    ScopedListenerManager createListenerManager(ScopedListenerManager parent) {
         return parent.createChild(Scope.BuildSession.class);
     }
 


### PR DESCRIPTION
Preparation for strictly scoping all Global services.

Introduces a new interface `ScopedListenerManager` to be used as a service instead of the currently injectable `DefaultListenerManager`.