### PR TITLE
fix doc formatting in version range section

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/single_versions.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/single_versions.adoc
@@ -26,7 +26,7 @@ Gradle supports different ways of declaring a version string:
 ** An upper bound exclude acts as a prefix exclude.
 This means that `[1.0, 2.0[` will also exclude all versions starting with `2.0` that are smaller than `2.0`.
 For example versions like `2.0-dev1` or `2.0-SNAPSHOT` are no longer included in the range.
-* A _prefix_ version range: e.g. `1.+`, `1.3.+`
+* A _prefix_ version range: e.g. `1.\+`, `1.3.+`
 ** Only versions exactly matching the portion before the `+` are included.
 ** The range `+` on its own will include any version.
 * A `latest-status` version: e.g. `latest.integration`, `latest.release`


### PR DESCRIPTION
Fix doc formatting in version range section.

### Context
\+ within \`..\` spans break formatting if not escaped.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
