### PR TITLE
Remove UsedByScanPlugin annotation from public APIs

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionConstraint.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionConstraint.java
@@ -16,7 +16,6 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.Describable;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -91,7 +90,6 @@ import java.util.List;
  *
  * @since 4.4
  */
-@UsedByScanPlugin
 public interface VersionConstraint extends Describable {
     /**
      * The branch to select versions from. When not {@code null} selects only those versions that were built from the specified branch.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ComponentIdentifier.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ComponentIdentifier.java
@@ -15,14 +15,11 @@
  */
 package org.gradle.api.artifacts.component;
 
-import org.gradle.internal.scan.UsedByScanPlugin;
-
 /**
  * An opaque immutable identifier for a component instance. There are various sub-interfaces that expose specific details about the identifier.
  *
  * @since 1.10
  */
-@UsedByScanPlugin
 public interface ComponentIdentifier {
     /**
      * Returns a human-consumable display name for this identifier.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ComponentSelector.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ComponentSelector.java
@@ -17,7 +17,6 @@ package org.gradle.api.artifacts.component;
 
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 import java.util.List;
 
@@ -27,7 +26,6 @@ import java.util.List;
  *
  * @since 1.10
  */
-@UsedByScanPlugin
 public interface ComponentSelector {
     /**
      * Returns a human-consumable display name for this selector.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ModuleComponentIdentifier.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ModuleComponentIdentifier.java
@@ -16,14 +16,12 @@
 package org.gradle.api.artifacts.component;
 
 import org.gradle.api.artifacts.ModuleIdentifier;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * An identifier for a component instance which is available as a module version.
  *
  * @since 1.10
  */
-@UsedByScanPlugin
 public interface ModuleComponentIdentifier extends ComponentIdentifier {
     /**
      * The module group of the component.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ModuleComponentSelector.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ModuleComponentSelector.java
@@ -17,14 +17,12 @@ package org.gradle.api.artifacts.component;
 
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.VersionConstraint;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * Criteria for selecting a component instance that is available as a module version.
  *
  * @since 1.10
  */
-@UsedByScanPlugin
 public interface ModuleComponentSelector extends ComponentSelector {
     /**
      * The group of the module to select the component from.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ProjectComponentIdentifier.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ProjectComponentIdentifier.java
@@ -17,14 +17,12 @@ package org.gradle.api.artifacts.component;
 
 import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * An identifier for a component instance that is built as part of the current build.
  *
  * @since 1.10
  */
-@UsedByScanPlugin
 @HasInternalProtocol
 public interface ProjectComponentIdentifier extends ComponentIdentifier {
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ProjectComponentSelector.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ProjectComponentSelector.java
@@ -16,14 +16,12 @@
 package org.gradle.api.artifacts.component;
 
 import org.gradle.internal.HasInternalProtocol;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * Criteria for selecting a component instance that is built as part of the current build.
  *
  * @since 1.10
  */
-@UsedByScanPlugin
 @HasInternalProtocol
 public interface ProjectComponentSelector extends ComponentSelector {
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionCause.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionCause.java
@@ -15,15 +15,12 @@
  */
 package org.gradle.api.artifacts.result;
 
-import org.gradle.internal.scan.UsedByScanPlugin;
-
 /**
  * The possible component selection causes. There are a limited number of causes, but each of them
  * can be provided with a custom description, via {@link ComponentSelectionDescriptor}.
  *
  * @since 4.6
  */
-@UsedByScanPlugin
 public enum ComponentSelectionCause {
     /**
      * This component was selected because it's the root component.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionDescriptor.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionDescriptor.java
@@ -16,14 +16,12 @@
 package org.gradle.api.artifacts.result;
 
 import org.gradle.internal.HasInternalProtocol;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * A component selection description, which wraps a cause with an optional custom description.
  *
  * @since 4.6
  */
-@UsedByScanPlugin
 @HasInternalProtocol
 public interface ComponentSelectionDescriptor {
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionReason.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionReason.java
@@ -17,7 +17,6 @@
 package org.gradle.api.artifacts.result;
 
 import org.gradle.internal.HasInternalProtocol;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 import java.util.List;
 
@@ -26,7 +25,6 @@ import java.util.List;
  *
  * @since 1.3
  */
-@UsedByScanPlugin
 @HasInternalProtocol
 public interface ComponentSelectionReason {
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/DependencyResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/DependencyResult.java
@@ -17,14 +17,12 @@
 package org.gradle.api.artifacts.result;
 
 import org.gradle.api.artifacts.component.ComponentSelector;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * An edge in the dependency graph. Provides information about the origin of the dependency and the requested component.
  *
  * @see ResolutionResult
  */
-@UsedByScanPlugin
 public interface DependencyResult {
     /**
      * <p>Returns the requested component.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolutionResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolutionResult.java
@@ -22,7 +22,6 @@ import org.gradle.api.Action;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.HasInternalProtocol;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 import java.util.Set;
 
@@ -30,7 +29,6 @@ import java.util.Set;
  * Contains the information about the result of dependency resolution. You can use this type to determine all the component instances that are included
  * in the resolved dependency graph, and the dependencies between them.
  */
-@UsedByScanPlugin
 @HasInternalProtocol
 public interface ResolutionResult {
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedComponentResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedComponentResult.java
@@ -17,7 +17,6 @@
 package org.gradle.api.artifacts.result;
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -26,7 +25,6 @@ import java.util.Set;
 /**
  * Represents a component instance in the resolved dependency graph. Provides some basic identity and dependency information about the component.
  */
-@UsedByScanPlugin
 public interface ResolvedComponentResult extends ComponentResult {
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedDependencyResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedDependencyResult.java
@@ -16,12 +16,9 @@
 
 package org.gradle.api.artifacts.result;
 
-import org.gradle.internal.scan.UsedByScanPlugin;
-
 /**
  * A dependency that was resolved successfully.
  */
-@UsedByScanPlugin
 public interface ResolvedDependencyResult extends DependencyResult {
     /**
      * Returns the selected component. This may not necessarily be the same as the requested component. For example, a dynamic version

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/UnresolvedDependencyResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/UnresolvedDependencyResult.java
@@ -17,12 +17,10 @@
 package org.gradle.api.artifacts.result;
 
 import org.gradle.api.artifacts.component.ComponentSelector;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * A dependency that could not be resolved.
  */
-@UsedByScanPlugin
 public interface UnresolvedDependencyResult extends DependencyResult {
     /**
      * Returns the selector that was attempted to be resolved. This may not be the same as the requested component.

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributeContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributeContainer.java
@@ -18,7 +18,6 @@ package org.gradle.api.attributes;
 
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.HasInternalProtocol;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 import javax.annotation.Nullable;
 import java.util.Set;
@@ -39,7 +38,6 @@ import java.util.Set;
  * @since 3.3
  */
 @HasInternalProtocol
-@UsedByScanPlugin
 public interface AttributeContainer extends HasAttributes {
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/Category.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/Category.java
@@ -18,7 +18,6 @@ package org.gradle.api.attributes;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.Named;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * This attribute describes the categories of variants for a given module.
@@ -35,7 +34,6 @@ import org.gradle.internal.scan.UsedByScanPlugin;
  *
  * @since 5.3
  */
-@UsedByScanPlugin
 public interface Category extends Named {
 
     Attribute<Category> CATEGORY_ATTRIBUTE = Attribute.of("org.gradle.category", Category.class);


### PR DESCRIPTION
These APIs should not need additional protection as any public API can be used by the scans plugin (as well as by any third-party plugin).

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
