### PR TITLE
Support typesafe project accessors in declarative DSL

### DIFF
--- a/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/project/DeclarativeDSLCustomDependenciesExtensionsSpec.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/project/DeclarativeDSLCustomDependenciesExtensionsSpec.groovy
@@ -49,7 +49,7 @@ class DeclarativeDSLCustomDependenciesExtensionsSpec extends AbstractIntegration
 
         and: "a build script that adds dependencies using the custom extension"
         file("build.gradle.something") << defineDeclarativeDSLBuildScript()
-        file("settings.gradle") << defineSettings()
+        file("settings.gradle") << defineSettings(typeSafeProjectAccessors)
 
         expect: "a dependency has been added to the api configuration"
         succeeds("dependencies", "--configuration", "api")
@@ -58,6 +58,110 @@ class DeclarativeDSLCustomDependenciesExtensionsSpec extends AbstractIntegration
         and: "a dependency has been added to the implementation configuration"
         succeeds("dependencies", "--configuration", "implementation")
         outputContains("org.apache.commons:commons-lang3:3.12.0")
+
+        where:
+        typeSafeProjectAccessors << [true, false]
+    }
+
+    def 'can configure an extension using DependencyCollector in declarative DSL with @Restricted methods available on supertype'() {
+        given:
+        file("buildSrc/src/main/java/com/example/restricted/LibraryExtension.java") << """
+            package com.example.restricted;
+
+            import org.gradle.api.Action;
+            import org.gradle.api.model.ObjectFactory;
+            import org.gradle.declarative.dsl.model.annotations.Configuring;
+            import org.gradle.declarative.dsl.model.annotations.Restricted;
+
+            import javax.inject.Inject;
+
+            @Restricted
+            public abstract class LibraryExtension {
+                private final SubDependencies sub;
+
+                @Inject
+                public LibraryExtension(ObjectFactory objectFactory) {
+                    this.sub = objectFactory.newInstance(SubDependencies.class);
+                }
+
+                public SubDependencies getSub() {
+                    return sub;
+                }
+
+                @Configuring
+                public void sub(Action<? super SubDependencies> configure) {
+                    configure.execute(getSub());
+                }
+            }
+        """
+        file("buildSrc/src/main/java/com/example/restricted/BaseDependencies.java") << """
+            package com.example.restricted;
+
+            import org.gradle.api.artifacts.dsl.Dependencies;
+            import org.gradle.declarative.dsl.model.annotations.Restricted;
+
+            @Restricted
+            public interface BaseDependencies extends Dependencies {
+                @Restricted
+                default String baseMethod(String arg) {
+                    System.out.println(arg);
+                    return arg;
+                }
+            }
+        """
+        file("buildSrc/src/main/java/com/example/restricted/SubDependencies.java") << """
+            package com.example.restricted;
+
+            import org.gradle.declarative.dsl.model.annotations.Restricted;
+            import org.gradle.api.artifacts.dsl.DependencyCollector;
+
+            @Restricted
+            public interface SubDependencies extends BaseDependencies {
+                @Restricted
+                default String subMethod(String arg) {
+                    System.out.println(arg);
+                    return arg;
+                }
+
+                DependencyCollector getConf();
+            }
+        """
+        file("buildSrc/src/main/java/com/example/restricted/RestrictedPlugin.java") << """
+            package com.example.restricted;
+
+            import org.gradle.api.Plugin;
+            import org.gradle.api.Project;
+
+            public class RestrictedPlugin implements Plugin<Project> {
+                @Override
+                public void apply(Project project) {
+                    project.getExtensions().create("library", LibraryExtension.class);
+                }
+            }
+        """
+        file("buildSrc/build.gradle") << defineRestrictedPluginBuild()
+
+        file("build.gradle.something") << """
+            plugins {
+                id("com.example.restricted")
+            }
+
+            library {
+                sub {
+                    conf(baseMethod("base:name:1.0"))
+                    conf(subMethod("sub:name:1.0"))
+                }
+            }
+        """
+        file("settings.gradle") << defineSettings(typeSafeProjectAccessors)
+
+        expect:
+        succeeds("build")
+        outputContains("base:name:1.0")
+        outputContains("sub:name:1.0")
+
+        where:
+        typeSafeProjectAccessors << [true, false]
     }
 
     def 'can configure an extension using DependencyCollector in declarative DSL with a getter name NOT associated with an expected configuration name'() {
@@ -489,7 +593,7 @@ class DeclarativeDSLCustomDependenciesExtensionsSpec extends AbstractIntegration
         """
     }
 
-    private String defineSettings() {
+    private String defineSettings(boolean typeSafeProjectAccessors = false) {
         return """
             dependencyResolutionManagement {
                 repositories {
@@ -498,6 +602,7 @@ class DeclarativeDSLCustomDependenciesExtensionsSpec extends AbstractIntegration
             }
 
             rootProject.name = 'example'
+            ${ if (typeSafeProjectAccessors) { 'enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")' }  }
         """
     }
 }

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/DependencyCollectorFunctionExtractorAndRuntimeResolver.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/DependencyCollectorFunctionExtractorAndRuntimeResolver.kt
@@ -95,7 +95,9 @@ class DependencyCollectorFunctionExtractorAndRuntimeResolver(
             })
 
         val declarationsBySchemaFunctions = discoveredCollectorDeclarations.associate { it.addingSchemaFunction to it.runtimeFunction }
-        collectorDeclarationsByClass[kClass] = declarationsBySchemaFunctions
+        if (!declarationsBySchemaFunctions.isEmpty()) {
+            collectorDeclarationsByClass[kClass] = declarationsBySchemaFunctions
+        }
 
         return declarationsBySchemaFunctions.keys
     }

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/TypeSafeProjectAccessorsSchemaBuildingComponent.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/TypeSafeProjectAccessorsSchemaBuildingComponent.kt
@@ -122,7 +122,7 @@ class TypesafeProjectAccessorTypeDiscovery : TypeDiscovery {
         fun visit(type: KType) {
             val classifier = type.classifier
             if (classifier is KClass<*> && add(classifier)) {
-                classifier.supertypes.forEach(::visit)
+                (classifier.supertypes - Any::class.createType()).forEach(::visit) // No need to visit Any, it only clutters the extracted functions
             }
         }
         add(kClass)


### PR DESCRIPTION
Refine the traversal of the class hierarchy when extracting dynamic functions to avoid problems with the Any type revealed by NiA's usage of typesafe project accessors.

