### PR TITLE
fix(kotlin-dsl): unable to use `events = setOf()` in testLogging

### DIFF
--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/AbstractConsoleJvmTestLoggingFunctionalTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/AbstractConsoleJvmTestLoggingFunctionalTest.groovy
@@ -156,7 +156,30 @@ abstract class AbstractConsoleJvmTestLoggingFunctionalTest extends AbstractInteg
         taskOutput.contains('Finishing test: MyTest > testExpectation')
     }
 
-    static String javaProject() {
+    def "can use setOf() in Kotlin DSL to configure logging no events"() {
+        given:
+        buildKotlinFile << testLoggingStandardStreamWithEmptyEventSet()
+
+        file(JAVA_TEST_FILE_PATH) << javaTestClass {
+            """
+                System.out.println("standard output");
+                System.err.println("standard error");
+            """
+        }
+
+        when:
+        executer.withConsole(consoleType)
+        succeeds(TEST_TASK_NAME)
+
+        then:
+        def taskOutput = getTaskOutput(result).readLines().findAll { !it.isBlank() } .join('\n')
+        !taskOutput.contains("""MyTest > testExpectation ${TestLogEvent.STANDARD_OUT.consoleMarker}
+    standard output""")
+        !taskOutput.contains("""MyTest > testExpectation ${TestLogEvent.STANDARD_ERROR.consoleMarker}
+    standard error""")
+    }
+
+    private static String javaProject() {
         """
             apply plugin: 'java'
 
@@ -168,17 +191,17 @@ abstract class AbstractConsoleJvmTestLoggingFunctionalTest extends AbstractInteg
         """
     }
 
-    static String testLoggingEvents(String... events) {
+    private static String testLoggingEvents(String... events) {
         """
             test {
                 testLogging {
-                    events ${events.collect { "'$it'" }.join(', ')}
+                    events(${events.collect { "'$it'" }.join(', ')})
                 }
             }
         """
     }
 
-    static String testLoggingStandardStream() {
+    private static String testLoggingStandardStream() {
         """
             test {
                 testLogging {
@@ -188,7 +211,16 @@ abstract class AbstractConsoleJvmTestLoggingFunctionalTest extends AbstractInteg
         """
     }
 
-    static String javaTestClass(Closure<String> testMethodBody) {
+    private static String testLoggingStandardStreamWithEmptyEventSet() {
+        """
+            test {
+                showStandardStreams = true
+                testLogging.events = setOf()
+            }
+        """
+    }
+
+    private static String javaTestClass(Closure<String> testMethodBody) {
         """
             import org.junit.Test;
 
@@ -201,15 +233,15 @@ abstract class AbstractConsoleJvmTestLoggingFunctionalTest extends AbstractInteg
         """
     }
 
-    static String getTaskOutput(ExecutionResult result) {
+    private static String getTaskOutput(ExecutionResult result) {
         result.groupedOutput.task(TEST_TASK_PATH).output.trim()
     }
 
-    static boolean matchesTaskOutput(String taskOutput, String regexToFind) {
+    private static boolean matchesTaskOutput(String taskOutput, String regexToFind) {
         (taskOutput =~ /(?ms)($regexToFind)/).matches()
     }
 
-    static String testLogEventRegex(String event) {
+    private static String testLogEventRegex(String event) {
         "MyTest > testExpectation.*$event.*"
     }
 

--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/AbstractConsoleJvmTestLoggingFunctionalTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/AbstractConsoleJvmTestLoggingFunctionalTest.groovy
@@ -172,11 +172,18 @@ abstract class AbstractConsoleJvmTestLoggingFunctionalTest extends AbstractInteg
         succeeds(TEST_TASK_NAME)
 
         then:
-        def taskOutput = getTaskOutput(result).readLines().findAll { !it.isBlank() } .join('\n')
-        !taskOutput.contains("""MyTest > testExpectation ${TestLogEvent.STANDARD_OUT.consoleMarker}
+        if (result.groupedOutput.hasTask(TEST_TASK_PATH)) {
+            def taskOutput = getTaskOutput(result).readLines().findAll { !it.isBlank() }.join('\n')
+            assert !taskOutput.contains("""MyTest > testExpectation ${TestLogEvent.STANDARD_OUT.consoleMarker}
     standard output""")
-        !taskOutput.contains("""MyTest > testExpectation ${TestLogEvent.STANDARD_ERROR.consoleMarker}
+            assert !taskOutput.contains("""MyTest > testExpectation ${TestLogEvent.STANDARD_ERROR.consoleMarker}
     standard error""")
+        } else {
+            outputDoesNotContain("""MyTest > testExpectation ${TestLogEvent.STANDARD_OUT.consoleMarker}
+    standard output""")
+            outputDoesNotContain("""MyTest > testExpectation ${TestLogEvent.STANDARD_ERROR.consoleMarker}
+    standard error""")
+        }
     }
 
     private static String javaProject() {

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/DefaultTestLogging.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/DefaultTestLogging.java
@@ -45,7 +45,7 @@ public class DefaultTestLogging implements TestLogging {
 
     @Override
     public void setEvents(Set<TestLogEvent> events) {
-        this.events = EnumSet.copyOf(events);
+        this.events = events.isEmpty() ? EnumSet.noneOf(TestLogEvent.class) : EnumSet.copyOf(events);
     }
 
     @Override

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/TestEventLoggerTest.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/TestEventLoggerTest.groovy
@@ -102,4 +102,9 @@ class TestEventLoggerTest extends Specification {
         then:
         !textOutputFactory.toString().contains("formatted exception")
     }
+
+    def "allows empty event set"() {
+        expect:
+        testLogging.setEvents(new HashSet<TestLogEvent>())
+    }
 }

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/TestEventLoggerTest.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/TestEventLoggerTest.groovy
@@ -105,6 +105,6 @@ class TestEventLoggerTest extends Specification {
 
     def "allows empty event set"() {
         expect:
-        testLogging.setEvents(new HashSet<TestLogEvent>())
+        testLogging.setEvents(Collections.emptySet())
     }
 }


### PR DESCRIPTION
### Context
It fixes a bug that prevents to use `evennts = setOf()` which would be the natural approach for Kotlin DSL. (since EnumSet.of() throws an exception on empty sets)

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes. (no user facing change)
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
