### PR TITLE
Do not emit ExecutePlannedTransformStep op when running them unplanned

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/NodeExecutionContext.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/NodeExecutionContext.java
@@ -25,4 +25,8 @@ public interface NodeExecutionContext {
      * Locates the given execution service.
      */
     <T> T getService(Class<T> type) throws ServiceLookupException;
+
+    default boolean isFallbackContext() {
+        return false;
+    }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformExecutionBuildOperationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformExecutionBuildOperationIntegrationTest.groovy
@@ -46,7 +46,7 @@ class ArtifactTransformExecutionBuildOperationIntegrationTest extends AbstractIn
     public final ScopeIdsFixture scopeIds = new ScopeIdsFixture(executer, temporaryFolder)
 
     def setup() {
-        requireOwnGradleUserHomeDir()
+        requireOwnGradleUserHomeDir("Artifact transforms should run every time and not be shared between tests")
 
         // group name is included in the capabilities of components, which are part of the transform identity
         buildFile << """

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformStepNode.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformStepNode.java
@@ -358,7 +358,7 @@ public abstract class TransformStepNode extends CreationOrderedNode implements S
         public TransformStepSubject calculateValue(NodeExecutionContext context) {
             TransformStepBuildOperation buildOperation = createBuildOperation(context);
             ProjectInternal owningProject = transformStep.getOwningProject();
-            return owningProject == null
+            return (owningProject == null || context.isFallbackContext())
                 ? buildOperation.transform()
                 : buildOperationRunner.call(buildOperation);
         }


### PR DESCRIPTION
It is possible to execute project transforms outside the execution plan. Those are not running "planned", so we should not emit the planned transform build operation.

Those build operations affect the progress bar, and we do some work on the build scan plugin side to ignore the unplanned events.