### PR TITLE
Fix typo in doc: writing_build_scripts

### DIFF
--- a/platforms/documentation/docs/src/snippets/tutorial/configureObject/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/tutorial/configureObject/groovy/build.gradle
@@ -3,7 +3,7 @@ class UserInfo {
     String email
 }
 
-tasks.register('configure') {
+tasks.register('greet') {
     def user = configure(new UserInfo()) {
         name = "Isaac Newton"
         email = "isaac@newton.me"

--- a/platforms/documentation/docs/src/snippets/tutorial/configureObject/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/tutorial/configureObject/kotlin/build.gradle.kts
@@ -1,9 +1,9 @@
 class UserInfo(
-    var name: String? = null, 
+    var name: String? = null,
     var email: String? = null
 )
 
-tasks.register("configure") {
+tasks.register("greet") {
     val user = UserInfo().apply {
         name = "Isaac Newton"
         email = "isaac@newton.me"

--- a/platforms/documentation/docs/src/snippets/tutorial/configureObject/tests/configureObject.sample.conf
+++ b/platforms/documentation/docs/src/snippets/tutorial/configureObject/tests/configureObject.sample.conf
@@ -1,4 +1,4 @@
 executable: gradle
-args: configure
+args: greet
 flags: --quiet
 expected-output-file: configureObject.out


### PR DESCRIPTION
I try to fix typo in tutorial [writing_build_scripts](https://docs.gradle.org/current/userguide/writing_build_scripts.html#writing_build_scripts).  

currently, the documentation seems inconsistent with the code snippet. (In doc, the task name is `greet`. However, the code snippets show `configure`).  

![截屏2024-04-14 17 05 37](https://github.com/gradle/gradle/assets/43426962/8c88df7d-9fe7-41fb-8c07-fc59350a4a5c)


