### PR TITLE
Update docs for Test Suites

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
@@ -272,8 +272,8 @@ You can also access the configurations of a test suite in a top-level `dependenc
 === Example of using version catalogs with test suites
 
 ====
-include::sample[dir="snippets/testing/test-suite-version-catalogs/kotlin",files="build.gradle.kts[tags=version-catalog-deps]"]
-include::sample[dir="snippets/testing/test-suite-version-catalogs/groovy",files="build.gradle[tags=version-catalog-deps]"]
+include::sample[dir="snippets/testing/test-suite-version-catalogs/kotlin",files="build.gradle.kts[tags=version-catalogs-deps]"]
+include::sample[dir="snippets/testing/test-suite-version-catalogs/groovy",files="build.gradle[tags=version-catalogs-deps]"]
 ====
 
 == Differences between similar methods on link:{groovyDslPath}/org.gradle.api.plugins.jvm.JvmTestSuite.html[JvmTestSuite] and link:{groovyDslPath}/org.gradle.api.tasks.testing.Test.html[Test] task types

--- a/platforms/documentation/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
@@ -239,7 +239,7 @@ include::sample[dir="snippets/testing/test-suite-multi-configure-each-extracted/
 
 Gradle 7.6 changed the API of the test suite's `dependencies` block to be more strongly-typed.
 
-Each dependency scope returns a link:{groovyDslPath}/org.gradle.api.artifacts.dsl.DependencyAdder.html[`DependencyAdder`] that provides strongly-typed methods to add and configure dependencies.
+Each dependency scope returns a link:{groovyDslPath}/org.gradle.api.artifacts.dsl.DependencyCollector.html[`DependencyCollector`] that provides strongly-typed methods to add and configure dependencies.
 
 There is also a link:{javadocPath}/org/gradle/api/artifacts/dsl/DependencyFactory.html[`DependencyFactory`] with factory methods to create new dependencies from different notations.
 Dependencies can be created lazily using these factory methods, as shown below.
@@ -247,7 +247,7 @@ Dependencies can be created lazily using these factory methods, as shown below.
 This API differs from the top-level `dependencies` block in the following ways:
 
 * Dependencies must be declared using a `String`, an instance of `Dependency`, a `FileCollection`, a `Provider` of `Dependency`, or a `ProviderConvertible` of `MinimalExternalModuleDependency`.
-* Outside of Gradle build scripts, you must explicitly call a getter for the `DependencyAdder` and `add`.
+* Outside of Gradle build scripts, you must explicitly call a getter for the `DependencyCollector` and `add`.
     ** `dependencies.add("implementation", x)` becomes `getImplementation().add(x)`
 * You cannot declare dependencies with the `Map` notation from Kotlin and Java.
   Use multi-argument methods instead in Kotlin and Java.
@@ -267,6 +267,14 @@ To access these methods, you need to use the top-level `dependencies` block.
 
 NOTE: Adding dependencies via the test suite's own `dependencies` block is the preferred and recommended way.
 You can also access the configurations of a test suite in a top-level `dependencies` block after creating the test suite, but the exact names of the configurations used by test suites should be considered an implementation detail subject to change.
+
+[[sec:using_version_catalog_with_test_suites]]
+=== Example of using version catalogs with test suites
+
+====
+include::sample[dir="snippets/testing/test-suite-version-catalogs/kotlin",files="build.gradle.kts[tags=version-catalog-deps]"]
+include::sample[dir="snippets/testing/test-suite-version-catalogs/groovy",files="build.gradle[tags=version-catalog-deps]"]
+====
 
 == Differences between similar methods on link:{groovyDslPath}/org.gradle.api.plugins.jvm.JvmTestSuite.html[JvmTestSuite] and link:{groovyDslPath}/org.gradle.api.tasks.testing.Test.html[Test] task types
 

--- a/platforms/documentation/docs/src/snippets/testing/test-suite-version-catalogs/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/testing/test-suite-version-catalogs/groovy/build.gradle
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'java'
+    id 'jvm-test-suite'
+}
+
+version = '1.0.0'
+group = 'org.gradle.sample'
+
+repositories {
+    mavenCentral()
+}
+
+testing {
+    suites {
+        // tag::version-catalogs-deps[]
+        test {
+            dependencies {
+                runtimeOnly libs.guava
+                implementation libs.commons.lang3
+                implementation.bundle(libs.bundles.groovy)
+            }
+        }
+        // end::version-catalogs-deps[]
+    }
+}

--- a/platforms/documentation/docs/src/snippets/testing/test-suite-version-catalogs/groovy/gradle/libs.versions.toml
+++ b/platforms/documentation/docs/src/snippets/testing/test-suite-version-catalogs/groovy/gradle/libs.versions.toml
@@ -1,0 +1,13 @@
+[versions]
+groovy = "3.0.5"
+checkstyle = "8.37"
+
+[libraries]
+groovy-core = { module = "org.codehaus.groovy:groovy", version.ref = "groovy" }
+groovy-json = { module = "org.codehaus.groovy:groovy-json", version.ref = "groovy" }
+groovy-nio = { module = "org.codehaus.groovy:groovy-nio", version.ref = "groovy" }
+commons-lang3 = { group = "org.apache.commons", name = "commons-lang3", version = { strictly = "[3.8, 4.0[", prefer="3.9" } }
+guava = "com.google.guava:guava:29.0-jre"
+
+[bundles]
+groovy = ["groovy-core", "groovy-json", "groovy-nio"]

--- a/platforms/documentation/docs/src/snippets/testing/test-suite-version-catalogs/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/testing/test-suite-version-catalogs/kotlin/build.gradle.kts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    java
+    `jvm-test-suite`
+}
+
+version = "1.0.2"
+group = "org.gradle.sample"
+
+repositories {
+    mavenCentral()
+}
+
+testing {
+    suites {
+        // tag::version-catalogs-deps[]
+        val test by getting(JvmTestSuite::class) {
+            dependencies {
+                runtimeOnly(libs.guava)
+                implementation(libs.commons.lang3)
+                implementation.bundle(libs.bundles.groovy)
+            }
+        }
+        // end::version-catalogs-deps[]
+    }
+}

--- a/platforms/documentation/docs/src/snippets/testing/test-suite-version-catalogs/kotlin/gradle/libs.versions.toml
+++ b/platforms/documentation/docs/src/snippets/testing/test-suite-version-catalogs/kotlin/gradle/libs.versions.toml
@@ -1,0 +1,13 @@
+[versions]
+groovy = "3.0.5"
+checkstyle = "8.37"
+
+[libraries]
+groovy-core = { module = "org.codehaus.groovy:groovy", version.ref = "groovy" }
+groovy-json = { module = "org.codehaus.groovy:groovy-json", version.ref = "groovy" }
+groovy-nio = { module = "org.codehaus.groovy:groovy-nio", version.ref = "groovy" }
+commons-lang3 = { group = "org.apache.commons", name = "commons-lang3", version = { strictly = "[3.8, 4.0[", prefer="3.9" } }
+guava = "com.google.guava:guava:29.0-jre"
+
+[bundles]
+groovy = ["groovy-core", "groovy-json", "groovy-nio"]

--- a/platforms/documentation/docs/src/snippets/testing/test-suite-version-catalogs/tests/checkTaskOutput.out
+++ b/platforms/documentation/docs/src/snippets/testing/test-suite-version-catalogs/tests/checkTaskOutput.out
@@ -1,0 +1,23 @@
+> Task :dependencies
+
+testRuntimeClasspath - Runtime classpath of source set 'test'.
++--- org.apache.commons:commons-lang3:{strictly [3.8, 4.0[; prefer 3.9} -> 3.9
++--- org.codehaus.groovy:groovy:3.0.5
++--- org.codehaus.groovy:groovy-json:3.0.5
+|    \--- org.codehaus.groovy:groovy:3.0.5
++--- org.codehaus.groovy:groovy-nio:3.0.5
+|    \--- org.codehaus.groovy:groovy:3.0.5
+\--- com.google.guava:guava:29.0-jre
+     +--- com.google.guava:failureaccess:1.0.1
+     +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+     +--- com.google.code.findbugs:jsr305:3.0.2
+     +--- org.checkerframework:checker-qual:2.11.1
+     +--- com.google.errorprone:error_prone_annotations:2.3.4
+     \--- com.google.j2objc:j2objc-annotations:1.3
+
+(*) - Indicates repeated occurrences of a transitive dependency subtree. Gradle expands transitive dependency subtrees only once per project; repeat occurrences only display the root of the subtree, followed by this annotation.
+
+A web-based, searchable dependency report is available by adding the --scan option.
+
+BUILD SUCCESSFUL in 0s
+1 actionable task: 1 executed

--- a/platforms/documentation/docs/src/snippets/testing/test-suite-version-catalogs/tests/checkTaskOutput.sample.conf
+++ b/platforms/documentation/docs/src/snippets/testing/test-suite-version-catalogs/tests/checkTaskOutput.sample.conf
@@ -1,0 +1,5 @@
+executable: gradle
+args: dependencies --configuration testRuntimeClasspath
+expected-output-file: checkTaskOutput.out
+allow-additional-output: true
+allow-disordered-output: true


### PR DESCRIPTION
- Update type name `DependencyAdder` to `DependencyCollector`.
- Fix broken link to `DependencyAdder` in https://docs.gradle.org/current/userguide/jvm_test_suite_plugin.html#sec:differences_with_top_level_dependencies
- Provide example of using Version Catalogs with new deps block.

Addresses concerns raised in: https://github.com/gradle/gradle/issues/22720#issuecomment-1327937047

Preview updated docs here: https://builds.gradle.org/repository/download/Gradle_Master_Check_BuildDistributions/81107052:id/distributions/gradle-8.9-docs.zip!/gradle-8.9-20240415195436%2B0000/docs/userguide/jvm_test_suite_plugin.html#sec:differences_with_top_level_dependencies
