### PR TITLE
Rebase performance tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ develocity.internal.testdistribution.writeTraceFile=true
 gradle.internal.testdistribution.queryResponseTimeout=PT20S
 develocity.internal.testdistribution.queryResponseTimeout=PT20S
 # Default performance baseline
-defaultPerformanceBaselines=8.8-commit-d8cad9010179
+defaultPerformanceBaselines=8.9-commit-aeebddc86c47
 
 # Skip dependency analysis for tests
 systemProp.dependency.analysis.test.analysis=false


### PR DESCRIPTION
Because we saw a few performance test builds failing with doc-only changes.