### PR TITLE
Fix flaky JavaCrossCompilationIntegrationTest

### DIFF
--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/java/JavaCrossCompilationIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/java/JavaCrossCompilationIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.internal.FileUtils
+import org.gradle.internal.jvm.Jvm
 import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 import org.gradle.util.GradleVersion
@@ -43,7 +44,10 @@ class JavaCrossCompilationIntegrationTest extends AbstractIntegrationSpec {
         def javaVersion = toJavaVersion(version)
         def target = AvailableJavaHomes.getJdk(javaVersion)
         Assume.assumeNotNull(target)
+        withJavaProjectUsingToolchainsForJavaVersion(target)
+    }
 
+    def withJavaProjectUsingToolchainsForJavaVersion(Jvm jvm) {
         buildFile << """
             apply plugin: 'java'
             ${mavenCentralRepository()}
@@ -127,8 +131,10 @@ class JavaCrossCompilationIntegrationTest extends AbstractIntegrationSpec {
 
     def "can build and run application using target Java version"() {
         given:
-        withJavaProjectUsingToolchainsForJavaVersion(version)
-        def target = AvailableJavaHomes.getJdk(toJavaVersion(version))
+        JavaVersion javaVersion = toJavaVersion(version)
+        Jvm target = javaVersion.majorVersion == JavaVersion.current().majorVersion ? Jvm.current() : AvailableJavaHomes.getJdk(javaVersion)
+        Assume.assumeNotNull(target)
+        withJavaProjectUsingToolchainsForJavaVersion(target)
         buildFile << """
             apply plugin: 'application'
 


### PR DESCRIPTION
See https://ge.gradle.org/scans/tests?search.timeZoneId=Asia%2FShanghai&tests.container=org.gradle.java.JavaCrossCompilationIntegrationTest&tests.test=can%20build%20and%20run%20application%20using%20target%20Java%20version%20%5Bversion:%201.8%2C%20%232%5D

When there are two JDKs with same major version installed, the test might behave flaky because it starts the test with

```
export JAVA_HOME=/jdkPath1
gradle run -Porg.gradle.java.installations.paths=/jdkPath2
```

Now if the target JDK path matches current JDK version, we'll just use current JDK path instead of searching another Java homes.
