### PR TITLE
Mark flaky ProjectConfigurationProgressEventCrossVersionSpec

### DIFF
--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/ProjectConfigurationProgressEventCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/ProjectConfigurationProgressEventCrossVersionSpec.groovy
@@ -21,6 +21,7 @@ import org.gradle.integtests.tooling.fixture.ProgressEvents
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.tooling.BuildException
@@ -277,6 +278,7 @@ class ProjectConfigurationProgressEventCrossVersionSpec extends ToolingApiSpecif
     }
 
     @Timeout(value = 10, unit = TimeUnit.MINUTES)
+    @Flaky(because = "https://github.com/gradle/gradle-private/issues/3638")
     def "reports plugin configuration results for remote script plugins"() {
         given:
         toolingApi.requireIsolatedUserHome() // So that the script is not cached


### PR DESCRIPTION
We found another timeout build today, so re-mark it as `@Flaky`: https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_Quick_1_bucket3/81122912?buildTab=tests&orderBy=duration&order=desc&suite=org.gradle.integtests.tooling.r51.ProjectConfigurationProgressEventCrossVersionSpec%3A+reports+plugin+configuration+results+for+remote+script+plugins%3A+&package=org.gradle.integtests.tooling.r51&class=ProjectConfigurationProgressEventCrossVersionSpec

cc @donat 