### PR TITLE
Remove PluginDependenciesSpecExtensions.develocity

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecExtensions.kt
@@ -33,11 +33,11 @@ import org.gradle.plugin.use.PluginDependencySpec
  *
  * @since 6.0
  */
-@Deprecated("Gradle Enterprise has been renamed to Develocity", replaceWith = ReplaceWith("id(\"com.gradle.develocity\")"))
+@Deprecated("Gradle Enterprise has been renamed to Develocity", replaceWith = ReplaceWith("id(\"com.gradle.develocity\").version(\"${AutoAppliedGradleEnterprisePlugin.VERSION}\")"))
 val PluginDependenciesSpec.`gradle-enterprise`: PluginDependencySpec
     get() {
         DeprecationLogger.deprecate("The ${PluginDependencySpec::class.simpleName}.`gradle-enterprise` property")
-            .withAdvice("Please use id(\"com.gradle.develocity\") instead.")
+            .withAdvice("Please use id(\"com.gradle.develocity\").version(\"${AutoAppliedGradleEnterprisePlugin.VERSION}\") instead.")
             .willBeRemovedInGradle9()
             .withDocumentation(Documentation.kotlinDslExtensionReference("gradle-enterprise"))
             .nagUser()

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecExtensions.kt
@@ -33,11 +33,11 @@ import org.gradle.plugin.use.PluginDependencySpec
  *
  * @since 6.0
  */
-@Deprecated("Gradle Enterprise has been renamed to Develocity", replaceWith = ReplaceWith("id(\"com.gradle.develocity\").version(\"${AutoAppliedGradleEnterprisePlugin.VERSION}\")"))
+@Deprecated("Gradle Enterprise has been renamed to Develocity", replaceWith = ReplaceWith("id(\"com.gradle.develocity\") version \"${AutoAppliedGradleEnterprisePlugin.VERSION}\""))
 val PluginDependenciesSpec.`gradle-enterprise`: PluginDependencySpec
     get() {
         DeprecationLogger.deprecate("The ${PluginDependencySpec::class.simpleName}.`gradle-enterprise` property")
-            .withAdvice("Please use id(\"com.gradle.develocity\").version(\"${AutoAppliedGradleEnterprisePlugin.VERSION}\") instead.")
+            .withAdvice("Please use 'id(\"com.gradle.develocity\") version \"${AutoAppliedGradleEnterprisePlugin.VERSION}\"' instead.")
             .willBeRemovedInGradle9()
             .withDocumentation(Documentation.kotlinDslExtensionReference("gradle-enterprise"))
             .nagUser()

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecExtensions.kt
@@ -33,28 +33,13 @@ import org.gradle.plugin.use.PluginDependencySpec
  *
  * @since 6.0
  */
-@Deprecated("Gradle Enterprise has been renamed to Develocity", replaceWith = ReplaceWith("develocity"))
+@Deprecated("Gradle Enterprise has been renamed to Develocity", replaceWith = ReplaceWith("id(\"com.gradle.develocity\")"))
 val PluginDependenciesSpec.`gradle-enterprise`: PluginDependencySpec
     get() {
-        DeprecationLogger.deprecateProperty(PluginDependencySpec::class.java, "`gradle-enterprise`")
-            .replaceWith("develocity")
+        DeprecationLogger.deprecate("The ${PluginDependencySpec::class.simpleName}.`gradle-enterprise` property")
+            .withAdvice("Please use id(\"com.gradle.develocity\") instead.")
             .willBeRemovedInGradle9()
             .withDocumentation(Documentation.kotlinDslExtensionReference("gradle-enterprise"))
             .nagUser()
         return this.id(AutoAppliedGradleEnterprisePlugin.GRADLE_ENTERPRISE_PLUGIN_ID.id).version(AutoAppliedGradleEnterprisePlugin.VERSION)
     }
-
-
-/**
- * The `develocity` plugin.
- *
- * Visit the [Develocity Plugin User Manual](https://docs.gradle.com/enterprise/gradle-plugin/) for additional information.
- *
- * By default, the applied plugin version will be the same as the one used by the `--scan` command line option.
- *
- * You can also use e.g. `develocity version "3.17"` to request a different version.
- *
- * @since 8.8
- */
-val PluginDependenciesSpec.develocity: PluginDependencySpec
-    get() = this.id(AutoAppliedGradleEnterprisePlugin.ID.id).version(AutoAppliedGradleEnterprisePlugin.VERSION)

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecScopeTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecScopeTest.kt
@@ -61,20 +61,6 @@ class PluginDependenciesSpecScopeTest {
     }
 
     @Test
-    fun `given develocity plugin accessor, it should create a single request matching the auto-applied plugin version`() {
-        expecting(plugin(id = "com.gradle.develocity", version = AutoAppliedGradleEnterprisePlugin.VERSION)) {
-            develocity
-        }
-    }
-
-    @Test
-    fun `given develocity plugin accessor with version, it should create a single request with given version`() {
-        expecting(plugin(id = "com.gradle.develocity", version = "1.7.1")) {
-            develocity version "1.7.1"
-        }
-    }
-
-    @Test
     fun `given kotlin plugin accessor, it should create a single request with no version`() {
         expecting(plugin(id = "org.jetbrains.kotlin.jvm", version = null)) {
             kotlin("jvm")

--- a/testing/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-public-api-changes.json
@@ -10,14 +10,6 @@
         },
         {
             "type": "org.gradle.kotlin.dsl.PluginDependenciesSpecExtensionsKt",
-            "member": "Method org.gradle.kotlin.dsl.PluginDependenciesSpecExtensionsKt.getDevelocity(org.gradle.plugin.use.PluginDependenciesSpec)",
-            "acceptation": "We directly add a new method as non-incubating",
-            "changes": [
-                "Method added to public class"
-            ]
-        },
-        {
-            "type": "org.gradle.kotlin.dsl.PluginDependenciesSpecExtensionsKt",
             "member": "Method org.gradle.kotlin.dsl.PluginDependenciesSpecExtensionsKt.getGradle-enterprise$annotations(org.gradle.plugin.use.PluginDependenciesSpec)",
             "acceptation": "Adding the deprecation annotation added this new method, we directly ignore it",
             "changes": [

--- a/testing/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/BuildScanIntegrationTest.kt
+++ b/testing/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/BuildScanIntegrationTest.kt
@@ -17,6 +17,7 @@
 package org.gradle.kotlin.dsl.caching
 
 import org.gradle.kotlin.dsl.fixtures.normalisedPath
+import org.gradle.plugin.management.internal.autoapply.AutoAppliedGradleEnterprisePlugin
 
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.MatcherAssert.assertThat
@@ -51,7 +52,7 @@ class BuildScanIntegrationTest : AbstractScriptCachingIntegrationTest() {
 
         executer.expectDocumentedDeprecationWarning(
             "The PluginDependencySpec.`gradle-enterprise` property has been deprecated. " +
-                "This is scheduled to be removed in Gradle 9.0. Please use id(\"com.gradle.develocity\") instead. " +
+                "This is scheduled to be removed in Gradle 9.0. Please use id(\"com.gradle.develocity\").version(\"${AutoAppliedGradleEnterprisePlugin.VERSION}\") instead. " +
                 "For more information, please refer to https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.kotlin.dsl/gradle-enterprise.html in the Gradle documentation.")
         executer.expectDeprecationWarning("WARNING: The following functionality has been deprecated and will be removed in the next major release of the Develocity Gradle plugin. For assistance with migration, see https://gradle.com/help/gradle-plugin-develocity-migration.")
         executer.expectDeprecationWarning("""- The deprecated "gradleEnterprise.buildScan.termsOfServiceUrl" API has been replaced by "develocity.buildScan.termsOfUseUrl"""")

--- a/testing/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/BuildScanIntegrationTest.kt
+++ b/testing/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/BuildScanIntegrationTest.kt
@@ -29,31 +29,6 @@ import java.io.File
 class BuildScanIntegrationTest : AbstractScriptCachingIntegrationTest() {
 
     @Test
-    fun `can publish build scan using develocity extension`() {
-
-        val buildCacheDir = existing("build-cache")
-
-        withLocalBuildCacheSettings(buildCacheDir)
-
-        val settingsFile = existing("settings.gradle.kts")
-        settingsFile.writeText(
-            """
-            plugins {
-                develocity
-            }
-
-            develocity.buildScan {
-                termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
-                termsOfUseAgree = "yes"
-            }
-            """ + settingsFile.readText()
-        )
-        build("--scan", "--build-cache", "-Dscan.dump").apply {
-            assertThat(output, containsString("Build scan written to"))
-        }
-    }
-
-    @Test
     fun `using the gradle enterprise extension is deprecated`() {
 
         val buildCacheDir = existing("build-cache")
@@ -76,7 +51,7 @@ class BuildScanIntegrationTest : AbstractScriptCachingIntegrationTest() {
 
         executer.expectDocumentedDeprecationWarning(
             "The PluginDependencySpec.`gradle-enterprise` property has been deprecated. " +
-                "This is scheduled to be removed in Gradle 9.0. Please use the develocity property instead. " +
+                "This is scheduled to be removed in Gradle 9.0. Please use id(\"com.gradle.develocity\") instead. " +
                 "For more information, please refer to https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.kotlin.dsl/gradle-enterprise.html in the Gradle documentation.")
         executer.expectDeprecationWarning("WARNING: The following functionality has been deprecated and will be removed in the next major release of the Develocity Gradle plugin. For assistance with migration, see https://gradle.com/help/gradle-plugin-develocity-migration.")
         executer.expectDeprecationWarning("""- The deprecated "gradleEnterprise.buildScan.termsOfServiceUrl" API has been replaced by "develocity.buildScan.termsOfUseUrl"""")

--- a/testing/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/BuildScanIntegrationTest.kt
+++ b/testing/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/BuildScanIntegrationTest.kt
@@ -52,7 +52,7 @@ class BuildScanIntegrationTest : AbstractScriptCachingIntegrationTest() {
 
         executer.expectDocumentedDeprecationWarning(
             "The PluginDependencySpec.`gradle-enterprise` property has been deprecated. " +
-                "This is scheduled to be removed in Gradle 9.0. Please use id(\"com.gradle.develocity\").version(\"${AutoAppliedGradleEnterprisePlugin.VERSION}\") instead. " +
+                "This is scheduled to be removed in Gradle 9.0. Please use 'id(\"com.gradle.develocity\") version \"${AutoAppliedGradleEnterprisePlugin.VERSION}\"' instead. " +
                 "For more information, please refer to https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.kotlin.dsl/gradle-enterprise.html in the Gradle documentation.")
         executer.expectDeprecationWarning("WARNING: The following functionality has been deprecated and will be removed in the next major release of the Develocity Gradle plugin. For assistance with migration, see https://gradle.com/help/gradle-plugin-develocity-migration.")
         executer.expectDeprecationWarning("""- The deprecated "gradleEnterprise.buildScan.termsOfServiceUrl" API has been replaced by "develocity.buildScan.termsOfUseUrl"""")


### PR DESCRIPTION
Users should use `id("com.gradle.develocity")` directly. That means specifying the version, though that might not have been a good idea anyway to use the bundled version.