### PR TITLE
Resolve a symlink Groovy JAR location in classpath (#28664)

### DIFF
--- a/platforms/jvm/plugins-groovy/src/main/java/org/gradle/api/internal/plugins/GroovyJarFile.java
+++ b/platforms/jvm/plugins-groovy/src/main/java/org/gradle/api/internal/plugins/GroovyJarFile.java
@@ -19,6 +19,7 @@ import org.gradle.util.internal.VersionNumber;
 
 import javax.annotation.Nullable;
 import java.io.File;
+import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -61,6 +62,14 @@ public class GroovyJarFile {
 
     @Nullable
     public static GroovyJarFile parse(File file) {
+        try {
+            if (file.getName().contains("groovy")) {
+                // Resolve a symlink file to the real location
+                file = file.toPath().toRealPath().toFile();
+            }
+        } catch (IOException e) {
+            // Let the code use the original File otherwise
+        }
         Matcher matcher = FILE_NAME_PATTERN.matcher(file.getName());
         return matcher.matches() ? new GroovyJarFile(file, matcher) : null;
     }

--- a/platforms/jvm/plugins-groovy/src/test/groovy/org/gradle/api/internal/plugins/GroovyJarFileTest.groovy
+++ b/platforms/jvm/plugins-groovy/src/test/groovy/org/gradle/api/internal/plugins/GroovyJarFileTest.groovy
@@ -15,10 +15,15 @@
  */
 package org.gradle.api.internal.plugins
 
+import java.nio.file.Files
 import org.gradle.util.internal.VersionNumber
 import spock.lang.Specification
+import spock.lang.TempDir
 
 class GroovyJarFileTest extends Specification {
+    @TempDir
+    def tempDir
+
     def "parse non-Groovy file"() {
         expect:
         GroovyJarFile.parse(new File("groovy-other-2.0.5.jar")) == null
@@ -85,5 +90,33 @@ class GroovyJarFileTest extends Specification {
         "/lib/groovy-5.0.2-indy.jar" | "5.0.2" | "org.apache.groovy:groovy:5.0.2:indy"
     }
 
+    def "parse symlinked Jar"(String symlinkName, String fileName, String version, String dependencyNotation) {
+        File symlinkFile = new File(tempDir.toFile(), symlinkName)
+        File actualFile = new File(tempDir.toRealPath().toFile(), fileName)
+
+        if (!actualFile.exists()) {
+            actualFile.createNewFile()
+        }
+        if (!symlinkFile.exists()) {
+            Files.createSymbolicLink(symlinkFile.toPath(), actualFile.toPath())
+        }
+
+        def jar = GroovyJarFile.parse(symlinkFile)
+
+        expect:
+        jar != null
+        jar.file == actualFile
+        jar.baseName == "groovy"
+        jar.version == VersionNumber.parse("$version")
+        !jar.groovyAll
+        !jar.indy
+        jar.dependencyNotation == "$dependencyNotation"
+
+        where:
+        symlinkName            | fileName           | version | dependencyNotation
+        "Maven-groovy-2.x.jar" | "groovy-2.0.5.jar" | "2.0.5" | "org.codehaus.groovy:groovy:2.0.5"
+        "Maven-groovy-4.x.jar" | "groovy-4.1.0.jar" | "4.1.0" | "org.apache.groovy:groovy:4.1.0"
+        "Maven-groovy-5.x.jar" | "groovy-5.0.2.jar" | "5.0.2" | "org.apache.groovy:groovy:5.0.2"
+    }
 
 }

--- a/platforms/jvm/plugins-groovy/src/test/groovy/org/gradle/api/internal/plugins/GroovyJarFileTest.groovy
+++ b/platforms/jvm/plugins-groovy/src/test/groovy/org/gradle/api/internal/plugins/GroovyJarFileTest.groovy
@@ -15,14 +15,14 @@
  */
 package org.gradle.api.internal.plugins
 
-import java.nio.file.Files
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.internal.VersionNumber
+import org.junit.Rule
 import spock.lang.Specification
-import spock.lang.TempDir
 
 class GroovyJarFileTest extends Specification {
-    @TempDir
-    def tempDir
+    @Rule
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def "parse non-Groovy file"() {
         expect:
@@ -91,15 +91,8 @@ class GroovyJarFileTest extends Specification {
     }
 
     def "parse symlinked Jar"(String symlinkName, String fileName, String version, String dependencyNotation) {
-        File symlinkFile = new File(tempDir.toFile(), symlinkName)
-        File actualFile = new File(tempDir.toRealPath().toFile(), fileName)
-
-        if (!actualFile.exists()) {
-            actualFile.createNewFile()
-        }
-        if (!symlinkFile.exists()) {
-            Files.createSymbolicLink(symlinkFile.toPath(), actualFile.toPath())
-        }
+        def actualFile = tmpDir.file(fileName).touch()
+        def symlinkFile = tmpDir.file(symlinkName).createLink(actualFile)
 
         def jar = GroovyJarFile.parse(symlinkFile)
 


### PR DESCRIPTION
In certain environments the classpath can contain a symlinked location for the Groovy libraries that can be named different than the target location. This causes the logic matching the name of the JAR file to fail although the target location is preserving the actual expected name.

Resolve the symlink if any is found to eliminate the failure in this code path.

<!--- The issue this PR addresses -->
<!-- Fixes #28664 -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
I am not sure how many might find themselves in the same position. For us it is the entire Gradle development population in the company who deal with the issues coming from this and that is a pretty good number.
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [X] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
