### PR TITLE
Mark flaky test as `@ToBeFixedForConfigurationCache`

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/model/ObjectFactoryNamedTypeIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/model/ObjectFactoryNamedTypeIntegrationTest.groovy
@@ -154,6 +154,7 @@ class ObjectFactoryNamedTypeIntegrationTest extends AbstractIntegrationSpec {
         result.assertTaskSkipped(":a")
     }
 
+    @ToBeFixedForConfigurationCache(skip = INVESTIGATE, because = "Flaky")
     def "cannot mutate named instance from groovy"() {
         buildFile << """
             interface Thing extends Named { }


### PR DESCRIPTION
This was missing from https://github.com/gradle/gradle/pull/28783/files
