### PR TITLE
Rebaseline performance tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ develocity.internal.testdistribution.writeTraceFile=true
 gradle.internal.testdistribution.queryResponseTimeout=PT20S
 develocity.internal.testdistribution.queryResponseTimeout=PT20S
 # Default performance baseline
-defaultPerformanceBaselines=8.9-commit-aeebddc86c47
+defaultPerformanceBaselines=8.9-commit-ddec0863e620
 
 # Skip dependency analysis for tests
 systemProp.dependency.analysis.test.analysis=false


### PR DESCRIPTION
Because the failure blocks `master`.
