### PR TITLE
Correct wording in call to action when using init

### DIFF
--- a/platforms/core-runtime/logging/src/main/java/org/gradle/api/internal/DocumentationRegistry.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/api/internal/DocumentationRegistry.java
@@ -29,7 +29,7 @@ public class DocumentationRegistry {
     public static final String BASE_URL = "https://docs.gradle.org/" + GradleVersion.current().getVersion();
     public static final String DSL_PROPERTY_URL_FORMAT = "%s/dsl/%s.html#%s:%s";
     public static final String KOTLIN_DSL_URL_FORMAT = "%s/kotlin-dsl/gradle/%s";
-    public static final String LEARN_MORE_STRING = "To learn more about Gradle by exploring our Samples at ";
+    public static final String LEARN_MORE_STRING = "Learn more about Gradle by exploring our Samples at ";
 
     /**
      * Returns the location of the documentation for the given feature, referenced by id. The location may be local or remote.


### PR DESCRIPTION
Correct the wording in the message that sometimes appears after running init:

```
> Task :init
Learn more about Gradle by exploring our Samples at https://docs.gradle.org/8.9-20240418040000+0000/samples/sample_building_kotlin_applications.html

BUILD SUCCESSFUL in 67ms
```