### PR TITLE
Provide precise reason for cc invalidation when input files changed

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDependencyResolutionFeaturesIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDependencyResolutionFeaturesIntegrationTest.groovy
@@ -706,7 +706,7 @@ class ConfigurationCacheDependencyResolutionFeaturesIntegrationTest extends Abst
 
         then:
         configurationCache.assertStateStored()
-        outputContains("Calculating task graph as configuration cache cannot be reused because file '${lockFile}' has changed.")
+        outputContains("Calculating task graph as configuration cache cannot be reused because file '${lockFile}' has been removed.")
         outputContains("result = [lib-1.4.jar]")
     }
 
@@ -795,7 +795,7 @@ class ConfigurationCacheDependencyResolutionFeaturesIntegrationTest extends Abst
         configurationCacheRun("resolve1")
 
         then:
-        outputContains("Calculating task graph as configuration cache cannot be reused because file 'gradle/verification-metadata.xml' has changed.".replace('/', File.separator))
+        outputContains("Calculating task graph as configuration cache cannot be reused because file 'gradle/verification-metadata.xml' has been removed.".replace('/', File.separator))
         configurationCache.assertStateStored()
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintChecker.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintChecker.kt
@@ -56,6 +56,7 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
         val ignoredFileSystemCheckInputs: String?
         fun gradleProperty(propertyName: String): String?
         fun fingerprintOf(fileCollection: FileCollectionInternal): HashCode
+        fun hashCodeAndTypeOf(file: File): Pair<HashCode, FileType>
         fun hashCodeOf(file: File): HashCode?
         fun hashCodeOfDirectoryContent(file: File): HashCode?
         fun displayNameOf(fileOrDirectory: File): String
@@ -159,8 +160,11 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
                 }
             }
             is ConfigurationCacheFingerprint.InputFile -> input.run {
-                if (hasFileChanged(file, hash)) {
-                    return "file '${displayNameOf(file)}' has changed"
+                return when (checkFileUpToDateStatus(file, hash)) {
+                    UpToDateStatus.FileChanged -> "file '${displayNameOf(file)}' has changed"
+                    UpToDateStatus.Removed -> "file '${displayNameOf(file)}' has been removed"
+                    UpToDateStatus.TypeChanged -> "file '${displayNameOf(file)}' has been replaced by a directory"
+                    UpToDateStatus.Unchanged -> null
                 }
             }
             is ConfigurationCacheFingerprint.DirectoryChildren -> input.run {
@@ -290,7 +294,7 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
         previous: List<ConfigurationCacheFingerprint.InputFile>,
         current: List<File>
     ): Int = current.zip(previous)
-        .takeWhile { (initScript, fingerprint) -> isUpToDate(initScript, fingerprint.hash) }
+        .takeWhile { (initScript, fingerprint) -> isFileUpToDate(initScript, fingerprint.hash) }
         .count()
 
     private
@@ -311,16 +315,42 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
     }
 
     private
-    fun hasFileChanged(file: File, originalHash: HashCode) =
-        !isUpToDate(file, originalHash)
-
-    private
     fun hasDirectoryChanged(file: File, originalHash: HashCode?) =
         host.hashCodeOfDirectoryContent(file) != originalHash
 
     private
-    fun isUpToDate(file: File, originalHash: HashCode) =
-        host.hashCodeOf(file) == originalHash
+    fun isFileUpToDate(file: File, originalHash: HashCode) =
+        checkFileUpToDateStatus(file, originalHash) == UpToDateStatus.Unchanged
+
+    enum class UpToDateStatus {
+        Unchanged,
+        FileChanged,
+        TypeChanged,
+        Removed
+    }
+
+    private
+    fun checkFileUpToDateStatus(file: File, originalHash: HashCode): UpToDateStatus {
+        val (hashCode, fileType) = host.hashCodeAndTypeOf(file)
+        return doCheckFileUpToDateStatus(originalHash, hashCode, fileType)
+    }
+
+    private
+    fun doCheckFileUpToDateStatus(
+        originalHash: HashCode,
+        snapshotHash: HashCode,
+        snapshotType: FileType
+    ): UpToDateStatus {
+        if (snapshotHash == originalHash) {
+            return UpToDateStatus.Unchanged
+        }
+
+        return when (snapshotType) {
+            FileType.RegularFile -> UpToDateStatus.FileChanged
+            FileType.Directory -> UpToDateStatus.TypeChanged
+            FileType.Missing -> UpToDateStatus.Removed
+        }
+    }
 
     private
     fun displayNameOf(file: File) =

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -50,6 +50,7 @@ import org.gradle.internal.execution.WorkExecutionTracker
 import org.gradle.internal.execution.WorkInputListeners
 import org.gradle.internal.execution.impl.DefaultFileNormalizationSpec
 import org.gradle.internal.execution.model.InputNormalizer
+import org.gradle.internal.file.FileType
 import org.gradle.internal.fingerprint.DirectorySensitivity
 import org.gradle.internal.fingerprint.LineEndingSensitivity
 import org.gradle.internal.hash.HashCode
@@ -406,7 +407,10 @@ class ConfigurationCacheFingerprintController internal constructor(
             gradleProperties.find(propertyName)?.uncheckedCast()
 
         override fun hashCodeOf(file: File) =
-            fileSystemAccess.read(file.absolutePath).hash
+            hashCodeAndTypeOf(file).first
+
+        override fun hashCodeAndTypeOf(file: File): Pair<HashCode, FileType> =
+            fileSystemAccess.read(file.absolutePath).let { it.hash to it.type }
 
         override fun hashCodeOfDirectoryContent(file: File): HashCode = directoryChildrenNamesHash(file)
 

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
@@ -166,7 +166,6 @@ class ConfigurationCacheFingerprintCheckerTest {
         assertThat(
             checkFingerprintGiven(
                 mock {
-                    on { hashCodeOf(scriptFile) } doReturn TestHashCodes.hashCodeFrom(1)
                     on { hashCodeAndTypeOf(scriptFile) } doReturn (TestHashCodes.hashCodeFrom(1) to FileType.RegularFile)
                     on { displayNameOf(scriptFile) } doReturn "displayNameOf(scriptFile)"
                 },
@@ -188,7 +187,6 @@ class ConfigurationCacheFingerprintCheckerTest {
         assertThat(
             checkFingerprintGiven(
                 mock {
-                    on { hashCodeOf(inputFile) } doReturn missingFileHash
                     on { hashCodeAndTypeOf(inputFile) } doReturn (missingFileHash to FileType.Missing)
                     on { displayNameOf(inputFile) } doReturn "displayNameOf(inputFile)"
                 },
@@ -210,7 +208,6 @@ class ConfigurationCacheFingerprintCheckerTest {
         assertThat(
             checkFingerprintGiven(
                 mock {
-                    on { hashCodeOf(inputFile) } doReturn newDirectoryHash
                     on { hashCodeAndTypeOf(inputFile) } doReturn (newDirectoryHash to FileType.Directory)
                     on { displayNameOf(inputFile) } doReturn "displayNameOf(inputFile)"
                 },
@@ -229,7 +226,6 @@ class ConfigurationCacheFingerprintCheckerTest {
         assertThat(
             checkFingerprintGiven(
                 mock {
-                    on { hashCodeOf(inputFile) } doReturn TestHashCodes.hashCodeFrom(1)
                     on { hashCodeAndTypeOf(inputFile) } doReturn (TestHashCodes.hashCodeFrom(1) to FileType.Missing)
                     on { displayNameOf(inputFile) } doReturn "displayNameOf(inputFile)"
                 },
@@ -266,34 +262,16 @@ class ConfigurationCacheFingerprintCheckerTest {
         )
     }
 
-    data class FileInfo(
-        val file: File,
-        val hashCode: HashCode,
-        val fileType: FileType
-    )
-
     private
     fun invalidationReasonForInitScriptsChange(
         from: Iterable<Pair<File, HashCode>>,
         to: List<Pair<File, HashCode>>
-    ): InvalidationReason? =
-        invalidationReasonForFileSystemChange(
-            from.map { FileInfo(it.first, it.second, FileType.RegularFile) },
-            to.map { FileInfo(it.first, it.second, FileType.RegularFile) })
-
-    private
-    fun invalidationReasonForFileSystemChange(
-        from: Iterable<FileInfo>,
-        to: List<FileInfo>
-    ): InvalidationReason? = to.map { it.file to it }.toMap().let { toMap ->
+    ): InvalidationReason? = to.toMap().let { toMap ->
         checkFingerprintGiven(
             mock {
                 on { allInitScripts } doReturn toMap.keys.toList()
-                on { hashCodeOf(any()) }.then { invocation ->
-                    toMap[invocation.getArgument(0)]?.hashCode
-                }
                 on { hashCodeAndTypeOf(any()) }.then { invocation ->
-                    toMap[invocation.getArgument(0)]?.let { it.hashCode to it.fileType }
+                    toMap[invocation.getArgument(0)] to FileType.RegularFile
                 }
                 on { displayNameOf(any()) }.then { invocation ->
                     invocation.getArgument<File>(0).name

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
@@ -43,6 +43,7 @@ import org.gradle.configurationcache.serialization.beans.BeanStateWriter
 import org.gradle.configurationcache.serialization.runReadOperation
 import org.gradle.configurationcache.serialization.runWriteOperation
 import org.gradle.internal.Try
+import org.gradle.internal.file.FileType
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.serialize.Decoder
@@ -166,6 +167,7 @@ class ConfigurationCacheFingerprintCheckerTest {
             checkFingerprintGiven(
                 mock {
                     on { hashCodeOf(scriptFile) } doReturn TestHashCodes.hashCodeFrom(1)
+                    on { hashCodeAndTypeOf(scriptFile) } doReturn (TestHashCodes.hashCodeFrom(1) to FileType.RegularFile)
                     on { displayNameOf(scriptFile) } doReturn "displayNameOf(scriptFile)"
                 },
                 ConfigurationCacheFingerprint.InputFile(
@@ -174,6 +176,69 @@ class ConfigurationCacheFingerprintCheckerTest {
                 )
             ),
             equalTo("file 'displayNameOf(scriptFile)' has changed")
+        )
+    }
+
+    @Test
+    fun `build input file has been removed`() {
+        val inputFile = File("input.txt")
+        // no need to match a missing file hash, as long it is changed from the original one
+        val missingFileHash = TestHashCodes.hashCodeFrom(2)
+        val originalFileHash = TestHashCodes.hashCodeFrom(1)
+        assertThat(
+            checkFingerprintGiven(
+                mock {
+                    on { hashCodeOf(inputFile) } doReturn missingFileHash
+                    on { hashCodeAndTypeOf(inputFile) } doReturn (missingFileHash to FileType.Missing)
+                    on { displayNameOf(inputFile) } doReturn "displayNameOf(inputFile)"
+                },
+                ConfigurationCacheFingerprint.InputFile(
+                    inputFile,
+                    originalFileHash
+                )
+            ),
+            equalTo("file 'displayNameOf(inputFile)' has been removed")
+        )
+    }
+
+    @Test
+    fun `build input file is replaced by directory`() {
+        val inputFile = File("input.txt")
+        // all we care is that it is changed from the original one
+        val newDirectoryHash = TestHashCodes.hashCodeFrom(2)
+        val originalFileHash = TestHashCodes.hashCodeFrom(1)
+        assertThat(
+            checkFingerprintGiven(
+                mock {
+                    on { hashCodeOf(inputFile) } doReturn newDirectoryHash
+                    on { hashCodeAndTypeOf(inputFile) } doReturn (newDirectoryHash to FileType.Directory)
+                    on { displayNameOf(inputFile) } doReturn "displayNameOf(inputFile)"
+                },
+                ConfigurationCacheFingerprint.InputFile(
+                    inputFile,
+                    originalFileHash
+                )
+            ),
+            equalTo("file 'displayNameOf(inputFile)' has been replaced by a directory")
+        )
+    }
+
+    @Test
+    fun `build input file system entry has been removed`() {
+        val inputFile = File("input.txt")
+        assertThat(
+            checkFingerprintGiven(
+                mock {
+                    on { hashCodeOf(inputFile) } doReturn TestHashCodes.hashCodeFrom(1)
+                    on { hashCodeAndTypeOf(inputFile) } doReturn (TestHashCodes.hashCodeFrom(1) to FileType.Missing)
+                    on { displayNameOf(inputFile) } doReturn "displayNameOf(inputFile)"
+                },
+                ConfigurationCacheFingerprint.InputFileSystemEntry(
+                    inputFile,
+                    FileType.RegularFile
+                )
+            ),
+            equalTo("the file system entry 'displayNameOf(inputFile)' has been removed")
         )
     }
 
@@ -201,16 +266,34 @@ class ConfigurationCacheFingerprintCheckerTest {
         )
     }
 
+    data class FileInfo(
+        val file: File,
+        val hashCode: HashCode,
+        val fileType: FileType
+    )
+
     private
     fun invalidationReasonForInitScriptsChange(
         from: Iterable<Pair<File, HashCode>>,
         to: List<Pair<File, HashCode>>
-    ): InvalidationReason? = to.toMap().let { toMap ->
+    ): InvalidationReason? =
+        invalidationReasonForFileSystemChange(
+            from.map { FileInfo(it.first, it.second, FileType.RegularFile) },
+            to.map { FileInfo(it.first, it.second, FileType.RegularFile) })
+
+    private
+    fun invalidationReasonForFileSystemChange(
+        from: Iterable<FileInfo>,
+        to: List<FileInfo>
+    ): InvalidationReason? = to.map { it.file to it }.toMap().let { toMap ->
         checkFingerprintGiven(
             mock {
                 on { allInitScripts } doReturn toMap.keys.toList()
                 on { hashCodeOf(any()) }.then { invocation ->
-                    toMap[invocation.getArgument(0)]
+                    toMap[invocation.getArgument(0)]?.hashCode
+                }
+                on { hashCodeAndTypeOf(any()) }.then { invocation ->
+                    toMap[invocation.getArgument(0)]?.let { it.hashCode to it.fileType }
                 }
                 on { displayNameOf(any()) }.then { invocation ->
                     invocation.getArgument<File>(0).name


### PR DESCRIPTION
Issue: #26553

This PR covers improving reason messages for files that are read to derive configuration data. Note that for file system entries accessed via java.io and java.nio methods such as `File.exists()` or  `File.isFile()` (and [others](https://github.com/gradle/gradle/issues/23638)) we already had proper messages.

This was my test project:

```
// build.gradle
def readInputFile(File input) {
    try {
        return "First lines: " + input.readLines().take(5).join("\n")
    } catch(FileNotFoundException) {
        return "${input} does not exist"
    }
}

task readFile() {
    String baseDir = System.getenv("BASE_DIR") ?: "."
    String fileName = System.getenv("INPUT_FILE") ?: "input.txt"
    def inputFile = new File(baseDir, fileName)
    def Provider<String> message = layout.file(provider { inputFile }).map {
        readInputFile(it.asFile)
    }
    doLast {
        println(message.get())
    }
}
```

And this is how I manually tested it:

```
INPUT_FILE=somefile.txt /tmp/gradle/rchaves-spike-better-info-on-undeclared-cc-inputs/bin/gradle readFile --console=plain --configuration-cache  
```

Then I:
* changed the contents of the file (reason: file changed)
* removed the file (reason: file removed)
* replaced the file with a directory (reason: file replaced with a directory)

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
