### PR TITLE
Fix broken javadoc

### DIFF
--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/CleanupAction.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/CleanupAction.java
@@ -20,7 +20,7 @@ package org.gradle.cache;
  * An action that cleans up a {@link CleanableStore}.
  *
  * @see org.gradle.cache.internal.CompositeCleanupAction
- * @see CacheBuilder#withCleanup(CleanupAction)
+ * @see CacheBuilder#withCleanupStrategy(CacheCleanupStrategy)
  */
 public interface CleanupAction {
 

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/PersistentCache.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/PersistentCache.java
@@ -26,10 +26,10 @@ import java.io.File;
  * <p>By default, a shared lock is held on this cache by this process, to prevent it being removed or rebuilt by another process
  * while it is in use. You can change this use {@link CacheBuilder#withInitialLockMode(org.gradle.cache.FileLockManager.LockMode)}.
  *
- * <p>You can use {@link CacheBuilder#withInitializer(org.gradle.api.Action)} to provide an action to initialize the contents
+ * <p>You can use {@link CacheBuilder#withInitializer(java.util.function.Consumer)} to provide an action to initialize the contents
  * of the cache, for building a read-only cache. An exclusive lock is held by this process while the initializer is running.</p>
  *
- * <p>You can also use {@link #useCache(org.gradle.internal.Factory)} to perform some action on the cache while holding an exclusive
+ * <p>You can also use {@link #useCache(java.util.function.Supplier)} to perform some action on the cache while holding an exclusive
  * lock on the cache.
  * </p>
  */
@@ -43,7 +43,7 @@ public interface PersistentCache extends ExclusiveCacheAccessCoordinator, Closea
     /**
      * Creates an indexed cache implementation that is contained within this cache. This method may be used at any time.
      *
-     * <p>The returned cache may only be used by an action being run from {@link #useCache(org.gradle.internal.Factory)}.
+     * <p>The returned cache may only be used by an action being run from {@link #useCache(java.util.function.Supplier)}.
      * In this instance, an exclusive lock will be held on the cache.
      *
      */
@@ -52,7 +52,7 @@ public interface PersistentCache extends ExclusiveCacheAccessCoordinator, Closea
     /**
      * Creates an indexed cache implementation that is contained within this store. This method may be used at any time.
      *
-     * <p>The returned cache may only be used by an action being run from {@link #useCache(org.gradle.internal.Factory)}.
+     * <p>The returned cache may only be used by an action being run from {@link #useCache(java.util.function.Supplier)}.
      * In this instance, an exclusive lock will be held on the cache.
      *
      */


### PR DESCRIPTION
The error blocks master nightly build: https://ge.gradle.org/s/yo5srl3zhaocg/console-log/task/:persistent-cache:javadoc?anchor=317&page=1

The changes were in:

https://github.com/gradle/gradle/commit/7b8634c44e8d1c023c43da575b039d2d9679bd49#diff-044e93b86f4913589016f5e4f41f8dee90e773d0274c34ee886e19383cce134bL78

https://github.com/gradle/gradle/commit/2602607d5b48984304b6bc6ddb554366a6ec1756#diff-960b38f5e29fd546cdc714bb986b84c0997f486f7c81718aa9c3c27b996daa77L50

https://github.com/gradle/gradle/commit/76257843c9b12111e9a6e19b4e91f4f728ac4f49#diff-05551e5257857cecb1f07fa8af2026724556feae7645a43de8a54a0fdd3b2df7L31

