### PR TITLE
More explicitly model the lifecycle of BuildCacheController

### DIFF
--- a/platforms/core-execution/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceIntegrationTest.groovy
+++ b/platforms/core-execution/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceIntegrationTest.groovy
@@ -274,7 +274,7 @@ class HttpBuildCacheServiceIntegrationTest extends HttpBuildCacheFixture {
 
         then:
         withBuildCache().fails("jar")
-            .assertHasCause("Using insecure protocols with remote build cache, without explicit opt-in, is unsupported.")
+            .assertHasDescription("Using insecure protocols with remote build cache, without explicit opt-in, is unsupported.")
             .assertHasResolution("Switch remote build cache to a secure protocol (like HTTPS) or allow insecure protocols.")
             .assertHasResolution(Documentation.dslReference(HttpBuildCache, "allowInsecureProtocol").getConsultDocumentationMessage())
     }

--- a/platforms/core-execution/build-cache-local/src/integTest/groovy/org/gradle/caching/local/internal/AbstractBuildCacheCleanupIntegrationTest.groovy
+++ b/platforms/core-execution/build-cache-local/src/integTest/groovy/org/gradle/caching/local/internal/AbstractBuildCacheCleanupIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.cache.internal.GradleUserHomeCleanupFixture
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.cache.FileAccessTimeJournalFixture
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.internal.hash.Hashing
@@ -84,6 +85,7 @@ abstract class AbstractBuildCacheCleanupIntegrationTest extends AbstractIntegrat
         )
     }
 
+    @ToBeFixedForConfigurationCache(because = "Cache is cleaned twice on load after store")
     def "cleans up entries when #cleanupTrigger"() {
         long lastCleanupCheck = initializeHome()
 

--- a/platforms/core-execution/build-cache/build.gradle.kts
+++ b/platforms/core-execution/build-cache/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
 
     api(libs.jsr305)
 
-    implementation(project(":base-annotations"))
+    api(project(":base-annotations"))
     implementation(libs.commonsIo)
     api(libs.guava)
     implementation(libs.slf4jApi)

--- a/platforms/core-execution/build-cache/src/main/java/org/gradle/caching/internal/controller/BuildCacheController.java
+++ b/platforms/core-execution/build-cache/src/main/java/org/gradle/caching/internal/controller/BuildCacheController.java
@@ -30,6 +30,8 @@ import java.util.Optional;
 
 /**
  * High-level controller for build-cache operations; can load and store {@link CacheableEntity}s with a given {@link BuildCacheKey}.
+ *
+ * <p>Note that some implementations are mutable and may change behavior over the lifetime of a build.</p>
  */
 @ServiceScope(Scope.Gradle.class)
 public interface BuildCacheController extends Closeable {

--- a/platforms/core-execution/build-cache/src/main/java/org/gradle/caching/internal/controller/BuildCacheController.java
+++ b/platforms/core-execution/build-cache/src/main/java/org/gradle/caching/internal/controller/BuildCacheController.java
@@ -19,6 +19,8 @@ package org.gradle.caching.internal.controller;
 import org.gradle.caching.BuildCacheKey;
 import org.gradle.caching.internal.CacheableEntity;
 import org.gradle.caching.internal.controller.service.BuildCacheLoadResult;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
 
 import java.io.Closeable;
@@ -29,6 +31,7 @@ import java.util.Optional;
 /**
  * High-level controller for build-cache operations; can load and store {@link CacheableEntity}s with a given {@link BuildCacheKey}.
  */
+@ServiceScope(Scope.Gradle.class)
 public interface BuildCacheController extends Closeable {
 
     boolean isEnabled();

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/ExecutionEngine.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/ExecutionEngine.java
@@ -25,11 +25,14 @@ import org.gradle.internal.Try;
 import org.gradle.internal.execution.UnitOfWork.Identity;
 import org.gradle.internal.execution.caching.CachingState;
 import org.gradle.internal.execution.history.ExecutionOutputState;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Optional;
 
+@ServiceScope({Scope.Build.class, Scope.Gradle.class})
 public interface ExecutionEngine {
     Request createRequest(UnitOfWork work);
 

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryStore.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryStore.java
@@ -203,7 +203,6 @@ public class DefaultPersistentDirectoryStore implements ReferencablePersistentCa
         @Override
         public void cleanup() {
             if (cacheCleanupStrategy != null && requiresCleanup()) {
-                String description = "Cleaning " + getDisplayName();
                 buildOperationRunner.run(new RunnableBuildOperation() {
                     @Override
                     public void run(BuildOperationContext context) {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
@@ -274,13 +274,6 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
     }
 
     @Override
-    public void resetStateForAllBuilds() {
-        for (BuildState build : buildsByIdentifier.values()) {
-            build.resetModel();
-        }
-    }
-
-    @Override
     public void stop() {
         CompositeStoppable.stoppable(buildsByIdentifier.values()).stop();
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/caching/configuration/internal/BuildCacheCompositeConfigurationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/caching/configuration/internal/BuildCacheCompositeConfigurationIntegrationTest.groovy
@@ -121,7 +121,8 @@ class BuildCacheCompositeConfigurationIntegrationTest extends AbstractIntegratio
         }
 
         def finalizeOps = operations.all(FinalizeBuildCacheConfigurationBuildOperationType)
-        finalizeOps.size() == expectedCacheDirs.size()
+        def opsPerCache = configCache ? 2 : 1
+        finalizeOps.size() == expectedCacheDirs.size() * opsPerCache
         def pathToCacheDirMap = finalizeOps.collectEntries {
             [
                 it.details.buildPath,

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/BuildCacheServices.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/BuildCacheServices.java
@@ -24,7 +24,7 @@ import org.gradle.caching.configuration.internal.BuildCacheServiceRegistration;
 import org.gradle.caching.configuration.internal.DefaultBuildCacheConfiguration;
 import org.gradle.caching.configuration.internal.DefaultBuildCacheServiceRegistration;
 import org.gradle.caching.internal.controller.impl.LifecycleAwareBuildCacheController;
-import org.gradle.caching.internal.controller.impl.RootBuildCacheControllerRef;
+import org.gradle.caching.internal.controller.impl.LifecycleAwareBuildCacheControllerFactory;
 import org.gradle.caching.internal.origin.OriginMetadataFactory;
 import org.gradle.caching.internal.packaging.BuildCacheEntryPacker;
 import org.gradle.caching.internal.packaging.impl.DefaultTarPackerFileSystemSupport;
@@ -77,8 +77,8 @@ public final class BuildCacheServices extends AbstractPluginServiceRegistry {
         registration.addProvider(new Object() {
             private static final String GRADLE_VERSION_KEY = "gradleVersion";
 
-            RootBuildCacheControllerRef createRootBuildCacheControllerRef() {
-                return new RootBuildCacheControllerRef();
+            LifecycleAwareBuildCacheControllerFactory createRootBuildCacheControllerRef() {
+                return new LifecycleAwareBuildCacheControllerFactory();
             }
 
             OriginMetadataFactory createOriginMetadataFactory(
@@ -131,7 +131,7 @@ public final class BuildCacheServices extends AbstractPluginServiceRegistry {
 
             LifecycleAwareBuildCacheController createBuildCacheController(
                 BuildState build,
-                RootBuildCacheControllerRef rootControllerRef,
+                LifecycleAwareBuildCacheControllerFactory rootControllerRef,
                 BuildCacheControllerFactory buildCacheControllerFactory,
                 InstantiatorFactory instantiatorFactory,
                 ServiceRegistry services

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/controller/impl/LifecycleAwareBuildCacheController.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/controller/impl/LifecycleAwareBuildCacheController.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.caching.internal.controller.impl;
+
+import org.gradle.caching.configuration.internal.BuildCacheConfigurationInternal;
+import org.gradle.caching.internal.controller.BuildCacheController;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+
+@ServiceScope(Scope.Gradle.class)
+public interface LifecycleAwareBuildCacheController extends BuildCacheController {
+    /**
+     * Called when the configuration for this controller is available.
+     * The implementation may or may not use the given configuration. For example, the controller for an included build might use the configuration from the root build instead.
+     */
+    void configurationAvailable(BuildCacheConfigurationInternal configuration);
+
+    /**
+     * Resets the state of this controller in preparation for loading configuration from the cache.
+     */
+    void resetState();
+}

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/controller/impl/LifecycleAwareBuildCacheController.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/controller/impl/LifecycleAwareBuildCacheController.java
@@ -21,6 +21,11 @@ import org.gradle.caching.internal.controller.BuildCacheController;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
+/**
+ * This class is in this package, alongside {@link RootBuildCacheControllerRef}, to keep the complexity of the Gradle-specific {@link BuildCacheController} lifecycle in one place.
+ *
+ * At some point we aim to better model services who need data from the Gradle model, and this complexity can go away.
+ */
 @ServiceScope(Scope.Gradle.class)
 public interface LifecycleAwareBuildCacheController extends BuildCacheController {
     /**

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/controller/impl/LifecycleAwareBuildCacheController.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/controller/impl/LifecycleAwareBuildCacheController.java
@@ -22,7 +22,7 @@ import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 /**
- * This class is in this package, alongside {@link RootBuildCacheControllerRef}, to keep the complexity of the Gradle-specific {@link BuildCacheController} lifecycle in one place.
+ * This class is in this package, alongside {@link LifecycleAwareBuildCacheControllerFactory}, to keep the complexity of the Gradle-specific {@link BuildCacheController} lifecycle in one place.
  *
  * At some point we aim to better model services who need data from the Gradle model, and this complexity can go away.
  */

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/controller/impl/LifecycleAwareBuildCacheControllerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/controller/impl/LifecycleAwareBuildCacheControllerFactory.java
@@ -55,7 +55,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * <p>Currently, there is no simple, general way to know where in the above lifecycle a given piece of work will run.</p>
  */
 @ServiceScope(Scope.BuildTree.class)
-public class RootBuildCacheControllerRef {
+public class LifecycleAwareBuildCacheControllerFactory {
     private final RootBuildCacheController rootController = new RootBuildCacheController();
 
     public LifecycleAwareBuildCacheController createForRootBuild(Path identityPath, BuildCacheControllerFactory buildCacheControllerFactory, InstanceGenerator instanceGenerator) {

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/controller/impl/RootBuildCacheControllerRef.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/controller/impl/RootBuildCacheControllerRef.java
@@ -51,6 +51,8 @@ import java.util.concurrent.atomic.AtomicReference;
  *       Once configuration is available, it will be used, as per the above.
  *     </li>
  * </ul>
+ *
+ * <p>Currently, there is no simple, general way to know where in the above lifecycle a given piece of work will run.</p>
  */
 @ServiceScope(Scope.BuildTree.class)
 public class RootBuildCacheControllerRef {
@@ -109,7 +111,11 @@ public class RootBuildCacheControllerRef {
         protected abstract BuildCacheController getDelegate();
     }
 
+    /**
+     * This implementation tracks the state of the root build.
+     */
     private static class RootBuildCacheController extends DelegatingBuildCacheController {
+        // Holds an immutable BCC that represents the current state of the root build's cache configuration.
         private final AtomicReference<BuildCacheController> delegate = new AtomicReference<>();
         private Path identityPath;
         private BuildCacheControllerFactory buildCacheControllerFactory;
@@ -146,8 +152,12 @@ public class RootBuildCacheControllerRef {
         }
     }
 
+    /**
+     * This implementation manages the state of all other builds in the tree.
+     */
     private static class NonRootBuildCacheController extends DelegatingBuildCacheController {
         private final RootBuildCacheController rootController;
+        // Holds a BCC that represents the current state of this build's cache configuration, but only if used as an 'early' build.
         private final AtomicReference<BuildCacheController> delegate = new AtomicReference<>();
         private final Path identityPath;
         private final BuildCacheControllerFactory buildCacheControllerFactory;

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/controller/impl/RootBuildCacheControllerRef.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/controller/impl/RootBuildCacheControllerRef.java
@@ -20,12 +20,15 @@ import org.gradle.caching.BuildCacheKey;
 import org.gradle.caching.internal.CacheableEntity;
 import org.gradle.caching.internal.controller.BuildCacheController;
 import org.gradle.caching.internal.controller.service.BuildCacheLoadResult;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
 
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 
+@ServiceScope(Scope.BuildTree.class)
 public class RootBuildCacheControllerRef {
 
     private BuildCacheController buildCacheController;

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/controller/impl/RootBuildCacheControllerRef.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/controller/impl/RootBuildCacheControllerRef.java
@@ -21,41 +21,43 @@ import org.gradle.caching.internal.CacheableEntity;
 import org.gradle.caching.internal.controller.BuildCacheController;
 import org.gradle.caching.internal.controller.NoOpBuildCacheController;
 import org.gradle.caching.internal.controller.service.BuildCacheLoadResult;
+import org.gradle.internal.UncheckedException;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 @ServiceScope(Scope.BuildTree.class)
 public class RootBuildCacheControllerRef {
+    private final RootBuildCacheController rootController = new RootBuildCacheController();
 
-    private final DelegatingBuildCacheController sharedInstance = new DelegatingBuildCacheController();
-
-    public void set(BuildCacheController buildCacheController) {
-        sharedInstance.set(buildCacheController);
+    public BuildCacheController getForRootBuild() {
+        return rootController;
     }
 
     public BuildCacheController getForNonRootBuild() {
-        return sharedInstance;
+        return new NonRootBuildCacheController(rootController);
     }
 
-    private static class DelegatingBuildCacheController implements BuildCacheController {
-        private final AtomicReference<BuildCacheController> delegate = new AtomicReference<>();
+    public void effectiveControllerAvailable(BuildCacheController buildCacheController, Supplier<BuildCacheController> factory) {
+        ((DelegatingBuildCacheController) buildCacheController).effectiveControllerAvailable(factory);
+    }
 
-        private DelegatingBuildCacheController() {
-            this.delegate.set(NoOpBuildCacheController.INSTANCE);
+    public void resetState() {
+        try {
+            rootController.close();
+        } catch (IOException e) {
+            throw UncheckedException.throwAsUncheckedException(e);
         }
+    }
 
-        void set(BuildCacheController buildCacheController) {
-            if (!this.delegate.compareAndSet(NoOpBuildCacheController.INSTANCE, buildCacheController)) {
-                throw new IllegalStateException("Build cache controller already set");
-            }
-        }
-
+    private static abstract class DelegatingBuildCacheController implements BuildCacheController {
         @Override
         public boolean isEnabled() {
             return getDelegate().isEnabled();
@@ -71,15 +73,72 @@ public class RootBuildCacheControllerRef {
             getDelegate().store(cacheKey, entity, snapshots, executionTime);
         }
 
-        private BuildCacheController getDelegate() {
+        protected abstract BuildCacheController getDelegate();
+
+        public abstract void effectiveControllerAvailable(Supplier<BuildCacheController> factory);
+    }
+
+    private static class RootBuildCacheController extends DelegatingBuildCacheController {
+        private final AtomicReference<BuildCacheController> delegate = new AtomicReference<>();
+
+        private RootBuildCacheController() {
+            this.delegate.set(NoOpBuildCacheController.INSTANCE);
+        }
+
+        @Override
+        public void effectiveControllerAvailable(Supplier<BuildCacheController> factory) {
+            if (!this.delegate.compareAndSet(NoOpBuildCacheController.INSTANCE, factory.get())) {
+                throw new IllegalStateException("Build cache controller already set");
+            }
+        }
+
+        @Override
+        protected BuildCacheController getDelegate() {
             return delegate.get();
         }
 
         @Override
-        public void close() {
-            // This instance ends up in build/gradle scoped services for nesteds
-            // We don't want to invoke close at that time.
-            // Instead, close it at the root.
+        public void close() throws IOException {
+            BuildCacheController controller = delegate.getAndSet(NoOpBuildCacheController.INSTANCE);
+            controller.close();
+        }
+    }
+
+    private static class NonRootBuildCacheController extends DelegatingBuildCacheController {
+        private final RootBuildCacheController rootController;
+        private final AtomicReference<BuildCacheController> delegate = new AtomicReference<>();
+
+        private NonRootBuildCacheController(RootBuildCacheController rootController) {
+            this.rootController = rootController;
+            this.delegate.set(NoOpBuildCacheController.INSTANCE);
+        }
+
+        @Override
+        public void effectiveControllerAvailable(Supplier<BuildCacheController> factory) {
+            BuildCacheController rootController = this.rootController.getDelegate();
+            if (rootController != NoOpBuildCacheController.INSTANCE) {
+                // The root controller is available, so don't use the build specific controller
+                return;
+            }
+            // Use the build specific controller
+            if (!this.delegate.compareAndSet(NoOpBuildCacheController.INSTANCE, factory.get())) {
+                throw new IllegalStateException("Build cache controller already set");
+            }
+        }
+
+        @Override
+        protected BuildCacheController getDelegate() {
+            BuildCacheController controller = delegate.get();
+            if (controller != NoOpBuildCacheController.INSTANCE) {
+                return controller;
+            }
+            return rootController.delegate.get();
+        }
+
+        @Override
+        public void close() throws IOException {
+            BuildCacheController controller = delegate.getAndSet(NoOpBuildCacheController.INSTANCE);
+            controller.close();
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/controller/impl/RootBuildCacheControllerRef.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/controller/impl/RootBuildCacheControllerRef.java
@@ -19,6 +19,7 @@ package org.gradle.caching.internal.controller.impl;
 import org.gradle.caching.BuildCacheKey;
 import org.gradle.caching.internal.CacheableEntity;
 import org.gradle.caching.internal.controller.BuildCacheController;
+import org.gradle.caching.internal.controller.NoOpBuildCacheController;
 import org.gradle.caching.internal.controller.service.BuildCacheLoadResult;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
@@ -27,55 +28,58 @@ import org.gradle.internal.snapshot.FileSystemSnapshot;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
 @ServiceScope(Scope.BuildTree.class)
 public class RootBuildCacheControllerRef {
 
-    private BuildCacheController buildCacheController;
+    private final DelegatingBuildCacheController sharedInstance = new DelegatingBuildCacheController();
 
     public void set(BuildCacheController buildCacheController) {
-        // This instance ends up in build/gradle scoped services for nesteds
-        // We don't want to invoke close at that time.
-        // Instead, close it at the root.
-        this.buildCacheController = new CloseShieldBuildCacheController(buildCacheController);
+        sharedInstance.set(buildCacheController);
     }
 
     public BuildCacheController getForNonRootBuild() {
-        if (!isSet()) {
-            throw new IllegalStateException("Root build cache controller not yet assigned");
+        return sharedInstance;
+    }
+
+    private static class DelegatingBuildCacheController implements BuildCacheController {
+        private final AtomicReference<BuildCacheController> delegate = new AtomicReference<>();
+
+        private DelegatingBuildCacheController() {
+            this.delegate.set(NoOpBuildCacheController.INSTANCE);
         }
 
-        return buildCacheController;
-    }
-
-    public boolean isSet() {
-        return buildCacheController != null;
-    }
-
-    private static class CloseShieldBuildCacheController implements BuildCacheController {
-        private final BuildCacheController delegate;
-
-        private CloseShieldBuildCacheController(BuildCacheController delegate) {
-            this.delegate = delegate;
+        void set(BuildCacheController buildCacheController) {
+            if (!this.delegate.compareAndSet(NoOpBuildCacheController.INSTANCE, buildCacheController)) {
+                throw new IllegalStateException("Build cache controller already set");
+            }
         }
 
         @Override
         public boolean isEnabled() {
-            return delegate.isEnabled();
+            return getDelegate().isEnabled();
         }
 
         @Override
         public Optional<BuildCacheLoadResult> load(BuildCacheKey cacheKey, CacheableEntity cacheableEntity) {
-            return delegate.load(cacheKey, cacheableEntity);
+            return getDelegate().load(cacheKey, cacheableEntity);
         }
 
         @Override
         public void store(BuildCacheKey cacheKey, CacheableEntity entity, Map<String, FileSystemSnapshot> snapshots, Duration executionTime) {
-            delegate.store(cacheKey, entity, snapshots, executionTime);
+            getDelegate().store(cacheKey, entity, snapshots, executionTime);
+        }
+
+        private BuildCacheController getDelegate() {
+            return delegate.get();
         }
 
         @Override
         public void close() {
+            // This instance ends up in build/gradle scoped services for nesteds
+            // We don't want to invoke close at that time.
+            // Instead, close it at the root.
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/services/BuildCacheControllerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/services/BuildCacheControllerFactory.java
@@ -19,8 +19,11 @@ package org.gradle.caching.internal.services;
 import org.gradle.caching.configuration.internal.BuildCacheConfigurationInternal;
 import org.gradle.caching.internal.controller.BuildCacheController;
 import org.gradle.internal.instantiation.InstanceGenerator;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.util.Path;
 
+@ServiceScope(Scope.Gradle.class)
 public interface BuildCacheControllerFactory {
     String REMOTE_CONTINUE_ON_ERROR_PROPERTY = "org.gradle.unsafe.build-cache.remote-continue-on-error";
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/RootBuildCacheControllerSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/RootBuildCacheControllerSettingsProcessor.java
@@ -20,10 +20,7 @@ import org.gradle.StartParameter;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.caching.configuration.internal.BuildCacheConfigurationInternal;
-import org.gradle.caching.internal.controller.BuildCacheController;
-import org.gradle.caching.internal.controller.impl.RootBuildCacheControllerRef;
-import org.gradle.caching.internal.services.BuildCacheControllerFactory;
-import org.gradle.internal.instantiation.InstantiatorFactory;
+import org.gradle.caching.internal.controller.impl.LifecycleAwareBuildCacheController;
 import org.gradle.internal.service.ServiceRegistry;
 
 public class RootBuildCacheControllerSettingsProcessor implements SettingsProcessor {
@@ -34,14 +31,9 @@ public class RootBuildCacheControllerSettingsProcessor implements SettingsProces
         // before configuring them. This achieves that.
 
         ServiceRegistry services = gradle.getServices();
-        BuildCacheController cacheController = services.get(BuildCacheController.class);
-        RootBuildCacheControllerRef rootControllerRef = services.get(RootBuildCacheControllerRef.class);
-        rootControllerRef.effectiveControllerAvailable(cacheController, () -> {
-            BuildCacheControllerFactory buildCacheControllerFactory = services.get(BuildCacheControllerFactory.class);
-            BuildCacheConfigurationInternal buildCacheConfiguration = services.get(BuildCacheConfigurationInternal.class);
-            InstantiatorFactory instantiatorFactory = services.get(InstantiatorFactory.class);
-            return buildCacheControllerFactory.createController(gradle.getIdentityPath(), buildCacheConfiguration, instantiatorFactory.inject(services));
-        });
+        LifecycleAwareBuildCacheController cacheController = services.get(LifecycleAwareBuildCacheController.class);
+        BuildCacheConfigurationInternal buildCacheConfiguration = services.get(BuildCacheConfigurationInternal.class);
+        cacheController.configurationAvailable(buildCacheConfiguration);
     }
 
     private final SettingsProcessor delegate;

--- a/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
@@ -19,7 +19,7 @@ package org.gradle.internal.build;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
-import org.gradle.caching.internal.controller.impl.RootBuildCacheControllerRef;
+import org.gradle.caching.internal.controller.impl.LifecycleAwareBuildCacheController;
 import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
@@ -76,7 +76,7 @@ public abstract class AbstractBuildState implements BuildState, Closeable {
         projectStateRegistry.get().discardProjectsFor(this);
         workGraphController.get().resetState();
         buildLifecycleController.get().resetModel();
-        buildServices.get(RootBuildCacheControllerRef.class).resetState();
+        buildLifecycleController.get().getGradle().getServices().get(LifecycleAwareBuildCacheController.class).resetState();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
@@ -19,6 +19,7 @@ package org.gradle.internal.build;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
+import org.gradle.caching.internal.controller.impl.RootBuildCacheControllerRef;
 import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
@@ -75,6 +76,7 @@ public abstract class AbstractBuildState implements BuildState, Closeable {
         projectStateRegistry.get().discardProjectsFor(this);
         workGraphController.get().resetState();
         buildLifecycleController.get().resetModel();
+        buildServices.get(RootBuildCacheControllerRef.class).resetState();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
@@ -110,9 +110,4 @@ public interface BuildStateRegistry {
      * Visits all registered builds, ordered by {@link BuildState#getIdentityPath()}
      */
     void visitBuilds(Consumer<? super BuildState> visitor);
-
-    /**
-     * Restarts each build in the tree.
-     */
-    void resetStateForAllBuilds();
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationTreeFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationTreeFixture.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.fixtures
 
+import junit.framework.AssertionFailedError
 import org.gradle.api.specs.Spec
 import org.gradle.api.specs.Specs
 import org.gradle.internal.logging.events.StyledTextOutputEvent
@@ -95,7 +96,11 @@ class BuildOperationTreeFixture extends BuildOperationTreeQueries {
     @Override
     BuildOperationRecord only(Pattern displayName) {
         def records = all(displayName)
-        assert records.size() == 1: "Error matching pattern: $displayName"
+        if (records.isEmpty()) {
+            throw new AssertionFailedError("No operations found with display name that matches $displayName")
+        } else if (records.size() > 1) {
+            throw new AssertionFailedError("Multiple operations found with display name that matches $displayName")
+        }
         return records.first()
     }
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context

This PR reworks the `BuildCacheController` instance that is created in each "Gradle" scope so that its behavior reflects the current state of the cache configuration in the root build. Previously, the behavior of the instance would reflect the state of the cache configuration at the time the instance was created (i.e. located as a service). Given that it is easy to accidentally change the timing of service creation, this change should make the behavior of caching more deterministic because the controller will always use the cache configuration once it is available.

This PR doesn't attempt to fix a related problem, where it is currently easy to accidentally use the controller before the cache configuration is available.

This PR attempts to clean up the controllers between storing and loading the configuration cache entry on a configuration cache miss build. Previously, the cache configuration loaded from the CC was ignored. This should help with accuracy, but does introduce a couple of regressions, which can be addressed in a later PR:

- Cache cleanup currently happens as a side effect of closing the cache controller. This means cleanup will be attempted twice in a CC miss build (because two controllers are created - one for the store operation and one for the load operation).
- The "finalizing cache configuration" build operation is currently run as a side effect of creating the controller. This means 2 such build operations will happen per root build.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
