### PR TITLE
Fix flaky JavaCrossCompilationIntegrationTest

### DIFF
--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
@@ -436,7 +436,7 @@ class JavaCompileToolchainIntegrationTest extends AbstractIntegrationSpec implem
      */
     @Requires(UnitTestPreconditions.Jdk9OrLater)
     def "Java deprecation messages with different JDKs"() {
-        def jdk = AvailableJavaHomes.getJdk(javaVersion)
+        def jdk = javaVersion == JavaVersion.current() ? Jvm.current() : AvailableJavaHomes.getJdk(javaVersion)
 
         buildFile << """
             plugins {


### PR DESCRIPTION
See https://ge.gradle.org/s/szspge6cginbc/tests/task/:language-java:forkingIntegTest/details/org.gradle.api.tasks.compile.JavaCompileToolchainIntegrationTest/Java%20deprecation%20messages%20with%20different%20JDKs%20%5BjavaVersion:%2021%2C%20deprecationMessage:%20%5Bdeprecation%5D%20foo()%20in%20Foo%20has%20been%20deprecated%2C%20%231%5D?top-execution=1

When there are two JDKs with same major version installed, the test might behave flaky because it starts the test with

```
export JAVA_HOME=/jdkPath1
gradle run -Porg.gradle.java.installations.paths=/jdkPath2
```

Now if the target JDK path matches current JDK version, we'll just use current JDK path instead of searching another Java homes.
