### PR TITLE
Upgrade `kotlinx-metadata`

### DIFF
--- a/build-logic-commons/build-platform/build.gradle.kts
+++ b/build-logic-commons/build-platform/build.gradle.kts
@@ -80,7 +80,7 @@ dependencies {
         api("org.codenarc:CodeNarc:$codenarcVersion")
         api("org.eclipse.jgit:org.eclipse.jgit:5.13.3.202401111512-r")
         api("org.javassist:javassist:3.27.0-GA")
-        api("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.6.0")
+        api("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.6.2")
         api("org.jsoup:jsoup:1.15.3")
         api("org.junit.jupiter:junit-jupiter:5.8.2")
         api("org.junit.vintage:junit-vintage-engine:5.8.2")

--- a/platforms/core-configuration/kotlin-dsl/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
     implementation(libs.futureKotlin("assignment-compiler-plugin-embeddable")) {
         isTransitive = false
     }
-    implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.9.0") {
+    implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.8.0") {
         isTransitive = false
     }
 

--- a/platforms/core-configuration/kotlin-dsl/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
     implementation(libs.futureKotlin("assignment-compiler-plugin-embeddable")) {
         isTransitive = false
     }
-    implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.5.0") {
+    implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.7.0") {
         isTransitive = false
     }
 

--- a/platforms/core-configuration/kotlin-dsl/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
     implementation(libs.futureKotlin("assignment-compiler-plugin-embeddable")) {
         isTransitive = false
     }
-    implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.8.0") {
+    implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.9.0") {
         isTransitive = false
     }
 

--- a/platforms/core-configuration/kotlin-dsl/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
     implementation(libs.futureKotlin("assignment-compiler-plugin-embeddable")) {
         isTransitive = false
     }
-    implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.7.0") {
+    implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.8.0") {
         isTransitive = false
     }
 

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorFragments.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorFragments.kt
@@ -16,10 +16,9 @@
 
 package org.gradle.kotlin.dsl.accessors
 
-import kotlinx.metadata.Flag
 import kotlinx.metadata.KmType
 import kotlinx.metadata.KmVariance
-import kotlinx.metadata.flagsOf
+import kotlinx.metadata.hasAnnotations
 import kotlinx.metadata.jvm.JvmMethodSignature
 import org.gradle.api.reflect.TypeOf
 import org.gradle.internal.deprecation.ConfigurationDeprecationType
@@ -48,11 +47,8 @@ import org.gradle.kotlin.dsl.support.bytecode.newValueParameterOf
 import org.gradle.kotlin.dsl.support.bytecode.nullable
 import org.gradle.kotlin.dsl.support.bytecode.providerConvertibleOfStar
 import org.gradle.kotlin.dsl.support.bytecode.providerOfStar
-import org.gradle.kotlin.dsl.support.bytecode.publicFunctionFlags
-import org.gradle.kotlin.dsl.support.bytecode.publicFunctionWithAnnotationsFlags
 import org.gradle.kotlin.dsl.support.bytecode.publicStaticMethod
 import org.gradle.kotlin.dsl.support.bytecode.publicStaticSyntheticMethod
-import org.gradle.kotlin.dsl.support.bytecode.readOnlyPropertyFlags
 import org.gradle.kotlin.dsl.support.uppercaseFirstChar
 import org.jetbrains.org.objectweb.asm.MethodVisitor
 
@@ -73,9 +69,9 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
     val name = config.target
     val propertyName = name.original
     val className = "${propertyName.uppercaseFirstChar()}ConfigurationAccessorsKt"
-    val (functionFlags, deprecationBlock) =
-        if (config.hasDeclarationDeprecations()) publicFunctionWithAnnotationsFlags to config.getDeclarationDeprecationBlock()
-        else publicFunctionFlags to ""
+    val (functionHasAnnotations, deprecationBlock) =
+        if (config.hasDeclarationDeprecations()) true to config.getDeclarationDeprecationBlock()
+        else false to ""
 
     className to sequenceOf(
         AccessorFragment(
@@ -104,7 +100,6 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
             },
             metadata = {
                 kmPackage.functions += newFunctionOf(
-                    flags = functionFlags,
                     receiverType = GradleType.dependencyHandler,
                     returnType = nullable(GradleType.dependency),
                     name = signature.name,
@@ -112,7 +107,9 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
                         newValueParameterOf("dependencyNotation", KotlinType.any),
                     ),
                     signature = signature
-                )
+                ).apply {
+                    hasAnnotations = functionHasAnnotations
+                }
             },
             signature = JvmMethodSignature(
                 name.original,
@@ -155,7 +152,6 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
             },
             metadata = {
                 kmPackage.functions += newFunctionOf(
-                    flags = functionFlags,
                     receiverType = GradleType.dependencyHandler,
                     returnType = GradleType.externalModuleDependency,
                     name = propertyName,
@@ -164,7 +160,9 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
                         newValueParameterOf("dependencyConfiguration", actionTypeOf(GradleType.externalModuleDependency))
                     ),
                     signature = signature
-                )
+                ).apply {
+                    hasAnnotations = functionHasAnnotations
+                }
             },
             signature = JvmMethodSignature(
                 propertyName,
@@ -206,7 +204,6 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
             },
             metadata = {
                 kmPackage.functions += newFunctionOf(
-                    flags = functionFlags,
                     receiverType = GradleType.dependencyHandler,
                     returnType = KotlinType.unit,
                     name = propertyName,
@@ -215,7 +212,9 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
                         newValueParameterOf("dependencyConfiguration", actionTypeOf(GradleType.externalModuleDependency))
                     ),
                     signature = signature
-                )
+                ).apply {
+                    hasAnnotations = functionHasAnnotations
+                }
             },
             signature = JvmMethodSignature(
                 propertyName,
@@ -257,7 +256,6 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
             },
             metadata = {
                 kmPackage.functions += newFunctionOf(
-                    flags = functionFlags,
                     receiverType = GradleType.dependencyHandler,
                     returnType = KotlinType.unit,
                     name = propertyName,
@@ -266,7 +264,9 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
                         newValueParameterOf("dependencyConfiguration", actionTypeOf(GradleType.externalModuleDependency))
                     ),
                     signature = signature
-                )
+                ).apply {
+                    hasAnnotations = functionHasAnnotations
+                }
             },
             signature = JvmMethodSignature(
                 propertyName,
@@ -345,7 +345,6 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
             },
             metadata = {
                 kmPackage.functions += newFunctionOf(
-                    flags = functionFlags,
                     receiverType = GradleType.dependencyHandler,
                     returnType = GradleType.externalModuleDependency,
                     name = propertyName,
@@ -359,7 +358,9 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
                         newOptionalValueParameterOf("dependencyConfiguration", actionTypeOf(GradleType.externalModuleDependency)),
                     ),
                     signature = signature
-                )
+                ).apply {
+                    hasAnnotations = functionHasAnnotations
+                }
             },
             signature = JvmMethodSignature(
                 propertyName,
@@ -398,7 +399,6 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
             },
             metadata = {
                 kmPackage.functions += newFunctionOf(
-                    flags = functionFlags,
                     receiverType = GradleType.dependencyHandler,
                     returnType = KotlinType.typeParameter,
                     name = propertyName,
@@ -410,7 +410,9 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
                         newTypeParameterOf(name = "T", variance = KmVariance.INVARIANT, upperBound = GradleType.dependency)
                     ),
                     signature = signature
-                )
+                ).apply {
+                    hasAnnotations = functionHasAnnotations
+                }
             },
             signature = JvmMethodSignature(
                 propertyName,
@@ -448,7 +450,6 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
             },
             metadata = {
                 kmPackage.functions += newFunctionOf(
-                    flags = functionFlags,
                     receiverType = GradleType.dependencyConstraintHandler,
                     returnType = GradleType.dependencyConstraint,
                     name = propertyName,
@@ -456,7 +457,9 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
                         newValueParameterOf("constraintNotation", KotlinType.any),
                     ),
                     signature = signature
-                )
+                ).apply {
+                    hasAnnotations = functionHasAnnotations
+                }
             },
             signature = JvmMethodSignature(
                 propertyName,
@@ -492,7 +495,6 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
             },
             metadata = {
                 kmPackage.functions += newFunctionOf(
-                    flags = functionFlags,
                     receiverType = GradleType.dependencyConstraintHandler,
                     returnType = GradleType.dependencyConstraint,
                     name = propertyName,
@@ -501,7 +503,9 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
                         newValueParameterOf("block", actionTypeOf(GradleType.dependencyConstraint))
                     ),
                     signature = signature
-                )
+                ).apply {
+                    hasAnnotations = functionHasAnnotations
+                }
             },
             signature = JvmMethodSignature(
                 propertyName,
@@ -660,7 +664,7 @@ fun fragmentsForContainerElementOf(
                 kmPackage.properties += newPropertyOf(
                     name = propertyName,
                     receiverType = receiverType,
-                    returnType = genericTypeOf(classOf(providerType), kotlinReturnType),
+                    propertyType = genericTypeOf(classOf(providerType), kotlinReturnType),
                     getterSignature = signature
                 )
             },
@@ -670,13 +674,6 @@ fun fragmentsForContainerElementOf(
             )
         )
     )
-}
-
-
-private
-fun MetadataFragmentScope.maybeHasAnnotations(flags: Int): Int = when {
-    useLowPriorityInOverloadResolution -> flags + flagsOf(Flag.HAS_ANNOTATIONS)
-    else -> flags
 }
 
 
@@ -717,12 +714,13 @@ fun fragmentsForExtension(accessor: Accessor.ForExtension): Fragments {
             },
             metadata = {
                 kmPackage.properties += newPropertyOf(
-                    flags = maybeHasAnnotations(readOnlyPropertyFlags),
                     name = propertyName,
                     receiverType = receiverType,
-                    returnType = kotlinExtensionType,
+                    propertyType = kotlinExtensionType,
                     getterSignature = signature
-                )
+                ).apply {
+                    getter.hasAnnotations = useLowPriorityInOverloadResolution
+                }
             }
         ),
 
@@ -756,7 +754,6 @@ fun fragmentsForExtension(accessor: Accessor.ForExtension): Fragments {
             },
             metadata = {
                 kmPackage.functions += newFunctionOf(
-                    flags = maybeHasAnnotations(publicFunctionFlags),
                     receiverType = receiverType,
                     returnType = KotlinType.unit,
                     name = propertyName,
@@ -764,7 +761,9 @@ fun fragmentsForExtension(accessor: Accessor.ForExtension): Fragments {
                         newValueParameterOf("configure", actionTypeOf(kotlinExtensionType))
                     ),
                     signature = signature
-                )
+                ).apply {
+                    hasAnnotations = useLowPriorityInOverloadResolution
+                }
             }
         )
     )
@@ -806,7 +805,7 @@ fun fragmentsForConvention(accessor: Accessor.ForConvention): Fragments {
                 kmPackage.properties += newPropertyOf(
                     name = propertyName,
                     receiverType = receiverType,
-                    returnType = kotlinConventionType,
+                    propertyType = kotlinConventionType,
                     getterSignature = signature
                 )
             }

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/Stage1BlocksAccessorClassPath.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/Stage1BlocksAccessorClassPath.kt
@@ -16,9 +16,7 @@
 
 package org.gradle.kotlin.dsl.accessors
 
-import kotlinx.metadata.Flag
 import kotlinx.metadata.KmType
-import kotlinx.metadata.flagsOf
 import org.gradle.api.Project
 import org.gradle.api.internal.catalog.ExternalModuleDependencyFactory
 import org.gradle.api.internal.file.FileCollectionFactory
@@ -199,7 +197,3 @@ fun IO.writeClassFileTo(binDir: File, internalClassName: InternalName, classByte
     val classFile = binDir.resolve("$internalClassName.class")
     writeFile(classFile, classBytes)
 }
-
-
-internal
-val nonInlineGetterFlags = flagsOf(Flag.IS_PUBLIC, Flag.PropertyAccessor.IS_NOT_DEFAULT)

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/normalization/KotlinApiClassExtractor.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/normalization/KotlinApiClassExtractor.kt
@@ -69,7 +69,7 @@ class KotlinApiMemberWriter(apiMemberAdapter: ClassVisitor) : ApiMemberWriter(ap
             it.name == kotlinMetadataAnnotationSignature
         }?.let {
             val classHeader = parseKotlinClassHeader(it)
-            when (val kotlinMetadata = KotlinClassMetadata.read(classHeader)) {
+            when (val kotlinMetadata = KotlinClassMetadata.readLenient(classHeader)) {
                 is KotlinClassMetadata.Class -> kotlinMetadata.kmClass.extractFunctionMetadata()
                 is KotlinClassMetadata.FileFacade -> kotlinMetadata.kmPackage.extractFunctionMetadata()
                 is KotlinClassMetadata.MultiFileClassPart -> kotlinMetadata.kmPackage.extractFunctionMetadata()

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/bytecode/KotlinMetadata.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/bytecode/KotlinMetadata.kt
@@ -52,6 +52,10 @@ import java.io.File
 
 
 internal
+val OUTPUT_METADATA_VERSION = JvmMetadataVersion(1, 7)
+
+
+internal
 fun publicKotlinClass(
     internalClassName: InternalName,
     header: Metadata,
@@ -79,7 +83,7 @@ fun beginFileFacadeClassHeader() = KmPackage()
 internal
 fun KmPackage.closeHeader(moduleName: String): Metadata {
     this.moduleName = moduleName
-    return KotlinClassMetadata.FileFacade(this, JvmMetadataVersion.LATEST_STABLE_SUPPORTED, 0)
+    return KotlinClassMetadata.FileFacade(this, OUTPUT_METADATA_VERSION, 0)
         .write()
 }
 
@@ -92,7 +96,7 @@ fun moduleMetadataBytesFor(fileFacades: List<InternalName>): ByteArray {
         fileFacades.map { it.value }.toMutableList(),
         emptyMap<String, String>().toMutableMap()
     )
-    return KotlinModuleMetadata(kmModule, JvmMetadataVersion.LATEST_STABLE_SUPPORTED).write()
+    return KotlinModuleMetadata(kmModule, OUTPUT_METADATA_VERSION).write()
 }
 
 
@@ -300,9 +304,9 @@ fun jvmGetterSignatureFor(pluginsExtension: ExtensionSpec): JvmMethodSignature =
 
 internal
 fun jvmGetterSignatureFor(propertyName: String, desc: String): JvmMethodSignature =
-    // Accessors honor the kotlin property jvm interop convention.
-    // The only difference with JavaBean 1.01 is to prefer `get` over `is` for boolean properties.
-    // The following code also complies with Section 8.8 of the spec, "Capitalization of inferred names.".
-    // Sun: "However to support the occasional use of all upper-case names,
+// Accessors honor the kotlin property jvm interop convention.
+// The only difference with JavaBean 1.01 is to prefer `get` over `is` for boolean properties.
+// The following code also complies with Section 8.8 of the spec, "Capitalization of inferred names.".
+// Sun: "However to support the occasional use of all upper-case names,
     //       we check if the first two characters of the name are both upper case and if so leave it alone."
     JvmMethodSignature("get${propertyName.uppercaseFirstChar()}", desc)

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/bytecode/KotlinMetadata.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/bytecode/KotlinMetadata.kt
@@ -27,10 +27,10 @@ import kotlinx.metadata.KmValueParameter
 import kotlinx.metadata.KmVariance
 import kotlinx.metadata.Visibility
 import kotlinx.metadata.declaresDefaultValue
-import kotlinx.metadata.hasGetter
 import kotlinx.metadata.isInline
 import kotlinx.metadata.isNotDefault
 import kotlinx.metadata.isNullable
+import kotlinx.metadata.jvm.JvmMetadataVersion
 import kotlinx.metadata.jvm.JvmMethodSignature
 import kotlinx.metadata.jvm.KmModule
 import kotlinx.metadata.jvm.KmPackageParts
@@ -79,7 +79,8 @@ fun beginFileFacadeClassHeader() = KmPackage()
 internal
 fun KmPackage.closeHeader(moduleName: String): Metadata {
     this.moduleName = moduleName
-    return KotlinClassMetadata.writeFileFacade(this)
+    return KotlinClassMetadata.FileFacade(this, JvmMetadataVersion.LATEST_STABLE_SUPPORTED, 0)
+        .write()
 }
 
 
@@ -91,7 +92,7 @@ fun moduleMetadataBytesFor(fileFacades: List<InternalName>): ByteArray {
         fileFacades.map { it.value }.toMutableList(),
         emptyMap<String, String>().toMutableMap()
     )
-    return KotlinModuleMetadata.write(kmModule)
+    return KotlinModuleMetadata(kmModule, JvmMetadataVersion.LATEST_STABLE_SUPPORTED).write()
 }
 
 
@@ -255,7 +256,6 @@ fun newPropertyOf(
     visibility = Visibility.PUBLIC
     receiverParameterType = receiverType
     returnType = propertyType
-    hasGetter = true
     getter.isInline = true
     getter.visibility = Visibility.PUBLIC
     syntheticMethodForAnnotations = getterSignature

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/bytecode/KotlinMetadata.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/bytecode/KotlinMetadata.kt
@@ -51,6 +51,10 @@ import org.jetbrains.org.objectweb.asm.Opcodes
 import java.io.File
 
 
+/**
+ * `1.7` for compatibility with Kotlin 1.8.*
+ * (see [JvmMetadataVersion.LATEST_STABLE_SUPPORTED] for details).
+ */
 internal
 val OUTPUT_METADATA_VERSION = JvmMetadataVersion(1, 7)
 
@@ -304,9 +308,9 @@ fun jvmGetterSignatureFor(pluginsExtension: ExtensionSpec): JvmMethodSignature =
 
 internal
 fun jvmGetterSignatureFor(propertyName: String, desc: String): JvmMethodSignature =
-// Accessors honor the kotlin property jvm interop convention.
-// The only difference with JavaBean 1.01 is to prefer `get` over `is` for boolean properties.
-// The following code also complies with Section 8.8 of the spec, "Capitalization of inferred names.".
-// Sun: "However to support the occasional use of all upper-case names,
+    // Accessors honor the kotlin property jvm interop convention.
+    // The only difference with JavaBean 1.01 is to prefer `get` over `is` for boolean properties.
+    // The following code also complies with Section 8.8 of the spec, "Capitalization of inferred names.".
+    // Sun: "However to support the occasional use of all upper-case names,
     //       we check if the first two characters of the name are both upper case and if so leave it alone."
     JvmMethodSignature("get${propertyName.uppercaseFirstChar()}", desc)

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -210,10 +210,9 @@ public class JavaCompilerArgumentsBuilder {
             List<File> annotationProcessorPath = spec.getAnnotationProcessorPath();
             if (annotationProcessorPath == null || annotationProcessorPath.isEmpty()) {
                 args.add("-proc:none");
-            } else {
-                args.add("-processorpath");
-                args.add(Joiner.on(File.pathSeparator).join(annotationProcessorPath));
             }
+            args.add("-processorpath");
+            args.add(Joiner.on(File.pathSeparator).join(annotationProcessorPath));
             if (compileOptions.getAnnotationProcessorGeneratedSourcesDirectory() != null) {
                 args.add("-s");
                 args.add(compileOptions.getAnnotationProcessorGeneratedSourcesDirectory().getPath());


### PR DESCRIPTION
This PR upgrade the kotlinx-metadata used by the Kotlin DSL to the latest kotlinx-metadata in the Kotlin 1.9 family: 0.8.0.

The kotlinx-metadata version used in our build is upgraded to the latest in the 0.6.x family but we should make the effort to upgrade to 0.8.0 eventually.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
