### PR TITLE
Move `Settings.include` (single-arg) to `SettingsInternal`

### DIFF
--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/settings/SettingsDslSchema.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/settings/SettingsDslSchema.kt
@@ -61,9 +61,12 @@ fun pluginManagementEvaluationSchema(): EvaluationSchema =
 internal
 fun settingsEvaluationSchema(settings: Settings): EvaluationSchema {
     val schemaBuildingComponent = gradleDslGeneralSchemaComponent() +
-        ThirdPartyExtensionsComponent(Settings::class, settings, "settingsExtension")
+        /** TODO: Instead of [SettingsInternal], this should rely on the public API of [Settings];
+         *  missing single-arg [Settings.include] (or missing vararg support) prevents this from happening,
+         *  and we use the [SettingsInternal.include] single-argument workaround for now. */
+        ThirdPartyExtensionsComponent(SettingsInternal::class, settings, "settingsExtension")
 
-    return buildEvaluationSchema(Settings::class, schemaBuildingComponent, ignoreTopLevelPluginsAndPluginManagement)
+    return buildEvaluationSchema(SettingsInternal::class, schemaBuildingComponent, ignoreTopLevelPluginsAndPluginManagement)
 }
 
 

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/SettingsDelegate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/SettingsDelegate.kt
@@ -134,10 +134,6 @@ abstract class SettingsDelegate : Settings {
     override fun getPluginManager(): PluginManager =
         delegate.pluginManager
 
-    override fun include(projectPath: String) {
-        delegate.include(projectPath)
-    }
-
     override fun include(projectPaths: Iterable<String>) =
         delegate.include(projectPaths)
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
@@ -125,17 +125,6 @@ public interface Settings extends PluginAware, ExtensionAware {
     }
 
     /**
-     * This is a version of {@link Settings#include(String...)} for just one argument.
-     * FIXME: this public API should not be released!
-     * @since 8.8
-     */
-    @Adding // TODO: support varargs and remove the workaround
-    @Incubating
-    default void include(String projectPath) {
-        include(new String[] {projectPath});
-    }
-
-    /**
      * <p>Adds the given projects to the build. Each path in the supplied list is treated as the path of a project to
      * add to the build. Note that these path are not file paths, but instead specify the location of the new project in
      * the project hierarchy. As such, the supplied paths must use the ':' character as separator (and NOT '/').</p>

--- a/subprojects/core/build.gradle.kts
+++ b/subprojects/core/build.gradle.kts
@@ -89,6 +89,7 @@ dependencies {
     api(project(":build-option"))
     api(project(":cli"))
     api(project(":core-api"))
+    api(project(":declarative-dsl-api"))
     api(project(":enterprise-logging"))
     api(project(":enterprise-operations"))
     api(project(":execution"))

--- a/subprojects/core/src/main/java/org/gradle/api/internal/SettingsInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/SettingsInternal.java
@@ -17,12 +17,14 @@
 package org.gradle.api.internal;
 
 import org.gradle.StartParameter;
+import org.gradle.api.Incubating;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.cache.CacheConfigurationsInternal;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.plugins.PluginAwareInternal;
 import org.gradle.api.internal.project.ProjectRegistry;
 import org.gradle.caching.configuration.internal.BuildCacheConfigurationInternal;
+import org.gradle.declarative.dsl.model.annotations.Adding;
 import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.initialization.DefaultProjectDescriptor;
 import org.gradle.initialization.IncludedBuildSpec;
@@ -76,4 +78,14 @@ public interface SettingsInternal extends Settings, PluginAwareInternal, Finaliz
 
     @Override
     CacheConfigurationsInternal getCaches();
+
+    /**
+     * This is a version of {@link Settings#include(String...)} for just one argument.
+     * If varargs get supoprted in Declarative DSL this overload will no longer be needed.
+     */
+    @Adding
+    @Incubating
+    default void include(String projectPath) {
+        include(new String[] {projectPath});
+    }
 }


### PR DESCRIPTION
We have introduced that method as a workaround for Declarative DSL not supporting varargs.
This method should not get into a release. Move it to `SettingsInternal` and build the schema from that interface instead.

Fixes https://github.com/gradle/gradle-private/issues/4123