### PR TITLE
Preperate the JPMS arguments by exporting internal Java compilation modules

### DIFF
--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.jvm;
 
+import org.gradle.api.NonNullApi;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -27,13 +29,16 @@ import java.util.List;
  * a warning they can do nothing about. On Java 16+, strong encapsulation of JDK internals is
  * enforced and not having the explicit permissions for reflective accesses will result in runtime exceptions.
  */
+@NonNullApi
 public class JpmsConfiguration {
 
     public static final List<String> GROOVY_JPMS_ARGS = Collections.unmodifiableList(Arrays.asList(
         "--add-opens=java.base/java.lang=ALL-UNNAMED",
         "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
         "--add-opens=java.base/java.util=ALL-UNNAMED",
-        "--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED" // required by PreferenceCleaningGroovySystemLoader
+        "--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED", // required by PreferenceCleaningGroovySystemLoader
+        "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED", // Required by JdkTools and JdkJavaCompiler
+        "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED" // Required by JdkTools and JdkJavaCompiler
     ));
 
     public static final List<String> GRADLE_DAEMON_JPMS_ARGS;

--- a/testing/architecture-test/src/changes/archunit_store/internal-api-nullability.txt
+++ b/testing/architecture-test/src/changes/archunit_store/internal-api-nullability.txt
@@ -2052,7 +2052,6 @@ Class <org.gradle.internal.jvm.JavaHomeException> is not annotated (directly or 
 Class <org.gradle.internal.jvm.JavaInfo> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (JavaInfo.java:0)
 Class <org.gradle.internal.jvm.JavaModuleDetector$ModuleInfoLocator> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (JavaModuleDetector.java:0)
 Class <org.gradle.internal.jvm.JavaModuleDetector> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (JavaModuleDetector.java:0)
-Class <org.gradle.internal.jvm.JpmsConfiguration> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (JpmsConfiguration.java:0)
 Class <org.gradle.internal.jvm.Jvm> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (Jvm.java:0)
 Class <org.gradle.internal.jvm.UnsupportedJavaRuntimeException> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (UnsupportedJavaRuntimeException.java:0)
 Class <org.gradle.internal.jvm.inspection.CachingJvmMetadataDetector> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (CachingJvmMetadataDetector.java:0)


### PR DESCRIPTION
This is a preparation PR for [`bhegyi/problems/java-compile/internal-formatting`](https://github.com/gradle/gradle/tree/bhegyi/problems/java-compile/internal-formatting). 

We have tests that rely on the used distribution's `JpmsConfiguration` class. This introduces failures with complex tests running nested Gradle invocations using Java compilation, as they will use the "old" set of arguments instead of the new one.

This PR will ensure that the next wrapper will contain the correct list of flags.