### PR TITLE
cd -P in wrapper to handle being with non-terminal symlinks

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -84,7 +84,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd "${APP_HOME:-./}" > /dev/null && pwd -P ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum

--- a/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -119,7 +119,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=\${0##*/}
 # Discard cd standard output in case \$CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=\$( cd "\${APP_HOME:-./}${appHomeRelativePath}" > /dev/null && pwd -P ) || exit
+APP_HOME=\$( cd -P "\${APP_HOME:-./}${appHomeRelativePath}" > /dev/null && printf '%s\n' "\$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum


### PR DESCRIPTION
### Context
Currently, I get (Debian 4.4.1-18, so /bin -> /usr/bin; /usr/bin/gradle -> ../share/gradle/bin/gradle)
```
$ gradle
/bin/gradle: 23: cd: can't cd to /bin/../share/gradle/bin/..
openjdk version "17.0.10" 2024-01-16
OpenJDK Runtime Environment (build 17.0.10+7-Debian-1deb12u1)
OpenJDK 64-Bit Server VM (build 17.0.10+7-Debian-1deb12u1, mixed mode, sharing)
Error: Could not find or load main class org.gradle.launcher.GradleMain
Caused by: java.lang.ClassNotFoundException: org.gradle.launcher.GradleMain
```
this corresponds to the first cd here:
```sh
SAVED="`pwd`"
cd "`dirname \"$PRG\"`/.." >/dev/null
APP_HOME="`pwd -P`"
cd "$SAVED" >/dev/null
```
note that `pwd` has -P, but the cd doesn't; per POSIX, the default cd mode is -L, which transforms `/bin/../share/gradle/bin/..` to `/share/gradle` before giving it to chdir(2). This obviously doesn't exist.

cd -P instead executes `chdir("/bin/../share/gradle/bin/..")` which works as expected.

In this version (with `app_path=/bin/gradle` overridden), the issue manifests as
```
$ ./gradlew
./gradlew: 88: cd: can't cd to /bin/../share/gradle/bin/
```
and indeed correcting it to `cd -P` fixes it as well.

Additionally, rather than invoking `pwd -P`, we can now just use out `$PWD`, which (POSIX, XCU, cd, DESCRIPTION, 10, ll. 88190-88191):
> If the −P option is in effect, the PWD environment variable shall be set to the string that would be output by *pwd* **−P**.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective. – idk how that would happen really
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic. – likewise
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.