### PR TITLE
Disable Gradle Enterprise -> Develocity plugin deprecations

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,8 @@ gradle.internal.testdistribution.writeTraceFile=true
 develocity.internal.testdistribution.writeTraceFile=true
 gradle.internal.testdistribution.queryResponseTimeout=PT20S
 develocity.internal.testdistribution.queryResponseTimeout=PT20S
+# Disable GE -> DV deprecation warnings, see https://github.com/gradle/gradle-org-conventions-plugin/issues/26
+systemProp.develocity.deprecation.muteWarnings=true
 # Default performance baseline
 defaultPerformanceBaselines=8.9-commit-ddec0863e620
 


### PR DESCRIPTION
Until we [fix it in the convention plugin](https://github.com/gradle/gradle-org-conventions-plugin/issues/26).