### PR TITLE
Correct User Guide to remove statement that Gradle automatically tests code in buildSrc

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/best-practices/organizing_gradle_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/best-practices/organizing_gradle_projects.adoc
@@ -139,7 +139,7 @@ Complex build logic is usually a good candidate for being encapsulated either as
 Custom task and plugin implementations should not live in the build script.
 It is very convenient to use `buildSrc` for that purpose as long as the code does not need to be shared among multiple, independent projects.
 
-The directory `buildSrc` is treated as an <<composite_builds.adoc#composite_build_intro,included build>>. Upon discovery of the directory, Gradle automatically compiles and tests this code and puts it in the classpath of your build script.
+The directory `buildSrc` is treated as an <<composite_builds.adoc#composite_build_intro,included build>>. Upon discovery of the directory, Gradle automatically compiles this code and puts it in the classpath of your build script.
 For multi-project builds there can be only one `buildSrc` directory, which has to sit in the root project directory.
 `buildSrc` should be preferred over <<plugins.adoc#sec:script_plugins,script plugins>> as it is easier to maintain, refactor and test the code.
 


### PR DESCRIPTION
The User Guide incorrectly states that Gradle automatically tests code in `buildSrc`.

### Context
Per https://discuss.gradle.org/t/how-is-the-automatic-test-of-buildsrc-triggered/48292, since Gradle 8.0, `buildSrc` tests aren't run automatically.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
