### PR TITLE
Use Failure to determine problem location

### DIFF
--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
@@ -115,7 +115,7 @@ public class LoggingDeprecatedFeatureHandler implements FeatureHandler<Deprecate
     }
 
     private static String getDefaultDeprecationIdDisplayName(DeprecatedFeatureUsage usage) {
-        if(usage.getProblemId() != null) {
+        if (usage.getProblemId() != null) {
             return usage.getProblemId();
         }
         return createDefaultDeprecationId(usage.getProblemIdDisplayName());

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/problems/failure/DefaultFailureFactory.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/problems/failure/DefaultFailureFactory.java
@@ -31,6 +31,13 @@ import java.util.Set;
 
 public class DefaultFailureFactory implements FailureFactory {
 
+    public static DefaultFailureFactory withDefaultClassifier() {
+        return new DefaultFailureFactory(new CompositeStackTraceClassifier(
+            new InternalStackTraceClassifier(),
+            StackTraceClassifier.USER_CODE
+        ));
+    }
+
     private final StackTraceClassifier stackTraceClassifier;
 
     public DefaultFailureFactory(StackTraceClassifier stackTraceClassifier) {

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/problems/failure/InternalStackTraceClassifier.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/problems/failure/InternalStackTraceClassifier.java
@@ -38,7 +38,11 @@ public class InternalStackTraceClassifier implements StackTraceClassifier {
             // Groovy calls
             className.startsWith("groovy.lang") ||
             className.startsWith("org.codehaus.groovy.") ||
-            // Gradle calls
-            className.startsWith("org.gradle.");
+            isGradleCall(className);
+    }
+
+    public static boolean isGradleCall(String className) {
+        return className.startsWith("org.gradle.") ||
+            className.startsWith("worker.org.gradle.");
     }
 }

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/deprecation/DeprecatedFeatureUsageTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/deprecation/DeprecatedFeatureUsageTest.groovy
@@ -24,7 +24,7 @@ class DeprecatedFeatureUsageTest extends Specification {
 
     def "formats messages"() {
         given:
-        def featureUsage = new DeprecatedFeatureUsage(summary, removalDetails, advice, contextualAdvice, documentationReference, DeprecatedFeatureUsage.Type.USER_CODE_DIRECT, "id", "id display name", getClass())
+        def featureUsage = new DeprecatedFeatureUsage(summary, removalDetails, advice, contextualAdvice, documentationReference, DeprecatedFeatureUsage.Type.USER_CODE_DIRECT, "id display name", "id", getClass())
 
         expect:
         featureUsage.formattedMessage() == expected
@@ -39,7 +39,7 @@ class DeprecatedFeatureUsageTest extends Specification {
 
     def "returns documentation url"() {
         given:
-        def featureUsage = new DeprecatedFeatureUsage("summary", "removalDetails", "advice", "contextualAdvice", documentationReference, DeprecatedFeatureUsage.Type.USER_CODE_DIRECT, "id", "id display name", getClass())
+        def featureUsage = new DeprecatedFeatureUsage("summary", "removalDetails", "advice", "contextualAdvice", documentationReference, DeprecatedFeatureUsage.Type.USER_CODE_DIRECT, "id display name", "id", getClass())
 
         expect:
         featureUsage.getDocumentationUrl()?.getUrl() == expected

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/deprecation/LoggingDeprecatedFeatureHandlerTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/deprecation/LoggingDeprecatedFeatureHandlerTest.groovy
@@ -396,7 +396,7 @@ feature1 removal""")
         useStackTrace(fakeStackTrace)
 
         when:
-        handler.featureUsed(new DeprecatedFeatureUsage(new DeprecatedFeatureUsage('fake', "removal", null, null, null, DeprecatedFeatureUsage.Type.USER_CODE_DIRECT, "id", "id display name", LoggingDeprecatedFeatureHandlerTest)))
+        handler.featureUsed(new DeprecatedFeatureUsage(new DeprecatedFeatureUsage('fake', "removal", null, null, null, DeprecatedFeatureUsage.Type.USER_CODE_DIRECT, "id display name", "id", LoggingDeprecatedFeatureHandlerTest)))
         def events = outputEventListener.events
 
         then:
@@ -422,7 +422,7 @@ feature1 removal""")
         useStackTrace()
 
         when:
-        handler.featureUsed(new DeprecatedFeatureUsage('fake', "removal", null, null, null, DeprecatedFeatureUsage.Type.USER_CODE_DIRECT, "id", "id display name", LoggingDeprecatedFeatureHandlerTest))
+        handler.featureUsed(new DeprecatedFeatureUsage('fake', "removal", null, null, null, DeprecatedFeatureUsage.Type.USER_CODE_DIRECT, "id display name", "id", LoggingDeprecatedFeatureHandlerTest))
         def events = outputEventListener.events
 
         then:
@@ -521,6 +521,6 @@ feature1 removal""")
     }
 
     private static DeprecatedFeatureUsage deprecatedFeatureUsage(String summary, Class<?> calledFrom = LoggingDeprecatedFeatureHandlerTest) {
-        new DeprecatedFeatureUsage(summary, "removal", null, null, null, DeprecatedFeatureUsage.Type.USER_CODE_DIRECT, GradleCoreProblemGroup.deprecation().toString(), "id display name", calledFrom)
+        new DeprecatedFeatureUsage(summary, "removal", null, null, null, DeprecatedFeatureUsage.Type.USER_CODE_DIRECT, "id display name", GradleCoreProblemGroup.deprecation().toString(), calledFrom)
     }
 }

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/deprecation/LoggingDeprecatedFeatureHandlerTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/deprecation/LoggingDeprecatedFeatureHandlerTest.groovy
@@ -24,7 +24,6 @@ import org.gradle.api.problems.internal.ProblemEmitter
 import org.gradle.internal.Describables
 import org.gradle.internal.featurelifecycle.DeprecatedUsageProgressDetails
 import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler
-import org.gradle.internal.featurelifecycle.StackTraceSanitizerTest
 import org.gradle.internal.logging.CollectingTestOutputEventListener
 import org.gradle.internal.logging.ConfigureLogging
 import org.gradle.internal.operations.BuildOperationListener
@@ -397,7 +396,7 @@ feature1 removal""")
         useStackTrace(fakeStackTrace)
 
         when:
-        handler.featureUsed(new DeprecatedFeatureUsage(new DeprecatedFeatureUsage('fake', "removal", null, null, null, DeprecatedFeatureUsage.Type.USER_CODE_DIRECT, "id", "id display name", StackTraceSanitizerTest)))
+        handler.featureUsed(new DeprecatedFeatureUsage(new DeprecatedFeatureUsage('fake', "removal", null, null, null, DeprecatedFeatureUsage.Type.USER_CODE_DIRECT, "id", "id display name", LoggingDeprecatedFeatureHandlerTest)))
         def events = outputEventListener.events
 
         then:
@@ -411,7 +410,7 @@ feature1 removal""")
 
         where:
         fakeStackTrace = [
-            new StackTraceElement(StackTraceSanitizerTest.name, 'calledFrom', 'FeatureUsageTest.java', 23),
+            new StackTraceElement(LoggingDeprecatedFeatureHandlerTest.name, 'calledFrom', 'FeatureUsageTest.java', 23),
             new StackTraceElement('some.ArbitraryClass', 'withSource', 'ArbitraryClass.java', 42),
         ]
         deprecationTracePropertyName = LoggingDeprecatedFeatureHandler.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME
@@ -423,7 +422,7 @@ feature1 removal""")
         useStackTrace()
 
         when:
-        handler.featureUsed(new DeprecatedFeatureUsage('fake', "removal", null, null, null, DeprecatedFeatureUsage.Type.USER_CODE_DIRECT, "id", "id display name", StackTraceSanitizerTest))
+        handler.featureUsed(new DeprecatedFeatureUsage('fake', "removal", null, null, null, DeprecatedFeatureUsage.Type.USER_CODE_DIRECT, "id", "id display name", LoggingDeprecatedFeatureHandlerTest))
         def events = outputEventListener.events
 
         then:

--- a/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/ProblemLocationAnalyzer.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/ProblemLocationAnalyzer.java
@@ -16,12 +16,12 @@
 
 package org.gradle.internal.problems;
 
+import org.gradle.internal.problems.failure.Failure;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.problems.Location;
 
 import javax.annotation.Nullable;
-import java.util.List;
 
 @ServiceScope(Scope.BuildTree.class)
 public interface ProblemLocationAnalyzer {
@@ -30,5 +30,5 @@ public interface ProblemLocationAnalyzer {
      * @return A display name for the location or null for an unknown location.
      */
     @Nullable
-    Location locationForUsage(List<StackTraceElement> stack, boolean fromException);
+    Location locationForUsage(Failure failure, boolean fromException);
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/failure/Failure.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/failure/Failure.java
@@ -60,4 +60,9 @@ public interface Failure {
      */
     List<Failure> getCauses();
 
+    /**
+     * Returns the index of the first matching frame in the stack trace, or {@code -1} if not found.
+     */
+    int indexOfStackFrame(int start, StackFramePredicate predicate);
+
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/failure/StackFramePredicate.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/failure/StackFramePredicate.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.problems.failure;
+
+public interface StackFramePredicate {
+
+    StackFramePredicate USER_CODE = new StackFramePredicate() {
+        @Override
+        public boolean test(StackTraceElement frame, StackTraceRelevance relevance) {
+            return StackTraceRelevance.USER_CODE.equals(relevance);
+        }
+    };
+
+    boolean test(StackTraceElement frame, StackTraceRelevance relevance);
+
+}

--- a/platforms/ide/problems-api/src/main/java/org/gradle/problems/Location.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/problems/Location.java
@@ -53,4 +53,9 @@ public class Location {
     public String getFormatted() {
         return sourceLongDisplayName.getCapitalizedDisplayName() + ": line " + lineNumber;
     }
+
+    @Override
+    public String toString() {
+        return getFormatted();
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/problems/DefaultProblemLocationAnalyzer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/problems/DefaultProblemLocationAnalyzer.java
@@ -23,8 +23,12 @@ import org.gradle.initialization.ClassLoaderScopeRegistryListener;
 import org.gradle.initialization.ClassLoaderScopeRegistryListenerManager;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.problems.failure.Failure;
+import org.gradle.internal.problems.failure.InternalStackTraceClassifier;
+import org.gradle.internal.problems.failure.StackFramePredicate;
 import org.gradle.problems.Location;
 
+import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.HashMap;
@@ -34,6 +38,9 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 public class DefaultProblemLocationAnalyzer implements ProblemLocationAnalyzer, ClassLoaderScopeRegistryListener, Closeable {
+
+    private static final StackFramePredicate GRADLE_CODE = (frame, relevance) -> InternalStackTraceClassifier.isGradleCall(frame.getClassName());
+
     private final Lock lock = new ReentrantLock();
     private final Map<String, ClassLoaderScopeOrigin.Script> scripts = new HashMap<>();
     private final ClassLoaderScopeRegistryListenerManager listenerManager;
@@ -72,7 +79,8 @@ public class DefaultProblemLocationAnalyzer implements ProblemLocationAnalyzer, 
     }
 
     @Override
-    public Location locationForUsage(List<StackTraceElement> stack, boolean fromException) {
+    public Location locationForUsage(Failure failure, boolean fromException) {
+        List<StackTraceElement> stack = failure.getStackTrace();
         int startPos;
         int endPos;
         if (fromException) {
@@ -85,58 +93,49 @@ public class DefaultProblemLocationAnalyzer implements ProblemLocationAnalyzer, 
             endPos = stack.size();
         } else {
             // When analysing a problem stack trace, consider only the deepest user code in the stack.
-            startPos = findFirstUserCode(stack);
-            if (startPos == stack.size()) {
+            startPos = failure.indexOfStackFrame(0, StackFramePredicate.USER_CODE);
+            if (startPos == -1) {
                 // No user code in the stack
                 return null;
             }
-            endPos = findNextGradleType(startPos, stack);
+            // Treat Gradle code as the boundary to allow stepping over JDK and Groovy calls
+            endPos = failure.indexOfStackFrame(startPos + 1, GRADLE_CODE);
+            if (endPos == -1) {
+                endPos = stack.size();
+            }
         }
 
         lock.lock();
         try {
-            for (int i = startPos; i < endPos; i++) {
-                StackTraceElement element = stack.get(i);
-                if (element.getLineNumber() >= 0 && scripts.containsKey(element.getFileName())) {
-                    ClassLoaderScopeOrigin.Script source = scripts.get(element.getFileName());
-                    int lineNumber = element.getLineNumber();
-                    return new Location(source.getLongDisplayName(), source.getShortDisplayName(), lineNumber);
-                }
-            }
-            return null;
+            return locationFromStackRange(startPos, endPos, stack);
         } finally {
             lock.unlock();
         }
     }
 
-    private int findNextGradleType(int startPos, List<StackTraceElement> stack) {
-        for (int i = startPos; i < stack.size(); i++) {
-            StackTraceElement element = stack.get(i);
-            if (element.getClassName().startsWith("org.gradle.")) {
-                return i;
+    @Nullable
+    private Location locationFromStackRange(int startPos, int endPos, List<StackTraceElement> stack) {
+        for (int i = startPos; i < endPos; i++) {
+            Location location = tryGetLocation(stack.get(i));
+            if (location != null) {
+                return location;
             }
         }
-        return stack.size();
+        return null;
     }
 
-    private int findFirstUserCode(List<StackTraceElement> stack) {
-        int pos = 0;
-        while (pos < stack.size() && isNonUserCode(stack.get(pos))) {
-            pos++;
+    @Nullable
+    private Location tryGetLocation(StackTraceElement frame) {
+        int lineNumber = frame.getLineNumber();
+        if (lineNumber < 0) {
+            return null;
         }
-        return pos;
-    }
 
-    private static boolean isNonUserCode(StackTraceElement element) {
-        String className = element.getClassName();
-        return className.startsWith("org.gradle.") ||
-            className.startsWith("jdk.") ||
-            className.startsWith("java.lang.reflect.") ||
-            className.startsWith("java.util.concurrent.") ||
-            className.equals("java.lang.Thread") ||
-            className.startsWith("sun.") ||
-            className.startsWith("com.sun.") ||
-            className.startsWith("groovy.lang.") ||
-            className.startsWith("org.codehaus.groovy.");
+        ClassLoaderScopeOrigin.Script source = scripts.get(frame.getFileName());
+        if (source == null) {
+            return null;
+        }
+
+        return new Location(source.getLongDisplayName(), source.getShortDisplayName(), lineNumber);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -79,11 +79,8 @@ import org.gradle.internal.operations.BuildOperationListenerManager;
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
 import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.gradle.internal.operations.DefaultBuildOperationProgressEventEmitter;
-import org.gradle.internal.problems.failure.CompositeStackTraceClassifier;
 import org.gradle.internal.problems.failure.DefaultFailureFactory;
 import org.gradle.internal.problems.failure.FailureFactory;
-import org.gradle.internal.problems.failure.InternalStackTraceClassifier;
-import org.gradle.internal.problems.failure.StackTraceClassifier;
 import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.internal.scripts.DefaultScriptFileResolver;
 import org.gradle.internal.scripts.DefaultScriptFileResolverListeners;
@@ -314,9 +311,6 @@ public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
     }
 
     FailureFactory createFailureFactory() {
-        return new DefaultFailureFactory(new CompositeStackTraceClassifier(
-            new InternalStackTraceClassifier(),
-            StackTraceClassifier.USER_CODE
-        ));
+        return DefaultFailureFactory.withDefaultClassifier();
     }
 }


### PR DESCRIPTION
A step towards https://github.com/gradle/gradle/issues/28517

Updates `ProblemLocationAnalyzer` implementation to determine the location from stacktrace classified by the `FailureFactory` service, rather than its own flavor of stack trace filitering.
