### PR TITLE
Make `GradleLifecycle` callbacks consistent between Groovy and Kotlin

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -33,6 +33,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Describable;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
+import org.gradle.api.IsolatedAction;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NonExtensible;
 import org.gradle.api.artifacts.dsl.DependencyCollector;
@@ -856,12 +857,17 @@ abstract class AbstractClassGenerator implements ClassGenerator {
         @Override
         public void visitInstanceMethod(Method method) {
             Class<?>[] parameterTypes = method.getParameterTypes();
-            if (parameterTypes.length > 0 && parameterTypes[parameterTypes.length - 1].equals(Action.class)) {
-                actionMethods.add(method);
-            } else if (parameterTypes.length > 0 && parameterTypes[parameterTypes.length - 1].equals(Closure.class)) {
-                closureMethods.put(method.getName(), method);
-            } else if (method.getName().equals("toString") && parameterTypes.length == 0 && method.getDeclaringClass() != Object.class) {
-                providesOwnToString = true;
+            if (parameterTypes.length == 0) {
+                if (method.getName().equals("toString") && method.getDeclaringClass() != Object.class) {
+                    providesOwnToString = true;
+                }
+            } else {
+                Class<?> lastParameterType = parameterTypes[parameterTypes.length - 1];
+                if (lastParameterType.equals(Action.class) || lastParameterType.equals(IsolatedAction.class)) {
+                    actionMethods.add(method);
+                } else if (lastParameterType.equals(Closure.class)) {
+                    closureMethods.put(method.getName(), method);
+                }
             }
         }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/util/internal/ConfigureUtil.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/util/internal/ConfigureUtil.java
@@ -19,6 +19,7 @@ package org.gradle.util.internal;
 import groovy.lang.Closure;
 import org.codehaus.groovy.runtime.GeneratedClosure;
 import org.gradle.api.Action;
+import org.gradle.api.IsolatedAction;
 import org.gradle.internal.Actions;
 import org.gradle.internal.metaobject.ConfigureDelegate;
 import org.gradle.internal.metaobject.DynamicInvokeResult;
@@ -118,6 +119,16 @@ public class ConfigureUtil {
         }
 
         return new WrappedConfigureAction<T>(configureClosure);
+    }
+
+    /**
+     * Creates an isolated action that uses the given closure to configure objects of type T.
+     */
+    public static <T> IsolatedAction<T> configureUsingIsolatedAction(@Nullable final Closure configureClosure) {
+        if (configureClosure == null) {
+            return t -> {};
+        }
+        return t -> configure(configureClosure, t);
     }
 
     /**

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/util/ConfigureUtilTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/util/ConfigureUtilTest.groovy
@@ -179,6 +179,21 @@ class ConfigureUtilTest extends Specification {
         b.prop == "p"
     }
 
+    def createsIsolatedActionThatCanConfigureObjects() {
+        given:
+        def c = new TestConfigurable()
+        def b = new Bean()
+
+        when:
+        def action = ConfigureUtil.configureUsingIsolatedAction { prop = "p" }
+        action.execute(c)
+        action.execute(b)
+
+        then:
+        c.props.prop == "p"
+        b.prop == "p"
+    }
+
     void configureByMapTriesMethodForExtensibleObjects() {
         given:
         Bean bean = TestUtil.instantiatorFactory().decorateLenient().newInstance(Bean)

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleLifecycleIsolationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleLifecycleIsolationIntegrationTest.groovy
@@ -27,18 +27,18 @@ class GradleLifecycleIsolationIntegrationTest extends AbstractIntegrationSpec {
             include 'sub'
 
             def log = []
-            gradle.lifecycle.beforeProject { p ->
-                log << "1: before $p.name $p.version"
-                p.version = 'from action'
+            gradle.lifecycle.beforeProject {
+                log << "1: before $name $version"
+                version = 'from action'
             }
-            gradle.lifecycle.beforeProject { p ->
-                log << "2: before $p.name $p.version"
+            gradle.lifecycle.beforeProject {
+                log << "2: before $name $version"
             }
-            gradle.lifecycle.afterProject { p ->
-                log << "1: after $p.name $p.version"
+            gradle.lifecycle.afterProject {
+                log << "1: after $name $version"
             }
-            gradle.lifecycle.afterProject { p ->
-                log << "2: after $p.name $p.version"
+            gradle.lifecycle.afterProject {
+                log << "2: after $name $version"
             }
             gradle.lifecycle.afterProject {
                 println log

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleLifecycleSupportedTypesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleLifecycleSupportedTypesIntegrationTest.groovy
@@ -48,7 +48,7 @@ class GradleLifecycleSupportedTypesIntegrationTest extends AbstractIntegrationSp
                 SomeBean bean = new SomeBean()
                 ${type} value = ${reference}
                 bean.value = ${reference}
-                gradle.lifecycle.beforeProject { target ->
+                gradle.lifecycle.beforeProject {
                     println "this.value = " + value
                     println "bean.value = " + bean.value
                 }

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -642,9 +642,9 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
             gradle.isolatedProjectEvaluationListenerProvider.afterProject(action);
         }
 
-        private void assertBeforeProjectsLoaded(String beforeProject) {
+        private void assertBeforeProjectsLoaded(String methodName) {
             if (gradle.projectsLoaded) {
-                throw new IllegalStateException("GradleLifecycle#" + beforeProject + " cannot be called after settings have been evaluated.");
+                throw new IllegalStateException("GradleLifecycle#" + methodName + " cannot be called after settings have been evaluated.");
             }
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -96,6 +96,7 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
     private List<IncludedBuildInternal> includedBuilds;
     private final MutableActionSet<Project> rootProjectActions = new MutableActionSet<>();
     private final IsolatedProjectEvaluationListenerProvider isolatedProjectEvaluationListenerProvider;
+    private GradleLifecycle lifecycle;
     private boolean projectsLoaded;
     private Path identityPath;
     private Supplier<? extends ClassLoaderScope> classLoaderScope;
@@ -201,7 +202,10 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
 
     @Override
     public GradleLifecycle getLifecycle() {
-        return services.get(ObjectFactory.class).newInstance(DefaultGradleLifecycle.class, this);
+        if (lifecycle == null) {
+            lifecycle = instantiateGradleLifecycle();
+        }
+        return lifecycle;
     }
 
     @Override
@@ -612,7 +616,11 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
     @Inject
     public abstract PublicBuildPath getPublicBuildPath();
 
-    public static class DefaultGradleLifecycle implements GradleLifecycle {
+    private DefaultGradleLifecycle instantiateGradleLifecycle() {
+        return services.get(ObjectFactory.class).newInstance(DefaultGradleLifecycle.class, this);
+    }
+
+    static class DefaultGradleLifecycle implements GradleLifecycle {
 
         private final DefaultGradle gradle;
 


### PR DESCRIPTION
In Kotlin, the target `Project` is the implicit receiver and it should be same in Groovy.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
