### PR TITLE
Always run build step `KILL_PROCESSES_STARTED_BY_GRADLE`

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
+++ b/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
@@ -69,7 +69,7 @@ class FlakyTestQuarantine(model: CIBuildModel, stage: Stage, os: Os, arch: Arch 
                 executionMode = BuildStep.ExecutionMode.ALWAYS
             }
         }
-        killProcessStep(KILL_PROCESSES_STARTED_BY_GRADLE, os, arch)
+        killProcessStep(KILL_PROCESSES_STARTED_BY_GRADLE, os, arch, executionMode = BuildStep.ExecutionMode.ALWAYS)
     }
 
     steps {

--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -146,6 +146,7 @@ fun applyDefaults(
     gradleTasks: String,
     dependsOnQuickFeedbackLinux: Boolean = false,
     os: Os = Os.LINUX,
+    arch: Arch = Arch.AMD64,
     extraParameters: String = "",
     timeout: Int = 90,
     daemon: Boolean = true,
@@ -159,6 +160,7 @@ fun applyDefaults(
 
     buildType.steps {
         extraSteps()
+        killProcessStep(buildType, KILL_PROCESSES_STARTED_BY_GRADLE, os, arch, executionMode = ExecutionMode.ALWAYS)
         checkCleanM2AndAndroidUserHome(os, buildType)
     }
 
@@ -203,7 +205,7 @@ fun applyTestDefaults(
     buildType.killProcessStep(KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS, os, arch)
     buildType.gradleRunnerStep(model, gradleTasks, os, extraParameters, daemon, maxParallelForks = maxParallelForks)
     buildType.addRetrySteps(model, gradleTasks, os, arch, extraParameters)
-    buildType.killProcessStep(KILL_PROCESSES_STARTED_BY_GRADLE, os, arch)
+    buildType.killProcessStep(KILL_PROCESSES_STARTED_BY_GRADLE, os, arch, executionMode = ExecutionMode.ALWAYS)
 
     buildType.steps {
         extraSteps()

--- a/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
@@ -17,6 +17,7 @@
 package configurations
 
 import common.KillProcessMode.KILL_ALL_GRADLE_PROCESSES
+import common.KillProcessMode.KILL_PROCESSES_STARTED_BY_GRADLE
 import common.Os
 import common.applyPerformanceTestSettings
 import common.buildToolGradleParameters
@@ -27,6 +28,7 @@ import common.killProcessStep
 import common.performanceTestCommandLine
 import common.removeSubstDirOnWindows
 import common.substDirOnWindows
+import jetbrains.buildServer.configs.kotlin.BuildStep
 import jetbrains.buildServer.configs.kotlin.BuildSteps
 import jetbrains.buildServer.configs.kotlin.ParameterDisplay
 import model.CIBuildModel
@@ -102,6 +104,7 @@ class PerformanceTest(
                     }
                 }
                 removeSubstDirOnWindows(os)
+                killProcessStep(buildTypeThis, KILL_PROCESSES_STARTED_BY_GRADLE, os, executionMode = BuildStep.ExecutionMode.ALWAYS)
                 checkCleanM2AndAndroidUserHome(os)
             }
         }

--- a/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
+++ b/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
@@ -70,7 +70,7 @@ class RerunFlakyTest(os: Os, arch: Arch = Arch.AMD64) : BuildType({
                 executionMode = BuildStep.ExecutionMode.ALWAYS
             }
         }
-        killProcessStep(KILL_PROCESSES_STARTED_BY_GRADLE, os, arch)
+        killProcessStep(KILL_PROCESSES_STARTED_BY_GRADLE, os, arch, BuildStep.ExecutionMode.ALWAYS)
     }
 
     steps {

--- a/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
+++ b/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
@@ -74,6 +74,7 @@ class ApplyDefaultConfigurationTest {
             listOf(
                 "KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS",
                 "GRADLE_RUNNER",
+                "KILL_PROCESSES_STARTED_BY_GRADLE",
                 "CHECK_CLEAN_M2_ANDROID_USER_HOME"
             ),
             steps.items.map(BuildStep::name)

--- a/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
@@ -65,6 +65,7 @@ class PerformanceTestBuildTypeTest {
             listOf(
                 "KILL_ALL_GRADLE_PROCESSES",
                 "GRADLE_RUNNER",
+                "KILL_PROCESSES_STARTED_BY_GRADLE",
                 "CHECK_CLEAN_M2_ANDROID_USER_HOME"
             ),
             performanceTest.steps.items.map(BuildStep::name)
@@ -129,6 +130,7 @@ class PerformanceTestBuildTypeTest {
                 "SETUP_VIRTUAL_DISK_FOR_PERF_TEST",
                 "GRADLE_RUNNER",
                 "REMOVE_VIRTUAL_DISK_FOR_PERF_TEST",
+                "KILL_PROCESSES_STARTED_BY_GRADLE",
                 "CHECK_CLEAN_M2_ANDROID_USER_HOME"
             ),
             performanceTest.steps.items.map(BuildStep::name)


### PR DESCRIPTION
We have a build step that kills all processes started during Gradle build but it only runs when all previous steps succeed. Now let's run it always to kill leftover processes when a build is canceled.
