### PR TITLE
Use Gradle Enterprise in messages about deprecated plugins

### DIFF
--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInIntegrationTest.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInIntegrationTest.groovy
@@ -108,7 +108,7 @@ class GradleEnterprisePluginCheckInIntegrationTest extends AbstractIntegrationSp
 
         when:
         if (applied && VersionNumber.parse(pluginVersion) < MINIMUM_SUPPORTED_PLUGIN_VERSION_SINCE_GRADLE_9) {
-            executer.expectDocumentedDeprecationWarning("Develocity plugin $pluginVersion has been deprecated. Starting with Gradle 9.0, only Develocity plugin 3.13.1 or newer is supported. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#unsupported_ge_plugin_3.13")
+            executer.expectDocumentedDeprecationWarning("Gradle Enterprise plugin $pluginVersion has been deprecated. Starting with Gradle 9.0, only Gradle Enterprise plugin 3.13.1 or newer is supported. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#unsupported_ge_plugin_3.13")
         }
         succeeds("t", "--configuration-cache")
 

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/core/BuildScanAutoApplyIntegrationTest.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/core/BuildScanAutoApplyIntegrationTest.groovy
@@ -18,8 +18,8 @@ package org.gradle.internal.enterprise.core
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-import org.gradle.internal.enterprise.GradleEnterprisePluginCheckInFixture
 import org.gradle.internal.enterprise.DevelocityPluginCheckInFixture
+import org.gradle.internal.enterprise.GradleEnterprisePluginCheckInFixture
 import org.gradle.internal.enterprise.impl.DefaultGradleEnterprisePluginCheckInService
 import org.gradle.internal.enterprise.impl.legacy.LegacyGradleEnterprisePluginCheckInService
 import org.gradle.plugin.management.internal.autoapply.AutoAppliedGradleEnterprisePlugin
@@ -122,7 +122,7 @@ class BuildScanAutoApplyIntegrationTest extends AbstractIntegrationSpec {
 
         and:
         if (!GradleContextualExecuter.configCache && VersionNumber.parse(version) < PLUGIN_MINIMUM_NON_DEPRECATED_VERSION) {
-            executer.expectDocumentedDeprecationWarning("Develocity plugin $version has been deprecated. Starting with Gradle 9.0, only Develocity plugin 3.13.1 or newer is supported. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#unsupported_ge_plugin_3.13")
+            executer.expectDocumentedDeprecationWarning("Gradle Enterprise plugin $version has been deprecated. Starting with Gradle 9.0, only Gradle Enterprise plugin 3.13.1 or newer is supported. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#unsupported_ge_plugin_3.13")
         }
 
         and:
@@ -156,7 +156,7 @@ class BuildScanAutoApplyIntegrationTest extends AbstractIntegrationSpec {
 
         and:
         if (!GradleContextualExecuter.configCache && VersionNumber.parse(version) < PLUGIN_MINIMUM_NON_DEPRECATED_VERSION) {
-            executer.expectDocumentedDeprecationWarning("Develocity plugin $version has been deprecated. Starting with Gradle 9.0, only Develocity plugin 3.13.1 or newer is supported. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#unsupported_ge_plugin_3.13")
+            executer.expectDocumentedDeprecationWarning("Gradle Enterprise plugin $version has been deprecated. Starting with Gradle 9.0, only Gradle Enterprise plugin 3.13.1 or newer is supported. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#unsupported_ge_plugin_3.13")
         }
 
         and:
@@ -194,7 +194,7 @@ class BuildScanAutoApplyIntegrationTest extends AbstractIntegrationSpec {
 
         and:
         if (!GradleContextualExecuter.configCache && VersionNumber.parse(version) < PLUGIN_MINIMUM_NON_DEPRECATED_VERSION) {
-            executer.expectDocumentedDeprecationWarning("Develocity plugin $version has been deprecated. Starting with Gradle 9.0, only Develocity plugin 3.13.1 or newer is supported. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#unsupported_ge_plugin_3.13")
+            executer.expectDocumentedDeprecationWarning("Gradle Enterprise plugin $version has been deprecated. Starting with Gradle 9.0, only Gradle Enterprise plugin 3.13.1 or newer is supported. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#unsupported_ge_plugin_3.13")
         }
 
         and:

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/legacy/LegacyGradleEnterpriseCheckInConfigCachingIntegTest.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/legacy/LegacyGradleEnterpriseCheckInConfigCachingIntegTest.groovy
@@ -44,7 +44,7 @@ class LegacyGradleEnterpriseCheckInConfigCachingIntegTest extends AbstractIntegr
         succeeds "t", "--configuration-cache"
 
         then:
-        scanPlugin.assertUnsupportedMessage(output, "Build scans have been disabled due to incompatibility between your Develocity plugin version (3.3.4) and configuration caching. Please use Develocity plugin version 3.4 or later for compatibility with configuration caching.")
+        scanPlugin.assertUnsupportedMessage(output, "Build scans have been disabled due to incompatibility between your Gradle Enterprise plugin version (3.3.4) and configuration caching. Please use Gradle Enterprise plugin version 3.4 or later for compatibility with configuration caching.")
     }
 
 }

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginCheckInService.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginCheckInService.java
@@ -50,15 +50,15 @@ public class DefaultGradleEnterprisePluginCheckInService implements GradleEnterp
     public static final String UNSUPPORTED_TOGGLE = "org.gradle.internal.unsupported-enterprise-plugin";
     public static final String UNSUPPORTED_TOGGLE_MESSAGE = "Enterprise plugin unsupported due to secret toggle";
 
-    // For Gradle versions 8+, configuration caching builds are not compatible with Develocity plugin < 3.12
+    // For Gradle versions 8+, configuration caching builds are not compatible with Gradle Enterprise plugin < 3.12
     public static final VersionNumber MINIMUM_SUPPORTED_PLUGIN_VERSION_FOR_CONFIGURATION_CACHING = VersionNumber.version(3, 12);
-    public static final String UNSUPPORTED_PLUGIN_DUE_TO_CONFIGURATION_CACHING_MESSAGE = String.format("Develocity plugin has been disabled as it is " +
-            "incompatible with this version of Gradle and the configuration caching feature - please upgrade to version %s.%s or later of the Develocity plugin to restore functionality.",
+    public static final String UNSUPPORTED_PLUGIN_DUE_TO_CONFIGURATION_CACHING_MESSAGE = String.format("Gradle Enterprise plugin has been disabled as it is " +
+            "incompatible with this version of Gradle and the configuration caching feature - please upgrade to version %s.%s or later of the Gradle Enterprise plugin to restore functionality.",
         MINIMUM_SUPPORTED_PLUGIN_VERSION_FOR_CONFIGURATION_CACHING.getMajor(),
         MINIMUM_SUPPORTED_PLUGIN_VERSION_FOR_CONFIGURATION_CACHING.getMinor());
 
     public static final VersionNumber MINIMUM_SUPPORTED_PLUGIN_VERSION_FOR_ISOLATED_PROJECTS = VersionNumber.version(3, 15);
-    public static final String UNSUPPORTED_PLUGIN_DUE_TO_ISOLATED_PROJECTS_MESSAGE = "Develocity plugin has been disabled as it is incompatible with isolated projects feature";
+    public static final String UNSUPPORTED_PLUGIN_DUE_TO_ISOLATED_PROJECTS_MESSAGE = "Gradle Enterprise plugin has been disabled as it is incompatible with the isolated projects feature";
 
     // Gradle versions 9+ are not compatible Develocity plugin < 3.13.1
     public static final VersionNumber MINIMUM_SUPPORTED_PLUGIN_VERSION_SINCE_GRADLE_9 = VersionNumber.parse("3.13.1");
@@ -130,8 +130,8 @@ public class DefaultGradleEnterprisePluginCheckInService implements GradleEnterp
     }
 
     private static void nagAboutDeprecatedPluginVersion(String pluginVersion) {
-        DeprecationLogger.deprecateIndirectUsage("Develocity plugin " + pluginVersion)
-            .startingWithGradle9(String.format("only Develocity plugin %s.%s.%s or newer is supported",
+        DeprecationLogger.deprecateIndirectUsage("Gradle Enterprise plugin " + pluginVersion)
+            .startingWithGradle9(String.format("only Gradle Enterprise plugin %s.%s.%s or newer is supported",
                 MINIMUM_SUPPORTED_PLUGIN_VERSION_SINCE_GRADLE_9.getMajor(),
                 MINIMUM_SUPPORTED_PLUGIN_VERSION_SINCE_GRADLE_9.getMinor(),
                 MINIMUM_SUPPORTED_PLUGIN_VERSION_SINCE_GRADLE_9.getMicro()

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/legacy/LegacyGradleEnterprisePluginCheckInService.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/legacy/LegacyGradleEnterprisePluginCheckInService.java
@@ -70,8 +70,8 @@ public class LegacyGradleEnterprisePluginCheckInService implements BuildScanConf
         if (Boolean.getBoolean(UNSUPPORTED_TOGGLE)) {
             return UNSUPPORTED_TOGGLE_MESSAGE;
         } else if (buildModelParameters.isConfigurationCache()) {
-            return "Build scans have been disabled due to incompatibility between your Develocity plugin version (" + pluginVersion.toString() + ") and configuration caching. " +
-                "Please use Develocity plugin version 3.4 or later for compatibility with configuration caching.";
+            return "Build scans have been disabled due to incompatibility between your Gradle Enterprise plugin version (" + pluginVersion + ") and configuration caching. " +
+                "Please use Gradle Enterprise plugin version 3.4 or later for compatibility with configuration caching.";
         } else {
             return null;
         }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
@@ -178,8 +178,8 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
         then:
         scanRunner()
             .expectLegacyDeprecationWarningIf(FIRST_VERSION_SUPPORTING_CHECK_IN_SERVICE <= versionNumber && versionNumber < FIRST_VERSION_CALLING_BUILD_PATH,
-                "Develocity plugin $version has been deprecated. " +
-                    "Starting with Gradle 9.0, only Develocity plugin 3.13.1 or newer is supported. " +
+                "Gradle Enterprise plugin $version has been deprecated. " +
+                    "Starting with Gradle 9.0, only Gradle Enterprise plugin 3.13.1 or newer is supported. " +
                     "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#unsupported_ge_plugin_3.13"
             )
             .expectLegacyDeprecationWarningIf(versionNumber < FIRST_VERSION_CALLING_BUILD_PATH,
@@ -205,8 +205,8 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
         then:
         scanRunner()
             .expectLegacyDeprecationWarningIf(versionNumber < FIRST_VERSION_CALLING_BUILD_PATH,
-                "Develocity plugin $version has been deprecated. " +
-                    "Starting with Gradle 9.0, only Develocity plugin 3.13.1 or newer is supported. " +
+                "Gradle Enterprise plugin $version has been deprecated. " +
+                    "Starting with Gradle 9.0, only Gradle Enterprise plugin 3.13.1 or newer is supported. " +
                     "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#unsupported_ge_plugin_3.13"
             )
             .expectLegacyDeprecationWarningIf(versionNumber < FIRST_VERSION_CALLING_BUILD_PATH,
@@ -231,8 +231,8 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
         then:
         scanRunner("-Dorg.gradle.unsafe.isolated-projects=true")
             .expectLegacyDeprecationWarningIf(versionNumber < FIRST_VERSION_CALLING_BUILD_PATH,
-                "Develocity plugin $version has been deprecated. " +
-                    "Starting with Gradle 9.0, only Develocity plugin 3.13.1 or newer is supported. " +
+                "Gradle Enterprise plugin $version has been deprecated. " +
+                    "Starting with Gradle 9.0, only Gradle Enterprise plugin 3.13.1 or newer is supported. " +
                     "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#unsupported_ge_plugin_3.13"
             )
             .expectLegacyDeprecationWarningIf(versionNumber < FIRST_VERSION_CALLING_BUILD_PATH,
@@ -258,7 +258,7 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
             .build().output
 
         then:
-        output.contains("Develocity plugin has been disabled as it is incompatible with isolated projects feature")
+        output.contains("Gradle Enterprise plugin has been disabled as it is incompatible with the isolated projects feature")
         !output.contains("Build scan written to")
 
         where:
@@ -316,8 +316,8 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
                 "WARNING: The following functionality has been deprecated and will be removed in the next major release of the Develocity Gradle plugin. " +
                     "For assistance with migration, see https://gradle.com/help/gradle-plugin-develocity-migration.")
             .expectLegacyDeprecationWarningIf(FIRST_VERSION_SUPPORTING_CHECK_IN_SERVICE <= versionNumber && versionNumber < FIRST_VERSION_CALLING_BUILD_PATH,
-                "Develocity plugin $pluginVersion has been deprecated. " +
-                    "Starting with Gradle 9.0, only Develocity plugin 3.13.1 or newer is supported. " +
+                "Gradle Enterprise plugin $pluginVersion has been deprecated. " +
+                    "Starting with Gradle 9.0, only Gradle Enterprise plugin 3.13.1 or newer is supported. " +
                     "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#unsupported_ge_plugin_3.13"
             )
             .expectLegacyDeprecationWarningIf(versionNumber < FIRST_VERSION_CALLING_BUILD_PATH,


### PR DESCRIPTION
All the deprecated versions are Gradle Enterprise plugins and the versions we suggest upgrading to are also Gradle Enterprise plugin. We shouldn't talk about upgrading to a Develocity plugin in that case.
