### PR TITLE
Fix type cycles stackoverflow in ExternalPluginsInstrumentationTypeRegistry

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/types/ExternalPluginsInstrumentationTypeRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/types/ExternalPluginsInstrumentationTypeRegistry.java
@@ -18,9 +18,11 @@ package org.gradle.internal.classpath.types;
 
 import com.google.common.collect.ImmutableMap;
 
+import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -44,38 +46,67 @@ public class ExternalPluginsInstrumentationTypeRegistry implements Instrumentati
 
     @Override
     public Set<String> getSuperTypes(String type) {
-        // TODO: This can probably be optimized: optimize it if it has performance impact
         Set<String> superTypes = Collections.emptySet();
         if (type.startsWith(GRADLE_CORE_PACKAGE_PREFIX)) {
             superTypes = gradleCoreInstrumentationTypeRegistry.getSuperTypes(type);
         }
-        return !superTypes.isEmpty() ? superTypes : Collections.unmodifiableSet(computeAndCacheSuperTypesForExternalType(type));
+
+        if (!superTypes.isEmpty()) {
+            return superTypes;
+        } else {
+            superTypes = instrumentedSuperTypes.get(type);
+            return superTypes != null
+                ? superTypes
+                : computeAndCacheInstrumentedSuperTypes(type, new HashSet<>());
+        }
     }
 
-    private Set<String> computeAndCacheSuperTypesForExternalType(String type) {
+    private Set<String> computeAndCacheInstrumentedSuperTypes(String type, Set<String> visited) {
         // We intentionally avoid using computeIfAbsent, since ConcurrentHashMap doesn't allow map modifications in the computeIfAbsent map function.
         // The result is, that multiple threads could recalculate the same key multiple times, but that is not a problem in our case.
         Set<String> computedInstrumentedSuperTypes = instrumentedSuperTypes.get(type);
         if (computedInstrumentedSuperTypes == null) {
-            computedInstrumentedSuperTypes = computeInstrumentedSuperTypes(type);
+            computedInstrumentedSuperTypes = computeInstrumentedSuperTypes(type, visited);
             instrumentedSuperTypes.put(type, computedInstrumentedSuperTypes);
         }
         return computedInstrumentedSuperTypes;
     }
 
-    private Set<String> computeInstrumentedSuperTypes(String type) {
+    private Set<String> computeInstrumentedSuperTypes(String type, Set<String> visited) {
+        // In case of detected type cycle, calculate super types without recursive cache
+        Set<String> superTypes = visited.add(type)
+            ? computeSuperTypesWithRecursiveCaching(type, visited)
+            : computeSuperTypesWithoutRecursiveCaching(type);
+
+        // Keep just classes in the `org.gradle.` package. If we ever allow 3rd party plugins to contribute instrumentation,
+        // we would need to be more precise and actually check if types are instrumented.
+        return superTypes.stream()
+            .filter(superType -> superType.startsWith(GRADLE_CORE_PACKAGE_PREFIX))
+            .collect(Collectors.toSet());
+    }
+
+    private Set<String> computeSuperTypesWithRecursiveCaching(String type, Set<String> visited) {
         Set<String> collected = new HashSet<>();
         collected.add(type);
         for (String superType : getDirectSuperTypes(type)) {
             if (collected.add(superType)) {
-                collected.addAll(computeAndCacheSuperTypesForExternalType(superType));
+                collected.addAll(computeAndCacheInstrumentedSuperTypes(superType, visited));
             }
         }
-        // Keep just classes in the `org.gradle.` package. If we ever allow 3rd party plugins to contribute instrumentation,
-        // we would need to be more precise and actually check if types are instrumented.
-        return collected.stream()
-            .filter(superType -> superType.startsWith(GRADLE_CORE_PACKAGE_PREFIX))
-            .collect(Collectors.toSet());
+        return collected;
+    }
+
+    private Set<String> computeSuperTypesWithoutRecursiveCaching(String type) {
+        Queue<String> superTypes = new ArrayDeque<>(getDirectSuperTypes(type));
+        Set<String> collected = new HashSet<>();
+        collected.add(type);
+        while (!superTypes.isEmpty()) {
+            String superType = superTypes.poll();
+            if (collected.add(superType)) {
+                superTypes.addAll(getDirectSuperTypes(superType));
+            }
+        }
+        return collected;
     }
 
     private Set<String> getDirectSuperTypes(String type) {


### PR DESCRIPTION
So this solves cycling inheritence:
If we have:
```
class A extends B {}
class B extends C {}
class C extends A {}
```
then we get stackoverflow when we for example try to discover subtypes of A.

This happens because we recursively tried to discover all type subtrees of A and on the way we also try to cache them.
What we do now is that if we find a cycle we then discover subtrees without recursion and without caching the subtrees.

----
Now why cycles can happen? For example we have two libraries on the classpath that creates class cycles (use same class names). 
One example that creates and issue is old Develocity and new Develocity plugin on the classpath:
```
dependencies {
    classpath("com.gradle:gradle-enterprise-gradle-plugin:3.14.1")
    classpath("com.gradle:develocity-gradle-plugin:3.17.2")
}
```