### PR TITLE
Use strong types for additional data in problem reports

### DIFF
--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
@@ -953,7 +953,7 @@ project.extensions.create("some", SomeExtension)
                 'Assign a value to \'strings\'',
                 'Mark property \'strings\' as optional',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'strings',
             ]

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/ProblemRecordingTypeValidationContext.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/ProblemRecordingTypeValidationContext.java
@@ -19,6 +19,7 @@ package org.gradle.internal.reflect;
 import org.gradle.api.Action;
 import org.gradle.api.problems.internal.DefaultProblemBuilder;
 import org.gradle.api.problems.internal.Problem;
+import org.gradle.api.problems.internal.TypeValidationDataSpec;
 import org.gradle.internal.reflect.validation.DefaultTypeAwareProblemBuilder;
 import org.gradle.internal.reflect.validation.TypeAwareProblemBuilder;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
@@ -28,8 +29,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.function.Supplier;
-
-import static org.gradle.internal.reflect.validation.DefaultTypeAwareProblemBuilder.PLUGIN_ID;
 
 abstract public class ProblemRecordingTypeValidationContext implements TypeValidationContext {
     private final Class<?> rootType;
@@ -52,14 +51,13 @@ abstract public class ProblemRecordingTypeValidationContext implements TypeValid
         return pluginId.get();
     }
 
-
     @Override
     public void visitPropertyProblem(Action<? super TypeAwareProblemBuilder> problemSpec) {
         DefaultTypeAwareProblemBuilder problemBuilder = getDefaultTypeAwareProblemBuilder(problemSpec);
         problemBuilder.withAnnotationType(rootType);
         pluginId()
             .map(PluginId::getId)
-            .ifPresent(id -> problemBuilder.additionalData(PLUGIN_ID, id));
+            .ifPresent(id -> problemBuilder.additionalData(TypeValidationDataSpec.class, data -> data.pluginId(id)));
         recordProblem(problemBuilder.build());
     }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/validation/DelegatingProblemBuilder.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/validation/DelegatingProblemBuilder.java
@@ -16,9 +16,11 @@
 
 package org.gradle.internal.reflect.validation;
 
+import org.gradle.api.Action;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.problems.ProblemGroup;
 import org.gradle.api.problems.Severity;
+import org.gradle.api.problems.internal.AdditionalDataSpec;
 import org.gradle.api.problems.internal.DocLink;
 import org.gradle.api.problems.internal.InternalProblemBuilder;
 import org.gradle.api.problems.internal.Problem;
@@ -115,8 +117,8 @@ class DelegatingProblemBuilder implements InternalProblemBuilder {
     }
 
     @Override
-    public InternalProblemBuilder additionalData(String key, Object value) {
-        return validateDelegate(delegate.additionalData(key, value));
+    public <U extends AdditionalDataSpec> InternalProblemBuilder additionalData(Class<? extends U> specType, Action<? super U> config) {
+        return validateDelegate(delegate.additionalData(specType, config));
     }
 
     @Override

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/reflect/validation/DefaultTypeAwareProblemBuilderTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/reflect/validation/DefaultTypeAwareProblemBuilderTest.groovy
@@ -16,30 +16,30 @@
 
 package org.gradle.internal.reflect.validation
 
-import com.google.common.collect.ImmutableMap
+import org.gradle.api.problems.internal.DefaultTypeValidationData
 import spock.lang.Specification
-
-import static DefaultTypeAwareProblemBuilder.PROPERTY_NAME
-import static DefaultTypeAwareProblemBuilder.TYPE_IS_IRRELEVANT_IN_ERROR_MESSAGE
-import static DefaultTypeAwareProblemBuilder.TYPE_NAME
-import static java.lang.Boolean.TRUE
 
 class DefaultTypeAwareProblemBuilderTest extends Specification {
 
     def "render introduction without type"() {
         given:
-        def result = DefaultTypeAwareProblemBuilder.introductionFor ImmutableMap.of(TYPE_IS_IRRELEVANT_IN_ERROR_MESSAGE, TRUE.toString(),
-            TYPE_NAME, "foo", PROPERTY_NAME, "bar")
+        def data = DefaultTypeValidationData.builder()
+            .typeName("foo")
+            .propertyName("bar")
+            .build()
 
         expect:
-        result == "Property 'bar' "
+        DefaultTypeAwareProblemBuilder.introductionFor(Optional.of(data), true) == "Property 'bar' "
     }
 
     def "render introduction with type"() {
         given:
-        def result = DefaultTypeAwareProblemBuilder.introductionFor ImmutableMap.of(TYPE_NAME, "foo", PROPERTY_NAME, "bar")
+        def data = DefaultTypeValidationData.builder()
+            .typeName("foo")
+            .propertyName("bar")
+            .build()
 
         expect:
-        result == "Type 'foo' property 'bar' "
+        DefaultTypeAwareProblemBuilder.introductionFor(Optional.of(data), false) == "Type 'foo' property 'bar' "
     }
 }

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/ValidateStep.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/ValidateStep.java
@@ -139,7 +139,6 @@ public class ValidateStep<C extends BeforeExecutionContext, R extends Result> im
             UnknownImplementationSnapshot unknownImplSnapshot = (UnknownImplementationSnapshot) implementation;
             workValidationContext.visitPropertyProblem(problem -> problem
                 .forProperty(propertyName)
-                .typeIsIrrelevantInErrorMessage()
                 .id(TextUtil.screamingSnakeToKebabCase(UNKNOWN_IMPLEMENTATION_NESTED), "Unknown property implementation", GradleCoreProblemGroup.validation().property())
                 .contextualLabel(unknownImplSnapshot.getProblemDescription())
                 .documentedAt(userManual("validation_problems", "implementation_unknown"))
@@ -154,7 +153,6 @@ public class ValidateStep<C extends BeforeExecutionContext, R extends Result> im
         if (implementation instanceof UnknownImplementationSnapshot) {
             UnknownImplementationSnapshot unknownImplSnapshot = (UnknownImplementationSnapshot) implementation;
             workValidationContext.visitPropertyProblem(problem -> problem
-                .typeIsIrrelevantInErrorMessage()
                 .id(TextUtil.screamingSnakeToKebabCase(UNKNOWN_IMPLEMENTATION), "Unknown property implementation", GradleCoreProblemGroup.validation().property())
                 .contextualLabel(descriptionPrefix + work + " " + unknownImplSnapshot.getProblemDescription())
                 .documentedAt(userManual("validation_problems", "implementation_unknown"))

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/DeprecatedFeatureUsage.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/DeprecatedFeatureUsage.java
@@ -18,6 +18,7 @@ package org.gradle.internal.deprecation;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import org.gradle.api.problems.internal.DeprecationData;
 import org.gradle.api.problems.internal.DocLink;
 import org.gradle.internal.featurelifecycle.FeatureUsage;
 
@@ -102,7 +103,19 @@ public class DeprecatedFeatureUsage extends FeatureUsage {
          *
          * Example: deprecated CLI switch.
          */
-        BUILD_INVOCATION
+        BUILD_INVOCATION;
+
+        public DeprecationData.Type toDeprecationDataType() {
+            switch (this) {
+                case USER_CODE_DIRECT:
+                    return DeprecationData.Type.USER_CODE_DIRECT;
+                case USER_CODE_INDIRECT:
+                    return DeprecationData.Type.USER_CODE_INDIRECT;
+                case BUILD_INVOCATION:
+                    return DeprecationData.Type.BUILD_INVOCATION;
+            }
+            throw new IllegalStateException("Unknown deprecation type: " + this);
+        }
     }
 
     /**

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
@@ -21,6 +21,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.logging.configuration.WarningMode;
 import org.gradle.api.problems.Problems;
+import org.gradle.api.problems.internal.DeprecationDataSpec;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblemReporter;
 import org.gradle.api.problems.internal.InternalProblemSpec;
@@ -103,7 +104,12 @@ public class LoggingDeprecatedFeatureHandler implements FeatureHandler<Deprecate
                     .contextualLabel(usage.getSummary())
                     .details(usage.getRemovalDetails())
                     .documentedAt(usage.getDocumentationUrl())
-                    .additionalData("type", usage.getType().name())
+                    .additionalData(DeprecationDataSpec.class, new Action<DeprecationDataSpec>() {
+                        @Override
+                        public void execute(DeprecationDataSpec data) {
+                            data.type(usage.getType().toDeprecationDataType());
+                        }
+                    })
                     .severity(WARNING);
 
                 addPossibleLocation(diagnostics, problemSpec);

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/deprecation/DeprecationMessagesTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/deprecation/DeprecationMessagesTest.groovy
@@ -19,10 +19,12 @@ package org.gradle.internal.deprecation
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.logging.configuration.WarningMode
 import org.gradle.api.problems.Severity
+import org.gradle.api.problems.internal.DefaultDeprecationData
 import org.gradle.api.problems.internal.DefaultProblem
 import org.gradle.api.problems.internal.DefaultProblemDefinition
 import org.gradle.api.problems.internal.DefaultProblemId
 import org.gradle.api.problems.internal.DefaultProblems
+import org.gradle.api.problems.internal.DeprecationData
 import org.gradle.api.problems.internal.GradleCoreProblemGroup
 import org.gradle.api.problems.internal.ProblemEmitter
 import org.gradle.api.tasks.bundling.AbstractArchiveTask
@@ -38,7 +40,6 @@ import spock.lang.Specification
 
 import static org.gradle.api.internal.DocumentationRegistry.RECOMMENDATION
 import static org.gradle.internal.deprecation.DeprecationMessageBuilder.createDefaultDeprecationId
-
 
 class DeprecationMessagesTest extends Specification {
 
@@ -83,7 +84,7 @@ class DeprecationMessagesTest extends Specification {
         then:
         expectMessage "$summary This is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}."
 
-        1 * problemEmitter.emit(createProblem(summary), identifier)
+        1 * problemEmitter.emit({ it.definition.id.displayName == 'Summary is deprecated.' }, identifier)
     }
 
     def "logs deprecation message with custom problem id"() {
@@ -99,14 +100,14 @@ class DeprecationMessagesTest extends Specification {
         then:
         expectMessage "$summary This is scheduled to be removed in Gradle ${NEXT_GRADLE_VERSION}."
 
-        1 * problemEmitter.emit(createProblem(deprecationDisplayName), identifier)
+        1 * problemEmitter.emit({ it.definition.id.displayName == 'summary deprecation' }, identifier)
     }
 
     def createProblem(deprecationDisplayName) {
         def id = new DefaultProblemId(createDefaultDeprecationId(deprecationDisplayName), deprecationDisplayName, GradleCoreProblemGroup.deprecation())
         def definition = new DefaultProblemDefinition(id, Severity.WARNING, null)
 
-        return new DefaultProblem(definition, "Summary is deprecated.", [], [], "This is scheduled to be removed in Gradle 9.0.", null, ["type": "USER_CODE_DIRECT"])
+        return new DefaultProblem(definition, "Summary is deprecated.", [], [], "This is scheduled to be removed in Gradle 9.0.", null, new DefaultDeprecationData(DeprecationData.Type.USER_CODE_DIRECT))
     }
 
     def "logs deprecation message with advice"() {

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/AbstractPluginValidationIntegrationSpec.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/AbstractPluginValidationIntegrationSpec.groovy
@@ -142,7 +142,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'Add an input or output annotation',
                     'Mark it as @Internal',
                 ]
-                additionalData == [
+                additionalData.asMap == [
                     'typeName' : 'MyTask',
                     'propertyName' : 'badTime',
                 ]
@@ -155,7 +155,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'Add an input or output annotation',
                     'Mark it as @Internal',
                 ]
-                additionalData == [
+                additionalData.asMap == [
                     'typeName' : 'MyTask',
                     'propertyName' : 'oldThing',
                 ]
@@ -168,7 +168,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'Add an input or output annotation',
                     'Mark it as @Internal',
                 ]
-                additionalData == [
+                additionalData.asMap == [
                     'parentPropertyName' : 'options',
                     'typeName' : 'MyTask',
                     'propertyName' : 'badNested',
@@ -182,7 +182,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'Add an input or output annotation',
                     'Mark it as @Internal',
                 ]
-                additionalData == [
+                additionalData.asMap == [
                     'typeName' : 'MyTask',
                     'propertyName' : 'ter',
                 ]
@@ -273,7 +273,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'Remove the @Optional annotation',
                     "Use the java.lang.$className type instead"
                 ]
-                additionalData == [
+                additionalData.asMap == [
                     'typeName' : 'MyTask',
                     'propertyName' : 'primitive'
                 ]
@@ -335,28 +335,28 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                 contextualLabel == 'Type \'MyTask\' is incorrectly annotated with @CacheableTransform'
                 details == 'This annotation only makes sense on TransformAction types'
                 solutions == [ 'Remove the annotation' ]
-                additionalData == [ 'typeName' : 'MyTask' ]
+                additionalData.asMap == [ 'typeName' : 'MyTask' ]
             }
             verifyAll(receivedProblem(1)) {
                 fqid == 'validation:type-validation:invalid-use-of-type-annotation'
                 contextualLabel == 'Type \'MyTask.Options\' is incorrectly annotated with @CacheableTask'
                 details == 'This annotation only makes sense on Task types'
                 solutions == [ 'Remove the annotation' ]
-                additionalData == [ 'typeName' : 'MyTask.Options' ]
+                additionalData.asMap == [ 'typeName' : 'MyTask.Options' ]
             }
             verifyAll(receivedProblem(2)) {
                 fqid == 'validation:type-validation:invalid-use-of-type-annotation'
                 contextualLabel == 'Type \'MyTask.Options\' is incorrectly annotated with @CacheableTransform'
                 details == 'This annotation only makes sense on TransformAction types'
                 solutions == [ 'Remove the annotation' ]
-                additionalData == [ 'typeName' : 'MyTask.Options' ]
+                additionalData.asMap == [ 'typeName' : 'MyTask.Options' ]
             }
             verifyAll(receivedProblem(3)) {
                 fqid == 'validation:type-validation:invalid-use-of-type-annotation'
                 contextualLabel == 'Type \'MyTask.Options\' is incorrectly annotated with @DisableCachingByDefault'
                 details == 'This annotation only makes sense on Task, TransformAction types'
                 solutions == [ 'Remove the annotation' ]
-                additionalData == [ 'typeName' : 'MyTask.Options' ]
+                additionalData.asMap == [ 'typeName' : 'MyTask.Options' ]
             }
         }
     }
@@ -410,7 +410,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'Add an input or output annotation',
                     'Mark it as @Internal',
                 ]
-                additionalData == [
+                additionalData.asMap == [
                     'typeName' : 'MyTask',
                     'propertyName' : 'badTime',
                 ]
@@ -423,7 +423,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'Add an input or output annotation',
                     'Mark it as @Internal',
                 ]
-                additionalData == [
+                additionalData.asMap == [
                     'parentPropertyName' : 'options',
                     'typeName' : 'MyTask',
                     'propertyName' : 'badNested',
@@ -564,7 +564,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                 contextualLabel == "Type \'MyTask\' property \'mutablePropertyWithSetter\' of mutable type '${testedType.replace('<String>', '')}' is writable"
                 details == "Properties of type '${testedType.replace('<String>', '')}' are already mutable"
                 solutions == [ 'Remove the \'setMutablePropertyWithSetter\' method' ]
-                additionalData == [
+                additionalData.asMap == [
                     'typeName' : 'MyTask',
                     'propertyName' : 'mutablePropertyWithSetter',
                 ]
@@ -632,7 +632,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'Make the getter public',
                     'Annotate the public version of the getter',
                 ]
-                additionalData == [
+                additionalData.asMap == [
                     'typeName' : 'MyTask',
                     'propertyName' : 'badTime',
                 ]
@@ -645,7 +645,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'Make the getter public',
                     'Annotate the public version of the getter',
                 ]
-                additionalData == [
+                additionalData.asMap == [
                     'parentPropertyName' : 'options',
                     'typeName' : 'MyTask',
                     'propertyName' : 'badNested',
@@ -659,7 +659,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'Make the getter public',
                     'Annotate the public version of the getter',
                 ]
-                additionalData == [
+                additionalData.asMap == [
                     'typeName' : 'MyTask',
                     'propertyName' : 'outputDir',
                 ]
@@ -718,7 +718,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'Remove the annotations',
                     'Rename the method',
                 ]
-                additionalData == [ 'typeName' : 'MyTask' ]
+                additionalData.asMap == [ 'typeName' : 'MyTask' ]
             }
             verifyAll(receivedProblem(1)) {
                 fqid == 'validation:type-validation:ignored-annotations-on-method'
@@ -728,7 +728,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'Remove the annotations',
                     'Rename the method',
                 ]
-                additionalData == [ 'typeName' : 'MyTask.Options' ]
+                additionalData.asMap == [ 'typeName' : 'MyTask.Options' ]
             }
         }
     }
@@ -799,7 +799,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'Add an input or output annotation',
                     'Mark it as @Internal',
                 ]
-                additionalData == [
+                additionalData.asMap == [
                     'typeName' : 'MyTask',
                     'propertyName' : 'readWrite',
                 ]
@@ -812,7 +812,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'Remove the annotations',
                     'Rename the method',
                 ]
-                additionalData == [ 'typeName' : 'MyTask' ]
+                additionalData.asMap == [ 'typeName' : 'MyTask' ]
             }
             verifyAll(receivedProblem(2)) {
                 fqid == 'validation:type-validation:ignored-annotations-on-method'
@@ -822,7 +822,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'Remove the annotations',
                     'Rename the method',
                 ]
-                additionalData == [ 'typeName' : 'MyTask' ]
+                additionalData.asMap == [ 'typeName' : 'MyTask' ]
             }
             verifyAll(receivedProblem(3)) {
                 fqid == 'validation:type-validation:ignored-annotations-on-method'
@@ -832,7 +832,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'Remove the annotations',
                     'Rename the method',
                 ]
-                additionalData == [ 'typeName' : 'MyTask.Options' ]
+                additionalData.asMap == [ 'typeName' : 'MyTask.Options' ]
             }
             verifyAll(receivedProblem(4)) {
                 fqid == 'validation:type-validation:ignored-annotations-on-method'
@@ -842,7 +842,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'Remove the annotations',
                     'Rename the method',
                 ]
-                additionalData == [ 'typeName' : 'MyTask.Options' ]
+                additionalData.asMap == [ 'typeName' : 'MyTask.Options' ]
             }
         }
     }
@@ -894,7 +894,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'Remove the input annotations',
                     'Remove the @ReplacedBy annotation',
                 ]
-                additionalData == [
+                additionalData.asMap == [
                     'typeName' : 'MyTask',
                     'propertyName' : 'oldProperty',
                 ]
@@ -937,7 +937,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                 contextualLabel == 'Type \'MyTask\' property \'file\' has conflicting type annotations declared: @InputFile, @OutputFile'
                 details == 'The different annotations have different semantics and Gradle cannot determine which one to pick'
                 solutions == [ 'Choose between one of the conflicting annotations' ]
-                additionalData == [
+                additionalData.asMap == [
                     'typeName' : 'MyTask',
                     'propertyName' : 'file',
                 ]

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsPart1IntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsPart1IntegrationTest.groovy
@@ -58,7 +58,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
                 'Add an input or output annotation',
                 'Mark it as @Internal',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'parentPropertyName' : 'tree',
                 'typeName' : 'MyTask',
                 'propertyName' : 'nonAnnotated',
@@ -110,7 +110,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
                 'Remove the property',
                 'Use a different annotation, e.g one of @Console, @Destroys, @Inject, @Input, @InputDirectory, @InputFile, @InputFiles, @Internal, @LocalState, @Nested, @OptionValues, @OutputDirectories, @OutputDirectory, @OutputFile, @OutputFiles, @ReplacedBy or @ServiceReference',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'parentPropertyName' : 'options',
                 'typeName' : 'MyTask',
                 'propertyName' : 'nestedThing',
@@ -124,7 +124,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
                 'Remove the property',
                 'Use a different annotation, e.g one of @Console, @Destroys, @Inject, @Input, @InputDirectory, @InputFile, @InputFiles, @Internal, @LocalState, @Nested, @OptionValues, @OutputDirectories, @OutputDirectory, @OutputFile, @OutputFiles, @ReplacedBy or @ServiceReference',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'thing',
             ]
@@ -184,7 +184,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
             contextualLabel == 'Type \'MyTask\' property \'dirProp\' is annotated with @InputDirectory but missing a normalization strategy'
             details == 'If you don\'t declare the normalization, outputs can\'t be re-used between machines or locations on the same machine, therefore caching efficiency drops significantly'
             solutions == [ 'Declare the normalization strategy by annotating the property with either @PathSensitive, @Classpath or @CompileClasspath' ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'dirProp',
             ]
@@ -194,7 +194,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
             contextualLabel == 'Type \'MyTask\' property \'fileProp\' is annotated with @InputFile but missing a normalization strategy'
             details == 'If you don\'t declare the normalization, outputs can\'t be re-used between machines or locations on the same machine, therefore caching efficiency drops significantly'
             solutions == [ 'Declare the normalization strategy by annotating the property with either @PathSensitive, @Classpath or @CompileClasspath' ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'fileProp',
             ]
@@ -204,7 +204,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
             contextualLabel == 'Type \'MyTask\' property \'filesProp\' is annotated with @InputFiles but missing a normalization strategy'
             details == 'If you don\'t declare the normalization, outputs can\'t be re-used between machines or locations on the same machine, therefore caching efficiency drops significantly'
             solutions == [ 'Declare the normalization strategy by annotating the property with either @PathSensitive, @Classpath or @CompileClasspath' ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'filesProp',
             ]
@@ -373,7 +373,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
                 'Remove the property',
                 'Use a different annotation, e.g one of @Inject, @InputArtifact or @InputArtifactDependencies',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTransformAction',
                 'propertyName' : 'inputFile',
             ]
@@ -386,7 +386,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
                 'Add an input annotation',
                 'Mark it as @Internal',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTransformAction',
                 'propertyName' : 'badTime',
             ]
@@ -399,7 +399,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
                 'Add an input annotation',
                 'Mark it as @Internal',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTransformAction',
                 'propertyName' : 'oldThing',
             ]
@@ -478,7 +478,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
                 'Remove the property',
                 'Use a different annotation, e.g one of @Console, @Inject, @Input, @InputDirectory, @InputFile, @InputFiles, @Internal, @Nested, @ReplacedBy or @ServiceReference',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTransformParameters',
                 'propertyName' : 'inputFile',
             ]
@@ -488,7 +488,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
             contextualLabel == 'Type \'MyTransformParameters\' property \'incrementalNonFileInput\' is annotated with @Incremental but that is not allowed for \'Input\' properties'
             details == 'This modifier is used in conjunction with a property of type \'Input\' but this doesn\'t have semantics'
             solutions == [ 'Remove the \'@Incremental\' annotation' ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTransformParameters',
                 'propertyName' : 'incrementalNonFileInput',
             ]
@@ -501,7 +501,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
                 'Add an input annotation',
                 'Mark it as @Internal',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTransformParameters',
                 'propertyName' : 'badTime',
             ]
@@ -514,7 +514,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
                 'Add an input annotation',
                 'Mark it as @Internal',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTransformParameters',
                 'propertyName' : 'oldThing',
             ]
@@ -584,7 +584,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
                 'Add an input or output annotation',
                 'Mark it as @Internal',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'PluginTask',
                 'propertyName' : 'badProperty',
             ]
@@ -642,7 +642,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
                  'Add @CacheableTask',
                  'Add @UntrackedTask(because = ...)',
              ]
-             additionalData == [ 'typeName' : 'MyTask' ]
+             additionalData.asMap == [ 'typeName' : 'MyTask' ]
          }
          verifyAll(receivedProblem(1)) {
              fqid == 'validation:type-validation:not-cacheable-without-reason'
@@ -652,7 +652,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
                  'Add @DisableCachingByDefault(because = ...)',
                  'Add @CacheableTransform',
              ]
-             additionalData == [ 'typeName' : 'MyTransformAction' ]
+             additionalData.asMap == [ 'typeName' : 'MyTransformAction' ]
          }
     }
 
@@ -742,7 +742,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
                 'Extract artifact metadata and annotate with @Input',
                 'Extract artifact files and annotate with @InputFiles',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'direct',
             ]
@@ -755,7 +755,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
                 'Extract artifact metadata and annotate with @Input',
                 'Extract artifact files and annotate with @InputFiles',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'listPropertyInput',
             ]
@@ -768,7 +768,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
                 'Extract artifact metadata and annotate with @Input',
                 'Extract artifact files and annotate with @InputFiles',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'mapPropertyInput',
             ]
@@ -781,7 +781,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
                 'Extract artifact metadata and annotate with @Input',
                 'Extract artifact files and annotate with @InputFiles',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'parentPropertyName' : 'nestedBean',
                 'typeName' : 'MyTask',
                 'propertyName' : 'nestedInput',
@@ -795,7 +795,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
                 'Extract artifact metadata and annotate with @Input',
                 'Extract artifact files and annotate with @InputFiles',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'propertyInput',
             ]
@@ -808,7 +808,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
                 'Extract artifact metadata and annotate with @Input',
                 'Extract artifact files and annotate with @InputFiles',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'providerInput',
             ]
@@ -821,7 +821,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
                 'Extract artifact metadata and annotate with @Input',
                 'Extract artifact files and annotate with @InputFiles',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'setPropertyInput',
             ]

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsPart2IntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsPart2IntegrationTest.groovy
@@ -91,7 +91,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             contextualLabel == 'Type \'MyTask\' property \'direct\' has @Input annotation used on type \'java.net.URL\' or a property of this type'
             details == 'Type \'java.net.URL\' is not supported on properties annotated with @Input because Java Serialization can be inconsistent for this type'
             solutions == [ 'Use type \'java.net.URI\' instead' ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'direct',
             ]
@@ -101,7 +101,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             contextualLabel == 'Type \'MyTask\' property \'listPropertyInput\' has @Input annotation used on type \'java.net.URL\' or a property of this type'
             details == 'Type \'java.net.URL\' is not supported on properties annotated with @Input because Java Serialization can be inconsistent for this type'
             solutions == [ 'Use type \'java.net.URI\' instead' ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'listPropertyInput',
             ]
@@ -111,7 +111,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             contextualLabel == 'Type \'MyTask\' property \'mapPropertyInput\' has @Input annotation used on type \'java.net.URL\' or a property of this type'
             details == 'Type \'java.net.URL\' is not supported on properties annotated with @Input because Java Serialization can be inconsistent for this type'
             solutions == [ 'Use type \'java.net.URI\' instead' ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'mapPropertyInput',
             ]
@@ -121,7 +121,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             contextualLabel == 'Type \'MyTask\' property \'nestedBean.nestedInput\' has @Input annotation used on type \'java.net.URL\' or a property of this type'
             details == 'Type \'java.net.URL\' is not supported on properties annotated with @Input because Java Serialization can be inconsistent for this type'
             solutions == [ 'Use type \'java.net.URI\' instead' ]
-            additionalData == [
+            additionalData.asMap == [
                 'parentPropertyName' : 'nestedBean',
                 'typeName' : 'MyTask',
                 'propertyName' : 'nestedInput',
@@ -132,7 +132,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             contextualLabel == 'Type \'MyTask\' property \'propertyInput\' has @Input annotation used on type \'java.net.URL\' or a property of this type'
             details == 'Type \'java.net.URL\' is not supported on properties annotated with @Input because Java Serialization can be inconsistent for this type'
             solutions == [ 'Use type \'java.net.URI\' instead' ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'propertyInput',
             ]
@@ -142,7 +142,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             contextualLabel == 'Type \'MyTask\' property \'providerInput\' has @Input annotation used on type \'java.net.URL\' or a property of this type'
             details == 'Type \'java.net.URL\' is not supported on properties annotated with @Input because Java Serialization can be inconsistent for this type'
             solutions == [ 'Use type \'java.net.URI\' instead' ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'providerInput',
             ]
@@ -152,7 +152,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             contextualLabel == 'Type \'MyTask\' property \'setPropertyInput\' has @Input annotation used on type \'java.net.URL\' or a property of this type'
             details == 'Type \'java.net.URL\' is not supported on properties annotated with @Input because Java Serialization can be inconsistent for this type'
             solutions == [ 'Use type \'java.net.URI\' instead' ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'setPropertyInput',
             ]
@@ -242,7 +242,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
                 'Annotate with @InputFiles for collections of files',
                 'If you want to track the path, return File.absolutePath as a String and keep @Input',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'file',
             ]
@@ -256,7 +256,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
                 'Annotate with @InputFiles for collections of files',
                 'If you want to track the path, return File.absolutePath as a String and keep @Input',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'fileCollection',
             ]
@@ -270,7 +270,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
                 'Annotate with @InputFiles for collections of files',
                 'If you want to track the path, return File.absolutePath as a String and keep @Input',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'filePath',
             ]
@@ -284,7 +284,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
                 'Annotate with @InputFiles for collections of files',
                 'If you want to track the path, return File.absolutePath as a String and keep @Input',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'fileTree',
             ]
@@ -294,7 +294,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             contextualLabel == 'Type \'MyTask\' property \'inputDirectory\' is annotated with @InputDirectory but missing a normalization strategy'
             details == 'If you don\'t declare the normalization, outputs can\'t be re-used between machines or locations on the same machine, therefore caching efficiency drops significantly'
             solutions == [ 'Declare the normalization strategy by annotating the property with either @PathSensitive, @Classpath or @CompileClasspath' ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'inputDirectory',
             ]
@@ -304,7 +304,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             contextualLabel == 'Type \'MyTask\' property \'inputFile\' is annotated with @InputFile but missing a normalization strategy'
             details == 'If you don\'t declare the normalization, outputs can\'t be re-used between machines or locations on the same machine, therefore caching efficiency drops significantly'
             solutions == [ 'Declare the normalization strategy by annotating the property with either @PathSensitive, @Classpath or @CompileClasspath' ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'inputFile',
             ]
@@ -314,7 +314,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             contextualLabel == 'Type \'MyTask\' property \'inputFiles\' is annotated with @InputFiles but missing a normalization strategy'
             details == 'If you don\'t declare the normalization, outputs can\'t be re-used between machines or locations on the same machine, therefore caching efficiency drops significantly'
             solutions == [ 'Declare the normalization strategy by annotating the property with either @PathSensitive, @Classpath or @CompileClasspath' ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'inputFiles',
             ]
@@ -444,7 +444,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
                 'Add an input or output annotation',
                 'Mark it as @Internal',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'parentPropertyName' : 'doubleIterableOptions.*.*',
                 'typeName' : 'MyTask',
                 'propertyName' : 'notAnnotated',
@@ -458,7 +458,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
                 'Add an input or output annotation',
                 'Mark it as @Internal',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'parentPropertyName' : 'iterableMappedOptions.*.<key>.*',
                 'typeName' : 'MyTask',
                 'propertyName' : 'notAnnotated',
@@ -472,7 +472,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
                 'Add an input or output annotation',
                 'Mark it as @Internal',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'parentPropertyName' : 'iterableOptions.*',
                 'typeName' : 'MyTask',
                 'propertyName' : 'notAnnotated',
@@ -486,7 +486,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
                 'Add an input or output annotation',
                 'Mark it as @Internal',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'parentPropertyName' : 'mappedOptions.<key>',
                 'typeName' : 'MyTask',
                 'propertyName' : 'notAnnotated',
@@ -500,7 +500,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
                 'Add an input or output annotation',
                 'Mark it as @Internal',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'parentPropertyName' : 'namedIterable.<name>',
                 'typeName' : 'MyTask',
                 'propertyName' : 'notAnnotated',
@@ -514,7 +514,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
                 'Add an input or output annotation',
                 'Mark it as @Internal',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'parentPropertyName' : 'options',
                 'typeName' : 'MyTask',
                 'propertyName' : 'notAnnotated',
@@ -528,7 +528,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
                 'Add an input or output annotation',
                 'Mark it as @Internal',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'parentPropertyName' : 'optionsList.*',
                 'typeName' : 'MyTask',
                 'propertyName' : 'notAnnotated',
@@ -542,7 +542,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
                 'Add an input or output annotation',
                 'Mark it as @Internal',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'parentPropertyName' : 'providedOptions',
                 'typeName' : 'MyTask',
                 'propertyName' : 'notAnnotated',
@@ -649,7 +649,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             contextualLabel == "Type 'MyTask' property 'mapWithUnsupportedKey' where key of nested map is of type 'java.lang.Boolean'"
             details == 'Key of nested map must be one of the following types: \'Enum\', \'Integer\', \'String\''
             solutions == [ 'Change type of key to one of the following types: \'Enum\', \'Integer\', \'String\'' ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'mapWithUnsupportedKey',
             ]
@@ -693,7 +693,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
                 'Use a different input annotation if type is not a bean',
                 'Use a different package that doesn\'t conflict with standard Java or Kotlin types for custom types',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : "my$typeName",
             ]
@@ -791,7 +791,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
                 'Use a different input annotation if type is not a bean',
                 'Use a different package that doesn\'t conflict with standard Java or Kotlin types for custom types'
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : "my$typeName"
             ]

--- a/platforms/extensibility/plugin-development/src/test/groovy/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerializationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/test/groovy/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerializationTest.groovy
@@ -20,10 +20,16 @@ import com.google.common.collect.HashMultimap
 import com.google.gson.Gson
 import org.gradle.api.problems.Severity
 import org.gradle.api.problems.internal.DefaultProblemReporter
+import org.gradle.api.problems.internal.DeprecationData
+import org.gradle.api.problems.internal.DeprecationDataSpec
 import org.gradle.api.problems.internal.DocLink
+import org.gradle.api.problems.internal.GeneralData
+import org.gradle.api.problems.internal.GeneralDataSpec
 import org.gradle.api.problems.internal.GradleCoreProblemGroup
 import org.gradle.api.problems.internal.InternalProblemReporter
 import org.gradle.api.problems.internal.ProblemEmitter
+import org.gradle.api.problems.internal.TypeValidationData
+import org.gradle.api.problems.internal.TypeValidationDataSpec
 import spock.lang.Specification
 
 class ValidationProblemSerializationTest extends Specification {
@@ -184,8 +190,12 @@ class ValidationProblemSerializationTest extends Specification {
         given:
         def problem = problemReporter.create {
             it.id("id", "label", GradleCoreProblemGroup.validation())
-                .additionalData("key 1", "value 1")
-                .additionalData("key 2", "value 2")
+                .additionalData(TypeValidationDataSpec.class) {
+                    it.propertyName("property")
+                    it.typeName("type")
+                    it.parentPropertyName("parent")
+                    it.pluginId("id")
+                }
         }
 
         when:
@@ -198,7 +208,51 @@ class ValidationProblemSerializationTest extends Specification {
         deserialized[0].definition.id.displayName == "label"
         deserialized[0].locations == [] as List
         deserialized[0].definition.documentationLink == null
-        deserialized[0].additionalData["key 1"] == "value 1"
-        deserialized[0].additionalData["key 2"] == "value 2"
+        (deserialized[0].additionalData as TypeValidationData).propertyName == 'property'
+        (deserialized[0].additionalData as TypeValidationData).typeName == 'type'
+        (deserialized[0].additionalData as TypeValidationData).parentPropertyName == 'parent'
+        (deserialized[0].additionalData as TypeValidationData).pluginId == 'id'
+    }
+
+    def "can serialize generic additional data"() {
+        given:
+        def problem = problemReporter.create {
+            it.id("id", "label")
+                .additionalData(GeneralDataSpec) {
+                    it.put('foo', 'bar')
+                }
+        }
+
+        when:
+        def json = gson.toJson([problem])
+        def deserialized = ValidationProblemSerialization.parseMessageList(json)
+
+        then:
+        deserialized.size() == 1
+        deserialized[0].definition.id.name == "id"
+        deserialized[0].definition.id.displayName == "label"
+        deserialized[0].additionalData instanceof GeneralData
+        (deserialized[0].additionalData as GeneralData).asMap == ['foo' : 'bar']
+    }
+
+    def "can serialize deprecation additional data"() {
+        given:
+        def problem = problemReporter.create {
+            it.id("id", "label")
+                .additionalData(DeprecationDataSpec) {
+                    it.type(DeprecationData.Type.BUILD_INVOCATION)
+                }
+        }
+
+        when:
+        def json = gson.toJson([problem])
+        def deserialized = ValidationProblemSerialization.parseMessageList(json)
+
+        then:
+        deserialized.size() == 1
+        deserialized[0].definition.id.name == "id"
+        deserialized[0].definition.id.displayName == "label"
+        deserialized[0].additionalData instanceof DeprecationData
+        (deserialized[0].additionalData as DeprecationData).type == DeprecationData.Type.BUILD_INVOCATION
     }
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/AdditionalData.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/AdditionalData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,30 +14,25 @@
  * limitations under the License.
  */
 
-package org.gradle.tooling.events.problems;
+package org.gradle.api.problems.internal;
 
+import org.gradle.api.Action;
 import org.gradle.api.Incubating;
-import org.gradle.api.NonNullApi;
-
-import java.util.Map;
 
 /**
- * Additional data attached to the problem.
+ * Marker interface for additional data that can be attached to a {@link Problem}.
  * <p>
- * There are no subtypes defined for this interface yet. Clients should expect some defined in future versions of Gradle.
- * <p>
- * The information returned by {@code #getAsMap} is considered dynamic information and subject to change between Gradle versions.
+ * This is effectively a sealed interface that is used to restrict the types of additional data that can be attached to a problem.
+ * The list interfaces supported by the problems API are:
+ * <ul>
+ *     <li>{@link GeneralData}</li>
+ *     <li>{@link org.gradle.api.problems.internal.TypeValidationData}</li>
+ *     <li>{@link org.gradle.api.problems.internal.DeprecationData}</li>
+ * </ul>
  *
- * @since 8.6
+ * @see InternalProblemSpec#additionalData(Class, Action)
  */
 @Incubating
-@NonNullApi
 public interface AdditionalData {
 
-    /**
-     * Returns additional data as a map.
-     *
-     * @since 8.6
-     */
-    Map<String, Object> getAsMap();
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/AdditionalDataBuilder.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/AdditionalDataBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,8 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.reflect.validation;
+package org.gradle.api.problems.internal;
 
-import org.gradle.api.NonNullApi;
-import org.gradle.api.problems.internal.InternalProblemSpec;
-
-import javax.annotation.Nullable;
-
-@NonNullApi
-public interface TypeAwareProblemBuilder extends InternalProblemSpec {
-    TypeAwareProblemBuilder withAnnotationType(@Nullable Class<?> classWithAnnotationAttached);
-
-    TypeAwareProblemBuilder forProperty(String propertyName);
-
-    TypeAwareProblemBuilder parentProperty(@Nullable String parentProperty);
+public interface AdditionalDataBuilder<T extends AdditionalData>  {
+    T build();
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/AdditionalDataBuilderFactory.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/AdditionalDataBuilderFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.problems.internal;
+
+import com.google.common.base.Preconditions;
+
+public class AdditionalDataBuilderFactory {
+
+    @SuppressWarnings("unchecked")
+    public static <T extends AdditionalData, S extends AdditionalDataSpec> AdditionalDataBuilder<T> builderFor(Class<? extends S> type) {
+        Preconditions.checkNotNull(type);
+        if (TypeValidationDataSpec.class.isAssignableFrom(type)) {
+            return (AdditionalDataBuilder<T>) DefaultTypeValidationData.builder();
+        } else if (DeprecationDataSpec.class.isAssignableFrom(type)) {
+            return (AdditionalDataBuilder<T>) DefaultDeprecationData.builder();
+        } else if (GeneralDataSpec.class.isAssignableFrom(type)) {
+            return (AdditionalDataBuilder<T>) DefaultGeneralData.builder();
+        } else {
+            throw new IllegalArgumentException("Unsupported type: " + type);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <S extends AdditionalData> AdditionalDataBuilder<S>  builderFor(S instance) {
+        Preconditions.checkNotNull(instance);
+        if (TypeValidationData.class.isInstance(instance)) {
+            return (AdditionalDataBuilder<S>) DefaultTypeValidationData.builder((TypeValidationData) instance);
+        } else if (DeprecationData.class.isInstance(instance)) {
+            return (AdditionalDataBuilder<S>) DefaultDeprecationData.builder((DeprecationData) instance);
+        } else if (GeneralData.class.isInstance(instance)) {
+            return (AdditionalDataBuilder<S>) DefaultGeneralData.builder((GeneralData) instance);
+        } else {
+            throw new IllegalArgumentException("Unsupported instance: " + instance);
+        }
+    }
+}

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/AdditionalDataSpec.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/AdditionalDataSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,10 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.reflect.validation;
+package org.gradle.api.problems.internal;
 
-import org.gradle.api.NonNullApi;
-import org.gradle.api.problems.internal.InternalProblemSpec;
-
-import javax.annotation.Nullable;
-
-@NonNullApi
-public interface TypeAwareProblemBuilder extends InternalProblemSpec {
-    TypeAwareProblemBuilder withAnnotationType(@Nullable Class<?> classWithAnnotationAttached);
-
-    TypeAwareProblemBuilder forProperty(String propertyName);
-
-    TypeAwareProblemBuilder parentProperty(@Nullable String parentProperty);
+/**
+ * Marker interface for additional data that can be attached to a {@link Problem}.
+ */
+public interface AdditionalDataSpec {
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultDeprecationData.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultDeprecationData.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.problems.internal;
+
+public class DefaultDeprecationData implements DeprecationData {
+
+    private final Type type;
+
+    public DefaultDeprecationData(Type type) {
+        this.type = type;
+    }
+
+    @Override
+    public Type getType() {
+        return type;
+    }
+
+    public static AdditionalDataBuilder<DeprecationData> builder() {
+        return new DefaultDeprecationDataBuilder();
+    }
+
+    public static AdditionalDataBuilder<DeprecationData> builder(DeprecationData from) {
+        return new DefaultDeprecationDataBuilder(from);
+    }
+
+    private static class DefaultDeprecationDataBuilder implements DeprecationDataSpec, AdditionalDataBuilder<DeprecationData> {
+
+        private Type type;
+
+        public DefaultDeprecationDataBuilder() {
+            this.type = Type.USER_CODE_DIRECT;
+        }
+        public DefaultDeprecationDataBuilder(DeprecationData from) {
+            this.type = from.getType();
+        }
+
+        @Override
+        public DeprecationDataSpec type(Type type) {
+            this.type = type;
+            return this;
+        }
+
+        @Override
+        public DeprecationData build() {
+            return new DefaultDeprecationData(type);
+        }
+    }
+}

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultGeneralData.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultGeneralData.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.problems.internal;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.io.Serializable;
+import java.util.Map;
+
+public class DefaultGeneralData implements GeneralData, Serializable {
+
+    private final Map<String, String> map;
+
+    public DefaultGeneralData(Map<String, String> map) {
+        this.map = ImmutableMap.copyOf(map);
+    }
+
+    @Override
+    public Map<String, String> getAsMap() {
+        return map;
+    }
+
+    public static AdditionalDataBuilder<GeneralData> builder() {
+        return new DefaultGeneralDataBuilder();
+    }
+
+    public static AdditionalDataBuilder<GeneralData> builder(GeneralData from) {
+        return new DefaultGeneralDataBuilder(from);
+    }
+
+    private static class DefaultGeneralDataBuilder implements GeneralDataSpec, AdditionalDataBuilder<GeneralData> {
+        private final ImmutableMap.Builder<String, String> mapBuilder = ImmutableMap.builder();
+
+        private DefaultGeneralDataBuilder() {
+        }
+
+        private DefaultGeneralDataBuilder(GeneralData from) {
+            mapBuilder.putAll(from.getAsMap());
+        }
+
+        @Override
+        public GeneralDataSpec put(String key, String value) {
+            mapBuilder.put(key, value);
+            return this;
+        }
+
+        @Override
+        public GeneralData build() {
+            return new DefaultGeneralData(mapBuilder.build());
+        }
+    }
+}

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblem.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblem.java
@@ -22,7 +22,6 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 @NonNullApi
 public class DefaultProblem implements Serializable, Problem {
@@ -32,7 +31,7 @@ public class DefaultProblem implements Serializable, Problem {
     private final List<ProblemLocation> problemLocations;
     private final String details;
     private final RuntimeException exception;
-    private final Map<String, Object> additionalData;
+    private final AdditionalData additionalData;
 
     protected DefaultProblem(
         ProblemDefinition problemDefinition,
@@ -41,7 +40,7 @@ public class DefaultProblem implements Serializable, Problem {
         List<ProblemLocation> problemLocations,
         @Nullable String details,
         RuntimeException exception,
-        Map<String, Object> additionalData
+        @Nullable AdditionalData additionalData
     ) {
         this.problemDefinition = problemDefinition;
         this.contextualLabel = contextualLabel;
@@ -86,7 +85,7 @@ public class DefaultProblem implements Serializable, Problem {
     }
 
     @Override
-    public Map<String, Object> getAdditionalData() {
+    public AdditionalData getAdditionalData() {
         return additionalData;
     }
 

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultTypeValidationData.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultTypeValidationData.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.problems.internal;
+
+import java.io.Serializable;
+
+public class DefaultTypeValidationData implements TypeValidationData, Serializable {
+
+    private final String pluginId;
+    private final String propertyName;
+    private final String parentPropertyName;
+    private final String typeName;
+
+    public DefaultTypeValidationData(String pluginId, String propertyName, String parentPropertyName, String typeName) {
+        this.pluginId = pluginId;
+        this.propertyName = propertyName;
+        this.parentPropertyName = parentPropertyName;
+        this.typeName = typeName;
+    }
+
+    @Override
+    public String getPluginId() {
+        return pluginId;
+    }
+
+    @Override
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    @Override
+    public String getParentPropertyName() {
+        return parentPropertyName;
+    }
+
+    @Override
+    public String getTypeName() {
+        return typeName;
+    }
+
+    public static DefaultTypeValidationDataBuilder builder() {
+        return new DefaultTypeValidationDataBuilder();
+    }
+
+    public static AdditionalDataBuilder<TypeValidationData> builder(TypeValidationData from) {
+        return new DefaultTypeValidationDataBuilder(from);
+    }
+
+    private static class DefaultTypeValidationDataBuilder implements TypeValidationDataSpec, AdditionalDataBuilder<TypeValidationData> {
+
+        private String pluginId;
+        private String propertyName;
+        private String parentPropertyName;
+        private String typeName;
+
+        public DefaultTypeValidationDataBuilder() {
+        }
+
+        public DefaultTypeValidationDataBuilder(TypeValidationData from) {
+            this.pluginId = from.getPluginId();
+            this.propertyName = from.getPropertyName();
+            this.parentPropertyName = from.getParentPropertyName();
+            this.typeName = from.getTypeName();
+        }
+
+        @Override
+        public DefaultTypeValidationData build() {
+            return new DefaultTypeValidationData(pluginId, propertyName, parentPropertyName, typeName);
+        }
+
+        @Override
+        public TypeValidationDataSpec pluginId(String pluginId) {
+            this.pluginId = pluginId;
+            return this;
+        }
+
+        @Override
+        public TypeValidationDataSpec propertyName(String propertyName) {
+            this.propertyName = propertyName;
+            return this;
+        }
+
+        @Override
+        public TypeValidationDataSpec parentPropertyName(String parentPropertyName) {
+            this.parentPropertyName = parentPropertyName;
+            return this;
+        }
+
+        @Override
+        public TypeValidationDataSpec typeName(String typeName) {
+            this.typeName = typeName;
+            return this;
+        }
+    }
+}

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DeprecationData.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DeprecationData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.reflect.validation;
+package org.gradle.api.problems.internal;
 
-import org.gradle.api.NonNullApi;
-import org.gradle.api.problems.internal.InternalProblemSpec;
+/**
+ * Additional data type that can be used to attach deprecation information to a problem.
+ */
+public interface DeprecationData extends AdditionalData {
 
-import javax.annotation.Nullable;
+    enum Type {
+        USER_CODE_DIRECT,
+        USER_CODE_INDIRECT,
+        BUILD_INVOCATION
+    }
 
-@NonNullApi
-public interface TypeAwareProblemBuilder extends InternalProblemSpec {
-    TypeAwareProblemBuilder withAnnotationType(@Nullable Class<?> classWithAnnotationAttached);
-
-    TypeAwareProblemBuilder forProperty(String propertyName);
-
-    TypeAwareProblemBuilder parentProperty(@Nullable String parentProperty);
+    Type getType();
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DeprecationDataSpec.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DeprecationDataSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,11 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.reflect.validation;
+package org.gradle.api.problems.internal;
 
-import org.gradle.api.NonNullApi;
-import org.gradle.api.problems.internal.InternalProblemSpec;
-
-import javax.annotation.Nullable;
-
-@NonNullApi
-public interface TypeAwareProblemBuilder extends InternalProblemSpec {
-    TypeAwareProblemBuilder withAnnotationType(@Nullable Class<?> classWithAnnotationAttached);
-
-    TypeAwareProblemBuilder forProperty(String propertyName);
-
-    TypeAwareProblemBuilder parentProperty(@Nullable String parentProperty);
+/**
+ * Specifies configuration options when creating a new DeprecationData instance.
+ */
+public interface DeprecationDataSpec extends AdditionalDataSpec {
+    DeprecationDataSpec type(DeprecationData.Type type);
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/GeneralData.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/GeneralData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,14 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.reflect.validation;
+package org.gradle.api.problems.internal;
 
-import org.gradle.api.NonNullApi;
-import org.gradle.api.problems.internal.InternalProblemSpec;
+import java.util.Map;
 
-import javax.annotation.Nullable;
+/**
+ * General additional data type that can be used to attach arbitrary data to a problem with a string map.
+ */
+public interface GeneralData extends AdditionalData {
 
-@NonNullApi
-public interface TypeAwareProblemBuilder extends InternalProblemSpec {
-    TypeAwareProblemBuilder withAnnotationType(@Nullable Class<?> classWithAnnotationAttached);
-
-    TypeAwareProblemBuilder forProperty(String propertyName);
-
-    TypeAwareProblemBuilder parentProperty(@Nullable String parentProperty);
+    Map<String, String> getAsMap();
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/GeneralDataSpec.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/GeneralDataSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,11 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.reflect.validation;
+package org.gradle.api.problems.internal;
 
-import org.gradle.api.NonNullApi;
-import org.gradle.api.problems.internal.InternalProblemSpec;
-
-import javax.annotation.Nullable;
-
-@NonNullApi
-public interface TypeAwareProblemBuilder extends InternalProblemSpec {
-    TypeAwareProblemBuilder withAnnotationType(@Nullable Class<?> classWithAnnotationAttached);
-
-    TypeAwareProblemBuilder forProperty(String propertyName);
-
-    TypeAwareProblemBuilder parentProperty(@Nullable String parentProperty);
+/**
+ * Specifies configuration options when creating a new GeneralData instance.
+ */
+public interface GeneralDataSpec extends AdditionalDataSpec {
+    GeneralDataSpec put(String key, String value);
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblemBuilder.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblemBuilder.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.problems.internal;
 
+import org.gradle.api.Action;
 import org.gradle.api.problems.ProblemGroup;
 import org.gradle.api.problems.Severity;
 
@@ -71,7 +72,7 @@ public interface InternalProblemBuilder extends InternalProblemSpec {
     InternalProblemBuilder solution(String solution);
 
     @Override
-    InternalProblemBuilder additionalData(String key, Object value);
+    <U extends AdditionalDataSpec> InternalProblemBuilder additionalData(Class<? extends U> specType, Action<? super U> config);
 
     @Override
     InternalProblemBuilder withException(RuntimeException e);

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblemSpec.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblemSpec.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.problems.internal;
 
+import org.gradle.api.Action;
 import org.gradle.api.problems.ProblemGroup;
 import org.gradle.api.problems.ProblemSpec;
 import org.gradle.api.problems.Severity;
@@ -25,14 +26,18 @@ import javax.annotation.Nullable;
 public interface InternalProblemSpec extends ProblemSpec {
 
     /**
-     * Specifies arbitrary data associated with this problem.
+     * Attaches additional data describing the problem.
      * <p>
-     * The only supported value type is {@link String}. Future Gradle versions may support additional types.
+     * Only the types listed for {@link AdditionalData} can be used as arguments, otherwise an invalid problem report will be created.
+     * <p>
+     * If not additional data was configured for this problem, then a new instance will be created. If additional data was already configured, then the existing instance will be used and the configuration will be applied to it.
      *
+     * @param specType the type of the additional data configurer (see the AdditionalDataSpec interface for the list of supported types)
+     * @param config  The action configuring the additional data
      * @return this
-     * @throws RuntimeException for null values and for values with unsupported type.
+     * @param <U> The type of the configurator object that will be applied to the additional data
      */
-    InternalProblemSpec additionalData(String key, Object value);
+    <U extends AdditionalDataSpec> InternalProblemSpec additionalData(Class<? extends U> specType, Action<? super U> config);
 
     /**
      * Declares that this problem was emitted by a task with the given path.

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/Problem.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/Problem.java
@@ -18,7 +18,6 @@ package org.gradle.api.problems.internal;
 
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Interface for describing structured information about a problem.
@@ -61,9 +60,10 @@ public interface Problem {
     /**
      * Additional data attached to the problem.
      * <p>
-     * The only supported value type is {@link String}.
+     * The supported types are listed on {@link AdditionalData}.
      */
-    Map<String, Object> getAdditionalData();
+    @Nullable
+    AdditionalData getAdditionalData();
 
     /**
      * Returns a problem builder with fields initialized with values from this instance.

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/TypeValidationData.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/TypeValidationData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,14 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.reflect.validation;
+package org.gradle.api.problems.internal;
 
-import org.gradle.api.NonNullApi;
-import org.gradle.api.problems.internal.InternalProblemSpec;
-
-import javax.annotation.Nullable;
-
-@NonNullApi
-public interface TypeAwareProblemBuilder extends InternalProblemSpec {
-    TypeAwareProblemBuilder withAnnotationType(@Nullable Class<?> classWithAnnotationAttached);
-
-    TypeAwareProblemBuilder forProperty(String propertyName);
-
-    TypeAwareProblemBuilder parentProperty(@Nullable String parentProperty);
+/**
+ * Additional data type that can be used to attach type validation information to a problem.
+ */
+public interface TypeValidationData extends AdditionalData {
+    String getPluginId();
+    String getPropertyName();
+    String getParentPropertyName();
+    String getTypeName();
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/TypeValidationDataSpec.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/TypeValidationDataSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,14 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.reflect.validation;
+package org.gradle.api.problems.internal;
 
-import org.gradle.api.NonNullApi;
-import org.gradle.api.problems.internal.InternalProblemSpec;
-
-import javax.annotation.Nullable;
-
-@NonNullApi
-public interface TypeAwareProblemBuilder extends InternalProblemSpec {
-    TypeAwareProblemBuilder withAnnotationType(@Nullable Class<?> classWithAnnotationAttached);
-
-    TypeAwareProblemBuilder forProperty(String propertyName);
-
-    TypeAwareProblemBuilder parentProperty(@Nullable String parentProperty);
+/**
+ * Specifies configuration options when creating a new TypeValidationData instance.
+ */
+public interface TypeValidationDataSpec extends AdditionalDataSpec {
+    TypeValidationDataSpec pluginId(String pluginId);
+    TypeValidationDataSpec propertyName(String propertyName);
+    TypeValidationDataSpec parentPropertyName(String parentPropertyName);
+    TypeValidationDataSpec typeName(String typeName);
 }

--- a/platforms/ide/problems-api/src/test/groovy/org/gradle/api/problems/internal/DefaultProblemTest.groovy
+++ b/platforms/ide/problems-api/src/test/groovy/org/gradle/api/problems/internal/DefaultProblemTest.groovy
@@ -25,6 +25,7 @@ import spock.lang.Specification
 
 class DefaultProblemTest extends Specification {
     def "unbound builder result is equal to original"() {
+        def additionalData = Mock(AdditionalData)
         def problem = createTestProblem(severity, additionalData)
 
         def newProblem = problem.toBuilder().build()
@@ -41,9 +42,7 @@ class DefaultProblemTest extends Specification {
         newProblem == problem
 
         where:
-        severity         | additionalData
-        Severity.WARNING | [:]
-        Severity.ERROR   | [data1: "data2"]
+        severity << [Severity.WARNING, Severity.ERROR]
     }
 
     def "unbound builder result with modified #changedAspect is not equal"() {
@@ -62,7 +61,6 @@ class DefaultProblemTest extends Specification {
         where:
         changedAspect | changeClosure
         "severity"    | { it.severity(Severity.WARNING) }
-        "additionalData" | { it.additionalData("asdf", "adsf") }
         "locations"   | { it.fileLocation("file") }
         "details"     | { it.details("details") }
     }
@@ -72,7 +70,7 @@ class DefaultProblemTest extends Specification {
         given:
         def emitter = Mock(ProblemEmitter)
         def problemReporter = new DefaultProblemReporter(emitter, [], org.gradle.internal.operations.CurrentBuildOperationRef.instance(), HashMultimap.create())
-        def problem = createTestProblem(Severity.WARNING, [:])
+        def problem = createTestProblem(Severity.WARNING)
         def builder = problem.toBuilder()
         def newProblem = builder
             .solution("solution")
@@ -97,7 +95,7 @@ class DefaultProblemTest extends Specification {
         newProblem.class == DefaultProblem
     }
 
-    private static createTestProblem(Severity severity = Severity.ERROR, Map<String, String> additionalData = [data1: "data2"]) {
+    private static createTestProblem(Severity severity = Severity.ERROR, AdditionalData additionalData = null) {
         new DefaultProblem(
             new DefaultProblemDefinition(
                 new DefaultProblemId('message', "displayName", SharedProblemGroup.generic()),
@@ -126,7 +124,7 @@ class DefaultProblemTest extends Specification {
             [],
             'description',
             new RuntimeException('cause'),
-            [:]
+            null
         )
 
         when:

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ProblemsProgressEventConsumer.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ProblemsProgressEventConsumer.java
@@ -16,13 +16,17 @@
 
 package org.gradle.tooling.internal.provider.runner;
 
+import com.google.common.collect.ImmutableMap;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.problems.ProblemGroup;
 import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.Severity;
+import org.gradle.api.problems.internal.AdditionalData;
 import org.gradle.api.problems.internal.DefaultProblemProgressDetails;
+import org.gradle.api.problems.internal.DeprecationData;
 import org.gradle.api.problems.internal.DocLink;
 import org.gradle.api.problems.internal.FileLocation;
+import org.gradle.api.problems.internal.GeneralData;
 import org.gradle.api.problems.internal.LineInFileLocation;
 import org.gradle.api.problems.internal.OffsetInFileLocation;
 import org.gradle.api.problems.internal.PluginIdLocation;
@@ -30,6 +34,7 @@ import org.gradle.api.problems.internal.Problem;
 import org.gradle.api.problems.internal.ProblemDefinition;
 import org.gradle.api.problems.internal.ProblemLocation;
 import org.gradle.api.problems.internal.TaskPathLocation;
+import org.gradle.api.problems.internal.TypeValidationData;
 import org.gradle.internal.build.event.types.DefaultAdditionalData;
 import org.gradle.internal.build.event.types.DefaultContextualLabel;
 import org.gradle.internal.build.event.types.DefaultDetails;
@@ -60,6 +65,7 @@ import org.gradle.tooling.internal.protocol.problem.InternalSeverity;
 import org.gradle.tooling.internal.protocol.problem.InternalSolution;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -200,12 +206,31 @@ public class ProblemsProgressEventConsumer extends ClientForwardingBuildOperatio
             .collect(toImmutableList());
     }
 
-    private static InternalAdditionalData toInternalAdditionalData(Map<String, Object> additionalData) {
-        return new DefaultAdditionalData(
-            additionalData.entrySet().stream()
-                .filter(entry -> isSupportedType(entry.getValue()))
-                .collect(toMap(Map.Entry::getKey, Map.Entry::getValue))
-        );
+
+    @SuppressWarnings("unchecked")
+    private static InternalAdditionalData toInternalAdditionalData(@Nullable AdditionalData additionalData) {
+        if (additionalData instanceof DeprecationData) {
+            // For now, we only expose deprecation data to the tooling API with generic additional data
+            DeprecationData data = (DeprecationData) additionalData;
+            return new DefaultAdditionalData(ImmutableMap.of("type", data.getType().name()));
+        } else if (additionalData instanceof TypeValidationData) {
+            TypeValidationData data = (TypeValidationData) additionalData;
+            ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
+            Optional.ofNullable(data.getPluginId()).ifPresent(pluginId -> builder.put("pluginId", pluginId));
+            Optional.ofNullable(data.getPropertyName()).ifPresent(propertyName -> builder.put("propertyName", propertyName));
+            Optional.ofNullable(data.getParentPropertyName()).ifPresent(parentPropertyName -> builder.put("parentPropertyName", parentPropertyName));
+            Optional.ofNullable(data.getTypeName()).ifPresent(typeName -> builder.put("typeName", typeName));
+            return new DefaultAdditionalData(builder.build());
+        } else if (additionalData instanceof GeneralData) {
+            GeneralData data = (GeneralData) additionalData;
+            return new DefaultAdditionalData(
+                data.getAsMap().entrySet().stream()
+                    .filter(entry -> isSupportedType(entry.getValue()))
+                    .collect(toMap(Map.Entry::getKey, Map.Entry::getValue))
+            );
+        } else {
+            return new DefaultAdditionalData(Collections.emptyMap());
+        }
     }
 
     private static boolean isSupportedType(Object type) {

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r86/ProblemsServiceModelBuilderCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r86/ProblemsServiceModelBuilderCrossVersionTest.groovy
@@ -63,7 +63,7 @@ class ProblemsServiceModelBuilderCrossVersionTest extends ToolingApiSpecificatio
                         it.${targetVersion < GradleVersion.version("8.8") ? 'label("label").category("testcategory")' : 'id("testcategory", "label")'}
                             .withException(new RuntimeException("test"))
                             ${pre86api ? ".undocumented()" : ""}
-                            ${includeAdditionalMetadata ? ".additionalData(\"keyToString\", \"value\")" : ""}
+                            ${includeAdditionalMetadata ? targetVersion < GradleVersion.version("8.9") ? '.additionalData("keyToString", "value")"' : '.additionalData(org.gradle.api.problems.internal.GeneralData) { it.put("keyToString", "value") }' : ""}
                     }${pre86api ? ".report()" : ""}
                     return new CustomModel()
                 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r89/ProblemProgressEventCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r89/ProblemProgressEventCrossVersionTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.tooling.events.ProgressListener
 import org.gradle.tooling.events.problems.LineInFileLocation
 import org.gradle.tooling.events.problems.Severity
 import org.gradle.tooling.events.problems.SingleProblemEvent
+import org.gradle.tooling.events.problems.internal.GeneralData
 import org.gradle.util.GradleVersion
 import org.junit.Assume
 
@@ -90,6 +91,8 @@ class ProblemProgressEventCrossVersionTest extends ToolingApiSpecification {
             locations.size() == 2
             (locations[0] as LineInFileLocation).path == "build file '$buildFile.path'" // FIXME: the path should not contain a prefix nor extra quotes
             (locations[1] as LineInFileLocation).path == "build file '$buildFile.path'"
+            additionalData instanceof GeneralData
+            additionalData.asMap['type'] == 'USER_CODE_DIRECT'
         }
     }
 
@@ -101,7 +104,7 @@ class ProblemProgressEventCrossVersionTest extends ToolingApiSpecification {
                 $documentationConfig
                 .lineInFileLocation("/tmp/foo", 1, 2, 3)
                 $detailsConfig
-                .additionalData("aKey", "aValue")
+                .additionalData(org.gradle.api.problems.internal.GeneralDataSpec, data -> data.put("aKey", "aValue"))
                 .severity(Severity.WARNING)
                 .solution("try this instead")
             }
@@ -137,7 +140,7 @@ class ProblemProgressEventCrossVersionTest extends ToolingApiSpecification {
                 $documentationConfig
                 .lineInFileLocation("/tmp/foo", 1, 2, 3)
                 $detailsConfig
-                .additionalData("aKey", "aValue")
+                .additionalData(org.gradle.api.problems.internal.GeneralDataSpec, data -> data.put("aKey", "aValue"))
                 .severity(Severity.WARNING)
                 .solution("try this instead")
             }
@@ -261,6 +264,7 @@ class ProblemProgressEventCrossVersionTest extends ToolingApiSpecification {
         then:
         thrown(BuildException)
         listener.problems.size() == 1
+        (listener.problems[0].additionalData as GeneralData).asMap['typeName']== 'MyTask'
     }
 
     @TargetGradleVersion("=8.6")
@@ -286,7 +290,6 @@ class ProblemProgressEventCrossVersionTest extends ToolingApiSpecification {
         validateCompilationProblem(problems, buildFile)
         problems[0].failure.failure == null
     }
-
 
     class ProblemProgressListener implements ProgressListener {
 

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/SingleProblemEvent.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/SingleProblemEvent.java
@@ -77,4 +77,12 @@ public interface SingleProblemEvent extends ProblemEvent {
      */
     @Nullable
     FailureContainer getFailure();
+
+    /**
+     * Returns the additional data associated with this problem.
+     *
+     * @return the additional data
+     * @since 8.9
+     */
+    AdditionalData getAdditionalData();
 }

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/internal/DefaultSingleProblemEvent.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/internal/DefaultSingleProblemEvent.java
@@ -92,6 +92,7 @@ public class DefaultSingleProblemEvent extends BaseProgressEvent implements Sing
         return failure;
     }
 
+    @Override
     public AdditionalData getAdditionalData() {
         return additionalData;
     }

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/internal/GeneralData.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/internal/GeneralData.java
@@ -22,11 +22,11 @@ import org.gradle.tooling.events.problems.AdditionalData;
 import java.io.Serializable;
 import java.util.Map;
 
-public class DefaultAdditionalData implements AdditionalData, Serializable {
+public class GeneralData implements AdditionalData, Serializable {
 
     private final Map<String, Object> additionalData;
 
-    public DefaultAdditionalData(Map<String, Object> additionalData) {
+    public GeneralData(Map<String, Object> additionalData) {
         this.additionalData = ImmutableMap.copyOf(additionalData);
     }
 

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapter.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapter.java
@@ -78,7 +78,6 @@ import org.gradle.tooling.events.problems.ProblemGroup;
 import org.gradle.tooling.events.problems.ProblemId;
 import org.gradle.tooling.events.problems.Severity;
 import org.gradle.tooling.events.problems.Solution;
-import org.gradle.tooling.events.problems.internal.DefaultAdditionalData;
 import org.gradle.tooling.events.problems.internal.DefaultContextualLabel;
 import org.gradle.tooling.events.problems.internal.DefaultDetails;
 import org.gradle.tooling.events.problems.internal.DefaultDocumentationLink;
@@ -97,6 +96,7 @@ import org.gradle.tooling.events.problems.internal.DefaultSeverity;
 import org.gradle.tooling.events.problems.internal.DefaultSingleProblemEvent;
 import org.gradle.tooling.events.problems.internal.DefaultSolution;
 import org.gradle.tooling.events.problems.internal.DefaultTaskPathLocation;
+import org.gradle.tooling.events.problems.internal.GeneralData;
 import org.gradle.tooling.events.task.TaskFinishEvent;
 import org.gradle.tooling.events.task.TaskOperationDescriptor;
 import org.gradle.tooling.events.task.TaskOperationResult;
@@ -884,7 +884,7 @@ public class BuildProgressListenerAdapter implements InternalBuildProgressListen
     }
 
     private static AdditionalData toAdditionalData(InternalAdditionalData additionalData) {
-        return new DefaultAdditionalData(additionalData.getAsMap());
+        return new GeneralData(additionalData.getAsMap());
     }
 
     private static ContextualLabel toContextualLabel(@Nullable InternalContextualLabel contextualLabel) {

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileProblemsIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileProblemsIntegrationTest.groovy
@@ -258,7 +258,7 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec impleme
             fqid == 'compilation:java:java-compilation-error'
             details == 'warnings found and -Werror specified'
             solutions.empty
-            additionalData["formatted"] == "error: warnings found and -Werror specified"
+            additionalData.asMap == ["formatted" : "error: warnings found and -Werror specified"]
         }
 
         // Based on the Java version, the types in the lint message will differ...
@@ -286,18 +286,18 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec impleme
                 it.offset == 189
                 it.length == 21
             }
-            additionalData["formatted"] == """$fooFileLocation:5: warning: [cast] redundant cast to $expectedType
+            additionalData.asMap == ["formatted" : """$fooFileLocation:5: warning: [cast] redundant cast to $expectedType
                     String s = (String)"Hello World";
-                               ^"""
+                               ^"""]
         }
         verifyAll(receivedProblem(2)) {
             assertProblem(it, "WARNING", true)
             fqid == 'compilation:java:java-compilation-warning'
             details == 'redundant cast to java.lang.String'
             solutions.empty
-            additionalData["formatted"] == """${fooFileLocation}:10: warning: [cast] redundant cast to $expectedType
+            additionalData.asMap == ["formatted" : """${fooFileLocation}:10: warning: [cast] redundant cast to $expectedType
                     String s = (String)"Hello World";
-                               ^"""
+                               ^"""]
         }
     }
 
@@ -404,13 +404,13 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec impleme
             assertProblem(it, "WARNING", true)
             fqid == 'compilation:java:java-compilation-warning'
             details == 'redundant cast to java.lang.String'
-            additionalData == [ 'formatted' : 'redundant cast to java.lang.String' ]
+            additionalData.asMap == [ 'formatted' : 'redundant cast to java.lang.String' ]
         }
         verifyAll(receivedProblem(1)) {
             assertProblem(it, "WARNING", true)
             fqid == 'compilation:java:java-compilation-warning'
             details == 'redundant cast to java.lang.String'
-            additionalData == [ 'formatted' : 'redundant cast to java.lang.String' ]
+            additionalData.asMap == [ 'formatted' : 'redundant cast to java.lang.String' ]
         }
     }
 

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
@@ -28,6 +28,7 @@ import org.gradle.api.logging.Logging;
 import org.gradle.api.problems.ProblemSpec;
 import org.gradle.api.problems.Problems;
 import org.gradle.api.problems.Severity;
+import org.gradle.api.problems.internal.GeneralDataSpec;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblemReporter;
 import org.gradle.api.problems.internal.InternalProblemSpec;
@@ -89,10 +90,7 @@ public class DiagnosticToProblemListener implements DiagnosticListener<JavaFileO
     private void addFormattedMessage(ProblemSpec spec, Diagnostic<? extends JavaFileObject> diagnostic) {
         String formatted = messageFormatter.apply(diagnostic);
         System.err.println(formatted);
-
-        ((InternalProblemSpec) spec).additionalData(
-            "formatted", formatted
-        );
+        ((InternalProblemSpec) spec).additionalData(GeneralDataSpec.class, data -> data.put("formatted", formatted)); // TODO (donat) Introduce custom additional data type for compilation problems
     }
 
     private static void addDetails(ProblemSpec spec, Diagnostic<? extends JavaFileObject> diagnostic) {

--- a/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListenerTest.groovy
+++ b/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListenerTest.groovy
@@ -27,7 +27,7 @@ class DiagnosticToProblemListenerTest extends Specification {
 
     def spec = Mock(InternalProblemSpec) {
         // We report the formatted message in all cases
-        1 * additionalData("formatted", "Formatted message")
+        1 * additionalData(org.gradle.api.problems.internal.GeneralDataSpec, _)
     }
 
     def diagnosticToProblemListener = new DiagnosticToProblemListener(null, (fo) -> "Formatted message")

--- a/platforms/jvm/plugins-java-library/src/integTest/groovy/org/gradle/java/JavaLibraryDocumentationIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java-library/src/integTest/groovy/org/gradle/java/JavaLibraryDocumentationIntegrationTest.groovy
@@ -113,7 +113,7 @@ class JavaLibraryDocumentationIntegrationTest extends AbstractIntegrationSpec {
         verifyAll(receivedProblem) {
             fqid == 'task-selection:no-matches'
             contextualLabel == 'Cannot locate tasks that match \':a:javadocJar\' as task \'javadocJar\' not found in project \':a\'. Some candidates are: \'javadoc\'.'
-            additionalData == [ 'requestedPath' : ':a:javadocJar']
+            additionalData.asMap == [ 'requestedPath' : ':a:javadocJar']
         }
 
         when:
@@ -137,7 +137,7 @@ class JavaLibraryDocumentationIntegrationTest extends AbstractIntegrationSpec {
         verifyAll(receivedProblem) {
             fqid == 'task-selection:selection-failed'
             contextualLabel == 'Cannot locate tasks that match \':a:sourcesJar\' as task \'sourcesJar\' not found in project \':a\'.'
-            additionalData == [ 'requestedPath' : ':a:sourcesJar']
+            additionalData.asMap == [ 'requestedPath' : ':a:sourcesJar']
         }
 
         when:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/TomlDependenciesExtensionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/TomlDependenciesExtensionIntegrationTest.groovy
@@ -808,14 +808,14 @@ key2=
             contextualLabel == 'Unexpected end of line, expected \', ", \'\'\', """, a number, a boolean, a date/time, an array, or a table'
             details == 'TOML syntax invalid.'
             solutions == [ 'Fix the TOML file according to the syntax described at https://toml.io' ]
-            additionalData == [:]
+            additionalData.asMap.isEmpty()
         }
         verifyAll(receivedProblem(1)) {
             fqid == 'dependency-version-catalog:toml-syntax-error'
             contextualLabel == 'Unexpected end of line, expected \', ", \'\'\', """, a number, a boolean, a date/time, an array, or a table'
             details == 'TOML syntax invalid.'
             solutions == [ 'Fix the TOML file according to the syntax described at https://toml.io' ]
-            additionalData == [:]
+            additionalData.asMap.isEmpty()
         }
     }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -221,7 +221,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
                     contextualLabel == "Property \'output\' points to \'${reserved.absolutePath}\' which is managed by Gradle"
                     details == 'Trying to write an output to a read-only location which is for Gradle internal use only'
                     solutions == ['Select a different output location']
-                    additionalData == [
+                    additionalData.asMap == [
                         'typeName': 'org.gradle.api.DefaultTask',
                         'propertyName': 'output',
                     ]

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionSymlinkIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionSymlinkIntegrationTest.groovy
@@ -400,7 +400,7 @@ class FileCollectionSymlinkIntegrationTest extends AbstractIntegrationSpec imple
                 "Make sure the ${inputNameLc} exists before the task is called",
                 "Make sure that the task which produces the $inputNameLc is declared as an input",
             ].collect{it.toString() }
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'CustomTask',
                 'propertyName' : 'brokenInputFile',
             ]

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
@@ -185,9 +185,8 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
             contextualLabel == 'Additional action of task \':customTask\' was loaded with an unknown classloader (class \'CustomTask_Decorated\').'
             details == 'Gradle cannot track the implementation for classes loaded with an unknown classloader.'
             solutions == [ 'Load your class by using one of Gradle\'s built-in ways.' ]
-            additionalData == [
-                'typeName' : 'CustomTask',
-                'typeIsIrrelevantInErrorMessage' : 'true',
+            additionalData.asMap == [
+                'typeName' : 'CustomTask'
             ]
         }
         verifyAll(receivedProblem(1)) {
@@ -195,9 +194,8 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
             contextualLabel == 'Implementation of task \':customTask\' was loaded with an unknown classloader (class \'CustomTask_Decorated\').'
             details == 'Gradle cannot track the implementation for classes loaded with an unknown classloader.'
             solutions == [ 'Load your class by using one of Gradle\'s built-in ways.' ]
-            additionalData == [
-                'typeName' : 'CustomTask',
-                'typeIsIrrelevantInErrorMessage' : 'true',
+            additionalData.asMap == [
+                'typeName' : 'CustomTask'
             ]
         }
     }
@@ -239,9 +237,8 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
             contextualLabel == 'Additional action of task \':customTask\' was loaded with an unknown classloader (class \'A\').'
             details == 'Gradle cannot track the implementation for classes loaded with an unknown classloader.'
             solutions == [ 'Load your class by using one of Gradle\'s built-in ways.' ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'CustomTask',
-                'typeIsIrrelevantInErrorMessage' : 'true',
             ]
         }
 
@@ -554,10 +551,9 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
             contextualLabel == "Property 'bean' was loaded with an unknown classloader (class 'A')."
             details == 'Gradle cannot track the implementation for classes loaded with an unknown classloader.'
             solutions == [ 'Load your class by using one of Gradle\'s built-in ways.' ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'CustomTask',
-                'propertyName' : 'bean',
-                'typeIsIrrelevantInErrorMessage' : 'true',
+                'propertyName' : 'bean'
             ]
         }
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputFilePropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputFilePropertiesIntegrationTest.groovy
@@ -109,7 +109,7 @@ class TaskInputFilePropertiesIntegrationTest extends AbstractIntegrationSpec imp
                 'Use a URI or URL instance',
                 'Use a TextResource instance',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'org.gradle.api.DefaultTask',
                 'propertyName' : 'input',
             ]
@@ -177,7 +177,7 @@ class TaskInputFilePropertiesIntegrationTest extends AbstractIntegrationSpec imp
                 'Use a URI or URL instance',
                 'Use a TextResource instance',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'CustomTask',
                 'propertyName' : 'input',
             ]
@@ -270,7 +270,7 @@ class TaskInputFilePropertiesIntegrationTest extends AbstractIntegrationSpec imp
                 'Assign a value to \'bar\'',
                 'Mark property \'bar\' as optional',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'FooTask',
                 'propertyName' : 'bar',
             ]

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
@@ -705,7 +705,7 @@ task someTask(type: SomeTask) {
                 "Use a $fileType as an input",
                 "Declare the input as a ${getOppositeKind(fileType)} instead",
             ].collect { it.toString() }
-            additionalData == [
+            additionalData.asMap == [
                 'typeName': 'org.gradle.api.DefaultTask',
                 'propertyName': 'input',
             ]
@@ -746,7 +746,7 @@ task someTask(type: SomeTask) {
                 'Configure \'output\' to point to a file, not a directory',
                 'Annotate \'output\' with @OutputDirectory instead of @OutputFiles',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'org.gradle.api.DefaultTask',
                 'propertyName' : 'output',
             ]
@@ -783,7 +783,7 @@ task someTask(type: SomeTask) {
             contextualLabel == "Property \'output\' is not writable because \'${outputFile.absolutePath}\' is not a directory"
             details == "Expected \'${outputFile.absolutePath}\' to be a directory but it\'s a file"
             solutions == [ 'Make sure that the \'output\' is configured to a directory' ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'org.gradle.api.DefaultTask',
                 'propertyName' : 'output',
             ]
@@ -826,7 +826,7 @@ task someTask(type: SomeTask) {
             contextualLabel == "Property \'output\' is not writable because \'${outputFile.absolutePath}\' is not a directory"
             details == "Expected the root of the file tree \'${outputFile.absolutePath}\' to be a directory but it\'s a file"
             solutions == [ 'Make sure that the root of the file tree \'output\' is configured to a directory' ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'org.gradle.api.DefaultTask',
                 'propertyName' : 'output',
             ]

--- a/subprojects/core/src/main/java/org/gradle/execution/DefaultTaskSelector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DefaultTaskSelector.java
@@ -23,6 +23,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.problems.ProblemSpec;
 import org.gradle.api.problems.Severity;
+import org.gradle.api.problems.internal.GeneralDataSpec;
 import org.gradle.api.problems.internal.InternalProblemSpec;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.api.specs.Spec;
@@ -113,7 +114,7 @@ public class DefaultTaskSelector implements TaskSelector {
 
     private static ProblemSpec configureProblem(ProblemSpec spec, NameMatcher matcher, SelectionContext context) {
         matcher.configureProblemId(spec);
-        ((InternalProblemSpec) spec).additionalData("requestedPath", Objects.requireNonNull(context.getOriginalPath().getPath()));
+        ((InternalProblemSpec) spec).additionalData(GeneralDataSpec.class, data -> data.put("requestedPath", Objects.requireNonNull(context.getOriginalPath().getPath())));
         spec.severity(Severity.ERROR);
         return spec;
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/MissingTaskDependencyDetector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/MissingTaskDependencyDetector.java
@@ -171,8 +171,7 @@ public class MissingTaskDependencyDetector {
 
     private void collectValidationProblem(Node producer, Node consumer, TypeValidationContext validationContext, String consumerProducerPath) {
         validationContext.visitPropertyProblem(problem ->
-            problem.typeIsIrrelevantInErrorMessage()
-                .id(TextUtil.screamingSnakeToKebabCase(IMPLICIT_DEPENDENCY), "Property has implicit dependency", GradleCoreProblemGroup.validation().property()) // TODO (donat) missing test coverage
+            problem.id(TextUtil.screamingSnakeToKebabCase(IMPLICIT_DEPENDENCY), "Property has implicit dependency", GradleCoreProblemGroup.validation().property()) // TODO (donat) missing test coverage
                 .contextualLabel("Gradle detected a problem with the following location: '" + consumerProducerPath + "'")
                 .documentedAt(userManual("validation_problems", IMPLICIT_DEPENDENCY.toLowerCase()))
                 .severity(Severity.ERROR)

--- a/subprojects/core/src/main/java/org/gradle/execution/selection/DefaultBuildTaskSelector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/selection/DefaultBuildTaskSelector.java
@@ -21,6 +21,7 @@ import org.gradle.api.Task;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.problems.ProblemSpec;
 import org.gradle.api.problems.Severity;
+import org.gradle.api.problems.internal.GeneralDataSpec;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblemSpec;
 import org.gradle.api.problems.internal.InternalProblems;
@@ -183,7 +184,7 @@ public class DefaultBuildTaskSelector implements BuildTaskSelector {
     private static void configureProblem(ProblemSpec spec, String message, String requestedPath, RuntimeException e) {
         spec.contextualLabel(message);
         spec.severity(Severity.ERROR);
-        ((InternalProblemSpec) spec).additionalData("requestedPath", Objects.requireNonNull(requestedPath));
+        ((InternalProblemSpec) spec).additionalData(GeneralDataSpec.class, data -> data.put("requestedPath", Objects.requireNonNull(requestedPath)));
         spec.withException(e);
     }
 

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskErrorExecutionIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskErrorExecutionIntegrationTest.groovy
@@ -147,7 +147,7 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
                 'Assign a value to \'destFile\'',
                 'Mark property \'destFile\' as optional',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'CustomTask',
                 'propertyName' : 'destFile',
             ]
@@ -159,7 +159,7 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
                 'Assign a value to \'srcFile\'',
                 'Mark property \'srcFile\' as optional',
             ]
-            additionalData == [
+            additionalData.asMap == [
                 'typeName' : 'CustomTask',
                 'propertyName' : 'srcFile',
             ]
@@ -186,7 +186,7 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
         verifyAll(receivedProblem) {
             fqid == 'task-selection:no-matches'
             contextualLabel == "Task 'someTest' not found in root project 'test' and its subprojects. Some candidates are: 'someTask', 'someTaskA', 'someTaskB'."
-            additionalData == ['requestedPath' : 'someTest']
+            additionalData.asMap == ['requestedPath' : 'someTest']
         }
         failure.assertHasDescription("Task 'someTest' not found in root project 'test' and its subprojects. Some candidates are: 'someTask', 'someTaskA', 'someTaskB'.")
         failure.assertHasResolutions(
@@ -203,7 +203,7 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
         verifyAll(receivedProblem) {
             fqid == 'task-selection:no-matches'
             contextualLabel == "Cannot locate tasks that match ':someTest' as task 'someTest' not found in root project 'test'. Some candidates are: 'someTask'."
-            additionalData == ['requestedPath' : ':someTest']
+            additionalData.asMap == ['requestedPath' : ':someTest']
         }
         failure.assertHasDescription("Cannot locate tasks that match ':someTest' as task 'someTest' not found in root project 'test'. Some candidates are: 'someTask'.")
         failure.assertHasResolutions(
@@ -220,7 +220,7 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
         verifyAll(receivedProblem) {
             fqid == 'task-selection:no-matches'
             contextualLabel == "Cannot locate tasks that match 'a:someTest' as task 'someTest' not found in project ':a'. Some candidates are: 'someTask', 'someTaskA'."
-            additionalData == ['requestedPath' : 'a:someTest']
+            additionalData.asMap == ['requestedPath' : 'a:someTest']
         }
         failure.assertHasDescription("Cannot locate tasks that match 'a:someTest' as task 'someTest' not found in project ':a'. Some candidates are: 'someTask', 'someTaskA'.")
         failure.assertHasResolutions(
@@ -259,7 +259,7 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
         verifyAll(receivedProblem) {
             fqid == 'task-selection:ambiguous-matches'
             contextualLabel == 'Task \'soTa\' is ambiguous in root project \'test\' and its subprojects. Candidates are: \'someTaskA\', \'someTaskAll\', \'someTaskB\'.'
-            additionalData == ['requestedPath' : 'soTa']
+            additionalData.asMap == ['requestedPath' : 'soTa']
         }
 
         when:
@@ -277,7 +277,7 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
         verifyAll(receivedProblem) {
             fqid == 'task-selection:ambiguous-matches'
             contextualLabel == 'Cannot locate tasks that match \'a:soTa\' as task \'soTa\' is ambiguous in project \':a\'. Candidates are: \'someTaskA\', \'someTaskAll\'.'
-            additionalData == ['requestedPath' : 'a:soTa']
+            additionalData.asMap == ['requestedPath' : 'a:soTa']
         }
     }
 
@@ -309,7 +309,7 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
         verifyAll(receivedProblem) {
             fqid == 'task-selection:no-matches'
             contextualLabel == 'Cannot locate tasks that match \'prog:someTask\' as project \'prog\' not found in root project \'test\'. Some candidates are: \'projA\', \'projB\'.'
-            additionalData == ['requestedPath' : 'prog:someTask']
+            additionalData.asMap == ['requestedPath' : 'prog:someTask']
         }
     }
 
@@ -341,7 +341,7 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
         verifyAll(receivedProblem) {
             fqid == 'task-selection:ambiguous-matches'
             contextualLabel == 'Cannot locate tasks that match \'proj:someTask\' as project \'proj\' is ambiguous in root project \'test\'. Candidates are: \'projA\', \'projB\'.'
-            additionalData == ['requestedPath' : 'proj:someTask']
+            additionalData.asMap == ['requestedPath' : 'proj:someTask']
         }
     }
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -850,11 +850,11 @@ tmpdir is currently ${System.getProperty("java.io.tmpdir")}""")
             }
             println "    ]"
         }
-        if (problem.additionalData.size() == 1) {
-            println "    additionalData == [ '${problem.additionalData.keySet().iterator().next()}' : '${problem.additionalData.values().iterator().next()}' ]"
-        } else if (problem.additionalData.size() > 1) {
-            println "    additionalData == ["
-            problem.additionalData.each { key, value ->
+        if (problem.additionalData?.size() == 1) {
+            println "    additionalData.asMap == [ '${problem.additionalData.asMap.keySet().iterator().next()}' : '${problem.additionalData.asMap.values().iterator().next()}' ]"
+        } else if (problem.additionalData?.size() > 1) {
+            println "    additionalData.asMap == ["
+            problem.additionalData.asMap.each { key, value ->
                 println "        '$key' : '$value',"
             }
             println "    ]"

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
@@ -60,7 +60,7 @@ class KnownProblemIds {
 
     private static final def KNOWN_DEFINITIONS = [
         'problems-api:missing-id' : 'Problem id must be specified',
-        'problems-api:invalid-additional-data' : 'ProblemBuilder.additionalData() only supports values of type String',
+        'problems-api:unsupported-additional-data' : 'Unsupported additional data type',
         'compilation:groovy-dsl:compilation-failed' : 'Groovy DSL script compilation problem',
         'compilation:java:java-compilation-error' : 'Java compilation error',
         'compilation:java:java-compilation-failed' : 'Java compilation error',

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/ReceivedProblem.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/ReceivedProblem.groovy
@@ -20,6 +20,7 @@ import groovy.transform.CompileStatic
 import org.gradle.api.problems.ProblemGroup
 import org.gradle.api.problems.ProblemId
 import org.gradle.api.problems.Severity
+import org.gradle.api.problems.internal.AdditionalData
 import org.gradle.api.problems.internal.DocLink
 import org.gradle.api.problems.internal.FileLocation
 import org.gradle.api.problems.internal.InternalProblemBuilder
@@ -41,7 +42,7 @@ class ReceivedProblem implements Problem {
     private final String details
     private final List<String> solutions
     private final List<ProblemLocation> locations
-    private final Map<String, Object> additionalData
+    private final ReceivedAdditionalData additionalData
     private final ReceivedException exception
 
     ReceivedProblem(long operationId, Map<String, Object> problemDetails) {
@@ -51,7 +52,7 @@ class ReceivedProblem implements Problem {
         this.details =  problemDetails['details'] as String
         this.solutions = problemDetails['solutions'] as List<String>
         this.locations = fromList(problemDetails['locations'] as List<Object>)
-        this.additionalData = (problemDetails['additionalData'] as Map<String, Object>).findAll { k, v -> v != null }
+        this.additionalData = new ReceivedAdditionalData(problemDetails['additionalData'] as Map<String, Object>)
         this.exception = problemDetails['exception'] == null ? null : new ReceivedException(problemDetails['exception'] as Map<String, Object>)
     }
 
@@ -121,7 +122,7 @@ class ReceivedProblem implements Problem {
     }
 
     @Override
-    Map<String, Object> getAdditionalData() {
+    ReceivedAdditionalData getAdditionalData() {
        additionalData
     }
 
@@ -343,6 +344,32 @@ class ReceivedProblem implements Problem {
         @Override
         String getPluginId() {
             pluginId
+        }
+    }
+
+    static class ReceivedAdditionalData implements AdditionalData {
+        private final Map<String, Object> data
+
+        ReceivedAdditionalData(Map<String, Object> data) {
+            if (data == null) {
+                this.data = [:]
+            } else {
+                def d = data.findAll { k, v -> v != null }
+                // GeneralData already contains asMap property; it is removed for clarity
+                if (d['asMap'] instanceof Map) {
+                    this.data = d['asMap'] as Map<String, Object>
+                } else {
+                    this.data = d
+                }
+            }
+        }
+
+        Map<String, Object> getAsMap() {
+            data
+        }
+
+        boolean containsAll(Map<String, Object> properties) {
+            data.entrySet().containsAll(properties.entrySet())
         }
     }
 }


### PR DESCRIPTION
One feature we want to support for the Problems API is to be attach domain-specific additional data to problem reports. There's a(n internal) solution that uses a string map, which is quite rudimentary and we don't want to make it part of the actual API. 

The ultimate goal is to  use template to declare additional data for problems.  
```
interface Problem<S> {
    S getAdditionalData();
}
```

This PR implements the first step to get there: it replaces the string map in the private API with on object reference. The main change is new signature for the `InternalProblemSpec.additionalData()` method:

    <U extends AdditionalDataSpec> InternalProblemSpec additionalData(Class<? extends U> specType, Action<? super U> config);

It allows producers to specify an action that configures additional data. The spec types, and their corresponding custom additional data types are predefined, with the (functionally sealed) `AdditionalData` and `AdditonalDataSpec` interfaces. The PR add support for three data types: generic data (ie the old string map), type validation data, and deprecation data.

We PR does not expose these new types on the Tooling API events, although it establishes the pattern on how to do it, should the use-case arise. For now, all additional data types are exposed with the original string map format with a clear documentation that the content of the map is subject of change between the releases. 

