### PR TITLE
Fix tests not setting up JPMS arguments for Gradle process

### DIFF
--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -644,7 +644,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
         return this;
     }
 
-    private JavaVersion getJavaVersionFromJavaHome() {
+    protected final JavaVersion getJavaVersionFromJavaHome() {
         try {
             return JVM_VERSION_DETECTOR.getJavaVersion(Jvm.forHome(getJavaHomeLocation()));
         } catch (IllegalArgumentException | JavaHomeException e) {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
@@ -159,15 +159,7 @@ public class NoDaemonGradleExecuter extends AbstractGradleExecuter {
 
     @Override
     protected boolean supportsWhiteSpaceInEnvVars() {
-        final Jvm current = Jvm.current();
-        if (getJavaHomeLocation().equals(current.getJavaHome())) {
-            // we can tell for sure
-            return current.getJavaVersion().isJava7Compatible();
-        } else {
-            // TODO improve lookup by reusing AvailableJavaHomes testfixture
-            // for now we play it safe and just return false;
-            return false;
-        }
+        return getRequestedJavaVersion().isJava7Compatible();
     }
 
     @Override

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
@@ -17,13 +17,10 @@
 package org.gradle.integtests.fixtures.executer;
 
 import org.gradle.api.Action;
-import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCachesProvider;
 import org.gradle.api.internal.file.TestFiles;
-import org.gradle.integtests.fixtures.AvailableJavaHomes;
 import org.gradle.internal.Factory;
 import org.gradle.internal.jvm.JpmsConfiguration;
-import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.process.internal.AbstractExecHandleBuilder;
 import org.gradle.process.internal.DefaultExecHandleBuilder;
@@ -126,26 +123,10 @@ public class NoDaemonGradleExecuter extends AbstractGradleExecuter {
     @Override
     protected List<String> getImplicitBuildJvmArgs() {
         List<String> buildJvmOptions = super.getImplicitBuildJvmArgs();
-        if (getRequestedJavaVersion().isJava9Compatible() && !isUseDaemon()) {
+        if (!isUseDaemon() && getJavaVersionFromJavaHome().isJava9Compatible()) {
             buildJvmOptions.addAll(JpmsConfiguration.GRADLE_DAEMON_JPMS_ARGS);
         }
         return buildJvmOptions;
-    }
-
-    private boolean isUsingJvm(Jvm jvm) {
-        return getJavaHomeLocation().equals(jvm.getJavaHome());
-    }
-
-    private JavaVersion getRequestedJavaVersion() {
-        if (isUsingJvm(Jvm.current())) {
-            return JavaVersion.current();
-        }
-
-        Jvm requestedJvm = AvailableJavaHomes.getAvailableJvms().stream()
-            .filter(this::isUsingJvm)
-            .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("Cannot find requested JVM " + getJavaHome() + " in AvailableJavaHomes"));
-        return requestedJvm.getJavaVersion();
     }
 
     private void addPropagatedSystemProperties(List<String> args) {
@@ -159,7 +140,7 @@ public class NoDaemonGradleExecuter extends AbstractGradleExecuter {
 
     @Override
     protected boolean supportsWhiteSpaceInEnvVars() {
-        return getRequestedJavaVersion().isJava7Compatible();
+        return getJavaVersionFromJavaHome().isJava7Compatible();
     }
 
     @Override

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossVersionPerformanceTest.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossVersionPerformanceTest.groovy
@@ -70,8 +70,6 @@ class AbstractCrossVersionPerformanceTest extends AbstractPerformanceTest {
         runner.addBuildMutator { invocationSettings ->
             new ApplyDevelocityPluginMutator(invocationSettings.projectDir)
         }
-        // Required by GradleLifecycle API used by Develocity
-        runner.gradleOpts += ["--add-opens=java.base/java.lang.invoke=ALL-UNNAMED"]
     }
 
     static {

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AbstractCrossBuildPerformanceTestRunner.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AbstractCrossBuildPerformanceTestRunner.groovy
@@ -111,7 +111,7 @@ abstract class AbstractCrossBuildPerformanceTestRunner<R extends CrossBuildPerfo
 
     protected void finalizeGradleSpec(GradleBuildExperimentSpec.GradleBuilder builder) {
         def invocation = builder.invocation
-        invocation.jvmArguments = customizeJvmOptions(invocation.jvmArguments)
+        invocation.jvmArguments = PerformanceTestJvmOptions.normalizeGradleJvmOptions(invocation.useDaemon, customizeJvmOptions(invocation.jvmArguments))
     }
 
     protected static List<String> customizeJvmOptions(List<String> jvmOptions) {

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunner.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunner.groovy
@@ -228,7 +228,7 @@ class CrossVersionPerformanceTestRunner extends PerformanceTestSpec {
     }
 
     private List<String> resolveGradleOpts() {
-        PerformanceTestJvmOptions.normalizeJvmOptions(this.gradleOpts)
+        PerformanceTestJvmOptions.normalizeGradleJvmOptions(useDaemon, PerformanceTestJvmOptions.normalizeJvmOptions(this.gradleOpts))
     }
 
     def <T extends LongRunningOperation> ToolingApiAction<T> toolingApi(String displayName, Function<ProjectConnection, T> initialAction) {

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestJvmOptions.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestJvmOptions.groovy
@@ -18,6 +18,7 @@ package org.gradle.performance.fixture
 
 import groovy.transform.CompileStatic
 import org.gradle.api.JavaVersion
+import org.gradle.internal.jvm.JpmsConfiguration
 
 @CompileStatic
 class PerformanceTestJvmOptions {
@@ -33,5 +34,14 @@ class PerformanceTestJvmOptions {
         }
 
         return jvmOptions
+    }
+
+    static List<String> normalizeGradleJvmOptions(boolean useDaemon, List<String> originalJvmOptions) {
+        if (JavaVersion.current().isJava9Compatible() && !useDaemon) {
+            List<String> jvmOptions = new ArrayList<>(originalJvmOptions)
+            jvmOptions.addAll(JpmsConfiguration.GRADLE_DAEMON_JPMS_ARGS)
+            return jvmOptions
+        }
+        return originalJvmOptions
     }
 }

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestJvmOptions.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestJvmOptions.groovy
@@ -37,7 +37,7 @@ class PerformanceTestJvmOptions {
     }
 
     static List<String> normalizeGradleJvmOptions(boolean useDaemon, List<String> originalJvmOptions) {
-        if (JavaVersion.current().isJava9Compatible() && !useDaemon) {
+        if (!useDaemon && JavaVersion.current().isJava9Compatible()) {
             List<String> jvmOptions = new ArrayList<>(originalJvmOptions)
             jvmOptions.addAll(JpmsConfiguration.GRADLE_DAEMON_JPMS_ARGS)
             return jvmOptions

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationCachePerformanceTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationCachePerformanceTest.groovy
@@ -53,11 +53,6 @@ class JavaConfigurationCachePerformanceTest extends AbstractCrossVersionPerforma
         // use the deprecated property so it works with previous versions
         runner.args = ["-D${ConfigurationCacheOption.DEPRECATED_PROPERTY_NAME}=true"]
 
-        // Workaround to make that test work on Java 17
-        // Unable to make field private final java.lang.Object[] java.lang.invoke.SerializedLambda.capturedArgs accessible
-        // module java.base does not "opens java.lang.invoke" to unnamed module
-        runner.gradleOpts += ["--add-opens=java.base/java.lang.invoke=ALL-UNNAMED"]
-
         and:
         runner.useDaemon = daemon == hot
         runner.addBuildMutator { configurationCacheInvocationListenerFor(it, action, stateDirectory) }


### PR DESCRIPTION
Modern Gradle requires several `--add-opens` switches to be used or weird failures happen. We need to configure the switches manually when attempting to run Gradle inside the client process, but we were missing a few places and did that in an ad-hoc way.

Fixes gradle/gradle-private#4187

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
