### PR TITLE
Fix getClass on enum classes

### DIFF
--- a/platforms/core-configuration/model-core/build.gradle.kts
+++ b/platforms/core-configuration/model-core/build.gradle.kts
@@ -8,7 +8,6 @@ description = "Implementation of configuration model types and annotation metada
 errorprone {
     disabledChecks.addAll(
         "AnnotateFormatMethod", // 1 occurrence, needs errorprone annotations
-        "GetClassOnEnum", // 4 occurrences
         "ImmutableEnumChecker", // 1 occurrences
         "ReferenceEquality", // 3 occurrences
         "UndefinedEquals", // 2 occurrences

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/EnumValueSnapshot.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/EnumValueSnapshot.java
@@ -26,7 +26,7 @@ public class EnumValueSnapshot implements ValueSnapshot {
 
     public EnumValueSnapshot(Enum<?> value) {
         // Don't retain the value, to allow ClassLoader to be collected
-        this.className = value.getClass().getName();
+        this.className = value.getDeclaringClass().getName();
         this.name = value.name();
     }
 
@@ -54,7 +54,7 @@ public class EnumValueSnapshot implements ValueSnapshot {
     private boolean isEqualEnum(Object value) {
         if (value instanceof Enum) {
             Enum<?> enumValue = (Enum<?>) value;
-            if (enumValue.name().equals(name) && enumValue.getClass().getName().equals(className)) {
+            if (enumValue.name().equals(name) && enumValue.getDeclaringClass().getName().equals(className)) {
                 return true;
             }
         }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/EnumValueSnapshot.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/EnumValueSnapshot.java
@@ -20,6 +20,8 @@ import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.snapshot.ValueSnapshot;
 import org.gradle.internal.snapshot.ValueSnapshotter;
 
+import javax.annotation.Nullable;
+
 public class EnumValueSnapshot implements ValueSnapshot {
     private final String className;
     private final String name;
@@ -44,19 +46,17 @@ public class EnumValueSnapshot implements ValueSnapshot {
     }
 
     @Override
-    public ValueSnapshot snapshot(Object value, ValueSnapshotter snapshotter) {
+    public ValueSnapshot snapshot(@Nullable Object value, ValueSnapshotter snapshotter) {
         if (isEqualEnum(value)) {
             return this;
         }
         return snapshotter.snapshot(value);
     }
 
-    private boolean isEqualEnum(Object value) {
-        if (value instanceof Enum) {
+    private boolean isEqualEnum(@Nullable Object value) {
+        if (value instanceof Enum<?>) {
             Enum<?> enumValue = (Enum<?>) value;
-            if (enumValue.name().equals(name) && enumValue.getDeclaringClass().getName().equals(className)) {
-                return true;
-            }
+            return enumValue.name().equals(name) && enumValue.getDeclaringClass().getName().equals(className);
         }
         return false;
     }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedEnumValueSnapshot.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedEnumValueSnapshot.java
@@ -50,10 +50,10 @@ public class IsolatedEnumValueSnapshot extends EnumValueSnapshot implements Isol
     @Nullable
     @Override
     public <S> S coerce(Class<S> type) {
-        if (type.isAssignableFrom(value.getClass())) {
+        if (type.isInstance(value)) {
             return type.cast(value);
         }
-        if (type.isEnum() && type.getName().equals(value.getClass().getName())) {
+        if (type.isEnum() && type.getName().equals(value.getDeclaringClass().getName())) {
             return type.cast(Enum.valueOf(Cast.uncheckedNonnullCast(type.asSubclass(Enum.class)), value.name()));
         }
         return null;

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedEnumValueSnapshot.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedEnumValueSnapshot.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 /**
  * Isolates an Enum value and is a snapshot for that value.
  */
-public class IsolatedEnumValueSnapshot extends EnumValueSnapshot implements Isolatable<Enum> {
+public class IsolatedEnumValueSnapshot extends EnumValueSnapshot implements Isolatable<Enum<?>> {
     private final Enum<?> value;
 
     public IsolatedEnumValueSnapshot(Enum<?> value) {
@@ -43,7 +43,7 @@ public class IsolatedEnumValueSnapshot extends EnumValueSnapshot implements Isol
     }
 
     @Override
-    public Enum isolate() {
+    public Enum<?> isolate() {
         return value;
     }
 

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/Type1.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/Type1.groovy
@@ -17,5 +17,5 @@
 package org.gradle.internal.snapshot.impl
 
 enum Type1 {
-    ONE, TWO
+    ONE {}, TWO {}
 }

--- a/platforms/core-execution/workers/src/test/groovy/org/gradle/workers/internal/IsolatableSerializerRegistryTest.groovy
+++ b/platforms/core-execution/workers/src/test/groovy/org/gradle/workers/internal/IsolatableSerializerRegistryTest.groovy
@@ -367,6 +367,6 @@ class IsolatableSerializerRegistryTest extends Specification {
     }
 
     enum EnumType {
-        FOO, BAR
+        FOO {}, BAR
     }
 }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationAttributesResolveIntegrationTest.groovy
@@ -919,7 +919,7 @@ All of them match the consumer attributes:
                         com {
                             acme {
                                 'Flavor.groovy'('package com.acme; enum Flavor { free, paid }')
-                                'BuildType.groovy'('package com.acme; enum BuildType { debug, release }')
+                                'BuildType.groovy'('package com.acme; enum BuildType { debug {}, release {} }')
                                 'TypedAttributesPlugin.groovy'('''package com.acme
 
                                     import org.gradle.api.Plugin


### PR DESCRIPTION
Enum constants may be implemented as subclasses, so getClass may be
unreliable, e.g. a subclass returns `false` from `isEnum`. This commit
fixes a bunch of places where the invalid class was exposed.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
