### PR TITLE
Expose BuildCacheKey to task execution [PoC]

### DIFF
--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
@@ -19,6 +19,7 @@ package org.gradle.internal.execution;
 import com.google.common.collect.ImmutableSortedMap;
 import org.gradle.api.Describable;
 import org.gradle.api.file.FileCollection;
+import org.gradle.caching.BuildCacheKey;
 import org.gradle.internal.execution.caching.CachingDisabledReason;
 import org.gradle.internal.execution.caching.CachingState;
 import org.gradle.internal.execution.history.OverlappingOutputs;
@@ -75,6 +76,11 @@ public interface UnitOfWork extends Describable {
      * Parameter object for {@link #execute(ExecutionRequest)}.
      */
     interface ExecutionRequest {
+
+        default Optional<BuildCacheKey> getCacheKey() {
+            return Optional.empty();
+        }
+
         /**
          * The directory to produce outputs into.
          * <p>

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/ExecuteStep.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/ExecuteStep.java
@@ -18,9 +18,11 @@ package org.gradle.internal.execution.steps;
 
 import com.google.common.base.Functions;
 import com.google.common.collect.ImmutableSortedMap;
+import org.gradle.caching.BuildCacheKey;
 import org.gradle.internal.execution.ExecutionEngine.Execution;
 import org.gradle.internal.execution.ExecutionEngine.ExecutionOutcome;
 import org.gradle.internal.execution.UnitOfWork;
+import org.gradle.internal.execution.caching.CachingState;
 import org.gradle.internal.execution.history.PreviousExecutionState;
 import org.gradle.internal.execution.history.changes.InputChangesInternal;
 import org.gradle.internal.operations.BuildOperationContext;
@@ -82,6 +84,13 @@ public class ExecuteStep<C extends ChangingOutputsContext> implements Step<C, Re
 
     private static Result executeInternal(UnitOfWork work, InputChangesContext context) {
         UnitOfWork.ExecutionRequest executionRequest = new UnitOfWork.ExecutionRequest() {
+
+            @Override
+            public Optional<BuildCacheKey> getCacheKey() {
+                return context.getCachingState().getCacheKeyCalculatedState()
+                    .map(CachingState.CacheKeyCalculatedState::getKey);
+            }
+
             @Override
             public File getWorkspace() {
                 return context.getWorkspace();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/cache/BuildCacheKeyHolder.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/cache/BuildCacheKeyHolder.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.cache;
+
+import org.gradle.caching.BuildCacheKey;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+public final class BuildCacheKeyHolder {
+
+    private static final ThreadLocal<BuildCacheKey> currentBuildCacheKey = new ThreadLocal<>();
+
+    /**
+     * Get build cache key for current execution, if available
+     *
+     * @return current build cache key
+     */
+    public static Optional<BuildCacheKey> getCurrentBuildCacheKey() {
+        return Optional.ofNullable(currentBuildCacheKey.get());
+    }
+
+    public static void runWithBuildCacheKey(@Nullable BuildCacheKey buildCacheKey, Runnable action) {
+        BuildCacheKey prev = currentBuildCacheKey.get();
+        currentBuildCacheKey.set(buildCacheKey);
+        try {
+            currentBuildCacheKey.set(buildCacheKey);
+        } finally {
+            currentBuildCacheKey.set(prev);
+        }
+    }
+
+    private BuildCacheKeyHolder() {
+    }
+}


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
This PR is a proof of concept, just for possible discussion, curious about opinions of Gradle maintainers as well. In the prototype the `BuildCacheKey` is exposed in the `org.gradle.api.internal.cache` package assuming there is no guarantee of forward compatibility unless it's clarified.

Some tasks may need Gradle calculated cache key to align standard cache semantics, not to duplicate artifact hash itself.
E.g. there are web artifact compiling tasks, that produce output with URL query parameters like `...?v={version}` where `version` can be random UUID or git commit or timestamp or whatever. The similar approach can be helpful if the output creates some manifest with unique build id.

The idea of this change is to reuse the Gradle build cache in the task.

Advantages:
* reproducible between sequential builds between local and CI/CD environment (if there is a remote cache)
* different if there are different task Inputs
* aligned with Gradle cache mechanism

But it has a major drawback: if the build is executed without build cache, Gradle skips cache calculation. So the task output will not be reproducible between `--build-cache` and `--no-build-cache`

## Alternative solutions
Manually calculate build cache key in the task implementation - taking into calculation at least:
* all inputs respecting absolute/relative file name sensitivity
* buildSrc/task implementation hash
* any implicit parameters like build properties

<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
