### PR TITLE
Improve resolution messages in the gradle/gradle build

### DIFF
--- a/build-logic-commons/module-identity/src/main/kotlin/gradlebuild.module-jar.gradle.kts
+++ b/build-logic-commons/module-identity/src/main/kotlin/gradlebuild.module-jar.gradle.kts
@@ -76,7 +76,8 @@ fun computeExternalDependenciesNotAccessibleFromProjectDependencies(
     while (queue.isNotEmpty()) {
         val dependency = when (val result = queue.removeFirst()) {
             is ResolvedDependencyResult -> result
-            else -> throw IllegalArgumentException("Expected ResolvedDependencyResult")
+            is UnresolvedDependencyResult -> throw result.failure
+            else -> throw AssertionError("Unknown dependency type: $result")
         }
 
         if (dependency.isConstraint) {


### PR DESCRIPTION
Found this meanwhile trying to do an included build in gradle/gradle. We found that the previous implementation shadowed the actual failure a bit too hard.