### PR TITLE
Report type validation problems from DefaultNodeValidator

### DIFF
--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidatePlugins.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidatePlugins.java
@@ -122,7 +122,6 @@ public abstract class ValidatePlugins extends DefaultTask {
                         messages.collect(joining()));
                 } else {
                     reportProblems(problems);
-
                     throw WorkValidationException.forProblems(messages.collect(toImmutableList()))
                         .withSummaryForPlugin()
                         .getWithExplanation(annotateTaskPropertiesDoc());

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r89/ProblemProgressEventCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r89/ProblemProgressEventCrossVersionTest.groovy
@@ -226,6 +226,43 @@ class ProblemProgressEventCrossVersionTest extends ToolingApiSpecification {
         problems[0].definition.id.group.name == 'compilation'
     }
 
+    def "Property validation failure should produce problem report with domain-specific additional data"() {
+        setup:
+        file('buildSrc/src/main/java/MyTask.java') << '''
+            import org.gradle.api.*;
+            import org.gradle.api.tasks.*;
+            import org.gradle.work.*;
+            @DisableCachingByDefault(because = "test task")
+            public class MyTask extends DefaultTask {
+                @Optional @Input
+                boolean getPrimitive() {
+                    return true;
+                }
+                @TaskAction public void execute() {}
+            }
+        '''
+        buildFile << '''
+            tasks.register('myTask', MyTask)
+        '''
+
+        when:
+        def listener = new ProblemProgressListener()
+        withConnection { connection ->
+            connection.newBuild()
+                .forTasks("myTask")
+                .addProgressListener(listener)
+                .setStandardError(System.err)
+                .setStandardOutput(System.out)
+                .addArguments("--info")
+
+                .run()
+        }
+
+        then:
+        thrown(BuildException)
+        listener.problems.size() == 1
+    }
+
     @TargetGradleVersion("=8.6")
     def "8.6 version doesn't send failure"() {
         buildFile """

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
@@ -18,8 +18,9 @@ package org.gradle.execution.plan;
 
 import org.gradle.api.internal.GeneratedSubclasses;
 import org.gradle.api.internal.TaskInternal;
-import org.gradle.api.problems.internal.Problem;
 import org.gradle.api.problems.Severity;
+import org.gradle.api.problems.internal.InternalProblems;
+import org.gradle.api.problems.internal.Problem;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.execution.WorkValidationContext;
 import org.gradle.internal.execution.WorkValidationException;
@@ -39,6 +40,13 @@ import static org.gradle.internal.reflect.validation.TypeValidationProblemRender
  * the build by throwing a {@link WorkValidationException} if any errors are found.
  */
 public class DefaultNodeValidator implements NodeValidator {
+
+    private final InternalProblems problemsService;
+
+    public DefaultNodeValidator(InternalProblems problemsService) {
+        this.problemsService = problemsService;
+    }
+
     @Override
     public boolean hasValidationProblems(LocalTaskNode node) {
         WorkValidationContext validationContext = validateNode(node);
@@ -73,6 +81,10 @@ public class DefaultNodeValidator implements NodeValidator {
     }
 
     private void reportErrors(List<? extends Problem> problems, TaskInternal task, WorkValidationContext validationContext) {
+        for (Problem problem : problems) {
+            problemsService.getInternalReporter().report(problem);
+        }
+
         Set<String> uniqueErrors = getUniqueErrors(problems);
         if (!uniqueErrors.isEmpty()) {
             throw WorkValidationException.forProblems(uniqueErrors)

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/ReceivedProblem.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/ReceivedProblem.groovy
@@ -51,7 +51,7 @@ class ReceivedProblem implements Problem {
         this.details =  problemDetails['details'] as String
         this.solutions = problemDetails['solutions'] as List<String>
         this.locations = fromList(problemDetails['locations'] as List<Object>)
-        this.additionalData = problemDetails['additionalData'] as Map<String, Object>
+        this.additionalData = (problemDetails['additionalData'] as Map<String, Object>).findAll { k, v -> v != null }
         this.exception = problemDetails['exception'] == null ? null : new ReceivedException(problemDetails['exception'] as Map<String, Object>)
     }
 


### PR DESCRIPTION
When we exposed type validation failures via the Problems API, we missed the reports created by DefaultNodeValidator. 