### PR TITLE
Allows for configuring RepositoryMode in settings in a declarative manner

### DIFF
--- a/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/settings/SoftwareTypeDeclarationIntegrationTest.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/settings/SoftwareTypeDeclarationIntegrationTest.groovy
@@ -283,6 +283,30 @@ class SoftwareTypeDeclarationIntegrationTest extends AbstractIntegrationSpec imp
         failure.assertHasCause("Class SoftwareTypeImplPlugin.AnotherSoftwareTypeExtension is private.")
     }
 
+    def 'can configure RepositoriesMode in settings'() {
+        given:
+        file("settings.gradle.dcl") << """
+            dependencyResolutionManagement {
+                repositoriesMode = failOnProjectRepos()
+                repositories {
+                    google()
+                }
+            }
+            rootProject.name = "example"
+        """
+
+        file("build.gradle.kts") << """
+            repositories {
+                mavenCentral()
+            }
+        """
+
+        expect:
+        fails(":build").with {
+            assertHasErrorOutput("Build was configured to prefer settings repositories over project repositories but repository 'MavenRepo' was added by build file 'build.gradle.kts'")
+        }
+    }
+
     static String getPluginsFromIncludedBuild() {
         return """
             pluginManagement {

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/resolve/DependencyResolutionManagement.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/resolve/DependencyResolutionManagement.java
@@ -48,7 +48,47 @@ public interface DependencyResolutionManagement {
     RepositoryHandler getRepositories();
 
     @Incubating
+    @Restricted
     Property<RepositoriesMode> getRepositoriesMode();
+
+    /**
+     * Returns the {@link RepositoriesMode#PREFER_PROJECT} repositories mode type to be used in Declarative
+     * Gradle files.
+     *
+     * @return {@link RepositoriesMode#PREFER_PROJECT}
+     * @since 8.9
+     */
+    @Incubating
+    @Restricted
+    default RepositoriesMode preferProject() {
+        return RepositoriesMode.PREFER_PROJECT;
+    }
+
+    /**
+     * Returns the {@link RepositoriesMode#PREFER_SETTINGS} repositories mode type to be used in Declarative
+     * Gradle files.
+     *
+     * @return {@link RepositoriesMode#PREFER_SETTINGS}
+     * @since 8.9
+     */
+    @Incubating
+    @Restricted
+    default RepositoriesMode preferSettings() {
+        return RepositoriesMode.PREFER_SETTINGS;
+    }
+
+    /**
+     * Returns the {@link RepositoriesMode#FAIL_ON_PROJECT_REPOS} repositories mode type to be used in Declarative
+     * Gradle files.
+     *
+     * @return {@link RepositoriesMode#FAIL_ON_PROJECT_REPOS}
+     * @since 8.9
+     */
+    @Incubating
+    @Restricted
+    default RepositoriesMode failOnProjectRepos() {
+        return RepositoriesMode.FAIL_ON_PROJECT_REPOS;
+    }
 
     /**
      * Registers component metadata rules used by all projects


### PR DESCRIPTION
This would support some currently commented out usage in the Now In Android prototype.

This is necessary because we don't want to support using enum constants in DCL files directly.

Ignore the flaky Windows test failure.