### PR TITLE
Fix task selection problem reports 

### DIFF
--- a/platforms/jvm/plugins-java-library/src/integTest/groovy/org/gradle/java/JavaLibraryDocumentationIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java-library/src/integTest/groovy/org/gradle/java/JavaLibraryDocumentationIntegrationTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.test.fixtures.archive.ZipTestFixture
 class JavaLibraryDocumentationIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {
+        enableProblemsApiCheck()
         buildFile << '''
             subprojects {
                 apply plugin: 'java-library'
@@ -108,6 +109,13 @@ class JavaLibraryDocumentationIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasDescription("Cannot locate tasks that match ':a:javadocJar' as task 'javadocJar' not found in project ':a'. Some candidates are: 'javadoc'.")
 
+        and:
+        verifyAll(receivedProblem) {
+            fqid == 'task-selection:no-matches'
+            contextualLabel == 'Cannot locate tasks that match \':a:javadocJar\' as task \'javadocJar\' not found in project \':a\'. Some candidates are: \'javadoc\'.'
+            additionalData == [ 'requestedPath' : ':a:javadocJar']
+        }
+
         when:
         buildFile << '''
             subprojects {
@@ -124,6 +132,13 @@ class JavaLibraryDocumentationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         failure.assertHasDescription("Cannot locate tasks that match ':a:sourcesJar' as task 'sourcesJar' not found in project ':a'.")
+
+        and:
+        verifyAll(receivedProblem) {
+            fqid == 'task-selection:selection-failed'
+            contextualLabel == 'Cannot locate tasks that match \':a:sourcesJar\' as task \'sourcesJar\' not found in project \':a\'.'
+            additionalData == [ 'requestedPath' : ':a:sourcesJar']
+        }
 
         when:
         buildFile << '''

--- a/subprojects/core/src/main/java/org/gradle/execution/DefaultTaskSelector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DefaultTaskSelector.java
@@ -21,8 +21,9 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.api.problems.ProblemSpec;
 import org.gradle.api.problems.Severity;
-import org.gradle.api.problems.internal.GradleCoreProblemGroup;
+import org.gradle.api.problems.internal.InternalProblemSpec;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.api.specs.Spec;
 import org.gradle.util.internal.NameMatcher;
@@ -94,32 +95,27 @@ public class DefaultTaskSelector implements TaskSelector {
         String searchContext = getSearchContext(targetProject, includeSubprojects);
 
         if (context.getOriginalPath().getPath().equals(taskName)) {
-            throw getProblemsService().getInternalReporter().throwing(builder -> {
-                if (!matcher.getMatches().isEmpty()) {
-                    builder.id("ambiguous", "task matches ambiguous tasks", GradleCoreProblemGroup.taskSelection());
-                } else if (!matcher.getCandidates().isEmpty()) {
-                    builder.id("no-matches", "task has no matches", GradleCoreProblemGroup.taskSelection());
-                } else {
-                    builder.id("failed", "task selection failed", GradleCoreProblemGroup.taskSelection());
-                }
-
+            throw getProblemsService().getInternalReporter().throwing(spec -> {
+                configureProblem(spec, matcher, context);
                 String message = matcher.formatErrorMessage("Task", searchContext);
-                builder.contextualLabel(message)
-                    .fileLocation(Objects.requireNonNull(context.getOriginalPath().getName()))
-                    .severity(Severity.ERROR)
+                spec.contextualLabel(message)
                     .withException(new TaskSelectionException(message));
             });
         }
         String message = String.format("Cannot locate %s that match '%s' as %s", context.getType(), context.getOriginalPath(),
             matcher.formatErrorMessage("task", searchContext));
 
-        throw getProblemsService().getInternalReporter().throwing(builder -> builder
-            .id("no-matches", "cannot locate task", GradleCoreProblemGroup.taskSelection())
+        throw getProblemsService().getInternalReporter().throwing(spec -> configureProblem(spec, matcher, context)
             .contextualLabel(message)
-            .fileLocation(Objects.requireNonNull(context.getOriginalPath().getName()))
-            .severity(Severity.ERROR)
             .withException(new TaskSelectionException(message)) // this instead of cause
         );
+    }
+
+    private static ProblemSpec configureProblem(ProblemSpec spec, NameMatcher matcher, SelectionContext context) {
+        matcher.configureProblemId(spec);
+        ((InternalProblemSpec) spec).additionalData("requestedPath", Objects.requireNonNull(context.getOriginalPath().getPath()));
+        spec.severity(Severity.ERROR);
+        return spec;
     }
 
     @Nonnull

--- a/subprojects/core/src/main/java/org/gradle/execution/selection/DefaultBuildTaskSelector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/selection/DefaultBuildTaskSelector.java
@@ -19,6 +19,11 @@ package org.gradle.execution.selection;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Task;
 import org.gradle.api.internal.project.ProjectState;
+import org.gradle.api.problems.ProblemSpec;
+import org.gradle.api.problems.Severity;
+import org.gradle.api.problems.internal.GradleCoreProblemGroup;
+import org.gradle.api.problems.internal.InternalProblemSpec;
+import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.configuration.project.BuiltInCommand;
@@ -36,6 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 import java.io.File;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -48,11 +54,14 @@ public class DefaultBuildTaskSelector implements BuildTaskSelector {
     private final BuildStateRegistry buildRegistry;
     private final TaskSelector taskSelector;
     private final List<BuiltInCommand> commands;
+    private final InternalProblems problemsService;
 
-    public DefaultBuildTaskSelector(BuildStateRegistry buildRegistry, TaskSelector taskSelector, List<BuiltInCommand> commands) {
+    @Inject
+    public DefaultBuildTaskSelector(BuildStateRegistry buildRegistry, TaskSelector taskSelector, List<BuiltInCommand> commands, InternalProblems problemsService) {
         this.buildRegistry = buildRegistry;
         this.taskSelector = taskSelector;
         this.commands = commands;
+        this.problemsService = problemsService;
     }
 
     @Override
@@ -163,7 +172,19 @@ public class DefaultBuildTaskSelector implements BuildTaskSelector {
         if (child != null) {
             return child;
         }
-        throw new ProjectSelectionException(String.format("Cannot locate %s that match '%s' as %s", context.getType(), context.getOriginalPath(), nameMatcher.formatErrorMessage("project", project.getDisplayName())));
+
+        throw problemsService.getInternalReporter().throwing(spec -> {
+            nameMatcher.configureProblemId(spec);
+            String message = String.format("Cannot locate %s that match '%s' as %s", context.getType(), context.getOriginalPath(), nameMatcher.formatErrorMessage("project", project.getDisplayName()));
+            configureProblem(spec, message, context.getOriginalPath().getPath(), new ProjectSelectionException(message));
+        });
+    }
+
+    private static void configureProblem(ProblemSpec spec, String message, String requestedPath, RuntimeException e) {
+        spec.contextualLabel(message);
+        spec.severity(Severity.ERROR);
+        ((InternalProblemSpec) spec).additionalData("requestedPath", Objects.requireNonNull(requestedPath));
+        spec.withException(e);
     }
 
     private TaskSelector.SelectionContext sanityCheckPath(String name, String type) {
@@ -173,12 +194,20 @@ public class DefaultBuildTaskSelector implements BuildTaskSelector {
         // - have empty or blank segments (eg `::a`, `a::b`, `a:  :b`, etc)
 
         if (name.isEmpty() || StringUtils.isBlank(name)) {
-            throw new TaskSelectionException(String.format("Cannot locate matching %s for an empty path. The path should include a task name (for example %s).", type, examplePaths()));
+            throw problemsService.getInternalReporter().throwing(spec -> {
+                spec.id("empty-path", "Empty path", GradleCoreProblemGroup.taskSelection());
+                String message = String.format("Cannot locate matching %s for an empty path. The path should include a task name (for example %s).", type, examplePaths());
+                configureProblem(spec, message, name, new TaskSelectionException(message));
+            });
         }
         Path path = Path.path(name);
         Pattern root = Pattern.compile("\\s*:(\\s*:)*\\s*");
         if (root.matcher(name).matches()) {
-            throw new TaskSelectionException(String.format("Cannot locate %s that match '%s'. The path should include a task name (for example %s).", type, name, examplePaths()));
+            throw problemsService.getInternalReporter().throwing(spec -> {
+                spec.id("missing-task-name", "Missing task name", GradleCoreProblemGroup.taskSelection());
+                String message = String.format("Cannot locate %s that match '%s'. The path should include a task name (for example %s).", type, name, examplePaths());
+                configureProblem(spec, message, name, new TaskSelectionException(message));
+            });
         }
         Pattern emptySegment = Pattern.compile("(:\\s*:)|(^\\s+:)|(:\\s*$)");
         if (emptySegment.matcher(name).find()) {
@@ -193,7 +222,12 @@ public class DefaultBuildTaskSelector implements BuildTaskSelector {
                     normalized.append(path.segment(i));
                 }
             }
-            throw new TaskSelectionException(String.format("Cannot locate %s that match '%s'. The path should not include an empty segment (try '%s' instead).", type, name, normalized));
+
+            throw problemsService.getInternalReporter().throwing(spec -> {
+                spec.id("empty-segments", "Empty segments", GradleCoreProblemGroup.taskSelection());
+                String message = String.format("Cannot locate %s that match '%s'. The path should not include an empty segment (try '%s' instead).", type, name, normalized);
+                configureProblem(spec, message, name, new TaskSelectionException(message));
+            });
         }
         return new TaskSelector.SelectionContext(path, type);
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
@@ -34,7 +34,9 @@ import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.api.logging.configuration.ShowStacktrace;
 import org.gradle.api.model.BuildTreeObjectFactory;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.api.tasks.util.PatternSet;
+import org.gradle.configuration.project.BuiltInCommand;
 import org.gradle.execution.DefaultTaskSelector;
 import org.gradle.execution.ProjectConfigurer;
 import org.gradle.execution.TaskNameResolver;
@@ -48,6 +50,7 @@ import org.gradle.initialization.exception.ExceptionCollector;
 import org.gradle.initialization.exception.MultipleBuildFailuresExceptionAnalyser;
 import org.gradle.initialization.exception.StackTraceSanitizingExceptionAnalyser;
 import org.gradle.internal.Factory;
+import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.build.DefaultBuildLifecycleControllerFactory;
 import org.gradle.internal.buildoption.DefaultFeatureFlags;
 import org.gradle.internal.buildoption.DefaultInternalOptions;
@@ -90,7 +93,6 @@ public class BuildTreeScopeServices {
         registration.add(DefaultBuildLifecycleControllerFactory.class);
         registration.add(BuildOptionBuildOperationProgressEventsEmitter.class);
         registration.add(BuildInclusionCoordinator.class);
-        registration.add(DefaultBuildTaskSelector.class);
         registration.add(DefaultProjectStateRegistry.class);
         registration.add(DefaultConfigurationTimeBarrier.class);
         registration.add(DeprecationsReporter.class);
@@ -122,12 +124,18 @@ public class BuildTreeScopeServices {
             domainObjectCollectionFactory);
     }
 
+
+
     protected InternalOptions createInternalOptions(StartParameter startParameter) {
         return new DefaultInternalOptions(startParameter.getSystemPropertiesArgs());
     }
 
     protected TaskSelector createTaskSelector(ProjectConfigurer projectConfigurer, ObjectFactory objectFactory) {
         return objectFactory.newInstance(DefaultTaskSelector.class, new TaskNameResolver(), projectConfigurer);
+    }
+
+    protected DefaultBuildTaskSelector createBuildTaskSelector(BuildStateRegistry buildRegistry, TaskSelector taskSelector, List<BuiltInCommand> commands, InternalProblems problemsService) {
+        return new DefaultBuildTaskSelector(buildRegistry, taskSelector, commands, problemsService);
     }
 
     protected ScopedListenerManager createListenerManager(ScopedListenerManager parent) {

--- a/subprojects/core/src/main/java/org/gradle/util/internal/NameMatcher.java
+++ b/subprojects/core/src/main/java/org/gradle/util/internal/NameMatcher.java
@@ -16,6 +16,8 @@
 package org.gradle.util.internal;
 
 import org.apache.commons.lang.StringUtils;
+import org.gradle.api.problems.ProblemSpec;
+import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 
 import java.util.Collection;
 import java.util.Map;
@@ -204,5 +206,15 @@ public class NameMatcher {
             return String.format("%s '%s' not found in %s. Some candidates are: %s.", singularItemDescription, pattern, container, GUtil.toString(candidates));
         }
         return String.format("%s '%s' not found in %s.", singularItemDescription, pattern, container);
+    }
+
+    public void configureProblemId(ProblemSpec spec) {
+        if (!getMatches().isEmpty()) {
+            spec.id("ambiguous-matches", "Ambiguous matches", GradleCoreProblemGroup.taskSelection());
+        } else if (!getCandidates().isEmpty()) {
+            spec.id("no-matches", "No matches", GradleCoreProblemGroup.taskSelection());
+        } else {
+            spec.id("selection-failed", "Selection failed", GradleCoreProblemGroup.taskSelection());
+        }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/selection/DefaultBuildTaskSelectorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/selection/DefaultBuildTaskSelectorTest.groovy
@@ -21,6 +21,8 @@ import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectState
 import org.gradle.api.plugins.internal.HelpBuiltInCommand
+import org.gradle.api.problems.internal.DefaultProblems
+import org.gradle.api.problems.internal.NoOpProblemEmitter
 import org.gradle.api.specs.Spec
 import org.gradle.execution.ProjectSelectionException
 import org.gradle.execution.TaskSelectionException
@@ -30,6 +32,7 @@ import org.gradle.internal.build.BuildProjectRegistry
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.build.IncludedBuildState
 import org.gradle.internal.build.RootBuildState
+import org.gradle.internal.operations.CurrentBuildOperationRef
 import org.gradle.util.Path
 import spock.lang.Specification
 
@@ -38,7 +41,7 @@ import java.util.function.Consumer
 class DefaultBuildTaskSelectorTest extends Specification {
     def buildRegistry = Mock(BuildStateRegistry)
     def taskSelector = Mock(TaskSelector)
-    def selector = new DefaultBuildTaskSelector(buildRegistry, taskSelector, [new HelpBuiltInCommand()])
+    def selector = new DefaultBuildTaskSelector(buildRegistry, taskSelector, [new HelpBuiltInCommand()], new DefaultProblems(new NoOpProblemEmitter(), Mock(CurrentBuildOperationRef)))
     def root = rootBuild()
     def target = root.state
 

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskErrorExecutionIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskErrorExecutionIntegrationTest.groovy
@@ -120,7 +120,7 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
         failure.assertHasCause("broken")
     }
 
-    def "reports task validation failure"() {
+    def "reports type validation failure"() {
         enableProblemsApiCheck()
         buildFile << '''
             class CustomTask extends DefaultTask {
@@ -183,9 +183,10 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
         fails "someTest"
 
         then:
-        verifyAll(receivedProblem(0)) {
+        verifyAll(receivedProblem) {
             fqid == 'task-selection:no-matches'
             contextualLabel == "Task 'someTest' not found in root project 'test' and its subprojects. Some candidates are: 'someTask', 'someTaskA', 'someTaskB'."
+            additionalData == ['requestedPath' : 'someTest']
         }
         failure.assertHasDescription("Task 'someTest' not found in root project 'test' and its subprojects. Some candidates are: 'someTask', 'someTaskA', 'someTaskB'.")
         failure.assertHasResolutions(
@@ -199,9 +200,10 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
         when:
         fails ":someTest"
         then:
-        verifyAll(receivedProblem(0)) {
+        verifyAll(receivedProblem) {
             fqid == 'task-selection:no-matches'
             contextualLabel == "Cannot locate tasks that match ':someTest' as task 'someTest' not found in root project 'test'. Some candidates are: 'someTask'."
+            additionalData == ['requestedPath' : ':someTest']
         }
         failure.assertHasDescription("Cannot locate tasks that match ':someTest' as task 'someTest' not found in root project 'test'. Some candidates are: 'someTask'.")
         failure.assertHasResolutions(
@@ -215,9 +217,10 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
         when:
         fails "a:someTest"
         then:
-        verifyAll(receivedProblem(0)) {
+        verifyAll(receivedProblem) {
             fqid == 'task-selection:no-matches'
             contextualLabel == "Cannot locate tasks that match 'a:someTest' as task 'someTest' not found in project ':a'. Some candidates are: 'someTask', 'someTaskA'."
+            additionalData == ['requestedPath' : 'a:someTest']
         }
         failure.assertHasDescription("Cannot locate tasks that match 'a:someTest' as task 'someTest' not found in project ':a'. Some candidates are: 'someTask', 'someTaskA'.")
         failure.assertHasResolutions(
@@ -230,6 +233,7 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
     }
 
     def "reports ambiguous task"() {
+        enableProblemsApiCheck()
         createDirs("a", "b")
         settingsFile << """
             rootProject.name = 'test'
@@ -252,8 +256,14 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
             SCAN,
             GET_HELP
         )
+        verifyAll(receivedProblem) {
+            fqid == 'task-selection:ambiguous-matches'
+            contextualLabel == 'Task \'soTa\' is ambiguous in root project \'test\' and its subprojects. Candidates are: \'someTaskA\', \'someTaskAll\', \'someTaskB\'.'
+            additionalData == ['requestedPath' : 'soTa']
+        }
 
         when:
+        resetProblemApiCheck()
         fails "a:soTa"
         then:
         failure.assertHasDescription("Cannot locate tasks that match 'a:soTa' as task 'soTa' is ambiguous in project ':a'. Candidates are: 'someTaskA', 'someTaskAll'.")
@@ -264,9 +274,15 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
             SCAN,
             GET_HELP
         )
+        verifyAll(receivedProblem) {
+            fqid == 'task-selection:ambiguous-matches'
+            contextualLabel == 'Cannot locate tasks that match \'a:soTa\' as task \'soTa\' is ambiguous in project \':a\'. Candidates are: \'someTaskA\', \'someTaskAll\'.'
+            additionalData == ['requestedPath' : 'a:soTa']
+        }
     }
 
     def "reports unknown project"() {
+        enableProblemsApiCheck()
         createDirs("projA", "projB")
         settingsFile << """
             rootProject.name = 'test'
@@ -288,9 +304,17 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
             SCAN,
             GET_HELP
         )
+
+        and:
+        verifyAll(receivedProblem) {
+            fqid == 'task-selection:no-matches'
+            contextualLabel == 'Cannot locate tasks that match \'prog:someTask\' as project \'prog\' not found in root project \'test\'. Some candidates are: \'projA\', \'projB\'.'
+            additionalData == ['requestedPath' : 'prog:someTask']
+        }
     }
 
     def "reports ambiguous project"() {
+        enableProblemsApiCheck()
         createDirs("projA", "projB")
         settingsFile << """
             rootProject.name = 'test'
@@ -312,5 +336,12 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
             SCAN,
             GET_HELP
         )
+
+        and:
+        verifyAll(receivedProblem) {
+            fqid == 'task-selection:ambiguous-matches'
+            contextualLabel == 'Cannot locate tasks that match \'proj:someTask\' as project \'proj\' is ambiguous in root project \'test\'. Candidates are: \'projA\', \'projB\'.'
+            additionalData == ['requestedPath' : 'proj:someTask']
+        }
     }
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -130,7 +130,7 @@ abstract class AbstractIntegrationSpec extends Specification {
     def cleanup() {
         if (enableProblemsApiCheck) {
             collectedProblems.each {
-                KnownProblemIds.assertHasKnownId(it)
+                KnownProblemIds.assertIsKnown(it)
             }
 
             if (getReceivedProblems().every {it == null }) {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
@@ -18,7 +18,7 @@ package org.gradle.integtests.fixtures.problems
 
 class KnownProblemIds {
 
-    static void assertHasKnownId(ReceivedProblem problem) {
+    static void assertIsKnown(ReceivedProblem problem) {
         assert problem != null
         def definition = problem.definition
         def knownDefinition = KNOWN_DEFINITIONS[problem.definition.id.fqid]
@@ -86,7 +86,12 @@ class KnownProblemIds {
         'deprecation:the-detachedconfiguration-configuration-has-been-deprecated-for-consumption' : 'The detachedConfiguration1 configuration has been deprecated for consumption.',
         'deprecation:configurations-acting-as-both-root-and-variant' : 'Configurations should not act as both a resolution root and a variant simultaneously.',
         'deprecation:repository-jcenter' : 'The RepositoryHandler.jcenter() method has been deprecated.',
-        'task-selection:no-matches' : 'cannot locate task',
+        'task-selection:ambiguous-matches' : 'Ambiguous matches',
+        'task-selection:no-matches' : 'No matches',
+        'task-selection:selection-failed' : 'Selection failed',
+        'task-selection:empty-path' : 'Empty path',
+        'missing-task-name' : 'Missing task name',
+        'empty-segments' : 'Empty segments',
         'validation:property-validation:annotation-invalid-in-context' : 'Invalid annotation in context',
         'validation:property-validation:cannot-use-optional-on-primitive-types' : 'Property should be annotated with @Optional',
         'validation:property-validation:cannot-write-output' : 'Property is not writable',


### PR DESCRIPTION
The report incorrectly reported task paths as file locations. This PR fixes the issue by moving said paths to the additional data. Besides, not all task selection problems were reported. More specifically, invalid paths and project selection problems were ignored. This PR also fixes that problem.

Fixes https://github.com/gradle/gradle/issues/28732