### PR TITLE
Disable IP executer tests by default

### DIFF
--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
@@ -174,7 +174,14 @@ fun Project.createTestTask(name: String, executer: String, sourceSet: SourceSet,
             jvmArgumentProviders.add(SamplesBaseDirPropertyProvider(samplesDir))
         }
         setUpAgentIfNeeded(testType, executer)
+        disableForExecuter(executer)
     }
+
+
+internal
+fun IntegrationTest.disableForExecuter(executer: String) {
+    isEnabled = executer != "isolatedProjects"
+}
 
 
 private


### PR DESCRIPTION
Part of https://github.com/gradle/gradle/issues/29045

As soon as subproject will be ready for IP tests, than it should configure
```
tests.isolatedProjectsIntegTest {
    enabled = true
}
```