### PR TITLE
Avoid overhead of listener broadcasting for project observation listener

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/RelevantProjectsRegistry.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/RelevantProjectsRegistry.kt
@@ -24,6 +24,7 @@ import org.gradle.internal.build.BuildState
 import org.gradle.internal.service.scopes.Scope
 import org.gradle.internal.service.scopes.ServiceScope
 import org.gradle.util.Path
+import java.util.concurrent.ConcurrentHashMap
 
 
 @ServiceScope(Scope.Build::class)
@@ -33,7 +34,7 @@ class RelevantProjectsRegistry(
 ) : ProjectComponentObservationListener {
 
     private
-    val targetProjects = mutableSetOf<ProjectState>()
+    val targetProjects = ConcurrentHashMap.newKeySet<ProjectState>()
 
     fun relevantProjects(nodes: List<Node>): Set<ProjectState> {
         val result = mutableSetOf<ProjectState>()

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ProjectComponentObservationListener.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ProjectComponentObservationListener.java
@@ -16,9 +16,6 @@
 
 package org.gradle.api.internal.artifacts.configurations;
 
-import org.gradle.internal.service.scopes.EventScope;
-import org.gradle.internal.service.scopes.Scope;
-import org.gradle.internal.service.scopes.StatefulListener;
 import org.gradle.util.Path;
 
 import javax.annotation.Nullable;
@@ -26,8 +23,6 @@ import javax.annotation.Nullable;
 /**
  * A listener that is notified when one project observes the local component metadata of another.
  */
-@StatefulListener
-@EventScope(Scope.Build.class)
 public interface ProjectComponentObservationListener {
     /**
      * Called when one project observes the local component metadata of another project.


### PR DESCRIPTION
The broadcaster infrastructure adds a non signigicant overhead. This listener gets called for each project dependency for every resolution, and seemingly causes a performance hit.

May fix #29026

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
