### PR TITLE
Remove unnecessary feature flag

### DIFF
--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileProblemsIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileProblemsIntegrationTest.groovy
@@ -47,11 +47,6 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         enableProblemsApiCheck()
 
-        propertiesFile << """
-            # Feature flag as of 8.6 to enable the Problems API
-            systemProp.org.gradle.internal.emit-compiler-problems=true
-        """
-
         buildFile << """
             plugins {
                 id 'java'


### PR DESCRIPTION
We've made the java compiler error reporting feature flag obsolete in #28281, which makes this flag application unnecessary