### PR TITLE
Revert "Disable IP executer tests by default"

### DIFF
--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
@@ -174,14 +174,7 @@ fun Project.createTestTask(name: String, executer: String, sourceSet: SourceSet,
             jvmArgumentProviders.add(SamplesBaseDirPropertyProvider(samplesDir))
         }
         setUpAgentIfNeeded(testType, executer)
-        disableForExecuter(executer)
     }
-
-
-internal
-fun IntegrationTest.disableForExecuter(executer: String) {
-    isEnabled = executer != "isolatedProjects"
-}
 
 
 private


### PR DESCRIPTION
This reverts PR https://github.com/gradle/gradle/pull/29056

In cross version tests, we use `-PonlyTestGradleVersion=X-Y` to split the cross versions to many buckets. In PR #29056, all test tasks disabled in such way was enabled, causing each bucket running all tests and make the total build extremely slow. For example, all builds in this bucket (Gradle 9.0-10.0) should be no-op, but it obviously start running all tests after #29056: https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_QuickFeedbackCrossVersion_5_bucket9?branch=&buildTypeTab=overview&mode=builds