### PR TITLE
Use guava cache instead of Map for CachingToolingImplementationLoader

### DIFF
--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/loader/CachingToolingImplementationLoader.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/loader/CachingToolingImplementationLoader.java
@@ -15,46 +15,73 @@
  */
 package org.gradle.tooling.internal.consumer.loader;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.gradle.api.NonNullApi;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
+import org.gradle.tooling.GradleConnectionException;
 import org.gradle.tooling.internal.consumer.ConnectionParameters;
 import org.gradle.tooling.internal.consumer.Distribution;
 import org.gradle.tooling.internal.consumer.connection.ConsumerConnection;
 import org.gradle.tooling.internal.protocol.InternalBuildProgressListener;
 
 import java.io.Closeable;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 
 public class CachingToolingImplementationLoader implements ToolingImplementationLoader, Closeable {
     private final ToolingImplementationLoader loader;
-    private final Map<ClassPath, ConsumerConnection> connections = new HashMap<ClassPath, ConsumerConnection>();
+    private final Cache<ClassPath, ConsumerConnection> connections = CacheBuilder.newBuilder()
+        .maximumSize(15)
+        .build();
 
     public CachingToolingImplementationLoader(ToolingImplementationLoader loader) {
         this.loader = loader;
     }
 
     @Override
-    public ConsumerConnection create(Distribution distribution, ProgressLoggerFactory progressLoggerFactory, InternalBuildProgressListener progressListener, ConnectionParameters connectionParameters, BuildCancellationToken cancellationToken) {
+    public ConsumerConnection create(final Distribution distribution, final ProgressLoggerFactory progressLoggerFactory, final InternalBuildProgressListener progressListener, final ConnectionParameters connectionParameters, final BuildCancellationToken cancellationToken) {
         ClassPath classpath = distribution.getToolingImplementationClasspath(progressLoggerFactory, progressListener, connectionParameters, cancellationToken);
 
-        ConsumerConnection connection = connections.get(classpath);
-        if (connection == null) {
-            connection = loader.create(distribution, progressLoggerFactory, progressListener, connectionParameters, cancellationToken);
-            connections.put(classpath, connection);
+        try {
+            return connections.get(classpath, new ConsumerConnectionCreator(distribution, progressLoggerFactory, progressListener, connectionParameters, cancellationToken));
+        } catch (ExecutionException e) {
+            throw new GradleConnectionException(String.format("Could not create an instance of Tooling API implementation using the specified %s.", distribution.getDisplayName()), e);
         }
-
-        return connection;
     }
 
     @Override
     public void close() {
         try {
-            CompositeStoppable.stoppable(connections.values()).stop();
+            CompositeStoppable.stoppable(connections.asMap().values()).stop();
         } finally {
-            connections.clear();
+            connections.invalidateAll();
         }
+    }
+
+    @NonNullApi
+    private class ConsumerConnectionCreator implements Callable<ConsumerConnection> {
+        private final Distribution distribution;
+        private final ProgressLoggerFactory progressLoggerFactory;
+        private final InternalBuildProgressListener progressListener;
+        private final ConnectionParameters connectionParameters;
+        private final BuildCancellationToken cancellationToken;
+
+        public ConsumerConnectionCreator(Distribution distribution, ProgressLoggerFactory progressLoggerFactory, InternalBuildProgressListener progressListener, ConnectionParameters connectionParameters, BuildCancellationToken cancellationToken) {
+            this.distribution = distribution;
+            this.progressLoggerFactory = progressLoggerFactory;
+            this.progressListener = progressListener;
+            this.connectionParameters = connectionParameters;
+            this.cancellationToken = cancellationToken;
+        }
+
+        @Override
+        public ConsumerConnection call() throws Exception {
+            return loader.create(distribution, progressLoggerFactory, progressListener, connectionParameters, cancellationToken);
+        }
+
     }
 }

--- a/platforms/ide/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/loader/CachingToolingImplementationLoaderTest.groovy
+++ b/platforms/ide/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/loader/CachingToolingImplementationLoaderTest.groovy
@@ -33,7 +33,7 @@ class CachingToolingImplementationLoaderTest extends Specification {
     final BuildCancellationToken cancellationToken = Mock()
     final CachingToolingImplementationLoader loader = new CachingToolingImplementationLoader(target)
 
-    def delegatesToTargetLoaderToCreateImplementation() {
+    def "delegates to target loader to create implementation"() {
         def distribution = Mock(Distribution)
         def connection = Mock(ConsumerConnection)
 
@@ -47,7 +47,7 @@ class CachingToolingImplementationLoaderTest extends Specification {
         0 * _._
     }
 
-    def reusesImplementationWithSameClasspath() {
+    def "reuses implementation with same classpath"() {
         def distribution = Mock(Distribution)
         def connection = Mock(ConsumerConnection)
 
@@ -63,7 +63,7 @@ class CachingToolingImplementationLoaderTest extends Specification {
         0 * _._
     }
 
-    def createsNewImplementationWhenClasspathNotSeenBefore() {
+    def "creates a new implementation when classpath has not been seen before"() {
         def connection1 = Mock(ConsumerConnection)
         def connection2 = Mock(ConsumerConnection)
         def distribution1 = Mock(Distribution)
@@ -83,29 +83,29 @@ class CachingToolingImplementationLoaderTest extends Specification {
         0 * _._
     }
 
-    def closesConnectionsWhenClosed() {
+    def "close connections when closed"() {
         def connection1 = Mock(ConsumerConnection)
         def connection2 = Mock(ConsumerConnection)
         def distribution1 = Mock(Distribution)
         def distribution2 = Mock(Distribution)
 
         given:
+        target.create(distribution1, loggerFactory, progressListener, params, cancellationToken) >> connection1
+        target.create(distribution2, loggerFactory, progressListener, params, cancellationToken) >> connection2
+        params.getGradleUserHomeDir() >> null
+        distribution1.getToolingImplementationClasspath(loggerFactory, progressListener, params, cancellationToken) >> DefaultClassPath.of(new File('a.jar'))
+        distribution2.getToolingImplementationClasspath(loggerFactory, progressListener, params, cancellationToken) >> DefaultClassPath.of(new File('b.jar'))
+
         loader.create(distribution1, loggerFactory, progressListener, params, cancellationToken)
         loader.create(distribution2, loggerFactory, progressListener, params, cancellationToken)
         loader.create(distribution1, loggerFactory, progressListener, params, cancellationToken)
-
-        _ * target.create(distribution1, loggerFactory, progressListener, params, cancellationToken) >> connection1
-        _ * target.create(distribution2, loggerFactory, progressListener, params, cancellationToken) >> connection2
-        _ * params.getGradleUserHomeDir() >> null
-        _ * distribution1.getToolingImplementationClasspath(loggerFactory, progressListener, params, cancellationToken) >> DefaultClassPath.of(new File('a.jar'))
-        _ * distribution2.getToolingImplementationClasspath(loggerFactory, progressListener, params, cancellationToken) >> DefaultClassPath.of(new File('b.jar'))
 
         when:
         loader.close()
 
         then:
-        connection1.stop()
-        connection2.stop()
+        1 * connection1.stop()
+        1 * connection2.stop()
         0 * _
     }
 }


### PR DESCRIPTION
The team city agent is very long running and therefore runs into [OutOfMemory](https://youtrack.jetbrains.com/issue/TW-87414) when we cache things for to long.
The assumption is 15 different gradle versions, which is implied by the max cache size, seems to be enough for all use cases and if not there is just a small performance penalty. Same goes for the 7 days expiration time. expiration is handle on [normal access methods](https://stackoverflow.com/questions/10144194/how-does-guava-expire-entries-in-its-cachebuilder) not by some background event magic.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
