### PR TITLE
Software type plugins can only expose exactly one software type

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/SoftwareTypeRegistrationPluginTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/SoftwareTypeRegistrationPluginTarget.java
@@ -24,13 +24,19 @@ import org.gradle.api.Project;
 import org.gradle.api.internal.plugins.software.SoftwareType;
 import org.gradle.api.internal.tasks.properties.InspectionScheme;
 import org.gradle.api.internal.plugins.software.RegistersSoftwareTypes;
+import org.gradle.api.problems.Severity;
+import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.configuration.ConfigurationTargetIdentifier;
-import org.gradle.internal.properties.annotations.PropertyMetadata;
+import org.gradle.internal.exceptions.DefaultMultiCauseException;
 import org.gradle.internal.properties.annotations.TypeMetadata;
+import org.gradle.internal.reflect.DefaultTypeValidationContext;
+import org.gradle.internal.reflect.validation.TypeValidationProblemRenderer;
 import org.gradle.plugin.software.internal.SoftwareTypeRegistry;
 
 import javax.annotation.Nullable;
 import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
 
 /**
  * A {@link PluginTarget} that inspects the plugin for {@link RegistersSoftwareTypes} annotations and registers the
@@ -81,23 +87,56 @@ public class SoftwareTypeRegistrationPluginTarget implements PluginTarget {
         Optional<RegistersSoftwareTypes> registersSoftwareType = typeMetadata.getTypeAnnotationMetadata().getAnnotation(RegistersSoftwareTypes.class);
         registersSoftwareType.ifPresent(registration -> {
             for (Class<? extends Plugin<Project>> softwareTypeImplClass : registration.value()) {
-                validateSoftwareTypePluginExposesSoftwareTypes(softwareTypeImplClass);
+                validateSoftwareTypePluginExposesExactlyOneSoftwareType(softwareTypeImplClass, typeMetadata.getType());
                 softwareTypeRegistry.register(softwareTypeImplClass);
             }
         });
     }
 
-    void validateSoftwareTypePluginExposesSoftwareTypes(Class<? extends Plugin<Project>> softwareTypePluginImplClass) {
+    void validateSoftwareTypePluginExposesExactlyOneSoftwareType(Class<? extends Plugin<Project>> softwareTypePluginImplClass, Class<?> registeringPlugin) {
+        DefaultTypeValidationContext typeValidationContext = DefaultTypeValidationContext.withRootType(softwareTypePluginImplClass, false);
         TypeToken<?> softwareTypePluginImplType = TypeToken.of(softwareTypePluginImplClass);
         TypeMetadata softwareTypePluginImplMetadata = inspectionScheme.getMetadataStore().getTypeMetadata(softwareTypePluginImplType.getRawType());
+        softwareTypePluginImplMetadata.visitValidationFailures(null, typeValidationContext);
 
-        for (PropertyMetadata propertyMetadata : softwareTypePluginImplMetadata.getPropertiesMetadata()) {
-            Optional<SoftwareType> registersSoftwareType = propertyMetadata.getAnnotation(SoftwareType.class);
-            if (registersSoftwareType.isPresent()) {
-                return;
-            }
+        long exposedSoftwareTypes = softwareTypePluginImplMetadata.getPropertiesMetadata().stream()
+            .map(propertyMetadata -> propertyMetadata.getAnnotation(SoftwareType.class))
+            .filter(Optional::isPresent)
+            .count();
+
+        if (exposedSoftwareTypes == 0) {
+            typeValidationContext.visitTypeProblem(problem ->
+                problem.withAnnotationType(softwareTypePluginImplClass)
+                    .id("missing-software-type", "Missing software type annotation", GradleCoreProblemGroup.validation().type())
+                    .contextualLabel("is registered as a software type plugin but does not expose a software type")
+                    .severity(Severity.ERROR)
+                    .details("This class was registered as a software type plugin, but it does not expose a software type. Software type plugins must expose exactly one software type via a property with the @SoftwareType annotation.")
+                    .solution("Add @SoftwareType annotations to properties of " + softwareTypePluginImplClass.getSimpleName())
+                    .solution("Remove " + softwareTypePluginImplClass.getSimpleName() + " from the @RegistersSoftwareTypes annotation on " + registeringPlugin.getSimpleName())
+            );
+        } else if (exposedSoftwareTypes > 1) {
+            typeValidationContext.visitTypeProblem(problem ->
+                problem.withAnnotationType(softwareTypePluginImplClass)
+                    .id("missing-software-type", "Missing software type annotation", GradleCoreProblemGroup.validation().type())
+                    .contextualLabel("is registered as a software type plugin, but it exposes multiple software types")
+                    .severity(Severity.ERROR)
+                    .details("This class was registered as a software type plugin, but it exposes multiple software types. Software type plugins must expose exactly one software type via a property with the @SoftwareType annotation.")
+                    .solution("Add the @SoftwareType annotation to only one property of " + softwareTypePluginImplClass.getSimpleName())
+            );
         }
 
-        throw new InvalidUserDataException("A plugin with type '" + softwareTypePluginImplClass.getName() + "' was registered as a software type plugin, but it does not expose any software types. Software type plugins must expose software types via properties with the @SoftwareType annotation.");
+        if (!typeValidationContext.getProblems().isEmpty()) {
+            throw new DefaultMultiCauseException(
+                String.format(typeValidationContext.getProblems().size() == 1
+                        ? "A problem was found with the %s plugin."
+                        : "Some problems were found with the %s plugin.",
+                    softwareTypePluginImplClass.getSimpleName()),
+                typeValidationContext.getProblems().stream()
+                    .map(TypeValidationProblemRenderer::renderMinimalInformationAbout)
+                    .sorted()
+                    .map(InvalidUserDataException::new)
+                    .collect(toImmutableList())
+            );
+        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/SoftwareTypeRegistrationPluginTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/SoftwareTypeRegistrationPluginTarget.java
@@ -34,7 +34,9 @@ import org.gradle.internal.reflect.validation.TypeValidationProblemRenderer;
 import org.gradle.plugin.software.internal.SoftwareTypeRegistry;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
@@ -99,12 +101,14 @@ public class SoftwareTypeRegistrationPluginTarget implements PluginTarget {
         TypeMetadata softwareTypePluginImplMetadata = inspectionScheme.getMetadataStore().getTypeMetadata(softwareTypePluginImplType.getRawType());
         softwareTypePluginImplMetadata.visitValidationFailures(null, typeValidationContext);
 
-        long exposedSoftwareTypes = softwareTypePluginImplMetadata.getPropertiesMetadata().stream()
+        List<String> exposedSoftwareTypes = softwareTypePluginImplMetadata.getPropertiesMetadata().stream()
             .map(propertyMetadata -> propertyMetadata.getAnnotation(SoftwareType.class))
             .filter(Optional::isPresent)
-            .count();
+            .map(annotation -> annotation.get().name())
+            .sorted()
+            .collect(Collectors.toList());
 
-        if (exposedSoftwareTypes == 0) {
+        if (exposedSoftwareTypes.isEmpty()) {
             typeValidationContext.visitTypeProblem(problem ->
                 problem.withAnnotationType(softwareTypePluginImplClass)
                     .id("missing-software-type", "Missing software type annotation", GradleCoreProblemGroup.validation().type())
@@ -114,14 +118,15 @@ public class SoftwareTypeRegistrationPluginTarget implements PluginTarget {
                     .solution("Add @SoftwareType annotations to properties of " + softwareTypePluginImplClass.getSimpleName())
                     .solution("Remove " + softwareTypePluginImplClass.getSimpleName() + " from the @RegistersSoftwareTypes annotation on " + registeringPlugin.getSimpleName())
             );
-        } else if (exposedSoftwareTypes > 1) {
+        } else if (exposedSoftwareTypes.size() > 1) {
             typeValidationContext.visitTypeProblem(problem ->
                 problem.withAnnotationType(softwareTypePluginImplClass)
-                    .id("missing-software-type", "Missing software type annotation", GradleCoreProblemGroup.validation().type())
+                    .id("multiple-software-types", "Multiple software type annotations", GradleCoreProblemGroup.validation().type())
                     .contextualLabel("is registered as a software type plugin, but it exposes multiple software types")
                     .severity(Severity.ERROR)
-                    .details("This class was registered as a software type plugin, but it exposes multiple software types. Software type plugins must expose exactly one software type via a property with the @SoftwareType annotation.")
+                    .details("This class was registered as a software type plugin, but it exposes multiple software types: [" + String.join(", ", exposedSoftwareTypes) + "]. Software type plugins must expose exactly one software type via a property with the @SoftwareType annotation.")
                     .solution("Add the @SoftwareType annotation to only one property of " + softwareTypePluginImplClass.getSimpleName())
+                    .solution("Split " + softwareTypePluginImplClass.getSimpleName() + " into multiple plugins, each exposing a single software type and register all plugins in " + registeringPlugin.getSimpleName() + " using the @RegistersSoftwareTypes annotation")
             );
         }
 


### PR DESCRIPTION
This changes the software type plugin validation to only allow plugins to expose exactly one software type.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
