### PR TITLE
Make SoftwareType annotations default the public type to the method return type

### DIFF
--- a/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/settings/SoftwareTypeFixture.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/settings/SoftwareTypeFixture.groovy
@@ -275,7 +275,7 @@ trait SoftwareTypeFixture {
 
     static String getProjectPluginThatProvidesSoftwareType(
         String implementationTypeClassName = "TestSoftwareTypeExtension",
-        String publicTypeClassName = "TestSoftwareTypeExtension",
+        String publicTypeClassName = null,
         String softwareTypePluginClassName = "SoftwareTypeImplPlugin",
         String softwareType = "testSoftwareType"
     ) {
@@ -293,7 +293,7 @@ trait SoftwareTypeFixture {
 
             abstract public class ${softwareTypePluginClassName} implements Plugin<Project> {
 
-                @SoftwareType(name="${softwareType}", modelPublicType=${publicTypeClassName}.class)
+                @SoftwareType(${getSoftwareTypeArguments(softwareType, publicTypeClassName)})
                 abstract public ${implementationTypeClassName} getTestSoftwareTypeExtension();
 
                 @Override
@@ -309,6 +309,11 @@ trait SoftwareTypeFixture {
                 }
             }
         """
+    }
+
+    private static getSoftwareTypeArguments(String name, String modelPublicType) {
+        return "name=\"${name}\"" +
+            (modelPublicType ? ", modelPublicType=${modelPublicType}.class" : "")
     }
 
     static String getProjectPluginThatDoesNotProvideSoftwareType(String implementationTypeClassName = "TestSoftwareTypeExtension", String softwareTypePluginClassName = "SoftwareTypeImplPlugin") {

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/DefaultSoftwareTypeRegistry.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/DefaultSoftwareTypeRegistry.java
@@ -103,11 +103,15 @@ public class DefaultSoftwareTypeRegistry implements SoftwareTypeRegistry {
                 softwareTypeImplementationsBuilder.add(
                     new DefaultSoftwareTypeImplementation(
                         softwareType.name(),
-                        softwareType.modelPublicType(),
+                        publicTypeOf(propertyMetadata, softwareType),
                         Cast.uncheckedNonnullCast(pluginClass)
                     )
                 );
             });
+        }
+
+        private static Class<?> publicTypeOf(PropertyMetadata propertyMetadata, SoftwareType softwareType) {
+            return softwareType.modelPublicType() == Void.class ? propertyMetadata.getDeclaredType().getRawType() : softwareType.modelPublicType();
         }
     }
 }

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/SoftwareTypeAnnotationHandler.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/SoftwareTypeAnnotationHandler.java
@@ -50,7 +50,7 @@ public class SoftwareTypeAnnotationHandler extends AbstractPropertyAnnotationHan
         propertyMetadata.getAnnotation(SoftwareType.class).ifPresent(softwareType -> {
             Class<?> publicType = softwareType.modelPublicType();
             Class<?> valueType = propertyMetadata.getDeclaredType().getRawType();
-            if (!publicType.isAssignableFrom(valueType)) {
+            if (publicType != Void.class && !publicType.isAssignableFrom(valueType)) {
                 validationContext.visitPropertyProblem(problem ->
                     problem
                         .forProperty(propertyMetadata.getPropertyName())

--- a/platforms/extensibility/plugin-use/src/test/groovy/org/gradle/plugin/software/internal/DefaultSoftwareTypeRegistryTest.groovy
+++ b/platforms/extensibility/plugin-use/src/test/groovy/org/gradle/plugin/software/internal/DefaultSoftwareTypeRegistryTest.groovy
@@ -31,7 +31,7 @@ class DefaultSoftwareTypeRegistryTest extends Specification {
     def inspectionScheme = Mock(InspectionScheme)
     def registry = new DefaultSoftwareTypeRegistry(inspectionScheme)
 
-    def "can register and retrieve a software type"() {
+    def "can register and retrieve a software type (public type = #modelPublicType.simpleName)"() {
         def pluginTypeMetadata = Mock(TypeMetadata)
         def modelTypeMetadata = Mock(TypeMetadata)
         def propertyMetadata = Mock(PropertyMetadata)
@@ -48,10 +48,10 @@ class DefaultSoftwareTypeRegistryTest extends Specification {
         1 * metadataStore.getTypeMetadata(SoftwareTypeImpl) >> pluginTypeMetadata
         1 * pluginTypeMetadata.getPropertiesMetadata() >> [propertyMetadata]
         1 * propertyMetadata.getPropertyType() >> SoftwareType.class
-        1 * propertyMetadata.getDeclaredType() >> TypeToken.of(TestModel.class)
+        (1..2) * propertyMetadata.getDeclaredType() >> TypeToken.of(TestModel.class)
         1 * propertyMetadata.getAnnotation(SoftwareType.class) >> Optional.of(softwareType)
         2 * softwareType.name() >> "test"
-        1 * softwareType.modelPublicType() >> TestModel
+        (1..2) * softwareType.modelPublicType() >> modelPublicType
         1 * metadataStore.getTypeMetadata(TestModel) >> modelTypeMetadata
         1 * modelTypeMetadata.getPropertiesMetadata() >> []
 
@@ -59,6 +59,9 @@ class DefaultSoftwareTypeRegistryTest extends Specification {
         implementations.size() == 1
         implementations[0].modelPublicType == TestModel
         implementations[0].softwareType == "test"
+
+        where:
+        modelPublicType << [TestModel, Void]
     }
 
     def "cannot register a plugin that is not a software type"() {
@@ -96,7 +99,7 @@ class DefaultSoftwareTypeRegistryTest extends Specification {
         1 * propertyMetadata.getDeclaredType() >> TypeToken.of(TestModel.class)
         1 * propertyMetadata.getAnnotation(SoftwareType.class) >> Optional.of(softwareType)
         2 * softwareType.name() >> "test"
-        1 * softwareType.modelPublicType() >> TestModel
+        2 * softwareType.modelPublicType() >> TestModel
         1 * metadataStore.getTypeMetadata(TestModel) >> modelTypeMetadata
         1 * modelTypeMetadata.getPropertiesMetadata() >> []
 
@@ -130,7 +133,7 @@ class DefaultSoftwareTypeRegistryTest extends Specification {
         1 * duplicatePropertyMetadata.getDeclaredType() >> TypeToken.of(TestModel.class)
         1 * duplicatePropertyMetadata.getAnnotation(SoftwareType.class) >> Optional.of(softwareType)
         4 * softwareType.name() >> "test"
-        1 * softwareType.modelPublicType() >> TestModel
+        2 * softwareType.modelPublicType() >> TestModel
         2 * metadataStore.getTypeMetadata(TestModel) >> modelTypeMetadata
         1 * modelTypeMetadata.getPropertiesMetadata() >> []
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/plugins/software/SoftwareType.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/plugins/software/SoftwareType.java
@@ -41,9 +41,10 @@ public @interface SoftwareType {
 
     /**
      * The model type used to configure the software type.  Note that this class should be the same type or a super type of the return type
-     * of the method that this annotation is applied to.
+     * of the method that this annotation is applied to.  If this value is not set, the public model type will default to the return type of
+     * the method.
      *
      * @since 8.9
      */
-    Class<?> modelPublicType();
+    Class<?> modelPublicType() default Void.class;
 }


### PR DESCRIPTION
If the user does not provide an explicit public type in the `@SoftwareType` annotation, Gradle will default to the return type of the method the annotation is applied to.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
