### PR TITLE
Let `ConfigurationCacheProblemsSummary` use synchronized shared mutable state

### DIFF
--- a/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
+++ b/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
@@ -45,7 +45,6 @@ abstract class ExternalModulesExtension(isBundleGroovy4: Boolean) {
     val bouncycastlePkix = "org.bouncycastle:bcpkix-jdk18on"
     val bouncycastleProvider = "org.bouncycastle:bcprov-jdk18on"
     val bsh = "org.apache-extras.beanshell:bsh"
-    val capsule = "io.usethesource:capsule"
     val commonsCodec = "commons-codec:commons-codec"
     val commonsCompress = "org.apache.commons:commons-compress"
     val commonsHttpclient = "org.apache.httpcomponents:httpclient"
@@ -228,7 +227,6 @@ abstract class ExternalModulesExtension(isBundleGroovy4: Boolean) {
         bouncycastlePgp to License.MIT,
         bouncycastleProvider to License.MIT,
         bsh to License.Apache2,
-        capsule to License.BSDStyle,
         commonsCodec to License.Apache2,
         commonsCompress to License.Apache2,
         commonsHttpclient to License.Apache2,

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -880,11 +880,6 @@
             <pgp value="7E22D50A7EBD9D2CD269B2D4056ACA74D46000BF"/>
          </artifact>
       </component>
-      <component group="io.usethesource" name="capsule" version="0.6.3">
-         <artifact name="capsule-0.6.3.jar">
-            <sha256 value="38df64de67bd7c953f3643bdc34fe5fc674eb7e42b8f65f01e2233b8e5006a09" origin="Verified" reason="Artifact is not signed"/>
-         </artifact>
-      </component>
       <component group="it.unimi.dsi" name="fastutil" version="8.5.2">
          <artifact name="fastutil-8.5.2.jar">
             <pgp value="0CB5871FB7BF3B351614BBF6CA85FFE638D4407A"/>

--- a/platforms/core-configuration/configuration-cache/build.gradle.kts
+++ b/platforms/core-configuration/configuration-cache/build.gradle.kts
@@ -81,7 +81,7 @@ dependencies {
     implementation(project(":tooling-api"))
 
     implementation(libs.asm)
-    implementation(libs.capsule)
+    implementation(libs.fastutil)
     implementation(libs.groovyJson)
     implementation(libs.slf4jApi)
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblemsSummary.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblemsSummary.kt
@@ -16,19 +16,16 @@
 
 package org.gradle.configurationcache.problems
 
+import com.google.common.collect.ImmutableList
+import com.google.common.collect.ImmutableSet
 import com.google.common.collect.Ordering
-import io.usethesource.capsule.Set
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet
 import org.gradle.api.Task
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.configurationcache.extensions.capitalized
 import org.gradle.internal.logging.ConsoleRenderer
 import java.io.File
 import java.util.Comparator.comparing
-import java.util.concurrent.atomic.AtomicReference
-
-
-private
-const val maxReportedProblems = 4096
 
 
 private
@@ -52,23 +49,74 @@ enum class ProblemSeverity {
 
 
 internal
-class ConfigurationCacheProblemsSummary {
+class ConfigurationCacheProblemsSummary(
 
     private
-    val summary = AtomicReference(Summary.empty)
+    val maxCollectedProblems: Int = 4096
 
-    fun get(): Summary =
-        summary.get()
+) {
+    /**
+     * Reported more problems than can be collected.
+     */
+    private
+    var overflowed: Boolean = false
 
-    fun onProblem(problem: PropertyProblem, severity: ProblemSeverity): Boolean =
-        summary
-            .updateAndGet { it.insert(problem, severity) }
-            .overflowed.not()
+    private
+    var problemCount: Int = 0
+
+    private
+    var failureCount: Int = 0
+
+    private
+    var suppressedCount: Int = 0
+
+    private
+    var uniqueProblems = ObjectOpenHashSet<UniquePropertyProblem>()
+
+    private
+    var causes = ArrayList<Throwable>(maxCauses)
+
+    fun get(): Summary = synchronized(this) {
+        Summary(
+            problemCount,
+            failureCount,
+            suppressedCount,
+            ImmutableSet.copyOf(uniqueProblems),
+            ImmutableList.copyOf(causes),
+            overflowed,
+            maxCollectedProblems
+        )
+    }
+
+    fun onProblem(problem: PropertyProblem, severity: ProblemSeverity): Boolean {
+        synchronized(this) {
+            problemCount += 1
+            when (severity) {
+                ProblemSeverity.Failure -> failureCount += 1
+                ProblemSeverity.Suppressed -> suppressedCount += 1
+                ProblemSeverity.Info -> {}
+            }
+            if (overflowed) {
+                return false
+            }
+            if (problemCount > maxCollectedProblems) {
+                overflowed = true
+                return false
+            }
+            val uniqueProblem = UniquePropertyProblem.of(problem)
+            if (uniqueProblems.add(uniqueProblem) && causes.size < maxCauses) {
+                problem.exception?.let {
+                    causes.add(it)
+                }
+            }
+            return true
+        }
+    }
 }
 
 
 internal
-class Summary private constructor(
+class Summary(
     /**
      * Total of all problems, regardless of severity.
      */
@@ -82,65 +130,31 @@ class Summary private constructor(
     /**
      * Total number of [suppressed][ProblemSeverity.Suppressed] problems.
      */
+    private
     val suppressedCount: Int,
 
     private
-    val uniqueProblems: Set.Immutable<UniquePropertyProblem>,
+    val uniqueProblems: Set<UniquePropertyProblem>,
 
     val causes: List<Throwable>,
 
-    val overflowed: Boolean
+    private
+    val overflowed: Boolean,
+
+    private
+    val maxCollectedProblems: Int
 ) {
-    companion object {
-        val empty = Summary(
-            problemCount = 0,
-            failureCount = 0,
-            suppressedCount = 0,
-            uniqueProblems = Set.Immutable.of(),
-            causes = emptyList(),
-            overflowed = false
-        )
-    }
+    val uniqueProblemCount: Int
+        get() = uniqueProblems.size
 
     val nonSuppressedProblemCount: Int
         get() = problemCount - suppressedCount
 
-    fun insert(problem: PropertyProblem, severity: ProblemSeverity): Summary {
-        val newProblemCount = problemCount + 1
-        val newFailureCount = if (severity == ProblemSeverity.Failure) failureCount + 1 else failureCount
-        val newSuppressedCount = if (severity == ProblemSeverity.Suppressed) suppressedCount + 1 else suppressedCount
-        if (overflowed || newProblemCount > maxReportedProblems) {
-            return Summary(
-                newProblemCount,
-                newFailureCount,
-                newSuppressedCount,
-                uniqueProblems,
-                causes,
-                true
-            )
-        }
-        val uniqueProblem = UniquePropertyProblem.of(problem)
-        val newUniqueProblems = uniqueProblems.__insert(uniqueProblem)
-        val newCauses = problem
-            .takeIf { newUniqueProblems !== uniqueProblems && causes.size < maxCauses }
-            ?.exception?.let { causes + it }
-            ?: causes
-        return Summary(
-            newProblemCount,
-            newFailureCount,
-            newSuppressedCount,
-            newUniqueProblems,
-            newCauses,
-            false
-        )
-    }
-
     fun textForConsole(cacheActionText: String, htmlReportFile: File? = null): String {
         val documentationRegistry = DocumentationRegistry()
-        val uniqueProblemCount = uniqueProblems.size
         return StringBuilder().apply {
             appendLine()
-            appendSummaryHeader(cacheActionText, problemCount, uniqueProblemCount)
+            appendSummaryHeader(cacheActionText, problemCount)
             appendLine()
             Ordering.from(consoleComparator()).leastOf(uniqueProblems, maxConsoleProblems).forEach { problem ->
                 append("- ")
@@ -164,8 +178,7 @@ class Summary private constructor(
     private
     fun StringBuilder.appendSummaryHeader(
         cacheAction: String,
-        totalProblemCount: Int,
-        uniqueProblemCount: Int
+        totalProblemCount: Int
     ) {
         append(totalProblemCount)
         append(if (totalProblemCount == 1) " problem was found " else " problems were found ")
@@ -173,7 +186,7 @@ class Summary private constructor(
         append(" the configuration cache")
         if (overflowed) {
             append(", only the first ")
-            append(maxReportedProblems)
+            append(maxCollectedProblems)
             append(" were considered")
         }
         if (totalProblemCount != uniqueProblemCount) {
@@ -201,7 +214,7 @@ fun consoleComparator() =
         .thenComparing { p: UniquePropertyProblem -> p.message }
 
 
-private
+internal
 data class UniquePropertyProblem(
     val userCodeLocation: String,
     val message: String,

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblemsSummaryTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblemsSummaryTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.problems
+
+import org.gradle.internal.Describables
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+
+class ConfigurationCacheProblemsSummaryTest {
+
+    @Test
+    fun `keeps track of unique problems upto maxCollectedProblems`() {
+        val subject = ConfigurationCacheProblemsSummary(maxCollectedProblems = 2)
+        assertTrue(
+            "1st problem",
+            subject.onProblem(buildLogicProblem("build.gradle", "failure"), ProblemSeverity.Failure)
+        )
+        assertTrue(
+            "2nd problem (same message as 1st but different location)",
+            subject.onProblem(buildLogicProblem("build.gradle.kts", "failure"), ProblemSeverity.Failure)
+        )
+        assertFalse(
+            "overflow",
+            subject.onProblem(buildLogicProblem("build.gradle", "another failure"), ProblemSeverity.Failure)
+        )
+        assertThat(
+            subject.get().uniqueProblemCount,
+            equalTo(2)
+        )
+    }
+
+    @Test
+    fun `keeps track of total problem count`() {
+        val subject = ConfigurationCacheProblemsSummary(maxCollectedProblems = 2)
+        assertTrue(
+            "1st problem",
+            subject.onProblem(buildLogicProblem("build.gradle", "failure"), ProblemSeverity.Failure)
+        )
+        assertTrue(
+            "2nd problem",
+            subject.onProblem(buildLogicProblem("build.gradle", "failure"), ProblemSeverity.Failure)
+        )
+        assertFalse(
+            "overflow",
+            subject.onProblem(buildLogicProblem("build.gradle", "failure"), ProblemSeverity.Failure)
+        )
+
+        val summary = subject.get()
+        assertThat(
+            "Keeps track of total problem count regardless of maxCollectedProblems",
+            summary.problemCount,
+            equalTo(3)
+        )
+    }
+
+    private
+    fun buildLogicProblem(location: String, message: String) = PropertyProblem(
+        PropertyTrace.BuildLogic(Describables.of(location), 1),
+        StructuredMessage.build { text(message) }
+    )
+}

--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -63,7 +63,6 @@ dependencies {
         api(libs.bouncycastlePkix)      { version { strictly(bouncycastleVersion) }}
         api(libs.bouncycastleProvider)  { version { strictly(bouncycastleVersion) }}
         api(libs.bsh)                   { version { strictly("2.0b6") }}
-        api(libs.capsule)               { version { strictly("0.6.3") }}
         api(libs.commonsCodec)          { version { strictly("1.16.1") } }
         api(libs.commonsCompress)       { version { strictly("1.26.1") } }
         api(libs.commonsHttpclient)     { version { strictly("4.5.14") } }

--- a/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -34,7 +34,7 @@ import static org.hamcrest.MatcherAssert.assertThat
 
 abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
 
-    protected static final THIRD_PARTY_LIB_COUNT = 144
+    protected static final THIRD_PARTY_LIB_COUNT = 143
 
     @Shared String baseVersion = GradleVersion.current().baseVersion.version
 


### PR DESCRIPTION
To track unique problems so the dependency on the `capsule` library (which was being used in a single place) can be removed.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
