### PR TITLE
Upgrade tested AGP versions

### DIFF
--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/ide/AndroidStudioProvisioningPlugin.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/ide/AndroidStudioProvisioningPlugin.kt
@@ -45,9 +45,9 @@ import org.gradle.process.CommandLineArgumentProvider
 import java.util.concurrent.Callable
 
 
-// Android Studio Iguana 2023.2.1 Patch 1
+// Android Studio Jellyfish 2023.3.1
 private
-const val defaultAndroidStudioVersion = "2023.2.1.24"
+const val defaultAndroidStudioVersion = "2023.3.1.18"
 
 
 class AndroidStudioProvisioningPlugin : Plugin<Project> {

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
@@ -424,7 +424,7 @@ performanceTest.registerAndroidTestProject("largeAndroidBuild2", RemoteProject) 
 performanceTest.registerAndroidTestProject("nowInAndroidBuild", RemoteProject) {
     remoteUri = 'https://github.com/android/nowinandroid.git'
     // Pinned from main branch
-    ref = "88c3eb0b90ace5499962d9495464fa2388ec9e9a" // latest of March 29th, 2024
+    ref = "b85cf7d4766ca84a424700f86a96f5eab0a3cfbd" // latest of May 14th, 2024
     doLast {
         setMaxWorkers(outputDirectory, 8)
     }

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -83,10 +83,10 @@ object Config {
     const val performanceTestResultsJsonName = "perf-results.json"
     const val performanceTestResultsJson = "performance-tests/$performanceTestResultsJsonName"
 
-    // Android Studio Iguana 2023.2.1 Patch 1
+    // Android Studio Jellyfish 2023.3.1
     // Find all references here https://developer.android.com/studio/archive
     // Update verification-metadata.xml
-    const val performanceTestAndroidStudioVersion = "2023.2.1.24"
+    const val performanceTestAndroidStudioVersion = "2023.3.1.18"
     val performanceTestAndroidStudioJvmArgs = listOf("-Xms256m", "-Xmx4096m")
 }
 

--- a/gradle/dependency-management/agp-versions.properties
+++ b/gradle/dependency-management/agp-versions.properties
@@ -1,4 +1,4 @@
 # Generated - Update by running `./gradlew updateAgpVersions`
-latests=7.3.1,7.4.2,8.0.2,8.1.4,8.2.2,8.3.0,8.4.0-beta02,8.5.0-alpha04
-nightlyBuildId=11688955
-nightlyVersion=8.5.0-dev
+latests=7.3.1,7.4.2,8.0.2,8.1.4,8.2.2,8.3.2,8.4.0,8.5.0-beta01
+nightlyBuildId=11829825
+nightlyVersion=8.6.0-dev

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -346,18 +346,18 @@
       </trusted-keys>
    </configuration>
    <components>
-      <component group="android-studio" name="android-studio" version="2023.2.1.24">
-         <artifact name="android-studio-2023.2.1.24.linux.tar.gz">
-            <sha256 value="0026427572849c9cbb0c94d6f9718ea08bc345dccfe3b372b54100a95fff99b5" origin="Verified" reason="Artifact is not signed"/>
+      <component group="android-studio" name="android-studio" version="2023.3.1.18">
+         <artifact name="android-studio-2023.3.1.18.linux.tar.gz">
+            <sha256 value="46a9b4a311820b2c1841110affa286d65665ac9f8970fd9e9eb903c3d7aa436e" origin="Verified" reason="Artifact is not signed"/>
          </artifact>
-         <artifact name="android-studio-2023.2.1.24.mac.zip">
-            <sha256 value="c0bf9d6f7ee5fe8f61e556a2326c73dabea4ba0b2e6b13bfed824268dcc7e585" origin="Verified" reason="Artifact is not signed"/>
+         <artifact name="android-studio-2023.3.1.18.mac.zip">
+            <sha256 value="b0b5a2cec33e331c30727a06356c2724e7d9a8f5e78dc76cdb62eb6f2442c569" origin="Verified" reason="Artifact is not signed"/>
          </artifact>
-         <artifact name="android-studio-2023.2.1.24.mac_arm.zip">
-            <sha256 value="736c7c372353925378205087c59b58ac7a0e9a26c096e72796017f4f5f29562b" origin="Verified" reason="Artifact is not signed"/>
+         <artifact name="android-studio-2023.3.1.18.mac_arm.zip">
+            <sha256 value="86755aaa6d515cbbc0e953f228333289daf573a2728a4ee592054ca43b4cf52d" origin="Verified" reason="Artifact is not signed"/>
          </artifact>
-         <artifact name="android-studio-2023.2.1.24.windows.zip">
-            <sha256 value="da1c548b6d57f1dd63737cb248cf6760eddbd79ab21e8b1e3c3b55123ab4ef57" origin="Verified" reason="Artifact is not signed"/>
+         <artifact name="android-studio-2023.3.1.18.windows.zip">
+            <sha256 value="35c673127615c86bde61f5ab91abdcdd510275c8c81e26fa2910166a0d6852da" origin="Verified" reason="Artifact is not signed"/>
          </artifact>
       </component>
       <component group="antlr" name="antlr" version="2.7.7">

--- a/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
@@ -95,5 +95,5 @@ Gradle plugins written in Groovy must use Groovy 3.x for compatibility with Grad
 
 == Android
 
-Gradle is tested with Android Gradle Plugin 7.3 through 8.3.
+Gradle is tested with Android Gradle Plugin 7.3 through 8.4.
 Alpha and beta versions may or may not work.

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/SelfResolvingDependencyIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/SelfResolvingDependencyIntegrationTest.groovy
@@ -53,7 +53,7 @@ task verify {
         executer.expectDocumentedDeprecationWarning("Directly resolving a file collection dependency's files has been deprecated. This will fail with an error in Gradle 9.0. Add the dependency to a resolvable configuration and resolve the configuration. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_self_resolving_dependency")
         executer.expectDocumentedDeprecationWarning("Directly resolving a file collection dependency's files has been deprecated. This will fail with an error in Gradle 9.0. Add the dependency to a resolvable configuration and resolve the configuration. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_self_resolving_dependency")
         executer.expectDocumentedDeprecationWarning("Accessing the build dependencies of a file collection dependency has been deprecated. This will fail with an error in Gradle 9.0. Add the dependency to a resolvable configuration use the configuration to track task dependencies. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_self_resolving_dependency")
-        run "verify", "-Dorg.gradle.internal.deprecation.preliminary.DefaultFileCollectionDependency.enabled=true"
+        run "verify"
 
         then:
         outputContains("files: [lib.jar]")

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultFileCollectionDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultFileCollectionDependency.java
@@ -86,13 +86,11 @@ public class DefaultFileCollectionDependency extends AbstractDependency implemen
     @Override
     @Deprecated
     public Set<File> resolve() {
-        if (emitDeprecation()) {
-            DeprecationLogger.deprecate("Directly resolving a file collection dependency's files")
-                .withAdvice("Add the dependency to a resolvable configuration and resolve the configuration.")
-                .willBecomeAnErrorInGradle9()
-                .withUpgradeGuideSection(8, "deprecate_self_resolving_dependency")
-                .nagUser();
-        }
+        DeprecationLogger.deprecate("Directly resolving a file collection dependency's files")
+            .withAdvice("Add the dependency to a resolvable configuration and resolve the configuration.")
+            .willBecomeAnErrorInGradle9()
+            .withUpgradeGuideSection(8, "deprecate_self_resolving_dependency")
+            .nagUser();
 
         return source.getFiles();
     }
@@ -100,7 +98,6 @@ public class DefaultFileCollectionDependency extends AbstractDependency implemen
     @Override
     @Deprecated
     public Set<File> resolve(boolean transitive) {
-
         DeprecationLogger.deprecate("Directly resolving a file collection dependency's files")
             .withAdvice("Add the dependency to a resolvable configuration and resolve the configuration.")
             .willBecomeAnErrorInGradle9()
@@ -113,25 +110,13 @@ public class DefaultFileCollectionDependency extends AbstractDependency implemen
     @Override
     @Deprecated
     public TaskDependency getBuildDependencies() {
-        if (emitDeprecation()) {
-            DeprecationLogger.deprecate("Accessing the build dependencies of a file collection dependency")
-                .withAdvice("Add the dependency to a resolvable configuration use the configuration to track task dependencies.")
-                .willBecomeAnErrorInGradle9()
-                .withUpgradeGuideSection(8, "deprecate_self_resolving_dependency")
-                .nagUser();
-        }
+        DeprecationLogger.deprecate("Accessing the build dependencies of a file collection dependency")
+            .withAdvice("Add the dependency to a resolvable configuration use the configuration to track task dependencies.")
+            .willBecomeAnErrorInGradle9()
+            .withUpgradeGuideSection(8, "deprecate_self_resolving_dependency")
+            .nagUser();
 
         return source.getBuildDependencies();
-    }
-
-    private static boolean emitDeprecation() {
-        // TODO #27437: Always emit deprecation here.
-        // AGP currently uses these deprecated APIs. An issue has been filed for them to migrate away.
-        // This property exists to allow AGP to test whether they have properly resolved this deprecation.
-        // This property WILL be removed without warning.
-
-        // TODO: Be sure to update SelfResolvingDependencyIntegrationTest when this property is removed.
-        return Boolean.getBoolean("org.gradle.internal.deprecation.preliminary.DefaultFileCollectionDependency.enabled");
     }
 
     @Override

--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -73,7 +73,7 @@ dependencies {
         api(libs.commonsMath)           { version { strictly("3.6.1") }}
         api(libs.eclipseSisuPlexus)     { version { strictly("0.3.5"); because("transitive dependency of Maven modules to process POM metadata") }}
         api(libs.errorProneAnnotations) { version { strictly("2.26.1") }}
-        api(libs.gradleProfiler)        { version { strictly("0.21.0-alpha-3") }}
+        api(libs.gradleProfiler)        { version { strictly("0.21.0-alpha-4") }}
         api(libs.develocityTestAnnotation) { version { strictly("2.0.1") }}
         api(libs.gcs)                   { version { strictly("v1-rev20220705-1.32.1") }}
         api(libs.googleApiClient)       { version { strictly("1.34.0"); because("our GCS version requires 1.34.0") }}


### PR DESCRIPTION
Migrate SelfResolvingDependency deprecation to a full deprecation from a preliminary deprecation. AGP stopped using that class in the newest stable version, 8.4

Fixes #27437

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
