### PR TITLE
Make `-PrerunAllTests` work without CI

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -254,9 +254,9 @@ fun configureTests() {
 
         configureJvmForTest()
         addOsAsInputs()
+        configureRerun()
 
         if (BuildEnvironment.isCiServer) {
-            configureRerun()
             develocity.testRetry {
                 maxRetries.convention(determineMaxRetries())
                 maxFailures = determineMaxFailures()


### PR DESCRIPTION
In the past, `-PrerunAllTests` only works on CI,
but it should work in local environment as well.
