### PR TITLE
Expose root variant in ResolutionResult

### DIFF
--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -53,6 +53,22 @@ Example:
 ADD RELEASE FEATURES BELOW
 vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv -->
 
+<a name="dependency-resolution"></a>
+### Dependency management improvements
+
+Gradle's [dependency management](userguide/core_dependency_management.html) infrastructure allows projects to depend on artifacts from external repositories, other projects from the same build, or projects from included builds.
+
+#### Root variant exposed by `ResolutionResult`
+
+The `ResolutionResult` API now exposes the root variant of the resolved graph in addition to its owning component. 
+The root variant is a synthetic variant representing the `Configuration` being resolved, and exposes the first-level dependencies of a resolution.
+Previously, the API only exposed the root component, which exposed the first-level dependencies as well dependencies from other selected variants in the root component. 
+
+This API allows dependency graphs to be traversed more precisely, at the variant-level instead of at the component level.
+When traversing at the variant level, it is possible to differentiate between the production code of a component and its test fixtures.
+
+TODO #29930: Link to userguide on how to traverse a graph
+
 <a name="config-cache"></a>
 ### Configuration cache improvements
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -102,6 +102,7 @@ import org.gradle.api.internal.artifacts.transform.VariantSelectorFactory;
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeRegistry;
 import org.gradle.api.internal.attributes.AttributeDescriberRegistry;
+import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.DefaultAttributesSchema;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -641,7 +642,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             List<ResolverProviderFactory> resolverFactories,
             ExternalModuleComponentResolverFactory moduleDependencyResolverFactory,
             ProjectDependencyResolver projectDependencyResolver,
-            DependencyLockingProvider dependencyLockingProvider
+            DependencyLockingProvider dependencyLockingProvider,
+            AttributeDesugaring attributeDesugaring
         ) {
             DefaultConfigurationResolver defaultResolver = new DefaultConfigurationResolver(
                 dependencyGraphResolver,
@@ -671,7 +673,10 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 dependencyLockingProvider
             );
 
-            return new ShortCircuitEmptyConfigurationResolver(defaultResolver);
+            return new ShortCircuitEmptyConfigurationResolver(
+                defaultResolver,
+                attributeDesugaring
+            );
         }
 
         @Provides

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -25,7 +25,6 @@ import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.UnresolvedDependency;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
@@ -84,6 +83,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.store.StoreSet
 import org.gradle.api.internal.artifacts.repositories.ContentFilteringRepository;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
 import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
+import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal;
 import org.gradle.api.internal.artifacts.transform.ArtifactVariantSelector;
 import org.gradle.api.internal.artifacts.transform.VariantSelectorFactory;
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
@@ -236,7 +236,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         ResolvedConfigurationDependencyGraphVisitor oldModelVisitor = new ResolvedConfigurationDependencyGraphVisitor(oldModelBuilder);
 
         BinaryStore newModelStore = stores.nextBinaryStore();
-        Store<ResolvedComponentResult> newModelCache = stores.newModelCache();
+        Store<ResolvedComponentResultInternal> newModelCache = stores.newModelCache();
         ResolutionStrategyInternal resolutionStrategy = resolveContext.getResolutionStrategy();
         StreamingResolutionResultBuilder newModelBuilder = new StreamingResolutionResultBuilder(newModelStore, newModelCache, attributeContainerSerializer, componentResultSerializer, componentSelectionDescriptorFactory, resolutionStrategy.getIncludeAllSelectableVariantResults());
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/InMemoryResolutionResultBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/InMemoryResolutionResultBuilder.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.ivyservice;
 
 import org.gradle.api.artifacts.result.ResolutionResult;
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphComponent;
@@ -27,6 +26,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.Resolved
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ResolutionResultGraphBuilder;
 import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
+import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 
 import java.util.Collections;
@@ -42,11 +42,19 @@ public class InMemoryResolutionResultBuilder implements DependencyGraphVisitor {
     private final ResolutionResultGraphBuilder resolutionResultBuilder = new ResolutionResultGraphBuilder();
     private final boolean includeAllSelectableVariantResults;
 
-    private ResolvedComponentResult root;
+    private long rootVariantId;
+    private long rootComponentId;
     private ImmutableAttributes requestAttributes;
 
     public InMemoryResolutionResultBuilder(boolean includeAllSelectableVariantResults) {
         this.includeAllSelectableVariantResults = includeAllSelectableVariantResults;
+    }
+
+    @Override
+    public void start(RootGraphNode root) {
+        this.rootVariantId = root.getNodeId();
+        this.rootComponentId = root.getOwner().getResultId();
+        this.requestAttributes = root.getResolveState().getAttributes();
     }
 
     @Override
@@ -73,17 +81,11 @@ public class InMemoryResolutionResultBuilder implements DependencyGraphVisitor {
         resolutionResultBuilder.visitOutgoingEdges(node.getOwner().getResultId(), node.getOutgoingEdges());
     }
 
-    @Override
-    public void finish(RootGraphNode root) {
-        Long resultId = root.getOwner().getResultId();
-        this.root = resolutionResultBuilder.getRoot(resultId);
-        this.requestAttributes = root.getResolveState().getAttributes();
-    }
-
     public MinimalResolutionResult getResolutionResult() {
         if (requestAttributes == null) {
             throw new IllegalStateException("Resolution result not computed yet");
         }
-        return new MinimalResolutionResult(() -> root, requestAttributes);
+        ResolvedComponentResultInternal root = resolutionResultBuilder.getRoot(rootComponentId);
+        return new MinimalResolutionResult(rootVariantId, () -> root, requestAttributes);
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
@@ -40,6 +40,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ResolutionResultGraphBuilder;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
 import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
+import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.specs.Spec;
@@ -53,9 +54,14 @@ import java.util.Set;
 
 public class ShortCircuitEmptyConfigurationResolver implements ConfigurationResolver {
     private final ConfigurationResolver delegate;
+    private final AttributeDesugaring attributeDesugaring;
 
-    public ShortCircuitEmptyConfigurationResolver(ConfigurationResolver delegate) {
+    public ShortCircuitEmptyConfigurationResolver(
+        ConfigurationResolver delegate,
+        AttributeDesugaring attributeDesugaring
+    ) {
         this.delegate = delegate;
+        this.attributeDesugaring = attributeDesugaring;
     }
 
     @Override
@@ -104,12 +110,14 @@ public class ShortCircuitEmptyConfigurationResolver implements ConfigurationReso
         );
     }
 
-    private static VisitedGraphResults emptyGraphResults(ResolveContext resolveContext) {
+    private VisitedGraphResults emptyGraphResults(ResolveContext resolveContext) {
         RootComponentMetadataBuilder.RootComponentState root = resolveContext.toRootComponent();
         MinimalResolutionResult emptyResult = ResolutionResultGraphBuilder.empty(
             root.getModuleVersionIdentifier(),
             root.getComponentIdentifier(),
-            resolveContext.getAttributes().asImmutable()
+            resolveContext.getAttributes().asImmutable(),
+            resolveContext.getName(),
+            attributeDesugaring
         );
         return new DefaultVisitedGraphResults(emptyResult, Collections.emptySet(), null);
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphComponent.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphComponent.java
@@ -33,7 +33,7 @@ public interface ResolvedGraphComponent {
      * Returns a simple id for this component, unique across components in the same graph.
      * This id cannot be used across graphs.
      */
-    Long getResultId();
+    long getResultId();
 
     ComponentGraphResolveState getResolveState();
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphDependency.java
@@ -50,7 +50,7 @@ public interface ResolvedGraphDependency {
     /**
      * Returns the simple id of the source variant, as per {@link ResolvedGraphVariant#getNodeId()}.
      */
-    Long getFromVariant();
+    long getFromVariant();
 
     /**
      * Returns the simple id of the selected variant, as per {@link ResolvedGraphVariant#getNodeId()}.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphVariant.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphVariant.java
@@ -26,7 +26,7 @@ public interface ResolvedGraphVariant {
      * Returns a simple id for this node, unique across all nodes in the same graph.
      * This id cannot be used across graphs.
      */
-    Long getNodeId();
+    long getNodeId();
 
     /**
      * Get the resolve state of the owning component.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -77,14 +77,14 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
     private boolean root;
     private Pair<Capability, Collection<NodeState>> capabilityReject;
 
-    ComponentState(Long resultId, ModuleResolveState module, ModuleVersionIdentifier id, ComponentIdentifier componentIdentifier, ComponentMetaDataResolver resolver) {
+    ComponentState(long resultId, ModuleResolveState module, ModuleVersionIdentifier id, ComponentIdentifier componentIdentifier, ComponentMetaDataResolver resolver) {
         this.resultId = resultId;
         this.module = module;
         this.id = id;
         this.componentIdentifier = componentIdentifier;
         this.resolver = resolver;
         this.implicitCapability = DefaultImmutableCapability.defaultCapabilityForComponent(id);
-        this.hashCode = 31 * id.hashCode() ^ resultId.hashCode();
+        this.hashCode = 31 * id.hashCode() ^ Long.hashCode(resultId);
     }
 
     @Override
@@ -98,7 +98,7 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
     }
 
     @Override
-    public Long getResultId() {
+    public long getResultId() {
         return resultId;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -417,7 +417,7 @@ class EdgeState implements DependencyGraphEdge {
     }
 
     @Override
-    public Long getFromVariant() {
+    public long getFromVariant() {
         return from.getNodeId();
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -74,7 +74,7 @@ import java.util.stream.Collectors;
  */
 public class NodeState implements DependencyGraphNode {
     private static final Logger LOGGER = LoggerFactory.getLogger(NodeState.class);
-    private final Long nodeId;
+    private final long nodeId;
     private final ComponentState component;
     private final List<EdgeState> incomingEdges = new ArrayList<>();
     private final List<EdgeState> outgoingEdges = new ArrayList<>();
@@ -157,7 +157,7 @@ public class NodeState implements DependencyGraphNode {
     }
 
     @Override
-    public Long getNodeId() {
+    public long getNodeId() {
         return nodeId;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DetachedResolvedGraphDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DetachedResolvedGraphDependency.java
@@ -32,7 +32,7 @@ public class DetachedResolvedGraphDependency implements ResolvedGraphDependency 
     private final ComponentSelectionReason reason;
     private final ModuleVersionResolveException failure;
     private final boolean constraint;
-    private final Long fromVariant;
+    private final long fromVariant;
     private final Long targetVariant;
 
     public DetachedResolvedGraphDependency(ComponentSelector requested,
@@ -40,7 +40,7 @@ public class DetachedResolvedGraphDependency implements ResolvedGraphDependency 
                                            ComponentSelectionReason reason,
                                            ModuleVersionResolveException failure,
                                            boolean constraint,
-                                           Long fromVariant,
+                                           long fromVariant,
                                            Long targetVariant
     ) {
         assert requested != null;
@@ -81,7 +81,7 @@ public class DetachedResolvedGraphDependency implements ResolvedGraphDependency 
     }
 
     @Override
-    public Long getFromVariant() {
+    public long getFromVariant() {
         return fromVariant;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.UnresolvedDependency;
 import org.gradle.api.artifacts.component.ComponentSelector;
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphComponent;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphEdge;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
@@ -28,6 +27,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.Dependen
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphDependency;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode;
 import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
+import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -59,18 +59,19 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
     private final Map<ComponentSelector, ModuleVersionResolveException> failures = new HashMap<>();
     private final BinaryStore store;
     private final AdhocHandlingComponentResultSerializer componentResultSerializer;
-    private final Store<ResolvedComponentResult> cache;
+    private final Store<ResolvedComponentResultInternal> cache;
     private final ComponentSelectorSerializer componentSelectorSerializer;
     private final boolean includeAllSelectableVariantResults;
     private final DependencyResultSerializer dependencyResultSerializer;
     private final Set<Long> visitedComponents = new HashSet<>();
 
+    private long rootVariantId;
     private ImmutableAttributes rootAttributes;
     private boolean mayHaveVirtualPlatforms;
 
     public StreamingResolutionResultBuilder(
         BinaryStore store,
-        Store<ResolvedComponentResult> cache,
+        Store<ResolvedComponentResultInternal> cache,
         AttributeContainerSerializer attributeContainerSerializer,
         AdhocHandlingComponentResultSerializer componentResultSerializer,
         ComponentSelectionDescriptorFactory componentSelectionDescriptorFactory,
@@ -87,13 +88,14 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
     public MinimalResolutionResult getResolutionResult(Set<UnresolvedDependency> dependencyLockingFailures) {
         BinaryStore.BinaryData data = store.done();
         RootFactory rootSource = new RootFactory(data, failures, cache, componentSelectorSerializer, dependencyResultSerializer, componentResultSerializer, dependencyLockingFailures);
-        return new MinimalResolutionResult(rootSource::create, rootAttributes);
+        return new MinimalResolutionResult(rootVariantId, rootSource::create, rootAttributes);
     }
 
     @Override
     public void start(final RootGraphNode root) {
-        rootAttributes = root.getMetadata().getAttributes();
-        mayHaveVirtualPlatforms = root.getResolveOptimizations().mayHaveVirtualPlatforms();
+        this.rootVariantId = root.getNodeId();
+        this.rootAttributes = root.getMetadata().getAttributes();
+        this.mayHaveVirtualPlatforms = root.getResolveOptimizations().mayHaveVirtualPlatforms();
     }
 
     @Override
@@ -149,20 +151,20 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
         }
     }
 
-    private static class RootFactory implements Factory<ResolvedComponentResult> {
+    private static class RootFactory implements Factory<ResolvedComponentResultInternal> {
 
         private final static Logger LOG = Logging.getLogger(RootFactory.class);
         private final AdhocHandlingComponentResultSerializer componentResultSerializer;
 
         private final BinaryStore.BinaryData data;
         private final Map<ComponentSelector, ModuleVersionResolveException> failures;
-        private final Store<ResolvedComponentResult> cache;
+        private final Store<ResolvedComponentResultInternal> cache;
         private final Object lock = new Object();
         private final ComponentSelectorSerializer componentSelectorSerializer;
         private final DependencyResultSerializer dependencyResultSerializer;
         private final Set<UnresolvedDependency> dependencyLockingFailures;
 
-        RootFactory(BinaryStore.BinaryData data, Map<ComponentSelector, ModuleVersionResolveException> failures, Store<ResolvedComponentResult> cache, ComponentSelectorSerializer componentSelectorSerializer, DependencyResultSerializer dependencyResultSerializer, AdhocHandlingComponentResultSerializer componentResultSerializer, Set<UnresolvedDependency> dependencyLockingFailures) {
+        RootFactory(BinaryStore.BinaryData data, Map<ComponentSelector, ModuleVersionResolveException> failures, Store<ResolvedComponentResultInternal> cache, ComponentSelectorSerializer componentSelectorSerializer, DependencyResultSerializer dependencyResultSerializer, AdhocHandlingComponentResultSerializer componentResultSerializer, Set<UnresolvedDependency> dependencyLockingFailures) {
             this.data = data;
             this.failures = failures;
             this.cache = cache;
@@ -173,7 +175,7 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
         }
 
         @Override
-        public ResolvedComponentResult create() {
+        public ResolvedComponentResultInternal create() {
             synchronized (lock) {
                 return cache.load(() -> {
                     try {
@@ -189,7 +191,7 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
             }
         }
 
-        private ResolvedComponentResult deserialize(Decoder decoder) {
+        private ResolvedComponentResultInternal deserialize(Decoder decoder) {
             componentSelectorSerializer.reset();
             int valuesRead = 0;
             byte type = -1;
@@ -205,7 +207,7 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
                             // Last entry, complete the result
                             Long rootId = decoder.readSmallLong();
                             builder.addDependencyLockingFailures(rootId, dependencyLockingFailures);
-                            ResolvedComponentResult root = builder.getRoot(rootId);
+                            ResolvedComponentResultInternal root = builder.getRoot(rootId);
                             LOG.debug("Loaded resolution results ({}) from {}", clock.getElapsed(), data);
                             return root;
                         case COMPONENT:

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/ResolutionResultsStoreFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/ResolutionResultsStoreFactory.java
@@ -16,8 +16,8 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.store;
 
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.TransientConfigurationResults;
+import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal;
 import org.gradle.api.internal.file.temp.TemporaryFileProvider;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -40,7 +40,7 @@ public class ResolutionResultsStoreFactory implements Closeable {
     private final int maxSize;
 
     private CachedStoreFactory<TransientConfigurationResults> oldModelCache;
-    private CachedStoreFactory<ResolvedComponentResult> newModelCache;
+    private CachedStoreFactory<ResolvedComponentResultInternal> newModelCache;
 
     private final AtomicInteger storeSetBaseId = new AtomicInteger();
 
@@ -80,7 +80,7 @@ public class ResolutionResultsStoreFactory implements Closeable {
         return oldModelCache;
     }
 
-    private synchronized CachedStoreFactory<ResolvedComponentResult> getNewModelCache() {
+    private synchronized CachedStoreFactory<ResolvedComponentResultInternal> getNewModelCache() {
         if (newModelCache == null) {
             newModelCache = new CachedStoreFactory<>("Resolution result");
             cleanUpLater.add(newModelCache);
@@ -100,7 +100,7 @@ public class ResolutionResultsStoreFactory implements Closeable {
             }
 
             @Override
-            public Store<ResolvedComponentResult> newModelCache() {
+            public Store<ResolvedComponentResultInternal> newModelCache() {
                 return getNewModelCache().createCachedStore(storeSetId);
             }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/StoreSet.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/StoreSet.java
@@ -15,15 +15,15 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.store;
 
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.TransientConfigurationResults;
+import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal;
 import org.gradle.cache.internal.BinaryStore;
 import org.gradle.cache.internal.Store;
 
 public interface StoreSet {
     BinaryStore nextBinaryStore();
 
-    Store<ResolvedComponentResult> newModelCache();
+    Store<ResolvedComponentResultInternal> newModelCache();
 
     Store<TransientConfigurationResults> oldModelCache();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/resolver/DefaultResolutionOutputs.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/resolver/DefaultResolutionOutputs.java
@@ -21,6 +21,7 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.ArtifactView;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ResolverResults;
 import org.gradle.api.internal.artifacts.configurations.ArtifactCollectionInternal;
@@ -30,6 +31,7 @@ import org.gradle.api.internal.artifacts.configurations.ResolutionResultProvider
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSelectionSpec;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.SelectedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults;
+import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -80,6 +82,14 @@ public class DefaultResolutionOutputs implements ResolutionOutputsInternal {
     @Override
     public ResolutionResultProvider<ResolverResults> getRawResults() {
         return resolutionAccess.getResults();
+    }
+
+    @Override
+    public Provider<ResolvedVariantResult> getRootVariant() {
+        return new DefaultProvider<>(() -> {
+            MinimalResolutionResult resolutionResult = getVisitedGraphResults().getResolutionResult();
+            return resolutionResult.getRootSource().get().getVariant(resolutionResult.getRootVariantId());
+        });
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/resolver/ResolutionOutputs.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/resolver/ResolutionOutputs.java
@@ -19,7 +19,9 @@ package org.gradle.api.internal.artifacts.resolver;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ArtifactCollection;
 import org.gradle.api.artifacts.ArtifactView;
+import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.provider.Provider;
 import org.gradle.internal.HasInternalProtocol;
 
 /**
@@ -30,6 +32,11 @@ import org.gradle.internal.HasInternalProtocol;
  */
 @HasInternalProtocol
 public interface ResolutionOutputs {
+
+    /**
+     * Returns the resolved dependency graph as a reference to the root variant.
+     */
+    Provider<ResolvedVariantResult> getRootVariant();
 
     /**
      * A {@link FileCollection} containing all resolved files. The returned collection

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/resolver/ResolutionOutputsInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/resolver/ResolutionOutputsInternal.java
@@ -37,6 +37,12 @@ public interface ResolutionOutputsInternal extends ResolutionOutputs {
 
     /**
      * Returns the resolved dependency graph as a reference to the root component.
+     *
+     * <p>This is here to support the existing public APIs. However, it is much more useful to expose
+     * the root variant, which the public interface exposes at {@link #getRootVariant()}. Currently,
+     * in order to traverse a graph the component is required, as it holds each variant's dependency set,
+     * however we should have each variant own their outgoing dependencies as that better reflects the
+     * reality of the structure of the graph.</p>
      */
     Provider<ResolvedComponentResult> getRootComponent();
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolutionResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolutionResult.java
@@ -21,6 +21,7 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.resolver.ResolutionAccess;
 import org.gradle.api.internal.attributes.AttributeDesugaring;
@@ -56,6 +57,11 @@ public class DefaultResolutionResult implements ResolutionResult {
     @Override
     public Provider<ResolvedComponentResult> getRootComponent() {
         return resolutionAccess.getPublicView().getRootComponent();
+    }
+
+    @Override
+    public Provider<ResolvedVariantResult> getRootVariant() {
+        return resolutionAccess.getPublicView().getRootVariant();
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResult.java
@@ -143,8 +143,9 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
         throw new InvalidUserCodeException("Variant '" + variant.getDisplayName() + "' doesn't belong to resolved component '" + this + "'. " + moreInfo + " Most likely you are using a variant from another component to get the dependencies of this component.");
     }
 
+    @Override
     @Nullable
-    public ResolvedVariantResult getVariant(Long id) {
+    public ResolvedVariantResult getVariant(long id) {
         return selectedVariantsById.get(id);
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/MinimalResolutionResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/MinimalResolutionResult.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts.result;
 
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 
 import java.util.function.Supplier;
@@ -26,21 +25,28 @@ import java.util.function.Supplier;
  */
 public class MinimalResolutionResult {
 
-    private final Supplier<ResolvedComponentResult> rootSource;
+    private final long rootVariantId;
+    private final Supplier<ResolvedComponentResultInternal> rootSource;
     private final ImmutableAttributes requestedAttributes;
 
     public MinimalResolutionResult(
-        Supplier<ResolvedComponentResult> rootSource,
+        long rootVariantId,
+        Supplier<ResolvedComponentResultInternal> rootSource,
         ImmutableAttributes requestedAttributes
     ) {
+        this.rootVariantId = rootVariantId;
         this.rootSource = rootSource;
         this.requestedAttributes = requestedAttributes;
+    }
+
+    public long getRootVariantId() {
+        return rootVariantId;
     }
 
     /**
      * A function which provides root of the dependency graph.
      */
-    public Supplier<ResolvedComponentResult> getRootSource() {
+    public Supplier<ResolvedComponentResultInternal> getRootSource() {
         return rootSource;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/ResolvedComponentResultInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/ResolvedComponentResultInternal.java
@@ -49,4 +49,12 @@ public interface ResolvedComponentResultInternal extends ResolvedComponentResult
      * @since 7.5
      */
     List<ResolvedVariantResult> getAvailableVariants();
+
+    /**
+     * Get a variant by its node ID.
+     *
+     * @return null if this component does not have a variant with the specified ID.
+     */
+    @Nullable
+    ResolvedVariantResult getVariant(long id);
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -33,7 +33,6 @@ import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.artifacts.ResolvableDependencies
 import org.gradle.api.artifacts.ResolveException
 import org.gradle.api.artifacts.ResolvedConfiguration
-import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.DocumentationRegistry
@@ -58,6 +57,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults
 import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact
 import org.gradle.api.internal.artifacts.result.MinimalResolutionResult
+import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal
 import org.gradle.api.internal.attributes.AttributeDesugaring
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.file.TestFiles
@@ -535,7 +535,7 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         _ * artifactTaskDependencies.getDependencies(_) >> requiredTasks
 
         and:
-        _ * resolver.resolveBuildDependencies(_) >> DefaultResolverResults.buildDependenciesResolved(Mock(VisitedGraphResults), visitedArtifactSet, Mock(ResolverResults.LegacyResolverResults))
+        _ * resolver.resolveBuildDependencies(_) >> DefaultResolverResults.buildDependenciesResolved(Stub(VisitedGraphResults), visitedArtifactSet, Mock(ResolverResults.LegacyResolverResults))
 
         expect:
         configuration.buildDependencies.getDependencies(targetTask) == requiredTasks
@@ -1044,9 +1044,9 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
 
     def "provides resolution result"() {
         def config = conf("conf")
-        def resolvedComponentResult = Mock(ResolvedComponentResult)
-        Supplier<ResolvedComponentResult> rootSource = () -> resolvedComponentResult
-        def result = new MinimalResolutionResult(rootSource, ImmutableAttributes.EMPTY)
+        def resolvedComponentResult = Mock(ResolvedComponentResultInternal)
+        Supplier<ResolvedComponentResultInternal> rootSource = () -> resolvedComponentResult
+        def result = new MinimalResolutionResult(0, rootSource, ImmutableAttributes.EMPTY)
         def graphResults = new DefaultVisitedGraphResults(result, [] as Set, null)
 
         resolver.resolveGraph(config) >> DefaultResolverResults.graphResolved(graphResults, visitedArtifacts(), Mock(ResolverResults.LegacyResolverResults))
@@ -1747,13 +1747,13 @@ All Artifacts:
     }
 
     private ResolverResults buildDependenciesResolved() {
-        def resolutionResult = new MinimalResolutionResult(() -> Stub(ResolvedComponentResult), ImmutableAttributes.EMPTY)
+        def resolutionResult = new MinimalResolutionResult(0, () -> Stub(ResolvedComponentResultInternal), ImmutableAttributes.EMPTY)
         def visitedGraphResults = new DefaultVisitedGraphResults(resolutionResult, [] as Set, null)
         DefaultResolverResults.buildDependenciesResolved(visitedGraphResults, visitedArtifacts([] as Set), Mock(ResolverResults.LegacyResolverResults))
     }
 
     private ResolverResults graphResolved(ResolveException failure) {
-        def resolutionResult = new MinimalResolutionResult(() -> Stub(ResolvedComponentResult), ImmutableAttributes.EMPTY)
+        def resolutionResult = new MinimalResolutionResult(0, () -> Stub(ResolvedComponentResultInternal), ImmutableAttributes.EMPTY)
         def visitedGraphResults = new DefaultVisitedGraphResults(resolutionResult, [] as Set, failure)
 
         def visitedArtifactSet = Stub(VisitedArtifactSet) {
@@ -1771,7 +1771,7 @@ All Artifacts:
     }
 
     private ResolverResults graphResolved(Set<File> files = []) {
-        def resolutionResult = new MinimalResolutionResult(() -> Stub(ResolvedComponentResult), ImmutableAttributes.EMPTY)
+        def resolutionResult = new MinimalResolutionResult(0, () -> Stub(ResolvedComponentResultInternal), ImmutableAttributes.EMPTY)
         def visitedGraphResults = new DefaultVisitedGraphResults(resolutionResult, [] as Set, null)
 
         def legacyResults = DefaultResolverResults.DefaultLegacyResolverResults.graphResolved(
@@ -1783,7 +1783,7 @@ All Artifacts:
     }
 
     private visitedArtifacts(Set<File> files = []) {
-        Stub(VisitedArtifactSet) {
+        Mock(VisitedArtifactSet) {
             select(_) >> selectedArtifacts(files)
         }
     }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolverSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolverSpec.groovy
@@ -25,9 +25,11 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvi
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSelectionSpec
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor
+import org.gradle.api.internal.attributes.AttributeDesugaring
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.specs.Specs
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.util.AttributeTestUtil
 import spock.lang.Specification
 
 class ShortCircuitEmptyConfigurationResolverSpec extends Specification {
@@ -35,7 +37,7 @@ class ShortCircuitEmptyConfigurationResolverSpec extends Specification {
     def delegate = Mock(ConfigurationResolver)
     def resolveContext = Stub(ResolveContext)
 
-    def dependencyResolver = new ShortCircuitEmptyConfigurationResolver(delegate)
+    def dependencyResolver = new ShortCircuitEmptyConfigurationResolver(delegate, new AttributeDesugaring(AttributeTestUtil.attributesFactory()))
 
     def "returns empty build dependencies when no dependencies"() {
         def depVisitor = Mock(TaskDependencyResolveContext)

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/results/DefaultVisitedGraphResultsTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/results/DefaultVisitedGraphResultsTest.groovy
@@ -29,7 +29,7 @@ import java.util.function.Supplier
  */
 class DefaultVisitedGraphResultsTest extends Specification {
 
-    MinimalResolutionResult resolutionResult = new MinimalResolutionResult(Mock(Supplier), ImmutableAttributes.EMPTY)
+    MinimalResolutionResult resolutionResult = new MinimalResolutionResult(0, Mock(Supplier), ImmutableAttributes.EMPTY)
 
     def "hasResolutionFailure returns true if there is a failure"() {
         given:

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolutionResultGraphBuilderSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolutionResultGraphBuilderSpec.groovy
@@ -274,7 +274,7 @@ class ResolutionResultGraphBuilderSpec extends Specification {
     }
 
     class DummyModuleVersionSelection implements ResolvedGraphComponent {
-        Long resultId
+        long resultId
         ModuleVersionIdentifier moduleVersion
         ComponentSelectionReason selectionReason
         ComponentIdentifier componentId

--- a/platforms/software/publish/src/test/groovy/org/gradle/api/publish/internal/mapping/DefaultDependencyCoordinateResolverFactoryTest.groovy
+++ b/platforms/software/publish/src/test/groovy/org/gradle/api/publish/internal/mapping/DefaultDependencyCoordinateResolverFactoryTest.groovy
@@ -16,31 +16,25 @@
 
 package org.gradle.api.publish.internal.mapping
 
-
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.ResolvableDependencies
-import org.gradle.api.artifacts.result.ResolutionResult
-import org.gradle.api.artifacts.result.ResolvedComponentResult
-import org.gradle.api.artifacts.result.ResolvedVariantResult
 import org.gradle.api.component.SoftwareComponentVariant
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver
 import org.gradle.api.internal.attributes.AttributeDesugaring
 import org.gradle.api.internal.attributes.ImmutableAttributes
-import org.gradle.api.internal.provider.Providers
 import org.gradle.api.publish.internal.component.ResolutionBackedVariant
 import org.gradle.api.publish.internal.versionmapping.VariantVersionMappingStrategyInternal
 import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInternal
-import spock.lang.Specification
+import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 
 import javax.annotation.Nullable
 
 /**
  * Tests {@link DefaultDependencyCoordinateResolverFactory}.
  */
-class DefaultDependencyCoordinateResolverFactoryTest extends Specification {
+class DefaultDependencyCoordinateResolverFactoryTest extends AbstractProjectBuilderSpec {
 
     ProjectDependencyPublicationResolver projectDependencyResolver = Mock()
     ImmutableModuleIdentifierFactory moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
@@ -88,7 +82,7 @@ class DefaultDependencyCoordinateResolverFactoryTest extends Specification {
 
     def "returns legacy resolver if dependency version mapping is enabled with default configuration and variant is not resolution-backed"() {
         given:
-        def conf = conf()
+        def conf = project.configurations.create("conf")
         def variant = nonResolutionBacked()
         def versionMappingStrategy = versionMappingStrategy(true, conf, null)
 
@@ -101,7 +95,7 @@ class DefaultDependencyCoordinateResolverFactoryTest extends Specification {
 
     def "returns legacy resolver if dependency version mapping is enabled with explicit configuration and variant is not resolution-backed"() {
         given:
-        def conf = conf()
+        def conf = project.configurations.create("conf")
         def variant = nonResolutionBacked()
         def versionMappingStrategy = versionMappingStrategy(true, null, conf)
 
@@ -114,8 +108,8 @@ class DefaultDependencyCoordinateResolverFactoryTest extends Specification {
 
     def "returns legacy resolver if version mapping is enabled with default configuration and dependency mapping is disabled with resolution configuration"() {
         given:
-        def dependencyMappingConf = conf()
-        def versionMappingConf = conf()
+        def dependencyMappingConf = project.configurations.create("conf1")
+        def versionMappingConf = project.configurations.create("conf2")
         def variant = resolutionBacked(false, dependencyMappingConf)
         def versionMappingStrategy = versionMappingStrategy(true, versionMappingConf, null)
 
@@ -128,8 +122,8 @@ class DefaultDependencyCoordinateResolverFactoryTest extends Specification {
 
     def "returns legacy resolver if version mapping is enabled with user configuration and dependency mapping is disabled with resolution configuration"() {
         given:
-        def dependencyMappingConf = conf()
-        def versionMappingConf = conf()
+        def dependencyMappingConf = project.configurations.create("conf1")
+        def versionMappingConf = project.configurations.create("conf2")
         def variant = resolutionBacked(false, dependencyMappingConf)
         def versionMappingStrategy = versionMappingStrategy(true, null, versionMappingConf)
 
@@ -155,7 +149,7 @@ class DefaultDependencyCoordinateResolverFactoryTest extends Specification {
 
     def "returns resolution backed resolver if dependency mapping is enabled with configuration"() {
         given:
-        def conf = conf()
+        def conf = project.configurations.create("conf")
         def variant = resolutionBacked(true, conf)
         def versionMappingStrategy = Mock(VersionMappingStrategyInternal)
 
@@ -163,25 +157,6 @@ class DefaultDependencyCoordinateResolverFactoryTest extends Specification {
         with(factory.createCoordinateResolvers(variant, versionMappingStrategy).get()) {
             variantResolver instanceof ResolutionBackedVariantDependencyResolver
             componentResolver instanceof ResolutionBackedComponentDependencyResolver
-        }
-    }
-
-    Configuration conf() {
-        ResolvedVariantResult rootVariant = Mock(ResolvedVariantResult) {
-            getDisplayName() >> "conf"
-        }
-        ResolvedComponentResult root = Mock(ResolvedComponentResult) {
-            getVariants() >> [rootVariant]
-            getDependenciesForVariant(_) >> []
-            getDependencies() >> []
-        }
-        Stub(Configuration) {
-            getName() >> "conf"
-            getIncoming() >> Mock(ResolvableDependencies) {
-                getResolutionResult() >> Mock(ResolutionResult) {
-                    getRootComponent() >> Providers.of(root)
-                }
-            }
         }
     }
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolutionResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolutionResult.java
@@ -19,6 +19,7 @@ package org.gradle.api.artifacts.result;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.HasInternalProtocol;
@@ -51,10 +52,21 @@ public interface ResolutionResult {
      * You can walk the graph recursively from the root to obtain information about resolved dependencies.
      * For example, Gradle's built-in 'dependencies' task uses this to render the dependency tree.
      *
-     * @return a provider for the root node of the resolved dependency graph
+     * @return a provider for the root component of the resolved dependency graph
      * @since 7.4
      */
     Provider<ResolvedComponentResult> getRootComponent();
+
+    /**
+     * The root variant of the dependency graph. This is a synthetic variant that represents the thing being resolved.
+     * All outgoing dependencies of this variant represent first-level declared dependencies of the resolution.
+     *
+     * @return a provider for the root variant of the dependency graph.
+     *
+     * @since 8.11
+     */
+    @Incubating
+    Provider<ResolvedVariantResult> getRootVariant();
 
     /**
      * Retrieves all dependencies, including unresolved dependencies.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedComponentResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedComponentResult.java
@@ -17,6 +17,7 @@
 package org.gradle.api.artifacts.result;
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.internal.HasInternalProtocol;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
 import javax.annotation.Nullable;
@@ -27,6 +28,7 @@ import java.util.Set;
  * Represents a component instance in the resolved dependency graph. Provides some basic identity and dependency information about the component.
  */
 @UsedByScanPlugin
+@HasInternalProtocol
 public interface ResolvedComponentResult extends ComponentResult {
 
     /**


### PR DESCRIPTION
There is no way to get the root variant of the root component from a ResolutionResult without looping through all varaints and finding the root variant with its display name.

This commit exposes the root varaint so that users do not need to rely on variant display names to begin traversing dependency graphs.


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
