### PR TITLE
Add `buildTreePath` for isolated project view

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
@@ -679,6 +679,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
 
                 println("project name = " + isolatedProject.name)
                 println("project path = " + isolatedProject.path)
+                println("project buildTreePath = " + isolatedProject.buildTreePath)
                 println("project projectDir = " + isolatedProject.projectDirectory)
                 println("project rootDir = " + isolatedProject.rootProject.projectDirectory)
             }

--- a/subprojects/core-api/src/main/java/org/gradle/api/project/IsolatedProject.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/project/IsolatedProject.java
@@ -49,6 +49,15 @@ public interface IsolatedProject {
     String getPath();
 
     /**
+     * Returns a path to the project for the full build tree.
+     *
+     * @return The build tree path
+     * @since 8.9
+     */
+    @Incubating
+    String getBuildTreePath();
+
+    /**
      * <p>The directory containing the project build file.</p>
      *
      * @return The project directory. Never returns null.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultIsolatedProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultIsolatedProject.java
@@ -40,6 +40,11 @@ public final class DefaultIsolatedProject implements IsolatedProject {
     }
 
     @Override
+    public String getBuildTreePath() {
+        return project.getBuildTreePath();
+    }
+
+    @Override
     public Directory getProjectDirectory() {
         return project.getLayout().getProjectDirectory();
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
@@ -110,7 +110,9 @@ class DefaultProjectSpec extends Specification {
 
     def "can view as an IsolatedProject"() {
         given:
-        def project = project('root', null, Stub(GradleInternal))
+        def rootBuild = Stub(GradleInternal)
+        rootBuild.identityPath >> Path.ROOT
+        def project = project('root', null, rootBuild)
 
         when:
         def isolatedProject = project.isolated
@@ -118,6 +120,7 @@ class DefaultProjectSpec extends Specification {
         then:
         isolatedProject.name == 'root'
         isolatedProject.path == ':'
+        isolatedProject.buildTreePath == ':'
         isolatedProject.projectDirectory === project.layout.projectDirectory
         isolatedProject.rootProject === isolatedProject
     }
@@ -177,6 +180,45 @@ class DefaultProjectSpec extends Specification {
         nestedChild2.path == ":child1:child2"
         nestedChild2.buildTreePath == ":nested:child1:child2"
         nestedChild2.identityPath == Path.path(":nested:child1:child2")
+    }
+
+    def "isolated project view preserves the path and build tree path"() {
+        def rootBuild = Stub(GradleInternal)
+        rootBuild.isRootBuild() >> true
+        rootBuild.parent >> null
+        rootBuild.identityPath >> Path.ROOT
+
+        def nestedBuild = Stub(GradleInternal)
+        rootBuild.isRootBuild() >> false
+        nestedBuild.parent >> rootBuild
+        nestedBuild.identityPath >> Path.path(":nested")
+
+        def rootProject = project("root", null, rootBuild)
+        def child1 = project("child1", rootProject, rootBuild)
+        def child2 = project("child2", child1, rootBuild)
+
+        def nestedRootProject = project("root", null, nestedBuild)
+        def nestedChild1 = project("child1", nestedRootProject, nestedBuild)
+        def nestedChild2 = project("child2", nestedChild1, nestedBuild)
+
+        expect:
+        rootProject.isolated.path == ":"
+        rootProject.isolated.buildTreePath == ':'
+
+        child1.isolated.path == ":child1"
+        child1.isolated.buildTreePath == ":child1"
+
+        child2.isolated.path == ":child1:child2"
+        child2.isolated.buildTreePath == ":child1:child2"
+
+        nestedRootProject.isolated.path == ":"
+        nestedRootProject.isolated.buildTreePath == ":nested"
+
+        nestedChild1.isolated.path == ":child1"
+        nestedChild1.isolated.buildTreePath == ":nested:child1"
+
+        nestedChild2.isolated.path == ":child1:child2"
+        nestedChild2.isolated.buildTreePath == ":nested:child1:child2"
     }
 
     ProjectInternal project(String name, @Nullable ProjectInternal parent, GradleInternal build) {


### PR DESCRIPTION
to make the view more useful in the case of composite builds