### PR TITLE
Fix broken TeamCity config

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
@@ -9,6 +9,7 @@ import model.CIBuildModel
 import model.Stage
 import model.StageName
 import model.TestCoverage
+import model.TestType
 
 const val functionalTestTag = "FunctionalTest"
 
@@ -103,7 +104,8 @@ private fun determineFlakyTestStrategy(stage: Stage): String {
 }
 
 fun getTestTaskName(testCoverage: TestCoverage, subprojects: List<String>): String {
-    val testTaskName = "${testCoverage.testType.name}Test"
+    val testTaskName =
+        if (testCoverage.testType == TestType.isolatedProjects) "isolatedProjectsIntegTest" else "${testCoverage.testType.name}Test"
     return when {
         subprojects.isEmpty() -> {
             testTaskName

--- a/.teamcity/test-buckets.json
+++ b/.teamcity/test-buckets.json
@@ -1473,7 +1473,6 @@
 					"ear",
 					"resources-s3",
 					"plugins-jvm-test-fixtures",
-					"plugins",
 					"plugins-version-catalog",
 					"build-events"
 				]


### PR DESCRIPTION
PR#29041 removes `plugins subproject, but #29059 references `plugins`.

This caused some NPEs on CI.
