### PR TITLE
Fix BuildScanIntegrationTest

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/BuildScanIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/BuildScanIntegrationTest.kt
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package org.gradle.kotlin.dsl.caching
+package org.gradle.kotlin.dsl.integration
 
+import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
 import org.gradle.kotlin.dsl.fixtures.normalisedPath
 import org.gradle.plugin.management.internal.autoapply.AutoAppliedGradleEnterprisePlugin
 
@@ -27,7 +28,7 @@ import org.junit.Test
 import java.io.File
 
 
-class BuildScanIntegrationTest : AbstractScriptCachingIntegrationTest() {
+class BuildScanIntegrationTest : AbstractKotlinIntegrationTest() {
 
     @Test
     fun `using the gradle enterprise extension is deprecated`() {

--- a/testing/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/BuildScanIntegrationTest.kt
+++ b/testing/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/BuildScanIntegrationTest.kt
@@ -54,7 +54,10 @@ class BuildScanIntegrationTest : AbstractScriptCachingIntegrationTest() {
             "The PluginDependencySpec.`gradle-enterprise` property has been deprecated. " +
                 "This is scheduled to be removed in Gradle 9.0. Please use 'id(\"com.gradle.develocity\") version \"${AutoAppliedGradleEnterprisePlugin.VERSION}\"' instead. " +
                 "For more information, please refer to https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.kotlin.dsl/gradle-enterprise.html in the Gradle documentation.")
-        executer.expectDeprecationWarning("WARNING: The following functionality has been deprecated and will be removed in the next major release of the Develocity Gradle plugin. For assistance with migration, see https://gradle.com/help/gradle-plugin-develocity-migration.")
+        executer.expectDeprecationWarning(
+            "WARNING: The following functionality has been deprecated and will be removed in the next major release of the Develocity Gradle plugin. " +
+                "Run with '-Ddevelocity.deprecation.captureOrigin=true' to see where the deprecated functionality is being used. " +
+                "For assistance with migration, see https://gradle.com/help/gradle-plugin-develocity-migration.")
         executer.expectDeprecationWarning("""- The deprecated "gradleEnterprise.buildScan.termsOfServiceUrl" API has been replaced by "develocity.buildScan.termsOfUseUrl"""")
         executer.expectDeprecationWarning("""- The deprecated "gradleEnterprise.buildScan.termsOfServiceAgree" API has been replaced by "develocity.buildScan.termsOfUseAgree"""")
         build("--scan", "--build-cache", "-Dscan.dump").apply {


### PR DESCRIPTION
Adapts the expected deprecation message after the upgrade of scans to 3.17.3.
I also move the test to kotlin-dsl, there isn't a reason why this should only run as part of smoke tests.

Fixes https://github.com/gradle/gradle-private/issues/4199