### PR TITLE
Fix flaky buildlifecycle sample test

### DIFF
--- a/platforms/documentation/docs/src/snippets/buildlifecycle/basic/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/buildlifecycle/basic/groovy/build.gradle
@@ -11,7 +11,9 @@ tasks.register('test') {
 }
 
 tasks.register('testBoth') {
-	doFirst {
+    mustRunAfter("test")
+
+    doFirst {
 	  println 'This is executed first during the execution phase.'
 	}
 	doLast {

--- a/platforms/documentation/docs/src/snippets/buildlifecycle/basic/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/buildlifecycle/basic/kotlin/build.gradle.kts
@@ -11,6 +11,8 @@ tasks.register("test") {
 }
 
 tasks.register("testBoth") {
+    mustRunAfter("test")
+
     doFirst {
         println("This is executed first during the execution phase.")
     }


### PR DESCRIPTION
This PR fixes the flakiness like [this](https://ge.gradle.org/s/uquirsjgzlj3e/tests/task/:docs:docsTest/details/org.gradle.docs.samples.Bucket3SnippetsTest/snippet-buildlifecycle-basic_kotlin_buildlifecycle.sample).

`test` and `testBoth` are independent of each other,
resulting in potentially varying output order.
This PR addresses the flakiness by introducing explicit ordering. This PR fixes the flakiness by introducing explicit ordering.
