### PR TITLE
Move ConfigurationCacheGradlePropertiesIntegrationTest out of flaky test quarantine

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheGradlePropertiesIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheGradlePropertiesIntegrationTest.groovy
@@ -18,13 +18,11 @@ package org.gradle.configurationcache
 
 import org.gradle.configurationcache.fixtures.GradlePropertiesIncludedBuildFixture
 import org.gradle.configurationcache.fixtures.SystemPropertiesCompositeBuildFixture
-import org.gradle.test.fixtures.Flaky
 import spock.lang.Issue
 
 import static org.gradle.initialization.IGradlePropertiesLoader.ENV_PROJECT_PROPERTIES_PREFIX
 import static org.gradle.initialization.IGradlePropertiesLoader.SYSTEM_PROJECT_PROPERTIES_PREFIX
 
-@Flaky(because = 'https://github.com/gradle/gradle-private/issues/3859')
 class ConfigurationCacheGradlePropertiesIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
 
     def "invalidates cache when set of Gradle property defining system properties changes"() {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/SystemPropertiesCompositeBuildFixture.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/SystemPropertiesCompositeBuildFixture.groovy
@@ -23,7 +23,9 @@ import org.gradle.test.fixtures.file.TestFile
 class SystemPropertiesCompositeBuildFixture {
 
     static Set<List<BuildWithSystemPropertyDefined>> definitions() {
-        Set<List<BuildWithSystemPropertyDefined>> containsIncludedBuildDefinitions = new HashSet()
+        // The order needs to be consistent here for the retry plugin to work,
+        // see https://github.com/gradle/gradle/pull/25605
+        Set<List<BuildWithSystemPropertyDefined>> containsIncludedBuildDefinitions = new LinkedHashSet<>()
 
         Set<List<BuildWithSystemPropertyDefined>> allDefinitions = [
             new RootBuild() as BuildWithSystemPropertyDefined,


### PR DESCRIPTION
The underlying problem has been fixed already by https://github.com/gradle/gradle/pull/25605.