### PR TITLE
Introduce `@ToBeFixedForIsolatedProjects`

### DIFF
--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForConfigurationCacheExtension.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForConfigurationCacheExtension.groovy
@@ -17,21 +17,16 @@
 package org.gradle.integtests.fixtures
 
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-import org.gradle.internal.reflect.ClassInspector
-import org.gradle.test.fixtures.ResettableExpectations
-import org.opentest4j.TestAbortedException
 import org.spockframework.runtime.extension.IAnnotationDrivenExtension
-import org.spockframework.runtime.extension.IMethodInterceptor
-import org.spockframework.runtime.extension.IMethodInvocation
 import org.spockframework.runtime.model.FeatureInfo
 
-import java.lang.reflect.Field
-import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.Predicate
 
 import static org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache.Skip.DO_NOT_SKIP
 
 class ToBeFixedForConfigurationCacheExtension implements IAnnotationDrivenExtension<ToBeFixedForConfigurationCache> {
+
+    private final ToBeFixedSpecInterceptor toBeFixedSpecInterceptor = new ToBeFixedSpecInterceptor("Configuration Cache")
 
     @Override
     void visitFeatureAnnotation(ToBeFixedForConfigurationCache annotation, FeatureInfo feature) {
@@ -49,128 +44,7 @@ class ToBeFixedForConfigurationCacheExtension implements IAnnotationDrivenExtens
             return
         }
 
-        if (feature.isParameterized()) {
-            feature.addInterceptor(new ToBeFixedIterationInterceptor(annotation.iterationMatchers()))
-        } else {
-            feature.getFeatureMethod().addInterceptor(new ToBeFixedInterceptor())
-        }
-    }
-
-    private static class ToBeFixedInterceptor implements IMethodInterceptor {
-
-        @Override
-        void intercept(IMethodInvocation invocation) throws Throwable {
-            if (failsAsExpected(invocation)) {
-                return
-            }
-            throw new UnexpectedSuccessException()
-        }
-    }
-
-    private static class ToBeFixedIterationInterceptor implements IMethodInterceptor {
-
-        private final String[] iterationMatchers
-
-        ToBeFixedIterationInterceptor(String[] iterationMatchers) {
-            this.iterationMatchers = iterationMatchers
-        }
-
-        @Override
-        void intercept(IMethodInvocation invocation) throws Throwable {
-            final AtomicBoolean pass = new AtomicBoolean()
-            invocation.getFeature().getFeatureMethod().interceptors.add(
-                0,
-                new InnerIterationInterceptor(pass, iterationMatchers)
-            )
-            try {
-                invocation.proceed()
-            } catch (Throwable ex) {
-                expectedFailure(ex)
-                pass.set(true)
-            }
-
-            if (pass.get()) {
-                throw new TestAbortedException("Failed as expected.")
-            } else {
-                throw new UnexpectedSuccessException()
-            }
-        }
-
-        private static class InnerIterationInterceptor implements IMethodInterceptor {
-            private final AtomicBoolean pass
-            private final String[] iterationMatchers
-
-            InnerIterationInterceptor(AtomicBoolean pass, String[] iterationMatchers) {
-                this.pass = pass
-                this.iterationMatchers = iterationMatchers
-            }
-
-            @Override
-            void intercept(IMethodInvocation invocation) throws Throwable {
-                if (iterationMatches(iterationMatchers, invocation.iteration.displayName)) {
-                    if (failsAsExpected(invocation)) {
-                        pass.set(true)
-                    }
-                } else {
-                    invocation.proceed()
-                }
-            }
-        }
-    }
-
-    private static boolean failsAsExpected(IMethodInvocation invocation) {
-        try {
-            invocation.proceed()
-        } catch (Throwable ex) {
-            expectedFailure(ex)
-            ignoreCleanupAssertionsOf(invocation)
-            return true
-        }
-        // Trigger validation failures early so they can still fail the test the usual way
-        try {
-            allResettableExpectationsOf(invocation.instance).forEach { expectations ->
-                expectations.resetExpectations()
-            }
-        } catch (Throwable ex) {
-            expectedFailure(ex)
-            ignoreCleanupAssertionsOf(invocation)
-            return true
-        }
-        return false
-    }
-
-    private static ignoreCleanupAssertionsOf(IMethodInvocation invocation) {
-        def instance = invocation.instance
-        if (instance instanceof AbstractIntegrationSpec) {
-            instance.ignoreCleanupAssertions()
-        }
-        allResettableExpectationsOf(instance).forEach { expectations ->
-            try {
-                expectations.resetExpectations()
-            } catch (Throwable error) {
-                error.printStackTrace()
-            }
-        }
-    }
-
-    private static List<ResettableExpectations> allResettableExpectationsOf(instance) {
-        allInstanceFieldsOf(instance).findResults { field ->
-            try {
-                def fieldValue = field.tap { accessible = true }.get(instance)
-                fieldValue instanceof ResettableExpectations ? fieldValue : null
-            } catch (Exception ignored) {
-                null
-            }
-        }
-    }
-
-    private static Collection<Field> allInstanceFieldsOf(instance) {
-        ClassInspector.inspect(instance.getClass()).instanceFields
-    }
-
-    private static void expectedFailure(Throwable ex) {
-        System.err.println("Failed with configuration cache as expected:")
-        ex.printStackTrace()
+        toBeFixedSpecInterceptor.intercept(feature, annotation.iterationMatchers())
     }
 
     private static boolean isEnabledSpec(ToBeFixedForConfigurationCache annotation, FeatureInfo feature) {
@@ -179,19 +53,5 @@ class ToBeFixedForConfigurationCacheExtension implements IAnnotationDrivenExtens
 
     static boolean isEnabledBottomSpec(String[] bottomSpecs, Predicate<String> specNamePredicate) {
         bottomSpecs.length == 0 || bottomSpecs.any { specNamePredicate.test(it) }
-    }
-
-    static boolean iterationMatches(String[] iterationMatchers, String iterationName) {
-        isAllIterations(iterationMatchers) || iterationMatchers.any { iterationName.matches(it) }
-    }
-
-    static boolean isAllIterations(String[] iterationMatchers) {
-        iterationMatchers.length == 0
-    }
-
-    static class UnexpectedSuccessException extends Exception {
-        UnexpectedSuccessException() {
-            super("Expected to fail with configuration cache, but succeeded!")
-        }
     }
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForConfigurationCacheRule.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForConfigurationCacheRule.groovy
@@ -22,7 +22,7 @@ import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
 import static org.gradle.integtests.fixtures.ToBeFixedForConfigurationCacheExtension.isEnabledBottomSpec
-import static org.gradle.integtests.fixtures.ToBeFixedForConfigurationCacheExtension.iterationMatches
+import static ToBeFixedSpecInterceptor.iterationMatches
 
 /**
  * JUnit Rule supporting the {@link ToBeFixedForConfigurationCache} annotation.
@@ -60,8 +60,8 @@ class ToBeFixedForConfigurationCacheRule implements TestRule {
         void evaluate() throws Throwable {
             try {
                 next.evaluate()
-                throw new ToBeFixedForConfigurationCacheExtension.UnexpectedSuccessException()
-            } catch (ToBeFixedForConfigurationCacheExtension.UnexpectedSuccessException ex) {
+                throw new ToBeFixedSpecInterceptor.UnexpectedSuccessException("Configuration Cache")
+            } catch (ToBeFixedSpecInterceptor.UnexpectedSuccessException ex) {
                 throw ex
             } catch (Throwable ex) {
                 System.err.println("Failed with configuration cache as expected:")

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForIsolatedProjects.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForIsolatedProjects.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures
+
+import org.spockframework.runtime.extension.ExtensionAnnotation
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@ExtensionAnnotation(ToBeFixedForIsolatedProjectsExtension.class)
+public @interface ToBeFixedForIsolatedProjects {
+
+    String because() default "";
+}

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForIsolatedProjectsExtension.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForIsolatedProjectsExtension.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures
+
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.spockframework.runtime.extension.IAnnotationDrivenExtension
+import org.spockframework.runtime.model.FeatureInfo
+
+class ToBeFixedForIsolatedProjectsExtension implements IAnnotationDrivenExtension<ToBeFixedForIsolatedProjects> {
+
+    private final ToBeFixedSpecInterceptor toBeFixedSpecInterceptor = new ToBeFixedSpecInterceptor("Isolated Projects")
+
+    @Override
+    void visitFeatureAnnotation(ToBeFixedForIsolatedProjects annotation, FeatureInfo feature) {
+        if (GradleContextualExecuter.isNotIsolatedProjects()) {
+            return
+        }
+
+        toBeFixedSpecInterceptor.intercept(feature, new String[0])
+    }
+}

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedSpecInterceptor.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedSpecInterceptor.groovy
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures
+
+import org.gradle.internal.reflect.ClassInspector
+import org.gradle.test.fixtures.ResettableExpectations
+import org.opentest4j.TestAbortedException
+import org.spockframework.runtime.extension.IMethodInterceptor
+import org.spockframework.runtime.extension.IMethodInvocation
+import org.spockframework.runtime.model.FeatureInfo
+
+import java.lang.reflect.Field
+import java.util.concurrent.atomic.AtomicBoolean
+
+class ToBeFixedSpecInterceptor {
+
+    private final String feature
+
+    ToBeFixedSpecInterceptor(String feature) {
+        this.feature = feature
+    }
+
+    void intercept(FeatureInfo featureInfo, String[] iterationMatchers) {
+        if (featureInfo.isParameterized()) {
+            featureInfo.addInterceptor(new ToBeFixedIterationInterceptor(iterationMatchers))
+        } else {
+            featureInfo.getFeatureMethod().addInterceptor(new ToBeFixedInterceptor())
+        }
+    }
+
+    static boolean iterationMatches(String[] iterationMatchers, String iterationName) {
+        isAllIterations(iterationMatchers) || iterationMatchers.any { iterationName.matches(it) }
+    }
+
+    static boolean isAllIterations(String[] iterationMatchers) {
+        iterationMatchers.length == 0
+    }
+
+    static class UnexpectedSuccessException extends Exception {
+        UnexpectedSuccessException(String feature) {
+            super("Expected to fail with $feature, but succeeded!")
+        }
+    }
+
+    private class ToBeFixedInterceptor implements IMethodInterceptor {
+
+        @Override
+        void intercept(IMethodInvocation invocation) throws Throwable {
+            if (failsAsExpected(invocation, feature)) {
+                return
+            }
+            throw new UnexpectedSuccessException(feature)
+        }
+    }
+
+    private class ToBeFixedIterationInterceptor implements IMethodInterceptor {
+        private final String[] iterationMatchers
+
+        ToBeFixedIterationInterceptor(String[] iterationMatchers) {
+            this.iterationMatchers = iterationMatchers
+        }
+
+        @Override
+        void intercept(IMethodInvocation invocation) throws Throwable {
+            final AtomicBoolean pass = new AtomicBoolean()
+            invocation.getFeature().getFeatureMethod().interceptors.add(
+                0,
+                new InnerIterationInterceptor(pass, iterationMatchers)
+            )
+            try {
+                invocation.proceed()
+            } catch (Throwable ex) {
+                expectedFailure(ex, feature)
+                pass.set(true)
+            }
+
+            if (pass.get()) {
+                throw new TestAbortedException("Failed as expected.")
+            } else {
+                throw new UnexpectedSuccessException(feature)
+            }
+        }
+
+        private class InnerIterationInterceptor implements IMethodInterceptor {
+            private final AtomicBoolean pass
+            private final String[] iterationMatchers
+
+            InnerIterationInterceptor(AtomicBoolean pass, String[] iterationMatchers) {
+                this.pass = pass
+                this.iterationMatchers = iterationMatchers
+            }
+
+            @Override
+            void intercept(IMethodInvocation invocation) throws Throwable {
+                if (iterationMatches(iterationMatchers, invocation.iteration.displayName)) {
+                    if (failsAsExpected(invocation, feature)) {
+                        pass.set(true)
+                    }
+                } else {
+                    invocation.proceed()
+                }
+            }
+        }
+    }
+
+    private static boolean failsAsExpected(IMethodInvocation invocation, String feature) {
+        try {
+            invocation.proceed()
+        } catch (Throwable ex) {
+            expectedFailure(ex, feature)
+            ignoreCleanupAssertionsOf(invocation)
+            return true
+        }
+        // Trigger validation failures early so they can still fail the test the usual way
+        try {
+            allResettableExpectationsOf(invocation.instance).forEach { expectations ->
+                expectations.resetExpectations()
+            }
+        } catch (Throwable ex) {
+            expectedFailure(ex, feature)
+            ignoreCleanupAssertionsOf(invocation)
+            return true
+        }
+        return false
+    }
+
+    private static ignoreCleanupAssertionsOf(IMethodInvocation invocation) {
+        def instance = invocation.instance
+        if (instance instanceof AbstractIntegrationSpec) {
+            instance.ignoreCleanupAssertions()
+        }
+        allResettableExpectationsOf(instance).forEach { expectations ->
+            try {
+                expectations.resetExpectations()
+            } catch (Throwable error) {
+                error.printStackTrace()
+            }
+        }
+    }
+
+    private static List<ResettableExpectations> allResettableExpectationsOf(instance) {
+        allInstanceFieldsOf(instance).findResults { field ->
+            try {
+                def fieldValue = field.tap { accessible = true }.get(instance)
+                fieldValue instanceof ResettableExpectations ? fieldValue : null
+            } catch (Exception ignored) {
+                null
+            }
+        }
+    }
+
+    private static Collection<Field> allInstanceFieldsOf(instance) {
+        ClassInspector.inspect(instance.getClass()).instanceFields
+    }
+
+    private static void expectedFailure(Throwable ex, String feature) {
+        System.err.println("Failed with $feature as expected:")
+        ex.printStackTrace()
+    }
+}

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithConfigurationCacheExtension.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithConfigurationCacheExtension.groovy
@@ -24,9 +24,9 @@ import org.spockframework.runtime.extension.IMethodInvocation
 import org.spockframework.runtime.model.FeatureInfo
 import org.spockframework.runtime.model.SpecInfo
 
-import static org.gradle.integtests.fixtures.ToBeFixedForConfigurationCacheExtension.isAllIterations
+import static ToBeFixedSpecInterceptor.isAllIterations
 import static org.gradle.integtests.fixtures.ToBeFixedForConfigurationCacheExtension.isEnabledBottomSpec
-import static org.gradle.integtests.fixtures.ToBeFixedForConfigurationCacheExtension.iterationMatches
+import static ToBeFixedSpecInterceptor.iterationMatches
 
 class UnsupportedWithConfigurationCacheExtension implements IAnnotationDrivenExtension<UnsupportedWithConfigurationCache> {
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithConfigurationCacheRule.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithConfigurationCacheRule.groovy
@@ -22,7 +22,7 @@ import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
 import static org.gradle.integtests.fixtures.ToBeFixedForConfigurationCacheExtension.isEnabledBottomSpec
-import static org.gradle.integtests.fixtures.ToBeFixedForConfigurationCacheExtension.iterationMatches
+import static ToBeFixedSpecInterceptor.iterationMatches
 import static org.junit.Assume.assumeTrue
 
 class UnsupportedWithConfigurationCacheRule implements TestRule {


### PR DESCRIPTION
Part of https://github.com/gradle/gradle/issues/29045

Currently, to mark tests as `unsupported with isolated projects` we can use `Preconditions`.
For CC we have such a [machinery](https://github.com/gradle/gradle/blob/1a5e48701b602def428d9c79e3793adff7a4f798/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithConfigurationCache.java#L37), that allows to control test behavior in more flexible manner, but IMO, having the same for IP is not justified so far.

