### PR TITLE
Set Gradle user home outside of test project to fix flakiness in NativeServicesIntegrationTest

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/NativeServicesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/NativeServicesIntegrationTest.groovy
@@ -57,6 +57,8 @@ class NativeServicesIntegrationTest extends AbstractIntegrationSpec {
 
     def "native services are #description with systemProperties == #systemProperties"() {
         given:
+        // We set Gradle User Home to a different temporary directory that is outside
+        // a project dir to avoid file lock issues on Windows due to native services being loaded
         executer.withGradleUserHomeDir(tmpDir.testDirectory).withNoExplicitNativeServicesDir()
         nativeDir = new File(executer.gradleUserHomeDir, 'native')
         executer.withArguments(systemProperties.collect { it.toString() })

--- a/subprojects/core/src/integTest/groovy/org/gradle/NativeServicesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/NativeServicesIntegrationTest.groovy
@@ -57,7 +57,7 @@ class NativeServicesIntegrationTest extends AbstractIntegrationSpec {
 
     def "native services are #description with systemProperties == #systemProperties"() {
         given:
-        executer.requireOwnGradleUserHomeDir().withNoExplicitNativeServicesDir()
+        executer.withGradleUserHomeDir(tmpDir.testDirectory).withNoExplicitNativeServicesDir()
         nativeDir = new File(executer.gradleUserHomeDir, 'native')
         executer.withArguments(systemProperties.collect { it.toString() })
         buildFile << """


### PR DESCRIPTION
More exactly for `NativeServicesIntegrationTest#native services are initialized with systemProperties` test.

We replace `requireOwnGradleUserHomeDir()` with `withGradleUserHomeDir()` so Gradle user home is located in a different temp dir and not in the test project dir. With that a test project dir is always removed without file lock issues.
