### PR TITLE
DPE Launch + Landing Page for Gradle Manual/Docs

### DIFF
--- a/platforms/documentation/docs/src/docs/css/manual.css
+++ b/platforms/documentation/docs/src/docs/css/manual.css
@@ -15,6 +15,16 @@
  */
 /* Custom Admonition Blocks */
 :root {
+    --gradle-blue: #209BC4;
+    --gradle-bg-dark: #010002;
+    --gradle-bg-gray: #F8F8F8;
+    --gradle-bg-white: #FFFFFF;
+    --gradle-blue: #209BC4;
+    --gradle-blue-lite: #4DC9C0;
+    --gradle-blue-dark: #1b3262;
+    --gradle-blue-darker: #19274f;
+    --button-gradient-angle: 160deg;
+
 	--caution-color: #e40046;
 	--caution-on-color: #fff;
 	--important-color: #802392;
@@ -4316,6 +4326,63 @@ code[data-lang="text"] .fun {
 	li.L9 {
 		background: #111 !important;
 	}
+}
+
+/* DPE University button*/
+/* CSS */
+.badge-wrapper {
+    padding-top: 0px;
+    padding-bottom: 20px;
+    a {
+        text-decoration: none;
+    }
+    a:link {
+        text-decoration: none;
+    }
+    a:visited {
+        text-decoration: none;
+    }
+    a:hover {
+        text-decoration: none;
+    }
+    a:active {
+        text-decoration: none;
+    }
+}
+.badge {
+    background-color: var(--black-color);
+    height: 24px;
+    border-radius: 12px;
+    border-color: var(--black-color);
+    border-style: solid;
+    border-width: 1px;
+    padding: 5px;
+    a {
+        color: var(--gradle-blue);
+    }
+}
+.badge-type {
+    border-radius: 8px;
+    margin-right: 10px;
+    padding-left: 10px;
+    padding-right: 10px;
+}
+.badge-text {
+    color: var(--white-color);
+}
+.button--blue {
+  color: white;
+  border-color: transparent;
+  &:hover {
+    color: white;
+  }
+}
+.button--blue {
+  background: var(--gradle-blue);
+  background: linear-gradient(var(--button-gradient-angle), var(--gradle-blue) 0%, var(--gradle-blue-lite) 100%);
+  &:hover {
+    background: var(--gradle-blue-lite);
+  }
 }
 
 /* Custom Download button*/

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/getting_started_dev.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/getting_started_dev.adoc
@@ -15,6 +15,15 @@
 [[dev_introduction]]
 = Getting Started
 
+++++
+<div class="badge-wrapper">
+    <a class="badge" href="https://dpeuniversity.gradle.com/app/courses/012de84f-fcd3-45d4-9c4c-284382eb3f3f/" target="_blank">
+        <span class="badge-type button--blue">LEARN</span>
+        <span class="badge-text">Introduction to Gradle for Developers&nbsp;&nbsp;&nbsp;&gt;</span>
+    </a>
+</div>
+++++
+
 Build engineers that are ready to configure custom build logic and write their own plugins should start here.
 
 To get started engineering Gradle builds:

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache.adoc
@@ -17,14 +17,12 @@
 
 ++++
 <div class="badge-wrapper">
-    <a class="badge" href="https://dpeuniversity.gradle.com/app/courses/54469478-55ba-416d-9cef-3b5aa33dd2a5/" target="_blank">
+    <a class="badge" href="https://dpeuniversity.gradle.com/app/courses/ec69d0b8-9171-4969-ac3e-82dea16f87b0/" target="_blank">
         <span class="badge-type button--blue">LEARN</span>
-        <span class="badge-text">Gradle Build Cache Deep Dive&nbsp;&nbsp;&nbsp;&gt;</span>
+        <span class="badge-text">Incremental Builds and Build Caching with Gradle&nbsp;&nbsp;&nbsp;&gt;</span>
     </a>
 </div>
 ++++
-
-TIP: Want to learn the tips and tricks top engineering teams use to keep builds fast and performant? https://gradle.org/training/#build-cache-deep-dive[Register here] for our Build Cache Training.
 
 [[sec:build_cache_intro]]
 == Overview

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache.adoc
@@ -15,6 +15,15 @@
 [[build_cache]]
 = Build Cache
 
+++++
+<div class="badge-wrapper">
+    <a class="badge" href="https://dpeuniversity.gradle.com/app/courses/54469478-55ba-416d-9cef-3b5aa33dd2a5/" target="_blank">
+        <span class="badge-type button--blue">LEARN</span>
+        <span class="badge-text">Gradle Build Cache Deep Dive&nbsp;&nbsp;&nbsp;&gt;</span>
+    </a>
+</div>
+++++
+
 TIP: Want to learn the tips and tricks top engineering teams use to keep builds fast and performant? https://gradle.org/training/#build-cache-deep-dive[Register here] for our Build Cache Training.
 
 [[sec:build_cache_intro]]

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache_performance.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache_performance.adoc
@@ -14,6 +14,15 @@
 
 = Build cache performance
 
+++++
+<div class="badge-wrapper">
+    <a class="badge" href="https://dpeuniversity.gradle.com/app/courses/4fcbecbc-7cff-449a-a509-07cf70403f0c/" target="_blank">
+        <span class="badge-type button--blue">LEARN</span>
+        <span class="badge-text">Maintaining Optimal Gradle Build Cache Performance&nbsp;&nbsp;&nbsp;&gt;</span>
+    </a>
+</div>
+++++
+
 The sole reason to use any build cache is to make builds faster.
 But how much faster can you go when using the cache?
 Measuring the impact is both important and complicated, as cache performance is determined by many factors.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/inspect.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/inspect.adoc
@@ -15,6 +15,15 @@
 [[inspecting_build_scans]]
 = Inspecting Gradle Builds
 
+++++
+<div class="badge-wrapper">
+    <a class="badge" href="https://dpeuniversity.gradle.com/app/courses/b5069222-cfd0-4393-b645-7a2c713853d5/" target="_blank">
+        <span class="badge-type button--blue">LEARN</span>
+        <span class="badge-text">How to Use Build Scans&nbsp;&nbsp;&nbsp;&gt;</span>
+    </a>
+</div>
+++++
+
 Gradle provides multiple ways to inspect your build:
 
 - Profile with build scans

--- a/platforms/documentation/docs/src/docs/userguide/overview/quick_start.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/overview/quick_start.adoc
@@ -15,9 +15,15 @@
 [[quick_start]]
 = Gradle Quick Start
 
+== Installing Gradle
+
+Most projects will start with an existing Gradle build which does not require the installation of Gradle.
+However, if you are starting a project from scratch, and you need to install Gradle, check out the <<installation.adoc#installation,installation guide>>.
+
 == DPE University
 
-Want to get up and running with Gradle quickly? Take our free, self-paced Gradle Built Tool courses at DPE University:
+Want to get up and running with Gradle quickly? Take our free, self-paced Gradle Build Tool courses at DPE University:
+
 ++++
 <div class="badge-wrapper">
     <a class="badge" href="https://dpeuniversity.gradle.com/" target="_blank">
@@ -27,32 +33,25 @@ Want to get up and running with Gradle quickly? Take our free, self-paced Gradle
 </div>
 ++++
 
-== Installing Gradle
-
-Most projects will start with an existing Gradle build which does not require the installation of Gradle.
-However, if you are starting a project from scratch, and you need to install Gradle, check out the <<installation.adoc#installation,installation guide>>.
-
 == For Software Developers
 
 For software developers that need to build, test, and publish their app, or add dependencies to their build, get started here:
 
 === 1. Core Concepts
 
-The core concepts section goes through the Gradle basics so that you can quickly understand how to invoke tasks, turn on features, apply plugins, add dependencies to your project, and more.
-
 [sidebar]
-<<gradle_basics.adoc#gradle,*Read Core Concepts*>> +
+_Description_: *Learn how to invoke tasks and add dependencies.* +
 _Training level_: **Beginner** +
-_Reading time_: **25 minutes**
+_Reading time_: **25 minutes** +
+<<gradle_basics.adoc#gradle,-> Read Core Concepts >>
 
 === 2. Hands-on Tutorial
 
-The tutorial will take you from initializing a Gradle build for a basic Java App to enabling and leveraging the Gradle build cache.
-
 [sidebar]
-<<part1_gradle_init#part1_begin,*Take the Tutorial*>> +
+_Description_: *Initialize a Gradle build for a basic Java App.* +
 _Training level_: **Beginner** +
-_Training time_: **55 minutes**
+_Training time_: **45 minutes** +
+<<part1_gradle_init#part1_begin,-> Start the Tutorial >>
 
 == For Build Engineers and Plugin Developers
 
@@ -60,22 +59,19 @@ Build engineers and plugin developers that are ready to configure custom build l
 
 === 1. Core Concepts
 
-The core concepts section goes through some Gradle authoring basics so that you can quickly understand how to configure builds, create tasks, and write plugins.
-
 [sidebar]
-<<gradle_directories.adoc#gradle_directories,*Read Core Concepts*>> +
+_Description_: *Learn to configure builds, create tasks, and write plugins.* +
 _Training level_: **Intermediate** +
-_Reading time_: **35 minutes**
+_Reading time_: **35 minutes** +
+<<gradle_directories.adoc#gradle_directories,-> Read Core Concepts >>
 
 === 2. Hands-on Tutorial
 
-The tutorial will take you from initializing a Gradle build for a basic Java App all the way through authoring a very basic plugin.
-No previous experience is necessary but a basic knowledge of Java, Groovy, or Kotlin is nice to have.
-
 [sidebar]
-<<partr1_gradle_init#part1_begin,*Take the Tutorial*>> +
+_Description_: *Initialize a Gradle project and create a basic plugin.* +
 _Training level_: **Intermediate** +
-_Training time_: **65 minutes**
+_Training time_: **55 minutes** +
+<<partr1_gradle_init#part1_begin,-> Start the Tutorial >>
 
 [[reference]]
 === 3. API Reference

--- a/platforms/documentation/docs/src/docs/userguide/overview/quick_start.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/overview/quick_start.adoc
@@ -1,0 +1,87 @@
+// Copyright (C) 2023 Gradle, Inc.
+//
+// Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://creativecommons.org/licenses/by-nc-sa/4.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+[[quick_start]]
+= Gradle Quick Start
+
+== DPE University
+
+Want to get up and running with Gradle quickly? Take our free, self-paced Gradle Built Tool courses at DPE University:
+++++
+<div class="badge-wrapper">
+    <a class="badge" href="https://dpeuniversity.gradle.com/" target="_blank">
+        <span class="badge-type button--blue">LEARN</span>
+        <span class="badge-text">Take courses on DPE University&nbsp;&nbsp;&nbsp;&gt;</span>
+    </a>
+</div>
+++++
+
+== Installing Gradle
+
+Most projects will start with an existing Gradle build which does not require the installation of Gradle.
+However, if you are starting a project from scratch, and you need to install Gradle, check out the <<installation.adoc#installation,installation guide>>.
+
+== For Software Developers
+
+For software developers that need to build, test, and publish their app, or add dependencies to their build, get started here:
+
+== 1. Core Concepts
+
+The core concepts section goes through the Gradle basics so that you can quickly understand how to invoke tasks, turn on features, apply plugins, add dependencies to your project, and more.
+
+[sidebar]
+<<gradle_basics.adoc#gradle,*Read Core Concepts*>> +
+_Training level_: **Beginner** +
+_Reading time_: **25 minutes**
+
+=== 2. Hands-on Tutorial
+
+The tutorial will take you from initializing a Gradle build for a basic Java App to enabling and leveraging the Gradle build cache.
+
+[sidebar]
+<<part1_gradle_init#part1_begin,*Take the Tutorial*>> +
+_Training level_: **Beginner** +
+_Training time_: **55 minutes**
+
+== For Build Engineers and Plugin Developers
+
+Build engineers and plugin developers that are ready to configure custom build logic or write their own plugins should start here:
+
+=== 1. Core Concepts
+
+The core concepts section goes through some Gradle authoring basics so that you can quickly understand how to configure builds, create tasks, and write plugins.
+
+[sidebar]
+<<gradle_directories.adoc#gradle_directories,*Read Core Concepts*>> +
+_Training level_: **Intermediate** +
+_Reading time_: **35 minutes**
+
+=== 2. Hands-on Tutorial
+
+The tutorial will take you from initializing a Gradle build for a basic Java App all the way through authoring a very basic plugin.
+No previous experience is necessary but a basic knowledge of Java, Groovy, or Kotlin is nice to have.
+
+[sidebar]
+<<partr1_gradle_init#part1_begin,*Take the Tutorial*>> +
+_Training level_: **Intermediate** +
+_Training time_: **65 minutes**
+
+[[reference]]
+=== 3. Reference
+
+Gradle's API references can be found in the links below:
+
+- link:{javadocPath}/index.html[Javadocs^]
+- link:{groovyDslPath}/index.html[Groovy DSL Reference^]
+- link:{kotlinDslPath}/index.html[Kotlin DSL Reference^]

--- a/platforms/documentation/docs/src/docs/userguide/overview/quick_start.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/overview/quick_start.adoc
@@ -36,7 +36,7 @@ However, if you are starting a project from scratch, and you need to install Gra
 
 For software developers that need to build, test, and publish their app, or add dependencies to their build, get started here:
 
-== 1. Core Concepts
+=== 1. Core Concepts
 
 The core concepts section goes through the Gradle basics so that you can quickly understand how to invoke tasks, turn on features, apply plugins, add dependencies to your project, and more.
 
@@ -78,7 +78,7 @@ _Training level_: **Intermediate** +
 _Training time_: **65 minutes**
 
 [[reference]]
-=== 3. Reference
+=== 3. API Reference
 
 Gradle's API references can be found in the links below:
 

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/getting_started_eng.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/getting_started_eng.adoc
@@ -15,6 +15,15 @@
 [[introduction]]
 = Getting Started
 
+++++
+<div class="badge-wrapper">
+    <a class="badge" href="https://dpeuniversity.gradle.com/app/courses/012de84f-fcd3-45d4-9c4c-284382eb3f3f/" target="_blank">
+        <span class="badge-type button--blue">LEARN</span>
+        <span class="badge-text">Introduction to Gradle for Developers&nbsp;&nbsp;&nbsp;&gt;</span>
+    </a>
+</div>
+++++
+
 Everyone has to start somewhere, and if you're new to Gradle, this is where to begin.
 
 To get started using Gradle:

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/build_scans.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/build_scans.adoc
@@ -15,6 +15,15 @@
 [[build_scans]]
 = Build Scans
 
+++++
+<div class="badge-wrapper">
+    <a class="badge" href="https://dpeuniversity.gradle.com/app/courses/b5069222-cfd0-4393-b645-7a2c713853d5/" target="_blank">
+        <span class="badge-type button--blue">LEARN</span>
+        <span class="badge-text">How to Use Build Scans&nbsp;&nbsp;&nbsp;&gt;</span>
+    </a>
+</div>
+++++
+
 A build scan is a *representation of metadata captured* as you run your build.
 
 image::gradle-basic-1.png[]

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/gradle_optimizations.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/gradle_optimizations.adoc
@@ -15,6 +15,15 @@
 [[gradle_optimizations]]
 = Gradle Incremental Builds and Build Caching
 
+++++
+<div class="badge-wrapper">
+    <a class="badge" href="https://dpeuniversity.gradle.com/app/courses/ec69d0b8-9171-4969-ac3e-82dea16f87b0/" target="_blank">
+        <span class="badge-type button--blue">LEARN</span>
+        <span class="badge-text">Incremental Builds and Build Caching with Gradle&nbsp;&nbsp;&nbsp;&gt;</span>
+    </a>
+</div>
+++++
+
 Gradle uses two main features to reduce build time: *incremental builds* and *build caching*.
 
 image::gradle-basic-8.png[]

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/tutorial/part5_gradle_inc_builds.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/tutorial/part5_gradle_inc_builds.adoc
@@ -15,6 +15,15 @@
 [[part5_gradle_inc_builds]]
 = Part 5: Exploring Incremental Builds
 
+++++
+<div class="badge-wrapper">
+    <a class="badge" href="https://dpeuniversity.gradle.com/app/courses/ec69d0b8-9171-4969-ac3e-82dea16f87b0/" target="_blank">
+        <span class="badge-type button--blue">LEARN</span>
+        <span class="badge-text">Incremental Builds and Build Caching with Gradle&nbsp;&nbsp;&nbsp;&gt;</span>
+    </a>
+</div>
+++++
+
 Learn the basics of Gradle's incremental builds.
 
 ****

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/tutorial/part6_gradle_caching.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/tutorial/part6_gradle_caching.adoc
@@ -15,6 +15,15 @@
 [[part6_gradle_caching]]
 = Part 6: Enabling the Gradle Build Cache
 
+++++
+<div class="badge-wrapper">
+    <a class="badge" href="https://dpeuniversity.gradle.com/app/courses/ec69d0b8-9171-4969-ac3e-82dea16f87b0/" target="_blank">
+        <span class="badge-type button--blue">LEARN</span>
+        <span class="badge-text">Incremental Builds and Build Caching with Gradle&nbsp;&nbsp;&nbsp;&gt;</span>
+    </a>
+</div>
+++++
+
 Learn the basics of Gradle's caching system.
 
 ****

--- a/platforms/documentation/docs/src/main/resources/footer.html
+++ b/platforms/documentation/docs/src/main/resources/footer.html
@@ -7,9 +7,9 @@
             <div class="site-footer__link-group">
                 <header><strong>Docs</strong></header>
                 <ul class="site-footer__links-list">
-                    <li itemprop="name"><a href="/userguide/userguide.html" itemprop="url">User Manual</a></li>
-                    <li itemprop="name"><a href="/dsl/" itemprop="url">DSL Reference</a></li>
                     <li itemprop="name"><a href="/release-notes.html" itemprop="url">Release Notes</a></li>
+                    <li itemprop="name"><a href="/dsl/" itemprop="url">Groovy DSL</a></li>
+                    <li itemprop="name"><a href="/kotlin-dsl/" itemprop="url">Kotlin DSL</a></li>
                     <li itemprop="name"><a href="/javadoc/" itemprop="url">Javadoc</a></li>
                 </ul>
             </div>
@@ -19,15 +19,16 @@
                     <li itemprop="name"><a href="https://blog.gradle.org/" itemprop="url">Blog</a></li>
                     <li itemprop="name"><a href="https://newsletter.gradle.org/" itemprop="url">Newsletter</a></li>
                     <li itemprop="name"><a href="https://twitter.com/gradle" itemprop="url">Twitter</a></li>
-                    <li itemprop="name"><a href="https://status.gradle.com/" itemprop="url">Status Page</a></li>
+                    <li itemprop="name"><a href="https://status.gradle.com/" itemprop="url">Status</a></li>
                 </ul>
             </div>
             <div class="site-footer__link-group">
                 <header><strong>Products</strong></header>
                 <ul class="site-footer__links-list">
+                    <li itemprop="name"><a href="https://gradle.com/develocity/" itemprop="url">Develocity</a></li>
                     <li itemprop="name"><a href="https://gradle.com/build-scans/" itemprop="url">Build Scan™</a></li>
                     <li itemprop="name"><a href="https://gradle.com/build-cache/" itemprop="url">Build Cache</a></li>
-                    <li itemprop="name"><a href="https://gradle.com/enterprise/resources/" itemprop="url">Develocity Docs</a></li>
+                    <li itemprop="name"><a href="https://gradle.org/services/" itemprop="url">Services</a></li>
                 </ul>
             </div>
             <div class="site-footer__link-group">
@@ -35,8 +36,8 @@
                 <ul class="site-footer__links-list">
                     <li itemprop="name"><a href="https://discuss.gradle.org/c/help-discuss" itemprop="url">Forums</a></li>
                     <li itemprop="name"><a href="https://github.com/gradle/" itemprop="url">GitHub</a></li>
-                    <li itemprop="name"><a href="https://gradle.org/training/" itemprop="url">Training</a></li>
-                    <li itemprop="name"><a href="https://gradle.org/services/" itemprop="url">Services</a></li>
+                    <li itemprop="name"><a href="https://gradle.org/training/" itemprop="url">Events</a></li>
+                    <li itemprop="name"><a href="https://dpeuniversity.gradle.com/" itemprop="url">DPE University</a></li>
                 </ul>
             </div>
         </section>

--- a/platforms/documentation/docs/src/main/resources/header.html
+++ b/platforms/documentation/docs/src/main/resources/header.html
@@ -115,7 +115,7 @@
             <h3 id="overview">Overview</h3>
             <ul>
                 <li><a href="../userguide/userguide.html">What is Gradle?</a></li>
-                <li><a href="../userguide/about_manual.html">The User Manual</a></li>
+                <li><a href="../userguide/quick_start.html">Quick Start</a></li>
             </ul>
 
             <h3 id="what-is-new">Releases</h3>

--- a/platforms/documentation/docs/src/main/resources/header.html
+++ b/platforms/documentation/docs/src/main/resources/header.html
@@ -63,7 +63,10 @@
                         </div>
                     </li>
                     <li class="site-header__navigation-item" itemprop="name">
-                        <a target="_top" class="site-header__navigation-link" href="https://gradle.org/training/" itemprop="url">Training</a>
+                        <a target="_top" class="site-header__navigation-link" href="https://dpeuniversity.gradle.com/" itemprop="url">DPE University</a>
+                    </li>
+                    <li class="site-header__navigation-item" itemprop="name">
+                        <a target="_top" class="site-header__navigation-link" href="https://gradle.org/training/" itemprop="url">Events</a>
                     </li>
                     <li class="site-header__navigation-item site-header__navigation-submenu-section" tabindex="0">
                         <span class="site-header__navigation-link">


### PR DESCRIPTION
[BUILD LINK](https://builds.gradle.org/repository/download/Gradle_Release_Check_BuildDistributions/82221937:id/distributions/gradle-8.8-docs.zip!/gradle-8.8-20240514190022%2B0000/docs/userguide/quick_start.html):
1. New quick start page
2. New header
3. New footer
4. A number of pages with links to specific DPE U courses