### PR TITLE
LightTree source data improvements

### DIFF
--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/parsing/GrammarToTree.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/parsing/GrammarToTree.kt
@@ -97,7 +97,8 @@ import org.jetbrains.kotlin.utils.doNothing
 class GrammarToTree(
     private val sourceIdentifier: SourceIdentifier,
     private val sourceCode: String,
-    private val sourceOffset: Int
+    private val sourceOffset: Int,
+    private val suffixLength: Int
 ) {
 
     inner
@@ -108,6 +109,11 @@ class GrammarToTree(
         fun sourceData(node: LighterASTNode, offset: Int = sourceOffset): LightTreeSourceData =
             sourceData.computeIfAbsent(node) {
                 it.sourceData(sourceIdentifier, sourceCode, offset)
+            }
+
+        fun rootSourceData(): LightTreeSourceData =
+            sourceData.computeIfAbsent(root) {
+                LightTreeSourceData(sourceIdentifier, sourceCode, sourceOffset, sourceOffset..sourceCode.lastIndex - suffixLength)
             }
 
         fun parsingError(node: LighterASTNode, message: String): ParsingError {
@@ -159,7 +165,7 @@ class GrammarToTree(
 
         return LanguageTreeResult(
             imports = imports.filterIsInstance<Element<Import>>().map { it.element },
-            topLevelBlock = Block(statements.map { it.asBlockElement() }, tree.sourceData(tree.root)),
+            topLevelBlock = Block(statements.map { it.asBlockElement() }, tree.rootSourceData()),
             headerFailures = headerFailures,
             codeFailures = collectFailures(statements)
         )

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/parsing/LanguageTreeBuilder.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/parsing/LanguageTreeBuilder.kt
@@ -5,16 +5,15 @@ import org.gradle.internal.declarativedsl.language.SourceIdentifier
 
 
 interface LanguageTreeBuilder {
-    fun build(tree: LightTree, sourceCode: String, sourceOffset: Int, sourceIdentifier: SourceIdentifier): LanguageTreeResult
+    fun build(parsedLightTree: ParsedLightTree, sourceIdentifier: SourceIdentifier): LanguageTreeResult
 }
 
 
 class DefaultLanguageTreeBuilder : LanguageTreeBuilder {
     override fun build(
-        tree: LightTree,
-        sourceCode: String,
-        sourceOffset: Int,
+        parsedLightTree: ParsedLightTree,
         sourceIdentifier: SourceIdentifier
     ): LanguageTreeResult =
-        GrammarToTree(sourceIdentifier, sourceCode, sourceOffset).script(tree)
+        GrammarToTree(sourceIdentifier, parsedLightTree.wrappedCode, parsedLightTree.originalCodeOffset, parsedLightTree.suffixLength)
+            .script(parsedLightTree.lightTree)
 }

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/parsing/LightTreeUtil.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/parsing/LightTreeUtil.kt
@@ -34,7 +34,7 @@ fun FlyweightCapableTreeStructure<LighterASTNode>.sourceData(
         sourceIdentifier,
         sourceCode,
         sourceOffset,
-        this.root
+        root.range()
     )
 
 
@@ -42,10 +42,10 @@ class LightTreeSourceData(
     override val sourceIdentifier: SourceIdentifier,
     private val sourceCode: String,
     private val sourceOffset: Int,
-    private val node: LighterASTNode
+    private val nodeRange: IntRange,
 ) : SourceData {
     override val indexRange: IntRange by lazy {
-        val originalRange = node.range()
+        val originalRange = nodeRange
         val first = originalRange.first - sourceOffset
         val last = originalRange.last - sourceOffset
         first..last
@@ -64,9 +64,8 @@ class LightTreeSourceData(
     override
     val endColumn: Int
         get() = lineColumnInfo.endColumn
-
     override
-    fun text(): String = node.asText
+    fun text(): String = sourceCode.substring((indexRange.first + sourceOffset)..(indexRange.last + sourceOffset))
 
     private
     class LineColumnInfo(val startLine: Int, val startColumn: Int, val endLine: Int, val endColumn: Int) {
@@ -91,7 +90,7 @@ class LightTreeSourceData(
                 val realEndIndex = offset + offsetRelativeIndexRange.last
                 check(text.isValidIndex(realEndIndex))
 
-                check(realStartIndex <= realEndIndex)
+                check(realEndIndex - realStartIndex >= -1) // -1 is for empty intervals
 
                 var startLine = -1
                 var startColumn = -1
@@ -109,6 +108,10 @@ class LightTreeSourceData(
                     if (i == realEndIndex) {
                         endLine = line
                         endColumn = column
+                        if (realStartIndex == realEndIndex + 1) { // might be an empty range, e.g. 20..19
+                            startLine = line
+                            startColumn = column + 1
+                        }
                         break
                     }
 
@@ -200,7 +203,7 @@ fun LighterASTNode.isKind(expected: IElementType) =
 
 internal
 fun LighterASTNode.sourceData(sourceIdentifier: SourceIdentifier, sourceCode: String, sourceOffset: Int) =
-    LightTreeSourceData(sourceIdentifier, sourceCode, sourceOffset, this)
+    LightTreeSourceData(sourceIdentifier, sourceCode, sourceOffset, this.range())
 
 
 private
@@ -210,7 +213,7 @@ fun LighterASTNode.print(indent: String) {
 
 
 internal
-fun LighterASTNode.range() = startOffset..endOffset
+fun LighterASTNode.range() = startOffset.until(endOffset)
 
 
 private

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/demo/demoUtils.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/demo/demoUtils.kt
@@ -37,10 +37,10 @@ fun AnalysisSchema.resolve(
     code: String,
     resolver: Resolver = tracingCodeResolver()
 ): ResolutionResult {
-    val (parseTree, sourceCode, sourceOffset) = parse(code)
+    val parsedTree = parse(code)
 
     val languageBuilder = DefaultLanguageTreeBuilder()
-    val tree = languageBuilder.build(parseTree, sourceCode, sourceOffset, SourceIdentifier("demo"))
+    val tree = languageBuilder.build(parsedTree, SourceIdentifier("demo"))
 
     val failures = tree.allFailures
 
@@ -52,7 +52,7 @@ fun AnalysisSchema.resolve(
                     "Parsing error: " + failure.message
                 )
                 is UnsupportedConstruct -> println(
-                    failure.languageFeature.toString() + " in " + sourceCode.slice(sourceOffset..sourceOffset + 100)
+                    failure.languageFeature.toString() + " in " + parsedTree.wrappedCode.slice(parsedTree.originalCodeOffset..parsedTree.originalCodeOffset + 100)
                 )
                 is MultipleFailuresResult -> failure.failures.forEach { printFailures(it) }
             }

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/dom/DomResolutionTest.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/dom/DomResolutionTest.kt
@@ -300,7 +300,7 @@ object DomResolutionTest {
 
     private
     fun parseAsTopLevelBlock(@Language("kts") code: String): Block {
-        val (tree, sourceCode, sourceOffset) = parse(code)
-        return DefaultLanguageTreeBuilder().build(tree, sourceCode, sourceOffset, SourceIdentifier("test")).topLevelBlock
+        val tree = parse(code)
+        return DefaultLanguageTreeBuilder().build(tree, SourceIdentifier("test")).topLevelBlock
     }
 }

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/dom/DomResolutionTest.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/dom/DomResolutionTest.kt
@@ -23,12 +23,8 @@ import org.gradle.declarative.dsl.model.annotations.Restricted
 import org.gradle.internal.declarativedsl.analysis.DataTypeRef
 import org.gradle.internal.declarativedsl.analysis.SchemaFunction
 import org.gradle.internal.declarativedsl.analysis.tracingCodeResolver
-import org.gradle.internal.declarativedsl.language.Block
-import org.gradle.internal.declarativedsl.language.SourceIdentifier
-import org.gradle.internal.declarativedsl.parsing.DefaultLanguageTreeBuilder
-import org.gradle.internal.declarativedsl.parsing.parse
+import org.gradle.internal.declarativedsl.parsing.ParseTestUtil.Parser.parseAsTopLevelBlock
 import org.gradle.internal.declarativedsl.schemaBuilder.schemaFromTypes
-import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
@@ -297,10 +293,4 @@ object DomResolutionTest {
 
     private
     class MyNestedElement
-
-    private
-    fun parseAsTopLevelBlock(@Language("kts") code: String): Block {
-        val tree = parse(code)
-        return DefaultLanguageTreeBuilder().build(tree, SourceIdentifier("test")).topLevelBlock
-    }
 }

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/dom/DomTest.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/dom/DomTest.kt
@@ -16,12 +16,8 @@
 
 package org.gradle.internal.declarativedsl.dom
 
-import org.gradle.internal.declarativedsl.parsing.DefaultLanguageTreeBuilder
-import org.gradle.internal.declarativedsl.parsing.parse
-import org.gradle.internal.declarativedsl.language.Block
 import org.gradle.internal.declarativedsl.language.SourceData
-import org.gradle.internal.declarativedsl.language.SourceIdentifier
-import org.intellij.lang.annotations.Language
+import org.gradle.internal.declarativedsl.parsing.ParseTestUtil.Parser.parseAsTopLevelBlock
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -118,12 +114,6 @@ object DomTest {
 
             DomPrettyPrinter(withSourceData = true).domAsString(convertBlockToDocument(tree))
         )
-    }
-
-    private
-    fun parseAsTopLevelBlock(@Language("kts") code: String): Block {
-        val parsedTree = parse(code)
-        return DefaultLanguageTreeBuilder().build(parsedTree, SourceIdentifier("test")).topLevelBlock
     }
 
     internal

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/dom/DomTest.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/dom/DomTest.kt
@@ -45,13 +45,13 @@ object DomTest {
 
         assertEquals(
             """
-            element(myFun)[0..107]
-                property(a, literal(1)[16..17])[12..17]
-                property(b, valueFactory(f, literal(x)[28..31], valueFactory(z.f, literal(y)[37..40])[35..41])[26..42])[22..42]
-                property(c, literal(true)[51..55])[47..55]
-                element(nested)[60..90]
-                    property(x, literal(y)[81..84])[77..84]
-                element(factory, literal(1)[103..104])[95..105]
+            element(myFun)[0..106]
+                property(a, literal(1)[16..16])[12..16]
+                property(b, valueFactory(f, literal(x)[28..30], valueFactory(z.f, literal(y)[37..39])[35..40])[26..41])[22..41]
+                property(c, literal(true)[51..54])[47..54]
+                element(nested)[60..89]
+                    property(x, literal(y)[81..83])[77..83]
+                element(factory, literal(1)[103..103])[95..104]
 
             """.trimIndent(),
             DomPrettyPrinter(withSourceData = true).domAsString(convertBlockToDocument(tree))
@@ -97,22 +97,22 @@ object DomTest {
 
         assertEquals(
             """
-            element(myFun)[0..364]
-                property(a, literal(x)[16..19])[12..19]
-                error(UnsupportedSyntax(UnsupportedPropertyAccess)[24..29]
-                error(UnsupportedSyntax(ValueFactoryArgumentFormat)[34..48]
-                error(UnsupportedSyntax(ValueFactoryArgumentFormat)[53..78]
-                error(UnsupportedKotlinFeature(FunctionDeclaration)[92..95]
-                error(UnsupportedKotlinFeature(FunctionDeclaration), UnsupportedKotlinFeature(FunctionDeclaration)[237..240]
-                error(UnsupportedSyntax(DanglingExpr)[251..252]
-                error(UnsupportedSyntax(ElementWithExplicitReceiver)[259..262]
-                error(UnsupportedSyntax(AssignmentWithExplicitReceiver)[267..274]
-                error(UnsupportedSyntax(LocalVal)[279..288]
-                error(SyntaxError(Parsing failure, unexpected tokenType in expression: POSTFIX_EXPRESSION)[307..320]
-                error(SyntaxError(Unexpected tokens (use ';' to separate expressions on the same line))[320..321]
-                error(UnsupportedSyntax(UnsupportedThisValue)[326..334]
-                error(UnsupportedSyntax(UnsupportedNullValue)[339..347]
-                element(factory, literal(1)[360..361])[352..362]
+            element(myFun)[0..363]
+                property(a, literal(x)[16..18])[12..18]
+                error(UnsupportedSyntax(UnsupportedPropertyAccess)[24..28]
+                error(UnsupportedSyntax(ValueFactoryArgumentFormat)[34..47]
+                error(UnsupportedSyntax(ValueFactoryArgumentFormat)[53..77]
+                error(UnsupportedKotlinFeature(FunctionDeclaration)[92..94]
+                error(UnsupportedKotlinFeature(FunctionDeclaration), UnsupportedKotlinFeature(FunctionDeclaration)[237..239]
+                error(UnsupportedSyntax(DanglingExpr)[251..251]
+                error(UnsupportedSyntax(ElementWithExplicitReceiver)[259..261]
+                error(UnsupportedSyntax(AssignmentWithExplicitReceiver)[267..273]
+                error(UnsupportedSyntax(LocalVal)[279..287]
+                error(SyntaxError(Parsing failure, unexpected tokenType in expression: POSTFIX_EXPRESSION)[307..319]
+                error(SyntaxError(Unexpected tokens (use ';' to separate expressions on the same line))[320..320]
+                error(UnsupportedSyntax(UnsupportedThisValue)[326..333]
+                error(UnsupportedSyntax(UnsupportedNullValue)[339..346]
+                element(factory, literal(1)[360..360])[352..361]
 
             """.trimIndent(),
 
@@ -122,8 +122,8 @@ object DomTest {
 
     private
     fun parseAsTopLevelBlock(@Language("kts") code: String): Block {
-        val (tree, sourceCode, sourceOffset) = parse(code)
-        return DefaultLanguageTreeBuilder().build(tree, sourceCode, sourceOffset, SourceIdentifier("test")).topLevelBlock
+        val parsedTree = parse(code)
+        return DefaultLanguageTreeBuilder().build(parsedTree, SourceIdentifier("test")).topLevelBlock
     }
 
     internal

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/parsing/BasicParsingTest.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/parsing/BasicParsingTest.kt
@@ -421,6 +421,46 @@ class BasicParsingTest {
     }
 
     @Test
+    fun `keeps empty lines in line number counting`() {
+        val results = parse(
+            """
+            import a.b.c
+
+            // start of actual script content is here -- imports are counted separately because of the workarounds
+
+            f(x)
+
+
+            a = 1
+            """.trimIndent()
+        )
+
+        val expected = """
+            Import [indexes: 0..12, line/column: 1/1..1/13, file: test (
+                name parts = [a, b, c]
+            )
+            FunctionCall [indexes: 104..108, line/column: 3/1..3/5, file: test] (
+                name = f
+                args = [
+                    FunctionArgument.Positional [indexes: 106..107, line/column: 3/3..3/4, file: test] (
+                        expr = PropertyAccess [indexes: 106..107, line/column: 3/3..3/4, file: test] (
+                            name = x
+                        )
+                    )
+                ]
+            )
+            Assignment [indexes: 111..116, line/column: 6/1..6/6, file: test] (
+                lhs = PropertyAccess [indexes: 111..112, line/column: 6/1..6/2, file: test] (
+                    name = a
+                )
+                rhs = IntLiteral [indexes: 115..116, line/column: 6/5..6/6, file: test] (1)
+            )
+        """.trimIndent()
+
+        results.assert(expected)
+    }
+
+    @Test
     fun `parse infix function call with regular arguments`() {
         val results = parse(
             """

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/parsing/ParseTestUtils.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/parsing/ParseTestUtils.kt
@@ -1,8 +1,8 @@
 package org.gradle.internal.declarativedsl.parsing
 
 import org.gradle.internal.declarativedsl.language.LanguageTreeResult
-import org.gradle.internal.declarativedsl.prettyPrintLanguageTreeResult
 import org.gradle.internal.declarativedsl.language.SourceIdentifier
+import org.gradle.internal.declarativedsl.prettyPrintLanguageTreeResult
 import org.intellij.lang.annotations.Language
 import kotlin.test.assertEquals
 
@@ -11,8 +11,8 @@ class ParseTestUtil {
 
     companion object Parser {
         fun parse(@Language("kts") code: String): LanguageTreeResult {
-            val (tree, sourceCode, sourceOffset) = org.gradle.internal.declarativedsl.parsing.parse(code)
-            return DefaultLanguageTreeBuilder().build(tree, sourceCode, sourceOffset, SourceIdentifier("test"))
+            val parsedTree = org.gradle.internal.declarativedsl.parsing.parse(code)
+            return DefaultLanguageTreeBuilder().build(parsedTree, SourceIdentifier("test"))
         }
     }
 }

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/parsing/ParseTestUtils.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/parsing/ParseTestUtils.kt
@@ -1,5 +1,6 @@
 package org.gradle.internal.declarativedsl.parsing
 
+import org.gradle.internal.declarativedsl.language.Block
 import org.gradle.internal.declarativedsl.language.LanguageTreeResult
 import org.gradle.internal.declarativedsl.language.SourceIdentifier
 import org.gradle.internal.declarativedsl.prettyPrintLanguageTreeResult
@@ -13,6 +14,11 @@ class ParseTestUtil {
         fun parse(@Language("kts") code: String): LanguageTreeResult {
             val parsedTree = org.gradle.internal.declarativedsl.parsing.parse(code)
             return DefaultLanguageTreeBuilder().build(parsedTree, SourceIdentifier("test"))
+        }
+
+        fun parseAsTopLevelBlock(code: String): Block {
+            val parsedTree = org.gradle.internal.declarativedsl.parsing.parse(code)
+            return DefaultLanguageTreeBuilder().build(parsedTree, SourceIdentifier("test")).topLevelBlock
         }
     }
 }

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/prettyPrintResults.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/prettyPrintResults.kt
@@ -247,8 +247,9 @@ fun prettyPrintLanguageTree(languageTreeElement: LanguageTreeElement): String {
 private
 fun SourceData.prettyPrint(): String =
     buildString {
-        append("indexes: $indexRange, ")
-        append("line/column: ${lineRange.first}/$startColumn..${lineRange.last}/$endColumn, ")
+        // We add +1 here as that was how the original implementation worked, just to avoid fixing all test data:
+        append("indexes: ${indexRange.start}..${indexRange.endInclusive + 1}, ")
+        append("line/column: ${lineRange.first}/$startColumn..${lineRange.last}/${endColumn + 1}, ")
         append("file: ${sourceIdentifier.fileIdentifier}")
     }
 

--- a/platforms/core-configuration/declarative-dsl-provider/build.gradle.kts
+++ b/platforms/core-configuration/declarative-dsl-provider/build.gradle.kts
@@ -34,7 +34,6 @@ dependencies {
     implementation(project(":model-core"))
 
     implementation(libs.guava)
-    implementation(libs.futureKotlin("compiler-embeddable"))
     implementation(libs.futureKotlin("reflect"))
 
     integTestImplementation(project(":internal-testing"))

--- a/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/settings/DeclarativeDslProjectSettingsIntegrationSpec.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/settings/DeclarativeDslProjectSettingsIntegrationSpec.groovy
@@ -81,9 +81,9 @@ class DeclarativeDslProjectSettingsIntegrationSpec extends AbstractIntegrationSp
 
         where:
         kind               | code                  | expectedMessage
-        "syntax"           | "..."                 | "2:13: parsing error: Expecting an element"
-        "language feature" | "@A dependencies { }" | "2:13: unsupported language feature: AnnotationUsage"
-        "semantic"         | "x = 1"               | "2:13: unresolved reference 'x'"
+        "syntax"           | "..."                 | "3:13: parsing error: Expecting an element"
+        "language feature" | "@A dependencies { }" | "3:13: unsupported language feature: AnnotationUsage"
+        "semantic"         | "x = 1"               | "3:13: unresolved reference 'x'"
     }
 
     def 'can apply settings plugins'() {

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/evaluator/DeclarativeKotlinScriptEvaluator.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/evaluator/DeclarativeKotlinScriptEvaluator.kt
@@ -158,8 +158,8 @@ class DefaultDeclarativeKotlinScriptEvaluator(
 
     private
     fun languageModelFromLightParser(scriptSource: ScriptSource): LanguageTreeResult {
-        val (tree, code, codeOffset) = parse(scriptSource.resource.text)
-        return languageTreeBuilder.build(tree, code, codeOffset, SourceIdentifier(scriptSource.fileName))
+        val parsedTree = parse(scriptSource.resource.text)
+        return languageTreeBuilder.build(parsedTree, SourceIdentifier(scriptSource.fileName))
     }
 
     private


### PR DESCRIPTION
* Track the length of the suffix added by wrapping the code
* Support producing the "root source data" for the root block (required in the future)
* Keep blank lines in the document code
* Refactor the API and use sites of the `LanguageTreeBuilder`
* Deduplicate some parsing test utils