### PR TITLE
Add mitigation for cases, where the `Context` object becomes invalid

### DIFF
--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileProblemsIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileProblemsIntegrationTest.groovy
@@ -428,6 +428,17 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec {
         // TODO (donat) we can probably delete some of this method
         assert problem.definition.severity == Severity.valueOf(severity) : "Expected severity to be ${severity}, but was ${problem.definition.severity}"
 
+        switch (severity) {
+            case "ERROR":
+                assert problem.definition.id.displayName == "Java compilation error": "Expected label 'Java compilation error', but was ${problem.definition.id.displayName}"
+                break
+            case "WARNING":
+                assert problem.definition.id.displayName == "Java compilation warning": "Expected label 'Java compilation warning', but was ${problem.definition.id.displayName}"
+                break
+            default:
+                throw new IllegalArgumentException("Unknown severity: ${severity}")
+        }
+
         def details = problem.details
         assert details: "Expected details to be non-null, but was null"
 

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileProblemsIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileProblemsIntegrationTest.groovy
@@ -24,6 +24,8 @@ import org.gradle.api.problems.internal.FileLocation
 import org.gradle.api.problems.internal.LineInFileLocation
 import org.gradle.api.problems.internal.OffsetInFileLocation
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
 import org.gradle.integtests.fixtures.problems.ReceivedProblem
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
@@ -33,7 +35,7 @@ import spock.lang.Issue
 /**
  * Test class verifying the integration between the {@code JavaCompile} and the {@code Problems} service.
  */
-class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec {
+class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec implements JavaToolchainFixture {
 
     /**
      * A map of all possible file locations, and the number of occurrences we expect to find in the problems.
@@ -389,7 +391,7 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         executer.withArguments("--info", "--stacktrace")
-        executer.withToolchainDetectionEnabled()
+        withInstallations(AvailableJavaHomes.getJdk(JavaVersion.VERSION_1_8))
         succeeds(":compileJava")
 
         then:

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileProblemsIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileProblemsIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.tasks.compile
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 import org.gradle.api.JavaVersion
+import org.gradle.api.internal.tasks.compile.DiagnosticToProblemListener
 import org.gradle.api.problems.Severity
 import org.gradle.api.problems.internal.FileLocation
 import org.gradle.api.problems.internal.LineInFileLocation
@@ -26,6 +27,9 @@ import org.gradle.api.problems.internal.OffsetInFileLocation
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.problems.ReceivedProblem
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.IntegTestPreconditions
+import spock.lang.Issue
 
 /**
  * Test class verifying the integration between the {@code JavaCompile} and the {@code Problems} service.
@@ -61,7 +65,9 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def cleanup() {
-        assert possibleFileLocations == visitedFileLocations: "Not all expected files were visited: ${possibleFileLocations.keySet() - visitedFileLocations.keySet()}"
+        if (isProblemsApiCheckEnabled()) {
+            assert possibleFileLocations == visitedFileLocations: "Not all expected files were visited, unchecked files were: ${possibleFileLocations.keySet() - visitedFileLocations.keySet()}"
+        }
     }
 
     def "problem is received when a single-file compilation failure happens"() {
@@ -287,6 +293,120 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec {
             additionalData["formatted"] == """${fooFileLocation}:10: warning: [cast] redundant cast to $expectedType
                     String s = (String)"Hello World";
                                ^"""
+        }
+    }
+
+    @Issue("https://github.com/gradle/gradle/pull/29141")
+    @Requires(IntegTestPreconditions.Java8HomeAvailable)
+    def "problem listener have a recoverable failure when running on JDK8"() {
+        given:
+        disableProblemsApiCheck()
+        //
+        // 1. step: Create a simple annotation processor
+        //
+        file("processor/build.gradle") << """
+            plugins {
+                id 'java'
+            }
+
+            java {
+                sourceCompatibility = JavaVersion.VERSION_1_8
+                targetCompatibility = JavaVersion.VERSION_1_8
+            }
+        """
+        file("processor/src/main/java/DummyAnnotation.java") << """
+            package com.example;
+
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Retention;
+            import java.lang.annotation.RetentionPolicy;
+            import java.lang.annotation.Target;
+
+            @Retention(RetentionPolicy.RUNTIME)
+            @Target(ElementType.TYPE)
+            public @interface DummyAnnotation {
+            }
+        """
+        // A simple annotation processor
+        file("processor/src/main/java/DummyProcessor.java") << """
+            package com.example;
+
+            import javax.annotation.processing.AbstractProcessor;
+            import javax.annotation.processing.RoundEnvironment;
+            import javax.annotation.processing.Processor;
+            import javax.annotation.processing.ProcessingEnvironment;
+            import javax.annotation.processing.SupportedAnnotationTypes;
+            import javax.annotation.processing.SupportedSourceVersion;
+            import javax.lang.model.SourceVersion;
+            import javax.lang.model.element.TypeElement;
+            import javax.lang.model.element.Element;
+            import javax.tools.Diagnostic;
+
+            import java.util.Set;
+
+            @SupportedAnnotationTypes("com.example.DummyAnnotation")
+            @SupportedSourceVersion(SourceVersion.RELEASE_8)
+            public class DummyProcessor extends AbstractProcessor {
+                @Override
+                public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+                    for (Element element : roundEnv.getElementsAnnotatedWith(DummyAnnotation.class)) {
+                        processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE, "Processing: " + element.getSimpleName());
+                    }
+                    return true; // No further processing of this annotation type
+                }
+            }
+        """
+        // META-INF/services file for registering the annotation processor
+        file("processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor") << "com.example.DummyProcessor"
+
+        //
+        // 2. step: Create a simple project that uses the annotation processor
+        //
+        settingsFile << """\
+            include 'processor'
+        """
+        buildFile << """\
+        dependencies {
+            //annotationProcessor project(':processor')
+            annotationProcessor "org.immutables:value:2.+"
+        }
+
+        repositories {
+            mavenCentral()
+        }
+
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(8)
+            }
+        }
+
+        repositories {
+            mavenCentral()
+        }
+        """
+
+        def fooFileLocation = writeJavaCausingTwoCompilationWarnings("Foo")
+        possibleFileLocations.put(fooFileLocation, 2)
+
+        when:
+        executer.withArguments("--info", "--stacktrace")
+        executer.withToolchainDetectionEnabled()
+        def result = succeeds(":compileJava")
+
+        then:
+        result.output.contains(DiagnosticToProblemListener.FORMATTER_FALLBACK_MESSAGE)
+        verifyAll(receivedProblem(0)) {
+            assertProblem(it, "ERROR", false)
+            fqid == 'compilation:java:java-compilation-warning'
+            details == 'redundant cast to java.lang.String'
+            additionalData == [ 'formatted' : 'redundant cast to java.lang.String' ]
+        }
+        verifyAll(receivedProblem(1)) {
+            assertProblem(it, "ERROR", false)
+            fqid == 'compilation:java:java-compilation-warning'
+            details == 'redundant cast to java.lang.String'
+            additionalData == [ 'formatted' : 'redundant cast to java.lang.String' ]
         }
     }
 

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AnnotationProcessingCompileTask.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AnnotationProcessingCompileTask.java
@@ -99,7 +99,7 @@ class AnnotationProcessingCompileTask implements JavaCompiler.CompilationTask {
 
     private void setupProcessors() {
         processorClassloader = createProcessorClassLoader();
-        List<Processor> processors = new ArrayList<Processor>(processorDeclarations.size());
+        List<Processor> processors = new ArrayList<>(processorDeclarations.size());
         if (!processorDeclarations.isEmpty()) {
             SupportedOptionsCollectingProcessor supportedOptionsCollectingProcessor = new SupportedOptionsCollectingProcessor();
             for (AnnotationProcessorDeclaration declaredProcessor : processorDeclarations) {

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/ContextAwareJavaCompiler.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/ContextAwareJavaCompiler.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.tasks.compile;
 import com.sun.source.util.JavacTask;
 import com.sun.tools.javac.util.Context;
 
+import javax.annotation.Nullable;
 import javax.tools.DiagnosticListener;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaFileManager;
@@ -32,7 +33,7 @@ import java.io.Writer;
 public interface ContextAwareJavaCompiler extends JavaCompiler {
 
     JavacTask getTask(
-        Writer out,
+        @Nullable Writer out,
         JavaFileManager fileManager,
         DiagnosticListener<? super JavaFileObject> diagnosticListener,
         Iterable<String> options,

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
@@ -66,8 +66,7 @@ public class DiagnosticToProblemListener implements DiagnosticListener<JavaFileO
                 return formatter.format((JCDiagnostic) diagnostic, JavacMessages.instance(context).getCurrentLocale());
             } catch (Exception ex) {
                 // If for some reason the formatter fails, we can still get the message
-                //LOGGER.error(FORMETTER_FALLBACK_MESSAGE);
-                System.err.println(FORMATTER_FALLBACK_MESSAGE);
+                LOGGER.error(FORMATTER_FALLBACK_MESSAGE);
                 return diagnostic.getMessage(Locale.getDefault());
             }
         };

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
@@ -23,6 +23,8 @@ import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.JCDiagnostic;
 import com.sun.tools.javac.util.JavacMessages;
 import com.sun.tools.javac.util.Log;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.api.problems.ProblemSpec;
 import org.gradle.api.problems.Problems;
 import org.gradle.api.problems.Severity;
@@ -44,22 +46,28 @@ import java.util.function.Function;
 @ClientCodeWrapper.Trusted
 public class DiagnosticToProblemListener implements DiagnosticListener<JavaFileObject> {
 
+    private static final Logger LOGGER = Logging.getLogger(DiagnosticToProblemListener.class);
+
     private final InternalProblemReporter problemReporter;
-    private final Context context;
     private final Function<Diagnostic<? extends JavaFileObject>, String> messageFormatter;
 
-    DiagnosticToProblemListener(InternalProblemReporter problemReporter, Context context, Function<Diagnostic<? extends JavaFileObject>, String> messageFormatter) {
+    DiagnosticToProblemListener(InternalProblemReporter problemReporter, Function<Diagnostic<? extends JavaFileObject>, String> messageFormatter) {
         this.problemReporter = problemReporter;
-        this.context = context;
         this.messageFormatter = messageFormatter;
     }
 
     public DiagnosticToProblemListener(InternalProblemReporter problemReporter, Context context) {
         this.problemReporter = problemReporter;
-        this.context = context;
         this.messageFormatter = diagnostic -> {
-            DiagnosticFormatter<JCDiagnostic> formatter = Log.instance(context).getDiagnosticFormatter();
-            return formatter.format((JCDiagnostic) diagnostic, JavacMessages.instance(context).getCurrentLocale());
+            try {
+                DiagnosticFormatter<JCDiagnostic> formatter = Log.instance(context).getDiagnosticFormatter();
+                return formatter.format((JCDiagnostic) diagnostic, JavacMessages.instance(context).getCurrentLocale());
+            } catch (Exception ex) {
+                // If for some reason the formatter fails, we can still get the message
+                LOGGER.error("Failed to format diagnostic message, falling back to default message formatting");
+                //return diagnostic.getMessage(Locale.getDefault());
+                throw ex;
+            }
         };
     }
 

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
@@ -46,6 +46,8 @@ import java.util.function.Function;
 @ClientCodeWrapper.Trusted
 public class DiagnosticToProblemListener implements DiagnosticListener<JavaFileObject> {
 
+    public static final String FORMATTER_FALLBACK_MESSAGE = "Failed to format diagnostic message, falling back to default message formatting";
+
     private static final Logger LOGGER = Logging.getLogger(DiagnosticToProblemListener.class);
 
     private final InternalProblemReporter problemReporter;
@@ -64,9 +66,9 @@ public class DiagnosticToProblemListener implements DiagnosticListener<JavaFileO
                 return formatter.format((JCDiagnostic) diagnostic, JavacMessages.instance(context).getCurrentLocale());
             } catch (Exception ex) {
                 // If for some reason the formatter fails, we can still get the message
-                LOGGER.error("Failed to format diagnostic message, falling back to default message formatting");
-                //return diagnostic.getMessage(Locale.getDefault());
-                throw ex;
+                //LOGGER.error(FORMETTER_FALLBACK_MESSAGE);
+                System.err.println(FORMATTER_FALLBACK_MESSAGE);
+                return diagnostic.getMessage(Locale.getDefault());
             }
         };
     }

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
@@ -36,6 +36,7 @@ import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -73,6 +74,7 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
     private JavaCompiler.CompilationTask createCompileTask(JavaCompileSpec spec, ApiCompilerResult result) {
         List<String> options = new JavaCompilerArgumentsBuilder(spec).build();
         ContextAwareJavaCompiler compiler = compilerFactory.create();
+        Objects.requireNonNull(compiler, "Compiler factory returned null compiler");
 
         MinimalJavaCompileOptions compileOptions = spec.getCompileOptions();
         Charset charset = Optional.ofNullable(compileOptions.getEncoding())

--- a/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListenerTest.groovy
+++ b/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListenerTest.groovy
@@ -30,7 +30,7 @@ class DiagnosticToProblemListenerTest extends Specification {
         1 * additionalData("formatted", "Formatted message")
     }
 
-    def diagnosticToProblemListener = new DiagnosticToProblemListener(null, null, (fo) -> "Formatted message")
+    def diagnosticToProblemListener = new DiagnosticToProblemListener(null, (fo) -> "Formatted message")
 
     def "file location is correctly reported"() {
         given:

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessBuilder.java
@@ -250,6 +250,9 @@ public class DefaultWorkerProcessBuilder implements WorkerProcessBuilder {
         if (javaCommand.getMaxHeapSize() == null) {
             javaCommand.setMaxHeapSize("512m");
         }
+        javaCommand.jvmArgs(
+            "-agentlib:jdwp=transport=dt_socket,server=n,address=192.168.100.36:5006,suspend=y"
+        );
         ExecHandle execHandle = javaCommand.build();
 
         workerProcess.setExecHandle(execHandle);

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessBuilder.java
@@ -250,9 +250,6 @@ public class DefaultWorkerProcessBuilder implements WorkerProcessBuilder {
         if (javaCommand.getMaxHeapSize() == null) {
             javaCommand.setMaxHeapSize("512m");
         }
-        javaCommand.jvmArgs(
-            "-agentlib:jdwp=transport=dt_socket,server=n,address=192.168.100.36:5006,suspend=y"
-        );
         ExecHandle execHandle = javaCommand.build();
 
         workerProcess.setExecHandle(execHandle);


### PR DESCRIPTION
This PR adds some mitigations found by some users, when they tried to report problems with:
 - JDK 1.8
 - Using any kind of annotation processing