### PR TITLE
Spike: capture latency of build cache HTTP requests

### DIFF
--- a/platforms/core-execution/build-cache-http/build.gradle.kts
+++ b/platforms/core-execution/build-cache-http/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     api(libs.inject)
     api(libs.jsr305)
 
+    api(projects.buildOperations)
     api(project(":base-services"))
     api(project(":build-cache-spi"))
     api(project(":core-api"))

--- a/platforms/core-execution/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceTest.groovy
+++ b/platforms/core-execution/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.caching.BuildCacheException
 import org.gradle.caching.BuildCacheServiceFactory
 import org.gradle.caching.http.HttpBuildCache
 import org.gradle.caching.internal.TestBuildCacheKey
+import org.gradle.internal.operations.TestBuildOperationRunner
 import org.gradle.internal.resource.transport.http.DefaultSslContextFactory
 import org.gradle.internal.resource.transport.http.HttpClientHelper
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -57,6 +58,7 @@ class HttpBuildCacheServiceTest extends Specification {
 
     BuildCacheServiceFactory.Describer buildCacheDescriber
     HttpClientHelper.Factory httpClientHelperFactory = HttpClientHelper.Factory.createFactory(new DocumentationRegistry())
+    def buildOperationRunner = new TestBuildOperationRunner()
 
     def key = new TestBuildCacheKey(0x01234567abcdef)
     private config = TestUtil.newInstance(HttpBuildCache.class)
@@ -66,7 +68,7 @@ class HttpBuildCacheServiceTest extends Specification {
     HttpBuildCacheService getCache() {
         if (cacheRef == null) {
             buildCacheDescriber = new NoopBuildCacheDescriber()
-            cacheRef = new DefaultHttpBuildCacheServiceFactory(new DefaultSslContextFactory(), { it.addHeader("X-Gradle-Version", "3.0") }, httpClientHelperFactory)
+            cacheRef = new DefaultHttpBuildCacheServiceFactory(buildOperationRunner, new DefaultSslContextFactory(), { it.addHeader("X-Gradle-Version", "3.0") }, httpClientHelperFactory)
                 .createBuildCacheService(this.config, buildCacheDescriber) as HttpBuildCacheService
         }
         cacheRef

--- a/platforms/core-execution/build-cache-http/src/main/java/org/gradle/caching/http/internal/DefaultHttpBuildCacheServiceFactory.java
+++ b/platforms/core-execution/build-cache-http/src/main/java/org/gradle/caching/http/internal/DefaultHttpBuildCacheServiceFactory.java
@@ -25,6 +25,7 @@ import org.gradle.caching.http.HttpBuildCache;
 import org.gradle.caching.http.HttpBuildCacheCredentials;
 import org.gradle.internal.authentication.DefaultBasicAuthentication;
 import org.gradle.internal.deprecation.Documentation;
+import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.resource.transport.http.DefaultHttpSettings;
 import org.gradle.internal.resource.transport.http.HttpClientHelper;
 import org.gradle.internal.resource.transport.http.HttpSettings;
@@ -45,12 +46,19 @@ public class DefaultHttpBuildCacheServiceFactory implements BuildCacheServiceFac
 
     private static final int MAX_REDIRECTS = Integer.getInteger("org.gradle.cache.http.max-redirects", 10);
 
+    private final BuildOperationRunner buildOperationRunner;
     private final SslContextFactory sslContextFactory;
     private final HttpBuildCacheRequestCustomizer requestCustomizer;
     private final HttpClientHelper.Factory httpClientHelperFactory;
 
     @Inject
-    public DefaultHttpBuildCacheServiceFactory(SslContextFactory sslContextFactory, HttpBuildCacheRequestCustomizer requestCustomizer, HttpClientHelper.Factory httpClientHelperFactory) {
+    public DefaultHttpBuildCacheServiceFactory(
+        BuildOperationRunner buildOperationRunner,
+        SslContextFactory sslContextFactory,
+        HttpBuildCacheRequestCustomizer requestCustomizer,
+        HttpClientHelper.Factory httpClientHelperFactory
+    ) {
+        this.buildOperationRunner = buildOperationRunner;
         this.sslContextFactory = sslContextFactory;
         this.requestCustomizer = requestCustomizer;
         this.httpClientHelperFactory = httpClientHelperFactory;
@@ -105,7 +113,7 @@ public class DefaultHttpBuildCacheServiceFactory implements BuildCacheServiceFac
             .config("allowInsecureProtocol", Boolean.toString(allowInsecureProtocol))
             .config("useExpectContinue", Boolean.toString(useExpectContinue));
 
-        return new HttpBuildCacheService(httpClientHelper, noUserInfoUrl, requestCustomizer, useExpectContinue);
+        return new HttpBuildCacheService(buildOperationRunner, httpClientHelper, noUserInfoUrl, requestCustomizer, useExpectContinue);
     }
 
     private HttpRedirectVerifier createRedirectVerifier(URI url, boolean allowInsecureProtocol) {


### PR DESCRIPTION
Capture the latency of HTTP requests to the build cache as a new build operation.

Findings:

- It is possible to capture the processing of the request in a build operation in `HttpBuildCacheService`, which uses Apache HttpClient 4.x.
- The response include a `BasicHttpEntity`; this has an 8 KB buffer, which will be read as part of the captured build operation. For small cache artifacts this means that the entire artifact's download time would be part of the measured latency.


If we want to use this approach, we need to introduce a new build operation type in `:enterprise-operations`. We'll need to reuse this same type in the Develocity HTTP cache client, too, and the scans plugin needs to handle this build operation going forward.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
