### PR TITLE
Don't run ToolchainsParallelActionExecutionCrossVersionSpec with embedded executer

### DIFF
--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r81/ToolchainsParallelActionExecutionCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r81/ToolchainsParallelActionExecutionCrossVersionSpec.groovy
@@ -19,12 +19,13 @@ package org.gradle.integtests.tooling.r81
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
-import org.gradle.test.fixtures.Flaky
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.IntegTestPreconditions
 import org.gradle.tooling.BuildActionFailureException
 import org.gradle.util.GradleVersion
 
 @ToolingApiVersion(">=8.1")
-@Flaky(because = 'https://github.com/gradle/gradle-private/issues/3829')
+@Requires(IntegTestPreconditions.NotEmbeddedExecutor)
 class ToolchainsParallelActionExecutionCrossVersionSpec extends ToolingApiSpecification {
 
     def setup() {


### PR DESCRIPTION
`ToolchainsParallelActionExecutionCrossVersionSpec` has been flaky for a long time. Looking at the history, it only happens on embedded executer with TAPI `current -> current` execution.

It's possible that some shared state is broken by other tests in `embeddedCrossVersionTest`: the test itself is good, but the way we run it is wrong. This explains why it only happens with `current -> current` execution, because it's happening in a shared JVM.

This PR disables it for embedded executer.
