### PR TITLE
Add extra debug logging to `BuildPhaseOperationEventCrossVersionTest`

### DIFF
--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r76/BuildPhaseOperationEventCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r76/BuildPhaseOperationEventCrossVersionTest.groovy
@@ -177,6 +177,11 @@ class BuildPhaseOperationEventCrossVersionTest extends ToolingApiSpecification {
         def progressEvents = events.getAll()
         progressEvents.size() == 10
 
+        // NOTE This code is here to help debugging this flaky test -----------
+        println "Progress events:"
+        progressEvents.each { println it }
+        // --------------------------------------------------------------------
+
         // Root project configuration, we have 3 projects in root (root, a, b)
         assertStartEventHas(progressEvents[0], "CONFIGURE_ROOT_BUILD", 3)
         // We then configure included build c


### PR DESCRIPTION
This extra logging tries to help debugging the [BuildPhaseOperationEventCrossVersionTest flaky test](https://ge.gradle.org/scans/tests?search.names=not:gitBranchName&search.relativeStartTime=P28D&search.tags=not:LOCAL&search.timeZoneId=Europe%2FLisbon&search.values=master&tests.container=org.gradle.integtests.tooling.r76.BuildPhaseOperationEventCrossVersionTest&tests.sortField=FLAKY).

We couldn't reproduce the test, but we expect the test to fail at some time. With this little additional logging, we will be able to see the output and determine if the sequence of build operations are right or not.