### PR TITLE
Support empty blocks for configuring functions in DCL

### DIFF
--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/analysis/DefaultAnalysisSchema.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/analysis/DefaultAnalysisSchema.kt
@@ -192,16 +192,14 @@ object FunctionSemanticsInternal {
     @SerialName("accessAndConfigure")
     class DefaultAccessAndConfigure(
         override val accessor: ConfigureAccessor,
-        override val returnType: ReturnType
+        override val returnType: ReturnType,
+        override val configureBlockRequirement: ConfigureBlockRequirement
     ) : AccessAndConfigure {
         override val returnValueType: DataTypeRef
             get() = when (returnType) {
                 is ReturnType.ConfiguredObject -> accessor.objectType
                 is ReturnType.Unit -> DataTypeInternal.DefaultUnitType.ref
             }
-
-        override val configureBlockRequirement: ConfigureBlockRequirement.Required
-            get() = DefaultConfigureBlockRequirement.DefaultRequired
 
         /** Implementations for [ReturnType] */
         object DefaultReturnType {

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/analysis/Resolver.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/analysis/Resolver.kt
@@ -25,7 +25,7 @@ class ResolverImpl(
         val context = AnalysisContext(schema, importFqnBySimpleName, errorCollector)
         context.withScope(topLevelScope) { codeAnalyzer.analyzeStatementsInProgramOrder(context, topLevelBlock.statements) }
 
-        return ResolutionResult(topLevelReceiver, context.assignments, context.additions, errorCollector.errors)
+        return ResolutionResult(topLevelReceiver, context.assignments, context.additions, context.nestedObjectAccess, errorCollector.errors)
     }
 
     fun collectImports(

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/analysis/context.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/analysis/context.kt
@@ -84,7 +84,9 @@ class AnalysisContext(
     private
     val nextInstant = AtomicLong(1)
     private
-    val mutableAdditions = mutableListOf<DataAddition>()
+    val mutableAdditions = mutableListOf<DataAdditionRecord>()
+    private
+    val mutableNestedObjectAccess = mutableListOf<NestedObjectAccessRecord>()
 
     override val currentScopes: List<AnalysisScope>
         get() = mutableScopes
@@ -92,8 +94,11 @@ class AnalysisContext(
     override val assignments: List<AssignmentRecord>
         get() = mutableAssignments
 
-    val additions: List<DataAddition>
+    val additions: List<DataAdditionRecord>
         get() = mutableAdditions
+
+    val nestedObjectAccess: List<NestedObjectAccessRecord>
+        get() = mutableNestedObjectAccess
 
     private
     val typeRefContext = SchemaTypeRefContext(schema)
@@ -111,7 +116,11 @@ class AnalysisContext(
     }
 
     fun recordAddition(container: ObjectOrigin, dataObject: ObjectOrigin) {
-        mutableAdditions += DataAddition(container, dataObject)
+        mutableAdditions += DataAdditionRecord(container, dataObject)
+    }
+
+    fun recordNestedObjectAccess(container: ObjectOrigin, dataObject: ObjectOrigin.AccessAndConfigureReceiver) {
+        mutableNestedObjectAccess += NestedObjectAccessRecord(container, dataObject)
     }
 
     fun nextInstant(): Long = nextInstant.incrementAndGet()

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/analysis/resolution.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/analysis/resolution.kt
@@ -12,12 +12,16 @@ import org.gradle.internal.declarativedsl.language.LocalValue
 data class ResolutionResult(
     val topLevelReceiver: ObjectOrigin.TopLevelReceiver,
     val assignments: List<AssignmentRecord>,
-    val additions: List<DataAddition>,
+    val additions: List<DataAdditionRecord>,
+    val nestedObjectAccess: List<NestedObjectAccessRecord>,
     val errors: List<ResolutionError>,
 )
 
 
-data class DataAddition(val container: ObjectOrigin, val dataObject: ObjectOrigin)
+data class DataAdditionRecord(val container: ObjectOrigin, val dataObject: ObjectOrigin)
+
+
+data class NestedObjectAccessRecord(val container: ObjectOrigin, val dataObject: ObjectOrigin.AccessAndConfigureReceiver)
 
 
 data class ResolutionError(

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/DeclarativeReflectionToObjectConverter.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/DeclarativeReflectionToObjectConverter.kt
@@ -3,6 +3,7 @@ package org.gradle.internal.declarativedsl.mappingToJvm
 import org.gradle.declarative.dsl.schema.DataBuilderFunction
 import org.gradle.declarative.dsl.schema.DataProperty
 import org.gradle.declarative.dsl.schema.ExternalObjectProviderKey
+import org.gradle.declarative.dsl.schema.SchemaFunction
 import org.gradle.internal.declarativedsl.analysis.AssignmentMethod
 import org.gradle.internal.declarativedsl.analysis.ObjectOrigin
 import org.gradle.internal.declarativedsl.analysis.ParameterValueBinding
@@ -56,18 +57,18 @@ class DeclarativeReflectionToObjectConverter(
     }
 
     private
-    val reflectionIdentityObjects = mutableMapOf<Long, Any?>()
+    val reflectionIdentityObjects = mutableMapOf<ObjectAccessKey, Any?>()
 
     private
-    fun objectByIdentity(identity: Long, newObject: () -> Any?): Any? {
+    fun objectByIdentity(key: ObjectAccessKey, newObject: () -> Any?): Any? {
         // This code does not use `computeIfAbsent` because `newObject` can make reentrant calls, leading to CME.
         // Also, it does not check for the value being null, because null values are potentially allowed
-        if (identity !in reflectionIdentityObjects) {
+        if (key !in reflectionIdentityObjects) {
             val newInstance = newObject()
-            reflectionIdentityObjects[identity] = newInstance
+            reflectionIdentityObjects[key] = newInstance
             return newInstance
         } else {
-            return reflectionIdentityObjects[identity]
+            return reflectionIdentityObjects[key]
         }
     }
 
@@ -85,21 +86,26 @@ class DeclarativeReflectionToObjectConverter(
         return when (objectOrigin) {
             is ObjectOrigin.DelegatingObjectOrigin -> getObjectByResolvedOrigin(objectOrigin.delegate)
             is ObjectOrigin.ConstantOrigin -> objectOrigin.literal.value
-            is ObjectOrigin.External -> {
-                externalObjectsMap[objectOrigin.key] ?: error("No external object provided for external object key of ${objectOrigin.key}")
-            }
-            is ObjectOrigin.NewObjectFromMemberFunction -> objectByIdentity(objectOrigin.invocationId) { objectFromMemberFunction(objectOrigin) }
-            is ObjectOrigin.NewObjectFromTopLevelFunction -> objectByIdentity(objectOrigin.invocationId) { objectFromTopLevelFunction(/*objectOrigin*/) }
+            is ObjectOrigin.External -> externalObjectsMap[objectOrigin.key] ?: error("No external object provided for external object key of ${objectOrigin.key}")
+            is ObjectOrigin.NewObjectFromMemberFunction -> objectByIdentity(ObjectAccessKey.Identity(objectOrigin.invocationId)) { objectFromMemberFunction(objectOrigin) }
+            is ObjectOrigin.NewObjectFromTopLevelFunction -> objectByIdentity(ObjectAccessKey.Identity(objectOrigin.invocationId)) { objectFromTopLevelFunction(/*objectOrigin*/) }
             is ObjectOrigin.NullObjectOrigin -> null
             is ObjectOrigin.PropertyDefaultValue -> getPropertyValue(objectOrigin.receiver, objectOrigin.property)
             is ObjectOrigin.PropertyReference -> getPropertyValue(objectOrigin.receiver, objectOrigin.property)
             is ObjectOrigin.TopLevelReceiver -> topLevelObject
             is ObjectOrigin.ConfiguringLambdaReceiver -> objectFromConfiguringLambda(objectOrigin)
-            is ObjectOrigin.CustomConfigureAccessor -> customAccessors.getObjectFromCustomAccessor(
-                getObjectByResolvedOrigin(objectOrigin.receiver) ?: error("receiver for custom accessor is null"), objectOrigin.accessor
-            )
+            is ObjectOrigin.CustomConfigureAccessor -> objectFromCustomAccessor(objectOrigin)
         }
     }
+
+
+    private
+    sealed interface ObjectAccessKey {
+        data class Identity(val id: Long) : ObjectAccessKey
+        data class CustomAccessor(val owner: ObjectOrigin, val accessorId: String) : ObjectAccessKey
+        data class ConfiguringLambda(val owner: ObjectOrigin, val function: SchemaFunction) : ObjectAccessKey
+    }
+
 
     private
     fun objectFromMemberFunction(
@@ -133,12 +139,21 @@ class DeclarativeReflectionToObjectConverter(
     private
     fun objectFromConfiguringLambda(
         origin: ObjectOrigin.ConfiguringLambdaReceiver
-    ): Any? {
+    ): Any? = objectByIdentity(ObjectAccessKey.ConfiguringLambda(origin.receiver, origin.function)) {
         val function = origin.function
         val receiverInstance = getObjectByResolvedOrigin(origin.receiver)
             ?: error("Tried to invoke a function $function on a null receiver ${origin.receiver}")
 
-        return invokeFunctionAndGetResult(receiverInstance, origin).capturedValue
+        invokeFunctionAndGetResult(receiverInstance, origin).capturedValue
+    }
+
+    private
+    fun objectFromCustomAccessor(
+        origin: ObjectOrigin.CustomConfigureAccessor
+    ): Any? = objectByIdentity(ObjectAccessKey.CustomAccessor(origin.receiver, origin.accessor.customAccessorIdentifier)) {
+        customAccessors.getObjectFromCustomAccessor(
+            getObjectByResolvedOrigin(origin.receiver) ?: error("receiver for custom accessor is null"), origin.accessor
+        )
     }
 
     private

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/FunctionBinding.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/FunctionBinding.kt
@@ -47,7 +47,7 @@ object FunctionBinding {
                     param == kFunction.instanceParameter -> put(param, receiver)
                     param == kFunction.extensionReceiverParameter -> put(param, receiver)
 
-                    hasLambda && configureLambdaHandler.getTypeConfiguredByLambda(param.type) != null -> {
+                    (hasLambda || param.isOptional) && configureLambdaHandler.getTypeConfiguredByLambda(param.type) != null -> {
                         val newCaptor = configureLambdaHandler.produceValueCaptor(param.type)
                         check(captor == null) { "multiple lambda argument captors are not supported" }
                         captor = newCaptor

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/AccessorTest.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/AccessorTest.kt
@@ -95,8 +95,11 @@ object AccessorTest {
                         "configureCustomInstance",
                         emptyList(),
                         false,
-                        FunctionSemanticsInternal.DefaultAccessAndConfigure(ConfigureAccessorInternal.DefaultCustom(Configured::class.toDataTypeRef(), "test"),
-                            FunctionSemanticsInternal.DefaultAccessAndConfigure.DefaultReturnType.DefaultUnit)
+                        FunctionSemanticsInternal.DefaultAccessAndConfigure(
+                            ConfigureAccessorInternal.DefaultCustom(Configured::class.toDataTypeRef(), "test"),
+                            FunctionSemanticsInternal.DefaultAccessAndConfigure.DefaultReturnType.DefaultUnit,
+                            FunctionSemanticsInternal.DefaultConfigureBlockRequirement.DefaultRequired
+                        )
                     )
                 )
             } else emptyList()

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/AccessorTest.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/AccessorTest.kt
@@ -39,6 +39,7 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 
 object AccessorTest {
@@ -50,8 +51,15 @@ object AccessorTest {
                 x = 123
             }""".trimIndent()
         )
-        assertEquals(123, runtimeInstanceFromResult(schema, resolution, configureLambdas, runtimeCustomAccessors, ::MyReceiver).myHiddenInstance.x)
+        assertEquals(123, runtimeInstanceFromResult(schema, resolution, configureLambdas, runtimeCustomAccessors, ::MyReceiver).myHiddenInstance.value.x)
     }
+
+    @Test
+    fun `triggers the custom accessor with empty block`() {
+        val resolution = schema.resolve("configureCustomInstance { }")
+        assertTrue(runtimeInstanceFromResult(schema, resolution, configureLambdas, runtimeCustomAccessors, ::MyReceiver).myHiddenInstance.isInitialized())
+    }
+
 
     @Test
     fun `accesses receiver from runtime lambda argument mapping to JVM`() {
@@ -73,7 +81,7 @@ object AccessorTest {
     val runtimeCustomAccessors = object : RuntimeCustomAccessors {
         override fun getObjectFromCustomAccessor(receiverObject: Any, accessor: ConfigureAccessor.Custom): Any? =
             if (receiverObject is MyReceiver && accessor.customAccessorIdentifier == "test")
-                receiverObject.myHiddenInstance
+                receiverObject.myHiddenInstance.value
             else null
     }
 
@@ -109,17 +117,19 @@ object AccessorTest {
     class MyReceiver {
         val myLambdaReceiver = Configured()
 
+        @Suppress("unused")
         @Configuring
         fun configureLambdaArgument(configure: Configured.() -> Unit) {
             configure(myLambdaReceiver)
         }
 
+        @Suppress("unused")
         @Configuring
         fun configureLambdaArgumentWithCustomInterface(configure: MyFunctionalInterface<Configured>) {
             configure.action(myLambdaReceiver)
         }
 
-        val myHiddenInstance = Configured()
+        val myHiddenInstance = lazy { Configured() }
     }
 
     internal

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/EmptyBlocksTest.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/EmptyBlocksTest.kt
@@ -42,6 +42,19 @@ object EmptyBlocksTest {
     }
 
     @Test
+    fun `configuring function with no block for Kotlin default param leads to object access`() {
+        val resolution = schema.resolve(
+            """
+            configuring()
+            """.trimIndent()
+        )
+
+        val result = runtimeInstanceFromResult(schema, resolution, kotlinFunctionAsConfigureLambda, RuntimeCustomAccessors.none, ::TopLevel)
+
+        assertTrue { result.configuredLazy.isInitialized() }
+    }
+
+    @Test
     fun `empty adding block ensures that the object is created`() {
         val resolution = schema.resolve(
             """

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/EmptyBlocksTest.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/EmptyBlocksTest.kt
@@ -24,12 +24,12 @@ import org.gradle.internal.declarativedsl.schemaBuilder.kotlinFunctionAsConfigur
 import org.gradle.internal.declarativedsl.schemaBuilder.schemaFromTypes
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 
 object EmptyBlocksTest {
     @Test
-    fun `empty configuring block does not lead to object access`() {
+    fun `empty configuring block leads to object access`() {
         val resolution = schema.resolve(
             """
             configuring { }
@@ -38,22 +38,24 @@ object EmptyBlocksTest {
 
         val result = runtimeInstanceFromResult(schema, resolution, kotlinFunctionAsConfigureLambda, RuntimeCustomAccessors.none, ::TopLevel)
 
-        assertFalse { result.configuredLazy.isInitialized() }
+        assertTrue { result.configuredLazy.isInitialized() }
     }
 
     @Test
     fun `empty adding block ensures that the object is created`() {
         val resolution = schema.resolve(
             """
+            adding()
             adding { }
             adding { x = 2 }
-            addingWithArg(3) { }
+            addingWithArg(3)
+            addingWithArg(4) { }
             """.trimIndent()
         )
 
         val result = runtimeInstanceFromResult(schema, resolution, kotlinFunctionAsConfigureLambda, RuntimeCustomAccessors.none, ::TopLevel)
 
-        assertEquals(listOf(0, 2, 3), result.added.map { it.x })
+        assertEquals(listOf(0, 0, 2, 3, 4), result.added.map { it.x })
     }
 
 
@@ -67,18 +69,18 @@ object EmptyBlocksTest {
 
         @Suppress("unused")
         @Configuring
-        fun configuring(configure: Inner.() -> Unit) {
-            configuredLazy.value.configure()
+        fun configuring(block: Inner.() -> Unit = { }) {
+            configuredLazy.value.block()
         }
 
         @Adding
-        fun adding(configure: Inner.() -> Unit) =
-            Inner().also(configure).also(added::add)
+        fun adding(block: Inner.() -> Unit = { }) =
+            Inner().also(block).also(added::add)
 
         @Suppress("unused")
         @Adding
-        fun addingWithArg(x: Int, configure: Inner.() -> Unit) =
-            Inner().also(configure).also(added::add).also { it.x = x }
+        fun addingWithArg(x: Int = 100, block: Inner.() -> Unit = { }) =
+            Inner().also(block).also(added::add).also { it.x = x }
     }
 
     class Inner {

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/FunctionContractTest.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/FunctionContractTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.declarativedsl.mappingToJvm
+
+import org.gradle.declarative.dsl.model.annotations.Configuring
+import org.gradle.declarative.dsl.model.annotations.Restricted
+import org.gradle.internal.declarativedsl.demo.resolve
+import org.gradle.internal.declarativedsl.schemaBuilder.kotlinFunctionAsConfigureLambda
+import org.gradle.internal.declarativedsl.schemaBuilder.schemaFromTypes
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+
+object FunctionContractTest {
+    @Test
+    fun `should invoke a configuring function only once`() {
+        val resolution = schema.resolve(
+            """
+            configure { }
+            configure { x = 1 }
+            configure { y = 2 }
+            """.trimIndent()
+        )
+
+        val result = runtimeInstanceFromResult(schema, resolution, kotlinFunctionAsConfigureLambda, RuntimeCustomAccessors.none, ::Receiver)
+
+        assertEquals(1, result.x)
+        assertEquals(2, result.y)
+        assertEquals(1, result.invokedTimes)
+    }
+
+    private
+    val schema = schemaFromTypes(Receiver::class, this::class.nestedClasses)
+
+    class Receiver {
+
+        var invokedTimes = 0
+
+        @get:Restricted
+        var x: Int = 0
+
+        @get:Restricted
+        var y: Int = 0
+        @Configuring
+        fun configure(configure: Receiver.() -> Unit) {
+            configure(this)
+            invokedTimes++
+        }
+    }
+}

--- a/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/settings/SoftwareTypeDeclarationIntegrationTest.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/settings/SoftwareTypeDeclarationIntegrationTest.groovy
@@ -50,6 +50,21 @@ class SoftwareTypeDeclarationIntegrationTest extends AbstractIntegrationSpec imp
         outputDoesNotContain("Applying AnotherSoftwareTypeImplPlugin")
     }
 
+    def 'can configure a custom software type from included build without configuration block'() {
+        given:
+        withSoftwareTypePlugins().prepareToExecute()
+
+        file("settings.gradle.dcl") << pluginsFromIncludedBuild
+
+        file("build.gradle.dcl") << declarativeScriptWithEmptySoftwareTypeConfiguration
+
+        expect:
+        succeeds(":printTestSoftwareTypeExtensionConfiguration")
+
+        and:
+        outputContains("Applying SoftwareTypeImplPlugin")
+    }
+
     def 'can declare and configure a custom software type from published plugin'() {
         given:
         def pluginBuilder = withSoftwareTypePlugins()
@@ -306,6 +321,10 @@ class SoftwareTypeDeclarationIntegrationTest extends AbstractIntegrationSpec imp
                 }
             }
         """
+    }
+
+    static String getDeclarativeScriptWithEmptySoftwareTypeConfiguration() {
+        """testSoftwareType()"""
     }
 
     void assertThatDeclaredValuesAreSetProperly() {

--- a/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/settings/SoftwareTypeDeclarationIntegrationTest.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/settings/SoftwareTypeDeclarationIntegrationTest.groovy
@@ -50,21 +50,6 @@ class SoftwareTypeDeclarationIntegrationTest extends AbstractIntegrationSpec imp
         outputDoesNotContain("Applying AnotherSoftwareTypeImplPlugin")
     }
 
-    def 'can configure a custom software type from included build without configuration block'() {
-        given:
-        withSoftwareTypePlugins().prepareToExecute()
-
-        file("settings.gradle.dcl") << pluginsFromIncludedBuild
-
-        file("build.gradle.dcl") << declarativeScriptWithEmptySoftwareTypeConfiguration
-
-        expect:
-        succeeds(":printTestSoftwareTypeExtensionConfiguration")
-
-        and:
-        outputContains("Applying SoftwareTypeImplPlugin")
-    }
-
     def 'can declare and configure a custom software type from published plugin'() {
         given:
         def pluginBuilder = withSoftwareTypePlugins()
@@ -321,10 +306,6 @@ class SoftwareTypeDeclarationIntegrationTest extends AbstractIntegrationSpec imp
                 }
             }
         """
-    }
-
-    static String getDeclarativeScriptWithEmptySoftwareTypeConfiguration() {
-        """testSoftwareType()"""
     }
 
     void assertThatDeclaredValuesAreSetProperly() {

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/schemaFromGradleExtensions.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/schemaFromGradleExtensions.kt
@@ -95,7 +95,8 @@ data class ExtensionInfo(
         isDirectAccessOnly = true,
         semantics = FunctionSemanticsInternal.DefaultAccessAndConfigure(
             accessor = ConfigureAccessorInternal.DefaultCustom(type.toDataTypeRef(), customAccessorId),
-            FunctionSemanticsInternal.DefaultAccessAndConfigure.DefaultReturnType.DefaultUnit
+            FunctionSemanticsInternal.DefaultAccessAndConfigure.DefaultReturnType.DefaultUnit,
+            FunctionSemanticsInternal.DefaultConfigureBlockRequirement.DefaultRequired
         )
     )
 }

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/schemaFromSoftwareTypes.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/schemaFromSoftwareTypes.kt
@@ -80,7 +80,7 @@ data class SoftwareTypeInfo(
         semantics = FunctionSemanticsInternal.DefaultAccessAndConfigure(
             accessor = ConfigureAccessorInternal.DefaultCustom(delegate.modelPublicType.kotlin.toDataTypeRef(), customAccessorId),
             FunctionSemanticsInternal.DefaultAccessAndConfigure.DefaultReturnType.DefaultUnit,
-            FunctionSemanticsInternal.DefaultConfigureBlockRequirement.DefaultOptional
+            FunctionSemanticsInternal.DefaultConfigureBlockRequirement.DefaultRequired
         )
     )
 }

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/schemaFromSoftwareTypes.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/schemaFromSoftwareTypes.kt
@@ -80,7 +80,7 @@ data class SoftwareTypeInfo(
         semantics = FunctionSemanticsInternal.DefaultAccessAndConfigure(
             accessor = ConfigureAccessorInternal.DefaultCustom(delegate.modelPublicType.kotlin.toDataTypeRef(), customAccessorId),
             FunctionSemanticsInternal.DefaultAccessAndConfigure.DefaultReturnType.DefaultUnit,
-            FunctionSemanticsInternal.DefaultConfigureBlockRequirement.DefaultRequired
+            FunctionSemanticsInternal.DefaultConfigureBlockRequirement.DefaultOptional
         )
     )
 }

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/schemaFromSoftwareTypes.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/schemaFromSoftwareTypes.kt
@@ -79,7 +79,8 @@ data class SoftwareTypeInfo(
         isDirectAccessOnly = true,
         semantics = FunctionSemanticsInternal.DefaultAccessAndConfigure(
             accessor = ConfigureAccessorInternal.DefaultCustom(delegate.modelPublicType.kotlin.toDataTypeRef(), customAccessorId),
-            FunctionSemanticsInternal.DefaultAccessAndConfigure.DefaultReturnType.DefaultUnit
+            FunctionSemanticsInternal.DefaultAccessAndConfigure.DefaultReturnType.DefaultUnit,
+            FunctionSemanticsInternal.DefaultConfigureBlockRequirement.DefaultRequired
         )
     )
 }

--- a/platforms/core-configuration/declarative-dsl-tooling-models/src/main/kotlin/org/gradle/declarative/dsl/schema/FunctionSemantics.kt
+++ b/platforms/core-configuration/declarative-dsl-tooling-models/src/main/kotlin/org/gradle/declarative/dsl/schema/FunctionSemantics.kt
@@ -84,7 +84,7 @@ sealed interface FunctionSemantics : Serializable {
         override val configuredType: DataTypeRef
             get() = if (returnType is ReturnType.ConfiguredObject) returnValueType else accessor.objectType
 
-        override val configureBlockRequirement: ConfigureSemantics.ConfigureBlockRequirement.Required
+        override val configureBlockRequirement: ConfigureSemantics.ConfigureBlockRequirement
     }
 
     interface AddAndConfigure : NewObjectFunctionSemantics, ConfigureSemantics {


### PR DESCRIPTION
* Support optional configuring blocks for configuring functions (for now, only Kotlin functions and functions produced by custom code are eligible);
* Make sure that a configuring function is invoked when Declarative data is mapped to JVM objects, even if the configuring function has an empty block or none at all;
* Invoke the configuring function's JVM counterpart at most once for each receiver when mapping Declarative data to JVM objects (as opposed to an invocation per object access before, which could be even more than the number of call sites in the script).

* ~Bonus: support applying software type functions with no configuration block, like `softwareType()`~ (rolled back)

Fixes https://github.com/gradle/gradle/issues/29161