### PR TITLE
Enforce order between tasks to avoid flakiness

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/rules/OverlappingOutputsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/rules/OverlappingOutputsIntegrationTest.groovy
@@ -20,12 +20,12 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildCacheOperationFixtures
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.IntegTestPreconditions
 import org.gradle.util.internal.ToBeImplemented
 
-import static org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache.Skip.INVESTIGATE
-
+@Requires(value = IntegTestPreconditions.NotParallelOrConfigCacheExecutor, reason = "tests rely on order of task execution")
 class OverlappingOutputsIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture {
 
     def cacheOperations = new BuildCacheOperationFixtures(new BuildOperationsFixture(executer, temporaryFolder))
@@ -130,16 +130,9 @@ class OverlappingOutputsIntegrationTest extends AbstractIntegrationSpec implemen
                 ":second", file("build/overlap/second.txt")]
     }
 
-    private addMustRunAfter(String earlierTask, String laterTask) {
-        buildFile << """
-            ${laterTask}.mustRunAfter(${earlierTask})
-        """
-    }
-
     def "overlapping output directory with first, second then first, second"() {
         def (String first, TestFile firstOutput,
         String second, TestFile secondOutput) = useOverlappingOutputDirectories()
-        addMustRunAfter('first', 'second')
 
         when:
         withBuildCache().run(first, second)
@@ -163,7 +156,6 @@ class OverlappingOutputsIntegrationTest extends AbstractIntegrationSpec implemen
         result.assertTaskNotSkipped(second)
     }
 
-    @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "overlapping output directory with first, second then second, first"() {
         def (String first, TestFile firstOutput,
         String second, TestFile secondOutput) = useOverlappingOutputDirectories()
@@ -189,7 +181,6 @@ class OverlappingOutputsIntegrationTest extends AbstractIntegrationSpec implemen
         result.assertTasksNotSkipped(second, first)
     }
 
-    @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "overlapping output directory with first, second then second only"() {
         def (String first, TestFile firstOutput,
              String second, TestFile secondOutput) = useOverlappingOutputDirectories()
@@ -216,7 +207,6 @@ class OverlappingOutputsIntegrationTest extends AbstractIntegrationSpec implemen
         listCacheFiles().size() == 2
     }
 
-    @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "overlapping output directory with first cleanSecond second then first second"() {
         def (String first, TestFile firstOutput,
              String second, TestFile secondOutput) = useOverlappingOutputDirectories()
@@ -254,7 +244,6 @@ class OverlappingOutputsIntegrationTest extends AbstractIntegrationSpec implemen
                  ":dirTask", file("build/overlap/dirTask.txt") ]
     }
 
-    @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "overlapping output with fileTask, dirTask then fileTask, dirTask"() {
         def (String fileTask, TestFile fileTaskOutput,
              String dirTask, TestFile dirTaskOutput) = useOverlappingOutputFileAndDirectory()
@@ -279,7 +268,6 @@ class OverlappingOutputsIntegrationTest extends AbstractIntegrationSpec implemen
         result.assertTaskNotSkipped(dirTask)
     }
 
-    @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "overlapping output with fileTask, dirTask then dirTask, fileTask"() {
         def (String fileTask, TestFile fileTaskOutput,
              String dirTask, TestFile dirTaskOutput) = useOverlappingOutputFileAndDirectory()
@@ -317,7 +305,6 @@ class OverlappingOutputsIntegrationTest extends AbstractIntegrationSpec implemen
         result.assertTasksSkipped(dirTask, fileTask)
     }
 
-    @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "overlapping output with fileTask, dirTask then dirTask only"() {
         def (String fileTask, TestFile fileTaskOutput,
              String dirTask, TestFile dirTaskOutput) = useOverlappingOutputFileAndDirectory()
@@ -379,7 +366,6 @@ class OverlappingOutputsIntegrationTest extends AbstractIntegrationSpec implemen
     // This fails because cleanDirTask will remove fileTask's outputs.
     // So, unless we change this to only clean the *real* outputs of dirTask, this won't work.
     @ToBeImplemented
-    @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "overlapping output with fileTask, dirTask then fileTask, cleanDirTask, dirTask"() {
         def cleanDirTask = ":cleanDirTask"
         def (fileTask, fileTaskOutput,
@@ -425,7 +411,6 @@ class OverlappingOutputsIntegrationTest extends AbstractIntegrationSpec implemen
 
     def "overlapping output files with first, second then first, second"() {
         def (String first, String second, TestFile sharedOutput) = useOverlappingOutputFiles()
-        addMustRunAfter('first', 'second')
 
         when:
         withBuildCache().run(first, second)
@@ -454,7 +439,6 @@ class OverlappingOutputsIntegrationTest extends AbstractIntegrationSpec implemen
         result.assertTaskNotSkipped(first)
     }
 
-    @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "overlapping output files with first, second then second, first"() {
         def (String first, String second, TestFile sharedOutput) = useOverlappingOutputFiles()
 
@@ -477,7 +461,6 @@ class OverlappingOutputsIntegrationTest extends AbstractIntegrationSpec implemen
         result.assertTaskNotSkipped(first)
     }
 
-    @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "overlapping output files with first, second then second only"() {
         def (String first, String second, TestFile sharedOutput) = useOverlappingOutputFiles()
 
@@ -532,7 +515,6 @@ class OverlappingOutputsIntegrationTest extends AbstractIntegrationSpec implemen
                  ":dirTask", file("build/overlap/dirTask.txt")]
     }
 
-    @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "overlapping output with localStateFileTask, dirTask then localStateFileTask, dirTask"() {
         def (String localStateFileTask, TestFile localStateFileTaskOutput, TestFile localStateFileTaskState,
         String dirTask, TestFile dirTaskOutput) = useOverlappingLocalStateFileAndOutputDirectory()
@@ -560,7 +542,6 @@ class OverlappingOutputsIntegrationTest extends AbstractIntegrationSpec implemen
         result.assertTaskNotSkipped(dirTask)
     }
 
-    @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "overlapping file output with localStateFileTask, dirTask then dirTask, localStateFileTask"() {
         def (String localStateFileTask, TestFile localStateFileTaskOutput, TestFile localStateFileTaskState,
              String dirTask, TestFile dirTaskOutput) = useOverlappingLocalStateFileAndOutputDirectory()
@@ -614,8 +595,7 @@ class OverlappingOutputsIntegrationTest extends AbstractIntegrationSpec implemen
     @ToBeImplemented("We don't yet detect when somebody messes with a task's local state")
     def "overlapping output with localStateDirTask, fileTask then localStateDirTask, fileTask"() {
         def (String localStateDirTask, TestFile localStateDirTaskOutput, TestFile localStateDirTaskState,
-             String fileTask, TestFile fileTaskOutput) = useOverlappingLocalStateDirectoryAndOutputFile()
-        addMustRunAfter('localStateDirTask', 'fileTask')
+        String fileTask, TestFile fileTaskOutput) = useOverlappingLocalStateDirectoryAndOutputFile()
 
         when:
         withBuildCache().run(localStateDirTask, fileTask)
@@ -645,7 +625,6 @@ class OverlappingOutputsIntegrationTest extends AbstractIntegrationSpec implemen
     }
 
     @ToBeImplemented("We don't yet detect when somebody messes with a task's local state")
-    @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "overlapping output with localStateDirTask, fileTask then fileTask, localStateDirTask"() {
         def (String localStateDirTask, TestFile localStateDirTaskOutput, TestFile localStateDirTaskState,
              String fileTask, TestFile fileTaskOutput) = useOverlappingLocalStateDirectoryAndOutputFile()


### PR DESCRIPTION
...which was reproducible with the CC executer.


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
