### PR TITLE
Enable type-safe project accessor tests for CC

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/typesafe/TypeSafeProjectAccessorsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/typesafe/TypeSafeProjectAccessorsIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.integtests.resolve.typesafe
 
 import org.gradle.integtests.fixtures.FeaturePreviewsFixture
-import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 
 class TypeSafeProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAccessorsIntegrationTest {
@@ -27,7 +26,6 @@ class TypeSafeProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAcc
         """
     }
 
-    @UnsupportedWithConfigurationCache(because = "test makes direct access to the projects extension")
     def "generates type-safe project accessors for multi-project build"() {
         given:
         createDirs("one", "one/other", "two", "two/other")
@@ -50,7 +48,6 @@ class TypeSafeProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAcc
         outputContains 'Type-safe project accessors is an incubating feature.'
     }
 
-    @UnsupportedWithConfigurationCache(because = "test makes direct access to the projects extension")
     def "fails if a project doesn't follow convention"() {
         given:
         createDirs("1library")
@@ -65,7 +62,6 @@ class TypeSafeProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAcc
         failureDescriptionContains "Cannot generate project dependency accessors because project '1library' doesn't follow the naming convention: [a-zA-Z]([A-Za-z0-9\\-_])*"
     }
 
-    @UnsupportedWithConfigurationCache(because = "test makes direct access to the projects extension")
     def "fails if two subprojects have the same java name"() {
         given:
         createDirs("super-cool", "super--cool")
@@ -89,7 +85,6 @@ class TypeSafeProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAcc
         failureDescriptionContains "Cannot generate project dependency accessors because subprojects [super-cool, super--cool] of project : map to the same method name getSuperCool()"
     }
 
-    @UnsupportedWithConfigurationCache(because = "test makes direct access to the projects extension")
     def "can configure the project extension name"() {
         given:
         createDirs("one", "one/other", "two", "two/other")
@@ -116,7 +111,6 @@ class TypeSafeProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAcc
         outputContains 'Type-safe project accessors is an incubating feature.'
     }
 
-    @UnsupportedWithConfigurationCache(because = "test makes direct access to the projects extension")
     def "can refer to the root project via its name"() {
         given:
         buildFile << """
@@ -130,7 +124,6 @@ class TypeSafeProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAcc
         outputContains 'Type-safe project accessors is an incubating feature.'
     }
 
-    @UnsupportedWithConfigurationCache(because = "test makes direct access to the projects extension")
     def "can use the #notation notation on type-safe accessor"() {
         given:
         createDirs("other")
@@ -157,7 +150,6 @@ class TypeSafeProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAcc
         notation << [ 'platform', 'testFixtures']
     }
 
-    @UnsupportedWithConfigurationCache(because = "test makes direct access to the projects extension")
     def "buildSrc project accessors are independent from the main build accessors"() {
         given:
         file("buildSrc/build.gradle") << """


### PR DESCRIPTION
There seem to be no problem with running these tests with CC executer anymore. 