### PR TITLE
Set max-workers=1 for tests under CC

### DIFF
--- a/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/AbstractWorkerExecutorIntegrationTest.groovy
+++ b/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/AbstractWorkerExecutorIntegrationTest.groovy
@@ -26,6 +26,7 @@ abstract class AbstractWorkerExecutorIntegrationTest extends AbstractIntegration
 
     def setup() {
         fixture.prepareTaskTypeUsingWorker()
+        executer.withArgument("--max-workers=4")
     }
 
     void assertWorkerExecuted(String taskName) {

--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractBasicGroupedTaskLoggingFunctionalTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractBasicGroupedTaskLoggingFunctionalTest.groovy
@@ -31,6 +31,12 @@ abstract class AbstractBasicGroupedTaskLoggingFunctionalTest extends AbstractCon
     @Rule
     BlockingHttpServer server = new BlockingHttpServer()
 
+    @Override
+    def setup() {
+        // default for CC and parallel executers may be single worker
+        args("--max-workers=4")
+    }
+
     def "multi-project build tasks logs are grouped"() {
         server.start()
 
@@ -181,7 +187,7 @@ abstract class AbstractBasicGroupedTaskLoggingFunctionalTest extends AbstractCon
         when:
         def waiting = server.expectConcurrentAndBlock("a-waiting", "b-waiting")
         def done = server.expectAndBlock("b-done")
-        def build = executer.withArguments("--parallel").withTasks("run").start()
+        def build = executer.withArguments("--parallel", "--max-workers=4").withTasks("run").start()
 
         waiting.waitForAllPendingCalls()
         waiting.release("b-waiting")

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginDependenciesIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginDependenciesIntegrationTest.groovy
@@ -86,6 +86,7 @@ class PmdPluginDependenciesIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause("Incremental analysis only supports PMD 6.0.0 and newer. Please upgrade from PMD 5.1.1 or disable incremental analysis.")
 
         when:
+        // ensure parallel task execution so build problems from multiple upstream tasks are reported
         executer.withArgument("--max-workers=4")
         fails("check")
 

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginDependenciesIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginDependenciesIntegrationTest.groovy
@@ -86,6 +86,7 @@ class PmdPluginDependenciesIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause("Incremental analysis only supports PMD 6.0.0 and newer. Please upgrade from PMD 5.1.1 or disable incremental analysis.")
 
         when:
+        executer.withArgument("--max-workers=4")
         fails("check")
 
         then:

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractJvmFailFastIntegrationSpec.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractJvmFailFastIntegrationSpec.groovy
@@ -40,6 +40,8 @@ abstract class AbstractJvmFailFastIntegrationSpec extends AbstractTestingMultiVe
     def setup() {
         server.start()
         generator = new JvmBlockingTestClassGenerator(testDirectory, server, testFrameworkImports, testFrameworkDependencies, configureTestFramework)
+        // default for CC and parallel executers may be single worker
+        args("--max-workers=${DEFAULT_MAX_WORKERS}")
     }
 
     def "all tests run with #description"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/TransformLoggingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/TransformLoggingIntegrationTest.groovy
@@ -223,7 +223,7 @@ class TransformLoggingIntegrationTest extends AbstractConsoleGroupedTaskFunction
 
         when:
         def block = server.expectConcurrentAndBlock("lib1.jar", "lib2.jar")
-        def build = executer.withTasks(":util:resolveRed").start()
+        def build = executer.withTasks(":util:resolveRed").withArgument("--max-workers=2") start()
         then:
         block.waitForAllPendingCalls()
         poll {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildTaskFailureIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildTaskFailureIntegrationTest.groovy
@@ -135,6 +135,7 @@ class CompositeBuildTaskFailureIntegrationTest extends AbstractCompositeBuildInt
         server.expectConcurrent("buildA", "buildB")
 
         when:
+        executer.withArgument("--max-workers=4")
         fails(buildA, "assemble")
 
         then:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/GradleBuildTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/GradleBuildTaskIntegrationTest.groovy
@@ -299,7 +299,7 @@ class GradleBuildTaskIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         runs.times {
-            executer.withArgument("--parallel")
+            executer.withArgument("--parallel").withArgument("--max-workers=4")
             run 'otherBuild'
         }
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ConfigurationCacheGradleExecuter.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ConfigurationCacheGradleExecuter.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.fixtures.executer
 
+import org.gradle.initialization.ParallelismBuildOptions
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheMaxProblemsOption
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheOption
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheQuietOption
@@ -27,6 +28,7 @@ class ConfigurationCacheGradleExecuter extends DaemonGradleExecuter {
 
     static final List<String> CONFIGURATION_CACHE_ARGS = [
         "--${ConfigurationCacheOption.LONG_OPTION}",
+        "-D${ParallelismBuildOptions.MaxWorkersOption.GRADLE_PROPERTY}=1",
         "-D${ConfigurationCacheQuietOption.PROPERTY_NAME}=true",
         "-D${ConfigurationCacheMaxProblemsOption.PROPERTY_NAME}=0",
         "-Dorg.gradle.configuration-cache.internal.load-after-store=${testWithLoadAfterStore()}"
@@ -51,7 +53,8 @@ class ConfigurationCacheGradleExecuter extends DaemonGradleExecuter {
         if (args.contains("--no-configuration-cache")) { // Don't enable if explicitly disabled
             return args
         } else {
-            return args + CONFIGURATION_CACHE_ARGS
+            // let custom args to overried CC args
+            return CONFIGURATION_CACHE_ARGS + args
         }
     }
 }


### PR DESCRIPTION
so they run deterministically, and we avoid flakiness.


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
