### PR TITLE
Add upgrading guide section for gradle-enterprise extension deprecation

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/BuildScanIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/BuildScanIntegrationTest.kt
@@ -54,7 +54,7 @@ class BuildScanIntegrationTest : AbstractKotlinIntegrationTest() {
         executer.expectDocumentedDeprecationWarning(
             "The PluginDependencySpec.`gradle-enterprise` property has been deprecated. " +
                 "This is scheduled to be removed in Gradle 9.0. Please use 'id(\"com.gradle.develocity\") version \"${AutoAppliedGradleEnterprisePlugin.VERSION}\"' instead. " +
-                "For more information, please refer to https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.kotlin.dsl/gradle-enterprise.html in the Gradle documentation.")
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#gradle_enterprise_extension_deprecated")
         executer.expectDeprecationWarning(
             "WARNING: The following functionality has been deprecated and will be removed in the next major release of the Develocity Gradle plugin. " +
                 "Run with '-Ddevelocity.deprecation.captureOrigin=true' to see where the deprecated functionality is being used. " +

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecExtensions.kt
@@ -16,7 +16,6 @@
 package org.gradle.kotlin.dsl
 
 import org.gradle.internal.deprecation.DeprecationLogger
-import org.gradle.internal.deprecation.Documentation
 import org.gradle.plugin.management.internal.autoapply.AutoAppliedGradleEnterprisePlugin
 import org.gradle.plugin.use.PluginDependenciesSpec
 import org.gradle.plugin.use.PluginDependencySpec
@@ -39,7 +38,7 @@ val PluginDependenciesSpec.`gradle-enterprise`: PluginDependencySpec
         DeprecationLogger.deprecate("The ${PluginDependencySpec::class.simpleName}.`gradle-enterprise` property")
             .withAdvice("Please use 'id(\"com.gradle.develocity\") version \"${AutoAppliedGradleEnterprisePlugin.VERSION}\"' instead.")
             .willBeRemovedInGradle9()
-            .withDocumentation(Documentation.kotlinDslExtensionReference("gradle-enterprise"))
+            .withUpgradeGuideSection(8, "gradle_enterprise_extension_deprecated")
             .nagUser()
         return this.id(AutoAppliedGradleEnterprisePlugin.GRADLE_ENTERPRISE_PLUGIN_ID.id).version(AutoAppliedGradleEnterprisePlugin.VERSION)
     }

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -210,6 +210,7 @@ This allows for more granular control over which artifacts are selected.
 
 [[deprecated_namers]]
 ==== Deprecated `Namer` of `Task` and `Configuration`
+
 `Task` and `Configuration` have a link:{javadocPath}/org/gradle/api/Namer.html[`Namer`] inner class (also called `Namer`) that can be used as a common way to retrieve the name of a task or configuration.
 Now that these types implement link:{javadocPath}/org/gradle/api/Named.html[`Named`], these classes are no longer necessary and have been deprecated.
 They will be removed in Gradle 9.0.
@@ -267,6 +268,36 @@ beforeSettings {
 
 Calling link:{javadocPath}/org/gradle/caching/local/DirectoryBuildCache.html#setRemoveUnusedEntriesAfterDays-int-[buildCache.local.removeUnusedEntriesAfterDays] is deprecated and this method will be removed in Gradle 9.0.
 If set to a non-default value, this deprecated setting will take precedence over `Settings.caches.buildCache.setRemoveUnusedEntriesAfterDays()`.
+
+[[gradle_enterprise_extension_deprecated]]
+==== Deprecated Kotlin DSL gradle-enterprise plugin block extension ====
+
+In `settings.gradle.kts` (Kotlin DSL), you can use `gradle-enterprise` in the plugins block to apply the Gradle Enterprise plugin with the same version as `gradle --scan`.
+```kotlin
+plugins {
+    `gradle-enterprise`
+}
+```
+
+There is no equivalent to this in `settings.gradle` (Groovy DSL).
+
+Gradle Enterprise has been renamed to Develocity and the `com.gradle.enterprise` plugin has been renamed to `com.gradle.develocity`.
+Therefore, the `gradle-enterprise` plugin block extension has been deprecated and will be removed in Gradle 9.0.
+Instead of introducing a `develocity` plugin block extension for the Kotlin DSL, you should use the `com.gradle.develocity` plugin id directly.
+```kotlin
+plugins {
+    id("com.gradle.develocity") version "3.17.3"
+}
+```
+
+If you want to continue using the Gradle Enterprise plugin, you can specify the deprecated plugin id.
+```kotlin
+plugins {
+    id("com.gradle.enterprise") version "3.17.3"
+}
+```
+
+We encourage you to use the https://plugins.gradle.org/plugin/com.gradle.develocity[latest released Develocity plugin version], even when you are using an older Gradle version.
 
 === Potential breaking changes
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -283,7 +283,9 @@ There is no equivalent to this in `settings.gradle` (Groovy DSL).
 
 Gradle Enterprise has been renamed to Develocity and the `com.gradle.enterprise` plugin has been renamed to `com.gradle.develocity`.
 Therefore, the `gradle-enterprise` plugin block extension has been deprecated and will be removed in Gradle 9.0.
-Instead of introducing a `develocity` plugin block extension for the Kotlin DSL, you should use the `com.gradle.develocity` plugin id directly.
+
+The Develocity plugin must be applied with an explicit plugin id and version.
+There is no `develocity` shorthand available in the plugins block.
 ```kotlin
 plugins {
     id("com.gradle.develocity") version "3.17.3"


### PR DESCRIPTION
Adds an upgrading guide section for the deprecated `gradle-enterprise` extension. The section goes a little bit into detail why there isn't a `develocity` extension.

[Rendered upgrading guide](https://builds.gradle.org/repository/download/Gradle_Release_Check_BuildDistributions/82335677:id/distributions/gradle-8.8-docs.zip!/gradle-8.8-20240516143341%2B0000/docs/userguide/upgrading_version_8.html#gradle_enterprise_extension_deprecated)