### PR TITLE
Make a version of `JavaVersion#getMajorVersion()`, which returns int instead of `String`

### DIFF
--- a/platforms/core-runtime/base-services/src/test/groovy/org/gradle/internal/classloader/TransformReplacerTest.groovy
+++ b/platforms/core-runtime/base-services/src/test/groovy/org/gradle/internal/classloader/TransformReplacerTest.groovy
@@ -272,7 +272,7 @@ class TransformReplacerTest extends Specification {
     }
 
     private static int getCurrentJvmMajor() {
-        return JavaVersion.current().majorVersion.toInteger()
+        return JavaVersion.current().majorVersionNumber
     }
 
     private static ProtectionDomain protectionDomain(File path) {

--- a/platforms/core-runtime/java-language-extensions/src/main/java/org/gradle/api/JavaVersion.java
+++ b/platforms/core-runtime/java-language-extensions/src/main/java/org/gradle/api/JavaVersion.java
@@ -326,6 +326,15 @@ public enum JavaVersion {
         return String.valueOf(ordinal() + 1);
     }
 
+    /**
+     * Returns the major version number.
+     *
+     * @since 8.9
+     */
+    public int getMajorVersionNumber() {
+        return ordinal() + 1;
+    }
+
     private static JavaVersion getVersionForMajor(int major) {
         return major >= values().length ? JavaVersion.VERSION_HIGHER : values()[major - 1];
     }

--- a/platforms/core-runtime/java-language-extensions/src/main/java/org/gradle/api/JavaVersion.java
+++ b/platforms/core-runtime/java-language-extensions/src/main/java/org/gradle/api/JavaVersion.java
@@ -322,15 +322,23 @@ public enum JavaVersion {
         return versionName;
     }
 
+    /**
+     * Returns the major version number as a {@link String}
+     *
+     * @see #getMajorVersionNumber() for the integer value
+     * @since 1.8
+     */
     public String getMajorVersion() {
         return String.valueOf(getMajorVersionNumber());
     }
 
     /**
-     * Returns the major version number.
+     * Returns the major version number
      *
+     * @see #getMajorVersion() for the string value
      * @since 8.9
      */
+    @Incubating
     public int getMajorVersionNumber() {
         return ordinal() + 1;
     }

--- a/platforms/core-runtime/java-language-extensions/src/main/java/org/gradle/api/JavaVersion.java
+++ b/platforms/core-runtime/java-language-extensions/src/main/java/org/gradle/api/JavaVersion.java
@@ -323,7 +323,7 @@ public enum JavaVersion {
     }
 
     /**
-     * Returns the major version number as a {@link String}
+     * Returns the major version number as a {@link String}.
      *
      * @see #getMajorVersionNumber() for the integer value
      * @since 1.8
@@ -333,7 +333,7 @@ public enum JavaVersion {
     }
 
     /**
-     * Returns the major version number
+     * Returns the major version number.
      *
      * @see #getMajorVersion() for the string value
      * @since 8.9

--- a/platforms/core-runtime/java-language-extensions/src/main/java/org/gradle/api/JavaVersion.java
+++ b/platforms/core-runtime/java-language-extensions/src/main/java/org/gradle/api/JavaVersion.java
@@ -323,7 +323,7 @@ public enum JavaVersion {
     }
 
     public String getMajorVersion() {
-        return String.valueOf(ordinal() + 1);
+        return String.valueOf(getMajorVersionNumber());
     }
 
     /**

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/groovy/buildSrc/src/main/groovy/com/acme/InstrumentedJarsPlugin.groovy
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/groovy/buildSrc/src/main/groovy/com/acme/InstrumentedJarsPlugin.groovy
@@ -50,7 +50,7 @@ class InstrumentedJarsPlugin implements Plugin<Project> {
                 it.attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category, Category.LIBRARY))
                 it.attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
                 it.attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling, Bundling.EXTERNAL))
-                it.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, JavaVersion.current().majorVersion.toInteger())
+                it.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, JavaVersion.current().majorVersionNumber)
                 it.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements, 'instrumented-jar'))
             }
         }

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/kotlin/buildSrc/src/main/kotlin/com/acme/InstrumentedJarsPlugin.kt
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/kotlin/buildSrc/src/main/kotlin/com/acme/InstrumentedJarsPlugin.kt
@@ -63,7 +63,7 @@ class InstrumentedJarsPlugin @Inject constructor(
                 attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.LIBRARY))
                 attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
                 attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
-                attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, JavaVersion.current().majorVersion.toInt())
+                attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, JavaVersion.current().majorVersionNumber)
                 attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named("instrumented-jar"))
             }
         }

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced/groovy/producer/build.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced/groovy/producer/build.gradle
@@ -13,7 +13,7 @@ configurations {
             attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
             attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
             attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
-            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, JavaVersion.current().majorVersion.toInteger())
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, JavaVersion.current().majorVersionNumber)
             attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, 'instrumented-jar'))
         }
     }

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced/kotlin/producer/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced/kotlin/producer/build.gradle.kts
@@ -10,7 +10,7 @@ val instrumentedJars by configurations.creating {
         attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.LIBRARY))
         attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
         attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
-        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, JavaVersion.current().majorVersion.toInt())
+        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, JavaVersion.current().majorVersionNumber)
         attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named("instrumented-jar"))
     }
 }

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/test/TestTaskPropertiesServiceIntegrationTest.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/test/TestTaskPropertiesServiceIntegrationTest.groovy
@@ -119,7 +119,7 @@ class TestTaskPropertiesServiceIntegrationTest extends AbstractIntegrationSpec {
             file('build/resources/main'),
         ]
         def expectedExecutable = Jvm.current().javaExecutable.absolutePath
-        def expectedJavaVersion = JavaVersion.current().majorVersion.toInteger()
+        def expectedJavaVersion = JavaVersion.current().majorVersionNumber
         with(new JsonSlurper().parse(file('build/testTaskProperties.json')), Map) {
             usingJUnitPlatform == true
             forkEvery == 42

--- a/platforms/ide/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClientJdkCompatibilityTest.groovy
+++ b/platforms/ide/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClientJdkCompatibilityTest.groovy
@@ -245,7 +245,7 @@ abstract class ToolingApiClientJdkCompatibilityTest extends AbstractIntegrationS
     }
 
     private sortOutNotSupportedNotWorkingCombinations(String gradleVersion) {
-        Assume.assumeFalse(clientJdkVersion.majorVersion.toInteger() >= 16 && GradleVersion.version(gradleVersion) <= GradleVersion.version("4.0"))
+        Assume.assumeFalse(clientJdkVersion.majorVersionNumber >= 16 && GradleVersion.version(gradleVersion) <= GradleVersion.version("4.0"))
     }
 
     @Flaky

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
@@ -404,7 +404,7 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         // e: Unknown JVM target version: 21
         // Supported versions: 1.6, 1.8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18
         JvmInstallationMetadata jdkMetadata = AvailableJavaHomes.getJvmInstallationMetadata(AvailableJavaHomes.getDifferentVersion({
-            it.languageVersion.majorVersion.toInteger() <= 17
+            it.languageVersion.majorVersionNumber <= 17
         }))
 
         given:

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileCompatibilityIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileCompatibilityIntegrationTest.groovy
@@ -214,7 +214,7 @@ class JavaCompileCompatibilityIntegrationTest extends AbstractIntegrationSpec im
 
     def "configuring toolchain on java extension with source and target compatibility is supported"() {
         def jdk = Jvm.current()
-        def prevJavaVersion = JavaVersion.toVersion(jdk.javaVersion.majorVersion.toInteger() - 1)
+        def prevJavaVersion = JavaVersion.toVersion(jdk.javaVersion.majorVersionNumber - 1)
         buildFile << """
             apply plugin: 'java'
 

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
@@ -491,7 +491,7 @@ class JavaCompileToolchainIntegrationTest extends AbstractIntegrationSpec implem
     def "can compile with a custom compiler executable"() {
         def otherJdk = AvailableJavaHomes.getJdk(JavaVersion.current())
         def jdk = AvailableJavaHomes.getDifferentVersion {
-            def v = it.languageVersion.majorVersion.toInteger()
+            def v = it.languageVersion.majorVersionNumber
             11 <= v && v <= 18 // Java versions supported by ECJ releases used in the test
         }
 

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AbstractJavaCompileSpecFactory.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AbstractJavaCompileSpecFactory.java
@@ -81,7 +81,7 @@ public abstract class AbstractJavaCompileSpecFactory<T extends JavaCompileSpec> 
         if (toolchain != null) {
             languageVersion = toolchain.getLanguageVersion().asInt();
         } else {
-            languageVersion = JavaVersion.current().ordinal() + 1;
+            languageVersion = JavaVersion.current().getMajorVersionNumber();
         }
 
         return getForkingSpec(fallbackJavaHome, languageVersion);

--- a/platforms/jvm/language-java/src/test/groovy/org/gradle/api/tasks/compile/JavaCompileTest.groovy
+++ b/platforms/jvm/language-java/src/test/groovy/org/gradle/api/tasks/compile/JavaCompileTest.groovy
@@ -205,7 +205,7 @@ class JavaCompileTest extends AbstractProjectBuilderSpec {
         def javaCompile = project.tasks.create('compileJava', JavaCompile)
         javaCompile.destinationDirectory.fileValue(new File('somewhere'))
 
-        def prevJavaVersion = JavaVersion.toVersion(Jvm.current().javaVersion.majorVersion.toInteger() - 1).toString()
+        def prevJavaVersion = JavaVersion.toVersion(Jvm.current().javaVersion.majorVersionNumber - 1).toString()
 
         given:
         javaCompile.setSourceCompatibility(prevJavaVersion)

--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -592,7 +592,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         given:
         def someJdk = Jvm.current()
         setupProjectWithToolchain(someJdk.javaVersion)
-        def prevJavaVersion = JavaVersion.toVersion(someJdk.javaVersion.majorVersion.toInteger() - 1)
+        def prevJavaVersion = JavaVersion.toVersion(someJdk.javaVersion.majorVersionNumber - 1)
         project.java.sourceCompatibility = prevJavaVersion
 
         when:

--- a/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/compile/UpToDateScalaCompileIntegrationTest.groovy
+++ b/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/compile/UpToDateScalaCompileIntegrationTest.groovy
@@ -175,7 +175,7 @@ class UpToDateScalaCompileIntegrationTest extends AbstractIntegrationSpec implem
     def "compilation emits toolchain usage events"() {
         captureBuildOperations()
 
-        def jdkMetadata = AvailableJavaHomes.getJvmInstallationMetadata(AvailableJavaHomes.getDifferentJdk { it.languageVersion.majorVersion.toInteger() in 8..17 })
+        def jdkMetadata = AvailableJavaHomes.getJvmInstallationMetadata(AvailableJavaHomes.getDifferentJdk { it.languageVersion.majorVersionNumber in 8..17 })
 
         buildScript """
             apply plugin: 'scala'

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptClassPathResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptClassPathResolver.java
@@ -116,7 +116,7 @@ public class DefaultScriptClassPathResolver implements ScriptClassPathResolver {
         attributes.attribute(Category.CATEGORY_ATTRIBUTE, instantiator.named(Category.class, Category.LIBRARY));
         attributes.attribute(LIBRARY_ELEMENTS_ATTRIBUTE, instantiator.named(LibraryElements.class, LibraryElements.JAR));
         attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, instantiator.named(Bundling.class, Bundling.EXTERNAL));
-        attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.parseInt(JavaVersion.current().getMajorVersion()));
+        attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, JavaVersion.current().getMajorVersionNumber());
         attributes.attribute(GradlePluginApiVersion.GRADLE_PLUGIN_API_VERSION_ATTRIBUTE, instantiator.named(GradlePluginApiVersion.class, GradleVersion.current().getVersion()));
 
         DependencyHandler dependencyHandler = resolutionContext.getDependencyHandler();

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JavaToolchainFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JavaToolchainFixture.groovy
@@ -38,11 +38,11 @@ trait JavaToolchainFixture {
     }
 
     String javaPluginToolchainVersion(Jvm jvm) {
-        return javaPluginToolchainVersion(jvm.javaVersion.majorVersion.toInteger())
+        return javaPluginToolchainVersion(jvm.javaVersion.majorVersionNumber)
     }
 
     String javaPluginToolchainVersion(JvmInstallationMetadata installationMetadata) {
-        return javaPluginToolchainVersion(installationMetadata.languageVersion.majorVersion.toInteger())
+        return javaPluginToolchainVersion(installationMetadata.languageVersion.majorVersionNumber)
     }
 
     String javaPluginToolchainVersion(Integer majorVersion) {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenJavaModule.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenJavaModule.groovy
@@ -100,7 +100,7 @@ class MavenJavaModule extends DelegatingMavenModule<MavenFileModule> implements 
         assert runtimeElements.files*.name == [artifact(feature, artifactFileExtension)]
 
         // Verify it contains expected attributes
-        def currentJavaVersion = JavaVersion.current().majorVersion.toInteger()
+        def currentJavaVersion = JavaVersion.current().majorVersionNumber
         assertAttributes(apiElements, ["org.gradle.category": "library",
                                        "org.gradle.dependency.bundling": "external",
                                        "org.gradle.jvm.version": currentJavaVersion,


### PR DESCRIPTION
The 🧵 spawning this change: https://github.com/gradle/gradle/pull/28281#discussion_r1577414263

When developing the problem reporting for the compiler, I've noticed that this useful method is missing.
Meanwhile we don't rely on this that much, I think it's a worthwhile addition for the users too.