### PR TITLE
Rebaseline performance tests to fix new DCL test projects not understood by older Gradle

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ develocity.internal.testdistribution.writeTraceFile=true
 gradle.internal.testdistribution.queryResponseTimeout=PT20S
 develocity.internal.testdistribution.queryResponseTimeout=PT20S
 # Default performance baseline
-defaultPerformanceBaselines=8.9-commit-01d3387e659a
+defaultPerformanceBaselines=8.9-commit-d8fe33fcf6d6
 
 # Skip dependency analysis for tests
 systemProp.dependency.analysis.test.analysis=false


### PR DESCRIPTION
There was no real regression. 

Because of a file name change in DCL,
older builds would ignore the newer test projects and act as if those
were empty projects, doing no DCL work at all. 

That appeared as a regression, but with proper test data
the performance was equivalent.