### PR TITLE
Remove unnecessary classloader optimization

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/WorkerProcessClassPathProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/WorkerProcessClassPathProvider.java
@@ -16,7 +16,6 @@
 
 package org.gradle.process.internal.worker.child;
 
-import com.google.common.collect.Lists;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.JavaVersion;
@@ -62,7 +61,6 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -125,44 +123,6 @@ public class WorkerProcessClassPathProvider implements ClassPathProvider {
         "asm"
     };
 
-    // This list is ordered by the number of classes we load from each jar descending
-    private static final String[] WORKER_OPTIMIZED_LOADING_ORDER = new String[]{
-        "gradle-base-asm",
-        "gradle-base-services",
-        "guava",
-        "gradle-messaging",
-        "gradle-model-core",
-        "gradle-logging",
-        "gradle-core-api",
-        "gradle-workers",
-        "native-platform",
-        "gradle-core",
-        "gradle-native",
-        "gradle-file-collections",
-        "gradle-language-java",
-        "gradle-worker-processes",
-        "gradle-process-services",
-        "slf4j-api",
-        "gradle-language-jvm",
-        "gradle-persistent-cache",
-        "gradle-files",
-        "gradle-hashing",
-        "gradle-snapshots",
-        "gradle-worker",
-        "groovy",
-        "groovy-ant",
-        "groovy-json",
-        "groovy-templates",
-        "groovy-xml",
-        "kryo",
-        "gradle-platform-base",
-        "gradle-cli",
-        "jul-to-slf4j",
-        "javax.inject",
-        "gradle-jvm-services",
-        "asm"
-    };
-
     public WorkerProcessClassPathProvider(GlobalScopedCacheBuilderFactory cacheBuilderFactory, ModuleRegistry moduleRegistry) {
         this.cacheBuilderFactory = cacheBuilderFactory;
         this.moduleRegistry = moduleRegistry;
@@ -211,32 +171,10 @@ public class WorkerProcessClassPathProvider implements ClassPathProvider {
             for (String externalModule : RUNTIME_EXTERNAL_MODULES) {
                 classpath = classpath.plus(moduleRegistry.getExternalModule(externalModule).getImplementationClasspath());
             }
-            classpath = optimizeForClassloading(classpath);
             return classpath;
         }
 
         return null;
-    }
-
-    private static ClassPath optimizeForClassloading(ClassPath classpath) {
-        ClassPath optimizedForLoading = ClassPath.EMPTY;
-        List<File> optimizedFiles = Lists.newArrayListWithCapacity(WORKER_OPTIMIZED_LOADING_ORDER.length);
-        List<File> remainder = Lists.newArrayList(classpath.getAsFiles());
-        for (String module : WORKER_OPTIMIZED_LOADING_ORDER) {
-            Iterator<File> asFiles = remainder.iterator();
-            while (asFiles.hasNext()) {
-                File file = asFiles.next();
-                if (file.getName().startsWith(module)) {
-                    optimizedFiles.add(file);
-                    asFiles.remove();
-                }
-            }
-            if (remainder.isEmpty()) {
-                break;
-            }
-        }
-        classpath = optimizedForLoading.plus(optimizedFiles).plus(remainder);
-        return classpath;
     }
 
     private static File jarFile(PersistentCache cache) {


### PR DESCRIPTION
This is in the context of eliminating manual lists of modules in the source code that are hard to maintain.

This optimization does not seem to move the needle on our performance tests.