### PR TITLE
Acquire project locks in component state

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/model/CalculatedValueCache.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/model/CalculatedValueCache.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.model;
+
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * A cache backed by calculated values. This map is thread-safe.
+ */
+public interface CalculatedValueCache<K, V> {
+
+    /**
+     * @see Map#computeIfAbsent(Object, Function)
+     */
+    V computeIfAbsent(K key, Function<K, V> factory);
+
+    /**
+     * @see Map#clear()
+     */
+    void clear();
+
+}

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/model/CalculatedValueFactory.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/model/CalculatedValueFactory.java
@@ -38,4 +38,10 @@ public interface CalculatedValueFactory {
      * For example, the value might have been restored from the configuration cache.
      */
     <T> CalculatedValue<T> create(DisplayName displayName, T value);
+
+    /**
+     * Creates a cache backed by calculated values.
+     */
+    <K, V> CalculatedValueCache<K, V> createCache(DisplayName type);
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentGraphResolveState.java
@@ -113,6 +113,13 @@ public class DefaultLocalComponentGraphResolveState extends AbstractComponentGra
     }
 
     private void initCalculatedValues() {
+        // TODO: We wrap the CalculatedValues in an AtomicReference so that we can reset their state, however
+        //       CalculatedValues are not resettable for a reason. This is a pretty terrible hack.
+        //       We should get rid of reevaluate entirely, so that we do not need these AtomicReferences.
+        //       We are already on this path -- we deprecated mutating a configuration after observation.
+        //       However, while mutation is still allowed, we need hacks like this, as plugins are relying
+        //       on the deprecated behavior, for example the Spring dependency management plugin which adds
+        //       excludes to dependencies in a beforeResolve.
         this.graphSelectionCandidates.set(
             calculatedValueContainerFactory.create(Describables.of("variants of", getMetadata()), context ->
                 computeGraphSelectionCandidates(this, idGenerator, configurationFactory, calculatedValueContainerFactory, artifactTransformer)

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentGraphResolveState.java
@@ -44,7 +44,9 @@ import org.gradle.internal.component.model.VariantArtifactGraphResolveMetadata;
 import org.gradle.internal.component.model.VariantArtifactResolveState;
 import org.gradle.internal.component.model.VariantGraphResolveState;
 import org.gradle.internal.component.model.VariantResolveMetadata;
-import org.gradle.internal.lazy.Lazy;
+import org.gradle.internal.model.CalculatedValue;
+import org.gradle.internal.model.CalculatedValueCache;
+import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.resolve.resolver.VariantArtifactResolver;
 
 import javax.annotation.Nullable;
@@ -54,8 +56,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 /**
@@ -68,15 +69,16 @@ public class DefaultLocalComponentGraphResolveState extends AbstractComponentGra
     private final boolean adHoc;
     private final ConfigurationMetadataFactory configurationFactory;
     private final Transformer<LocalComponentArtifactMetadata, LocalComponentArtifactMetadata> artifactTransformer;
+    private final CalculatedValueContainerFactory calculatedValueContainerFactory;
 
     // The graph resolve state for each configuration of this component
-    private final ConcurrentMap<String, DefaultLocalConfigurationGraphResolveState> configurations = new ConcurrentHashMap<>();
+    private final CalculatedValueCache<String, DefaultLocalConfigurationGraphResolveState> configurations;
 
     // The variants to use for variant selection during graph resolution
-    private final Lazy<LocalComponentGraphSelectionCandidates> graphSelectionCandidates;
+    private final AtomicReference<CalculatedValue<LocalComponentGraphSelectionCandidates>> graphSelectionCandidates = new AtomicReference<>();
 
     // The public view of all selectable variants of this component
-    private final Lazy<List<ResolvedVariantResult>> selectableVariantResults;
+    private final AtomicReference<CalculatedValue<List<ResolvedVariantResult>>> selectableVariantResults = new AtomicReference<>();
 
     public DefaultLocalComponentGraphResolveState(
         long instanceId,
@@ -85,30 +87,42 @@ public class DefaultLocalComponentGraphResolveState extends AbstractComponentGra
         ComponentIdGenerator idGenerator,
         boolean adHoc,
         ConfigurationMetadataFactory configurationFactory,
+        CalculatedValueContainerFactory calculatedValueContainerFactory,
         @Nullable Transformer<LocalComponentArtifactMetadata, LocalComponentArtifactMetadata> artifactTransformer
     ) {
         super(instanceId, metadata, attributeDesugaring);
         this.idGenerator = idGenerator;
         this.adHoc = adHoc;
         this.configurationFactory = configurationFactory;
+        this.calculatedValueContainerFactory = calculatedValueContainerFactory;
         this.artifactTransformer = artifactTransformer;
 
-        // TODO: We should be using the CalculatedValue infrastructure to lazily compute these values
-        //       in order to properly manage project locks.
-        this.graphSelectionCandidates = Lazy.locking().of(() ->
-            computeGraphSelectionCandidates(this, idGenerator, configurationFactory, artifactTransformer)
-        );
-        this.selectableVariantResults = Lazy.locking().of(() ->
-            computeSelectableVariantResults(this)
-        );
+        // Mutable state
+        this.configurations = calculatedValueContainerFactory.createCache(Describables.of("configurations"));
+        initCalculatedValues();
     }
 
     @Override
     public void reevaluate() {
-        // TODO: This is not thread-safe. We do not atomically clear all the different fields at once.
+        // TODO: This is not really thread-safe.
+        //       We should atomically clear all the different fields at once.
+        //       Or better yet, we should not allow reevaluation of the state.
         configurations.clear();
         configurationFactory.invalidate();
-        // TODO: We are missing logic to invalidate allVariantsForGraphResolution and selectableVariantResults.
+        initCalculatedValues();
+    }
+
+    private void initCalculatedValues() {
+        this.graphSelectionCandidates.set(
+            calculatedValueContainerFactory.create(Describables.of("variants of", getMetadata()), context ->
+                computeGraphSelectionCandidates(this, idGenerator, configurationFactory, calculatedValueContainerFactory, artifactTransformer)
+            )
+        );
+        this.selectableVariantResults.set(
+            calculatedValueContainerFactory.create(Describables.of("public variants of", getMetadata()), context ->
+                computeSelectableVariantResults(this)
+            )
+        );
     }
 
     @Override
@@ -143,6 +157,7 @@ public class DefaultLocalComponentGraphResolveState extends AbstractComponentGra
             idGenerator,
             adHoc,
             configurationFactory,
+            calculatedValueContainerFactory,
             cachedTransformer
         );
     }
@@ -154,13 +169,16 @@ public class DefaultLocalComponentGraphResolveState extends AbstractComponentGra
 
     @Override
     public LocalComponentGraphSelectionCandidates getCandidatesForGraphVariantSelection() {
-        return graphSelectionCandidates.get();
+        CalculatedValue<LocalComponentGraphSelectionCandidates> value = graphSelectionCandidates.get();
+        value.finalizeIfNotAlready();
+        return value.get();
     }
 
     private static LocalComponentGraphSelectionCandidates computeGraphSelectionCandidates(
         DefaultLocalComponentGraphResolveState component,
         ComponentIdGenerator idGenerator,
         ConfigurationMetadataFactory configurationFactory,
+        CalculatedValueContainerFactory calculatedValueContainerFactory,
         @Nullable Transformer<LocalComponentArtifactMetadata, LocalComponentArtifactMetadata> artifactTransformer
     ) {
         ImmutableList.Builder<VariantGraphResolveState> configurationsWithAttributes = new ImmutableList.Builder<>();
@@ -172,7 +190,7 @@ public class DefaultLocalComponentGraphResolveState extends AbstractComponentGra
             }
 
             VariantGraphResolveState variantState = new DefaultLocalConfigurationGraphResolveState(
-                idGenerator.nextVariantId(), component, component.getMetadata(), configuration
+                idGenerator.nextVariantId(), component, component.getMetadata(), configuration, calculatedValueContainerFactory
             ).asVariant();
 
             if (!configuration.getAttributes().isEmpty()) {
@@ -191,7 +209,9 @@ public class DefaultLocalComponentGraphResolveState extends AbstractComponentGra
 
     @Override
     public List<ResolvedVariantResult> getAllSelectableVariantResults() {
-        return selectableVariantResults.get();
+        CalculatedValue<List<ResolvedVariantResult>> value = selectableVariantResults.get();
+        value.finalizeIfNotAlready();
+        return value.get();
     }
 
     private static List<ResolvedVariantResult> computeSelectableVariantResults(DefaultLocalComponentGraphResolveState component) {
@@ -225,27 +245,26 @@ public class DefaultLocalComponentGraphResolveState extends AbstractComponentGra
             if (artifactTransformer != null) {
                 md = md.copyWithTransformedArtifacts(artifactTransformer);
             }
-            return new DefaultLocalConfigurationGraphResolveState(idGenerator.nextVariantId(), this, getMetadata(), md);
+            return new DefaultLocalConfigurationGraphResolveState(idGenerator.nextVariantId(), this, getMetadata(), md, calculatedValueContainerFactory);
         });
     }
 
     private static class DefaultLocalConfigurationGraphResolveState extends AbstractVariantGraphResolveState implements VariantGraphResolveState, ConfigurationGraphResolveState {
         private final long instanceId;
         private final LocalConfigurationGraphResolveMetadata configuration;
-        private final Lazy<DefaultLocalConfigurationArtifactResolveState> artifactResolveState;
+        private final CalculatedValue<DefaultLocalConfigurationArtifactResolveState> artifactResolveState;
 
-        public DefaultLocalConfigurationGraphResolveState(long instanceId, AbstractComponentGraphResolveState<?> componentState, ComponentGraphResolveMetadata component, LocalConfigurationGraphResolveMetadata configuration) {
+        public DefaultLocalConfigurationGraphResolveState(
+            long instanceId,
+            AbstractComponentGraphResolveState<?> componentState,
+            ComponentGraphResolveMetadata component,
+            LocalConfigurationGraphResolveMetadata configuration,
+            CalculatedValueContainerFactory calculatedValueContainerFactory
+        ) {
             super(componentState);
             this.instanceId = instanceId;
             this.configuration = configuration;
-            // We deliberately avoid locking the initialization of `artifactResolveState`.
-            // This object may be shared across multiple worker threads, and the computation of
-            // `legacyVariants` below is likely to require acquiring the state lock for the
-            // project that owns this `Configuration` leading to a potential deadlock situation.
-            // For instance, a thread could acquire the `artifactResolveState` lock while another thread,
-            // which already owns the project lock, attempts to acquire the `artifactResolveState` lock.
-            // See https://github.com/gradle/gradle/issues/25416
-            this.artifactResolveState = Lazy.atomic().of(() -> {
+            this.artifactResolveState = calculatedValueContainerFactory.create(Describables.of("artifacts of", configuration), context -> {
                 Set<? extends VariantResolveMetadata> legacyVariants = configuration.prepareToResolveArtifacts().getVariants();
                 return new DefaultLocalConfigurationArtifactResolveState(component, configuration, legacyVariants);
             });
@@ -288,11 +307,13 @@ public class DefaultLocalComponentGraphResolveState extends AbstractComponentGra
 
         @Override
         public VariantArtifactGraphResolveMetadata resolveArtifacts() {
+            artifactResolveState.finalizeIfNotAlready();
             return artifactResolveState.get();
         }
 
         @Override
         public VariantArtifactResolveState prepareForArtifactResolution() {
+            artifactResolveState.finalizeIfNotAlready();
             return artifactResolveState.get();
         }
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalComponentGraphResolveStateFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalComponentGraphResolveStateFactory.java
@@ -143,6 +143,7 @@ public class LocalComponentGraphResolveStateFactory {
             idGenerator,
             adHoc,
             configurationFactory,
+            calculatedValueContainerFactory,
             null
         );
     }
@@ -215,12 +216,14 @@ public class LocalComponentGraphResolveStateFactory {
 
         @Override
         public void visitConsumableConfigurations(Consumer<LocalConfigurationGraphResolveMetadata> visitor) {
-            VariantIdentityUniquenessVerifier.buildReport(configurationsProvider).assertNoConflicts();
+            model.applyToMutableState(p -> {
+                VariantIdentityUniquenessVerifier.buildReport(configurationsProvider).assertNoConflicts();
 
-            configurationsProvider.visitAll(configuration -> {
-                if (configuration.isCanBeConsumed()) {
-                    visitor.accept(createConfigurationMetadata(configuration));
-                }
+                configurationsProvider.visitAll(configuration -> {
+                    if (configuration.isCanBeConsumed()) {
+                        visitor.accept(createConfigurationMetadata(configuration));
+                    }
+                });
             });
         }
 
@@ -232,18 +235,22 @@ public class LocalComponentGraphResolveStateFactory {
         @Nullable
         @Override
         public LocalConfigurationGraphResolveMetadata getConfiguration(String name) {
-            ConfigurationInternal configuration = configurationsProvider.findByName(name);
-            if (configuration == null) {
-                return null;
-            }
+            return model.fromMutableState(p -> {
+                ConfigurationInternal configuration = configurationsProvider.findByName(name);
+                if (configuration == null) {
+                    return null;
+                }
 
-            return createConfigurationMetadata(configuration);
+                return createConfigurationMetadata(configuration);
+            });
         }
 
         @Override
         public Set<String> getConfigurationNames() {
             Set<String> names = new HashSet<>();
-            configurationsProvider.visitAll(configuration -> names.add(configuration.getName()));
+            model.applyToMutableState(p ->
+                configurationsProvider.visitAll(configuration -> names.add(configuration.getName()))
+            );
             return names;
         }
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildTreeLocalComponentProvider.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildTreeLocalComponentProvider.java
@@ -25,19 +25,15 @@ import org.gradle.api.internal.project.HoldsProjectState;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.internal.Describables;
-import org.gradle.internal.Factory;
 import org.gradle.internal.build.CompositeBuildParticipantBuildState;
 import org.gradle.internal.build.IncludedBuildState;
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveState;
-import org.gradle.internal.model.CalculatedValueContainer;
+import org.gradle.internal.model.CalculatedValueCache;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.util.Path;
 
 import javax.inject.Inject;
 import java.io.File;
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Default implementation of {@link BuildTreeLocalComponentProvider}.
@@ -54,13 +50,13 @@ public class DefaultBuildTreeLocalComponentProvider implements BuildTreeLocalCom
     /**
      * Caches the "true" metadata instances for local components.
      */
-    private final ConcurrentMetadataCache originalComponents;
+    private final CalculatedValueCache<ProjectComponentIdentifier, LocalComponentGraphResolveState> originalComponents;
 
     /**
      * Contains copies of metadata instances in {@link #originalComponents}, except
      * with the component identifier replaced with the foreign counterpart.
      */
-    private final ConcurrentMetadataCache foreignIdentifiedComponents;
+    private final CalculatedValueCache<ProjectComponentIdentifier, LocalComponentGraphResolveState> foreignIdentifiedComponents;
 
     @Inject
     public DefaultBuildTreeLocalComponentProvider(
@@ -73,8 +69,8 @@ public class DefaultBuildTreeLocalComponentProvider implements BuildTreeLocalCom
         this.localComponentCache = localComponentCache;
         this.localComponentProvider = localComponentProvider;
 
-        this.originalComponents = new ConcurrentMetadataCache(calculatedValueContainerFactory);
-        this.foreignIdentifiedComponents = new ConcurrentMetadataCache(calculatedValueContainerFactory);
+        this.originalComponents = calculatedValueContainerFactory.createCache(Describables.of("local metadata"));
+        this.foreignIdentifiedComponents = calculatedValueContainerFactory.createCache(Describables.of("foreign metadata"));
     }
 
     @Override
@@ -88,11 +84,11 @@ public class DefaultBuildTreeLocalComponentProvider implements BuildTreeLocalCom
     }
 
     private LocalComponentGraphResolveState getLocalComponent(ProjectComponentIdentifier projectIdentifier, ProjectState projectState) {
-        return originalComponents.computeIfAbsent(projectIdentifier, () -> localComponentCache.computeIfAbsent(projectState, localComponentProvider::getComponent));
+        return originalComponents.computeIfAbsent(projectIdentifier, id -> localComponentCache.computeIfAbsent(projectState, localComponentProvider::getComponent));
     }
 
     private LocalComponentGraphResolveState getLocalComponentWithForeignId(ProjectComponentIdentifier projectIdentifier) {
-        return foreignIdentifiedComponents.computeIfAbsent(projectIdentifier, () -> copyComponentWithForeignId(projectIdentifier));
+        return foreignIdentifiedComponents.computeIfAbsent(projectIdentifier, this::copyComponentWithForeignId);
     }
 
     /**
@@ -109,15 +105,13 @@ public class DefaultBuildTreeLocalComponentProvider implements BuildTreeLocalCom
         }
 
         // Get the local component, then transform it to have a foreign identifier
-        // This accesses project state.
-        return projectState.fromMutableState(p -> {
-            LocalComponentGraphResolveState originalComponent = getLocalComponent(projectIdentifier, projectState);
-            ProjectComponentIdentifier foreignIdentifier = buildState.idToReferenceProjectFromAnotherBuild(projectIdentifier);
-            return originalComponent.copy(foreignIdentifier, originalArtifact -> {
-                // Currently need to resolve the file, so that the artifact can be used in both a script classpath and the main build. Instead, this should be resolved as required
-                File file = originalArtifact.getFile();
-                return new CompositeProjectComponentArtifactMetadata(foreignIdentifier, originalArtifact, file);
-            });
+        LocalComponentGraphResolveState originalComponent = getLocalComponent(projectIdentifier, projectState);
+        ProjectComponentIdentifier foreignIdentifier = buildState.idToReferenceProjectFromAnotherBuild(projectIdentifier);
+        return originalComponent.copy(foreignIdentifier, originalArtifact -> {
+            // Currently need to resolve the file, so that the artifact can be used in both a script classpath and
+            // the main build. This accesses project state. Instead, the file should be resolved as required.
+            File file = projectState.fromMutableState(p -> originalArtifact.getFile());
+            return new CompositeProjectComponentArtifactMetadata(foreignIdentifier, originalArtifact, file);
         });
     }
 
@@ -125,27 +119,5 @@ public class DefaultBuildTreeLocalComponentProvider implements BuildTreeLocalCom
     public void discardAll() {
         originalComponents.clear();
         foreignIdentifiedComponents.clear();
-    }
-
-    private static class ConcurrentMetadataCache {
-
-        private final CalculatedValueContainerFactory calculatedValueContainerFactory;
-        private final Map<ProjectComponentIdentifier, CalculatedValueContainer<LocalComponentGraphResolveState, ?>> cache = new ConcurrentHashMap<>();
-
-        public ConcurrentMetadataCache(CalculatedValueContainerFactory calculatedValueContainerFactory) {
-            this.calculatedValueContainerFactory = calculatedValueContainerFactory;
-        }
-
-        private LocalComponentGraphResolveState computeIfAbsent(ProjectComponentIdentifier projectIdentifier, Factory<LocalComponentGraphResolveState> factory) {
-            CalculatedValueContainer<LocalComponentGraphResolveState, ?> valueContainer = cache.computeIfAbsent(projectIdentifier, projectComponentIdentifier ->
-                calculatedValueContainerFactory.create(Describables.of("metadata of", projectIdentifier), context -> Objects.requireNonNull(factory.create())));
-            // Calculate the value after adding the entry to the map, so that the value container can take care of thread synchronization
-            valueContainer.finalizeIfNotAlready();
-            return valueContainer.get();
-        }
-
-        public void clear() {
-            cache.clear();
-        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/model/CalculatedValueContainerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/model/CalculatedValueContainerFactory.java
@@ -18,12 +18,16 @@ package org.gradle.internal.model;
 
 import org.gradle.api.internal.tasks.NodeExecutionContext;
 import org.gradle.internal.Cast;
+import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.resources.ProjectLeaseRegistry;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 
@@ -57,6 +61,11 @@ public class CalculatedValueContainerFactory implements CalculatedValueFactory {
         return new CalculatedValueContainer<>(displayName, value);
     }
 
+    @Override
+    public <K, V> CalculatedValueCache<K, V> createCache(DisplayName type) {
+        return new DefaultCalculatedValueCache<>(type, this);
+    }
+
     private static class SupplierBackedCalculator<T> implements ValueCalculator<T> {
         private final Supplier<T> supplier;
 
@@ -67,6 +76,38 @@ public class CalculatedValueContainerFactory implements CalculatedValueFactory {
         @Override
         public T calculateValue(NodeExecutionContext context) {
             return supplier.get();
+        }
+    }
+
+    private static class DefaultCalculatedValueCache<K, V> implements CalculatedValueCache<K, V> {
+
+        private final DisplayName type;
+        private final Map<K, CalculatedValue<V>> cache = new ConcurrentHashMap<>();
+        private final CalculatedValueContainerFactory calculatedValueContainerFactory;
+
+        public DefaultCalculatedValueCache(DisplayName type, CalculatedValueContainerFactory calculatedValueContainerFactory) {
+            this.type = type;
+            this.calculatedValueContainerFactory = calculatedValueContainerFactory;
+        }
+
+        @Override
+        public V computeIfAbsent(K key, Function<K, V> factory) {
+            CalculatedValue<V> value = cache.computeIfAbsent(key, k ->
+                calculatedValueContainerFactory.create(
+                    Describables.of(k, type),
+                    context -> factory.apply(k)
+                )
+            );
+
+            // Calculate the value after adding the entry to the map, so that the value
+            // container can take care of thread synchronization
+            value.finalizeIfNotAlready();
+            return value.get();
+        }
+
+        @Override
+        public void clear() {
+            cache.clear();
         }
     }
 }


### PR DESCRIPTION
Previously, project locks were not acquired in the component graph state when project state was being accessed. This led to some situations where data races could occur.

In many cases, when dependency resolution is properly declared, this does not matter, as walking the task dependency graph is single-threaded, and therefore these caches would be realized without any data races possible. However, when the parallel flag is enabled, for undeclared dependency resolution, or other potential edge cases, it was still possible to get data races when multiple resolutions both access project state simultaneously.

This change makes sure that all project state is wrapped in the proper locks before it is accessed.

This should also clear the way to making task graph calculation multithreaded, as resolving configurations during task dependency graph calculation is currently a major bottleneck of configuration-time.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
