### PR TITLE
Let `GradleLifecycle` callbacks preserve user code application context

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheServices.kt
@@ -31,6 +31,7 @@ import org.gradle.configurationcache.services.RemoteScriptUpToDateChecker
 import org.gradle.execution.ExecutionAccessChecker
 import org.gradle.execution.ExecutionAccessListener
 import org.gradle.internal.buildtree.BuildModelParameters
+import org.gradle.internal.code.UserCodeApplicationContext
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.execution.WorkExecutionTracker
 import org.gradle.internal.nativeintegration.filesystem.FileSystem
@@ -171,6 +172,6 @@ class ConfigurationCacheServices : AbstractPluginServiceRegistry() {
 
     private
     object IsolatedProjectEvaluationListenerProvider {
-        fun createIsolatedProjectEvaluationListenerProvider() = DefaultIsolatedProjectEvaluationListenerProvider()
+        fun createIsolatedProjectEvaluationListenerProvider(userCodeApplicationContext: UserCodeApplicationContext) = DefaultIsolatedProjectEvaluationListenerProvider(userCodeApplicationContext)
     }
 }

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/code/DefaultUserCodeApplicationContext.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/code/DefaultUserCodeApplicationContext.java
@@ -49,6 +49,7 @@ public class DefaultUserCodeApplicationContext implements UserCodeApplicationCon
     @Override
     public void gradleRuntime(Runnable runnable) {
         CurrentApplication current = currentApplication.get();
+        //noinspection ThreadLocalSetWithNull
         currentApplication.set(null);
         try {
             runnable.run();

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleLifecycleIsolationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleLifecycleIsolationIntegrationTest.groovy
@@ -83,28 +83,6 @@ class GradleLifecycleIsolationIntegrationTest extends AbstractIntegrationSpec {
         outputContains "after:settings file 'settings.gradle'"
     }
 
-    def 'lifecycle actions preserve user code application context for Gradle runtime'() {
-        given:
-        settingsFile """
-            ${userCodeApplicationContext}.gradleRuntime {
-                gradle.lifecycle.beforeProject {
-                    println("before:" + $currentApplication)
-                }
-
-                gradle.lifecycle.afterProject {
-                    println("after:" + $currentApplication)
-                }
-            }
-        """
-
-        when:
-        succeeds 'help'
-
-        then:
-        outputContains "before:null"
-        outputContains "after:null"
-    }
-
     def 'lifecycle actions preserve user code application context for plugins'() {
         given:
         groovyFile "build-logic/build.gradle", '''
@@ -136,6 +114,28 @@ class GradleLifecycleIsolationIntegrationTest extends AbstractIntegrationSpec {
         then:
         outputContains "before:plugin 'my-settings-plugin'"
         outputContains "after:plugin 'my-settings-plugin'"
+    }
+
+    def 'lifecycle actions preserve user code application context for Gradle runtime'() {
+        given:
+        settingsFile """
+            ${userCodeApplicationContext}.gradleRuntime {
+                gradle.lifecycle.beforeProject {
+                    println("before:" + $currentApplication)
+                }
+
+                gradle.lifecycle.afterProject {
+                    println("after:" + $currentApplication)
+                }
+            }
+        """
+
+        when:
+        succeeds 'help'
+
+        then:
+        outputContains "before:null"
+        outputContains "after:null"
     }
 
     def getCurrentApplication() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleLifecycleIsolationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleLifecycleIsolationIntegrationTest.groovy
@@ -116,7 +116,7 @@ class GradleLifecycleIsolationIntegrationTest extends AbstractIntegrationSpec {
         outputContains "after:plugin 'my-settings-plugin'"
     }
 
-    def 'lifecycle actions preserve user code application context for Gradle runtime'() {
+    def 'lifecycle actions can be registered in the context of the Gradle runtime'() {
         given:
         settingsFile """
             ${userCodeApplicationContext}.gradleRuntime {

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -631,7 +631,6 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
 
         @Override
         public void beforeProject(IsolatedAction<? super Project> action) {
-            // TODO:isolated how should decoration work for isolated actions? Should we just capture the current UserCodeApplication?
             assertBeforeProjectsLoaded("beforeProject");
             gradle.isolatedProjectEvaluationListenerProvider.beforeProject(action);
         }


### PR DESCRIPTION
### Context

The user code application context is required for proper attribution in reports and build scans.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
