### PR TITLE
Add toolchain detection for Nix package manager

### DIFF
--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/toolchain/DaemonClientToolchainServices.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/toolchain/DaemonClientToolchainServices.java
@@ -33,6 +33,7 @@ import org.gradle.jvm.toolchain.internal.InstallationSupplier;
 import org.gradle.jvm.toolchain.internal.IntellijInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.JabbaInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.JdkCacheDirectory;
+import org.gradle.jvm.toolchain.internal.NixInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.LinuxInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.OsXInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.SdkmanInstallationSupplier;
@@ -58,6 +59,7 @@ public class DaemonClientToolchainServices {
         registration.add(AsdfInstallationSupplier.class);
         registration.add(IntellijInstallationSupplier.class);
         registration.add(JabbaInstallationSupplier.class);
+        registration.add(NixInstallationSupplier.class);
         registration.add(SdkmanInstallationSupplier.class);
 
 //        registration.add(MavenToolchainsInstallationSupplier.class);

--- a/platforms/documentation/docs/src/docs/userguide/jvm/toolchains.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/toolchains.adoc
@@ -186,7 +186,7 @@ The following is a list of common package managers, tools, and locations that ar
 JVM auto-detection knows how to work with:
 
 * Operation-system specific locations: Linux, macOS, Windows
-* Package Managers: https://asdf-vm.com/#/[Asdf-vm], https://github.com/shyiko/jabba[Jabba], https://sdkman.io/[SDKMAN!]
+* Package Managers: https://asdf-vm.com/#/[Asdf-vm], https://github.com/shyiko/jabba[Jabba], https://nixos.org/nix[Nix], https://sdkman.io/[SDKMAN!]
 * https://maven.apache.org/guides/mini/guide-using-toolchains.html[Maven Toolchain] specifications
 * https://www.jetbrains.com/help/idea/sdk.html#jdk-from-ide[IntelliJ IDEA] installations
 

--- a/platforms/jvm/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/NixInstallationSupplier.java
+++ b/platforms/jvm/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/NixInstallationSupplier.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.internal.os.OperatingSystem;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+
+public class NixInstallationSupplier implements InstallationSupplier {
+    private static final Logger LOGGER = Logging.getLogger(NixInstallationSupplier.class);
+
+    private static final String STORE_PATH_PROPERTY_NAME = "org.gradle.java.installations.nix.store";
+    private static final String STORE_PATH_DEFAULT = "/nix/store";
+
+    // Paths will be of the form "{hash}-{suffix}", for example:
+    //
+    //     /nix/store/6375rn8kiq9pn4pgdkdiqgvg8b0gdycy-openjdk-19.0.2+7
+    //
+    // We know the the length of Nix store hashes (32),
+    // and the length of a hyphen (1), and only look at the suffix.
+    private static final int PREFIX_LENGTH = 33;
+
+    private static final Predicate<String> PATTERN = Pattern.compile("jdk", Pattern.CASE_INSENSITIVE).asPredicate();
+
+    private static final FileFilter FILTER = (final File file) -> {
+        final String name = file.getName();
+        if (name.length() < PREFIX_LENGTH) {
+            return false;
+        }
+        return PATTERN.test(name.substring(PREFIX_LENGTH));
+    };
+
+    @VisibleForTesting
+    final File store;
+
+    @Inject
+    public NixInstallationSupplier(ProviderFactory providerFactory) {
+        final OperatingSystem os = OperatingSystem.current();
+
+        // As of 2024-05, Nix is only officially supported on Linux and MacOS.
+        if (!os.isLinux() && !os.isMacOsX()) {
+            LOGGER.trace("Operating system not supported.");
+            store = null;
+            return;
+        }
+
+        File store = null;
+        
+        final Provider<String> storeProvider = providerFactory.gradleProperty(STORE_PATH_PROPERTY_NAME);
+        if (storeProvider.isPresent()) {
+            try {
+                store = new File(storeProvider.get());
+                if (!store.exists()) {
+                    store = null;
+                    LOGGER.warn("Initialization for store path '{}' failed. Path does not exist. Falling back to default '{}'.", store, STORE_PATH_DEFAULT);
+                }
+            } catch (Exception e) {
+                store = null;
+                final String message = "Initialization for store path '{}' failed. Falling back to default '{}'.";
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(message, store, STORE_PATH_DEFAULT, e);
+                } else {
+                    LOGGER.warn(message, store, STORE_PATH_DEFAULT);
+                }
+            }
+            if (store != null) {
+                this.store = store;
+                return;
+            }
+        }
+
+        try {
+            store = new File(STORE_PATH_DEFAULT);
+            if (!store.exists()) {
+                store = null;
+                LOGGER.debug("Initialization for default store path '{}' failed. Path does not exist.", STORE_PATH_DEFAULT);
+            }
+        } catch (Exception e) {
+            LOGGER.debug("Initialization for default store path '{}' failed.", STORE_PATH_DEFAULT, e);
+        }
+
+        this.store = store;
+    }
+
+    @Override
+    public Set<InstallationLocation> get() {
+        if (store == null) {
+            LOGGER.trace("Nothing to do since `store` is `null`.");
+            return Collections.emptySet();
+        }
+
+        final File[] list = store.listFiles(FILTER);
+        if (list == null) {
+            LOGGER.debug("Listing files within store path '{}' failed.");
+            return Collections.emptySet();
+        }
+
+        final HashSet<InstallationLocation> locations = new HashSet<InstallationLocation>(list.length);
+        for (final File file : list) {
+            locations.add(InstallationLocation.autoDetected(file, getSourceName()));
+        }
+        return locations;
+    }
+
+    @Override
+    public String getSourceName() {
+        return "Nix";
+    }
+
+    @VisibleForTesting
+    NixInstallationSupplier(File store) {
+        this.store = store;
+    }
+}

--- a/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/internal/services/ToolchainsJvmServices.java
+++ b/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/internal/services/ToolchainsJvmServices.java
@@ -47,6 +47,7 @@ import org.gradle.jvm.toolchain.internal.JabbaInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.JavaToolchainQueryService;
 import org.gradle.jvm.toolchain.internal.JdkCacheDirectory;
 import org.gradle.jvm.toolchain.internal.LinuxInstallationSupplier;
+import org.gradle.jvm.toolchain.internal.NixInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.MavenToolchainsInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.OsXInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.SdkmanInstallationSupplier;
@@ -95,6 +96,7 @@ public class ToolchainsJvmServices extends AbstractPluginServiceRegistry {
             registration.add(IntellijInstallationSupplier.class);
             registration.add(JabbaInstallationSupplier.class);
             registration.add(SdkmanInstallationSupplier.class);
+            registration.add(NixInstallationSupplier.class);
             registration.add(MavenToolchainsInstallationSupplier.class);
 
             registration.add(LinuxInstallationSupplier.class);


### PR DESCRIPTION
Related to #16645.

### Context
This change adds detection for JDKs installed via the [Nix](https://nixos.org/learn/) package manager (the Nix package repository contains numerous, see [stable](https://search.nixos.org/packages?query=jdk) and [unstable](https://search.nixos.org/packages?channel=unstable&query=jdk) channels).

I've been thinking about implementing this at least since 2021-03-25, and recently there was [another request for more liberal detection of JDKs in the Nix forums](https://discourse.nixos.org/t/auto-detecting-java-installations/4677/10) by @kravemir. Some downsides of this addition were mentioned by @raboof in https://github.com/gradle/gradle/issues/16645#issuecomment-808098771.

### Status of this PR

I haven't implemented any tests and also have not changed any documentation yet. This is because I would like to get some feedback by Gradle maintainers because I spend more. In case I get positive feedback on the core changes (which are there already) I will add tests and documentation. I might need help to set up integration tests for this change.

### Contributor Checklist
- [x] [Reviewed Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] All commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that I agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), and was written by myself.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.
