### PR TITLE
Use ge.gradle.org as TD backend

### DIFF
--- a/.teamcity/src/main/kotlin/projects/CheckProject.kt
+++ b/.teamcity/src/main/kotlin/projects/CheckProject.kt
@@ -29,7 +29,7 @@ class CheckProject(
         param("teamcity.ui.settings.readOnly", "true")
         // Avoid rebuilding same revision if it's already built on another branch
         param("teamcity.vcsTrigger.runBuildOnSameRevisionInEveryBranch", "false")
-        param("env.GRADLE_ENTERPRISE_ACCESS_KEY", "%ge.gradle.org.access.key%;%ge-td-dogfooding.grdev.net.access.key%")
+        param("env.GRADLE_ENTERPRISE_ACCESS_KEY", "%ge.gradle.org.access.key%")
 
         text(
             "additional.gradle.parameters",

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -281,7 +281,7 @@ fun configureTests() {
         distribution {
             this as TestDistributionExtensionInternal
             // Dogfooding TD against ge-td-dogfooding in order to test new features and benefit from bug fixes before they are released
-            server.set(uri("https://ge-td-dogfooding.grdev.net"))
+            server.set(uri("https://ge.gradle.org"))
         }
 
         if (project.testDistributionEnabled && !isUnitTest() && !isPerformanceProject()) {


### PR DESCRIPTION
This cherry-picks https://github.com/gradle/gradle/pull/29090 to `release7x` branch.