### PR TITLE
Revert org.gradle.native behaviour

### DIFF
--- a/platforms/core-execution/worker-processes/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
+++ b/platforms/core-execution/worker-processes/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
@@ -26,6 +26,7 @@ import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
 import org.gradle.internal.nativeintegration.services.NativeServices;
+import org.gradle.internal.nativeintegration.services.NativeServices.NativeServicesMode;
 import org.gradle.internal.remote.MessagingClient;
 import org.gradle.internal.remote.ObjectConnection;
 import org.gradle.internal.remote.services.MessagingServices;
@@ -83,9 +84,14 @@ public class SystemApplicationClassLoaderWorker implements Callable<Void> {
         LoggingServiceRegistry loggingServiceRegistry = LoggingServiceRegistry.newEmbeddableLogging();
         LoggingManagerInternal loggingManager = createLoggingManager(loggingServiceRegistry).setLevelInternal(config.getLogLevel());
 
+        // When not explicitly set, use the value from system properties
+        NativeServicesMode nativeServicesMode = config.getNativeServicesMode() == NativeServicesMode.NOT_SET
+            ? NativeServicesMode.fromSystemProperties()
+            : config.getNativeServicesMode();
+
         // Configure services
         File gradleUserHomeDir = new File(config.getGradleUserHomeDirPath());
-        NativeServices.initializeOnWorker(gradleUserHomeDir, config.getNativeServicesMode());
+        NativeServices.initializeOnWorker(gradleUserHomeDir, nativeServicesMode);
         DefaultServiceRegistry basicWorkerServices = new DefaultServiceRegistry(NativeServices.getInstance(), loggingServiceRegistry);
         basicWorkerServices.add(ExecutorFactory.class, new DefaultExecutorFactory());
         basicWorkerServices.addProvider(new MessagingServices());

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/NativeServicesInitializingAction.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/NativeServicesInitializingAction.java
@@ -50,7 +50,7 @@ public class NativeServicesInitializingAction implements Action<ExecutionListene
 
     @Override
     public void execute(ExecutionListener executionListener) {
-        NativeServices.initializeOnClient(buildLayout.getGradleUserHomeDir(), NativeServicesMode.fromProperties(allProperties));
+        NativeServices.initializeOnClient(buildLayout.getGradleUserHomeDir(), NativeServicesMode.fromSystemProperties());
         loggingManager.attachProcessConsole(loggingConfiguration.getConsoleOutput());
         action.execute(executionListener);
     }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonMain.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonMain.java
@@ -108,7 +108,7 @@ public class DaemonMain extends EntryPoint {
             throw new UncheckedIOException(e);
         }
 
-        NativeServices.initializeOnDaemon(gradleHomeDir, nativeServicesMode);
+        NativeServices.initializeOnDaemon(gradleHomeDir, NativeServicesMode.fromSystemProperties());
         DaemonServerConfiguration parameters = new DefaultDaemonServerConfiguration(daemonUid, daemonBaseDir, idleTimeoutMs, periodicCheckIntervalMs, singleUse, priority, startupOpts, nativeServicesMode);
         LoggingServiceRegistry loggingRegistry = LoggingServiceRegistry.newCommandLineProcessLogging();
         LoggingManagerInternal loggingManager = loggingRegistry.newInstance(LoggingManagerInternal.class);

--- a/subprojects/core/src/integTest/groovy/org/gradle/NativeServicesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/NativeServicesIntegrationTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.internal.nativeintegration.jansi.JansiStorageLocator
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
+import org.gradle.util.internal.ToBeImplemented
 import org.junit.Rule
 import spock.lang.Issue
 
@@ -55,9 +56,10 @@ class NativeServicesIntegrationTest extends AbstractIntegrationSpec {
         nativeDir.directory
     }
 
+    @ToBeImplemented("https://github.com/gradle/gradle/issues/28203")
     def "native services are #description with systemProperties == #systemProperties"() {
         given:
-        executer.requireOwnGradleUserHomeDir().withNoExplicitNativeServicesDir()
+        executer.requireOwnGradleUserHomeDir("To not reuse native services").withNoExplicitNativeServicesDir()
         nativeDir = new File(executer.gradleUserHomeDir, 'native')
         executer.withArguments(systemProperties.collect { it.toString() })
         buildFile << """
@@ -87,13 +89,15 @@ class NativeServicesIntegrationTest extends AbstractIntegrationSpec {
         nativeDir.exists() == initialized
 
         where:
+        // Works for all cases except -D$NATIVE_SERVICES_OPTION=false
         description       | systemProperties                    | initialized
         "initialized"     | ["-D$NATIVE_SERVICES_OPTION=true"]  | true
-        "not initialized" | ["-D$NATIVE_SERVICES_OPTION=false"] | false
+        "not initialized" | ["-D$NATIVE_SERVICES_OPTION=false"] | true // Should be false
         "initialized"     | ["-D$NATIVE_SERVICES_OPTION=''"]    | true
         "initialized"     | []                                  | true
     }
 
+    @ToBeImplemented("https://github.com/gradle/gradle/issues/28203")
     def "native services flag should be passed to the daemon and to the worker"() {
         given:
         executer.withArguments(systemProperties.collect { it.toString() })
@@ -130,9 +134,10 @@ class NativeServicesIntegrationTest extends AbstractIntegrationSpec {
         outputContains("Uses native integration in worker: $usesNativeIntegration")
 
         where:
+        // Works for all cases except -D$NATIVE_SERVICES_OPTION=false
         systemProperties                    | usesNativeIntegration
         ["-D$NATIVE_SERVICES_OPTION=true"]  | true
-        ["-D$NATIVE_SERVICES_OPTION=false"] | false
+        ["-D$NATIVE_SERVICES_OPTION=false"] | true // Should be false
         ["-D$NATIVE_SERVICES_OPTION=''"]    | true
         []                                  | true
     }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/ApplicationClassesInSystemClassLoaderWorkerImplementationFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/ApplicationClassesInSystemClassLoaderWorkerImplementationFactory.java
@@ -22,8 +22,6 @@ import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.file.temp.TemporaryFileProvider;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.internal.io.StreamByteBuffer;
-import org.gradle.internal.nativeintegration.services.NativeServices;
-import org.gradle.internal.nativeintegration.services.NativeServices.NativeServicesMode;
 import org.gradle.internal.process.ArgWriter;
 import org.gradle.internal.remote.Address;
 import org.gradle.internal.remote.internal.inet.MultiChoiceAddress;
@@ -150,10 +148,6 @@ public class ApplicationClassesInSystemClassLoaderWorkerImplementationFactory {
                 }
             }
 
-            // When not explicitly set, use the value from the daemon process
-            NativeServicesMode nativeServicesMode = processBuilder.getNativeServicesMode() == NativeServicesMode.NOT_SET
-                ? NativeServicesMode.from(NativeServices.getInstance().createNativeCapabilities().useNativeIntegrations())
-                : processBuilder.getNativeServicesMode();
             WorkerConfig config = new WorkerConfig(
                 logLevel,
                 publishProcessInfo,
@@ -162,7 +156,7 @@ public class ApplicationClassesInSystemClassLoaderWorkerImplementationFactory {
                 workerId,
                 displayName,
                 processBuilder.getWorker(),
-                nativeServicesMode
+                processBuilder.getNativeServicesMode()
             );
 
             // Serialize the worker config, this is consumed by SystemApplicationClassLoaderWorker


### PR DESCRIPTION
Since there are problems with testing Gradle with TestKit, because Gradle <= 8.7 sets `org.gradle.native=false` to a test process.

I left all the wiring, i.e. passing org.gradle.native flag between processes, in the code if we will fix the behaviour in the future (Gradle 9?).

Fixes #29000
Reverts #28203
