### PR TITLE
Fix typo in project_properties.adoc

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/project_properties.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/project_properties.adoc
@@ -30,7 +30,7 @@ $ gradle -PgradlePropertiesProp=commandLineValue
 Gradle can also set project properties when it sees specially-named system properties or environment variables.
 If the environment variable name looks like `ORG_GRADLE_PROJECT___prop__=somevalue`, then Gradle will set a `prop` property on your project object, with the value of `somevalue`.
 Gradle also supports this for system properties, but with a different naming pattern, which looks like `org.gradle.project.__prop__`.
-Both of the following will set the `foo' property on your Project object to `"bar"`.
+Both of the following will set the `foo` property on your Project object to `"bar"`.
 
 *Example 2:* Setting a project property via a *system property*:
 ====


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

In this page: https://docs.gradle.org/current/userguide/project_properties.html there is a typo that throws formatting off:
![image](https://github.com/gradle/gradle/assets/8446128/60488fe9-98ea-407a-a5e6-ff2ea2b160a0)


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
