### PR TITLE
Fix MacOSSdkPlatformPathLocator's flag to find sdk platform path

### DIFF
--- a/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/xcode/MacOSSdkPlatformPathLocator.java
+++ b/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/xcode/MacOSSdkPlatformPathLocator.java
@@ -30,6 +30,6 @@ public class MacOSSdkPlatformPathLocator extends AbstractLocator {
 
     @Override
     protected List<String> getXcrunFlags() {
-        return ImmutableList.of("--show-sdk-platform-path");
+        return ImmutableList.of("--show-sdk-path");
     }
 }


### PR DESCRIPTION
There has been a change in XCrun and running `xcrun --show-sdk-platform-path` now fails. I'm not sure when it started. I found another project with similar observations at https://github.com/rust-lang/cc-rs/issues/1001

It's failing on CI as well and our PRs just go red because of it like https://github.com/square/wire/actions/runs/9160562085/job/25183490538?pr=2952

```
~/workspace/wire on master*
$ xcrun --show-sdk-platform-path
2024-05-20 17:06:21.697 xcodebuild[74850:2022059] Writing error result bundle to /var/folders/v5/_408d47s3sqf9__x4y6v2p_40000gn/T/ResultBundle_2024-20-05_17-06-0021.xcresult
^[[Axcodebuild: error: SDK "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk" cannot be located.
xcrun: error: unable to lookup item 'PlatformPath' in SDK '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk'

~/workspace/wire on master*
$ xcrun --show-sdk-path
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
```

That'd be great to fix it.