### PR TITLE
Fix improper system prop instead of project prop use in docs

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/build_environment.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/build_environment.adoc
@@ -425,7 +425,7 @@ include::sample[dir="snippets/tutorial/gradleProperties/groovy",files="build.gra
 *Example 4:* Setting Gradle properties from the command line:
 ====
 ----
-$ gradle -DgradlePropertiesProp=commandLineValue
+$ gradle -PgradlePropertiesProp=commandLineValue
 ----
 ====
 


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/18087.

### Context
I was interested in `providers.gradleProperty` and got sidetracked. Apparently this one letter caused much confusion so here's a quick fix.

EDIT: I shan't wear this PR as a `contributed to open source` badge. 

EDIT 2: This should be followed up by a PR that moves the examples from **Gradle properties** section to **Project properties** section, with adjustments, because that's what they are about.

### Contributor Checklist
Check.