### PR TITLE
Add Daemon toolchain TAPI cross version tests

### DIFF
--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
@@ -60,7 +60,9 @@ import org.gradle.launcher.exec.BuildActionParameters;
 import org.gradle.launcher.exec.BuildActionResult;
 import org.gradle.process.internal.streams.SafeStreams;
 import org.gradle.tooling.events.OperationType;
+import org.gradle.tooling.internal.build.DefaultBuildEnvironment;
 import org.gradle.tooling.internal.consumer.parameters.FailsafeBuildProgressListenerAdapter;
+import org.gradle.tooling.internal.gradle.DefaultBuildIdentifier;
 import org.gradle.tooling.internal.protocol.BuildExceptionVersion1;
 import org.gradle.tooling.internal.protocol.InternalBuildActionFailureException;
 import org.gradle.tooling.internal.protocol.InternalBuildActionVersion2;
@@ -81,6 +83,7 @@ import org.gradle.tooling.internal.provider.connection.ProviderOperationParamete
 import org.gradle.tooling.internal.provider.serialization.PayloadSerializer;
 import org.gradle.tooling.internal.provider.serialization.SerializedPayload;
 import org.gradle.tooling.internal.provider.test.ProviderInternalTestExecutionRequest;
+import org.gradle.tooling.model.build.BuildEnvironment;
 import org.gradle.util.GradleVersion;
 import org.gradle.util.internal.GUtil;
 import org.slf4j.Logger;
@@ -149,10 +152,38 @@ public class ProviderConnection {
             throw new IllegalArgumentException("No model type or tasks specified.");
         }
         Parameters params = initParams(providerParameters);
+        if (BuildEnvironment.class.getName().equals(modelName)) {
+            //we don't really need to launch the daemon to acquire information needed for BuildEnvironment
+            if (tasks != null) {
+                throw new IllegalArgumentException("Cannot run tasks and fetch the build environment model.");
+            }
+            return new DefaultBuildEnvironment(
+                new DefaultBuildIdentifier(providerParameters.getProjectDir()),
+                params.buildLayout.getGradleUserHomeDir(),
+                GradleVersion.current().getVersion(),
+                reportableJavaHomeForBuild(params),
+                params.daemonParams.getEffectiveJvmArgs());
+        }
+
         StartParameterInternal startParameter = new ProviderStartParameterConverter().toStartParameter(providerParameters, params.buildLayout, params.properties);
         ProgressListenerConfiguration listenerConfig = ProgressListenerConfiguration.from(providerParameters, consumerVersion, payloadSerializer);
         BuildAction action = new BuildModelAction(startParameter, modelName, tasks != null, listenerConfig.clientSubscriptions);
         return run(action, cancellationToken, listenerConfig, listenerConfig.buildEventConsumer, providerParameters, params);
+    }
+
+    private static File reportableJavaHomeForBuild(Parameters params) {
+        DaemonParameters daemonParameters = params.daemonParams;
+        // Gradle daemon properties have been defined
+        if (daemonParameters.getRequestedJvmCriteria() != null) {
+            // TODO: We don't know what this will be without searching.
+            // We'll say it's the current JVM because we don't know any better for now.
+            return Jvm.current().getJavaHome();
+        } else if (daemonParameters.getRequestedJvmBasedOnJavaHome() != null) {
+            // Either the TAPI client or org.gradle.java.home has been provided
+            return daemonParameters.getRequestedJvmBasedOnJavaHome().getJavaHome();
+        } else {
+            return Jvm.current().getJavaHome();
+        }
     }
 
     @SuppressWarnings({"deprecation", "overloads"})

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
@@ -60,9 +60,7 @@ import org.gradle.launcher.exec.BuildActionParameters;
 import org.gradle.launcher.exec.BuildActionResult;
 import org.gradle.process.internal.streams.SafeStreams;
 import org.gradle.tooling.events.OperationType;
-import org.gradle.tooling.internal.build.DefaultBuildEnvironment;
 import org.gradle.tooling.internal.consumer.parameters.FailsafeBuildProgressListenerAdapter;
-import org.gradle.tooling.internal.gradle.DefaultBuildIdentifier;
 import org.gradle.tooling.internal.protocol.BuildExceptionVersion1;
 import org.gradle.tooling.internal.protocol.InternalBuildActionFailureException;
 import org.gradle.tooling.internal.protocol.InternalBuildActionVersion2;
@@ -83,7 +81,6 @@ import org.gradle.tooling.internal.provider.connection.ProviderOperationParamete
 import org.gradle.tooling.internal.provider.serialization.PayloadSerializer;
 import org.gradle.tooling.internal.provider.serialization.SerializedPayload;
 import org.gradle.tooling.internal.provider.test.ProviderInternalTestExecutionRequest;
-import org.gradle.tooling.model.build.BuildEnvironment;
 import org.gradle.util.GradleVersion;
 import org.gradle.util.internal.GUtil;
 import org.slf4j.Logger;
@@ -152,38 +149,10 @@ public class ProviderConnection {
             throw new IllegalArgumentException("No model type or tasks specified.");
         }
         Parameters params = initParams(providerParameters);
-        if (BuildEnvironment.class.getName().equals(modelName)) {
-            //we don't really need to launch the daemon to acquire information needed for BuildEnvironment
-            if (tasks != null) {
-                throw new IllegalArgumentException("Cannot run tasks and fetch the build environment model.");
-            }
-            return new DefaultBuildEnvironment(
-                new DefaultBuildIdentifier(providerParameters.getProjectDir()),
-                params.buildLayout.getGradleUserHomeDir(),
-                GradleVersion.current().getVersion(),
-                reportableJavaHomeForBuild(params),
-                params.daemonParams.getEffectiveJvmArgs());
-        }
-
         StartParameterInternal startParameter = new ProviderStartParameterConverter().toStartParameter(providerParameters, params.buildLayout, params.properties);
         ProgressListenerConfiguration listenerConfig = ProgressListenerConfiguration.from(providerParameters, consumerVersion, payloadSerializer);
         BuildAction action = new BuildModelAction(startParameter, modelName, tasks != null, listenerConfig.clientSubscriptions);
         return run(action, cancellationToken, listenerConfig, listenerConfig.buildEventConsumer, providerParameters, params);
-    }
-
-    private static File reportableJavaHomeForBuild(Parameters params) {
-        DaemonParameters daemonParameters = params.daemonParams;
-        // Gradle daemon properties have been defined
-        if (daemonParameters.getRequestedJvmCriteria() != null) {
-            // TODO: We don't know what this will be without searching.
-            // We'll say it's the current JVM because we don't know any better for now.
-            return Jvm.current().getJavaHome();
-        } else if (daemonParameters.getRequestedJvmBasedOnJavaHome() != null) {
-            // Either the TAPI client or org.gradle.java.home has been provided
-            return daemonParameters.getRequestedJvmBasedOnJavaHome().getJavaHome();
-        } else {
-            return Jvm.current().getJavaHome();
-        }
     }
 
     @SuppressWarnings({"deprecation", "overloads"})

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/DaemonToolchainCoexistWithCurrentOptionsCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/DaemonToolchainCoexistWithCurrentOptionsCrossVersionTest.groovy
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r88
+
+import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.tooling.fixture.DaemonJvmPropertiesFixture
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.IntegTestPreconditions
+
+@TargetGradleVersion(">=8.8")
+class DaemonToolchainCoexistWithCurrentOptionsCrossVersionTest extends ToolingApiSpecification implements DaemonJvmPropertiesFixture {
+
+    @Requires(IntegTestPreconditions.JavaHomeWithDifferentVersionAvailable)
+    def "Given disabled auto-detection When using daemon toolchain Then option is ignored resolving with expected toolchain"() {
+        given:
+        def otherJvm = AvailableJavaHomes.differentVersion
+        writeJvmCriteria(otherJvm.javaVersion.majorVersion)
+        captureJavaHome()
+
+        when:
+        withConnection {
+            it.newBuild().forTasks("help").withArguments("-Porg.gradle.java.installations.auto-detect=false").run()
+        }
+
+        then:
+        assertDaemonUsedJvm(otherJvm.javaHome)
+    }
+
+    @Requires(IntegTestPreconditions.JavaHomeWithDifferentVersionAvailable)
+    def "Given defined org.gradle.java.home gradle property When using daemon toolchain Then option is ignored resolving with expected toolchain"() {
+        given:
+        def otherJvm = AvailableJavaHomes.differentVersion
+        writeJvmCriteria(otherJvm.javaVersion.majorVersion)
+        captureJavaHome()
+        file("gradle.properties").writeProperties("org.gradle.java.home": AvailableJavaHomes.jdk8.javaHome.canonicalPath)
+
+        when:
+        withConnection {
+            it.newBuild().forTasks("help").run()
+        }
+
+        then:
+        assertDaemonUsedJvm(otherJvm.javaHome)
+    }
+
+    @Requires(IntegTestPreconditions.JavaHomeWithDifferentVersionAvailable)
+    def "Given daemon toolchain properties When executing any task passing them as arguments Then those are ignored since aren't defined on daemon-jvm properties file"() {
+        given:
+        def otherJvm = AvailableJavaHomes.differentVersion
+        def otherJvmMetadata = AvailableJavaHomes.getJvmInstallationMetadata(otherJvm)
+        captureJavaHome()
+
+
+        when:
+        withConnection {
+            it.newBuild().forTasks("help").withArguments("-PtoolchainVersion=$otherJvmMetadata.javaVersion -PtoolchainVendor=$otherJvmMetadata.vendor.knownVendor").run()
+        }
+
+        then:
+        assertDaemonUsedJvm(currentJavaHome)
+    }
+
+    @Requires(IntegTestPreconditions.JavaHomeWithDifferentVersionAvailable)
+    def "Given daemon toolchain properties defined on gradle properties When executing any task Then those are ignored since aren't defined on daemon-jvm properties file"() {
+        given:
+        def otherJvm = AvailableJavaHomes.differentVersion
+        def otherJvmMetadata = AvailableJavaHomes.getJvmInstallationMetadata(otherJvm)
+        captureJavaHome()
+        file("gradle.properties")
+            .writeProperties(
+                "toolchainVersion": otherJvmMetadata.javaVersion,
+                "toolchainVendor": otherJvmMetadata.vendor.knownVendor.name()
+            )
+
+        when:
+        withConnection {
+            it.newBuild().forTasks("help").run()
+        }
+
+        then:
+        assertDaemonUsedJvm(currentJavaHome)
+    }
+
+    @Requires(IntegTestPreconditions.JavaHomeWithDifferentVersionAvailable)
+    def "Given defined org.gradle.java.home under Build properties When executing any task Then this is ignored since isn't defined on gradle properties file"() {
+        given:
+        def otherJvm = AvailableJavaHomes.differentVersion
+        def otherJvmMetadata = AvailableJavaHomes.getJvmInstallationMetadata(otherJvm)
+        captureJavaHome()
+
+        file("gradle/gradle-daemon-jvm.properties")
+            .writeProperties(
+                "org.gradle.java.home": otherJvmMetadata.javaVersion,
+            )
+
+        when:
+        withConnection {
+            it.newBuild().forTasks("help").run()
+        }
+
+        then:
+        assertDaemonUsedJvm(currentJavaHome)
+    }
+}

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/DaemonToolchainCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/DaemonToolchainCrossVersionTest.groovy
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r88
+
+import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.tooling.fixture.DaemonJvmPropertiesFixture
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.IntegTestPreconditions
+import org.gradle.tooling.GradleConnectionException
+import org.gradle.tooling.model.build.BuildEnvironment
+import org.junit.Assume
+
+@TargetGradleVersion(">=8.8")
+class DaemonToolchainCrossVersionTest extends ToolingApiSpecification implements DaemonJvmPropertiesFixture {
+
+    @Requires(IntegTestPreconditions.Java8HomeAvailable)
+    def "Given daemon toolchain version When executing any task Then daemon jvm was set up with expected configuration"() {
+        given:
+        def jdk8 = AvailableJavaHomes.jdk8
+        writeJvmCriteria(jdk8.javaVersion.majorVersion)
+        captureJavaHome()
+
+        when:
+        withConnection {
+            it.newBuild().forTasks("help").run()
+        }
+
+        then:
+        assertDaemonUsedJvm(jdk8.javaHome)
+    }
+
+    @Requires(IntegTestPreconditions.JavaHomeWithDifferentVersionAvailable)
+    def "Given other daemon toolchain version When executing any task Then daemon jvm was set up with expected configuration"() {
+        given:
+        def otherJvm = AvailableJavaHomes.differentVersion
+        writeJvmCriteria(otherJvm.javaVersion.majorVersion)
+        captureJavaHome()
+
+        when:
+        withConnection {
+            it.newBuild().forTasks("help").run()
+        }
+
+        then:
+        assertDaemonUsedJvm(otherJvm.javaHome)
+    }
+
+    def "Given daemon toolchain criteria that doesn't match installed ones When executing any task Then fails with the expected message"() {
+        given:
+        // Java 10 is not available
+        def java10 = AvailableJavaHomes.getAvailableJdks { it.javaVersion == "10" }
+        Assume.assumeTrue(java10.isEmpty())
+        writeJvmCriteria("10")
+        captureJavaHome()
+
+        when:
+        withConnection {
+            it.newBuild().forTasks("help").run()
+        }
+
+        then:
+        def e= thrown(GradleConnectionException)
+        e.cause.message.contains("Cannot find a Java installation on your machine")
+    }
+
+    @Requires(IntegTestPreconditions.Java8HomeAvailable)
+    def "Given daemon toolchain criteria When obtaining build information Then build environment java home matches with expected one"() {
+        given:
+        def jdk8 = AvailableJavaHomes.jdk8
+        writeJvmCriteria(jdk8.javaVersion.majorVersion)
+        captureJavaHome()
+
+        when:
+        BuildEnvironment env = withConnection {
+            it.getModel(BuildEnvironment.class)
+        }
+
+        then:
+        env.java.javaHome == jdk8.javaHome
+    }
+}

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/DaemonToolchainCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/DaemonToolchainCrossVersionTest.groovy
@@ -23,7 +23,6 @@ import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
 import org.gradle.tooling.GradleConnectionException
-import org.gradle.tooling.model.build.BuildEnvironment
 import org.junit.Assume
 
 @TargetGradleVersion(">=8.8")
@@ -77,21 +76,5 @@ class DaemonToolchainCrossVersionTest extends ToolingApiSpecification implements
         then:
         def e= thrown(GradleConnectionException)
         e.cause.message.contains("Cannot find a Java installation on your machine")
-    }
-
-    @Requires(IntegTestPreconditions.Java8HomeAvailable)
-    def "Given daemon toolchain criteria When obtaining build information Then build environment java home matches with expected one"() {
-        given:
-        def jdk8 = AvailableJavaHomes.jdk8
-        writeJvmCriteria(jdk8.javaVersion.majorVersion)
-        captureJavaHome()
-
-        when:
-        BuildEnvironment env = withConnection {
-            it.getModel(BuildEnvironment.class)
-        }
-
-        then:
-        env.java.javaHome == jdk8.javaHome
     }
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/DaemonToolchainCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/DaemonToolchainCrossVersionTest.groovy
@@ -23,7 +23,6 @@ import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
 import org.gradle.tooling.GradleConnectionException
-import org.junit.Assume
 
 @TargetGradleVersion(">=8.8")
 class DaemonToolchainCrossVersionTest extends ToolingApiSpecification implements DaemonJvmPropertiesFixture {
@@ -34,6 +33,7 @@ class DaemonToolchainCrossVersionTest extends ToolingApiSpecification implements
         def jdk8 = AvailableJavaHomes.jdk8
         writeJvmCriteria(jdk8.javaVersion.majorVersion)
         captureJavaHome()
+        withInstallations(jdk8.javaHome)
 
         when:
         withConnection {
@@ -50,6 +50,7 @@ class DaemonToolchainCrossVersionTest extends ToolingApiSpecification implements
         def otherJvm = AvailableJavaHomes.differentVersion
         writeJvmCriteria(otherJvm.javaVersion.majorVersion)
         captureJavaHome()
+        withInstallations(otherJvm.javaHome)
 
         when:
         withConnection {
@@ -60,13 +61,14 @@ class DaemonToolchainCrossVersionTest extends ToolingApiSpecification implements
         assertDaemonUsedJvm(otherJvm.javaHome)
     }
 
+    @Requires(IntegTestPreconditions.Java11HomeAvailable)
     def "Given daemon toolchain criteria that doesn't match installed ones When executing any task Then fails with the expected message"() {
         given:
+        def jdk11 = AvailableJavaHomes.getJdk11()
         // Java 10 is not available
-        def java10 = AvailableJavaHomes.getAvailableJdks { it.javaVersion == "10" }
-        Assume.assumeTrue(java10.isEmpty())
         writeJvmCriteria("10")
         captureJavaHome()
+        withInstallations(jdk11.javaHome)
 
         when:
         withConnection {

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/DaemonToolchainCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/DaemonToolchainCrossVersionTest.groovy
@@ -24,7 +24,8 @@ import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
 import org.gradle.tooling.GradleConnectionException
 
-@TargetGradleVersion(">=8.8")
+// 8.8 did not support configuring the set of available Java homes or disabling auto-detection
+@TargetGradleVersion(">=8.9")
 class DaemonToolchainCrossVersionTest extends ToolingApiSpecification implements DaemonJvmPropertiesFixture {
 
     @Requires(IntegTestPreconditions.Java8HomeAvailable)

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/DaemonToolchainInvalidCriteriaCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/DaemonToolchainInvalidCriteriaCrossVersionTest.groovy
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r88
+
+import groovy.test.NotYetImplemented
+import org.gradle.integtests.tooling.fixture.DaemonJvmPropertiesFixture
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.tooling.GradleConnectionException
+
+@TargetGradleVersion(">=8.8")
+class DaemonToolchainInvalidCriteriaCrossVersionTest extends ToolingApiSpecification implements DaemonJvmPropertiesFixture {
+
+    def "Given empty daemon-jvm properties file When execute any task Then succeeds using the current java home"() {
+        given:
+        buildPropertiesFile.touch()
+        captureJavaHome()
+
+        when:
+        withConnection {
+            it.newBuild().forTasks("help").run()
+        }
+
+        then:
+        assertDaemonUsedJvm(currentJavaHome)
+    }
+
+    def "Given non-integer toolchain version When execute any task Then fails with expected exception message"() {
+        given:
+        writeJvmCriteria("stringVersion")
+
+        when:
+        withConnection {
+            it.newBuild().forTasks("help").run()
+        }
+
+        then:
+        def e= thrown(GradleConnectionException)
+        e.cause.message.contains("Value 'stringVersion' given for toolchainVersion is an invalid Java version")
+    }
+
+    def "Given negative toolchain version When execute any task Then fails with expected exception message"() {
+        given:
+        writeJvmCriteria("-1")
+
+        when:
+        withConnection {
+            it.newBuild().forTasks("help").run()
+        }
+
+        then:
+        def e= thrown(GradleConnectionException)
+        e.cause.message.contains("Value '-1' given for toolchainVersion is an invalid Java version")
+    }
+
+    @NotYetImplemented
+    def "Given unexpected toolchain vendor When execute any task Then fails with expected exception message"() {
+        given:
+        writeJvmCriteria("17", "unexpectedVendor")
+
+        when:
+        withConnection {
+            it.newBuild().forTasks("help").run()
+        }
+
+        then:
+        def e= thrown(GradleConnectionException)
+        e.cause.message.contains("Option toolchainVendor doesn't accept value 'unexpectedVendor'. Possible values are " +
+            "[ADOPTIUM, ADOPTOPENJDK, AMAZON, APPLE, AZUL, BELLSOFT, GRAAL_VM, HEWLETT_PACKARD, IBM, JETBRAINS, MICROSOFT, ORACLE, SAP, TENCENT, UNKNOWN]")
+    }
+
+    @NotYetImplemented
+    def "Given unexpected toolchain implementation When execute any task Then fails with expected exception message"() {
+        given:
+        writeJvmCriteria("17", "amazon", "unknownImplementation")
+
+        when:
+        withConnection {
+            it.newBuild().forTasks("help").run()
+        }
+
+        then:
+        def e= thrown(GradleConnectionException)
+        e.cause.message.contains("Option toolchainImplementation doesn't accept value 'unknownImplementation'. Possible values are [VENDOR_SPECIFIC, J9]")
+    }
+}

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/DaemonJvmPropertiesFixture.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/DaemonJvmPropertiesFixture.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.fixture
+
+import groovy.transform.SelfType
+import org.gradle.test.fixtures.file.TestFile
+
+@SelfType(ToolingApiSpecification)
+trait DaemonJvmPropertiesFixture {
+
+    def currentJavaHome = new File(System.getProperty("java.home")).canonicalFile
+
+    def setup() {
+        requireDaemons()
+    }
+
+    void assertDaemonUsedJvm(File expectedJavaHome) {
+        assert file("javaHome.txt").text == expectedJavaHome.canonicalPath
+    }
+
+    void captureJavaHome() {
+        buildFile << """
+            def javaHome = org.gradle.internal.jvm.Jvm.current().javaHome.canonicalPath
+            println javaHome
+            file("javaHome.txt").text = javaHome
+        """
+    }
+
+    void assertJvmCriteria(String version) {
+        Map<String, String> properties = buildPropertiesFile.properties
+        assert properties.get("toolchainVersion") == version
+    }
+
+    void writeJvmCriteria(String version) {
+        Properties properties = new Properties()
+        properties.put("toolchainVersion", version)
+        buildPropertiesFile.writeProperties(properties)
+        assertJvmCriteria(version)
+    }
+
+    TestFile getBuildPropertiesFile() {
+        return file("gradle/gradle-daemon-jvm.properties")
+    }
+}
+

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/DaemonJvmPropertiesFixture.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/DaemonJvmPropertiesFixture.groovy
@@ -33,6 +33,7 @@ trait DaemonJvmPropertiesFixture {
     }
 
     def setup() {
+        System.clearProperty("org.gradle.java.installations.paths")
         requireDaemons()
     }
 

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/DaemonJvmPropertiesFixture.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/DaemonJvmPropertiesFixture.groovy
@@ -22,7 +22,15 @@ import org.gradle.test.fixtures.file.TestFile
 @SelfType(ToolingApiSpecification)
 trait DaemonJvmPropertiesFixture {
 
-    def currentJavaHome = new File(System.getProperty("java.home")).canonicalFile
+    File currentJavaHome = findJavaHome()
+
+    private File findJavaHome() {
+        def potentialJavaHome = new File(System.getProperty("java.home")).canonicalFile
+        if (potentialJavaHome.name.equalsIgnoreCase( "jre")) {
+            return potentialJavaHome.parentFile
+        }
+        return potentialJavaHome
+    }
 
     def setup() {
         requireDaemons()

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/DaemonJvmPropertiesFixture.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/DaemonJvmPropertiesFixture.groovy
@@ -36,6 +36,13 @@ trait DaemonJvmPropertiesFixture {
         requireDaemons()
     }
 
+    void withInstallations(File... jdks) {
+        file("gradle.properties").writeProperties(
+            "org.gradle.java.installations.auto-detect": "false",
+            "org.gradle.java.installations.paths": jdks.collect { it.canonicalPath }.join(",")
+        )
+    }
+
     void assertDaemonUsedJvm(File expectedJavaHome) {
         assert file("javaHome.txt").text == expectedJavaHome.canonicalPath
     }


### PR DESCRIPTION
### Context
This PR represents the continuation of the initial proposed PR https://github.com/vmadalin/gradle/pull/47 of adding TAPI tests by reusing the same tests via specific CLI and TAPI executor to avoid duplicating the tests. However, this now follows the Gradle cross-version tests but also is more aligned with the [shared guidelines](https://github.com/gradle/gradle/pull/29222) even if that requires duplicating them. 

#### Testing
Integration tests:
[DaemonToolchainCoexistWithCurrentOptionsCrossVersionTest.groovy](https://github.com/gradle/gradle/pull/29252/files#diff-31ae7ef28846ca5a37fb63ec5c1e4be3ed99db84c401382a6b507f4c3244708b)
[DaemonToolchainCrossVersionTest.groovy](https://github.com/gradle/gradle/pull/29252/files#diff-86c7b3ad2aaf456e2918c03efe4d3a1ca13d8869db4637920cb5eff01a942d6f)
[DaemonToolchainInvalidCriteriaCrossVersionTest.groovy](https://github.com/gradle/gradle/pull/29252/files#diff-2ac2f8f176e341f9d6628a451ba31f02c89473d4563cd857d7b0284739be31d0)

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.
