### PR TITLE
Enable IP tests for build-init subproject

### DIFF
--- a/platforms/software/build-init/build.gradle.kts
+++ b/platforms/software/build-init/build.gradle.kts
@@ -110,3 +110,7 @@ packageCycles {
 }
 
 integTest.testJvmXmx = "1g"
+
+tasks.isolatedProjectsIntegTest {
+    enabled = true
+}


### PR DESCRIPTION
Relates to https://github.com/gradle/gradle/issues/28965