### PR TITLE
Remove JavaVersion from launcher

### DIFF
--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/api/JavaVersion.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/api/JavaVersion.java
@@ -17,8 +17,7 @@ package org.gradle.api;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.gradle.api.internal.jvm.JavaVersionParser;
 
 /**
  * An enumeration of Java versions.
@@ -182,18 +181,7 @@ public enum JavaVersion {
         }
 
         String name = value.toString();
-
-        int firstNonVersionCharIndex = findFirstNonVersionCharIndex(name);
-
-        String[] versionStrings = name.substring(0, firstNonVersionCharIndex).split("\\.");
-        List<Integer> versions = convertToNumber(name, versionStrings);
-
-        if (isLegacyVersion(versions)) {
-            assertTrue(name, versions.get(1) > 0);
-            return getVersionForMajor(versions.get(1));
-        } else {
-            return getVersionForMajor(versions.get(0));
-        }
+        return getVersionForMajor(JavaVersionParser.parseMajorVersion(name));
     }
 
     /**
@@ -333,50 +321,5 @@ public enum JavaVersion {
 
     private static JavaVersion getVersionForMajor(int major) {
         return major >= values().length ? JavaVersion.VERSION_HIGHER : values()[major - 1];
-    }
-
-    private static void assertTrue(String value, boolean condition) {
-        if (!condition) {
-            throw new IllegalArgumentException("Could not determine Java version from '" + value + "'.");
-        }
-    }
-
-    private static boolean isLegacyVersion(List<Integer> versions) {
-        return 1 == versions.get(0) && versions.size() > 1;
-    }
-
-    private static List<Integer> convertToNumber(String value, String[] versionStrs) {
-        List<Integer> result = new ArrayList<Integer>();
-        for (String s : versionStrs) {
-            assertTrue(value, !isNumberStartingWithZero(s));
-            try {
-                result.add(Integer.parseInt(s));
-            } catch (NumberFormatException e) {
-                assertTrue(value, false);
-            }
-        }
-        assertTrue(value, !result.isEmpty() && result.get(0) > 0);
-        return result;
-    }
-
-    private static boolean isNumberStartingWithZero(String number) {
-        return number.length() > 1 && number.startsWith("0");
-    }
-
-    private static int findFirstNonVersionCharIndex(String s) {
-        assertTrue(s, s.length() != 0);
-
-        for (int i = 0; i < s.length(); ++i) {
-            if (!isDigitOrPeriod(s.charAt(i))) {
-                assertTrue(s, i != 0);
-                return i;
-            }
-        }
-
-        return s.length();
-    }
-
-    private static boolean isDigitOrPeriod(char c) {
-        return (c >= '0' && c <= '9') || c == '.';
     }
 }

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/api/internal/jvm/JavaVersionParser.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/api/internal/jvm/JavaVersionParser.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.jvm;
+
+import org.gradle.api.NonNullApi;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Shared code between {@link org.gradle.api.JavaVersion} and other code for parsing a full
+ * Java version string.
+ */
+@NonNullApi
+public class JavaVersionParser {
+
+    public static int parseMajorVersion(String fullVersion) {
+        int firstNonVersionCharIndex = findFirstNonVersionCharIndex(fullVersion);
+
+        String[] versionStrings = fullVersion.substring(0, firstNonVersionCharIndex).split("\\.");
+        List<Integer> versions = convertToNumber(fullVersion, versionStrings);
+
+        if (isLegacyVersion(versions)) {
+            assertTrue(fullVersion, versions.get(1) > 0);
+            return versions.get(1);
+        } else {
+            return versions.get(0);
+        }
+    }
+
+    private static void assertTrue(String value, boolean condition) {
+        if (!condition) {
+            throw new IllegalArgumentException("Could not determine Java version from '" + value + "'.");
+        }
+    }
+
+    private static boolean isLegacyVersion(List<Integer> versions) {
+        return 1 == versions.get(0) && versions.size() > 1;
+    }
+
+    private static List<Integer> convertToNumber(String value, String[] versionStrs) {
+        List<Integer> result = new ArrayList<Integer>();
+        for (String s : versionStrs) {
+            assertTrue(value, !isNumberStartingWithZero(s));
+            try {
+                result.add(Integer.parseInt(s));
+            } catch (NumberFormatException e) {
+                assertTrue(value, false);
+            }
+        }
+        assertTrue(value, !result.isEmpty() && result.get(0) > 0);
+        return result;
+    }
+
+    private static boolean isNumberStartingWithZero(String number) {
+        return number.length() > 1 && number.startsWith("0");
+    }
+
+    private static int findFirstNonVersionCharIndex(String s) {
+        assertTrue(s, !s.isEmpty());
+
+        for (int i = 0; i < s.length(); ++i) {
+            if (!isDigitOrPeriod(s.charAt(i))) {
+                assertTrue(s, i != 0);
+                return i;
+            }
+        }
+
+        return s.length();
+    }
+
+    private static boolean isDigitOrPeriod(char c) {
+        return (c >= '0' && c <= '9') || c == '.';
+    }
+}

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/jvm/Jvm.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/jvm/Jvm.java
@@ -19,6 +19,7 @@ package org.gradle.internal.jvm;
 import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
 import org.gradle.api.JavaVersion;
+import org.gradle.api.internal.jvm.JavaVersionParser;
 import org.gradle.internal.FileUtils;
 import org.gradle.internal.SystemProperties;
 import org.gradle.internal.os.OperatingSystem;
@@ -48,7 +49,7 @@ public class Jvm implements JavaInfo {
     private final File javaHome;
     private final boolean userSupplied;
     private final String implementationJavaVersion;
-    private final JavaVersion javaVersion;
+    private final Integer javaVersionMajor;
 
     // Cached resolved executables
     private File javaExecutable;
@@ -66,8 +67,8 @@ public class Jvm implements JavaInfo {
         return jvm;
     }
 
-    private static Jvm create(File javaBase, @Nullable String implementationJavaVersion, @Nullable JavaVersion javaVersion) {
-        Jvm jvm = new Jvm(OperatingSystem.current(), javaBase, implementationJavaVersion, javaVersion);
+    private static Jvm create(File javaBase, @Nullable String implementationJavaVersion, @Nullable Integer javaVersionMajor) {
+        Jvm jvm = new Jvm(OperatingSystem.current(), javaBase, implementationJavaVersion, javaVersionMajor);
         Jvm current = current();
         return jvm.getJavaHome().equals(current.getJavaHome()) ? current : jvm;
     }
@@ -76,21 +77,21 @@ public class Jvm implements JavaInfo {
      * Constructs JVM details by inspecting the current JVM.
      */
     Jvm(OperatingSystem os) {
-        this(os, FileUtils.canonicalize(new File(System.getProperty("java.home"))), System.getProperty("java.version"), JavaVersion.current(), false);
+        this(os, FileUtils.canonicalize(new File(System.getProperty("java.home"))), System.getProperty("java.version"), JavaVersionParser.parseMajorVersion(System.getProperty("java.version")), false);
     }
 
     /**
      * Constructs JVM details from the given values
      */
-    Jvm(OperatingSystem os, File suppliedJavaBase, String implementationJavaVersion, JavaVersion javaVersion) {
-        this(os, suppliedJavaBase, implementationJavaVersion, javaVersion, true);
+    Jvm(OperatingSystem os, File suppliedJavaBase, String implementationJavaVersion, Integer javaVersionMajor) {
+        this(os, suppliedJavaBase, implementationJavaVersion, javaVersionMajor, true);
     }
 
-    private Jvm(OperatingSystem os, File suppliedJavaBase, String implementationJavaVersion, JavaVersion javaVersion, boolean userSupplied) {
+    private Jvm(OperatingSystem os, File suppliedJavaBase, String implementationJavaVersion, Integer javaVersionMajor, boolean userSupplied) {
         this.os = os;
         this.javaBase = suppliedJavaBase;
         this.implementationJavaVersion = implementationJavaVersion;
-        this.javaVersion = javaVersion;
+        this.javaVersionMajor = javaVersionMajor;
         this.userSupplied = userSupplied;
         this.javaHome = findJavaHome(suppliedJavaBase);
     }
@@ -117,8 +118,8 @@ public class Jvm implements JavaInfo {
     /**
      * Creates JVM instance for given values. This method is intended to be used for discovered java homes.
      */
-    public static Jvm discovered(File javaHome, String implementationJavaVersion, JavaVersion javaVersion) {
-        return create(javaHome, implementationJavaVersion, javaVersion);
+    public static Jvm discovered(File javaHome, String implementationJavaVersion, Integer javaVersionMajor) {
+        return create(javaHome, implementationJavaVersion, javaVersionMajor);
     }
 
     @Override
@@ -236,11 +237,19 @@ public class Jvm implements JavaInfo {
     }
 
     /**
+     * @return the major part of the java version if known, otherwise null
+     */
+    @Nullable
+    public Integer getJavaVersionMajor() {
+        return javaVersionMajor;
+    }
+
+    /**
      * @return the {@link JavaVersion} information
      */
     @Nullable
     public JavaVersion getJavaVersion() {
-        return javaVersion;
+        return JavaVersion.toVersion(javaVersionMajor);
     }
 
     /**
@@ -281,15 +290,15 @@ public class Jvm implements JavaInfo {
      */
     @Nullable
     public File getStandaloneJre() {
-        if (javaVersion.isJava9Compatible()) {
+        if (javaVersionMajor >= 9) {
             return null;
         }
         if (os.isWindows()) {
             File jreDir;
-            if (javaVersion.isJava5()) {
+            if (javaVersionMajor == 5) {
                 jreDir = new File(javaHome.getParentFile(), "jre" + implementationJavaVersion);
             } else {
-                jreDir = new File(javaHome.getParentFile(), "jre" + javaVersion.getMajorVersion());
+                jreDir = new File(javaHome.getParentFile(), "jre" + javaVersionMajor);
             }
             if (jreDir.isDirectory()) {
                 return jreDir;

--- a/platforms/core-runtime/launcher/build.gradle.kts
+++ b/platforms/core-runtime/launcher/build.gradle.kts
@@ -22,6 +22,8 @@ errorprone {
 }
 
 dependencies {
+    api(project(":toolchains-jvm-shared"))
+
     implementation(project(":base-services"))
     implementation(project(":functional"))
     implementation(project(":enterprise-operations"))
@@ -48,7 +50,6 @@ dependencies {
     implementation(project(":file-watching"))
     implementation(project(":problems-api"))
     implementation(project(":problems"))
-    implementation(project(":toolchains-jvm-shared"))
     implementation(project(":declarative-dsl-provider"))
 
     implementation(libs.groovy) // for 'ReleaseInfo.getVersion()'

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/BuildActionsFactory.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/BuildActionsFactory.java
@@ -19,7 +19,6 @@ package org.gradle.launcher.cli;
 import com.google.common.annotations.VisibleForTesting;
 import org.gradle.StartParameter;
 import org.gradle.api.Action;
-import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.tasks.userinput.UserInputReader;
@@ -45,6 +44,7 @@ import org.gradle.internal.service.scopes.BasicGlobalScopeServices;
 import org.gradle.internal.service.scopes.GlobalScopeServices;
 import org.gradle.internal.service.scopes.GradleUserHomeScopeServiceRegistry;
 import org.gradle.internal.service.scopes.Scope;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.launcher.bootstrap.ExecutionListener;
 import org.gradle.launcher.configuration.AllProperties;
 import org.gradle.launcher.daemon.bootstrap.ForegroundDaemonAction;
@@ -134,15 +134,15 @@ class BuildActionsFactory implements CommandLineActionCreator {
         // Gradle daemon properties have been defined
         if (daemonParameters.getRequestedJvmCriteria() != null) {
             DaemonJvmCriteria criteria = daemonParameters.getRequestedJvmCriteria();
-            daemonParameters.applyDefaultsFor(JavaVersion.toVersion(criteria.getJavaVersion()));
+            daemonParameters.applyDefaultsFor(criteria.getJavaVersion());
             return new DaemonRequestContext(daemonParameters.getRequestedJvmBasedOnJavaHome(), daemonParameters.getRequestedJvmCriteria(), daemonParameters.getEffectiveJvmArgs(), daemonParameters.shouldApplyInstrumentationAgent(), daemonParameters.getNativeServicesMode(), daemonParameters.getPriority());
         } else if (daemonParameters.getRequestedJvmBasedOnJavaHome() != null && daemonParameters.getRequestedJvmBasedOnJavaHome() != Jvm.current()) {
             // Either the TAPI client or org.gradle.java.home has been provided
-            JavaVersion detectedVersion = jvmVersionDetector.getJavaVersion(daemonParameters.getRequestedJvmBasedOnJavaHome());
+            JavaLanguageVersion detectedVersion = JavaLanguageVersion.of(jvmVersionDetector.getJavaVersionMajor(daemonParameters.getRequestedJvmBasedOnJavaHome()));
             daemonParameters.applyDefaultsFor(detectedVersion);
             return new DaemonRequestContext(daemonParameters.getRequestedJvmBasedOnJavaHome(), daemonParameters.getRequestedJvmCriteria(), daemonParameters.getEffectiveJvmArgs(), daemonParameters.shouldApplyInstrumentationAgent(), daemonParameters.getNativeServicesMode(), daemonParameters.getPriority());
         } else {
-            daemonParameters.applyDefaultsFor(JavaVersion.current());
+            daemonParameters.applyDefaultsFor(JavaLanguageVersion.current());
             return new DaemonRequestContext(Jvm.current(), daemonParameters.getRequestedJvmCriteria(), daemonParameters.getEffectiveJvmArgs(), daemonParameters.shouldApplyInstrumentationAgent(), daemonParameters.getNativeServicesMode(), daemonParameters.getPriority());
         }
     }
@@ -192,7 +192,7 @@ class BuildActionsFactory implements CommandLineActionCreator {
         return new DefaultDaemonContext(
             UUID.randomUUID().toString(),
             currentProcess.getJvm().getJavaHome(),
-            JavaVersion.current(),
+            JavaLanguageVersion.current(),
             null, 0L, 0,
             // The gradle options aren't being properly checked.
             requestContext.getDaemonOpts(),

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/client/JvmVersionValidator.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/client/JvmVersionValidator.java
@@ -16,7 +16,6 @@
 
 package org.gradle.launcher.daemon.client;
 
-import org.gradle.api.JavaVersion;
 import org.gradle.internal.jvm.JavaInfo;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.jvm.UnsupportedJavaRuntimeException;
@@ -34,7 +33,7 @@ public class JvmVersionValidator {
             return;
         }
 
-        JavaVersion javaVersion = versionDetector.getJavaVersion(resolvedJvm);
-        UnsupportedJavaRuntimeException.assertUsingVersion("Gradle", JavaVersion.VERSION_1_8, javaVersion);
+        int javaVersionMajor = versionDetector.getJavaVersionMajor(resolvedJvm);
+        UnsupportedJavaRuntimeException.assertUsingVersion("Gradle", 8, javaVersionMajor);
     }
 }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
@@ -16,13 +16,14 @@
 package org.gradle.launcher.daemon.configuration;
 
 import com.google.common.collect.ImmutableList;
-import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.internal.buildconfiguration.DaemonJvmPropertiesDefaults;
 import org.gradle.internal.jvm.JavaInfo;
 import org.gradle.internal.jvm.JpmsConfiguration;
 import org.gradle.internal.nativeintegration.services.NativeServices.NativeServicesMode;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JvmImplementation;
+import org.gradle.jvm.toolchain.internal.DefaultJavaLanguageVersion;
 import org.gradle.jvm.toolchain.internal.DefaultJvmVendorSpec;
 import org.gradle.jvm.toolchain.internal.DefaultToolchainConfiguration;
 import org.gradle.jvm.toolchain.internal.ToolchainConfiguration;
@@ -132,7 +133,7 @@ public class DaemonParameters {
         String requestedVersion = buildProperties.get(DaemonJvmPropertiesDefaults.TOOLCHAIN_VERSION_PROPERTY);
         if (requestedVersion != null) {
             try {
-                JavaVersion javaVersion = JavaVersion.toVersion(requestedVersion);
+                JavaLanguageVersion javaVersion = DefaultJavaLanguageVersion.fromFullVersion(requestedVersion);
                 this.requestedJvmCriteria = new DaemonJvmCriteria(javaVersion, DefaultJvmVendorSpec.any(), JvmImplementation.VENDOR_SPECIFIC);
             } catch (Exception e) {
                 // TODO: This should be pushed somewhere else so we consistently report this message in the right context.
@@ -150,8 +151,8 @@ public class DaemonParameters {
         this.requestedJvmBasedOnJavaHome = requestedJvmBasedOnJavaHome;
     }
 
-    public void applyDefaultsFor(JavaVersion javaVersion) {
-        if (javaVersion.compareTo(JavaVersion.VERSION_1_9) >= 0) {
+    public void applyDefaultsFor(JavaLanguageVersion javaVersion) {
+        if (javaVersion.asInt() >= 9) {
             Set<String> jpmsArgs = new LinkedHashSet<>(ALLOW_ENVIRONMENT_VARIABLE_OVERWRITE);
             jpmsArgs.addAll(JpmsConfiguration.GRADLE_DAEMON_JPMS_ARGS);
             jvmOptions.jvmArgs(jpmsArgs);

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/context/DaemonContext.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/context/DaemonContext.java
@@ -15,8 +15,8 @@
  */
 package org.gradle.launcher.daemon.context;
 
-import org.gradle.api.JavaVersion;
 import org.gradle.internal.nativeintegration.services.NativeServices.NativeServicesMode;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.launcher.daemon.configuration.DaemonParameters;
 
 import java.io.File;
@@ -48,7 +48,7 @@ public interface DaemonContext {
      */
     File getJavaHome();
 
-    JavaVersion getJavaVersion();
+    JavaLanguageVersion getJavaVersion();
 
     /**
      * The directory that should be used for daemon storage (not including the gradle version number).

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/context/DefaultDaemonContext.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/context/DefaultDaemonContext.java
@@ -16,11 +16,11 @@
 package org.gradle.launcher.daemon.context;
 
 import com.google.common.base.Joiner;
-import org.gradle.api.JavaVersion;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.nativeintegration.services.NativeServices.NativeServicesMode;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.launcher.daemon.configuration.DaemonParameters;
 
 import java.io.File;
@@ -44,12 +44,12 @@ public class DefaultDaemonContext implements DaemonContext {
     private final boolean applyInstrumentationAgent;
     private final DaemonParameters.Priority priority;
     private final NativeServicesMode nativeServicesMode;
-    private final JavaVersion javaVersion;
+    private final JavaLanguageVersion javaVersion;
 
     public DefaultDaemonContext(
         String uid,
         File javaHome,
-        JavaVersion javaVersion,
+        JavaLanguageVersion javaVersion,
         File daemonRegistryDir,
         Long pid,
         Integer idleTimeout,
@@ -88,7 +88,7 @@ public class DefaultDaemonContext implements DaemonContext {
     }
 
     @Override
-    public JavaVersion getJavaVersion() {
+    public JavaLanguageVersion getJavaVersion() {
         return javaVersion;
     }
 
@@ -139,7 +139,7 @@ public class DefaultDaemonContext implements DaemonContext {
             String uid = decoder.readNullableString();
             String pathname = decoder.readString();
             File javaHome = new File(pathname);
-            JavaVersion javaVersion = JavaVersion.valueOf(decoder.readString());
+            JavaLanguageVersion javaVersion = JavaLanguageVersion.of(decoder.readSmallInt());
             File registryDir = new File(decoder.readString());
             Long pid = decoder.readBoolean() ? decoder.readLong() : null;
             Integer idle = decoder.readBoolean() ? decoder.readInt() : null;
@@ -159,7 +159,7 @@ public class DefaultDaemonContext implements DaemonContext {
         public void write(Encoder encoder, DefaultDaemonContext context) throws Exception {
             encoder.writeNullableString(context.uid);
             encoder.writeString(context.javaHome.getPath());
-            encoder.writeString(context.javaVersion.name());
+            encoder.writeSmallInt(context.javaVersion.asInt());
             encoder.writeString(context.daemonRegistryDir.getPath());
             encoder.writeBoolean(context.pid != null);
             if (context.pid != null) {

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/DaemonServices.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/DaemonServices.java
@@ -16,7 +16,6 @@
 package org.gradle.launcher.daemon.server;
 
 import com.google.common.collect.ImmutableList;
-import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.tasks.userinput.UserInputReader;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -35,6 +34,7 @@ import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.GlobalScopeServices;
 import org.gradle.internal.service.scopes.GradleUserHomeScopeServiceRegistry;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.launcher.daemon.configuration.DaemonServerConfiguration;
 import org.gradle.launcher.daemon.context.DaemonContext;
 import org.gradle.launcher.daemon.context.DefaultDaemonContext;
@@ -96,7 +96,7 @@ public class DaemonServices extends DefaultServiceRegistry {
         LOGGER.debug("Creating daemon context with opts: {}", configuration.getJvmOptions());
         return new DefaultDaemonContext(configuration.getUid(),
             canonicalize(Jvm.current().getJavaHome()),
-            JavaVersion.current(),
+            JavaLanguageVersion.current(),
             configuration.getBaseDir(),
             processEnvironment.maybeGetPid(),
             configuration.getIdleTimeout(),

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/toolchain/DaemonJavaToolchainQueryService.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/toolchain/DaemonJavaToolchainQueryService.java
@@ -24,7 +24,6 @@ import org.gradle.internal.jvm.inspection.JvmInstallationMetadata;
 import org.gradle.internal.jvm.inspection.JvmInstallationMetadataComparator;
 import org.gradle.internal.jvm.inspection.JvmToolchainMetadata;
 import org.gradle.internal.os.OperatingSystem;
-import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.internal.JvmInstallationMetadataMatcher;
 
 import java.io.File;
@@ -59,7 +58,7 @@ public class DaemonJavaToolchainQueryService {
     }
 
     private Optional<JvmToolchainMetadata> locateToolchain(DaemonJvmCriteria toolchainSpec) {
-        Predicate<JvmInstallationMetadata> matcher = new JvmInstallationMetadataMatcher(JavaLanguageVersion.of(toolchainSpec.getJavaVersion().getMajorVersion()), toolchainSpec.getVendorSpec(), toolchainSpec.getJvmImplementation());
+        Predicate<JvmInstallationMetadata> matcher = new JvmInstallationMetadataMatcher(toolchainSpec.getJavaVersion(), toolchainSpec.getVendorSpec(), toolchainSpec.getJvmImplementation());
         JvmInstallationMetadataComparator metadataComparator = new JvmInstallationMetadataComparator(currentJavaHome);
 
         return javaInstallationRegistry.toolchains().stream()

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/toolchain/DaemonJvmCriteria.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/toolchain/DaemonJvmCriteria.java
@@ -16,23 +16,23 @@
 
 package org.gradle.launcher.daemon.toolchain;
 
-import org.gradle.api.JavaVersion;
 import org.gradle.internal.jvm.Jvm;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JvmImplementation;
 import org.gradle.jvm.toolchain.JvmVendorSpec;
 
 public class DaemonJvmCriteria {
-    private final JavaVersion javaVersion;
+    private final JavaLanguageVersion javaVersion;
     private final JvmVendorSpec vendorSpec;
     private final JvmImplementation jvmImplementation;
 
-    public DaemonJvmCriteria(JavaVersion javaVersion, JvmVendorSpec vendorSpec, JvmImplementation jvmImplementation) {
+    public DaemonJvmCriteria(JavaLanguageVersion javaVersion, JvmVendorSpec vendorSpec, JvmImplementation jvmImplementation) {
         this.javaVersion = javaVersion;
         this.vendorSpec = vendorSpec;
         this.jvmImplementation = jvmImplementation;
     }
 
-    public JavaVersion getJavaVersion() {
+    public JavaLanguageVersion getJavaVersion() {
         return javaVersion;
     }
 
@@ -45,7 +45,11 @@ public class DaemonJvmCriteria {
     }
 
     public boolean isCompatibleWith(Jvm other) {
-        return isCompatibleWith(other.getJavaVersion());
+        Integer javaVersionMajor = other.getJavaVersionMajor();
+        if (javaVersionMajor == null) {
+            return false;
+        }
+        return isCompatibleWith(JavaLanguageVersion.of(javaVersionMajor));
     }
 
     @Override
@@ -54,8 +58,8 @@ public class DaemonJvmCriteria {
         return String.format("JVM version '%s'", getJavaVersion());
     }
 
-    public boolean isCompatibleWith(JavaVersion javaVersion) {
+    public boolean isCompatibleWith(JavaLanguageVersion javaVersion) {
         // TODO: Implement comparisons for vendorSpec and jvmImplementation
-        return javaVersion == getJavaVersion(); // && vendorSpec.matches() && jvmImplementation == other.jvmImplementation;
+        return javaVersion.equals(getJavaVersion()); // && vendorSpec.matches() && jvmImplementation == other.jvmImplementation;
     }
 }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/DefaultConnection.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/DefaultConnection.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.tooling.internal.provider;
 
-import org.gradle.api.JavaVersion;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.initialization.BuildLayoutParameters;
 import org.gradle.internal.Cast;
@@ -105,7 +104,7 @@ public class DefaultConnection implements ConnectionVersion4,
 
     private void assertUsingSupportedJavaVersion() {
         try {
-            UnsupportedJavaRuntimeException.assertUsingVersion("Gradle", JavaVersion.VERSION_1_8);
+            UnsupportedJavaRuntimeException.assertUsingVersion("Gradle", 8);
         } catch (IllegalArgumentException e) {
             LOGGER.warn(e.getMessage());
         }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
@@ -18,7 +18,6 @@ package org.gradle.tooling.internal.provider;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
-import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.tasks.userinput.UserInputReader;
@@ -41,6 +40,7 @@ import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.console.GlobalUserInputReceiver;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
 import org.gradle.internal.service.ServiceRegistry;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.launcher.cli.converter.BuildLayoutConverter;
 import org.gradle.launcher.cli.converter.InitialPropertiesConverter;
 import org.gradle.launcher.cli.converter.LayoutToPropertiesConverter;
@@ -319,15 +319,15 @@ public class ProviderConnection {
         // Gradle daemon properties have been defined
         if (daemonParameters.getRequestedJvmCriteria() != null) {
             DaemonJvmCriteria criteria = daemonParameters.getRequestedJvmCriteria();
-            daemonParameters.applyDefaultsFor(JavaVersion.toVersion(criteria.getJavaVersion()));
+            daemonParameters.applyDefaultsFor(criteria.getJavaVersion());
             return new DaemonRequestContext(daemonParameters.getRequestedJvmBasedOnJavaHome(), daemonParameters.getRequestedJvmCriteria(), daemonParameters.getEffectiveJvmArgs(), daemonParameters.shouldApplyInstrumentationAgent(), daemonParameters.getNativeServicesMode(), daemonParameters.getPriority());
         } else if (daemonParameters.getRequestedJvmBasedOnJavaHome() != null && daemonParameters.getRequestedJvmBasedOnJavaHome() != Jvm.current()) {
             // Either the TAPI client or org.gradle.java.home has been provided
-            JavaVersion detectedVersion = jvmVersionDetector.getJavaVersion(daemonParameters.getRequestedJvmBasedOnJavaHome());
+            JavaLanguageVersion detectedVersion = JavaLanguageVersion.of(jvmVersionDetector.getJavaVersionMajor(daemonParameters.getRequestedJvmBasedOnJavaHome()));
             daemonParameters.applyDefaultsFor(detectedVersion);
             return new DaemonRequestContext(daemonParameters.getRequestedJvmBasedOnJavaHome(), daemonParameters.getRequestedJvmCriteria(), daemonParameters.getEffectiveJvmArgs(), daemonParameters.shouldApplyInstrumentationAgent(), daemonParameters.getNativeServicesMode(), daemonParameters.getPriority());
         } else {
-            daemonParameters.applyDefaultsFor(JavaVersion.current());
+            daemonParameters.applyDefaultsFor(JavaLanguageVersion.current());
             return new DaemonRequestContext(Jvm.current(), daemonParameters.getRequestedJvmCriteria(), daemonParameters.getEffectiveJvmArgs(), daemonParameters.shouldApplyInstrumentationAgent(), daemonParameters.getNativeServicesMode(), daemonParameters.getPriority());
         }
     }

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/jvm/UnsupportedJavaRuntimeException.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/jvm/UnsupportedJavaRuntimeException.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.jvm;
 
-import org.gradle.api.JavaVersion;
 import org.gradle.util.GradleVersion;
 
 public class UnsupportedJavaRuntimeException extends RuntimeException {
@@ -25,20 +24,20 @@ public class UnsupportedJavaRuntimeException extends RuntimeException {
         super(message);
     }
 
-    public static void assertUsingVersion(String component, JavaVersion minVersion) throws UnsupportedJavaRuntimeException {
-        JavaVersion current = JavaVersion.current();
-        if (current.compareTo(minVersion) >= 0) {
+    public static void assertUsingVersion(String component, int minVersion) throws UnsupportedJavaRuntimeException {
+        Integer current = Jvm.current().getJavaVersionMajor();
+        if (current == null || current >= minVersion) {
             return;
         }
         throw new UnsupportedJavaRuntimeException(String.format("%s %s requires Java %s or later to run. You are currently using Java %s.", component, GradleVersion.current().getVersion(),
-            minVersion.getMajorVersion(), current.getMajorVersion()));
+            minVersion, current));
     }
 
-    public static void assertUsingVersion(String component, JavaVersion minVersion, JavaVersion configuredVersion) throws UnsupportedJavaRuntimeException {
-        if (configuredVersion.compareTo(minVersion) >= 0) {
+    public static void assertUsingVersion(String component, int minVersion, int configuredVersion) throws UnsupportedJavaRuntimeException {
+        if (configuredVersion >= minVersion) {
             return;
         }
         throw new UnsupportedJavaRuntimeException(String.format("%s %s requires Java %s or later to run. Your build is currently configured to use Java %s.", component, GradleVersion.current().getVersion(),
-            minVersion.getMajorVersion(), configuredVersion.getMajorVersion()));
+            minVersion, configuredVersion));
     }
 }

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/test/impl/DefaultTestTaskPropertiesService.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/test/impl/DefaultTestTaskPropertiesService.java
@@ -185,6 +185,6 @@ public class DefaultTestTaskPropertiesService implements TestTaskPropertiesServi
     }
 
     private int detectJavaVersion(String executable) {
-        return Integer.parseInt(jvmVersionDetector.getJavaVersion(executable).getMajorVersion());
+        return jvmVersionDetector.getJavaVersionMajor(executable);
     }
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/DaemonJvmCompatibilityCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/DaemonJvmCompatibilityCrossVersionSpec.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r88
+
+import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+
+class DaemonJvmCompatibilityCrossVersionSpec extends ToolingApiSpecification {
+    def setup() {
+        buildFile.touch()
+        settingsFile << """
+            rootProject.name = "root"
+        """
+    }
+
+    @TargetGradleVersion(">=8.8")
+    def "can run a build with Java 21 followed by another build with a different version"() {
+        given:
+        def jdk21 = AvailableJavaHomes.getJdk21()
+        def jdk17 = AvailableJavaHomes.getJdk17()
+
+        file("gradle.properties").writeProperties("org.gradle.java.home": jdk21.javaHome.absolutePath)
+        withConnection { connection ->
+            connection.newBuild().forTasks('help').run()
+        }
+
+        file("gradle.properties").writeProperties("org.gradle.java.home": jdk17.javaHome.absolutePath)
+        withConnection { connection ->
+            connection.newBuild().forTasks('help').run()
+        }
+    }
+}

--- a/platforms/jvm/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/DefaultJvmVersionDetector.java
+++ b/platforms/jvm/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/DefaultJvmVersionDetector.java
@@ -17,7 +17,7 @@
 package org.gradle.internal.jvm.inspection;
 
 import org.gradle.api.GradleException;
-import org.gradle.api.JavaVersion;
+import org.gradle.api.internal.jvm.JavaVersionParser;
 import org.gradle.internal.jvm.JavaInfo;
 import org.gradle.jvm.toolchain.internal.InstallationLocation;
 import org.gradle.process.internal.ExecException;
@@ -34,12 +34,12 @@ public class DefaultJvmVersionDetector implements JvmVersionDetector {
     }
 
     @Override
-    public JavaVersion getJavaVersion(JavaInfo jvm) {
+    public int getJavaVersionMajor(JavaInfo jvm) {
         return getVersionFromJavaHome(jvm.getJavaHome());
     }
 
     @Override
-    public JavaVersion getJavaVersion(String javaCommand) {
+    public int getJavaVersionMajor(String javaCommand) {
         File executable = new File(javaCommand);
         File parentFolder = executable.getParentFile();
         if(parentFolder == null || !parentFolder.exists()) {
@@ -49,8 +49,9 @@ public class DefaultJvmVersionDetector implements JvmVersionDetector {
         return getVersionFromJavaHome(parentFolder.getParentFile());
     }
 
-    private JavaVersion getVersionFromJavaHome(File javaHome) {
-        return validate(detector.getMetadata(InstallationLocation.autoDetected(javaHome, "specific path"))).getLanguageVersion();
+    private int getVersionFromJavaHome(File javaHome) {
+        JvmInstallationMetadata metadata = validate(detector.getMetadata(InstallationLocation.autoDetected(javaHome, "specific path")));
+        return JavaVersionParser.parseMajorVersion(metadata.getJavaVersion());
     }
 
     private JvmInstallationMetadata validate(JvmInstallationMetadata metadata) {

--- a/platforms/jvm/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmVersionDetector.java
+++ b/platforms/jvm/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmVersionDetector.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.jvm.inspection;
 
-import org.gradle.api.JavaVersion;
 import org.gradle.internal.jvm.JavaInfo;
 
 /**
@@ -26,10 +25,10 @@ public interface JvmVersionDetector {
     /**
      * Probes the Java version for the given JVM installation.
      */
-    JavaVersion getJavaVersion(JavaInfo jvm);
+    int getJavaVersionMajor(JavaInfo jvm);
 
     /**
      * Probes the Java version for the given `java` command.
      */
-    JavaVersion getJavaVersion(String javaCommand);
+    int getJavaVersionMajor(String javaCommand);
 }

--- a/platforms/jvm/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
+++ b/platforms/jvm/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
@@ -97,7 +97,7 @@ public class DaemonGroovyCompiler extends AbstractDaemonCompiler<GroovyJavaJoint
         JavaForkOptions javaForkOptions = new BaseForkOptionsConverter(forkOptionsFactory).transform(mergeForkOptions(javaOptions, groovyOptions));
         javaForkOptions.setWorkingDir(daemonWorkingDir);
         javaForkOptions.setExecutable(javaOptions.getExecutable());
-        if (jvmVersionDetector.getJavaVersion(javaForkOptions.getExecutable()).isJava9Compatible()) {
+        if (jvmVersionDetector.getJavaVersionMajor(javaForkOptions.getExecutable()) >= 9) {
             javaForkOptions.jvmArgs(JpmsConfiguration.GROOVY_JPMS_ARGS);
         }
 

--- a/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/JavaLanguageVersion.java
+++ b/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/JavaLanguageVersion.java
@@ -16,6 +16,7 @@
 
 package org.gradle.jvm.toolchain;
 
+import org.gradle.api.Incubating;
 import org.gradle.jvm.toolchain.internal.DefaultJavaLanguageVersion;
 
 /**
@@ -31,6 +32,17 @@ public interface JavaLanguageVersion extends Comparable<JavaLanguageVersion> {
 
     static JavaLanguageVersion of(String version) {
         return of(Integer.parseInt(version));
+    }
+
+    /**
+     * Get the current (i.e., the current runtime) Java Language version.
+     *
+     * @return the current Java Language version
+     * @since 8.8
+     */
+    @Incubating
+    static JavaLanguageVersion current() {
+        return DefaultJavaLanguageVersion.fromFullVersion(System.getProperty("java.version"));
     }
 
     /**

--- a/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJavaLanguageVersion.java
+++ b/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJavaLanguageVersion.java
@@ -16,6 +16,7 @@
 
 package org.gradle.jvm.toolchain.internal;
 
+import org.gradle.api.internal.jvm.JavaVersionParser;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 
 import java.io.Serializable;
@@ -42,6 +43,10 @@ public class DefaultJavaLanguageVersion implements JavaLanguageVersion, Serializ
         } else {
             return new DefaultJavaLanguageVersion(version);
         }
+    }
+
+    public static JavaLanguageVersion fromFullVersion(String version) {
+        return of(JavaVersionParser.parseMajorVersion(version));
     }
 
     private final int version;

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessBuilder.java
@@ -243,7 +243,7 @@ public class DefaultWorkerProcessBuilder implements WorkerProcessBuilder {
         JavaExecHandleBuilder javaCommand = getJavaCommand();
         javaCommand.setDisplayName(displayName);
 
-        boolean java9Compatible = jvmVersionDetector.getJavaVersion(javaCommand.getExecutable()).isJava9Compatible();
+        boolean java9Compatible = jvmVersionDetector.getJavaVersionMajor(javaCommand.getExecutable()) >= 9;
         workerImplementationFactory.prepareJavaCommand(id, displayName, this, implementationClassPath, implementationModulePath, localAddress, javaCommand, shouldPublishJvmMemoryInfo, java9Compatible);
 
         javaCommand.args("'" + displayName + "'");

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AvailableJavaHomes.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AvailableJavaHomes.java
@@ -237,7 +237,7 @@ public abstract class AvailableJavaHomes {
      */
     public static Jvm getDifferentJdkWithValidJre() {
         return getSupportedJdk(jvm -> !isCurrentJavaHome(jvm)
-            && Jvm.discovered(jvm.getJavaHome().toFile(), null, jvm.getLanguageVersion()).getJre() != null);
+            && Jvm.discovered(jvm.getJavaHome().toFile(), null, Integer.parseInt(jvm.getLanguageVersion().getMajorVersion())).getJre() != null);
     }
 
     private static boolean isCurrentJavaHome(JvmInstallationMetadata metadata) {
@@ -272,7 +272,7 @@ public abstract class AvailableJavaHomes {
     }
 
     private static Jvm jvmFromMetadata(JvmInstallationMetadata metadata) {
-        return Jvm.discovered(metadata.getJavaHome().toFile(), metadata.getJavaVersion(), metadata.getLanguageVersion());
+        return Jvm.discovered(metadata.getJavaHome().toFile(), metadata.getJavaVersion(), Integer.parseInt(metadata.getLanguageVersion().getMajorVersion()));
     }
 
     public static List<JvmInstallationMetadata> getAvailableJvmMetadatas() {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/DaemonContextParser.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/DaemonContextParser.java
@@ -18,8 +18,8 @@ package org.gradle.integtests.fixtures.daemon;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
-import org.gradle.api.JavaVersion;
 import org.gradle.internal.nativeintegration.services.NativeServices.NativeServicesMode;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.launcher.daemon.configuration.DaemonParameters;
 import org.gradle.launcher.daemon.context.DaemonContext;
 import org.gradle.launcher.daemon.context.DefaultDaemonContext;
@@ -68,7 +68,7 @@ public class DaemonContextParser {
         if (matcher.matches()) {
             String uid = matcher.group(1) == null ? null : matcher.group(1).substring("uid=".length());
             String javaHome = matcher.group(2);
-            JavaVersion javaVersion = JavaVersion.toVersion(matcher.group(3));
+            JavaLanguageVersion javaVersion = JavaLanguageVersion.of(matcher.group(3));
             String daemonRegistryDir = matcher.group(4);
             String pidStr = matcher.group(5);
             Long pid = pidStr.equals("null") ? null : Long.parseLong(pidStr);
@@ -77,7 +77,7 @@ public class DaemonContextParser {
             boolean applyInstrumentationAgent = Boolean.parseBoolean(matcher.group(8));
             NativeServicesMode nativeServicesMode = matcher.group(9) == null ? NativeServicesMode.ENABLED : NativeServicesMode.valueOf(matcher.group(9));
             List<String> jvmOpts = Lists.newArrayList(Splitter.on(',').split(matcher.group(10)));
-            return new DefaultDaemonContext(uid, new File(javaHome), JavaVersion.toVersion(javaVersion), new File(daemonRegistryDir), pid, idleTimeout, jvmOpts, applyInstrumentationAgent, nativeServicesMode, priority);
+            return new DefaultDaemonContext(uid, new File(javaHome), javaVersion, new File(daemonRegistryDir), pid, idleTimeout, jvmOpts, applyInstrumentationAgent, nativeServicesMode, priority);
         } else {
             return null;
         }
@@ -91,7 +91,6 @@ public class DaemonContextParser {
         if (matcher.matches()) {
             String uid = matcher.group(1) == null ? null : matcher.group(1).substring("uid=".length());
             String javaHome = matcher.group(2);
-            JavaVersion javaVersion = JavaVersion.VERSION_1_8;
             String daemonRegistryDir = matcher.group(3);
             String pidStr = matcher.group(4);
             Long pid = pidStr.equals("null") ? null : Long.parseLong(pidStr);
@@ -100,7 +99,7 @@ public class DaemonContextParser {
             boolean applyInstrumentationAgent = Boolean.parseBoolean(matcher.group(7));
             NativeServicesMode nativeServicesMode = matcher.group(8) == null ? NativeServicesMode.ENABLED : NativeServicesMode.valueOf(matcher.group(8));
             List<String> jvmOpts = Lists.newArrayList(Splitter.on(',').split(matcher.group(9)));
-            return new DefaultDaemonContext(uid, new File(javaHome), JavaVersion.VERSION_1_8, new File(daemonRegistryDir), pid, idleTimeout, jvmOpts, applyInstrumentationAgent, nativeServicesMode, priority);
+            return new DefaultDaemonContext(uid, new File(javaHome), JavaLanguageVersion.of(8), new File(daemonRegistryDir), pid, idleTimeout, jvmOpts, applyInstrumentationAgent, nativeServicesMode, priority);
         } else {
             return null;
         }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -646,7 +646,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
 
     private JavaVersion getJavaVersionFromJavaHome() {
         try {
-            return JVM_VERSION_DETECTOR.getJavaVersion(Jvm.forHome(getJavaHomeLocation()));
+            return JavaVersion.toVersion(JVM_VERSION_DETECTOR.getJavaVersionMajor(Jvm.forHome(getJavaHomeLocation())));
         } catch (IllegalArgumentException | JavaHomeException e) {
             return JavaVersion.current();
         }


### PR DESCRIPTION
Fixes #29209

### Context
All references to `JavaVersion` are replaced with either a simple `int` or in more complex cases `JavaLanguageVersion`, as that is more appropriate for toolchains anyways. This fixes a problem where an older Tooling API would prevent newer Gradle versions from working on newer JDKs due to missing entries from a leaked `JavaVersion` class. This also removes the need to leak `JavaVersion` into Gradle versions `>= 8.9` in the Tooling API in order to give them access to the newer enum constants, as `JavaLanguageVersion` supports any `int` value. However, we must still leak `JavaVersion` in current Tooling API because versions prior to 8.9 should still get the newer enums.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
