### PR TITLE
Fix some more IP problems in Gradle build

### DIFF
--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildEnvironment.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildEnvironment.kt
@@ -26,11 +26,11 @@ import org.gradle.kotlin.dsl.*
 
 
 // `generatePrecompiledScriptPluginAccessors` task invokes this method without `gradle.build-environment` applied
-fun Project.getBuildEnvironmentExtension(): BuildEnvironmentExtension? = extensions.findByType(BuildEnvironmentExtension::class.java)
+fun Project.getBuildEnvironmentExtension(): BuildEnvironmentExtension = extensions.getByType(BuildEnvironmentExtension::class.java)
 
+fun Project.getBuildEnvironmentExtensionOrNull(): BuildEnvironmentExtension? = extensions.findByType(BuildEnvironmentExtension::class.java)
 
-fun Project.repoRoot(): Directory = getBuildEnvironmentExtension()?.repoRoot?.get() ?: layout.projectDirectory.parentOrRoot()
-
+fun Project.repoRoot(): Directory = getBuildEnvironmentExtensionOrNull()?.repoRoot?.get() ?: layout.projectDirectory.parentOrRoot()
 
 fun Directory.parentOrRoot(): Directory = if (this.file("version.txt").asFile.exists()) {
     this
@@ -50,10 +50,10 @@ fun Project.releasedVersionsFile() = repoRoot().file("released-versions.json")
 /**
  * We use command line Git instead of JGit, because JGit's `Repository.resolve` does not work with worktrees.
  */
-fun Project.currentGitBranchViaFileSystemQuery(): Provider<String> = getBuildEnvironmentExtension()?.gitBranch ?: objects.property(String::class.java)
+fun Project.currentGitBranchViaFileSystemQuery(): Provider<String> = getBuildEnvironmentExtensionOrNull()?.gitBranch ?: objects.property(String::class.java)
 
 
-fun Project.currentGitCommitViaFileSystemQuery(): Provider<String> = getBuildEnvironmentExtension()?.gitCommitId ?: objects.property(String::class.java)
+fun Project.currentGitCommitViaFileSystemQuery(): Provider<String> = getBuildEnvironmentExtensionOrNull()?.gitCommitId ?: objects.property(String::class.java)
 
 
 // pre-test/master/queue/alice/feature -> master

--- a/build-logic-settings/build-environment/src/main/kotlin/gradlebuild.build-environment.settings.gradle.kts
+++ b/build-logic-settings/build-environment/src/main/kotlin/gradlebuild.build-environment.settings.gradle.kts
@@ -20,16 +20,19 @@ import gradlebuild.basics.BuildEnvironmentService
 with(layout.rootDirectory) {
     gradle.lifecycle.beforeProject {
         val service = gradle.sharedServices.registerIfAbsent("buildEnvironmentService", BuildEnvironmentService::class) {
+            assert(project.path == ":") {
+                // We rely on the fact that root is configured first
+                "BuildEnvironmentService should be registered by the root"
+            }
             parameters.rootProjectDir = this@with
-            // We rely on the fact that these properties are read for a root project, because root is configured first
             parameters.artifactoryUserName = providers.gradleProperty("artifactoryUserName")
             parameters.artifactoryPassword = providers.gradleProperty("artifactoryPassword")
         }
         val buildEnvironmentExtension = extensions.create("buildEnvironment", BuildEnvironmentExtension::class)
         buildEnvironmentExtension.gitCommitId = service.flatMap { it.gitCommitId }
         buildEnvironmentExtension.gitBranch = service.flatMap { it.gitBranch }
+        buildEnvironmentExtension.repoRoot = this@with
         buildEnvironmentExtension.artifactoryUserName = service.flatMap { it.parameters.artifactoryUserName }
         buildEnvironmentExtension.artifactoryPassword = service.flatMap { it.parameters.artifactoryPassword }
-        buildEnvironmentExtension.repoRoot = this@with
     }
 }

--- a/build-logic-settings/build-environment/src/main/kotlin/gradlebuild.build-environment.settings.gradle.kts
+++ b/build-logic-settings/build-environment/src/main/kotlin/gradlebuild.build-environment.settings.gradle.kts
@@ -27,6 +27,11 @@ with(layout.rootDirectory) {
             parameters.rootProjectDir = this@with
             parameters.artifactoryUserName = providers.gradleProperty("artifactoryUserName")
             parameters.artifactoryPassword = providers.gradleProperty("artifactoryPassword")
+            parameters.testVersions = providers.gradleProperty("testVersions")
+            parameters.integtestAgentAllowed = providers.gradleProperty("org.gradle.integtest.agent.allowed")
+            parameters.integtestDebug = providers.gradleProperty("org.gradle.integtest.debug")
+            parameters.integtestLauncherDebug = providers.gradleProperty("org.gradle.integtest.launcher.debug")
+            parameters.integtestVerbose = providers.gradleProperty("org.gradle.integtest.verbose")
         }
         val buildEnvironmentExtension = extensions.create("buildEnvironment", BuildEnvironmentExtension::class)
         buildEnvironmentExtension.gitCommitId = service.flatMap { it.gitCommitId }
@@ -34,5 +39,10 @@ with(layout.rootDirectory) {
         buildEnvironmentExtension.repoRoot = this@with
         buildEnvironmentExtension.artifactoryUserName = service.flatMap { it.parameters.artifactoryUserName }
         buildEnvironmentExtension.artifactoryPassword = service.flatMap { it.parameters.artifactoryPassword }
+        buildEnvironmentExtension.testVersions = service.flatMap { it.parameters.testVersions }
+        buildEnvironmentExtension.integtestAgentAllowed = service.flatMap { it.parameters.integtestAgentAllowed }
+        buildEnvironmentExtension.integtestDebug = service.flatMap { it.parameters.integtestDebug }
+        buildEnvironmentExtension.integtestLauncherDebug = service.flatMap { it.parameters.integtestLauncherDebug }
+        buildEnvironmentExtension.integtestVerbose = service.flatMap { it.parameters.integtestVerbose }
     }
 }

--- a/build-logic-settings/build-environment/src/main/kotlin/gradlebuild.build-environment.settings.gradle.kts
+++ b/build-logic-settings/build-environment/src/main/kotlin/gradlebuild.build-environment.settings.gradle.kts
@@ -25,6 +25,7 @@ with(layout.rootDirectory) {
                 "BuildEnvironmentService should be registered by the root"
             }
             parameters.rootProjectDir = this@with
+            parameters.rootProjectBuildDir = project.layout.buildDirectory
             parameters.artifactoryUserName = providers.gradleProperty("artifactoryUserName")
             parameters.artifactoryPassword = providers.gradleProperty("artifactoryPassword")
             parameters.testVersions = providers.gradleProperty("testVersions")
@@ -37,6 +38,7 @@ with(layout.rootDirectory) {
         buildEnvironmentExtension.gitCommitId = service.flatMap { it.gitCommitId }
         buildEnvironmentExtension.gitBranch = service.flatMap { it.gitBranch }
         buildEnvironmentExtension.repoRoot = this@with
+        buildEnvironmentExtension.rootProjectBuildDir = service.flatMap { it.parameters.rootProjectBuildDir }
         buildEnvironmentExtension.artifactoryUserName = service.flatMap { it.parameters.artifactoryUserName }
         buildEnvironmentExtension.artifactoryPassword = service.flatMap { it.parameters.artifactoryPassword }
         buildEnvironmentExtension.testVersions = service.flatMap { it.parameters.testVersions }

--- a/build-logic-settings/build-environment/src/main/kotlin/gradlebuild.build-environment.settings.gradle.kts
+++ b/build-logic-settings/build-environment/src/main/kotlin/gradlebuild.build-environment.settings.gradle.kts
@@ -21,10 +21,15 @@ with(layout.rootDirectory) {
     gradle.lifecycle.beforeProject {
         val service = gradle.sharedServices.registerIfAbsent("buildEnvironmentService", BuildEnvironmentService::class) {
             parameters.rootProjectDir = this@with
+            // We rely on the fact that these properties are read for a root project, because root is configured first
+            parameters.artifactoryUserName = providers.gradleProperty("artifactoryUserName")
+            parameters.artifactoryPassword = providers.gradleProperty("artifactoryPassword")
         }
         val buildEnvironmentExtension = extensions.create("buildEnvironment", BuildEnvironmentExtension::class)
         buildEnvironmentExtension.gitCommitId = service.flatMap { it.gitCommitId }
         buildEnvironmentExtension.gitBranch = service.flatMap { it.gitBranch }
+        buildEnvironmentExtension.artifactoryUserName = service.flatMap { it.parameters.artifactoryUserName }
+        buildEnvironmentExtension.artifactoryPassword = service.flatMap { it.parameters.artifactoryPassword }
         buildEnvironmentExtension.repoRoot = this@with
     }
 }

--- a/build-logic-settings/build-environment/src/main/kotlin/gradlebuild.build-environment.settings.gradle.kts
+++ b/build-logic-settings/build-environment/src/main/kotlin/gradlebuild.build-environment.settings.gradle.kts
@@ -20,31 +20,17 @@ import gradlebuild.basics.BuildEnvironmentService
 with(layout.rootDirectory) {
     gradle.lifecycle.beforeProject {
         val service = gradle.sharedServices.registerIfAbsent("buildEnvironmentService", BuildEnvironmentService::class) {
-            assert(project.path == ":") {
+            check(project.path == ":") {
                 // We rely on the fact that root is configured first
                 "BuildEnvironmentService should be registered by the root"
             }
             parameters.rootProjectDir = this@with
             parameters.rootProjectBuildDir = project.layout.buildDirectory
-            parameters.artifactoryUserName = providers.gradleProperty("artifactoryUserName")
-            parameters.artifactoryPassword = providers.gradleProperty("artifactoryPassword")
-            parameters.testVersions = providers.gradleProperty("testVersions")
-            parameters.integtestAgentAllowed = providers.gradleProperty("org.gradle.integtest.agent.allowed")
-            parameters.integtestDebug = providers.gradleProperty("org.gradle.integtest.debug")
-            parameters.integtestLauncherDebug = providers.gradleProperty("org.gradle.integtest.launcher.debug")
-            parameters.integtestVerbose = providers.gradleProperty("org.gradle.integtest.verbose")
         }
         val buildEnvironmentExtension = extensions.create("buildEnvironment", BuildEnvironmentExtension::class)
         buildEnvironmentExtension.gitCommitId = service.flatMap { it.gitCommitId }
         buildEnvironmentExtension.gitBranch = service.flatMap { it.gitBranch }
         buildEnvironmentExtension.repoRoot = this@with
         buildEnvironmentExtension.rootProjectBuildDir = service.flatMap { it.parameters.rootProjectBuildDir }
-        buildEnvironmentExtension.artifactoryUserName = service.flatMap { it.parameters.artifactoryUserName }
-        buildEnvironmentExtension.artifactoryPassword = service.flatMap { it.parameters.artifactoryPassword }
-        buildEnvironmentExtension.testVersions = service.flatMap { it.parameters.testVersions }
-        buildEnvironmentExtension.integtestAgentAllowed = service.flatMap { it.parameters.integtestAgentAllowed }
-        buildEnvironmentExtension.integtestDebug = service.flatMap { it.parameters.integtestDebug }
-        buildEnvironmentExtension.integtestLauncherDebug = service.flatMap { it.parameters.integtestLauncherDebug }
-        buildEnvironmentExtension.integtestVerbose = service.flatMap { it.parameters.integtestVerbose }
     }
 }

--- a/build-logic-settings/build-environment/src/main/kotlin/gradlebuild/basics/BuildEnvironmentExtension.kt
+++ b/build-logic-settings/build-environment/src/main/kotlin/gradlebuild/basics/BuildEnvironmentExtension.kt
@@ -26,4 +26,9 @@ interface BuildEnvironmentExtension {
     val repoRoot: DirectoryProperty
     val artifactoryUserName: Property<String>
     val artifactoryPassword: Property<String>
+    val testVersions: Property<String>
+    val integtestAgentAllowed: Property<String>
+    val integtestDebug: Property<String>
+    val integtestLauncherDebug: Property<String>
+    val integtestVerbose: Property<String>
 }

--- a/build-logic-settings/build-environment/src/main/kotlin/gradlebuild/basics/BuildEnvironmentExtension.kt
+++ b/build-logic-settings/build-environment/src/main/kotlin/gradlebuild/basics/BuildEnvironmentExtension.kt
@@ -24,6 +24,7 @@ interface BuildEnvironmentExtension {
     val gitCommitId: Property<String>
     val gitBranch: Property<String>
     val repoRoot: DirectoryProperty
+    val rootProjectBuildDir: DirectoryProperty
     val artifactoryUserName: Property<String>
     val artifactoryPassword: Property<String>
     val testVersions: Property<String>

--- a/build-logic-settings/build-environment/src/main/kotlin/gradlebuild/basics/BuildEnvironmentExtension.kt
+++ b/build-logic-settings/build-environment/src/main/kotlin/gradlebuild/basics/BuildEnvironmentExtension.kt
@@ -24,4 +24,6 @@ interface BuildEnvironmentExtension {
     val gitCommitId: Property<String>
     val gitBranch: Property<String>
     val repoRoot: DirectoryProperty
+    val artifactoryUserName: Property<String>
+    val artifactoryPassword: Property<String>
 }

--- a/build-logic-settings/build-environment/src/main/kotlin/gradlebuild/basics/BuildEnvironmentExtension.kt
+++ b/build-logic-settings/build-environment/src/main/kotlin/gradlebuild/basics/BuildEnvironmentExtension.kt
@@ -25,11 +25,4 @@ interface BuildEnvironmentExtension {
     val gitBranch: Property<String>
     val repoRoot: DirectoryProperty
     val rootProjectBuildDir: DirectoryProperty
-    val artifactoryUserName: Property<String>
-    val artifactoryPassword: Property<String>
-    val testVersions: Property<String>
-    val integtestAgentAllowed: Property<String>
-    val integtestDebug: Property<String>
-    val integtestLauncherDebug: Property<String>
-    val integtestVerbose: Property<String>
 }

--- a/build-logic-settings/build-environment/src/main/kotlin/gradlebuild/basics/BuildEnvironmentService.kt
+++ b/build-logic-settings/build-environment/src/main/kotlin/gradlebuild/basics/BuildEnvironmentService.kt
@@ -32,6 +32,11 @@ abstract class BuildEnvironmentService : BuildService<BuildEnvironmentService.Pa
         val rootProjectDir: DirectoryProperty
         val artifactoryUserName: Property<String>
         val artifactoryPassword: Property<String>
+        val testVersions: Property<String>
+        val integtestAgentAllowed: Property<String>
+        val integtestDebug: Property<String>
+        val integtestLauncherDebug: Property<String>
+        val integtestVerbose: Property<String>
     }
 
     @get:Inject

--- a/build-logic-settings/build-environment/src/main/kotlin/gradlebuild/basics/BuildEnvironmentService.kt
+++ b/build-logic-settings/build-environment/src/main/kotlin/gradlebuild/basics/BuildEnvironmentService.kt
@@ -30,6 +30,7 @@ abstract class BuildEnvironmentService : BuildService<BuildEnvironmentService.Pa
 
     interface Parameters : BuildServiceParameters {
         val rootProjectDir: DirectoryProperty
+        val rootProjectBuildDir: DirectoryProperty
         val artifactoryUserName: Property<String>
         val artifactoryPassword: Property<String>
         val testVersions: Property<String>

--- a/build-logic-settings/build-environment/src/main/kotlin/gradlebuild/basics/BuildEnvironmentService.kt
+++ b/build-logic-settings/build-environment/src/main/kotlin/gradlebuild/basics/BuildEnvironmentService.kt
@@ -17,6 +17,7 @@
 package gradlebuild.basics
 
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.services.BuildService
@@ -29,6 +30,8 @@ abstract class BuildEnvironmentService : BuildService<BuildEnvironmentService.Pa
 
     interface Parameters : BuildServiceParameters {
         val rootProjectDir: DirectoryProperty
+        val artifactoryUserName: Property<String>
+        val artifactoryPassword: Property<String>
     }
 
     @get:Inject

--- a/build-logic-settings/build-environment/src/main/kotlin/gradlebuild/basics/BuildEnvironmentService.kt
+++ b/build-logic-settings/build-environment/src/main/kotlin/gradlebuild/basics/BuildEnvironmentService.kt
@@ -17,7 +17,6 @@
 package gradlebuild.basics
 
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.services.BuildService
@@ -31,13 +30,6 @@ abstract class BuildEnvironmentService : BuildService<BuildEnvironmentService.Pa
     interface Parameters : BuildServiceParameters {
         val rootProjectDir: DirectoryProperty
         val rootProjectBuildDir: DirectoryProperty
-        val artifactoryUserName: Property<String>
-        val artifactoryPassword: Property<String>
-        val testVersions: Property<String>
-        val integtestAgentAllowed: Property<String>
-        val integtestDebug: Property<String>
-        val integtestLauncherDebug: Property<String>
-        val integtestVerbose: Property<String>
     }
 
     @get:Inject

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild.binary-compatibility.gradle
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild.binary-compatibility.gradle
@@ -177,7 +177,7 @@ def checkBinaryCompatibility = tasks.register("checkBinaryCompatibility", gradle
         apiSourceFolders,
         baseVersion.get(),
         mainApiChangesJsonFile.asFile,
-        rootProject.layout.projectDirectory,
+        project.isolated.rootProject.projectDirectory,
         currentUpgradedPropertiesFile.get().asFile,
         baselineUpgradedPropertiesFile.get().asFile
     )

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild.binary-compatibility.gradle
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild.binary-compatibility.gradle
@@ -64,7 +64,7 @@ def DOCUMENTATION_ATTRIBUTE = objects.named(Category, Category.DOCUMENTATION)
 def SOURCES_ATTRIBUTE = objects.named(DocsType, "gradle-source-folders")
 
 configurations {
-    baseline
+    def baseline = baseline {}
     baselineClasspath {
         extendsFrom baseline
         attributes.attribute(ARTIFACT_TYPE, 'gradle-classpath')

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleReleaseNotesPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleReleaseNotesPlugin.java
@@ -82,7 +82,7 @@ public class GradleReleaseNotesPlugin implements Plugin<Project> {
         tasks.withType(AbstractCheckOrUpdateContributorsInReleaseNotes.class).configureEach(task -> {
             task.getGithubToken().set(project.getProviders().environmentVariable("GITHUB_TOKEN"));
             task.getReleaseNotes().set(extension.getReleaseNotes().getMarkdownFile());
-            task.getMilestone().convention(project.getProviders().fileContents(project.getRootProject().getLayout().getProjectDirectory().file("version.txt")).getAsText().map(String::trim));
+            task.getMilestone().convention(project.getProviders().fileContents(project.getIsolated().getRootProject().getProjectDirectory().file("version.txt")).getAsText().map(String::trim));
         });
 
         Configuration jquery = project.getConfigurations().create("jquery", conf -> {

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
@@ -17,7 +17,6 @@
 package gradlebuild.integrationtests
 
 import gradlebuild.basics.capitalize
-import gradlebuild.basics.getBuildEnvironmentExtension
 import gradlebuild.basics.repoRoot
 import gradlebuild.basics.testSplitExcludeTestClasses
 import gradlebuild.basics.testSplitIncludeTestClasses
@@ -195,10 +194,10 @@ fun IntegrationTest.setUpAgentIfNeeded(testType: TestType, executer: String) {
         })
     }
 
-    val environmentExtension = project.getBuildEnvironmentExtension()
     val integTestUseAgentSysPropName = "org.gradle.integtest.agent.allowed"
-    if (environmentExtension.integtestAgentAllowed.isPresent) {
-        val shouldUseAgent = environmentExtension.integtestAgentAllowed.get().toBoolean()
+    val integtestAgentAllowed = project.providers.gradleProperty(integTestUseAgentSysPropName);
+    if (integtestAgentAllowed.isPresent) {
+        val shouldUseAgent = integtestAgentAllowed.get().toBoolean()
         systemProperties[integTestUseAgentSysPropName] = shouldUseAgent.toString()
     }
 }
@@ -207,17 +206,19 @@ fun IntegrationTest.setUpAgentIfNeeded(testType: TestType, executer: String) {
 private
 fun IntegrationTest.addDebugProperties() {
     // TODO Move magic property out
-    val environmentExtension = project.getBuildEnvironmentExtension()
-    if (environmentExtension.integtestDebug.isPresent) {
+    val integtestDebug = project.providers.gradleProperty("org.gradle.integtest.debug")
+    if (integtestDebug.isPresent) {
         systemProperties["org.gradle.integtest.debug"] = "true"
         testLogging.showStandardStreams = true
     }
     // TODO Move magic property out
-    if (environmentExtension.integtestVerbose.isPresent) {
+    val integtestVerbose = project.providers.gradleProperty("org.gradle.integtest.verbose")
+    if (integtestVerbose.isPresent) {
         testLogging.showStandardStreams = true
     }
     // TODO Move magic property out
-    if (environmentExtension.integtestLauncherDebug.isPresent) {
+    val integtestLauncherDebug = project.providers.gradleProperty("org.gradle.integtest.launcher.debug")
+    if (integtestLauncherDebug.isPresent) {
         systemProperties["org.gradle.integtest.launcher.debug"] = "true"
     }
 }
@@ -225,10 +226,10 @@ fun IntegrationTest.addDebugProperties() {
 
 fun DistributionTest.setSystemPropertiesOfTestJVM(defaultVersions: String) {
     // use -PtestVersions=all or -PtestVersions=1.2,1.3…
-    val extension = project.getBuildEnvironmentExtension()
     val integTestVersionsSysProp = "org.gradle.integtest.versions"
-    if (extension.testVersions.isPresent) {
-        systemProperties[integTestVersionsSysProp] = extension.testVersions.get()
+    val testVersions = project.providers.gradleProperty("testVersions")
+    if (testVersions.isPresent) {
+        systemProperties[integTestVersionsSysProp] = testVersions.get()
     } else {
         systemProperties[integTestVersionsSysProp] = defaultVersions
     }

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
@@ -17,6 +17,7 @@
 package gradlebuild.integrationtests
 
 import gradlebuild.basics.capitalize
+import gradlebuild.basics.getBuildEnvironmentExtension
 import gradlebuild.basics.repoRoot
 import gradlebuild.basics.testSplitExcludeTestClasses
 import gradlebuild.basics.testSplitIncludeTestClasses
@@ -194,9 +195,10 @@ fun IntegrationTest.setUpAgentIfNeeded(testType: TestType, executer: String) {
         })
     }
 
+    val environmentExtension = project.getBuildEnvironmentExtension()
     val integTestUseAgentSysPropName = "org.gradle.integtest.agent.allowed"
-    if (project.hasProperty(integTestUseAgentSysPropName)) {
-        val shouldUseAgent = (project.property(integTestUseAgentSysPropName) as? String).toBoolean()
+    if (environmentExtension.integtestAgentAllowed.isPresent) {
+        val shouldUseAgent = environmentExtension.integtestAgentAllowed.get().toBoolean()
         systemProperties[integTestUseAgentSysPropName] = shouldUseAgent.toString()
     }
 }
@@ -205,16 +207,17 @@ fun IntegrationTest.setUpAgentIfNeeded(testType: TestType, executer: String) {
 private
 fun IntegrationTest.addDebugProperties() {
     // TODO Move magic property out
-    if (project.hasProperty("org.gradle.integtest.debug")) {
+    val environmentExtension = project.getBuildEnvironmentExtension()
+    if (environmentExtension.integtestDebug.isPresent) {
         systemProperties["org.gradle.integtest.debug"] = "true"
         testLogging.showStandardStreams = true
     }
     // TODO Move magic property out
-    if (project.hasProperty("org.gradle.integtest.verbose")) {
+    if (environmentExtension.integtestVerbose.isPresent) {
         testLogging.showStandardStreams = true
     }
     // TODO Move magic property out
-    if (project.hasProperty("org.gradle.integtest.launcher.debug")) {
+    if (environmentExtension.integtestLauncherDebug.isPresent) {
         systemProperties["org.gradle.integtest.launcher.debug"] = "true"
     }
 }
@@ -222,9 +225,10 @@ fun IntegrationTest.addDebugProperties() {
 
 fun DistributionTest.setSystemPropertiesOfTestJVM(defaultVersions: String) {
     // use -PtestVersions=all or -PtestVersions=1.2,1.3…
+    val extension = project.getBuildEnvironmentExtension()
     val integTestVersionsSysProp = "org.gradle.integtest.versions"
-    if (project.hasProperty("testVersions")) {
-        systemProperties[integTestVersionsSysProp] = project.property("testVersions")
+    if (extension.testVersions.isPresent) {
+        systemProperties[integTestVersionsSysProp] = extension.testVersions.get()
     } else {
         systemProperties[integTestVersionsSysProp] = defaultVersions
     }

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -27,6 +27,7 @@ import gradlebuild.basics.maxTestDistributionPartitionSecond
 import gradlebuild.basics.maxTestDistributionRemoteExecutors
 import gradlebuild.basics.predictiveTestSelectionEnabled
 import gradlebuild.basics.rerunAllTests
+import gradlebuild.basics.buildRunningOnCi
 import gradlebuild.basics.testDistributionEnabled
 import gradlebuild.basics.testJavaVendor
 import gradlebuild.basics.testJavaVersion
@@ -302,7 +303,7 @@ fun configureTests() {
 
 fun removeTeamcityTempProperty() {
     // Undo: https://github.com/JetBrains/teamcity-gradle/blob/e1dc98db0505748df7bea2e61b5ee3a3ba9933db/gradle-runner-agent/src/main/scripts/init.gradle#L818
-    if (project.hasProperty("teamcity")) {
+    if (project.buildRunningOnCi.get() && project.hasProperty("teamcity")) {
         @Suppress("UNCHECKED_CAST") val teamcity = project.property("teamcity") as MutableMap<String, Any>
         teamcity["teamcity.build.tempDir"] = ""
     }

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -175,7 +175,7 @@ class PerformanceTestPlugin : Plugin<Project> {
         }
 
         tasks.withType<TemplateProjectGeneratorTask>().configureEach {
-            sharedTemplateDirectory = project(":internal-performance-testing").file("src/templates")
+            sharedTemplateDirectory = project(":internal-performance-testing").isolated.projectDirectory.file("src/templates").asFile
         }
     }
 

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -22,6 +22,7 @@ import gradlebuild.basics.buildBranch
 import gradlebuild.basics.buildCommitId
 import gradlebuild.basics.capitalize
 import gradlebuild.basics.defaultPerformanceBaselines
+import gradlebuild.basics.getBuildEnvironmentExtension
 import gradlebuild.basics.includePerformanceTestScenarios
 import gradlebuild.basics.logicalBranch
 import gradlebuild.basics.performanceBaselines
@@ -320,7 +321,7 @@ class PerformanceTestPlugin : Plugin<Project> {
         // determineBaselines.determinedBaselines -> buildCommitDistribution.baselines
         val determineBaselines = tasks.register("determineBaselines", DetermineBaselines::class, false)
         val buildCommitDistribution = tasks.register("buildCommitDistribution", BuildCommitDistribution::class)
-        val buildCommitDistributionsDir = project.rootProject.layout.buildDirectory.dir("commit-distributions")
+        val buildCommitDistributionsDir = project.getBuildEnvironmentExtension().rootProjectBuildDir.dir("commit-distributions")
 
         determineBaselines.configure {
             configuredBaselines = extension.baselines

--- a/build-logic/publishing/src/main/kotlin/gradlebuild.publish-defaults.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/gradlebuild.publish-defaults.gradle.kts
@@ -27,10 +27,10 @@ val artifactoryUrl
     get() = System.getenv("GRADLE_INTERNAL_REPO_URL") ?: ""
 
 val artifactoryUserName
-    get() = getBuildEnvironmentExtension()?.artifactoryUserName?.orNull
+    get() = getBuildEnvironmentExtension().artifactoryUserName.orNull
 
 val artifactoryUserPassword
-    get() = getBuildEnvironmentExtension()?.artifactoryPassword?.orNull
+    get() = getBuildEnvironmentExtension().artifactoryPassword.orNull
 
 tasks.withType<AbstractPublishToMaven>().configureEach {
     val noUpload = project.gradleProperty("noUpload")

--- a/build-logic/publishing/src/main/kotlin/gradlebuild.publish-defaults.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/gradlebuild.publish-defaults.gradle.kts
@@ -29,7 +29,7 @@ val artifactoryUserName
     get() = project.providers.gradleProperty("artifactoryUserName").orNull
 
 val artifactoryUserPassword
-    get() = project.providers.gradleProperty("artifactoryPassword").orNull
+    get() = project.providers.gradleProperty("artifactoryUserPassword").orNull
 
 tasks.withType<AbstractPublishToMaven>().configureEach {
     val noUpload = project.gradleProperty("noUpload")

--- a/build-logic/publishing/src/main/kotlin/gradlebuild.publish-defaults.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/gradlebuild.publish-defaults.gradle.kts
@@ -15,7 +15,6 @@
  */
 
 import gradle.kotlin.dsl.accessors._25bd7e7076749e7e243da5bad7112e92.moduleIdentity
-import gradlebuild.basics.getBuildEnvironmentExtension
 import gradlebuild.basics.gradleProperty
 import org.gradle.api.publish.maven.MavenPublication
 
@@ -27,10 +26,10 @@ val artifactoryUrl
     get() = System.getenv("GRADLE_INTERNAL_REPO_URL") ?: ""
 
 val artifactoryUserName
-    get() = getBuildEnvironmentExtension().artifactoryUserName.orNull
+    get() = project.providers.gradleProperty("artifactoryUserName").orNull
 
 val artifactoryUserPassword
-    get() = getBuildEnvironmentExtension().artifactoryPassword.orNull
+    get() = project.providers.gradleProperty("artifactoryPassword").orNull
 
 tasks.withType<AbstractPublishToMaven>().configureEach {
     val noUpload = project.gradleProperty("noUpload")

--- a/build-logic/publishing/src/main/kotlin/gradlebuild.publish-defaults.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/gradlebuild.publish-defaults.gradle.kts
@@ -15,6 +15,7 @@
  */
 
 import gradle.kotlin.dsl.accessors._25bd7e7076749e7e243da5bad7112e92.moduleIdentity
+import gradlebuild.basics.getBuildEnvironmentExtension
 import gradlebuild.basics.gradleProperty
 import org.gradle.api.publish.maven.MavenPublication
 
@@ -26,10 +27,10 @@ val artifactoryUrl
     get() = System.getenv("GRADLE_INTERNAL_REPO_URL") ?: ""
 
 val artifactoryUserName
-    get() = findProperty("artifactoryUserName") as String?
+    get() = getBuildEnvironmentExtension()?.artifactoryUserName?.orNull
 
 val artifactoryUserPassword
-    get() = findProperty("artifactoryUserPassword") as String?
+    get() = getBuildEnvironmentExtension()?.artifactoryPassword?.orNull
 
 tasks.withType<AbstractPublishToMaven>().configureEach {
     val noUpload = project.gradleProperty("noUpload")

--- a/platforms/documentation/docs/build.gradle
+++ b/platforms/documentation/docs/build.gradle
@@ -109,8 +109,8 @@ tasks.named("stageDocs") {
 
 samples {
     templates {
-        javaAndroidApplication
-        structuringSoftwareProjects
+        javaAndroidApplication {}
+        structuringSoftwareProjects {}
         springBootWebApplication {
             target = "app"
         }
@@ -121,11 +121,11 @@ samples {
             sourceDirectory = gradlePluginInJava.sourceDirectory
             target = "buildSrc"
         }
-        buildSrcPluginJavaModuleTransform
+        buildSrcPluginJavaModuleTransform {}
 
-        javaApplication
-        javaListLibrary
-        javaUtilitiesLibrary
+        javaApplication {}
+        javaListLibrary {}
+        javaUtilitiesLibrary {}
         javaListLibraryInMyLibrary {
             sourceDirectory = javaListLibrary.sourceDirectory
             target = "my-library"
@@ -179,8 +179,8 @@ samples {
             target = "application"
         }
 
-        groovyListLibrary
-        groovyUtilitiesLibrary
+        groovyListLibrary {}
+        groovyUtilitiesLibrary {}
         groovyListLibraryInMyLibrary {
             sourceDirectory = groovyListLibrary.sourceDirectory
             target = "my-library"
@@ -190,7 +190,7 @@ samples {
             target = "my-library"
         }
 
-        projectInfoPlugin
+        projectInfoPlugin {}
 
         precompiledScriptPluginUtils {
             target = "convention-plugins"
@@ -199,7 +199,7 @@ samples {
             sourceDirectory = precompiledScriptPluginUtils.sourceDirectory
             target = "buildSrc"
         }
-        problemsApiUsage
+        problemsApiUsage {}
     }
 
     // TODO: Do this lazily so we don't need to walk the filesystem during configuration

--- a/subprojects/distributions-full/build.gradle.kts
+++ b/subprojects/distributions-full/build.gradle.kts
@@ -1,3 +1,5 @@
+import gradlebuild.basics.BuildEnvironmentExtension
+
 plugins {
     id("gradlebuild.distribution.packaging")
     id("gradlebuild.verify-build-environment")
@@ -25,8 +27,9 @@ dependencies {
 }
 
 // This is required for the separate promotion build and should be adjusted there in the future
+val buildEnvironmentExtension = extensions.getByType(BuildEnvironmentExtension::class)
 tasks.register<Copy>("copyDistributionsToRootBuild") {
     dependsOn("buildDists")
     from(layout.buildDirectory.dir("distributions"))
-    into(rootProject.layout.buildDirectory.dir("distributions"))
+    into(buildEnvironmentExtension.rootProjectBuildDir.dir("distributions"))
 }

--- a/testing/internal-integ-testing/build.gradle.kts
+++ b/testing/internal-integ-testing/build.gradle.kts
@@ -179,8 +179,8 @@ val prepareVersionsInfo = tasks.register<PrepareVersionsInfo>("prepareVersionsIn
 }
 
 val copyTestedVersionsInfo by tasks.registering(Copy::class) {
-    from(rootProject.layout.projectDirectory.file("gradle/dependency-management/agp-versions.properties"))
-    from(rootProject.layout.projectDirectory.file("gradle/dependency-management/kotlin-versions.properties"))
+    from(isolated.rootProject.projectDirectory.file("gradle/dependency-management/agp-versions.properties"))
+    from(isolated.rootProject.projectDirectory.file("gradle/dependency-management/kotlin-versions.properties"))
     into(layout.buildDirectory.dir("generated-resources/tested-versions"))
 }
 


### PR DESCRIPTION
This fixes IP issues for:
- gradlebuild.unittest-and-compile
- gradlebuild.publish-public-libraries
- gradlebuild.binary-compatibility plugin
- documentation/docs/build.gradle
- gradlebuild.cross-version-tests
- gradlebuild.distribution-testing
- gradlebuild.integration-tests
- PerformanceTestPlugin

The only remaining issues for sync are coming from IntelliJ init script and dependency-analysis plugin.

Note that sync fails with this exception:
```
java.lang.IllegalStateException: Cannot add listener of type ProjectComponentObservationListener after events have been broadcast.
	at org.gradle.internal.event.DefaultListenerManager$EventBroadcast.checkListenersCanBeAdded(DefaultListenerManager.java:334)
	at org.gradle.internal.event.DefaultListenerManager$EventBroadcast.maybeAdd(DefaultListenerManager.java:259)
	at org.gradle.internal.event.DefaultListenerManager$ListenerDetails.useAsListener(DefaultListenerManager.java:504)
	at org.gradle.internal.event.DefaultListenerManager.addListener(DefaultListenerManager.java:118)
	at org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprintController.addListener(ConfigurationCacheFingerprintController.kt:297)
	at org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprintController.access$addListener(ConfigurationCacheFingerprintController.kt:73)
	at org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprintController$Paused.maybeStart(ConfigurationCacheFingerprintController.kt:195)
	at org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprintController.maybeStartCollectingFingerprint(ConfigurationCacheFingerprintController.kt:251)
	at org.gradle.configurationcache.DefaultConfigurationCache.startCollectingCacheFingerprint(DefaultConfigurationCache.kt:467)
	at org.gradle.configurationcache.DefaultConfigurationCache.prepareForWork(DefaultConfigurationCache.kt:353)
	at org.gradle.configurationcache.DefaultConfigurationCache.runWorkThatContributesToCacheEntry(DefaultConfigurationCache.kt:342)
	at org.gradle.configurationcache.DefaultConfigurationCache.loadOrScheduleRequestedTasks(DefaultConfigurationCache.kt:152)
	at org.gradle.configurationcache.ConfigurationCacheAwareBuildTreeWorkController$scheduleAndRunRequestedTasks$executionResult$1.apply(ConfigurationCacheAwareBuildTreeWorkController.kt:45)
	at org.gradle.configurationcache.ConfigurationCacheAwareBuildTreeWorkController$scheduleAndRunRequestedTasks$executionResult$1.apply(ConfigurationCacheAwareBuildTreeWorkController.kt:44)
	at org.gradle.composite.internal.DefaultIncludedBuildTaskGraph.withNewWorkGraph(DefaultIncludedBuildTaskGraph.java:112)
... some more lines
```	

