### PR TITLE
Pull Property.replace() out of release again

### DIFF
--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -463,7 +463,6 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         return result;
     }
 
-    @Override
     public void replace(Transformer<? extends @org.jetbrains.annotations.Nullable FileCollection, ? super FileCollection> transformation) {
         FileCollection newValue = transformation.transform(shallowCopy());
         if (newValue != null) {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -312,7 +312,6 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         return new KeySetProvider();
     }
 
-    @Override
     public void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Map<? extends K, ? extends V>>, ? super Provider<Map<K, V>>> transformation) {
         Provider<? extends Map<? extends K, ? extends V>> newValue = transformation.transform(shallowCopy());
         if (newValue != null) {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -173,7 +173,6 @@ public class DefaultProperty<T> extends AbstractProperty<T, ProviderInternal<? e
         return String.format("property(%s, %s)", type.getName(), describeValue());
     }
 
-    @Override
     public void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends T>, ? super Provider<T>> transformation) {
         Provider<? extends T> newValue = transformation.transform(shallowCopy());
         if (newValue != null) {

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -152,35 +152,6 @@ println(files.elements.get()) // [.../dir2]
 
 This is analogous to the [`convention(...)`](javadoc/org/gradle/api/provider/Property.html#convention-T-) methods that have been available on lazy properties since Gradle 5.1.
 
-#### Updating lazy property based on its current value with `replace()`
-
-Modify a property based on its current value, such as appending text.
-previously required obtaining the current value explicitly by calling `Property.get()`:
-
-```kotlin
-val property = objects.property<String>()
-property.set("some value")
-property.set("${property.get()} and more")
-
-println(property.get()) // "some value and more""
-```
-
-This could lead to performance issues like configuration cache misses.
-
-Additionally, when attempting to construct a value [lazily](userguide/lazy_configuration.html), for instance, using `property.set(property.map { "$it and more" })`, a build failure could occur due to circular reference evaluation.
-
-[`Property`](javadoc/org/gradle/api/provider/Property.html#replace-org.gradle.api.Transformer-) and [`ConfigurableFileCollection`](javadoc/org/gradle/api/file/ConfigurableFileCollection.html#replace-org.gradle.api.Transformer-) now provide their respective `replace(Transformer<...>)` methods that allow lazily building the new value based on the current one:
-
-```kotlin
-val property = objects.property<String>()
-property.set("some value")
-property.replace { it.map { "$it and more" } }
-
-println(property.get()) // "some value and more"
-```
-
-Refer to the Javadoc for [`Property.replace(Transformer<>)`](javadoc/org/gradle/api/provider/Property.html#replace-org.gradle.api.Transformer-) and [`ConfigurableFileCollection.replace(Transformer<>)`](javadoc/org/gradle/api/file/ConfigurableFileCollection.html#replace-org.gradle.api.Transformer-) for more details, including limitations.
-
 #### New Gradle lifecycle callbacks
 
 This release introduces a new [`GradleLifecycle`](javadoc/org/gradle/api/invocation/GradleLifecycle.html) API, accessible via `gradle.lifecycle`, which plugin authors and build engineers can use to register actions to be executed at certain points in the build lifecycle.

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
@@ -17,7 +17,6 @@ package org.gradle.api.file;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.SupportsKotlinAssignmentOverloading;
-import org.gradle.api.Transformer;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.HasConfigurableValue;
 import org.gradle.api.provider.SupportsConvention;
@@ -114,43 +113,4 @@ public interface ConfigurableFileCollection extends FileCollection, HasConfigura
      * @return this
      */
     ConfigurableFileCollection builtBy(Object... tasks);
-
-    /**
-     * Replaces the current contents of this file collection with a one computed by the provided transformation.
-     * The transformation is applied to the file collection representing the current contents, and the returned collection is used as a new content.
-     * The current contents collection can be used to derive the new value, but doesn't have to.
-     * Returning null from the transformation empties this collection.
-     * For example, it is possible to filter out all text files from the collection:
-     * <pre class='autoTested'>
-     *     def collection = files("a.txt", "b.md")
-     *
-     *     collection.replace { it.filter { f -&gt; !f.name.endsWith(".txt") } }
-     *
-     *     println(collection.files) // ["b.md"]
-     * </pre>
-     * <p>
-     * <b>Further changes to this file collection, such as calls to {@link #setFrom(Object...)} or {@link #from(Object...)}, are not transformed, and override the replacement instead</b>.
-     * Because of this, this method inherently depends on the order of changes, and therefore must be used sparingly.
-     * <p>
-     * If this file collection consists of other mutable sources, then the current contents collection tracks changes to these sources.
-     * For example, changes to the upstream collection are visible:
-     * <pre class='autoTested'>
-     *     def upstream = files("a.txt", "b.md")
-     *     def collection = files(upstream)
-     *
-     *     collection.replace { it.filter { f -&gt; !f.name.endsWith(".txt") } }
-     *     upstream.from("c.md", "d.txt")
-     *
-     *     println(collection.files) // ["b.md", "c.md"]
-     * </pre>
-     * The provided transformation runs <b>eagerly</b>, so it can capture any objects without introducing memory leaks and without breaking configuration caching.
-     * However, transformations applied to the current contents collection (like {@link FileCollection#filter(Closure)}) are subject to the usual constraints.
-     * <p>
-     * The current contents collection inherits dependencies of this collection specified by {@link #builtBy(Object...)}.
-     *
-     * @param transformation the transformation to apply to the current value. May return null, which empties this collection.
-     * @since 8.8
-     */
-    @Incubating
-    void replace(Transformer<? extends @org.jetbrains.annotations.Nullable FileCollection, ? super FileCollection> transformation);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
@@ -16,9 +16,6 @@
 
 package org.gradle.api.provider;
 
-import org.gradle.api.Incubating;
-import org.gradle.api.Transformer;
-
 import javax.annotation.Nullable;
 import java.util.List;
 
@@ -84,47 +81,4 @@ public interface ListProperty<T> extends Provider<List<T>>, HasMultipleValues<T>
      */
     @Override
     ListProperty<T> unsetConvention();
-
-    /**
-     * Replaces the current value of this property with a one computed by the provided transformation.
-     * The transformation is applied to the provider of the current value, and the returned provider is used as a new value.
-     * The provider of the value can be used to derive the new value, but doesn't have to.
-     * Returning null from the transformation unsets the property.
-     * For example, the current value of a string list property can be reversed:
-     * <pre class='autoTested'>
-     *     def property = objects.listProperty(String).value(["a", "b"])
-     *
-     *     property.replace { it.map { value -&gt; value.reverse() } }
-     *
-     *     println(property.get()) // ["b", "a"]
-     * </pre>
-     * Note that simply writing {@code property.set(property.map { ... } } doesn't work and will cause an exception because of a circular reference evaluation at runtime.
-     * <p>
-     * <b>Further changes to the value of the property, such as calls to {@link #set(Iterable)}, are not transformed, and override the replacement instead</b>.
-     * Because of this, this method inherently depends on the order of property changes, and therefore must be used sparingly.
-     * <p>
-     * If the value of the property is specified via a provider, then the current value provider tracks that provider.
-     * For example, changes to the upstream property are visible:
-     * <pre class='autoTested'>
-     *     def upstream = objects.listProperty(String).value(["a", "b"])
-     *     def property = objects.listProperty(String).value(upstream)
-     *
-     *     property.replace { it.map { value -&gt; value.reverse() } }
-     *     upstream.set(["c", "d"])
-     *
-     *     println(property.get()) // ["d", "c"]
-     * </pre>
-     * The provided transformation runs <b>eagerly</b>, so it can capture any objects without introducing memory leaks and without breaking configuration caching.
-     * However, transformations applied to the current value provider (like {@link Provider#map(Transformer)}) are subject to the usual constraints.
-     * <p>
-     * If the property has no explicit value set, then the current value comes from the convention.
-     * Changes to convention of this property do not affect the current value provider in this case, though upstream changes are still visible if the convention was set to a provider.
-     * If there is no convention too, then the current value is a provider without a value.
-     * The replacement value becomes the explicit value of the property.
-     *
-     * @param transformation the transformation to apply to the current value. May return null, which unsets the property.
-     * @since 8.8
-     */
-    @Incubating
-    void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Iterable<? extends T>>, ? super Provider<List<T>>> transformation);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
@@ -18,7 +18,6 @@ package org.gradle.api.provider;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.SupportsKotlinAssignmentOverloading;
-import org.gradle.api.Transformer;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -289,49 +288,6 @@ public interface MapProperty<K, V> extends Provider<Map<K, V>>, HasConfigurableV
     @Incubating
     @Override
     MapProperty<K, V> unsetConvention();
-
-    /**
-     * Replaces the current value of this property with a one computed by the provided transformation.
-     * The transformation is applied to the provider of the current value, and the returned provider is used as a new value.
-     * The provider of the value can be used to derive the new value, but doesn't have to.
-     * Returning null from the transformation unsets the property.
-     * For example, the current value of a string map property can be filtered to retain only vowel keys:
-     * <pre class='autoTested'>
-     *     def property = objects.mapProperty(String, String).value(a: "a", b: "b")
-     *
-     *     property.replace { it.map { value -&gt; value.subMap("a", "e", "i", "o", "u") } }
-     *
-     *     println(property.get()) // [a: "a"]
-     * </pre>
-     * Note that simply writing {@code property.set(property.map { ... } } doesn't work and will cause an exception because of a circular reference evaluation at runtime.
-     * <p>
-     * <b>Further changes to the value of the property, such as calls to {@link #set(Map)}, are not transformed, and override the replacement instead</b>.
-     * Because of this, this method inherently depends on the order of property changes, and therefore must be used sparingly.
-     * <p>
-     * If the value of the property is specified via a provider, then the current value provider tracks that provider.
-     * For example, changes to the upstream property are visible:
-     * <pre class='autoTested'>
-     *     def upstream = objects.mapProperty(String, String).value(a: "a", b: "b")
-     *     def property = objects.mapProperty(String, String).value(upstream)
-     *
-     *     property.replace { it.map { value -&gt; value.subMap("a", "e", "i", "o", "u") } }
-     *     upstream.value(e: "e", f: "f")
-     *
-     *     println(property.get()) // [e: "e"]
-     * </pre>
-     * The provided transformation runs <b>eagerly</b>, so it can capture any objects without introducing memory leaks and without breaking configuration caching.
-     * However, transformations applied to the current value provider (like {@link Provider#map(Transformer)}) are subject to the usual constraints.
-     * <p>
-     * If the property has no explicit value set, then the current value comes from the convention.
-     * Changes to convention of this property do not affect the current value provider in this case, though upstream changes are still visible if the convention was set to a provider.
-     * If there is no convention too, then the current value is a provider without a value.
-     * The replacement value becomes the explicit value of the property.
-
-     * @param transformation the transformation to apply to the current value. May return null, which unsets the property.
-     * @since 8.8
-     */
-    @Incubating
-    void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Map<? extends K, ? extends V>>, ? super Provider<Map<K, V>>> transformation);
 
     /**
      * Disallows further changes to the value of this property. Calls to methods that change the value of this property, such as {@link #set(Map)} or {@link #put(Object, Object)} will fail.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
@@ -16,9 +16,7 @@
 
 package org.gradle.api.provider;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.SupportsKotlinAssignmentOverloading;
-import org.gradle.api.Transformer;
 import org.gradle.api.model.ObjectFactory;
 
 import javax.annotation.Nullable;
@@ -199,47 +197,4 @@ public interface Property<T> extends Provider<T>, HasConfigurableValue, Supports
      */
     @Override
     void finalizeValue();
-
-    /**
-     * Replaces the current value of this property with a one computed by the provided transformation.
-     * The transformation is applied to the provider of the current value, and the returned provider is used as a new value.
-     * The provider of the value can be used to derive the new value, but doesn't have to.
-     * Returning null from the transformation unsets the property.
-     * For example, the current value of a string property can be reversed:
-     * <pre class='autoTested'>
-     *     def property = objects.property(String).value("value")
-     *
-     *     property.replace { it.map { value -&gt; value.reverse() } }
-     *
-     *     println(property.get()) // "eulav"
-     * </pre>
-     * Note that simply writing {@code property.set(property.map { ... } } doesn't work and will cause an exception because of a circular reference evaluation at runtime.
-     * <p>
-     * <b>Further changes to the value of the property, such as calls to {@link #set(Object)}, are not transformed, and override the replacement instead</b>.
-     * Because of this, this method inherently depends on the order of property changes, and therefore must be used sparingly.
-     * <p>
-     * If the value of the property is specified via a provider, then the current value provider tracks that provider.
-     * For example, changes to the upstream property are visible:
-     * <pre class='autoTested'>
-     *     def upstream = objects.property(String).value("value")
-     *     def property = objects.property(String).value(upstream)
-     *
-     *     property.replace { it.map { value -&gt; value.reverse() } }
-     *     upstream.set("other")
-     *
-     *     println(property.get()) // "rehto"
-     * </pre>
-     * The provided transformation runs <b>eagerly</b>, so it can capture any objects without introducing memory leaks and without breaking configuration caching.
-     * However, transformations applied to the current value provider (like {@link Provider#map(Transformer)}) are subject to the usual constraints.
-     * <p>
-     * If the property has no explicit value set, then the current value comes from the convention.
-     * Changes to convention of this property do not affect the current value provider in this case, though upstream changes are still visible if the convention was set to a provider.
-     * If there is no convention too, then the current value is a provider without a value.
-     * The replacement value becomes the explicit value of the property.
-     *
-     * @param transformation the transformation to apply to the current value. May return null, which unsets the property.
-     * @since 8.8
-     */
-    @Incubating
-    void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends T>, ? super Provider<T>> transformation);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
@@ -16,9 +16,6 @@
 
 package org.gradle.api.provider;
 
-import org.gradle.api.Incubating;
-import org.gradle.api.Transformer;
-
 import javax.annotation.Nullable;
 import java.util.Set;
 
@@ -83,48 +80,4 @@ public interface SetProperty<T> extends Provider<Set<T>>, HasMultipleValues<T> {
      */
     @Override
     SetProperty<T> unsetConvention();
-
-    /**
-     * Replaces the current value of this property with a one computed by the provided transformation.
-     * The transformation is applied to the provider of the current value, and the returned provider is used as a new value.
-     * The provider of the value can be used to derive the new value, but doesn't have to.
-     * Returning null from the transformation unsets the property.
-     * For example, the current value of a string set property can be filtered to exclude vowels:
-     * <pre class='autoTested'>
-     *     def property = objects.setProperty(String).value(["a", "b"])
-     *
-     *     property.replace { it.map { value -&gt; value - ["a", "e", "i", "o", "u"] } }
-     *
-     *     println(property.get()) // ["b"]
-     * </pre>
-     * <p>
-     * Note that simply writing {@code property.set(property.map { ... } } doesn't work and will cause an exception because of a circular reference evaluation at runtime.
-     * <p>
-     * <b>Further changes to the value of the property, such as calls to {@link #set(Iterable)}, are not transformed, and override the replacement instead</b>.
-     * Because of this, this method inherently depends on the order of property changes, and therefore must be used sparingly.
-     * <p>
-     * If the value of the property is specified via a provider, then the current value provider tracks that provider.
-     * For example, changes to the upstream property are visible:
-     * <pre class='autoTested'>
-     *     def upstream = objects.setProperty(String).value(["a", "b"])
-     *     def property = objects.setProperty(String).value(upstream)
-     *
-     *     property.replace { it.map { value -&gt; value - ["a", "e", "i", "o", "u"] } }
-     *     upstream.set(["e", "f"])
-     *
-     *     println(property.get()) // ["f"]
-     * </pre>
-     * The provided transformation runs <b>eagerly</b>, so it can capture any objects without introducing memory leaks and without breaking configuration caching.
-     * However, transformations applied to the current value provider (like {@link Provider#map(Transformer)}) are subject to the usual constraints.
-     * <p>
-     * If the property has no explicit value set, then the current value comes from the convention.
-     * Changes to convention of this property do not affect the current value provider in this case, though upstream changes are still visible if the convention was set to a provider.
-     * If there is no convention too, then the current value is a provider without a value.
-     * The replacement value becomes the explicit value of the property.
-
-     * @param transformation the transformation to apply to the current value. May return null, which unsets the property.
-     * @since 8.8
-     */
-    @Incubating
-    void replace(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Iterable<? extends T>>, ? super Provider<Set<T>>> transformation);
 }


### PR DESCRIPTION
We've decided to revisit at least the handling of conventions.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
