### PR TITLE
Generate Override annotation and package name for precompiled script plugin adapters

### DIFF
--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/GeneratePluginAdaptersTask.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/GeneratePluginAdaptersTask.java
@@ -150,10 +150,11 @@ public abstract class GeneratePluginAdaptersTask extends DefaultTask {
 
     private void generateScriptPluginAdapter(PrecompiledGroovyScript scriptPlugin, String firstPassCode) {
         String targetClass = scriptPlugin.getTargetClassName();
-        File outputFile = getPluginAdapterSourcesOutputDirectory().file(scriptPlugin.getPluginAdapterClassName() + ".java").get().getAsFile();
+        File outputFile = getPluginAdapterSourcesOutputDirectory().file(scriptPlugin.getPluginAdapterFullClassName().replace(".", "/") + ".java").get().getAsFile();
 
         try (PrintWriter writer = new PrintWriter(Files.newBufferedWriter(Paths.get(outputFile.toURI())))) {
             writer.println("//CHECKSTYLE:OFF");
+            writer.println("package " + scriptPlugin.getPluginAdapterPackage() + ";");
             writer.println("import org.gradle.util.GradleVersion;");
             writer.println("import org.gradle.groovy.scripts.BasicScript;");
             writer.println("import org.gradle.groovy.scripts.ScriptSource;");
@@ -162,8 +163,9 @@ public abstract class GeneratePluginAdaptersTask extends DefaultTask {
             writer.println("/**");
             writer.println(" * Precompiled " + scriptPlugin.getId() + " script plugin.");
             writer.println(" **/");
-            writer.println("public class " + scriptPlugin.getPluginAdapterClassName() + " implements org.gradle.api.Plugin<" + targetClass + "> {");
+            writer.println("public class " + scriptPlugin.getPluginAdapterSimpleClassName() + " implements org.gradle.api.Plugin<" + targetClass + "> {");
             writer.println("    private static final String MIN_SUPPORTED_GRADLE_VERSION = \"5.0\";");
+            writer.println("    @Override");
             writer.println("    public void apply(" + targetClass + " target) {");
             writer.println("        assertSupportedByCurrentGradleVersion();");
             writer.println("        try {");

--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/PrecompiledGroovyScript.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/PrecompiledGroovyScript.java
@@ -86,7 +86,7 @@ class PrecompiledGroovyScript {
     }
 
     void declarePlugin(PluginDeclaration pluginDeclaration) {
-        pluginDeclaration.setImplementationClass(getPluginAdapterClassName());
+        pluginDeclaration.setImplementationClass(getPluginAdapterFullClassName());
         pluginDeclaration.setId(pluginId.getId());
     }
 
@@ -94,8 +94,16 @@ class PrecompiledGroovyScript {
         return pluginId.getId();
     }
 
-    String getPluginAdapterClassName() {
+    String getPluginAdapterSimpleClassName() {
         return precompiledScriptClassName + "Plugin";
+    }
+
+    String getPluginAdapterFullClassName() {
+        return getPluginAdapterPackage() + "." + getPluginAdapterSimpleClassName();
+    }
+
+    String getPluginAdapterPackage() {
+        return "precompiled";
     }
 
     String getFirstPassClassName() {

--- a/platforms/extensibility/plugin-development/src/test/groovy/org/gradle/plugin/devel/internal/precompiled/PrecompiledGroovyScriptTest.groovy
+++ b/platforms/extensibility/plugin-development/src/test/groovy/org/gradle/plugin/devel/internal/precompiled/PrecompiledGroovyScriptTest.groovy
@@ -34,17 +34,17 @@ class PrecompiledGroovyScriptTest extends Specification {
     def "creates valid java classname from script filename based plugin id"() {
         expect:
         def script = new PrecompiledGroovyScript(new File("/foo/bar/$filename"), loader)
-        script.pluginAdapterClassName == javaClass
+        script.pluginAdapterFullClassName == javaClass
 
         where:
         filename                               | javaClass
-        "foo.gradle"                           | "FooPlugin"
-        "foo.bar.gradle"                       | "FooBarPlugin"
-        "test-plugin.gradle"                   | "TestPluginPlugin"
-        "foo.bar.test-plugin.gradle"           | "FooBarTestPluginPlugin"
-        "foo.bar.-foo.gradle"                  | "FooBarFooPlugin"
-        "foo.bar._foo.gradle"                  | "FooBar_fooPlugin"
-        "123.gradle"                           | "_123Plugin"
-        "dev.gradleplugins.some-plugin.gradle" | "DevGradlepluginsSomePluginPlugin"
+        "foo.gradle"                           | "precompiled.FooPlugin"
+        "foo.bar.gradle"                       | "precompiled.FooBarPlugin"
+        "test-plugin.gradle"                   | "precompiled.TestPluginPlugin"
+        "foo.bar.test-plugin.gradle"           | "precompiled.FooBarTestPluginPlugin"
+        "foo.bar.-foo.gradle"                  | "precompiled.FooBarFooPlugin"
+        "foo.bar._foo.gradle"                  | "precompiled.FooBar_fooPlugin"
+        "123.gradle"                           | "precompiled._123Plugin"
+        "dev.gradleplugins.some-plugin.gradle" | "precompiled.DevGradlepluginsSomePluginPlugin"
     }
 }


### PR DESCRIPTION
For precompiled Groovy script plugins, we generate an adapter class. This class is written in Java, and is the actual plugin that Gradle interacts with. Then, the adapter executes the precompiled script.

We generate this adapter as source code. Newer compilers complain that the generated source code is missing an @Override annotation on its apply method. They also complain that the generated class lives in the default package.

This commit updates the generated code to add the missing annotation and to live in the 'precompiled' package.

For example, if the old generated class name was FooPlugin, the new class name is precompiled.FooPlugin

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
