### PR TITLE
Be more precise about which Kotlin jars are not part of the Gradle API

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyClassPathNotationConverter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyClassPathNotationConverter.java
@@ -36,6 +36,7 @@ import org.gradle.internal.typeconversion.TypeConversionException;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -126,10 +127,11 @@ public class DependencyClassPathNotationConverter implements NotationConverter<D
     }
 
     private void removeKotlin(Collection<File> apiClasspath) {
-        for (File file : new ArrayList<>(apiClasspath)) {
-            String name = file.getName();
-            if (name.contains("kotlin")) {
-                apiClasspath.remove(file);
+        Iterator<File> iterator = apiClasspath.iterator();
+        while (iterator.hasNext()) {
+            String name = iterator.next().getName();
+            if (name.startsWith("kotlin-") || name.startsWith("gradle-kotlin-")) {
+                iterator.remove();
             }
         }
     }


### PR DESCRIPTION
To allow Gradle modules to be named `*-kotlin-extensions`, e.g., core-kotlin-extensions.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
