### PR TITLE
Fix dependencies when CC report is used as included build

### DIFF
--- a/platforms/core-configuration/configuration-cache/build.gradle.kts
+++ b/platforms/core-configuration/configuration-cache/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 }
 
 tasks.processResources {
-    from(zipTree(provider { configurationCacheReportPath.files.first() })) {
+    from(zipTree(configurationCacheReportPath.elements.map { it.first().asFile })) {
         into("org/gradle/configurationcache/problems")
         exclude("META-INF/**")
     }


### PR DESCRIPTION
`provider {}` breaks dependency chains and should not be used to wrap lazy types.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
