### PR TITLE
Use JDKs provided by `teamcity-jdk-provider-plugin`

### DIFF
--- a/.teamcity/jdks.yaml
+++ b/.teamcity/jdks.yaml
@@ -1,0 +1,127 @@
+version: v1
+jdks:
+  - param: "linux.java7.oracle.64bit"
+    os: linux
+    arch: amd64
+    vendor: "oracle"
+    version: "7u80"
+    sha256: bad9a731639655118740bee119139c1ed019737ec802a630dd7ad7aab4309623
+  - params: [ "linux.java8.openjdk.64bit", "linux.java8.oracle.64bit" ]
+    os: linux
+    arch: amd64
+    vendor: "oracle"
+    version: "8u401"
+    sha256: 19684fccd7ff32a8400e952a643f0049449a772ef63b8037d5b917cbd137d173
+  - params: [ "env.JAVA_HOME", "linux.java11.openjdk.64bit" ]
+    os: linux
+    arch: amd64
+    vendor: "temurin"
+    version: "jdk-11.0.23+9"
+    sha256: 23e47ea7a3015be3240f21185fd902adebdcf76530757c9b482c7eb5bd3417c2
+  - param: "linux.java17.openjdk.64bit"
+    os: linux
+    arch: amd64
+    vendor: "temurin"
+    version: "jdk-17.0.11+9"
+    sha256: aa7fb6bb342319d227a838af5c363bfa1b4a670c209372f9e6585bd79da6220c
+  - param: "linux.java21.openjdk.64bit"
+    os: linux
+    arch: amd64
+    vendor: "temurin"
+    version: "jdk-21.0.3+9"
+    sha256: fffa52c22d797b715a962e6c8d11ec7d79b90dd819b5bc51d62137ea4b22a340
+  - param: "linux.java22.openjdk.64bit"
+    os: linux
+    arch: amd64
+    vendor: "temurin"
+    version: "jdk-22.0.1+8"
+    sha256: e59c6bf801cc023a1ea78eceb5e6756277f1564cd0a421ea984efe6cb96cfcf8
+  - params: [ "windows.java8.openjdk.64bit", "windows.java8.oracle.64bit" ]
+    os: windows
+    arch: amd64
+    vendor: "temurin"
+    version: "jdk8u392-b08"
+    sha256: 68711e896d0c40cd5accc06112a188c493658f9194a23fe8f8b6695394d9acf7
+  - params: [ "env.JAVA_HOME", "windows.java11.openjdk.64bit" ]
+    os: windows
+    arch: amd64
+    vendor: "temurin"
+    version: "jdk-11.0.23+9"
+    sha256: d7a9f8ceee9a5785dcbbcbec20a07b1366efec59ba652ef7e03f6f7d10f52b85
+  - param: "windows.java17.openjdk.64bit"
+    os: windows
+    arch: amd64
+    vendor: "temurin"
+    version: "jdk-17.0.11+9"
+    sha256: fdd6664d4131370398fbc8bfbb7b46dbfec4a22a090a511fe5c379dae188c390
+  - param: "windows.java21.openjdk.64bit"
+    os: windows
+    arch: amd64
+    vendor: "temurin"
+    version: "jdk-21.0.3+9"
+    sha256: c43a66cff7a403d56c5c5e1ff10d3d5f95961abf80f97f0e35380594909f0e4d
+  - param: "windows.java22.openjdk.64bit"
+    os: windows
+    arch: amd64
+    vendor: "temurin"
+    version: "jdk-22.0.1+8"
+    sha256: 4cf9d3c7ed8ec72a8adcca290d90fdd775100a38670410e674b05233a0c8288e
+  - param: "macos.java8.openjdk.64bit"
+    os: macos
+    arch: amd64
+    vendor: "temurin"
+    version: "jdk8u412-b08"
+    sha256: fd62491f7634c1cbed7557d6b21db7ef4818fbc0e63e678110d9d92cbea4ad8c
+  - params: [ "env.JAVA_HOME", "macos.java11.openjdk.64bit" ]
+    os: macos
+    arch: amd64
+    vendor: "temurin"
+    version: "jdk-11.0.23+9"
+    sha256: 4dbd21d9a0311d321f5886eda50c3086026ed61d02e1a85f7b8c2e9ad557bf03
+  - param: "macos.java17.openjdk.64bit"
+    os: macos
+    arch: amd64
+    vendor: "temurin"
+    version: "jdk-17.0.11+9"
+    sha256: f8b96724618f4df557c47f11048d1084e98ed3eb87f0dbd5b84f768a80c3348e
+  - param: "macos.java21.openjdk.64bit"
+    os: macos
+    arch: amd64
+    vendor: "temurin"
+    version: "jdk-21.0.3+9"
+    sha256: f777103aab94330d14a29bd99f3a26d60abbab8e2c375cec9602746096721a7c
+  - param: "macos.java22.openjdk.64bit"
+    os: macos
+    arch: amd64
+    vendor: "temurin"
+    version: "jdk-22.0.1+8"
+    sha256: 9445952d4487451af024a9a3f56373df76fbd928d9ff9186988aa27be2e4f10c
+  - param: "macos.java8.zulu.aarch64"
+    os: macos
+    arch: aarch64
+    vendor: "zulu"
+    version: "zulu8.78.0.19-ca-jdk8.0.412"
+  - params: [ "env.JAVA_HOME", "macos.java11.openjdk.aarch64" ]
+    os: macos
+    arch: aarch64
+    vendor: "temurin"
+    version: "jdk-11.0.23+9"
+    sha256: 49122443bdeab2c9f468bd400f58f85a9ea462846faa79084fd6fd786d9b492d
+  - param: "macos.java17.openjdk.aarch64"
+    os: macos
+    arch: aarch64
+    vendor: "temurin"
+    version: "jdk-17.0.11+9"
+    sha256: 09a162c58dd801f7cfacd87e99703ed11fb439adc71cfa14ceb2d3194eaca01c
+  - param: "macos.java21.openjdk.aarch64"
+    os: macos
+    arch: aarch64
+    vendor: "temurin"
+    version: "jdk-21.0.3+9"
+    sha256: b6be6a9568be83695ec6b7cb977f4902f7be47d74494c290bc2a5c3c951e254f
+  - param: "macos.java22.openjdk.aarch64"
+    os: macos
+    arch: aarch64
+    vendor: "temurin"
+    version: "jdk-22.0.1+8"
+    sha256: 80d6fa75e87280202ae7660139870fe50f07fca9dc6c4fbd3f2837cbd70ec902

--- a/.teamcity/src/main/kotlin/common/JvmVersion.kt
+++ b/.teamcity/src/main/kotlin/common/JvmVersion.kt
@@ -17,6 +17,7 @@
 package common
 
 enum class JvmVersion(val major: Int) {
+    java7(7),
     java8(8),
     java11(11),
     java17(17),

--- a/.teamcity/src/main/kotlin/common/Os.kt
+++ b/.teamcity/src/main/kotlin/common/Os.kt
@@ -56,14 +56,35 @@ enum class Os(
     fun asName() = name.lowercase().toCapitalized()
 
     fun javaInstallationLocations(arch: Arch = Arch.AMD64): String {
-        val paths = enumValues<JvmVersion>().joinToString(",") { version ->
-            val vendor = when {
-                version.major == 8 && this == LINUX -> JvmVendor.oracle
-                version.major == 8 && arch == Arch.AARCH64 -> JvmVendor.zulu
-                else -> JvmVendor.openjdk
-            }
-            javaHome(DefaultJvm(version, vendor), this, arch)
-        }
+        val paths = when {
+            this == LINUX ->
+                listOf(
+                    DefaultJvm(JvmVersion.java7, JvmVendor.oracle),
+                    DefaultJvm(JvmVersion.java8, JvmVendor.oracle),
+                    DefaultJvm(JvmVersion.java11, JvmVendor.openjdk),
+                    DefaultJvm(JvmVersion.java17, JvmVendor.openjdk),
+                    DefaultJvm(JvmVersion.java21, JvmVendor.openjdk),
+                    DefaultJvm(JvmVersion.java22, JvmVendor.openjdk),
+                )
+
+            arch == Arch.AARCH64 && this == MACOS ->
+                listOf(
+                    DefaultJvm(JvmVersion.java8, JvmVendor.zulu),
+                    DefaultJvm(JvmVersion.java11, JvmVendor.openjdk),
+                    DefaultJvm(JvmVersion.java17, JvmVendor.openjdk),
+                    DefaultJvm(JvmVersion.java21, JvmVendor.openjdk),
+                    DefaultJvm(JvmVersion.java22, JvmVendor.openjdk),
+                )
+
+            else ->
+                listOf(
+                    DefaultJvm(JvmVersion.java8, JvmVendor.openjdk),
+                    DefaultJvm(JvmVersion.java11, JvmVendor.openjdk),
+                    DefaultJvm(JvmVersion.java17, JvmVendor.openjdk),
+                    DefaultJvm(JvmVersion.java21, JvmVendor.openjdk),
+                    DefaultJvm(JvmVersion.java22, JvmVendor.openjdk),
+                )
+        }.joinToString(",") { javaHome(it, this, arch) }
         return """"-Porg.gradle.java.installations.paths=$paths""""
     }
 }

--- a/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
+++ b/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
@@ -150,7 +150,7 @@ class ApplyDefaultConfigurationTest {
     private
     fun expectedRunnerParam(daemon: String = "--daemon", extraParameters: String = "", os: Os = Os.LINUX): String {
         val linuxPaths =
-            "-Porg.gradle.java.installations.paths=%linux.java8.oracle.64bit%,%linux.java11.openjdk.64bit%,%linux.java17.openjdk.64bit%,%linux.java21.openjdk.64bit%,%linux.java22.openjdk.64bit%"
+            "-Porg.gradle.java.installations.paths=%linux.java7.oracle.64bit%,%linux.java8.oracle.64bit%,%linux.java11.openjdk.64bit%,%linux.java17.openjdk.64bit%,%linux.java21.openjdk.64bit%,%linux.java22.openjdk.64bit%"
         val windowsPaths =
             "-Porg.gradle.java.installations.paths=%windows.java8.openjdk.64bit%,%windows.java11.openjdk.64bit%,%windows.java17.openjdk.64bit%,%windows.java21.openjdk.64bit%,%windows.java22.openjdk.64bit%"
         val expectedInstallationPaths = if (os == Os.WINDOWS) windowsPaths else linuxPaths

--- a/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
@@ -78,7 +78,7 @@ class PerformanceTestBuildTypeTest {
             "-PautoDownloadAndroidStudio=true",
             "-PrunAndroidStudioInHeadlessMode=true",
             "-Porg.gradle.java.installations.auto-download=false",
-            "\"-Porg.gradle.java.installations.paths=%linux.java8.oracle.64bit%,%linux.java11.openjdk.64bit%,%linux.java17.openjdk.64bit%,%linux.java21.openjdk.64bit%,%linux.java22.openjdk.64bit%\"",
+            "\"-Porg.gradle.java.installations.paths=%linux.java7.oracle.64bit%,%linux.java8.oracle.64bit%,%linux.java11.openjdk.64bit%,%linux.java17.openjdk.64bit%,%linux.java21.openjdk.64bit%,%linux.java22.openjdk.64bit%\"",
             "\"-Porg.gradle.performance.branchName=%teamcity.build.branch%\"",
             "\"-Porg.gradle.performance.db.url=%performance.db.url%\"",
             "\"-Porg.gradle.performance.db.username=%performance.db.username%\"",

--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -66,6 +66,7 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.gradle.jvm.toolchain.JvmVendorSpec
+import org.gradle.jvm.toolchain.internal.LocationListInstallationSupplier.JAVA_INSTALLATIONS_PATHS_PROPERTY
 import org.jetbrains.kotlin.util.capitalizeDecapitalize.toUpperCaseAsciiOnly
 
 
@@ -261,6 +262,9 @@ val Project.maxTestDistributionRemoteExecutors: Int?
 
 val Project.maxTestDistributionLocalExecutors: Int?
     get() = gradleProperty(MAX_TEST_DISTRIBUTION_LOCAL_EXECUTORS).orNull?.toInt()
+
+val Project.toolchainInstallationPaths: String?
+    get() = gradleProperty(JAVA_INSTALLATIONS_PATHS_PROPERTY).orNull
 
 val Project.flakyTestStrategy: FlakyTestStrategy
     get() = gradleProperty(FLAKY_TEST).let {

--- a/build-logic/jvm/src/main/kotlin/gradlebuild/jvm/argumentproviders/CiEnvironmentProvider.kt
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild/jvm/argumentproviders/CiEnvironmentProvider.kt
@@ -17,9 +17,11 @@
 package gradlebuild.jvm.argumentproviders
 
 import gradlebuild.basics.BuildEnvironment
+import gradlebuild.basics.toolchainInstallationPaths
 import org.gradle.api.Named
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.testing.Test
+import org.gradle.jvm.toolchain.internal.LocationListInstallationSupplier.JAVA_INSTALLATIONS_PATHS_PROPERTY
 import org.gradle.process.CommandLineArgumentProvider
 
 
@@ -29,16 +31,23 @@ class CiEnvironmentProvider(private val test: Test) : CommandLineArgumentProvide
 
     override fun asArguments(): Iterable<String> {
         return if (BuildEnvironment.isCiServer) {
-            getRepoMirrorSystemProperties() + mapOf(
-                "org.gradle.test.maxParallelForks" to test.maxParallelForks,
-                "org.gradle.ci.agentCount" to 2,
-                "org.gradle.ci.agentNum" to BuildEnvironment.agentNum
-            ).map {
-                "-D${it.key}=${it.value}"
-            }
+            getRepoMirrorSystemProperties() +
+                getToolchainInstallationPathsProperty() +
+                mapOf(
+                    "org.gradle.test.maxParallelForks" to test.maxParallelForks,
+                    "org.gradle.ci.agentCount" to 2,
+                    "org.gradle.ci.agentNum" to BuildEnvironment.agentNum
+                ).map {
+                    "-D${it.key}=${it.value}"
+                }
         } else {
             listOf()
         }
+    }
+
+    private
+    fun getToolchainInstallationPathsProperty(): List<String> {
+        return test.project.toolchainInstallationPaths?.let { listOf("-D$JAVA_INSTALLATIONS_PATHS_PROPERTY=$it") } ?: emptyList()
     }
 
     private

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -32,6 +32,7 @@ import gradlebuild.basics.propertiesForPerformanceDb
 import gradlebuild.basics.releasedVersionsFile
 import gradlebuild.basics.repoRoot
 import gradlebuild.basics.toLowerCase
+import gradlebuild.basics.toolchainInstallationPaths
 import gradlebuild.integrationtests.addDependenciesAndConfigurations
 import gradlebuild.integrationtests.ide.AndroidStudioProvisioningExtension
 import gradlebuild.integrationtests.ide.AndroidStudioProvisioningPlugin
@@ -62,6 +63,7 @@ import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Zip
 import org.gradle.api.tasks.testing.Test
 import org.gradle.internal.os.OperatingSystem
+import org.gradle.jvm.toolchain.internal.LocationListInstallationSupplier.JAVA_INSTALLATIONS_PATHS_PROPERTY
 import org.gradle.kotlin.dsl.*
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
 import org.gradle.plugins.ide.eclipse.model.EclipseModel
@@ -234,6 +236,9 @@ class PerformanceTestPlugin : Plugin<Project> {
             inputs.files(performanceSourceSet.runtimeClasspath).withNormalizer(ClasspathNormalizer::class)
             inputs.file(performanceScenarioJson.absolutePath)
             inputs.file(tmpPerformanceScenarioJson.absolutePath)
+            project.toolchainInstallationPaths?.apply {
+                systemProperty(JAVA_INSTALLATIONS_PATHS_PROPERTY, this)
+            }
         }
     }
 
@@ -244,6 +249,10 @@ class PerformanceTestPlugin : Plugin<Project> {
             classpath = performanceSourceSet.runtimeClasspath
             maxParallelForks = 1
             systemProperty("org.gradle.performance.scenario.json", outputJson.absolutePath)
+
+            project.toolchainInstallationPaths?.apply {
+                systemProperty(JAVA_INSTALLATIONS_PATHS_PROPERTY, this)
+            }
 
             outputs.cacheIf { false }
             outputs.file(outputJson)

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecToolchainIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecToolchainIntegrationTest.groovy
@@ -59,11 +59,11 @@ class JavaExecToolchainIntegrationTest extends AbstractIntegrationSpec implement
         outputContains("Command: ${jdk.javaHome.absolutePath}")
 
         where:
-        type           | jdk                             | plugin
-        'differentJdk' | AvailableJavaHomes.differentJdk | 'java-base'
-        'current'      | Jvm.current()                   | 'java-base'
-        'differentJdk' | AvailableJavaHomes.differentJdk | 'jvm-toolchains'
-        'current'      | Jvm.current()                   | 'jvm-toolchains'
+        type           | jdk                                 | plugin
+        'differentJdk' | AvailableJavaHomes.differentVersion | 'java-base'
+        'current'      | Jvm.current()                       | 'java-base'
+        'differentJdk' | AvailableJavaHomes.differentVersion | 'jvm-toolchains'
+        'current'      | Jvm.current()                       | 'jvm-toolchains'
     }
 
     def "fails on toolchain and executable mismatch (with application plugin)"() {

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
@@ -617,7 +617,7 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
     }
 
     def "ignores toolchain usages at configuration time"() {
-        JvmInstallationMetadata jdkMetadata = AvailableJavaHomes.getJvmInstallationMetadata(AvailableJavaHomes.differentJdk)
+        JvmInstallationMetadata jdkMetadata = AvailableJavaHomes.getJvmInstallationMetadata(AvailableJavaHomes.differentVersion)
         buildFile << """
             println(javaToolchains.launcherFor {
                 languageVersion = JavaLanguageVersion.of(${jdkMetadata.languageVersion.majorVersion})


### PR DESCRIPTION
See https://github.com/gradle/teamcity-jdk-provider-plugin

This PR uses JDKs provided by the plugin, instead of depending on JDKs installed on CI agents. 
It also removes the detection for local JDKs on CI to avoid non-deterministic builds.