### PR TITLE
Move `:stdlib-kotlin-extensions` to internal package

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheIO.kt
@@ -21,7 +21,7 @@ import org.gradle.cache.internal.streams.BlockAddress
 import org.gradle.cache.internal.streams.BlockAddressSerializer
 import org.gradle.configurationcache.cacheentry.EntryDetails
 import org.gradle.configurationcache.cacheentry.ModelKey
-import org.gradle.configurationcache.extensions.useToRun
+import org.gradle.internal.extensions.stdlib.useToRun
 import org.gradle.configurationcache.initialization.ConfigurationCacheStartParameter
 import org.gradle.configurationcache.problems.ConfigurationCacheProblems
 import org.gradle.internal.serialize.graph.Codec

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheKey.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheKey.kt
@@ -16,7 +16,7 @@
 
 package org.gradle.configurationcache
 
-import org.gradle.configurationcache.extensions.unsafeLazy
+import org.gradle.internal.extensions.stdlib.unsafeLazy
 import org.gradle.configurationcache.initialization.ConfigurationCacheStartParameter
 import org.gradle.internal.buildtree.BuildActionModelRequirements
 import org.gradle.internal.hash.Hasher

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheRepository.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheRepository.kt
@@ -28,8 +28,8 @@ import org.gradle.cache.internal.streams.DefaultValueStore
 import org.gradle.cache.internal.streams.ValueStore
 import org.gradle.cache.scopes.BuildTreeScopedCacheBuilderFactory
 import org.gradle.configurationcache.ConfigurationCacheStateStore.StateFile
-import org.gradle.configurationcache.extensions.toDefaultLowerCase
-import org.gradle.configurationcache.extensions.unsafeLazy
+import org.gradle.internal.extensions.stdlib.toDefaultLowerCase
+import org.gradle.internal.extensions.stdlib.unsafeLazy
 import org.gradle.internal.concurrent.Stoppable
 import org.gradle.internal.file.FileAccessTimeJournal
 import org.gradle.internal.file.impl.SingleDepthFileAccessTracker

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
@@ -33,7 +33,7 @@ import org.gradle.api.services.internal.RegisteredBuildServiceProvider
 import org.gradle.caching.configuration.BuildCache
 import org.gradle.caching.configuration.internal.BuildCacheServiceRegistration
 import org.gradle.internal.extensions.core.serviceOf
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.configuration.problems.DocumentationSection.NotYetImplementedSourceDependencies
 import org.gradle.internal.flow.services.BuildFlowScope
 import org.gradle.internal.serialize.graph.DefaultReadContext

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/CrossProjectConfigurationReportingTaskExecutionGraph.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/CrossProjectConfigurationReportingTaskExecutionGraph.kt
@@ -24,13 +24,13 @@ import org.gradle.api.execution.TaskExecutionGraph
 import org.gradle.api.execution.TaskExecutionGraphListener
 import org.gradle.api.internal.project.CrossProjectModelAccess
 import org.gradle.api.internal.project.ProjectInternal
-import org.gradle.configurationcache.extensions.capitalized
-import org.gradle.internal.configuration.problems.ProblemFactory
-import org.gradle.internal.configuration.problems.ProblemsListener
 import org.gradle.execution.plan.FinalizedExecutionPlan
 import org.gradle.execution.plan.Node
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal
 import org.gradle.internal.build.ExecutionResult
+import org.gradle.internal.configuration.problems.ProblemFactory
+import org.gradle.internal.configuration.problems.ProblemsListener
+import org.gradle.internal.extensions.stdlib.capitalized
 import org.gradle.util.Path
 import java.util.Objects
 import java.util.function.BiConsumer

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
@@ -23,8 +23,8 @@ import org.gradle.api.internal.provider.ValueSourceProviderFactory
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logging
 import org.gradle.configurationcache.cacheentry.EntryDetails
-import org.gradle.configurationcache.extensions.toDefaultLowerCase
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.toDefaultLowerCase
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprintController
 import org.gradle.configurationcache.initialization.ConfigurationCacheStartParameter
 import org.gradle.configurationcache.metadata.ProjectMetadataController

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/EncryptionService.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/EncryptionService.kt
@@ -19,7 +19,7 @@ package org.gradle.configurationcache
 import org.gradle.cache.CacheBuilder
 import org.gradle.cache.PersistentCache
 import org.gradle.cache.scopes.GlobalScopedCacheBuilderFactory
-import org.gradle.configurationcache.extensions.useToRun
+import org.gradle.internal.extensions.stdlib.useToRun
 import org.gradle.configurationcache.initialization.ConfigurationCacheStartParameter
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.hash.Hashing

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
@@ -77,7 +77,7 @@ import org.gradle.configurationcache.CrossProjectModelAccessPattern.ALLPROJECTS
 import org.gradle.configurationcache.CrossProjectModelAccessPattern.CHILD
 import org.gradle.configurationcache.CrossProjectModelAccessPattern.DIRECT
 import org.gradle.configurationcache.CrossProjectModelAccessPattern.SUBPROJECT
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.configuration.problems.ProblemFactory
 import org.gradle.internal.configuration.problems.ProblemsListener
 import org.gradle.internal.configuration.problems.StructuredMessage

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintChecker.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintChecker.kt
@@ -23,8 +23,8 @@ import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.configurationcache.CheckedFingerprint
 import org.gradle.internal.extensions.core.fileSystemEntryType
-import org.gradle.configurationcache.extensions.filterKeysByPrefix
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.filterKeysByPrefix
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.configurationcache.logger
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.file.FileType

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -28,7 +28,7 @@ import org.gradle.configurationcache.ConfigurationCacheStateStore.StateFile
 import org.gradle.configurationcache.EncryptionService
 import org.gradle.configurationcache.InputTrackingState
 import org.gradle.internal.extensions.core.directoryChildrenNamesHash
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.configurationcache.initialization.ConfigurationCacheStartParameter
 import org.gradle.configurationcache.problems.ConfigurationCacheProblems
 import org.gradle.configurationcache.problems.ConfigurationCacheReport

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -47,7 +47,7 @@ import org.gradle.configurationcache.CoupledProjectsListener
 import org.gradle.configurationcache.InputTrackingState
 import org.gradle.configurationcache.UndeclaredBuildInputListener
 import org.gradle.internal.extensions.core.fileSystemEntryType
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.extensions.core.uri
 import org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprint.InputFile
 import org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprint.InputFileSystemEntry

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheStartParameter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheStartParameter.kt
@@ -19,7 +19,7 @@ package org.gradle.configurationcache.initialization
 import org.gradle.StartParameter
 import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.logging.LogLevel
-import org.gradle.configurationcache.extensions.unsafeLazy
+import org.gradle.internal.extensions.stdlib.unsafeLazy
 import org.gradle.configurationcache.serialization.Workarounds
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption
 import org.gradle.initialization.layout.BuildLayout

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/isolation/IsolatedActionSerializer.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/isolation/IsolatedActionSerializer.kt
@@ -18,9 +18,9 @@ package org.gradle.configurationcache.isolation
 
 import org.gradle.api.IsolatedAction
 import org.gradle.configurationcache.ConfigurationCacheError
-import org.gradle.configurationcache.extensions.invert
-import org.gradle.configurationcache.extensions.uncheckedCast
-import org.gradle.configurationcache.extensions.useToRun
+import org.gradle.internal.extensions.stdlib.invert
+import org.gradle.internal.extensions.stdlib.uncheckedCast
+import org.gradle.internal.extensions.stdlib.useToRun
 import org.gradle.configurationcache.logger
 import org.gradle.configurationcache.problems.AbstractProblemsListener
 import org.gradle.internal.configuration.problems.PropertyProblem

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/models/IntermediateModel.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/models/IntermediateModel.kt
@@ -16,7 +16,7 @@
 
 package org.gradle.configurationcache.models
 
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.tooling.provider.model.UnknownModelException
 
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/AbstractProblemsListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/AbstractProblemsListener.kt
@@ -18,7 +18,7 @@ package org.gradle.configurationcache.problems
 
 import org.gradle.configurationcache.ConfigurationCacheError
 import org.gradle.configurationcache.ConfigurationCacheThrowable
-import org.gradle.configurationcache.extensions.maybeUnwrapInvocationTargetException
+import org.gradle.internal.extensions.stdlib.maybeUnwrapInvocationTargetException
 import org.gradle.internal.configuration.problems.ProblemsListener
 import org.gradle.internal.configuration.problems.PropertyTrace
 import org.gradle.internal.configuration.problems.StructuredMessage

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblemsSummary.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblemsSummary.kt
@@ -22,8 +22,8 @@ import com.google.common.collect.Ordering
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet
 import org.gradle.api.Task
 import org.gradle.api.internal.DocumentationRegistry
-import org.gradle.configurationcache.extensions.capitalized
 import org.gradle.internal.configuration.problems.PropertyProblem
+import org.gradle.internal.extensions.stdlib.capitalized
 import org.gradle.internal.logging.ConsoleRenderer
 import java.io.File
 import java.util.Comparator.comparing

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/beans/BeanPropertyReader.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/beans/BeanPropertyReader.kt
@@ -17,7 +17,7 @@
 package org.gradle.configurationcache.serialization.beans
 
 import org.gradle.api.GradleException
-import org.gradle.configurationcache.extensions.unsafeLazy
+import org.gradle.internal.extensions.stdlib.unsafeLazy
 import org.gradle.internal.configuration.problems.PropertyKind
 import org.gradle.internal.configuration.problems.PropertyTrace
 import org.gradle.internal.serialize.graph.BeanStateReader

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/beans/BeanPropertyWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/beans/BeanPropertyWriter.kt
@@ -19,7 +19,7 @@ package org.gradle.configurationcache.serialization.beans
 import com.google.common.primitives.Primitives.wrap
 import org.gradle.api.internal.GeneratedSubclasses
 import org.gradle.api.internal.IConventionAware
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.configuration.problems.PropertyKind
 import org.gradle.internal.serialize.graph.BeanStateWriter
 import org.gradle.internal.serialize.graph.Codec

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ArtifactCollectionCodec.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ArtifactCollectionCodec.kt
@@ -27,7 +27,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Resol
 import org.gradle.api.internal.artifacts.transform.TransformedArtifactSet
 import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.file.FileCollectionStructureVisitor
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/AttributeContainerCodecs.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/AttributeContainerCodecs.kt
@@ -21,7 +21,7 @@ import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.internal.attributes.AttributeContainerInternal
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/DefaultCopySpecCodec.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/DefaultCopySpecCodec.kt
@@ -27,7 +27,7 @@ import org.gradle.api.internal.file.copy.CopySpecInternal
 import org.gradle.api.internal.file.copy.DefaultCopySpec
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.util.PatternSet
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ProviderCodecs.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ProviderCodecs.kt
@@ -41,7 +41,7 @@ import org.gradle.api.services.BuildServiceParameters
 import org.gradle.api.services.internal.BuildServiceDetails
 import org.gradle.api.services.internal.BuildServiceProvider
 import org.gradle.api.services.internal.BuildServiceRegistryInternal
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.configurationcache.serialization.IsolateOwners
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.configuration.problems.PropertyTrace

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/TaskNodeCodec.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/TaskNodeCodec.kt
@@ -29,7 +29,7 @@ import org.gradle.api.internal.tasks.TaskInputFilePropertyBuilderInternal
 import org.gradle.api.internal.tasks.TaskLocalStateInternal
 import org.gradle.api.specs.Spec
 import org.gradle.configurationcache.ProjectProvider
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.configuration.problems.PropertyKind
 import org.gradle.internal.configuration.problems.PropertyTrace
 import org.gradle.internal.serialize.graph.Codec

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/CalculateArtifactsCodec.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/CalculateArtifactsCodec.kt
@@ -29,7 +29,7 @@ import org.gradle.api.internal.artifacts.transform.BoundTransformStep
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.tasks.TaskDependencyContainer
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/ComponentVariantIdentifierCodec.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/ComponentVariantIdentifierCodec.kt
@@ -20,7 +20,7 @@ import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.capabilities.Capability
 import org.gradle.api.internal.artifacts.transform.ComponentVariantIdentifier
 import org.gradle.api.internal.attributes.ImmutableAttributes
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/IsolateTransformParametersCodec.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/IsolateTransformParametersCodec.kt
@@ -22,7 +22,7 @@ import org.gradle.api.internal.artifacts.transform.DefaultTransform
 import org.gradle.api.internal.artifacts.transform.TransformParameterScheme
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/TransformedArtifactCodec.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/TransformedArtifactCodec.kt
@@ -23,7 +23,7 @@ import org.gradle.api.internal.artifacts.transform.BoundTransformStep
 import org.gradle.api.internal.artifacts.transform.TransformingAsyncArtifactListener
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.tasks.TaskDependencyContainer
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/TransformedProjectArtifactSetCodec.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/TransformedProjectArtifactSetCodec.kt
@@ -19,7 +19,7 @@ package org.gradle.configurationcache.serialization.codecs.transform
 import org.gradle.api.internal.artifacts.transform.ComponentVariantIdentifier
 import org.gradle.api.internal.artifacts.transform.TransformStepNode
 import org.gradle.api.internal.artifacts.transform.TransformedProjectArtifactSet
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/services/Environment.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/services/Environment.kt
@@ -16,9 +16,9 @@
 
 package org.gradle.configurationcache.services
 
-import org.gradle.configurationcache.extensions.filterKeysByPrefix
+import org.gradle.internal.extensions.stdlib.filterKeysByPrefix
 import org.gradle.internal.extensions.core.getBroadcaster
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.initialization.Environment
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.resource.local.FileResourceListener

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/configurationcache/problems/JsonModelWriterTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/configurationcache/problems/JsonModelWriterTest.kt
@@ -17,7 +17,7 @@
 package org.gradle.configurationcache.problems
 
 import groovy.json.JsonSlurper
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.configuration.problems.DecoratedPropertyProblem
 import org.gradle.internal.configuration.problems.PropertyTrace
 import org.gradle.internal.configuration.problems.StructuredMessage

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/AbstractUserTypeCodecTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/AbstractUserTypeCodecTest.kt
@@ -18,8 +18,8 @@ package org.gradle.configurationcache.serialization.codecs
 
 import com.nhaarman.mockitokotlin2.mock
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
-import org.gradle.configurationcache.extensions.uncheckedCast
-import org.gradle.configurationcache.extensions.useToRun
+import org.gradle.internal.extensions.stdlib.uncheckedCast
+import org.gradle.internal.extensions.stdlib.useToRun
 import org.gradle.configurationcache.problems.AbstractProblemsListener
 import org.gradle.internal.configuration.problems.ProblemsListener
 import org.gradle.internal.configuration.problems.PropertyProblem

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/JavaObjectSerializationCodecTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/JavaObjectSerializationCodecTest.kt
@@ -19,8 +19,8 @@ package org.gradle.configurationcache.serialization.codecs
 import com.google.common.reflect.TypeToken
 import com.nhaarman.mockitokotlin2.mock
 import org.gradle.api.Project
-import org.gradle.configurationcache.extensions.uncheckedCast
-import org.gradle.configurationcache.extensions.useToRun
+import org.gradle.internal.extensions.stdlib.uncheckedCast
+import org.gradle.internal.extensions.stdlib.useToRun
 import org.gradle.internal.configuration.problems.DocumentationSection.NotYetImplementedJavaSerialization
 import org.gradle.internal.configuration.problems.PropertyKind
 import org.gradle.internal.configuration.problems.PropertyTrace

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/DefaultProblemFactory.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/DefaultProblemFactory.kt
@@ -18,9 +18,9 @@ package org.gradle.internal.configuration.problems
 
 import com.google.common.base.Supplier
 import org.gradle.api.InvalidUserCodeException
-import org.gradle.configurationcache.extensions.capitalized
 import org.gradle.internal.code.UserCodeApplicationContext
 import org.gradle.internal.code.UserCodeSource
+import org.gradle.internal.extensions.stdlib.capitalized
 import org.gradle.problems.ProblemDiagnostics
 import org.gradle.problems.buildtree.ProblemDiagnosticsFactory
 

--- a/platforms/core-configuration/flow-services/src/main/kotlin/org/gradle/internal/flow/services/BuildFlowScope.kt
+++ b/platforms/core-configuration/flow-services/src/main/kotlin/org/gradle/internal/flow/services/BuildFlowScope.kt
@@ -25,7 +25,7 @@ import org.gradle.api.flow.FlowActionSpec
 import org.gradle.api.flow.FlowParameters
 import org.gradle.api.flow.FlowProviders
 import org.gradle.api.flow.FlowScope
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.isolated.IsolationScheme
 import org.gradle.internal.service.scopes.Scope

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/BindingsBackedCodec.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/BindingsBackedCodec.kt
@@ -17,7 +17,7 @@
 package org.gradle.internal.serialize.graph
 
 import com.google.common.collect.ImmutableList
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.serialize.Serializer
 import kotlin.reflect.KClass
 

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
@@ -17,7 +17,7 @@
 package org.gradle.internal.serialize.graph
 
 import org.gradle.api.logging.Logger
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.configuration.problems.PropertyProblem
 import org.gradle.internal.configuration.problems.PropertyTrace
 import org.gradle.internal.configuration.problems.StructuredMessageBuilder

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Combinators.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Combinators.kt
@@ -16,8 +16,8 @@
 
 package org.gradle.internal.serialize.graph
 
-import org.gradle.configurationcache.extensions.uncheckedCast
-import org.gradle.configurationcache.extensions.useToRun
+import org.gradle.internal.extensions.stdlib.uncheckedCast
+import org.gradle.internal.extensions.stdlib.useToRun
 import org.gradle.internal.serialize.BaseSerializerFactory
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.Encoder

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
@@ -18,7 +18,7 @@ package org.gradle.internal.serialize.graph
 
 import it.unimi.dsi.fastutil.objects.ReferenceArrayList
 import org.gradle.api.logging.Logger
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.configuration.problems.ProblemsListener
 import org.gradle.internal.configuration.problems.PropertyProblem
 import org.gradle.internal.configuration.problems.PropertyTrace

--- a/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/configurationcache/extensions/CharSequenceExtensions.kt
+++ b/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/configurationcache/extensions/CharSequenceExtensions.kt
@@ -19,6 +19,10 @@ package org.gradle.configurationcache.extensions
 import java.util.Locale
 
 
+@Deprecated(
+    "This was never intended as a public API.",
+    ReplaceWith("this.let { if (it.isEmpty()) it else it[0].titlecase(java.util.Locale.getDefault()) + it.substring(1) }")
+)
 fun CharSequence.capitalized(): String =
     when {
         isEmpty() -> ""

--- a/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/internal/extensions/stdlib/AutoCloseableExtensions.kt
+++ b/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/internal/extensions/stdlib/AutoCloseableExtensions.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.configurationcache.extensions
+package org.gradle.internal.extensions.stdlib
 
 
 inline fun <T : AutoCloseable, U> T.useToRun(action: T.() -> U): U =

--- a/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/internal/extensions/stdlib/CastExtensions.kt
+++ b/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/internal/extensions/stdlib/CastExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,10 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.extensions.core
+package org.gradle.internal.extensions.stdlib
 
-import org.gradle.api.Project
-import org.gradle.api.plugins.ExtraPropertiesExtension
-import org.gradle.internal.extensions.stdlib.uncheckedCast
+import org.gradle.internal.Cast
 
 
-inline fun <reified T : Any> Project.setSingletonProperty(value: T) {
-    extra[T::class.java.name] = value
-}
-
-
-inline fun <reified T> Project.popSingletonProperty(): T? =
-    extra.remove(T::class.java.name)?.uncheckedCast()
-
-
-val Project.extra: ExtraPropertiesExtension
-    get() = extensions.extraProperties
+fun <T> Any.uncheckedCast(): T =
+    Cast.uncheckedNonnullCast(this)

--- a/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/internal/extensions/stdlib/CharSequenceExtensions.kt
+++ b/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/internal/extensions/stdlib/CharSequenceExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,18 @@
  * limitations under the License.
  */
 
-package org.gradle.configurationcache.extensions
+package org.gradle.internal.extensions.stdlib
+
+import java.util.Locale
 
 
-/**
- * Thread unsafe version of [lazy].
- *
- * @see LazyThreadSafetyMode.NONE
- */
-fun <T> unsafeLazy(initializer: () -> T): Lazy<T> = lazy(LazyThreadSafetyMode.NONE, initializer)
+fun CharSequence.capitalized(): String =
+    when {
+        isEmpty() -> ""
+        else -> get(0).let { initial ->
+            when {
+                initial.isLowerCase() -> initial.titlecase(Locale.getDefault()) + substring(1)
+                else -> toString()
+            }
+        }
+    }

--- a/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/internal/extensions/stdlib/ExceptionExtensions.kt
+++ b/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/internal/extensions/stdlib/ExceptionExtensions.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.configurationcache.extensions
+package org.gradle.internal.extensions.stdlib
 
 import java.lang.reflect.InvocationTargetException
 

--- a/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/internal/extensions/stdlib/MapExtensions.kt
+++ b/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/internal/extensions/stdlib/MapExtensions.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.configurationcache.extensions
+package org.gradle.internal.extensions.stdlib
 
 
 fun <V> Map<String, V>.filterKeysByPrefix(prefix: String): Map<String, V?> =

--- a/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/internal/extensions/stdlib/StringExtensions.kt
+++ b/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/internal/extensions/stdlib/StringExtensions.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.configurationcache.extensions
+package org.gradle.internal.extensions.stdlib
 
 import java.util.Locale
 

--- a/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/internal/extensions/stdlib/unsafeLazy.kt
+++ b/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/internal/extensions/stdlib/unsafeLazy.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-package org.gradle.configurationcache.extensions
-
-import org.gradle.internal.Cast
+package org.gradle.internal.extensions.stdlib
 
 
-fun <T> Any.uncheckedCast(): T =
-    Cast.uncheckedNonnullCast(this)
+/**
+ * Thread unsafe version of [lazy].
+ *
+ * @see LazyThreadSafetyMode.NONE
+ */
+fun <T> unsafeLazy(initializer: () -> T): Lazy<T> = lazy(LazyThreadSafetyMode.NONE, initializer)

--- a/platforms/core-configuration/stdlib-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/stdlib/LevelCodec.kt
+++ b/platforms/core-configuration/stdlib-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/stdlib/LevelCodec.kt
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.serialize.codecs.stdlib
 
-import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext

--- a/testing/architecture-test/src/test/java/org/gradle/architecture/test/ArchUnitFixture.java
+++ b/testing/architecture-test/src/test/java/org/gradle/architecture/test/ArchUnitFixture.java
@@ -77,6 +77,7 @@ public interface ArchUnitFixture {
         "org.gradle.configurationcache..",
         "org.gradle.internal.configuration.problems..",
         "org.gradle.internal.extensions.core..",
+        "org.gradle.internal.extensions.stdlib..",
         "org.gradle.internal.flow.services..",
         "org.gradle.internal.serialize.codecs..",
         "org.gradle.internal.serialize.graph..",


### PR DESCRIPTION
And deprecate `capitalized` extension, accidentally used by the nowInAndroid build.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
