### PR TITLE
Update gradle_daemon.adoc: fix typo in Daemon JVM Usage

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/gradle_daemon.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/gradle_daemon.adoc
@@ -203,7 +203,7 @@ To record the build's JVM requirements, run `./gradlew updateDaemonJvm`.
 This will generate a new `gradle-daemon-jvm.properties` file that captures the currently used JVM requirements.
 This is an auto-generated file that isn't intended to be edited by hand.
 
-If you want to specify a different JVM version, run `./gradle updateDaemonJvm --jvm-version=17`.
+If you want to specify a different JVM version, run `./gradlew updateDaemonJvm --jvm-version=17`.
 
 This new mechanism takes priority over `org.gradle.java.home`.
 


### PR DESCRIPTION
This fixes a typo for `updateDaemonJvm` usage 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
