### PR TITLE
Fix wrong relative path in the tests

### DIFF
--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
@@ -74,7 +74,7 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
 
         buildFile << """
             tasks.withType(JavaExec) {
-                executable = new File(".").getAbsoluteFile().toPath().relativize(new File("${executable}").toPath()).toString()
+                executable = new File(".").getCanonicalFile().toPath().relativize(new File("${executable}").toPath()).toString()
             }
         """
 

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -45,7 +45,7 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
             apply plugin: "java"
             tasks.withType(JavaCompile) {
                 options.fork = true
-                options.forkOptions.executable = new File(".").getAbsoluteFile().toPath().relativize(new File("${executable}").toPath()).toString()
+                options.forkOptions.executable = new File(".").getCanonicalFile().toPath().relativize(new File("${executable}").toPath()).toString()
             }
         """
 

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocIntegrationTest.groovy
@@ -140,7 +140,7 @@ Joe!""")
             task javadoc(type: Javadoc) {
                 destinationDir = file("build/javadoc")
                 source "src/main/java"
-                executable = new File(".").getAbsoluteFile().toPath().relativize(new File("${executable}").toPath()).toString()
+                executable = new File(".").getCanonicalFile().toPath().relativize(new File("${executable}").toPath()).toString()
             }
         """
 

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskToolchainIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskToolchainIntegrationTest.groovy
@@ -161,7 +161,7 @@ class TestTaskToolchainIntegrationTest extends AbstractIntegrationSpec implement
                 testImplementation 'junit:junit:4.13'
             }
             test {
-                executable = new File(".").getAbsoluteFile().toPath().relativize(new File("${executable}").toPath()).toString()
+                executable = new File(".").getCanonicalFile().toPath().relativize(new File("${executable}").toPath()).toString()
             }
         """
         when:


### PR DESCRIPTION
In the past, `new File(".").getAbsoluteFile().toPath().relativize()` results in the wrong relative path with Java 8 ([JDK-8211711](https://bugs.openjdk.org/browse/JDK-8211711))

```
import java.io.File;

public class Test {
  public static void main(String[] args) {
     System.out.println(new File("/home/tcagent1/work").getAbsoluteFile().toPath().relativize(new File("/opt/jdk/open-jdk-11").toPath()));
     System.out.println(new File("/home/tcagent1/work/.").getAbsoluteFile().toPath().relativize(new File("/opt/jdk/open-jdk-11").toPath()));
     System.out.println(new File("/home/tcagent1/work").getAbsoluteFile().toPath().relativize(new File("/home/tcagent1/jdk/my-jdk").toPath()));
     System.out.println(new File("/home/tcagent1/work/.").getAbsoluteFile().toPath().relativize(new File("/home/tcagent1/jdk/my-jdk").toPath()));
  }
}
```

Outputs: 

```
../../../opt/jdk/open-jdk-11
../../../../opt/jdk/open-jdk-11
../jdk/my-jdk
../../jdk/my-jdk
```

Obviously, `/home/tcagent1/work/.` and `/home/tcagent1/work` are the same directory, and the relative path should be same (this is correct with Java 9+). We didn't see problems in the past because the extra `..` hit root directory: `/../../../` is same as `/`. 

This PR fixes by using `getCanonicalFile()`.