### PR TITLE
Use @Category(Flaky) for KotlinScriptDependenciesResolverTest

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/resolver/KotlinScriptDependenciesResolverTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/resolver/KotlinScriptDependenciesResolverTest.kt
@@ -34,6 +34,7 @@ import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import java.io.File
 import kotlin.reflect.KClass
 import kotlin.script.dependencies.KotlinScriptExternalDependencies
@@ -42,7 +43,7 @@ import kotlin.script.dependencies.ScriptContents.Position
 import kotlin.script.dependencies.ScriptDependenciesResolver.ReportSeverity
 
 
-@Flaky(because = "https://github.com/gradle/gradle-private/issues/3717")
+@Category(Flaky::class) // https://github.com/gradle/gradle-private/issues/3717
 class KotlinScriptDependenciesResolverTest : AbstractKotlinIntegrationTest() {
 
     @Before


### PR DESCRIPTION
`KotlinScriptDependenciesResolverTest` was marked as flaky but [it didn't work](https://ge.gradle.org/scans/tests?search.relativeStartTime=P28D&search.timeZoneId=Asia%2FShanghai&tests.container=org.gradle.kotlin.dsl.resolver.KotlinScriptDependenciesResolverTest), because the class is still executed with JUnit 4. We need to use `@Category` to make sure it's properly handled by vintage engine.
