### PR TITLE
Lower the log level of the message informing about failing to get the `DiagnosticFormatter`

### DIFF
--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileProblemsIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileProblemsIntegrationTest.groovy
@@ -476,12 +476,12 @@ ${fooFileLocation}:9: warning: [cast] redundant cast to $expectedType
         writeJavaCausingTwoCompilationWarnings("Foo")
 
         when:
-        executer.withArguments("--info", "--stacktrace")
+        executer.withArguments("--info")
         withInstallations(AvailableJavaHomes.getJdk(JavaVersion.VERSION_1_8))
         succeeds(":compileJava")
 
         then:
-        result.error.contains(DiagnosticToProblemListener.FORMATTER_FALLBACK_MESSAGE)
+        result.assertOutputContains(DiagnosticToProblemListener.FORMATTER_FALLBACK_MESSAGE)
     }
 
     /**

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileProblemsIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileProblemsIntegrationTest.groovy
@@ -45,7 +45,7 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec impleme
     /**
      * A map of all visited file locations, and the number of occurrences we have found in the problems.
      * <p>
-     * This field will be updated by {@link #assertProblem(ReceivedProblem, String, Boolean, Closure)} as it asserts a problem.
+     * This field will be updated by {@link #assertProblem(ReceivedProblem, String, Boolean)} as it asserts a problem.
      */
     private final Map<String, Integer> visitedFileLocations = [:]
 
@@ -481,7 +481,7 @@ ${fooFileLocation}:9: warning: [cast] redundant cast to $expectedType
         succeeds(":compileJava")
 
         then:
-        result.assertOutputContains(DiagnosticToProblemListener.FORMATTER_FALLBACK_MESSAGE)
+        outputContains(DiagnosticToProblemListener.FORMATTER_FALLBACK_MESSAGE)
     }
 
     /**

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
@@ -73,7 +73,7 @@ public class DiagnosticToProblemListener implements DiagnosticListener<JavaFileO
                 return formatter.format((JCDiagnostic) diagnostic, JavacMessages.instance(context).getCurrentLocale());
             } catch (Exception ex) {
                 // If for some reason the formatter fails, we can still get the message
-                LOGGER.error(FORMATTER_FALLBACK_MESSAGE);
+                LOGGER.info(FORMATTER_FALLBACK_MESSAGE);
                 return diagnostic.getMessage(Locale.getDefault());
             }
         };


### PR DESCRIPTION
The previous loglevel felt too high, and created too much noise.