### PR TITLE
Stop worker daemons when the build is canceled

### DIFF
--- a/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClient.java
+++ b/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClient.java
@@ -62,6 +62,10 @@ class WorkerDaemonClient implements Stoppable, Describable {
         workerClient.stop();
     }
 
+    public void kill() {
+        workerClient.stopNow();
+    }
+
     DaemonForkOptions getForkOptions() {
         return forkOptions;
     }

--- a/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClientSessionHandler.java
+++ b/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClientSessionHandler.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.internal;
+
+import org.gradle.api.NonNullApi;
+import org.gradle.initialization.BuildCancellationToken;
+import org.gradle.internal.concurrent.Stoppable;
+
+@NonNullApi
+public class WorkerDaemonClientSessionHandler implements Stoppable {
+    private final WorkerDaemonClientsManager workerDaemonClientsManager;
+    private final BuildCancellationToken buildCancellationToken;
+
+    private final Runnable cancellationCallback = new KillWorkers();
+
+    public WorkerDaemonClientSessionHandler(WorkerDaemonClientsManager workerDaemonClientsManager, BuildCancellationToken buildCancellationToken) {
+        this.workerDaemonClientsManager = workerDaemonClientsManager;
+        this.buildCancellationToken = buildCancellationToken;
+    }
+
+    public void start() {
+        buildCancellationToken.addCallback(cancellationCallback);
+    }
+
+    @Override
+    public void stop() {
+        buildCancellationToken.removeCallback(cancellationCallback);
+    }
+
+    @NonNullApi
+    private class KillWorkers implements Runnable {
+        @Override
+        public void run() {
+            workerDaemonClientsManager.killAllWorkers();
+        }
+    }
+}

--- a/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonFactory.java
+++ b/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonFactory.java
@@ -30,9 +30,10 @@ public class WorkerDaemonFactory implements WorkerFactory {
     private final WorkerDaemonClientsManager clientsManager;
     private final BuildOperationRunner buildOperationRunner;
 
-    public WorkerDaemonFactory(WorkerDaemonClientsManager clientsManager, BuildOperationRunner buildOperationRunner) {
+    public WorkerDaemonFactory(WorkerDaemonClientsManager clientsManager, BuildOperationRunner buildOperationRunner, WorkerDaemonClientSessionHandler workerDaemonClientSessionHandler) {
         this.clientsManager = clientsManager;
         this.buildOperationRunner = buildOperationRunner;
+        workerDaemonClientSessionHandler.start();
     }
 
     @Override

--- a/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonFactory.java
+++ b/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonFactory.java
@@ -29,11 +29,12 @@ import javax.annotation.concurrent.ThreadSafe;
 public class WorkerDaemonFactory implements WorkerFactory {
     private final WorkerDaemonClientsManager clientsManager;
     private final BuildOperationRunner buildOperationRunner;
+    private final WorkerDaemonClientCancellationHandler workerDaemonClientCancellationHandler;
 
-    public WorkerDaemonFactory(WorkerDaemonClientsManager clientsManager, BuildOperationRunner buildOperationRunner, WorkerDaemonClientSessionHandler workerDaemonClientSessionHandler) {
+    public WorkerDaemonFactory(WorkerDaemonClientsManager clientsManager, BuildOperationRunner buildOperationRunner, WorkerDaemonClientCancellationHandler workerDaemonClientCancellationHandler) {
         this.clientsManager = clientsManager;
         this.buildOperationRunner = buildOperationRunner;
-        workerDaemonClientSessionHandler.start();
+        this.workerDaemonClientCancellationHandler = workerDaemonClientCancellationHandler;
     }
 
     @Override
@@ -41,6 +42,7 @@ public class WorkerDaemonFactory implements WorkerFactory {
         return new AbstractWorker(buildOperationRunner) {
             @Override
             public DefaultWorkResult execute(IsolatedParametersActionExecutionSpec<?> spec, BuildOperationRef parentBuildOperation) {
+                workerDaemonClientCancellationHandler.start();
                 // wrap in build operation for logging startup failures
                 final WorkerDaemonClient client = CurrentBuildOperationRef.instance().with(parentBuildOperation, this::reserveClient);
                 try {

--- a/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
+++ b/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
@@ -18,6 +18,7 @@ package org.gradle.workers.internal;
 
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.internal.ClassPathRegistry;
+import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.initialization.ClassLoaderRegistry;
 import org.gradle.initialization.GradleUserHomeDirProvider;
 import org.gradle.initialization.layout.ProjectCacheDir;
@@ -81,6 +82,10 @@ public class WorkersServices extends AbstractGradleModuleServices {
         @Provides
         WorkerExecutionQueueFactory createWorkerExecutionQueueFactory(ConditionalExecutionQueueFactory conditionalExecutionQueueFactory) {
             return new WorkerExecutionQueueFactory(conditionalExecutionQueueFactory);
+        }
+
+        WorkerDaemonClientSessionHandler createWorkerDaemonClientSessionHandler(WorkerDaemonClientsManager workerDaemonClientsManager, BuildCancellationToken buildCancellationToken) {
+            return new WorkerDaemonClientSessionHandler(workerDaemonClientsManager, buildCancellationToken);
         }
     }
 
@@ -154,8 +159,8 @@ public class WorkersServices extends AbstractGradleModuleServices {
         }
 
         @Provides
-        WorkerDaemonFactory createWorkerDaemonFactory(WorkerDaemonClientsManager workerDaemonClientsManager, BuildOperationRunner buildOperationRunner) {
-            return new WorkerDaemonFactory(workerDaemonClientsManager, buildOperationRunner);
+        WorkerDaemonFactory createWorkerDaemonFactory(WorkerDaemonClientsManager workerDaemonClientsManager, BuildOperationRunner buildOperationRunner, WorkerDaemonClientSessionHandler workerDaemonClientSessionHandler) {
+            return new WorkerDaemonFactory(workerDaemonClientsManager, buildOperationRunner, workerDaemonClientSessionHandler);
         }
     }
 }

--- a/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
+++ b/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
@@ -84,8 +84,9 @@ public class WorkersServices extends AbstractGradleModuleServices {
             return new WorkerExecutionQueueFactory(conditionalExecutionQueueFactory);
         }
 
-        WorkerDaemonClientSessionHandler createWorkerDaemonClientSessionHandler(WorkerDaemonClientsManager workerDaemonClientsManager, BuildCancellationToken buildCancellationToken) {
-            return new WorkerDaemonClientSessionHandler(workerDaemonClientsManager, buildCancellationToken);
+        @Provides
+        WorkerDaemonClientCancellationHandler createWorkerDaemonClientSessionHandler(WorkerDaemonClientsManager workerDaemonClientsManager, BuildCancellationToken buildCancellationToken) {
+            return new WorkerDaemonClientCancellationHandler(workerDaemonClientsManager, buildCancellationToken);
         }
     }
 
@@ -159,8 +160,8 @@ public class WorkersServices extends AbstractGradleModuleServices {
         }
 
         @Provides
-        WorkerDaemonFactory createWorkerDaemonFactory(WorkerDaemonClientsManager workerDaemonClientsManager, BuildOperationRunner buildOperationRunner, WorkerDaemonClientSessionHandler workerDaemonClientSessionHandler) {
-            return new WorkerDaemonFactory(workerDaemonClientsManager, buildOperationRunner, workerDaemonClientSessionHandler);
+        WorkerDaemonFactory createWorkerDaemonFactory(WorkerDaemonClientsManager workerDaemonClientsManager, BuildOperationRunner buildOperationRunner, WorkerDaemonClientCancellationHandler workerDaemonClientCancellationHandler) {
+            return new WorkerDaemonFactory(workerDaemonClientsManager, buildOperationRunner, workerDaemonClientCancellationHandler);
         }
     }
 }

--- a/platforms/core-execution/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonFactoryTest.groovy
+++ b/platforms/core-execution/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonFactoryTest.groovy
@@ -28,8 +28,9 @@ class WorkerDaemonFactoryTest extends Specification {
     def client = Mock(WorkerDaemonClient)
     def buildOperationRunner = Mock(BuildOperationRunner)
     def buildOperation = Mock(BuildOperationRef)
+    def workerDaemonClientSessionHandler = Mock(WorkerDaemonClientSessionHandler)
 
-    @Subject factory = new WorkerDaemonFactory(clientsManager, buildOperationRunner)
+    @Subject factory = new WorkerDaemonFactory(clientsManager, buildOperationRunner, workerDaemonClientSessionHandler)
 
     def workingDir = new File("some-dir")
     def projectCacheDir = new File("some-cache-dir")

--- a/platforms/core-execution/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonFactoryTest.groovy
+++ b/platforms/core-execution/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonFactoryTest.groovy
@@ -28,9 +28,9 @@ class WorkerDaemonFactoryTest extends Specification {
     def client = Mock(WorkerDaemonClient)
     def buildOperationRunner = Mock(BuildOperationRunner)
     def buildOperation = Mock(BuildOperationRef)
-    def workerDaemonClientSessionHandler = Mock(WorkerDaemonClientSessionHandler)
+    def workerDaemonClientCancellationHandler = Mock(WorkerDaemonClientCancellationHandler)
 
-    @Subject factory = new WorkerDaemonFactory(clientsManager, buildOperationRunner, workerDaemonClientSessionHandler)
+    @Subject factory = new WorkerDaemonFactory(clientsManager, buildOperationRunner, workerDaemonClientCancellationHandler)
 
     def workingDir = new File("some-dir")
     def projectCacheDir = new File("some-cache-dir")

--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/java/compile/daemon/JavaCompileDaemonCancellationIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/java/compile/daemon/JavaCompileDaemonCancellationIntegrationTest.groovy
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.java.compile.daemon
+
+import org.gradle.integtests.fixtures.ProcessFixture
+import org.gradle.integtests.fixtures.daemon.DaemonClientFixture
+import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
+import org.gradle.internal.os.OperatingSystem
+import org.gradle.test.fixtures.ConcurrentTestUtil
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.fixtures.server.http.BlockingHttpServer
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.UnitTestPreconditions
+import org.junit.Rule
+
+@Requires(UnitTestPreconditions.Jdk9OrLater)
+class JavaCompileDaemonCancellationIntegrationTest extends DaemonIntegrationSpec {
+    private static final String ANNOTATION_PROCESSOR_PROJECT_NAME = "processor"
+    public static final String TASK_STARTED_MESSAGE = "Build operation 'Task :compileJava' started"
+
+    @Rule
+    final BlockingHttpServer blockingHttpServer = new BlockingHttpServer()
+
+    private DaemonClientFixture client
+    private int daemonLogCheckpoint
+
+    def setup() {
+        blockingHttpServer.start()
+        if (OperatingSystem.current().windows) {
+            // The killed worker on Windows will cause a broken pipe error to be printed to the console,
+            // so we disable stack trace checks to avoid the test failing.
+            executer.withStackTraceChecksDisabled()
+        }
+
+        settingsFile << """
+            include '${ANNOTATION_PROCESSOR_PROJECT_NAME}'
+        """
+        writeAnnotationProcessorProject()
+    }
+
+    def "compiler daemon is stopped when build is cancelled"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'java'
+            }
+            ${dependsOnPidCapturingAnnotationProcessor}
+            tasks.withType(JavaCompile).configureEach {
+                options.fork = true
+            }
+        """
+        file('src/main/java/Foo.java') << blockingFooClass
+        def handler = blockingHttpServer.expectAndBlock("/block")
+
+        when:
+        startBuild("compileJava")
+
+        then:
+        handler.waitForAllPendingCalls()
+
+        then:
+        cancelBuild()
+
+        and:
+        pidFile().exists()
+        def pid1 = pidFile().text.strip() as long
+        new ProcessFixture(pid1).waitForFinish()
+
+        when:
+        handler = blockingHttpServer.expectAndBlock("/block")
+        startBuild("compileJava")
+
+        then:
+        handler.waitForAllPendingCalls()
+
+        then:
+        handler.releaseAll()
+
+        then:
+        succeeds()
+
+        and:
+        pidFile().exists()
+        def pid2 = pidFile().text.strip() as long
+        pid2 != pid1
+    }
+
+    private void startBuild(String task) {
+        executer
+            .withArgument('--debug')
+            .withWorkerDaemonsExpirationDisabled()
+            .withTasks(task)
+
+        client = new DaemonClientFixture(executer.start())
+        waitForDaemonLog(TASK_STARTED_MESSAGE)
+    }
+
+    private void cancelBuild() {
+        client.kill()
+        assert !client.gradleHandle.standardOutput.contains("BUILD FAIL")
+        assert !client.gradleHandle.standardOutput.contains("BUILD SUCCESS")
+        daemons.daemon.becomesIdle()
+    }
+
+    private void succeeds() {
+        client.gradleHandle.waitForFinish()
+        assert client.gradleHandle.standardOutput.contains("BUILD SUCCESS")
+        daemons.daemon.becomesIdle()
+    }
+
+    private void waitForDaemonLog(String output) {
+        String daemonLogSinceLastCheckpoint = ''
+        ConcurrentTestUtil.poll(120, {
+            daemonLogSinceLastCheckpoint = daemons.daemon.log.substring(daemonLogCheckpoint)
+            assert daemonLogSinceLastCheckpoint.contains(output)
+        })
+
+        daemonLogCheckpoint += daemonLogSinceLastCheckpoint.length()
+    }
+
+    TestFile pidFile(String rootPath = null) {
+        def root = rootPath ? file(rootPath) : testDirectory
+        return root.file('build/generated/sources/annotationProcessor/java/main/resources/pid.txt')
+    }
+
+    static String getBlockingFooClass() {
+        return """
+            @BlockingClass
+            public class Foo {
+                public static void main(String[] args) {
+                    System.out.println("Hello, world!");
+                }
+            }
+        """
+    }
+
+    static String getNonBlockingFooClass() {
+        return """
+            public class Foo {
+                public static void main(String[] args) {
+                    System.out.println("Hola, mundo!");
+                }
+            }
+        """
+    }
+
+    static String getDependsOnPidCapturingAnnotationProcessor() {
+        return """
+            dependencies {
+                compileOnly project(':${ANNOTATION_PROCESSOR_PROJECT_NAME}')
+                annotationProcessor project(':${ANNOTATION_PROCESSOR_PROJECT_NAME}')
+            }
+        """
+    }
+
+    private void writeAnnotationProcessorProject() {
+        file("${ANNOTATION_PROCESSOR_PROJECT_NAME}/build.gradle") << """
+            plugins {
+                id 'java'
+            }
+        """
+        file("${ANNOTATION_PROCESSOR_PROJECT_NAME}/src/main/java/BlockingClass.java") << """
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Retention;
+            import java.lang.annotation.RetentionPolicy;
+            import java.lang.annotation.Target;
+
+            @Retention(RetentionPolicy.SOURCE)
+            @Target(ElementType.TYPE)
+            public @interface BlockingClass {
+            }
+        """
+        file("${ANNOTATION_PROCESSOR_PROJECT_NAME}/src/main/java/BlockingProcessor.java") << """
+            import javax.annotation.processing.AbstractProcessor;
+            import javax.annotation.processing.RoundEnvironment;
+            import javax.annotation.processing.SupportedAnnotationTypes;
+            import javax.annotation.processing.SupportedSourceVersion;
+            import javax.lang.model.SourceVersion;
+            import javax.lang.model.element.TypeElement;
+            import java.util.Set;
+            import java.io.File;
+            import javax.tools.StandardLocation;
+            import java.io.Writer;
+            import javax.tools.FileObject;
+
+            @SupportedAnnotationTypes("BlockingClass")
+            @SupportedSourceVersion(SourceVersion.RELEASE_9)
+            public class BlockingProcessor extends AbstractProcessor {
+                private boolean pidWritten = false;
+
+                @Override
+                public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+                    try {
+                        if (!pidWritten) {
+                            System.out.println("Worker daemon pid is " + ProcessHandle.current().pid());
+                            FileObject file = processingEnv.getFiler().createResource(StandardLocation.SOURCE_OUTPUT, "resources", "pid.txt");
+                            Writer writer = file.openWriter();
+                            writer.write(String.valueOf(ProcessHandle.current().pid()));
+                            writer.close();
+                            pidWritten = true;
+
+                            ${blockingHttpServer.callFromBuild("block")}
+                        }
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                    return false;
+                }
+            }
+        """
+        file("${ANNOTATION_PROCESSOR_PROJECT_NAME}/src/main/resources/META-INF/services/javax.annotation.processing.Processor") << "BlockingProcessor\n"
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultMultiRequestWorkerProcessBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultMultiRequestWorkerProcessBuilder.java
@@ -169,6 +169,15 @@ class DefaultMultiRequestWorkerProcessBuilder<IN, OUT> implements MultiRequestWo
             }
 
             @Override
+            public void stopNow() {
+                try {
+                    workerProcess.stopNow();
+                } finally {
+                    requestProtocol = null;
+                }
+            }
+
+            @Override
             public OUT run(IN request) {
                 requestProtocol.run(new Request(request, CurrentBuildOperationRef.instance().get()));
                 boolean hasResult = receiver.awaitNextResult();

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/WorkerControl.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/WorkerControl.java
@@ -28,4 +28,9 @@ public interface WorkerControl {
      * Requests that the worker complete all work and stop. Blocks until the worker process has stopped.
      */
     ExecResult stop();
+
+    /**
+     * Requests that the worker stop immediately, without waiting for it to complete its work.
+     */
+    void stopNow();
 }


### PR DESCRIPTION
In #29043, with persistent worker daemons, we are seeing that if a build is canceled while running a worker daemon action (e.g. a compilation) we can get into a situation where the response from the canceled build is still in the communication queue for the worker daemon when the next build executes.  The compile task in the second build then gets the response from the first build and this ends up caching an incorrect result for the compile task.

To combat this, whenever a build is canceled, we immediately stop any worker daemons and remove them from the client manager as we can no longer guarantee that they (or their associated communications) are in a good state.  

This only has an effect on persistent worker daemons, as session scoped daemons are stopped anyways when the build session finishes.

Fixes #29043 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
