### PR TITLE
Add missing tapi cross-version constraints

### DIFF
--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r86/ProblemProgressEventCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r86/ProblemProgressEventCrossVersionTest.groovy
@@ -118,6 +118,7 @@ class ProblemProgressEventCrossVersionTest extends ToolingApiSpecification {
         problems.size() == 0
     }
 
+    @TargetGradleVersion(">=8.6 <8.9")
     def "Problems expose details via Tooling API events"() {
         given:
         withReportProblemTask """

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r87/ProblemProgressEventCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r87/ProblemProgressEventCrossVersionTest.groovy
@@ -81,7 +81,7 @@ class ProblemProgressEventCrossVersionTest extends ToolingApiSpecification {
         listener.problems.size() == 2
     }
 
-    @TargetGradleVersion(">=8.5")
+    @TargetGradleVersion(">=8.5 <8.9")
     @ToolingApiVersion("=8.7")
     def "Problems expose details via Tooling API events with failure"() {
         given:


### PR DESCRIPTION
Fixes [CI test failures](https://ge.gradle.org/scans/tests?search.names=gitBranchName&search.tags=CI&search.timeZoneId=Asia%2FShanghai&search.values=master&tests.container=org.gradle.integtests.tooling.r87.ProblemProgressEventCrossVersionTest). There's a test variant in the `r89` package providing similar coverage for the latest tapi/gradle versions.