### PR TITLE
Simplify dependency report task class hierarchy by including the HTML report version as a child of the abstract report task

### DIFF
--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/HtmlDependencyReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/HtmlDependencyReportTask.java
@@ -21,7 +21,6 @@ import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
-import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
@@ -34,6 +33,7 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.UntrackedTask;
+import org.gradle.api.tasks.diagnostics.AbstractDependencyReportTask;
 import org.gradle.api.tasks.diagnostics.internal.ConfigurationDetails;
 import org.gradle.api.tasks.diagnostics.internal.ProjectDetails;
 import org.gradle.api.tasks.diagnostics.internal.ProjectsWithConfigurations;
@@ -75,7 +75,7 @@ import static org.gradle.internal.Cast.uncheckedCast;
  * </pre>
  */
 @UntrackedTask(because = "We can't describe the dependency tree of all projects as input")
-public abstract class HtmlDependencyReportTask extends ConventionTask implements Reporting<DependencyReportContainer> {
+public abstract class HtmlDependencyReportTask extends AbstractDependencyReportTask implements Reporting<DependencyReportContainer> {
     private final Transient.Var<Set<Project>> projects = Transient.varOf(uncheckedCast(singleton(getProject())));
     private final Cached<ProjectsWithConfigurations<ProjectDetails.ProjectNameAndPath, ConfigurationDetails>> projectsWithConfigurations = Cached.of(this::computeProjectsWithConfigurations);
     private final DirectoryProperty reportDir;
@@ -94,6 +94,7 @@ public abstract class HtmlDependencyReportTask extends ConventionTask implements
      *
      * @since 7.1
      */
+    @Override
     @Internal
     public DirectoryProperty getProjectReportDirectory() {
         return reportDir;
@@ -166,6 +167,7 @@ public abstract class HtmlDependencyReportTask extends ConventionTask implements
      *
      * @return The set of files.
      */
+    @Override
     @Internal
     public Set<Project> getProjects() {
         return projects.get();
@@ -176,6 +178,7 @@ public abstract class HtmlDependencyReportTask extends ConventionTask implements
      *
      * @param projects The set of projects. Must not be null.
      */
+    @Override
     public void setProjects(Set<Project> projects) {
         this.projects.set(projects);
     }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/HtmlDependencyReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/HtmlDependencyReportTask.java
@@ -19,7 +19,6 @@ package org.gradle.api.reporting.dependencies;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
-import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
@@ -29,7 +28,6 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.reporting.Reporting;
 import org.gradle.api.reporting.dependencies.internal.DefaultDependencyReportContainer;
 import org.gradle.api.reporting.dependencies.internal.HtmlDependencyReporter;
-import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.UntrackedTask;
@@ -39,15 +37,10 @@ import org.gradle.api.tasks.diagnostics.internal.ProjectDetails;
 import org.gradle.api.tasks.diagnostics.internal.ProjectsWithConfigurations;
 import org.gradle.internal.logging.ConsoleRenderer;
 import org.gradle.internal.serialization.Cached;
-import org.gradle.internal.serialization.Transient;
 import org.gradle.util.internal.ClosureBackedAction;
 
 import javax.inject.Inject;
-import java.util.Set;
 import java.util.stream.Stream;
-
-import static java.util.Collections.singleton;
-import static org.gradle.internal.Cast.uncheckedCast;
 
 /**
  * Generates an HTML dependency report. This report
@@ -76,28 +69,12 @@ import static org.gradle.internal.Cast.uncheckedCast;
  */
 @UntrackedTask(because = "We can't describe the dependency tree of all projects as input")
 public abstract class HtmlDependencyReportTask extends AbstractDependencyReportTask implements Reporting<DependencyReportContainer> {
-    private final Transient.Var<Set<Project>> projects = Transient.varOf(uncheckedCast(singleton(getProject())));
     private final Cached<ProjectsWithConfigurations<ProjectDetails.ProjectNameAndPath, ConfigurationDetails>> projectsWithConfigurations = Cached.of(this::computeProjectsWithConfigurations);
-    private final DirectoryProperty reportDir;
     private final DependencyReportContainer reports;
 
     public HtmlDependencyReportTask() {
         reports = getObjectFactory().newInstance(DefaultDependencyReportContainer.class, this, getCallbackActionDecorator());
-        reportDir = getObjectFactory().directoryProperty();
         reports.getHtml().getRequired().set(true);
-    }
-
-    /**
-     * Returns the project report directory.
-     *
-     * @return the directory to store project reports
-     *
-     * @since 7.1
-     */
-    @Override
-    @Internal
-    public DirectoryProperty getProjectReportDirectory() {
-        return reportDir;
     }
 
     @Nested
@@ -159,28 +136,6 @@ public abstract class HtmlDependencyReportTask extends AbstractDependencyReportT
         reporter.render(projectsWithConfigurations.get(), reports.getHtml().getOutputLocation().getAsFile().get());
 
         getLogger().lifecycle("See the report at: {}", new ConsoleRenderer().asClickableFileUrl(reports.getHtml().getEntryPoint()));
-    }
-
-    /**
-     * Returns the set of projects to generate a report for. By default, the report is generated for the task's
-     * containing project.
-     *
-     * @return The set of files.
-     */
-    @Override
-    @Internal
-    public Set<Project> getProjects() {
-        return projects.get();
-    }
-
-    /**
-     * Specifies the set of projects to generate this report for.
-     *
-     * @param projects The set of projects. Must not be null.
-     */
-    @Override
-    public void setProjects(Set<Project> projects) {
-        this.projects.set(projects);
     }
 
     private ProjectsWithConfigurations<ProjectDetails.ProjectNameAndPath, ConfigurationDetails> computeProjectsWithConfigurations() {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/AbstractDependencyReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/AbstractDependencyReportTask.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -60,7 +61,6 @@ public abstract class AbstractDependencyReportTask extends AbstractProjectBasedR
     public void setRenderer(DependencyReportRenderer renderer) {
         this.renderer = renderer;
     }
-
 
     /**
      * Report model.
@@ -97,7 +97,7 @@ public abstract class AbstractDependencyReportTask extends AbstractProjectBasedR
     }
 
     private Set<Configuration> getReportConfigurations() {
-        return configurations != null ? configurations : getNonDeprecatedTaskConfigurations();
+        return configurations != null ? configurations : getConfigurationsWithDependencies();
     }
 
     /**
@@ -130,9 +130,9 @@ public abstract class AbstractDependencyReportTask extends AbstractProjectBasedR
         this.configurations = Collections.singleton(ConfigurationFinder.find(getTaskConfigurations(), configurationName));
     }
 
-    private Set<Configuration> getNonDeprecatedTaskConfigurations() {
+    private Set<Configuration> getConfigurationsWithDependencies() {
         Set<Configuration> filteredConfigurations = new HashSet<>();
-        for (Configuration configuration : getTaskConfigurations()) {
+        for (Configuration configuration : Objects.requireNonNull(getTaskConfigurations())) {
             if (((ConfigurationInternal)configuration).isDeclarableByExtension()) {
                 filteredConfigurations.add(configuration);
             }
@@ -141,5 +141,7 @@ public abstract class AbstractDependencyReportTask extends AbstractProjectBasedR
     }
 
     @Internal
-    public abstract ConfigurationContainer getTaskConfigurations();
+    public ConfigurationContainer getTaskConfigurations() {
+        return getProject().getConfigurations();
+    }
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyReportTask.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.tasks.diagnostics;
 
-import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.work.DisableCachingByDefault;
 
 /**
@@ -23,10 +22,4 @@ import org.gradle.work.DisableCachingByDefault;
  * execute the {@code dependencies} task from the command-line.
  */
 @DisableCachingByDefault(because = "Not worth caching")
-public abstract class DependencyReportTask extends AbstractDependencyReportTask {
-
-    @Override
-    public ConfigurationContainer getTaskConfigurations() {
-        return getProject().getConfigurations();
-    }
-}
+public abstract class DependencyReportTask extends AbstractDependencyReportTask {}

--- a/testing/architecture-test/src/changes/archunit-store/provider-task-properties.txt
+++ b/testing/architecture-test/src/changes/archunit-store/provider-task-properties.txt
@@ -141,7 +141,6 @@ Method <org.gradle.api.tasks.diagnostics.ConventionReportTask.getOutputFile()> d
 Method <org.gradle.api.tasks.diagnostics.ConventionReportTask.getProjects()> does not have raw return type assignable to org.gradle.api.provider.Property in (ConventionReportTask.java:0)
 Method <org.gradle.api.tasks.diagnostics.DependencyInsightReportTask.getDependencySpec()> does not have raw return type assignable to org.gradle.api.provider.Property in (DependencyInsightReportTask.java:0)
 Method <org.gradle.api.tasks.diagnostics.DependencyInsightReportTask.isShowSinglePathToDependency()> does not have raw return type assignable to org.gradle.api.provider.Property in (DependencyInsightReportTask.java:0)
-Method <org.gradle.api.tasks.diagnostics.DependencyReportTask.getTaskConfigurations()> does not have raw return type assignable to org.gradle.api.provider.Provider in (DependencyReportTask.java:0)
 Method <org.gradle.api.tasks.diagnostics.PropertyReportTask.getRenderer()> does not have raw return type assignable to org.gradle.api.provider.Property in (PropertyReportTask.java:0)
 Method <org.gradle.api.tasks.diagnostics.TaskReportTask.getDisplayGroup()> does not have raw return type assignable to org.gradle.api.provider.Property in (TaskReportTask.java:0)
 Method <org.gradle.api.tasks.diagnostics.TaskReportTask.getDisplayGroups()> does not have raw return type assignable to org.gradle.api.provider.Property in (TaskReportTask.java:0)

--- a/testing/architecture-test/src/changes/archunit-store/provider-task-properties.txt
+++ b/testing/architecture-test/src/changes/archunit-store/provider-task-properties.txt
@@ -37,7 +37,6 @@ Method <org.gradle.api.publish.maven.tasks.PublishToMavenRepository.getRepositor
 Method <org.gradle.api.reporting.GenerateBuildDashboard.getInputReports()> does not have raw return type assignable to org.gradle.api.provider.Provider in (GenerateBuildDashboard.java:0)
 Method <org.gradle.api.reporting.GenerateBuildDashboard.getReports()> does not have raw return type assignable to org.gradle.api.provider.Provider in (GenerateBuildDashboard.java:0)
 Method <org.gradle.api.reporting.GenerateBuildDashboard.getReports()> does not have raw return type assignable to org.gradle.api.provider.Provider in (GenerateBuildDashboard.java:0)
-Method <org.gradle.api.reporting.dependencies.HtmlDependencyReportTask.getProjects()> does not have raw return type assignable to org.gradle.api.provider.Property in (HtmlDependencyReportTask.java:0)
 Method <org.gradle.api.reporting.dependencies.HtmlDependencyReportTask.getReports()> does not have raw return type assignable to org.gradle.api.provider.Provider in (HtmlDependencyReportTask.java:0)
 Method <org.gradle.api.reporting.dependencies.HtmlDependencyReportTask.getReports()> does not have raw return type assignable to org.gradle.api.provider.Provider in (HtmlDependencyReportTask.java:0)
 Method <org.gradle.api.reporting.dependents.DependentComponentsReport.getComponents()> does not have raw return type assignable to org.gradle.api.provider.Property in (DependentComponentsReport.java:0)

--- a/testing/architecture-test/src/changes/archunit-store/public-api-not-extends-internal-types.txt
+++ b/testing/architecture-test/src/changes/archunit-store/public-api-not-extends-internal-types.txt
@@ -5,7 +5,6 @@ Class <org.gradle.api.artifacts.ResolveException> extends/implements org.gradle.
 Class <org.gradle.api.plugins.quality.CheckstylePlugin> extends/implements org.gradle.api.plugins.quality.internal.AbstractCodeQualityPlugin that is Gradle Internal API in (CheckstylePlugin.java:0)
 Class <org.gradle.api.plugins.quality.CodeNarcPlugin> extends/implements org.gradle.api.plugins.quality.internal.AbstractCodeQualityPlugin that is Gradle Internal API in (CodeNarcPlugin.java:0)
 Class <org.gradle.api.plugins.quality.PmdPlugin> extends/implements org.gradle.api.plugins.quality.internal.AbstractCodeQualityPlugin that is Gradle Internal API in (PmdPlugin.java:0)
-Class <org.gradle.api.reporting.dependencies.HtmlDependencyReportTask> extends/implements org.gradle.api.internal.ConventionTask that is Gradle Internal API in (HtmlDependencyReportTask.java:0)
 Class <org.gradle.api.tasks.AbstractCopyTask> extends/implements org.gradle.api.internal.ConventionTask, org.gradle.api.internal.file.copy.CopySpecSource that are Gradle Internal API in (AbstractCopyTask.java:0)
 Class <org.gradle.api.tasks.AbstractExecTask> extends/implements org.gradle.api.internal.ConventionTask that is Gradle Internal API in (AbstractExecTask.java:0)
 Class <org.gradle.api.tasks.Delete> extends/implements org.gradle.api.internal.ConventionTask that is Gradle Internal API in (Delete.java:0)


### PR DESCRIPTION
Changes from Slack discussion.