### PR TITLE
Retarget pending edges on module replacement

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolutionIssuesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolutionIssuesIntegrationTest.groovy
@@ -572,9 +572,9 @@ class ResolutionIssuesIntegrationTest extends AbstractIntegrationSpec {
             "org.bouncycastle:bctls-fips:1.0.9",
             "org.bouncycastle:bctls-jdk14:1.70",
             "org.bouncycastle:bctls-jdk18on:1.72"
-        ].each {
+        ].each { dep ->
             assert output.readLines().any {
-                it.startsWith("+--- ${it}")
+                it.startsWith("+--- ${dep}") || it.startsWith("\\--- ${dep}")
             }
         }
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolutionIssuesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolutionIssuesIntegrationTest.groovy
@@ -64,40 +64,6 @@ class ResolutionIssuesIntegrationTest extends AbstractIntegrationSpec {
         succeeds("resolve")
     }
 
-    @NotYetImplemented
-    @Issue("https://github.com/gradle/gradle/issues/26145")
-    @Issue("https://github.com/ljacomet/logging-capabilities/issues/33")
-    def "capability conflict in logging capabilities plugin causes corrupt resolution result"() {
-        buildFile << """
-            plugins {
-                id 'java-library'
-                id 'dev.jacomet.logging-capabilities' version '0.11.1'
-            }
-
-            ${mavenCentralRepository()}
-
-            dependencies {
-                implementation 'eu.medsea.mimeutil:mime-util:2.1.3'
-                implementation 'org.slf4j:slf4j-api:2.0.7'
-                runtimeOnly 'ch.qos.logback:logback-classic:1.3.11'
-            }
-
-            loggingCapabilities {
-                enforceLogback()
-            }
-
-            tasks.register("resolve") {
-                def root = configurations.runtimeClasspath.incoming.resolutionResult.rootComponent
-                doLast {
-                    println root.get()
-                }
-            }
-        """
-
-        expect:
-        succeeds("resolve", "--stacktrace")
-    }
-
     @Ignore("Original reproducer. Minified version below")
     @Requires(UnitTestPreconditions.Jdk17OrLater)
     @Issue("https://github.com/gradle/gradle/issues/26145#issuecomment-1957776331")
@@ -405,32 +371,6 @@ class ResolutionIssuesIntegrationTest extends AbstractIntegrationSpec {
         expect:
         succeeds(":resolve", "--stacktrace")
 //        succeeds(":compose:ui:ui:dependencies", "--configuration", "commonMainResolvableDependenciesMetadata", "--stacktrace")
-    }
-
-    @NotYetImplemented
-    @Issue("https://github.com/gradle/gradle/issues/14220#issuecomment-1423804572")
-    def "capability conflict causes cannot decrease hard edge count assertion"() {
-        buildFile << """
-            ${header}
-            ${mavenCentralRepository()}
-
-            ${selectHighest("org.dom4j:dom4j")}
-            ${withModules("dom4j:dom4j").addCapability("org.dom4j", "dom4j")}
-            ${withModules("org.hibernate:hibernate").addCapability("org.hibernate", "hibernate-core")}
-
-            dependencies {
-                implementation 'org.hibernate:hibernate-core:5.4.18.Final'
-
-                implementation ('jaxen:jaxen:1.1.1') {
-                    exclude group: 'com.ibm.icu', module: 'icu4j'
-                }
-
-                implementation 'org.unitils:unitils-database:3.3'
-            }
-        """
-
-        expect:
-        succeeds(":resolve", "--stacktrace")
     }
 
     @NotYetImplemented

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIssuesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIssuesIntegrationTest.groovy
@@ -23,11 +23,19 @@ import spock.lang.Issue
 
 class CapabilitiesConflictResolutionIssuesIntegrationTest extends AbstractIntegrationSpec {
 
+    def resolve = new ResolveTestFixture(buildFile, "runtimeClasspath")
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'test'
+        """
+    }
+
     @Issue("https://github.com/gradle/gradle/issues/14770")
     def "capabilities resolution shouldn't put graph in inconsistent state"() {
         file("shared/build.gradle") << """
             plugins {
-                id 'java'
+                id("java-library")
             }
 
             sourceSets {
@@ -126,15 +134,13 @@ class CapabilitiesConflictResolutionIssuesIntegrationTest extends AbstractIntegr
             }
         """
         settingsFile << """
-            rootProject.name = 'test'
             include 'shared'
             include 'p1'
             include 'p2'
         """
-        def resolve = new ResolveTestFixture(buildFile)
-        resolve.prepare()
 
         when:
+        resolve.prepare()
         run ":p1:checkDeps"
 
         then:
@@ -172,4 +178,233 @@ class CapabilitiesConflictResolutionIssuesIntegrationTest extends AbstractIntegr
             }
         }
     }
+
+    @Issue("https://github.com/gradle/gradle/issues/14220#issuecomment-1423804572")
+    def "pending dependencies are transferred to new module after capability conflict"() {
+
+        mavenRepo.module("org.hibernate", "hibernate-core", "5.4.18.Final")
+            .dependsOn("org.dom4j", "dom4j", "2.1.3", null, null, null, [[group: "*", module: "*"]])
+            .publish()
+        mavenRepo.module("jaxen", "jaxen", "1.1.1")
+            .dependsOn(mavenRepo.module("dom4j", "dom4j", "1.6.1").publish())
+            .publish()
+        mavenRepo.module("org.dom4j", "dom4j", "2.1.3").publish()
+            .dependsOn(mavenRepo.module("jaxen", "jaxen", "1.1.6").publish())
+            .publish()
+
+        buildFile << """
+            plugins {
+                id("java-library")
+            }
+
+            ${mavenTestRepository()}
+
+            dependencies {
+                implementation 'org.hibernate:hibernate-core:5.4.18.Final'
+                implementation 'jaxen:jaxen:1.1.1'
+            }
+        """
+
+        capability("org.dom4j", "dom4j") {
+            forModule("dom4j:dom4j")
+            selectHighest()
+        }
+
+        when:
+        resolve.prepare()
+        run ":checkDeps"
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module("org.hibernate:hibernate-core:5.4.18.Final") {
+                    module("org.dom4j:dom4j:2.1.3") {
+                        byConflictResolution("latest version of capability org.dom4j:dom4j")
+                        byConflictResolution("between versions 2.1.3 and 1.6.1")
+                    }
+                }
+                edge("jaxen:jaxen:1.1.1", "jaxen:jaxen:1.1.6") {
+                    byConflictResolution("between versions 1.1.6 and 1.1.1")
+                }
+            }
+        }
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/14220#issuecomment-1967573024")
+    def "first-level dependencies are retained after conflict resolution"() {
+
+        mavenRepo.module("org.bouncycastle", "bcprov-jdk14", "1.70").publish()
+        mavenRepo.module("org.bouncycastle", "bcprov-jdk18on", "1.71").publish()
+        mavenRepo.module("org.bouncycastle", "bctls-fips", "1.0.9").publish()
+        mavenRepo.module("org.bouncycastle", "bctls-jdk14", "1.70")
+            .dependsOn(mavenRepo.module("org.bouncycastle", "bcprov-jdk14", "1.70").publish())
+            .publish()
+        mavenRepo.module("org.bouncycastle", "bctls-jdk18on", "1.72")
+            .dependsOn(mavenRepo.module("org.bouncycastle", "bcprov-jdk18on", "1.72").publish())
+            .publish()
+
+        buildFile << """
+            plugins {
+                id("java-library")
+            }
+
+            ${mavenTestRepository()}
+
+            dependencies {
+                implementation("org.bouncycastle:bcprov-jdk14:1.70")
+                implementation("org.bouncycastle:bcprov-jdk18on:1.71")
+                implementation("org.bouncycastle:bctls-fips:1.0.9")
+                implementation("org.bouncycastle:bctls-jdk14:1.70")
+                implementation("org.bouncycastle:bctls-jdk18on:1.72")
+            }
+        """
+
+        capability("foo", "bcprov") {
+            forModule("org.bouncycastle:bcprov-jdk14")
+            forModule("org.bouncycastle:bcprov-jdk18on")
+            selectHighest()
+        }
+
+        capability("foo", "bctls") {
+            forModule("org.bouncycastle:bctls-fips")
+            forModule("org.bouncycastle:bctls-jdk14")
+            forModule("org.bouncycastle:bctls-jdk18on")
+            selectHighest()
+        }
+
+        when:
+        resolve.prepare()
+        run ":checkDeps"
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("org.bouncycastle:bcprov-jdk14:1.70", "org.bouncycastle:bcprov-jdk18on:1.72") {
+                    byConflictResolution("between versions 1.72 and 1.71")
+                }
+                edge("org.bouncycastle:bcprov-jdk18on:1.71", "org.bouncycastle:bcprov-jdk18on:1.72")
+                edge("org.bouncycastle:bctls-fips:1.0.9", "org.bouncycastle:bctls-jdk18on:1.72") {
+                    byConflictResolution("latest version of capability foo:bctls")
+                }
+                edge("org.bouncycastle:bctls-jdk14:1.70", "org.bouncycastle:bctls-jdk18on:1.72")
+                module("org.bouncycastle:bctls-jdk18on:1.72") {
+                    module("org.bouncycastle:bcprov-jdk18on:1.72")
+                }
+            }
+        }
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/14220#issuecomment-1291618229")
+    def "avoids corrupt serialized resolution result"() {
+
+        mavenRepo.module("org.codehaus.woodstox", "wstx-asl", "4.0.6")
+            .dependsOn(mavenRepo.module("org.codehaus.woodstox", "woodstox-core-asl", "4.0.6").publish())
+            .publish()
+        mavenRepo.module("javax.xml.stream", "stax-api", "1.0").publish()
+        mavenRepo.module("org.codehaus.woodstox", "woodstox-core-asl", "4.4.1")
+            .dependsOn(mavenRepo.module("javax.xml.stream", "stax-api", "1.0-2").publish())
+            .publish()
+        mavenRepo.module("stax", "stax-api", "1.0.1").publish()
+        mavenRepo.module("woodstox", "wstx-asl", "2.9.3").publish()
+
+        buildFile << """
+            plugins {
+                id("java-library")
+            }
+
+            ${mavenTestRepository()}
+
+            dependencies {
+                implementation("org.codehaus.woodstox:wstx-asl:4.0.6")
+                implementation("javax.xml.stream:stax-api:1.0")
+                implementation("org.codehaus.woodstox:woodstox-core-asl:4.4.1")
+                implementation("stax:stax-api:1.0.1")
+                implementation("woodstox:wstx-asl:2.9.3")
+            }
+        """
+
+        capability("woodstox", "wstx-asl") {
+            forModule("org.codehaus.woodstox:wstx-asl")
+            forModule("org.codehaus.woodstox:woodstox-core-asl")
+            selectHighest()
+        }
+
+        capability("stax", "stax-api") {
+            forModule("javax.xml.stream:stax-api")
+            selectHighest()
+        }
+
+        when:
+        resolve.prepare()
+        run ":checkDeps"
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("org.codehaus.woodstox:wstx-asl:4.0.6", "org.codehaus.woodstox:woodstox-core-asl:4.4.1") {
+                    byConflictResolution("latest version of capability woodstox:wstx-asl")
+                    edge("javax.xml.stream:stax-api:1.0-2", "stax:stax-api:1.0.1") {
+                        byConflictResolution("latest version of capability stax:stax-api")
+                    }
+                }
+                edge("javax.xml.stream:stax-api:1.0", "stax:stax-api:1.0.1")
+                module("org.codehaus.woodstox:woodstox-core-asl:4.4.1") {
+                    byConflictResolution("between versions 4.4.1 and 4.0.6")
+                }
+                module("stax:stax-api:1.0.1") {
+                    byConflictResolution("between versions 1.0-2 and 1.0.1")
+                }
+                edge("woodstox:wstx-asl:2.9.3", "org.codehaus.woodstox:woodstox-core-asl:4.4.1")
+            }
+        }
+    }
+
+    // region test fixtures
+
+    class CapabilityClosure {
+
+        private final String group
+        private final String artifactId
+        private final File buildFile
+
+        CapabilityClosure(String group, String artifactId, File buildFile) {
+            this.group = group
+            this.artifactId = artifactId
+            this.buildFile = buildFile
+        }
+
+        def forModule(String module) {
+            buildFile << """
+                dependencies.components.withModule('$module') {
+                    allVariants {
+                        withCapabilities {
+                            addCapability('$group', '$artifactId', id.version)
+                        }
+                    }
+                }
+            """
+        }
+
+        def selectHighest() {
+            buildFile << """
+                configurations.runtimeClasspath {
+                    resolutionStrategy {
+                        capabilitiesResolution {
+                            withCapability("$group:$artifactId") {
+                                selectHighestVersion()
+                            }
+                        }
+                    }
+                }
+            """
+        }
+    }
+
+    def capability(String group, String module, @DelegatesTo(CapabilityClosure) Closure<?> closure) {
+        def capabilityClosure = new CapabilityClosure(group, module, buildFile)
+        closure.delegate = capabilityClosure
+        closure.call(capabilityClosure)
+    }
+
+    // endregion
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DefaultPendingDependenciesVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DefaultPendingDependenciesVisitor.java
@@ -31,7 +31,7 @@ class DefaultPendingDependenciesVisitor implements PendingDependenciesVisitor {
     }
 
     @Override
-    public PendingState maybeAddAsPendingDependency(NodeState node, DependencyState dependencyState) {
+    public PendingState maybeAddAsPendingDependency(NodeState sourceNode, DependencyState dependencyState) {
         ModuleIdentifier key = dependencyState.getModuleIdentifier();
         boolean isConstraint = dependencyState.getDependency().isConstraint();
         if (!isConstraint) {
@@ -52,7 +52,7 @@ class DefaultPendingDependenciesVisitor implements PendingDependenciesVisitor {
         }
 
         // No hard dependency, queue up pending dependency in case we see a hard dependency later.
-        module.registerConstraintProvider(node);
+        module.registerConstraintProvider(sourceNode);
         return PendingState.PENDING;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -276,7 +276,7 @@ public class DependencyGraphBuilder {
             SelectorState selector = dependency.getSelector();
             ModuleResolveState module = selector.getTargetModule();
 
-            if (selector.canResolve() && module.getSelectors().size() > 0) {
+            if (selector.canAffectSelection() && module.getSelectors().size() > 0) {
                 // Have an unprocessed/new selector for this module. Need to re-select the target version (if there are any selectors that can be used).
                 performSelection(resolveState, module);
             }
@@ -358,13 +358,13 @@ public class DependencyGraphBuilder {
         }
     }
 
-    private static void attachToTargetRevisionsSerially(List<EdgeState> dependencies, Spec<EdgeState> dependencyFilter) {
+    private static void attachToTargetRevisionsSerially(List<EdgeState> edges, Spec<EdgeState> dependencyFilter) {
         // the following only needs to be done serially to preserve ordering of dependencies in the graph: we have visited the edges
         // but we still didn't add the result to the queue. Doing it from resolve threads would result in non-reproducible graphs, where
         // edges could be added in different order. To avoid this, the addition of new edges is done serially.
-        for (EdgeState dependency : dependencies) {
-            if (dependencyFilter.isSatisfiedBy(dependency)) {
-                dependency.attachToTargetConfigurations();
+        for (EdgeState edge : edges) {
+            if (dependencyFilter.isSatisfiedBy(edge)) {
+                edge.attachToTargetConfigurations();
             }
         }
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyState.java
@@ -42,9 +42,21 @@ import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.FORCED;
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.REQUESTED;
 
+/**
+ * A declared dependency, potentially transformed based on a substitution.
+ */
 class DependencyState {
+
+    /**
+     * The original requested component, before substitution.
+     */
     private final ComponentSelector requested;
+
+    /**
+     * The declared dependency this state is based off of, after substitution.
+     */
     private final DependencyMetadata dependency;
+
     private final List<ComponentSelectionDescriptorInternal> ruleDescriptors;
     private final ComponentSelectorConverter componentSelectorConverter;
     private final int hashCode;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -257,6 +257,10 @@ class ModuleResolveState implements CandidateModule {
         this.selected = selected;
         this.replaced = computeReplaced(selected);
 
+        if (replaced) {
+            selected.getModule().getPendingDependencies().retarget(pendingDependencies);
+        }
+
         doRestart(selected);
     }
 
@@ -408,6 +412,9 @@ class ModuleResolveState implements CandidateModule {
     }
 
     PendingDependencies getPendingDependencies() {
+        if (replaced) {
+            return selected.getModule().getPendingDependencies();
+        }
         return pendingDependencies;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -199,7 +199,7 @@ class ModuleResolveState implements CandidateModule {
     }
 
     /**
-     * Changes the selected target component for this module.
+     * Changes the selected target component for this module due to version conflict resolution.
      */
     private void changeSelection(ComponentState newSelection) {
         assert this.selected != null;
@@ -239,7 +239,8 @@ class ModuleResolveState implements CandidateModule {
     }
 
     /**
-     * Overrides the component selection for this module, when this module has been replaced by another.
+     * Overrides the component selection for this module, when this module has been replaced
+     * by another due to capability conflict resolution.
      */
     @Override
     public void replaceWith(ComponentState selected) {
@@ -310,6 +311,10 @@ class ModuleResolveState implements CandidateModule {
     }
 
     void addSelector(SelectorState selector, boolean deferSelection) {
+        // TODO: In some cases of module replacement and capability conflict resolution, the `selector` can be sourced
+        // from a DependencyState originally targeting a different module. This sounds wrong.
+        // Selectors should be used to select _versions_, but the versions between different modules should not
+        // be directly compared.
         selectors.add(selector, deferSelection);
         mergedConstraintAttributes = appendAttributes(mergedConstraintAttributes, selector);
         if (overriddenSelection) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -244,6 +244,12 @@ public class NodeState implements DependencyGraphNode {
      * @param discoveredEdges A collector for visited edges.
      */
     public void visitOutgoingDependencies(Collection<EdgeState> discoveredEdges) {
+
+        // TODO: Figure out how rejected components are handled when they're added to the queue
+//        if (component.isRejected()) {
+//            return;
+//        }
+
         // If this configuration's version is in conflict, do not traverse.
         // If none of the incoming edges are transitive, remove previous state and do not traverse.
         // If not traversed before, simply add all selected outgoing edges (either hard or pending edges)

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PendingDependencies.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PendingDependencies.java
@@ -20,6 +20,11 @@ import org.gradle.api.artifacts.ModuleIdentifier;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+/**
+ * Tracks hard dependencies targeting a given module. A module should end up in a graph if it has hard dependencies.
+ * Also tracks all constraints that have been observed when for a module. These constraints should be activated when
+ * the hard edge count becomes positive.
+ */
 public class PendingDependencies {
     private final ModuleIdentifier moduleIdentifier;
     private final Set<NodeState> constraintProvidingNodes;
@@ -58,6 +63,9 @@ public class PendingDependencies {
         reportActivePending = true;
     }
 
+    /**
+     * Return true iff all nodes in this module have no non-constraint edges
+     */
     public boolean isPending() {
         return hardEdges == 0;
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PendingDependencies.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PendingDependencies.java
@@ -87,4 +87,7 @@ public class PendingDependencies {
         return reportActivePending;
     }
 
+    public void retarget(PendingDependencies pendingDependencies) {
+        hardEdges += pendingDependencies.hardEdges;
+    }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PendingDependenciesVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PendingDependenciesVisitor.java
@@ -36,6 +36,21 @@ public interface PendingDependenciesVisitor {
         }
     }
 
+    /**
+     * If this dependency declaration is not a constraint, indicate whether an edge should be created.
+     *
+     * If this dependency declaration is a constraint:
+     * <ul>
+     *      <li>
+     *          If the target module is <strong>already present</strong> in the graph: indicate that an edge should be created
+     *      </li>
+     *      <li>
+     *          If the target module is <strong>not present</strong> in the graph: track the source node as a constraint provider for the target module
+     *      </li>
+     * </ul>
+     *
+     * @return The pending state of the <strong>target module</strong>
+     */
     PendingState maybeAddAsPendingDependency(NodeState node, DependencyState dependencyState);
 
     boolean markNotPending(ModuleIdentifier id);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -249,6 +249,9 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
         }
         this.reusable = true;
         if (markedReusableAlready) {
+            // TODO: We have hit an unstable graph. This selector has already added, removed, added again,
+            // and we are removing it once again. We should fail the resolution here and ask the user
+            // to fix the graph -- likely by adding a version constraint.
             return true;
         } else {
             markedReusableAlready = true;
@@ -257,11 +260,11 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     }
 
     /**
-     * Checks if the selector can be used for resolution.
+     * Checks if the selector affects selection at the moment it is added to a module
      *
      * @return {@code true} if the selector can resolve, {@code false} otherwise
      */
-    boolean canResolve() {
+    boolean canAffectSelection() {
         if (reusable) {
             return true;
         }
@@ -276,7 +279,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
         this.resolved = true;
         this.reusable = false;
 
-        // Target module can change, if this is called as the result of a module replacement conflict.
+        // Target module can change, if this is called as the result of a module or capability replacement conflict.
         this.targetModule = selected.getModule();
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/ConflictHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/ConflictHandler.java
@@ -32,7 +32,9 @@ public interface ConflictHandler<CANDIDATE, RESULT> {
     boolean hasConflicts();
 
     /**
-     * Resolves next conflict and trigger provided action after the resolution
+     * Resolves next conflict and trigger provided action after the resolution.
+     *
+     * Must be called only if {@link #hasConflicts()} returns true.
      */
     void resolveNextConflict(Action<RESULT> resolutionAction);
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
@@ -116,6 +116,7 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
     @Override
     public void resolveNextConflict(Action<ConflictResolutionResult> resolutionAction) {
         CapabilityConflict conflict = conflicts.poll();
+        // TODO: Ensure >= 2 nodes in this conflict are still selected
         Details details = new Details(conflict);
         for (Resolver resolver : resolvers) {
             resolver.resolve(details);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
@@ -39,6 +39,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictHandler {
     private final List<Resolver> resolvers;
@@ -115,8 +116,11 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
 
     @Override
     public void resolveNextConflict(Action<ConflictResolutionResult> resolutionAction) {
-        CapabilityConflict conflict = conflicts.poll();
-        // TODO: Ensure >= 2 nodes in this conflict are still selected
+        CapabilityConflict conflict = conflicts.remove().withSelectedNodes();
+        if (conflict.nodes.isEmpty()) {
+            return;
+        }
+
         Details details = new Details(conflict);
         for (Resolver resolver : resolvers) {
             resolver.resolve(details);
@@ -272,10 +276,15 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
 
     private static class CapabilityConflict {
 
+        private final String group;
+        private final String name;
+
         private final Collection<NodeState> nodes;
         private final Set<Capability> descriptors;
 
         private CapabilityConflict(String group, String name, Collection<NodeState> nodes) {
+            this.group = group;
+            this.name = name;
             this.nodes = nodes;
             final ImmutableSet.Builder<Capability> builder = new ImmutableSet.Builder<>();
             for (final NodeState node : nodes) {
@@ -285,6 +294,19 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
                 }
             }
             this.descriptors = builder.build();
+        }
+
+        /**
+         * Many things can happen in-between detection of a conflict and resolution of the conflict. By the time
+         * we resolve the conflict, some or all of the nodes that originally conflicted may no longer be present
+         * in the graph.
+         *
+         * @return a new conflict containing only nodes that are still present in the graph. This new conflict
+         * may contain no nodes.
+         */
+        public CapabilityConflict withSelectedNodes() {
+            List<NodeState> selectedNodes = nodes.stream().filter(NodeState::isSelected).collect(Collectors.toList());
+            return new CapabilityConflict(group, name, selectedNodes);
         }
 
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
@@ -121,6 +121,11 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
             return;
         }
 
+        // TODO: If the conflict only has a single node, we should execute the resolution action directly instead
+        // of going through the resolvers first. User-written resolvers may be written assuming there are at least
+        // 2 conflicting nodes.
+        // CapabilitiesRulesIntegrationTest#two capabilities conflict when one is a transitive of the other resolve successfully fails otherwise
+
         Details details = new Details(conflict);
         for (Resolver resolver : resolvers) {
             resolver.resolve(details);
@@ -232,6 +237,13 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
                             public void reject() {
                                 ComponentState component = node.getComponent();
                                 component.rejectForCapabilityConflict(capability, conflictedNodes(node, conflict.nodes));
+
+                                // TODO: Determine if we really need to select this rejected node.
+                                // How do we prevent the node from selecting its own dependencies when it
+                                // gets added to the graph?
+                                // Conceptually, it seems odd for a module to select a node that does not belong in the graph
+                                // however, this seems to be required currently for the sake of reporting the conflict
+                                // final graph visiting.
                                 component.selectAndRestartModule();
                             }
 


### PR DESCRIPTION
Previously, these hard edges were not properly tracked and we mistakenly removed edges that we assumed were constraints.
This surfaced as many errors, including missing first-level dependencies, silent incorrect graphs, and corrupt serialized
resolution result errors.

We migrate any reproducers fixed by this error to CapabilitiesConflictResolutionIssuesIntegrationTest.
We also ensured these reproducers use local test dependencies with their minimal set of transitive dependencies, while
still reproducing the original issue. Furthermore, we updated the tests to use the ResolveTestFixture for verification

Adds additional documentation to the dependency resolution engine.

May fix some issues reported in https://github.com/gradle/gradle/issues/14220

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
