### PR TITLE
Allow Configuration Cache for creating models without Isolated Projects

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/AbstractConfigurationCacheIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/AbstractConfigurationCacheIntegrationTest.groovy
@@ -46,6 +46,10 @@ abstract class AbstractConfigurationCacheIntegrationTest extends AbstractConfigu
         buildKotlinFile << script
     }
 
+    void withConfigurationCache() {
+        executer.withArguments(ENABLE_CLI_OPT, LOG_REPORT_LINK_AS_WARNING)
+    }
+
     void configurationCacheRun(String... tasks) {
         run(*CLI_OPTIONS, *tasks)
     }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/AbstractConfigurationCacheIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/AbstractConfigurationCacheIntegrationTest.groovy
@@ -51,7 +51,7 @@ abstract class AbstractConfigurationCacheIntegrationTest extends AbstractConfigu
     }
 
     void withConfigurationCacheLenient(String... moreExecuterArgs) {
-        executer.withArguments(ENABLE_CLI_OPT, LOG_REPORT_LINK_AS_WARNING,WARN_PROBLEMS_CLI_OPT, *moreExecuterArgs)
+        executer.withArguments(ENABLE_CLI_OPT, LOG_REPORT_LINK_AS_WARNING, WARN_PROBLEMS_CLI_OPT, *moreExecuterArgs)
     }
 
     void configurationCacheRun(String... tasks) {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/AbstractConfigurationCacheIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/AbstractConfigurationCacheIntegrationTest.groovy
@@ -46,8 +46,8 @@ abstract class AbstractConfigurationCacheIntegrationTest extends AbstractConfigu
         buildKotlinFile << script
     }
 
-    void withConfigurationCache() {
-        executer.withArguments(ENABLE_CLI_OPT, LOG_REPORT_LINK_AS_WARNING)
+    void withConfigurationCache(String... moreExecuterArgs) {
+        executer.withArguments(ENABLE_CLI_OPT, LOG_REPORT_LINK_AS_WARNING, *moreExecuterArgs)
     }
 
     void configurationCacheRun(String... tasks) {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/AbstractConfigurationCacheIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/AbstractConfigurationCacheIntegrationTest.groovy
@@ -50,6 +50,10 @@ abstract class AbstractConfigurationCacheIntegrationTest extends AbstractConfigu
         executer.withArguments(ENABLE_CLI_OPT, LOG_REPORT_LINK_AS_WARNING, *moreExecuterArgs)
     }
 
+    void withConfigurationCacheLenient(String... moreExecuterArgs) {
+        executer.withArguments(ENABLE_CLI_OPT, LOG_REPORT_LINK_AS_WARNING,WARN_PROBLEMS_CLI_OPT, *moreExecuterArgs)
+    }
+
     void configurationCacheRun(String... tasks) {
         run(*CLI_OPTIONS, *tasks)
     }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/actions/CustomModelStreamingBuildAction.java
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/actions/CustomModelStreamingBuildAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,24 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.cc.impl.isolated;
+package org.gradle.internal.cc.impl.actions;
 
-import org.gradle.internal.cc.impl.fixtures.SomeToolingModel;
+import org.gradle.internal.cc.impl.fixtures.CustomModel;
 import org.gradle.tooling.BuildAction;
 import org.gradle.tooling.BuildController;
 
-import java.util.ArrayList;
-import java.util.List;
+public class CustomModelStreamingBuildAction<T> implements BuildAction<T> {
+    private final Class<T> type;
+    private final int value;
 
-public class FetchModelsMultipleTimesForEachProject implements BuildAction<List<SomeToolingModel>> {
+    public CustomModelStreamingBuildAction(Class<T> type, int value) {
+        this.type = type;
+        this.value = value;
+    }
+
     @Override
-    public List<SomeToolingModel> execute(BuildController controller) {
-        List<SomeToolingModel> result = new ArrayList<>();
-        result.addAll(new FetchCustomModelForEachProject().execute(controller));
-        result.addAll(new FetchCustomModelForEachProject().execute(controller));
-        return result;
+    public T execute(BuildController controller) {
+        controller.send(new CustomModel(value));
+        return controller.getModel(type);
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/actions/FailingBuildAction.java
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/actions/FailingBuildAction.java
@@ -14,24 +14,16 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.cc.impl.isolated;
+package org.gradle.internal.cc.impl.actions;
 
-import org.gradle.internal.cc.impl.fixtures.CustomModel;
+import org.gradle.internal.cc.impl.fixtures.SomeToolingModel;
 import org.gradle.tooling.BuildAction;
 import org.gradle.tooling.BuildController;
-import org.gradle.tooling.model.GradleProject;
-import org.gradle.tooling.model.eclipse.EclipseProject;
 
-class ModelStreamingBuildAction implements BuildAction<CustomModel> {
+public class FailingBuildAction implements BuildAction<SomeToolingModel> {
     @Override
-    public CustomModel execute(BuildController controller) {
-        EclipseProject eclipseProject = controller.getModel(EclipseProject.class);
-        GradleProject gradleProject = controller.getModel(GradleProject.class);
-
-        // Intentionally sending models in an order different from requesting models
-        controller.send(gradleProject);
-        controller.send(eclipseProject);
-
-        return new CustomModel(42);
+    public SomeToolingModel execute(BuildController controller) {
+        controller.getBuildModel();
+        throw new RuntimeException("Build action expectedly failed");
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/actions/FetchAllIdeaProjects.java
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/actions/FetchAllIdeaProjects.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.internal.cc.impl.isolated;
+package org.gradle.internal.cc.impl.actions;
 
 import org.gradle.tooling.BuildAction;
 import org.gradle.tooling.BuildController;

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/actions/FetchCustomModelForEachProject.java
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/actions/FetchCustomModelForEachProject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.cc.impl.isolated;
+package org.gradle.internal.cc.impl.actions;
 
 import org.gradle.internal.cc.impl.fixtures.SomeToolingModel;
 import org.gradle.tooling.BuildAction;
@@ -22,29 +22,20 @@ import org.gradle.tooling.BuildController;
 import org.gradle.tooling.model.gradle.BasicGradleProject;
 import org.gradle.tooling.model.gradle.GradleBuild;
 
-public class FetchCustomModelForTargetProject implements BuildAction<SomeToolingModel> {
+import java.util.ArrayList;
+import java.util.List;
 
-    private final String targetProject;
-
-    public FetchCustomModelForTargetProject(String targetProject) {
-        this.targetProject = targetProject;
-    }
-
+public class FetchCustomModelForEachProject implements BuildAction<List<SomeToolingModel>> {
     @Override
-    public SomeToolingModel execute(BuildController controller) {
+    public List<SomeToolingModel> execute(BuildController controller) {
+        List<SomeToolingModel> result = new ArrayList<>();
         GradleBuild buildModel = controller.getBuildModel();
         for (BasicGradleProject project : buildModel.getProjects()) {
-            if (targetProject.equals(project.getBuildTreePath())) {
-                return controller.getModel(project, SomeToolingModel.class);
+            SomeToolingModel model = controller.findModel(project, SomeToolingModel.class);
+            if (model != null) {
+                result.add(model);
             }
         }
-        for (GradleBuild editableBuild : buildModel.getEditableBuilds()) {
-            for (BasicGradleProject project : editableBuild.getProjects()) {
-                if (targetProject.equals(project.getBuildTreePath())) {
-                    return controller.getModel(project, SomeToolingModel.class);
-                }
-            }
-        }
-        return null;
+        return result;
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/actions/FetchCustomModelForEachProjectInParallel.java
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/actions/FetchCustomModelForEachProjectInParallel.java
@@ -14,38 +14,38 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.cc.impl.isolated;
+package org.gradle.internal.cc.impl.actions;
 
 import org.gradle.internal.cc.impl.fixtures.SomeToolingModel;
 import org.gradle.tooling.BuildAction;
 import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.gradle.BasicGradleProject;
+import org.gradle.tooling.model.gradle.GradleBuild;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class FetchCustomModelForSameProjectInParallel implements BuildAction<List<SomeToolingModel>> {
-
+public class FetchCustomModelForEachProjectInParallel implements BuildAction<List<SomeToolingModel>> {
     @Override
     public List<SomeToolingModel> execute(BuildController controller) {
         List<FetchModelForProject> actions = new ArrayList<>();
-        for (int i = 1; i <= 2; i++) {
-            actions.add(new FetchModelForProject("nested-" + i));
+        GradleBuild buildModel = controller.getBuildModel();
+        for (BasicGradleProject project : buildModel.getProjects()) {
+            actions.add(new FetchModelForProject(project));
         }
         return controller.run(actions);
     }
 
     private static class FetchModelForProject implements BuildAction<SomeToolingModel> {
+        private final BasicGradleProject project;
 
-        private final String id;
-
-        private FetchModelForProject(String id) {
-            this.id = id;
+        public FetchModelForProject(BasicGradleProject project) {
+            this.project = project;
         }
 
         @Override
         public SomeToolingModel execute(BuildController controller) {
-            System.out.println("Executing " + id);
-            return controller.findModel(SomeToolingModel.class);
+            return controller.findModel(project, SomeToolingModel.class);
         }
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/actions/FetchCustomModelForEachProjectInTree.java
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/actions/FetchCustomModelForEachProjectInTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.cc.impl.isolated;
+package org.gradle.internal.cc.impl.actions;
 
 import org.gradle.internal.cc.impl.fixtures.SomeToolingModel;
 import org.gradle.tooling.BuildAction;
@@ -25,17 +25,24 @@ import org.gradle.tooling.model.gradle.GradleBuild;
 import java.util.ArrayList;
 import java.util.List;
 
-public class FetchPartialCustomModelForEachProject implements BuildAction<List<String>> {
+public class FetchCustomModelForEachProjectInTree implements BuildAction<List<SomeToolingModel>> {
     @Override
-    public List<String> execute(BuildController controller) {
-        List<String> result = new ArrayList<>();
+    public List<SomeToolingModel> execute(BuildController controller) {
+        List<SomeToolingModel> result = new ArrayList<>();
         GradleBuild buildModel = controller.getBuildModel();
+        collectModelsForProjects(controller, result, buildModel);
+        for (GradleBuild build : buildModel.getEditableBuilds()) {
+            collectModelsForProjects(controller, result, build);
+        }
+        return result;
+    }
+
+    private void collectModelsForProjects(BuildController controller, List<SomeToolingModel> result, GradleBuild buildModel) {
         for (BasicGradleProject project : buildModel.getProjects()) {
             SomeToolingModel model = controller.findModel(project, SomeToolingModel.class);
             if (model != null) {
-                result.add(model.getMessage());
+                result.add(model);
             }
         }
-        return result;
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/actions/FetchGradleProjectForTarget.java
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/actions/FetchGradleProjectForTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.cc.impl.isolated;
+package org.gradle.internal.cc.impl.actions;
 
 import org.gradle.tooling.BuildAction;
 import org.gradle.tooling.BuildController;

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/actions/FetchIdeaProjectForTarget.java
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/actions/FetchIdeaProjectForTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.cc.impl.isolated;
+package org.gradle.internal.cc.impl.actions;
 
 import org.gradle.tooling.BuildAction;
 import org.gradle.tooling.BuildController;

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/actions/FetchModelsMultipleTimesForEachProject.java
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/actions/FetchModelsMultipleTimesForEachProject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,21 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.cc.impl.isolated;
+package org.gradle.internal.cc.impl.actions;
 
 import org.gradle.internal.cc.impl.fixtures.SomeToolingModel;
 import org.gradle.tooling.BuildAction;
 import org.gradle.tooling.BuildController;
 
-public class FailingBuildAction implements BuildAction<SomeToolingModel> {
+import java.util.ArrayList;
+import java.util.List;
+
+public class FetchModelsMultipleTimesForEachProject implements BuildAction<List<SomeToolingModel>> {
     @Override
-    public SomeToolingModel execute(BuildController controller) {
-        controller.getBuildModel();
-        throw new RuntimeException("Build action expectedly failed");
+    public List<SomeToolingModel> execute(BuildController controller) {
+        List<SomeToolingModel> result = new ArrayList<>();
+        result.addAll(new FetchCustomModelForEachProject().execute(controller));
+        result.addAll(new FetchCustomModelForEachProject().execute(controller));
+        return result;
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/actions/FetchParameterizedCustomModelForEachProject.java
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/actions/FetchParameterizedCustomModelForEachProject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.cc.impl.isolated;
+package org.gradle.internal.cc.impl.actions;
 
 import org.gradle.api.Action;
 import org.gradle.internal.cc.impl.fixtures.SomeToolingModel;

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/actions/FetchPartialCustomModelForEachProject.java
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/actions/FetchPartialCustomModelForEachProject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.cc.impl.isolated;
+package org.gradle.internal.cc.impl.actions;
 
 import org.gradle.internal.cc.impl.fixtures.SomeToolingModel;
 import org.gradle.tooling.BuildAction;
@@ -25,24 +25,17 @@ import org.gradle.tooling.model.gradle.GradleBuild;
 import java.util.ArrayList;
 import java.util.List;
 
-public class FetchCustomModelForEachProjectInTree implements BuildAction<List<SomeToolingModel>> {
+public class FetchPartialCustomModelForEachProject implements BuildAction<List<String>> {
     @Override
-    public List<SomeToolingModel> execute(BuildController controller) {
-        List<SomeToolingModel> result = new ArrayList<>();
+    public List<String> execute(BuildController controller) {
+        List<String> result = new ArrayList<>();
         GradleBuild buildModel = controller.getBuildModel();
-        collectModelsForProjects(controller, result, buildModel);
-        for (GradleBuild build : buildModel.getEditableBuilds()) {
-            collectModelsForProjects(controller, result, build);
-        }
-        return result;
-    }
-
-    private void collectModelsForProjects(BuildController controller, List<SomeToolingModel> result, GradleBuild buildModel) {
         for (BasicGradleProject project : buildModel.getProjects()) {
             SomeToolingModel model = controller.findModel(project, SomeToolingModel.class);
             if (model != null) {
-                result.add(model);
+                result.add(model.getMessage());
             }
         }
+        return result;
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/actions/ModelStreamingBuildAction.java
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/actions/ModelStreamingBuildAction.java
@@ -14,24 +14,24 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.cc.impl.isolated;
+package org.gradle.internal.cc.impl.actions;
 
 import org.gradle.internal.cc.impl.fixtures.CustomModel;
 import org.gradle.tooling.BuildAction;
 import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.GradleProject;
+import org.gradle.tooling.model.eclipse.EclipseProject;
 
-class CustomModelStreamingBuildAction<T> implements BuildAction<T> {
-    private final Class<T> type;
-    private final int value;
-
-    public CustomModelStreamingBuildAction(Class<T> type, int value) {
-        this.type = type;
-        this.value = value;
-    }
-
+public class ModelStreamingBuildAction implements BuildAction<CustomModel> {
     @Override
-    public T execute(BuildController controller) {
-        controller.send(new CustomModel(value));
-        return controller.getModel(type);
+    public CustomModel execute(BuildController controller) {
+        EclipseProject eclipseProject = controller.getModel(EclipseProject.class);
+        GradleProject gradleProject = controller.getModel(GradleProject.class);
+
+        // Intentionally sending models in an order different from requesting models
+        controller.send(gradleProject);
+        controller.send(eclipseProject);
+
+        return new CustomModel(42);
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/fixtures/ToolingApiIdeaModelChecker.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/fixtures/ToolingApiIdeaModelChecker.groovy
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.fixtures
+
+import org.gradle.tooling.model.idea.IdeaContentRoot
+import org.gradle.tooling.model.idea.IdeaDependency
+import org.gradle.tooling.model.idea.IdeaJavaLanguageSettings
+import org.gradle.tooling.model.idea.IdeaModule
+import org.gradle.tooling.model.idea.IdeaModuleDependency
+import org.gradle.tooling.model.idea.IdeaProject
+import org.gradle.tooling.model.idea.IdeaSingleEntryLibraryDependency
+
+import static org.gradle.integtests.tooling.fixture.ToolingApiModelChecker.checkGradleProject
+import static org.gradle.integtests.tooling.fixture.ToolingApiModelChecker.checkModel
+import static org.gradle.integtests.tooling.fixture.ToolingApiModelChecker.checkProjectIdentifier
+
+class ToolingApiIdeaModelChecker {
+
+    static void checkIdeaProject(IdeaProject actual, IdeaProject expected) {
+        checkModel(actual, expected, [
+            { it.parent },
+            { it.name },
+            { it.description },
+            { it.jdkName },
+            { it.languageLevel.level },
+            [{ it.children }, { a, e -> checkIdeaModule(a, e) }],
+        ])
+    }
+
+    private static void checkIdeaModule(IdeaModule actualModule, IdeaModule expectedModule) {
+        checkModel(actualModule, expectedModule, [
+            { it.name },
+            [{ it.projectIdentifier }, { a, e -> checkProjectIdentifier(a, e) }],
+            [{ it.javaLanguageSettings }, { a, e -> checkLanguageSettings(a, e) }],
+            { it.jdkName },
+            [{ it.contentRoots }, { a, e -> checkContentRoot(a, e) }],
+            [{ it.gradleProject }, { a, e -> checkGradleProject(a, e) }],
+            { it.project.languageLevel.level }, // shallow check to avoid infinite recursion
+            { it.compilerOutput.inheritOutputDirs },
+            { it.compilerOutput.outputDir },
+            { it.compilerOutput.testOutputDir },
+            [{ it.dependencies }, { a, e -> checkDependency(a, e) }],
+        ])
+    }
+
+    private static void checkContentRoot(IdeaContentRoot actual, IdeaContentRoot expected) {
+        checkModel(actual, expected, [
+            { it.rootDirectory },
+            { it.excludeDirectories },
+        ])
+    }
+
+    private static void checkDependency(IdeaDependency actual, IdeaDependency expected) {
+        checkModel(actual, expected, [
+            { it.scope.scope },
+            { it.exported },
+        ])
+
+        if (expected instanceof IdeaModuleDependency) {
+            checkModel(actual, expected, [
+                { it.targetModuleName },
+            ])
+        }
+
+        if (expected instanceof IdeaSingleEntryLibraryDependency) {
+            checkModel(actual, expected, [
+                { it.file },
+                { it.source },
+                { it.javadoc },
+                { it.exported },
+            ])
+        }
+    }
+
+    private static void checkLanguageSettings(IdeaJavaLanguageSettings actual, IdeaJavaLanguageSettings expected) {
+        checkModel(actual, expected, [
+            { it.languageLevel },
+            { it.targetBytecodeVersion },
+            { it.jdk?.javaVersion },
+            { it.jdk?.javaHome },
+        ])
+    }
+
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsBuildOperationsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsBuildOperationsIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.internal.cc.impl.isolated
 
 import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.internal.cc.impl.actions.FetchCustomModelForEachProject
 import org.gradle.operations.configuration.ConfigurationCacheCheckFingerprintBuildOperationType
 import org.gradle.test.fixtures.file.TestFile
 

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsJavaPluginIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsJavaPluginIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.cc.impl.isolated
 
+import org.gradle.internal.cc.impl.actions.FetchCustomModelForEachProjectInParallel
 import org.gradle.test.fixtures.file.TestFile
 
 class IsolatedProjectsJavaPluginIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiBuildActionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiBuildActionIntegrationTest.groovy
@@ -16,6 +16,10 @@
 
 package org.gradle.internal.cc.impl.isolated
 
+import org.gradle.internal.cc.impl.actions.FailingBuildAction
+import org.gradle.internal.cc.impl.actions.FetchCustomModelForEachProject
+import org.gradle.internal.cc.impl.actions.FetchCustomModelForTargetProject
+import org.gradle.internal.cc.impl.actions.FetchModelsMultipleTimesForEachProject
 import org.gradle.internal.cc.impl.fixtures.SomeToolingModel
 
 class IsolatedProjectsToolingApiBuildActionIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiCompositeBuildsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiCompositeBuildsIntegrationTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.cc.impl.isolated
 
+import org.gradle.internal.cc.impl.actions.FetchCustomModelForEachProjectInTree
+
 class IsolatedProjectsToolingApiCompositeBuildsIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {
 
     def "invalidates cached state when plugin in buildSrc changes"() {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiCoupledProjectsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiCoupledProjectsIntegrationTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.cc.impl.isolated
 
+import org.gradle.internal.cc.impl.actions.FetchCustomModelForEachProject
+
 class IsolatedProjectsToolingApiCoupledProjectsIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {
 
     def "projects are treated as coupled when parent mutates child project"() {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiGradleLifecycleIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiGradleLifecycleIntegrationTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.cc.impl.isolated
 
+import org.gradle.internal.cc.impl.actions.FetchCustomModelForEachProject
+
 
 class IsolatedProjectsToolingApiGradleLifecycleIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {
 

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiGradleProjectIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiGradleProjectIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.cc.impl.isolated
 
+import org.gradle.internal.cc.impl.actions.FetchGradleProjectForTarget
 import org.gradle.plugins.ide.internal.tooling.model.IsolatedGradleProjectInternal
 import org.gradle.tooling.model.GradleProject
 

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiIdeaProjectIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiIdeaProjectIntegrationTest.groovy
@@ -22,19 +22,13 @@ import org.gradle.internal.cc.impl.actions.FetchIdeaProjectForTarget
 import org.gradle.plugins.ide.internal.tooling.idea.IsolatedIdeaModuleInternal
 import org.gradle.plugins.ide.internal.tooling.model.IsolatedGradleProjectInternal
 import org.gradle.tooling.model.idea.BasicIdeaProject
-import org.gradle.tooling.model.idea.IdeaContentRoot
-import org.gradle.tooling.model.idea.IdeaDependency
-import org.gradle.tooling.model.idea.IdeaJavaLanguageSettings
-import org.gradle.tooling.model.idea.IdeaModule
 import org.gradle.tooling.model.idea.IdeaModuleDependency
 import org.gradle.tooling.model.idea.IdeaProject
-import org.gradle.tooling.model.idea.IdeaSingleEntryLibraryDependency
 import org.gradle.tooling.provider.model.internal.PluginApplyingBuilder
 import org.gradle.util.internal.ToBeImplemented
 
-import static org.gradle.integtests.tooling.fixture.ToolingApiModelChecker.checkGradleProject
 import static org.gradle.integtests.tooling.fixture.ToolingApiModelChecker.checkModel
-import static org.gradle.integtests.tooling.fixture.ToolingApiModelChecker.checkProjectIdentifier
+import static org.gradle.internal.cc.impl.fixtures.ToolingApiIdeaModelChecker.checkIdeaProject
 
 class IsolatedProjectsToolingApiIdeaProjectIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {
 
@@ -510,71 +504,6 @@ class IsolatedProjectsToolingApiIdeaProjectIntegrationTest extends AbstractIsola
 
         // TODO:isolated check the model matches the vintage model
 //        checkIdeaProject(ideaModel, originalIdeaModel)
-    }
-
-    private static void checkIdeaProject(IdeaProject actual, IdeaProject expected) {
-        checkModel(actual, expected, [
-            { it.parent },
-            { it.name },
-            { it.description },
-            { it.jdkName },
-            { it.languageLevel.level },
-            [{ it.children }, { a, e -> checkIdeaModule(a, e) }],
-        ])
-    }
-
-    private static void checkIdeaModule(IdeaModule actualModule, IdeaModule expectedModule) {
-        checkModel(actualModule, expectedModule, [
-            { it.name },
-            [{ it.projectIdentifier }, { a, e -> checkProjectIdentifier(a, e) }],
-            [{ it.javaLanguageSettings }, { a, e -> checkLanguageSettings(a, e) }],
-            { it.jdkName },
-            [{ it.contentRoots }, { a, e -> checkContentRoot(a, e) }],
-            [{ it.gradleProject }, { a, e -> checkGradleProject(a, e) }],
-            { it.project.languageLevel.level }, // shallow check to avoid infinite recursion
-            { it.compilerOutput.inheritOutputDirs },
-            { it.compilerOutput.outputDir },
-            { it.compilerOutput.testOutputDir },
-            [{ it.dependencies }, { a, e -> checkDependency(a, e) }],
-        ])
-    }
-
-    private static void checkContentRoot(IdeaContentRoot actual, IdeaContentRoot expected) {
-        checkModel(actual, expected, [
-            { it.rootDirectory },
-            { it.excludeDirectories },
-        ])
-    }
-
-    private static void checkDependency(IdeaDependency actual, IdeaDependency expected) {
-        checkModel(actual, expected, [
-            { it.scope.scope },
-            { it.exported },
-        ])
-
-        if (expected instanceof IdeaModuleDependency) {
-            checkModel(actual, expected, [
-                { it.targetModuleName },
-            ])
-        }
-
-        if (expected instanceof IdeaSingleEntryLibraryDependency) {
-            checkModel(actual, expected, [
-                { it.file },
-                { it.source },
-                { it.javadoc },
-                { it.exported },
-            ])
-        }
-    }
-
-    private static void checkLanguageSettings(IdeaJavaLanguageSettings actual, IdeaJavaLanguageSettings expected) {
-        checkModel(actual, expected, [
-            { it.languageLevel },
-            { it.targetBytecodeVersion },
-            { it.jdk?.javaVersion },
-            { it.jdk?.javaHome },
-        ])
     }
 
     private static List<String> models(Object... models) {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiIdeaProjectIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiIdeaProjectIntegrationTest.groovy
@@ -17,6 +17,8 @@
 package org.gradle.internal.cc.impl.isolated
 
 import org.gradle.api.JavaVersion
+import org.gradle.internal.cc.impl.actions.FetchAllIdeaProjects
+import org.gradle.internal.cc.impl.actions.FetchIdeaProjectForTarget
 import org.gradle.plugins.ide.internal.tooling.idea.IsolatedIdeaModuleInternal
 import org.gradle.plugins.ide.internal.tooling.model.IsolatedGradleProjectInternal
 import org.gradle.tooling.model.idea.BasicIdeaProject

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiModelQueryIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiModelQueryIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.cc.impl.isolated
 
+import org.gradle.internal.cc.impl.actions.FetchCustomModelForEachProject
 import org.gradle.internal.cc.impl.fixtures.SomeToolingModel
 import org.gradle.tooling.model.GradleProject
 import org.gradle.tooling.model.gradle.GradleBuild

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiParallelConfigurationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiParallelConfigurationIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.cc.impl.isolated
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.internal.cc.impl.actions.FetchCustomModelForEachProjectInParallel
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.tooling.model.GradleProject

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiParallelModelQueryIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiParallelModelQueryIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.cc.impl.isolated
 
+import org.gradle.internal.cc.impl.actions.FetchCustomModelForSameProjectInParallel
 import org.gradle.internal.cc.impl.fixtures.SomeToolingModel
 
 class IsolatedProjectsToolingApiParallelModelQueryIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiParameterizedModelQueryIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiParameterizedModelQueryIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.cc.impl.isolated
 
+import org.gradle.internal.cc.impl.actions.FetchParameterizedCustomModelForEachProject
 import org.gradle.internal.cc.impl.fixtures.SomeToolingModel
 
 class IsolatedProjectsToolingApiParameterizedModelQueryIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiPhasedBuildActionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiPhasedBuildActionIntegrationTest.groovy
@@ -16,6 +16,9 @@
 
 package org.gradle.internal.cc.impl.isolated
 
+import org.gradle.internal.cc.impl.actions.FetchCustomModelForEachProject
+import org.gradle.internal.cc.impl.actions.FetchCustomModelForTargetProject
+import org.gradle.internal.cc.impl.actions.FetchPartialCustomModelForEachProject
 import org.gradle.internal.cc.impl.fixtures.SomeToolingModel
 
 class IsolatedProjectsToolingApiPhasedBuildActionIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiStreamingBuildActionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiStreamingBuildActionIntegrationTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.cc.impl.isolated
 
+import org.gradle.internal.cc.impl.actions.CustomModelStreamingBuildAction
+import org.gradle.internal.cc.impl.actions.ModelStreamingBuildAction
 import org.gradle.internal.cc.impl.fixtures.CustomModel
 import org.gradle.tooling.StreamedValueListener
 import org.gradle.tooling.model.GradleProject

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingModelsWithDependencyResolutionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingModelsWithDependencyResolutionIntegrationTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.cc.impl.isolated
 
+import org.gradle.internal.cc.impl.actions.FetchCustomModelForEachProject
+
 class IsolatedProjectsToolingModelsWithDependencyResolutionIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {
 
     def "caches BuildAction that queries model that performs dependency resolution"() {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingModelsWithDependencyResolutionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingModelsWithDependencyResolutionIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.internal.cc.impl.isolated
 
 import org.gradle.internal.cc.impl.actions.FetchCustomModelForEachProject
+import org.gradle.internal.cc.impl.actions.FetchPartialCustomModelForEachProject
 
 class IsolatedProjectsToolingModelsWithDependencyResolutionIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {
 

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/AbstractConfigurationCacheToolingApiIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/AbstractConfigurationCacheToolingApiIntegrationTest.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.tapi
+
+import org.gradle.integtests.fixtures.executer.GradleExecuter
+import org.gradle.internal.cc.impl.AbstractConfigurationCacheIntegrationTest
+import org.gradle.internal.cc.impl.fixtures.ToolingApiBackedGradleExecuter
+import org.gradle.internal.cc.impl.fixtures.ToolingApiSpec
+
+class AbstractConfigurationCacheToolingApiIntegrationTest extends AbstractConfigurationCacheIntegrationTest implements ToolingApiSpec {
+
+    final def fixture = new ConfigurationCacheToolingApiFixture(this)
+
+    @Override
+    GradleExecuter createExecuter() {
+        return new ToolingApiBackedGradleExecuter(distribution, temporaryFolder)
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/AbstractConfigurationCacheToolingApiIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/AbstractConfigurationCacheToolingApiIntegrationTest.groovy
@@ -29,4 +29,12 @@ class AbstractConfigurationCacheToolingApiIntegrationTest extends AbstractConfig
     GradleExecuter createExecuter() {
         return new ToolingApiBackedGradleExecuter(distribution, temporaryFolder)
     }
+
+    void withConfigurationCacheForModels(String... moreExecuterArgs) {
+        withConfigurationCache("-Dorg.gradle.configuration-cache.internal.tooling-models=true", *moreExecuterArgs)
+    }
+
+    void withConfigurationCacheLenientForModels(String... moreExecuterArgs) {
+        withConfigurationCacheLenient("-Dorg.gradle.configuration-cache.internal.tooling-models=true", *moreExecuterArgs)
+    }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/AbstractConfigurationCacheToolingApiIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/AbstractConfigurationCacheToolingApiIntegrationTest.groovy
@@ -31,10 +31,10 @@ class AbstractConfigurationCacheToolingApiIntegrationTest extends AbstractConfig
     }
 
     void withConfigurationCacheForModels(String... moreExecuterArgs) {
-        withConfigurationCache("-Dorg.gradle.configuration-cache.internal.tooling-models=true", *moreExecuterArgs)
+        withConfigurationCache("-Dorg.gradle.internal.configuration-cache.tooling=true", *moreExecuterArgs)
     }
 
     void withConfigurationCacheLenientForModels(String... moreExecuterArgs) {
-        withConfigurationCacheLenient("-Dorg.gradle.configuration-cache.internal.tooling-models=true", *moreExecuterArgs)
+        withConfigurationCacheLenient("-Dorg.gradle.internal.configuration-cache.tooling=true", *moreExecuterArgs)
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiBuildActionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiBuildActionIntegrationTest.groovy
@@ -16,10 +16,10 @@
 
 package org.gradle.internal.cc.impl.tapi
 
-import org.gradle.internal.cc.impl.isolated.FailingBuildAction
-import org.gradle.internal.cc.impl.isolated.FetchCustomModelForEachProject
-import org.gradle.internal.cc.impl.isolated.FetchCustomModelForTargetProject
-import org.gradle.internal.cc.impl.isolated.FetchModelsMultipleTimesForEachProject
+import org.gradle.internal.cc.impl.actions.FailingBuildAction
+import org.gradle.internal.cc.impl.actions.FetchCustomModelForEachProject
+import org.gradle.internal.cc.impl.actions.FetchCustomModelForTargetProject
+import org.gradle.internal.cc.impl.actions.FetchModelsMultipleTimesForEachProject
 
 class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractConfigurationCacheToolingApiIntegrationTest {
 

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiBuildActionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiBuildActionIntegrationTest.groovy
@@ -1,0 +1,598 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.tapi
+
+import org.gradle.internal.cc.impl.isolated.FailingBuildAction
+import org.gradle.internal.cc.impl.isolated.FetchCustomModelForEachProject
+import org.gradle.internal.cc.impl.isolated.FetchCustomModelForTargetProject
+import org.gradle.internal.cc.impl.isolated.FetchModelsMultipleTimesForEachProject
+
+class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractConfigurationCacheToolingApiIntegrationTest {
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'root'
+        """
+        createDirs("a", "b", "c")
+    }
+
+    def "caches execution of BuildAction that queries custom tooling model"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+        """
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+        """
+        file("a/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+        // Intentionally don't apply to project b. Should split this case (some projects don't have the model available) out into a separate test
+
+        when:
+        withConfigurationCache()
+        def model = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model.size() == 2
+        model[0].message == "It works from project :"
+        model[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 4
+        }
+        outputContains("creating model for root project 'root'")
+        outputContains("creating model for project ':a'")
+
+        when:
+        withConfigurationCache()
+        def model2 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model2.size() == 2
+        model2[0].message == "It works from project :"
+        model2[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateLoaded()
+        outputDoesNotContain("creating model")
+
+        when:
+        buildFile << """
+            myExtension.message = 'this is the root project'
+        """
+
+        withConfigurationCache()
+        def model3 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model3.size() == 2
+        model3[0].message == "this is the root project"
+        model3[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateRecreated {
+            fileChanged("build.gradle")
+            projectConfigured = 4
+        }
+        outputContains("creating model for root project 'root'")
+
+        when:
+        withConfigurationCache()
+        def model4 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model4.size() == 2
+        model4[0].message == "this is the root project"
+        model4[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateLoaded()
+
+        when:
+        file("a/build.gradle") << """
+            myExtension.message = 'this is project a'
+        """
+
+        withConfigurationCache()
+        def model5 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model5.size() == 2
+        model5[0].message == "this is the root project"
+        model5[1].message == "this is project a"
+
+        and:
+        fixture.assertStateRecreated {
+            fileChanged("a/build.gradle")
+            projectConfigured = 4
+        }
+        outputContains("creating model for project ':a'")
+    }
+
+    def "invalidates all cached models when build scoped input changes"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+        """
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+        """
+        file("a/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        withConfigurationCache()
+        def model = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model.size() == 2
+        model[0].message == "It works from project :"
+        model[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 4
+        }
+
+        when:
+        withConfigurationCache()
+        def model2 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model2.size() == 2
+        model2[0].message == "It works from project :"
+        model2[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateLoaded()
+
+        when:
+        settingsFile << """
+            println("some new stuff")
+        """
+
+        withConfigurationCache()
+        def model3 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model3.size() == 2
+        model3[0].message == "It works from project :"
+        model3[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateRecreated {
+            fileChanged("settings.gradle")
+            projectConfigured = 4
+        }
+
+        when:
+        withConfigurationCache()
+        def model4 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model4.size() == 2
+        model4[0].message == "It works from project :"
+        model4[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateLoaded()
+    }
+
+    def "invalidates cached model when model builder input changes"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc("""
+            project.providers.gradleProperty("shared-input").getOrNull()
+            project.providers.systemProperty("\${project.name}-input").getOrNull()
+        """)
+        settingsFile << """
+            include("a")
+            include("b")
+            include("c")
+        """
+        file("a/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+        file("b/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        withConfigurationCache("-Pshared-input=12", "-Da-input=14")
+        def model = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model.size() == 2
+        model[0].message == "It works from project :a"
+        model[1].message == "It works from project :b"
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 5
+        }
+
+        when:
+        withConfigurationCache("-Pshared-input=12", "-Da-input=14")
+        def model2 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model2.size() == 2
+        model2[0].message == "It works from project :a"
+        model2[1].message == "It works from project :b"
+
+        and:
+        fixture.assertStateLoaded()
+
+        when:
+        withConfigurationCache("-Pshared-input=2", "-Da-input=14")
+        def model3 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model3.size() == 2
+        model3[0].message == "It works from project :a"
+        model3[1].message == "It works from project :b"
+
+        and:
+        // TODO:isolated - should not invalidate all cached state
+        fixture.assertStateRecreated {
+            gradlePropertyChanged()
+            projectConfigured = 5
+        }
+
+        when:
+        withConfigurationCache("-Pshared-input=2", "-Da-input=14")
+        def model4 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model4.size() == 2
+        model4[0].message == "It works from project :a"
+        model4[1].message == "It works from project :b"
+
+        and:
+        fixture.assertStateLoaded()
+
+        when:
+        withConfigurationCache("-Pshared-input=2", "-Da-input=2")
+        def model5 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model5.size() == 2
+        model5[0].message == "It works from project :a"
+        model5[1].message == "It works from project :b"
+
+        and:
+        fixture.assertStateRecreated {
+            systemPropertyChanged("a-input")
+            projectConfigured = 5
+        }
+
+        when:
+        withConfigurationCache("-Pshared-input=2", "-Da-input=2")
+        def model6 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model6.size() == 2
+        model6[0].message == "It works from project :a"
+        model6[1].message == "It works from project :b"
+
+        and:
+        fixture.assertStateLoaded()
+
+        when:
+        withConfigurationCache("-Pshared-input=2", "-Da-input=2", "-Db-input=new")
+        def model7 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model7.size() == 2
+        model7[0].message == "It works from project :a"
+        model7[1].message == "It works from project :b"
+
+        and:
+        fixture.assertStateRecreated {
+            systemPropertyChanged("b-input")
+            projectConfigured = 5
+        }
+    }
+
+    def "caches execution of BuildAction that queries each model multiple times"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+        """
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+        """
+        file("a/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        withConfigurationCache()
+        def model = runBuildAction(new FetchModelsMultipleTimesForEachProject())
+
+        then:
+        model.size() == 4
+        model[0].message == "It works from project :"
+        model[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 4
+        }
+        outputContains("creating model for root project 'root'")
+        outputContains("creating model for project ':a'")
+
+        when:
+        withConfigurationCache()
+        def model2 = runBuildAction(new FetchModelsMultipleTimesForEachProject())
+
+        then:
+        model2.size() == 4
+        model2[0].message == "It works from project :"
+        model2[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateLoaded()
+        outputDoesNotContain("creating model")
+
+        when:
+        buildFile << """
+            myExtension.message = 'this is the root project'
+        """
+
+        withConfigurationCache()
+        def model3 = runBuildAction(new FetchModelsMultipleTimesForEachProject())
+
+        then:
+        model3.size() == 4
+        model3[0].message == "this is the root project"
+        model3[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateRecreated {
+            fileChanged("build.gradle")
+            projectConfigured = 4
+        }
+        outputContains("creating model for root project 'root'")
+
+        when:
+        withConfigurationCache()
+        def model4 = runBuildAction(new FetchModelsMultipleTimesForEachProject())
+
+        then:
+        model4.size() == 4
+        model4[0].message == "this is the root project"
+        model4[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateLoaded()
+    }
+
+    def "caches execution of BuildAction that queries nullable custom tooling model"() {
+        given:
+        withSomeNullableToolingModelBuilderPluginInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+        """
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+        """
+        file("a/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        withConfigurationCache()
+        def model = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model.empty
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 4
+        }
+        outputContains("creating model for root project 'root'")
+        outputContains("creating model for project ':a'")
+
+        when:
+        withConfigurationCache()
+        def model2 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model2.empty
+
+        and:
+        fixture.assertStateLoaded()
+        outputDoesNotContain("creating model")
+
+        when:
+        buildFile << """
+            println("changed")
+        """
+
+        withConfigurationCache()
+        def model3 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model3.empty
+
+        and:
+        fixture.assertStateRecreated {
+            fileChanged("build.gradle")
+            projectConfigured = 4
+        }
+        outputContains("creating model for root project 'root'")
+
+        when:
+        withConfigurationCache()
+        def model4 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model4.empty
+
+        and:
+        fixture.assertStateLoaded()
+    }
+
+    def "caches execution of different BuildAction types"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        withConfigurationCache()
+        def model = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 2
+        }
+        outputContains("creating model for root project 'root'")
+
+        and:
+        model.size() == 1
+        model[0].message == "It works from project :"
+
+
+        when:
+        withConfigurationCache()
+        def model2 = runBuildAction(new FetchModelsMultipleTimesForEachProject())
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 2
+        }
+        outputContains("creating model for root project 'root'")
+
+        and:
+        model2.size() == 2
+        model2[0].message == "It works from project :"
+
+
+        when:
+        withConfigurationCache()
+        def model3 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        fixture.assertStateLoaded()
+
+        and:
+        model3.size() == 1
+        model3[0].message == "It works from project :"
+
+
+        when:
+        withConfigurationCache()
+        def model4 = runBuildAction(new FetchModelsMultipleTimesForEachProject())
+
+        then:
+        fixture.assertStateLoaded()
+
+        and:
+        model4.size() == 2
+        model4[0].message == "It works from project :"
+    }
+
+    def "caches execution of BuildAction of same type with different state"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        settingsFile << """
+            include("a")
+        """
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+        """
+        file("a/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        withConfigurationCache()
+        def model = runBuildAction(new FetchCustomModelForTargetProject(":"))
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 3
+        }
+        outputContains("creating model for root project 'root'")
+
+        and:
+        model.message == "It works from project :"
+
+
+        when:
+        withConfigurationCache()
+        def model2 = runBuildAction(new FetchCustomModelForTargetProject(":a"))
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 3
+        }
+        outputContains("creating model for project ':a'")
+
+        and:
+        model2.message == "It works from project :a"
+
+
+        when:
+        withConfigurationCache()
+        def model3 = runBuildAction(new FetchCustomModelForTargetProject(":"))
+
+        then:
+        fixture.assertStateLoaded()
+
+        and:
+        model3.message == "It works from project :"
+
+
+        when:
+        withConfigurationCache()
+        def model4 = runBuildAction(new FetchCustomModelForTargetProject(":a"))
+
+        then:
+        fixture.assertStateLoaded()
+
+        and:
+        model4.message == "It works from project :a"
+    }
+
+    def "does not cache execution of BuildAction when it fails"() {
+        when:
+        withConfigurationCache()
+        runBuildActionFails(new FailingBuildAction())
+
+        then:
+        fixture.assertNoConfigurationCache()
+        failureDescriptionContains("Build action expectedly failed")
+
+        // TODO:isolated should not contain this output https://github.com/gradle/gradle/issues/27476
+        failure.assertOutputContains("Configuration cache entry stored.")
+    }
+
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiBuildActionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiBuildActionIntegrationTest.groovy
@@ -46,7 +46,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
         // Intentionally don't apply to project b. Should split this case (some projects don't have the model available) out into a separate test
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -62,7 +62,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
         outputContains("creating model for project ':a'")
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -79,7 +79,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
             myExtension.message = 'this is the root project'
         """
 
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model3 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -95,7 +95,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
         outputContains("creating model for root project 'root'")
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model4 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -111,7 +111,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
             myExtension.message = 'this is project a'
         """
 
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model5 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -142,7 +142,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -156,7 +156,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -172,7 +172,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
             println("some new stuff")
         """
 
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model3 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -187,7 +187,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model4 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -218,7 +218,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
         """
 
         when:
-        withConfigurationCache("-Pshared-input=12", "-Da-input=14")
+        withConfigurationCacheForModels("-Pshared-input=12", "-Da-input=14")
         def model = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -232,7 +232,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
         }
 
         when:
-        withConfigurationCache("-Pshared-input=12", "-Da-input=14")
+        withConfigurationCacheForModels("-Pshared-input=12", "-Da-input=14")
         def model2 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -244,7 +244,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
         fixture.assertStateLoaded()
 
         when:
-        withConfigurationCache("-Pshared-input=2", "-Da-input=14")
+        withConfigurationCacheForModels("-Pshared-input=2", "-Da-input=14")
         def model3 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -260,7 +260,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
         }
 
         when:
-        withConfigurationCache("-Pshared-input=2", "-Da-input=14")
+        withConfigurationCacheForModels("-Pshared-input=2", "-Da-input=14")
         def model4 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -272,7 +272,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
         fixture.assertStateLoaded()
 
         when:
-        withConfigurationCache("-Pshared-input=2", "-Da-input=2")
+        withConfigurationCacheForModels("-Pshared-input=2", "-Da-input=2")
         def model5 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -287,7 +287,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
         }
 
         when:
-        withConfigurationCache("-Pshared-input=2", "-Da-input=2")
+        withConfigurationCacheForModels("-Pshared-input=2", "-Da-input=2")
         def model6 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -299,7 +299,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
         fixture.assertStateLoaded()
 
         when:
-        withConfigurationCache("-Pshared-input=2", "-Da-input=2", "-Db-input=new")
+        withConfigurationCacheForModels("-Pshared-input=2", "-Da-input=2", "-Db-input=new")
         def model7 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -329,7 +329,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = runBuildAction(new FetchModelsMultipleTimesForEachProject())
 
         then:
@@ -345,7 +345,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
         outputContains("creating model for project ':a'")
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = runBuildAction(new FetchModelsMultipleTimesForEachProject())
 
         then:
@@ -362,7 +362,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
             myExtension.message = 'this is the root project'
         """
 
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model3 = runBuildAction(new FetchModelsMultipleTimesForEachProject())
 
         then:
@@ -378,7 +378,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
         outputContains("creating model for root project 'root'")
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model4 = runBuildAction(new FetchModelsMultipleTimesForEachProject())
 
         then:
@@ -405,7 +405,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -419,7 +419,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
         outputContains("creating model for project ':a'")
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -434,7 +434,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
             println("changed")
         """
 
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model3 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -448,7 +448,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
         outputContains("creating model for root project 'root'")
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model4 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -466,7 +466,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -481,7 +481,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
 
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = runBuildAction(new FetchModelsMultipleTimesForEachProject())
 
         then:
@@ -496,7 +496,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
 
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model3 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -508,7 +508,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
 
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model4 = runBuildAction(new FetchModelsMultipleTimesForEachProject())
 
         then:
@@ -533,7 +533,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = runBuildAction(new FetchCustomModelForTargetProject(":"))
 
         then:
@@ -547,7 +547,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
 
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = runBuildAction(new FetchCustomModelForTargetProject(":a"))
 
         then:
@@ -561,7 +561,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
 
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model3 = runBuildAction(new FetchCustomModelForTargetProject(":"))
 
         then:
@@ -572,7 +572,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
 
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model4 = runBuildAction(new FetchCustomModelForTargetProject(":a"))
 
         then:
@@ -584,7 +584,7 @@ class ConfigurationCacheToolingApiBuildActionIntegrationTest extends AbstractCon
 
     def "does not cache execution of BuildAction when it fails"() {
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         runBuildActionFails(new FailingBuildAction())
 
         then:

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiCompositeBuildsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiCompositeBuildsIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.cc.impl.tapi
 
-import org.gradle.internal.cc.impl.isolated.FetchCustomModelForEachProjectInTree
+import org.gradle.internal.cc.impl.actions.FetchCustomModelForEachProjectInTree
 
 class ConfigurationCacheToolingApiCompositeBuildsIntegrationTest extends AbstractConfigurationCacheToolingApiIntegrationTest {
 

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiCompositeBuildsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiCompositeBuildsIntegrationTest.groovy
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.tapi
+
+import org.gradle.internal.cc.impl.isolated.FetchCustomModelForEachProjectInTree
+
+class ConfigurationCacheToolingApiCompositeBuildsIntegrationTest extends AbstractConfigurationCacheToolingApiIntegrationTest {
+
+    def "invalidates cached state when plugin in buildSrc changes"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+        """
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+        """
+        file("a/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        withConfigurationCache()
+        def model = runBuildAction(new FetchCustomModelForEachProjectInTree())
+
+        then:
+        model.size() == 2
+        model[0].message == "It works from project :"
+        model[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 4
+        }
+
+        when:
+        withConfigurationCache()
+        def model2 = runBuildAction(new FetchCustomModelForEachProjectInTree())
+
+        then:
+        model2.size() == 2
+        model2[0].message == "It works from project :"
+        model2[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateLoaded()
+
+        when:
+        file("buildSrc/src/main/groovy/Thing.java") << """
+            // change source
+            class Thing { }
+        """
+
+        withConfigurationCache()
+        def model3 = runBuildAction(new FetchCustomModelForEachProjectInTree())
+
+        then:
+        model3.size() == 2
+        model3[0].message == "It works from project :"
+        model3[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateRecreated {
+            taskInputChanged(":buildSrc:compileGroovy")
+            projectConfigured = 4
+        }
+    }
+
+    def "invalidates cached state when plugin in child build changes"() {
+        given:
+        withSomeToolingModelBuilderPluginInChildBuild("plugins")
+        settingsFile << """
+            includeBuild("plugins")
+            include("a")
+            include("b")
+        """
+        buildFile << """
+            plugins {
+                id("my.plugin")
+            }
+        """
+        file("a/build.gradle") << """
+            plugins {
+                id("my.plugin")
+            }
+        """
+
+        when:
+        withConfigurationCache()
+        def model = runBuildAction(new FetchCustomModelForEachProjectInTree())
+
+        then:
+        model.size() == 2
+        model[0].message == "It works from project :"
+        model[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 4
+        }
+
+        when:
+        withConfigurationCache()
+        def model2 = runBuildAction(new FetchCustomModelForEachProjectInTree())
+
+        then:
+        model2.size() == 2
+        model2[0].message == "It works from project :"
+        model2[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateLoaded()
+
+        when:
+        file("plugins/src/main/groovy/Thing.java") << """
+            // change source
+            class Thing { }
+        """
+
+        withConfigurationCache()
+        def model3 = runBuildAction(new FetchCustomModelForEachProjectInTree())
+
+        then:
+        model3.size() == 2
+        model3[0].message == "It works from project :"
+        model3[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateRecreated {
+            taskInputChanged(":plugins:compileGroovy")
+            projectConfigured = 4
+        }
+    }
+
+    def "caches BuildAction that queries models from included build "() {
+        given:
+        withSomeToolingModelBuilderPluginInChildBuild("plugins")
+        settingsFile << """
+            includeBuild("plugins")
+            includeBuild("libs")
+        """
+        file("libs/settings.gradle") << """
+            include("a")
+            include("b")
+        """
+        file("libs/build.gradle") << """
+            plugins {
+                id("my.plugin")
+            }
+        """
+        file("libs/a/build.gradle") << """
+            plugins {
+                id("my.plugin")
+            }
+        """
+
+        when:
+        withConfigurationCache()
+        def model = runBuildAction(new FetchCustomModelForEachProjectInTree())
+
+        then:
+        model.size() == 2
+        model[0].message == "It works from project :libs"
+        model[1].message == "It works from project :libs:a"
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 5
+        }
+
+        when:
+        withConfigurationCache()
+        def model2 = runBuildAction(new FetchCustomModelForEachProjectInTree())
+
+        then:
+        model2.size() == 2
+        model2[0].message == "It works from project :libs"
+        model2[1].message == "It works from project :libs:a"
+
+        and:
+        fixture.assertStateLoaded()
+
+        when:
+        file("libs/build.gradle") << """
+            // some change
+        """
+
+        withConfigurationCache()
+        def model3 = runBuildAction(new FetchCustomModelForEachProjectInTree())
+
+        then:
+        model3.size() == 2
+        model3[0].message == "It works from project :libs"
+        model3[1].message == "It works from project :libs:a"
+
+        and:
+        fixture.assertStateRecreated {
+            fileChanged("libs/build.gradle")
+            projectConfigured = 5
+        }
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiCompositeBuildsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiCompositeBuildsIntegrationTest.groovy
@@ -35,7 +35,7 @@ class ConfigurationCacheToolingApiCompositeBuildsIntegrationTest extends Abstrac
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = runBuildAction(new FetchCustomModelForEachProjectInTree())
 
         then:
@@ -49,7 +49,7 @@ class ConfigurationCacheToolingApiCompositeBuildsIntegrationTest extends Abstrac
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = runBuildAction(new FetchCustomModelForEachProjectInTree())
 
         then:
@@ -66,7 +66,7 @@ class ConfigurationCacheToolingApiCompositeBuildsIntegrationTest extends Abstrac
             class Thing { }
         """
 
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model3 = runBuildAction(new FetchCustomModelForEachProjectInTree())
 
         then:
@@ -101,7 +101,7 @@ class ConfigurationCacheToolingApiCompositeBuildsIntegrationTest extends Abstrac
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = runBuildAction(new FetchCustomModelForEachProjectInTree())
 
         then:
@@ -115,7 +115,7 @@ class ConfigurationCacheToolingApiCompositeBuildsIntegrationTest extends Abstrac
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = runBuildAction(new FetchCustomModelForEachProjectInTree())
 
         then:
@@ -132,7 +132,7 @@ class ConfigurationCacheToolingApiCompositeBuildsIntegrationTest extends Abstrac
             class Thing { }
         """
 
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model3 = runBuildAction(new FetchCustomModelForEachProjectInTree())
 
         then:
@@ -170,7 +170,7 @@ class ConfigurationCacheToolingApiCompositeBuildsIntegrationTest extends Abstrac
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = runBuildAction(new FetchCustomModelForEachProjectInTree())
 
         then:
@@ -184,7 +184,7 @@ class ConfigurationCacheToolingApiCompositeBuildsIntegrationTest extends Abstrac
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = runBuildAction(new FetchCustomModelForEachProjectInTree())
 
         then:
@@ -200,7 +200,7 @@ class ConfigurationCacheToolingApiCompositeBuildsIntegrationTest extends Abstrac
             // some change
         """
 
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model3 = runBuildAction(new FetchCustomModelForEachProjectInTree())
 
         then:

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiFixture.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiFixture.groovy
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.tapi
+
+
+import org.gradle.configuration.ApplyScriptPluginBuildOperationType
+import org.gradle.configuration.project.ConfigureProjectBuildOperationType
+import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.integtests.fixtures.configurationcache.ConfigurationCacheBuildOperationsFixture
+import org.gradle.integtests.fixtures.configurationcache.ConfigurationCacheFixture
+import org.gradle.integtests.fixtures.configurationcache.ConfigurationCacheFixture.HasBuildActions
+import org.gradle.integtests.fixtures.configurationcache.ConfigurationCacheFixture.HasInvalidationReason
+import org.gradle.internal.cc.impl.fixtures.AbstractConfigurationCacheOptInFeatureIntegrationTest
+import org.gradle.internal.operations.trace.BuildOperationRecord
+import org.gradle.tooling.provider.model.internal.QueryToolingModelBuildOperationType
+
+class ConfigurationCacheToolingApiFixture {
+    private final AbstractConfigurationCacheOptInFeatureIntegrationTest spec
+    private final ConfigurationCacheFixture fixture
+    private final BuildOperationsFixture buildOperations
+    private final ConfigurationCacheBuildOperationsFixture configurationCacheBuildOperations
+
+    ConfigurationCacheToolingApiFixture(AbstractConfigurationCacheOptInFeatureIntegrationTest spec) {
+        this.spec = spec
+        this.fixture = new ConfigurationCacheFixture(spec)
+        this.buildOperations = fixture.buildOperations
+        this.configurationCacheBuildOperations = fixture.configurationCacheBuildOperations
+    }
+
+    /**
+     * Asserts that the cache entry was written with no problems.
+     *
+     * Also asserts that the expected set of projects is configured, the expected models are queried
+     * and the appropriate console logging, reports and build operations are generated.
+     */
+    void assertStateStored(@DelegatesTo(StoreDetails) Closure closure) {
+        def details = new StoreDetails()
+        details.runsTasks = false
+        details.loadsOnStore = false
+        closure.delegate = details
+        closure()
+
+        fixture.assertStateStored(details)
+
+        assertProjectsConfigured(details.projectConfigured)
+        assertModelsQueried()
+    }
+
+    /**
+     * Asserts that the cache entry was written with some problems.
+     *
+     * Also asserts that the expected set of projects is configured, the expected models are queried
+     * and the appropriate console logging, reports and build operations are generated.
+     */
+    void assertStateStoredWithProblems(@DelegatesTo(StateStoreWithProblemsDetails) Closure closure) {
+        def details = new StateStoreWithProblemsDetails()
+        closure.delegate = details
+        closure()
+
+        fixture.assertStateStoredWithProblems(details, details)
+
+        assertProjectsConfigured(details.projectConfigured)
+        assertModelsQueried()
+    }
+
+    /**
+     * Asserts that the cache entry was written but discarded due to some problems.
+     *
+     * Also asserts that the expected set of projects is configured, the expected models are queried
+     * and the appropriate console logging, reports and build operations are generated.
+     */
+    void assertStateStoredAndDiscarded(@DelegatesTo(StateDiscardedWithProblemsDetails) Closure closure) {
+        def details = new StateDiscardedWithProblemsDetails()
+        closure.delegate = details
+        closure()
+
+        fixture.assertStateStoredAndDiscarded(details, details)
+
+        assertProjectsConfigured(details.projectConfigured)
+        assertModelsQueried()
+    }
+
+    /**
+     * Asserts that the cache entry was discarded and stored again with no problems.
+     *
+     * Also asserts that the expected set of projects is configured, the expected models are queried
+     * and the appropriate console logging, reports and build operations are generated.
+     */
+    void assertStateRecreated(@DelegatesTo(StoreRecreateDetails) Closure closure) {
+        def details = new StoreRecreateDetails()
+        closure.delegate = details
+        closure()
+
+        doStateStored(details, details, details)
+    }
+
+    /**
+     * Asserts that the cache entry was updated with no problems.
+     *
+     * Also asserts that the expected set of projects is configured, the expected models are queried
+     * and the appropriate console logging, reports and build operations are generated.
+     */
+    void assertStateUpdated(@DelegatesTo(StoreUpdateDetails) Closure closure) {
+        def details = new StoreUpdateDetails()
+        closure.delegate = details
+        closure()
+
+        doStateStored(details, details, details)
+    }
+
+    private void doStateStored(HasBuildActions details, HasInvalidationReason invalidationDetails, HasIntermediateDetails intermediateDetails) {
+        fixture.assertStateRecreated(details, invalidationDetails)
+
+        assertProjectsConfigured(intermediateDetails.projectConfigured)
+        assertModelsQueried()
+    }
+
+    private void doStoreWithProblems(HasBuildActions details, HasInvalidationReason invalidationDetails, HasIntermediateDetails intermediateDetails, ConfigurationCacheFixture.HasProblems problems) {
+        fixture.assertStateRecreatedWithProblems(details, invalidationDetails, problems)
+
+        assertProjectsConfigured(intermediateDetails.projectConfigured)
+        assertModelsQueried()
+    }
+
+    /**
+     * Asserts that the cache entry was loaded and no projects are configured.
+     *
+     * Also asserts that the appropriate console logging, reports and build operations are generated.
+     */
+    void assertStateLoaded() {
+        fixture.assertStateLoaded(new ConfigurationCacheFixture.LoadDetails())
+
+        assertProjectsConfigured(0)
+        assertNoModelsQueried()
+    }
+
+    void assertNoConfigurationCache() {
+        configurationCacheBuildOperations.assertNoConfigurationCache()
+    }
+
+    private void assertProjectsConfigured(int projectsConfigured) {
+        def configuredProjects = buildOperations.all(ConfigureProjectBuildOperationType)
+        assert configuredProjects.collect { fullPath(it) }.toSet().size() == projectsConfigured
+
+        // Scripts - one or more for settings, and one for each project build script
+        def scripts = buildOperations.all(ApplyScriptPluginBuildOperationType)
+        assert scripts.size() >= projectsConfigured
+        // TODO: why no settings script?
+//        def sortedScripts = scripts.toSorted { it -> it.startTime }
+//        assert sortedScripts.first().details.targetType == "settings"
+        def nonSettingsScripts = scripts.findAll { it.details.targetType != "settings" }
+        def nonSettingsScriptTargets = nonSettingsScripts.collect { fullPath(it.details.buildPath, it.details.targetPath) }.toSet()
+        assert nonSettingsScriptTargets.size() == projectsConfigured
+    }
+
+    private void assertNoModelsQueried() {
+        def modelRequestCount = modelRequests()
+        assert modelRequestCount == 0
+    }
+
+    private void assertModelsQueried() {
+        def modelRequestCount = modelRequests()
+        assert modelRequestCount > 0
+    }
+
+    private int modelRequests() {
+        buildOperations.all(QueryToolingModelBuildOperationType).size()
+    }
+
+    private static String fullPath(BuildOperationRecord operationRecord) {
+        return fullPath(operationRecord.details.buildPath, operationRecord.details.projectPath)
+    }
+
+    private static String fullPath(String buildPath, String projectPath) {
+        if (buildPath == ':') {
+            return projectPath
+        } else if (projectPath == ':') {
+            return buildPath
+        } else {
+            return buildPath + projectPath
+        }
+    }
+
+    trait HasIntermediateDetails extends HasBuildActions {
+        int projectConfigured = 0
+    }
+
+    static class StoreDetails extends ConfigurationCacheFixture.StateStoreDetails implements HasIntermediateDetails {}
+
+    static class StateStoreWithProblemsDetails extends ConfigurationCacheFixture.StateStoreWithProblemsDetails implements HasIntermediateDetails {}
+
+    static class StateDiscardedWithProblemsDetails extends ConfigurationCacheFixture.StateDiscardedWithProblemsDetails implements HasIntermediateDetails {}
+
+    static class StoreRecreateDetails extends ConfigurationCacheFixture.StateRecreateDetails implements HasIntermediateDetails {}
+
+    static class StoreUpdateDetails extends ConfigurationCacheFixture.StateRecreateDetails implements HasIntermediateDetails {}
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiFixture.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiFixture.groovy
@@ -49,8 +49,6 @@ class ConfigurationCacheToolingApiFixture {
      */
     void assertStateStored(@DelegatesTo(StoreDetails) Closure closure) {
         def details = new StoreDetails()
-        details.runsTasks = false
-        details.loadsOnStore = false
         closure.delegate = details
         closure()
 
@@ -108,20 +106,6 @@ class ConfigurationCacheToolingApiFixture {
         doStateStored(details, details, details)
     }
 
-    /**
-     * Asserts that the cache entry was updated with no problems.
-     *
-     * Also asserts that the expected set of projects is configured, the expected models are queried
-     * and the appropriate console logging, reports and build operations are generated.
-     */
-    void assertStateUpdated(@DelegatesTo(StoreUpdateDetails) Closure closure) {
-        def details = new StoreUpdateDetails()
-        closure.delegate = details
-        closure()
-
-        doStateStored(details, details, details)
-    }
-
     private void doStateStored(HasBuildActions details, HasInvalidationReason invalidationDetails, HasIntermediateDetails intermediateDetails) {
         fixture.assertStateRecreated(details, invalidationDetails)
 
@@ -156,15 +140,16 @@ class ConfigurationCacheToolingApiFixture {
         def configuredProjects = buildOperations.all(ConfigureProjectBuildOperationType)
         assert configuredProjects.collect { fullPath(it) }.toSet().size() == projectsConfigured
 
-        // Scripts - one or more for settings, and one for each project build script
-        def scripts = buildOperations.all(ApplyScriptPluginBuildOperationType)
-        assert scripts.size() >= projectsConfigured
-        // TODO: why no settings script?
-//        def sortedScripts = scripts.toSorted { it -> it.startTime }
-//        assert sortedScripts.first().details.targetType == "settings"
-        def nonSettingsScripts = scripts.findAll { it.details.targetType != "settings" }
-        def nonSettingsScriptTargets = nonSettingsScripts.collect { fullPath(it.details.buildPath, it.details.targetPath) }.toSet()
-        assert nonSettingsScriptTargets.size() == projectsConfigured
+        // TODO: figure out why applied scripts do not correspond
+//        // Scripts - one or more for settings, and one for each project build script
+//        def scripts = buildOperations.all(ApplyScriptPluginBuildOperationType)
+//        assert scripts.size() >= projectsConfigured
+//        // TODO: why no settings script?
+////        def sortedScripts = scripts.toSorted { it -> it.startTime }
+////        assert sortedScripts.first().details.targetType == "settings"
+//        def nonSettingsScripts = scripts.findAll { it.details.targetType != "settings" }
+//        def nonSettingsScriptTargets = nonSettingsScripts.collect { fullPath(it.details.buildPath, it.details.targetPath) }.toSet()
+//        assert nonSettingsScriptTargets.size() == projectsConfigured
     }
 
     private void assertNoModelsQueried() {
@@ -199,13 +184,21 @@ class ConfigurationCacheToolingApiFixture {
         int projectConfigured = 0
     }
 
-    static class StoreDetails extends ConfigurationCacheFixture.StateStoreDetails implements HasIntermediateDetails {}
+    static class StoreDetails extends ConfigurationCacheFixture.StateStoreDetails implements HasIntermediateDetails {
+        StoreDetails() {
+            runsTasks = false
+            loadsOnStore = false
+        }
+    }
 
     static class StateStoreWithProblemsDetails extends ConfigurationCacheFixture.StateStoreWithProblemsDetails implements HasIntermediateDetails {}
 
     static class StateDiscardedWithProblemsDetails extends ConfigurationCacheFixture.StateDiscardedWithProblemsDetails implements HasIntermediateDetails {}
 
-    static class StoreRecreateDetails extends ConfigurationCacheFixture.StateRecreateDetails implements HasIntermediateDetails {}
-
-    static class StoreUpdateDetails extends ConfigurationCacheFixture.StateRecreateDetails implements HasIntermediateDetails {}
+    static class StoreRecreateDetails extends ConfigurationCacheFixture.StateRecreateDetails implements HasIntermediateDetails {
+        StoreRecreateDetails() {
+            runsTasks = false
+            loadsOnStore = false
+        }
+    }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiFixture.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiFixture.groovy
@@ -17,7 +17,6 @@
 package org.gradle.internal.cc.impl.tapi
 
 
-import org.gradle.configuration.ApplyScriptPluginBuildOperationType
 import org.gradle.configuration.project.ConfigureProjectBuildOperationType
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.configurationcache.ConfigurationCacheBuildOperationsFixture
@@ -52,6 +51,7 @@ class ConfigurationCacheToolingApiFixture {
         closure.delegate = details
         closure()
 
+        fixture.assertNoWarningThatIncubatingFeatureUsed()
         fixture.assertStateStored(details)
 
         assertProjectsConfigured(details.projectConfigured)
@@ -69,6 +69,7 @@ class ConfigurationCacheToolingApiFixture {
         closure.delegate = details
         closure()
 
+        fixture.assertNoWarningThatIncubatingFeatureUsed()
         fixture.assertStateStoredWithProblems(details, details)
 
         assertProjectsConfigured(details.projectConfigured)
@@ -86,6 +87,7 @@ class ConfigurationCacheToolingApiFixture {
         closure.delegate = details
         closure()
 
+        fixture.assertNoWarningThatIncubatingFeatureUsed()
         fixture.assertStateStoredAndDiscarded(details, details)
 
         assertProjectsConfigured(details.projectConfigured)
@@ -107,6 +109,7 @@ class ConfigurationCacheToolingApiFixture {
     }
 
     private void doStateStored(HasBuildActions details, HasInvalidationReason invalidationDetails, HasIntermediateDetails intermediateDetails) {
+        fixture.assertNoWarningThatIncubatingFeatureUsed()
         fixture.assertStateRecreated(details, invalidationDetails)
 
         assertProjectsConfigured(intermediateDetails.projectConfigured)
@@ -114,6 +117,7 @@ class ConfigurationCacheToolingApiFixture {
     }
 
     private void doStoreWithProblems(HasBuildActions details, HasInvalidationReason invalidationDetails, HasIntermediateDetails intermediateDetails, ConfigurationCacheFixture.HasProblems problems) {
+        fixture.assertNoWarningThatIncubatingFeatureUsed()
         fixture.assertStateRecreatedWithProblems(details, invalidationDetails, problems)
 
         assertProjectsConfigured(intermediateDetails.projectConfigured)
@@ -126,6 +130,7 @@ class ConfigurationCacheToolingApiFixture {
      * Also asserts that the appropriate console logging, reports and build operations are generated.
      */
     void assertStateLoaded() {
+        fixture.assertNoWarningThatIncubatingFeatureUsed()
         fixture.assertStateLoaded(new ConfigurationCacheFixture.LoadDetails())
 
         assertProjectsConfigured(0)

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiFixture.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiFixture.groovy
@@ -196,7 +196,12 @@ class ConfigurationCacheToolingApiFixture {
         }
     }
 
-    static class StateStoreWithProblemsDetails extends ConfigurationCacheFixture.StateStoreWithProblemsDetails implements HasIntermediateDetails {}
+    static class StateStoreWithProblemsDetails extends ConfigurationCacheFixture.StateStoreWithProblemsDetails implements HasIntermediateDetails {
+        StateStoreWithProblemsDetails() {
+            runsTasks = false
+            loadsOnStore = false
+        }
+    }
 
     static class StateDiscardedWithProblemsDetails extends ConfigurationCacheFixture.StateDiscardedWithProblemsDetails implements HasIntermediateDetails {
         StateDiscardedWithProblemsDetails() {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiFixture.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiFixture.groovy
@@ -198,7 +198,12 @@ class ConfigurationCacheToolingApiFixture {
 
     static class StateStoreWithProblemsDetails extends ConfigurationCacheFixture.StateStoreWithProblemsDetails implements HasIntermediateDetails {}
 
-    static class StateDiscardedWithProblemsDetails extends ConfigurationCacheFixture.StateDiscardedWithProblemsDetails implements HasIntermediateDetails {}
+    static class StateDiscardedWithProblemsDetails extends ConfigurationCacheFixture.StateDiscardedWithProblemsDetails implements HasIntermediateDetails {
+        StateDiscardedWithProblemsDetails() {
+            runsTasks = false
+            loadsOnStore = false
+        }
+    }
 
     static class StoreRecreateDetails extends ConfigurationCacheFixture.StateRecreateDetails implements HasIntermediateDetails {
         StoreRecreateDetails() {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiGradleLifecycleIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiGradleLifecycleIntegrationTest.groovy
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.tapi
+
+import org.gradle.internal.cc.impl.isolated.FetchCustomModelForEachProject
+
+
+class ConfigurationCacheToolingApiGradleLifecycleIntegrationTest extends AbstractConfigurationCacheToolingApiIntegrationTest {
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'root'
+        """
+        createDirs("a", "b") // avoid missing subproject directories warning
+    }
+
+    def "runs all lifecycle callbacks on cache miss"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+
+            gradle.lifecycle.beforeProject {
+                println("Callback before \$it")
+            }
+        """
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+        """
+        file("a/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        withConfigurationCache()
+        def model = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model.size() == 2
+        model[0].message == "It works from project :"
+        model[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 4
+        }
+
+        and:
+        outputContains("Callback before root project 'root'")
+        outputContains("Callback before project ':a'")
+        outputContains("Callback before project ':b'")
+
+
+        when:
+        withConfigurationCache()
+        def model2 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model2.size() == 2
+        fixture.assertStateLoaded()
+        outputDoesNotContain("Callback before")
+
+
+        when:
+        buildFile << """
+            myExtension.message = "updated message for root"
+        """
+
+        withConfigurationCache()
+        def model3 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model3.size() == 2
+        model3[0].message == "updated message for root"
+        model3[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateRecreated {
+            fileChanged("build.gradle")
+            projectConfigured = 4
+        }
+
+        and:
+        outputContains("Callback before root project 'root'")
+        outputContains("Callback before project ':a'")
+        outputContains("Callback before project ':b'")
+
+
+        when:
+        withConfigurationCache()
+        def model4 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model4.size() == 2
+        fixture.assertStateLoaded()
+        outputDoesNotContain("Callback before")
+
+
+        when:
+        file("a/build.gradle") << """
+            myExtension.message = "updated message for :a"
+        """
+
+        withConfigurationCache()
+        def model5 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model5.size() == 2
+        model5[0].message == "updated message for root"
+        model5[1].message == "updated message for :a"
+
+        and:
+        fixture.assertStateRecreated {
+            fileChanged("a/build.gradle")
+            projectConfigured = 4
+        }
+
+        and:
+        outputContains("Callback before root project 'root'")
+        outputContains("Callback before project ':a'")
+        outputContains("Callback before project ':b'")
+    }
+
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiGradleLifecycleIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiGradleLifecycleIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.cc.impl.tapi
 
-import org.gradle.internal.cc.impl.isolated.FetchCustomModelForEachProject
+import org.gradle.internal.cc.impl.actions.FetchCustomModelForEachProject
 
 
 class ConfigurationCacheToolingApiGradleLifecycleIntegrationTest extends AbstractConfigurationCacheToolingApiIntegrationTest {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiGradleLifecycleIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiGradleLifecycleIntegrationTest.groovy
@@ -47,7 +47,7 @@ class ConfigurationCacheToolingApiGradleLifecycleIntegrationTest extends Abstrac
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -67,7 +67,7 @@ class ConfigurationCacheToolingApiGradleLifecycleIntegrationTest extends Abstrac
 
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -81,7 +81,7 @@ class ConfigurationCacheToolingApiGradleLifecycleIntegrationTest extends Abstrac
             myExtension.message = "updated message for root"
         """
 
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model3 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -102,7 +102,7 @@ class ConfigurationCacheToolingApiGradleLifecycleIntegrationTest extends Abstrac
 
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model4 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -116,7 +116,7 @@ class ConfigurationCacheToolingApiGradleLifecycleIntegrationTest extends Abstrac
             myExtension.message = "updated message for :a"
         """
 
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model5 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiGradleProjectIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiGradleProjectIntegrationTest.groovy
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.tapi
+
+import org.gradle.internal.cc.impl.actions.FetchGradleProjectForTarget
+import org.gradle.tooling.model.GradleProject
+
+import static org.gradle.integtests.tooling.fixture.ToolingApiModelChecker.checkGradleProject
+
+class ConfigurationCacheToolingApiGradleProjectIntegrationTest extends AbstractConfigurationCacheToolingApiIntegrationTest {
+
+    def "can fetch GradleProject model for empty projects"() {
+        settingsFile << """
+            rootProject.name = 'root'
+
+            include(":lib1")
+            include(":lib1:lib11")
+        """
+
+        when:
+        // no configuration cache
+        def expectedProjectModel = fetchModel(GradleProject)
+
+        then:
+        fixture.assertNoConfigurationCache()
+
+        with(expectedProjectModel) {
+            it.name == "root"
+            it.tasks.size() > 0
+            it.children.size() == 1
+            it.children[0].children.size() == 1
+        }
+
+        when:
+        withConfigurationCache()
+        def projectModel = fetchModel(GradleProject)
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 3
+        }
+
+        checkGradleProject(projectModel, expectedProjectModel)
+
+        when:
+        withConfigurationCache()
+        fetchModel(GradleProject)
+
+        then:
+        fixture.assertStateLoaded()
+    }
+
+    def "can fetch GradleProject model without tasks"() {
+        settingsFile << """
+            rootProject.name = 'root'
+
+            include(":lib1")
+        """
+
+        buildFile << """
+            tasks.register("lazy") {
+                throw new RuntimeException("must not realize lazy tasks")
+            }
+        """
+
+        when:
+        // no configuration cache
+        executer.withArguments("-Dorg.gradle.internal.GradleProjectBuilderOptions=omit_all_tasks")
+        def expectedProjectModel = fetchModel(GradleProject)
+
+        then:
+        fixture.assertNoConfigurationCache()
+
+        with(expectedProjectModel) {
+            it.name == "root"
+            it.tasks.isEmpty()
+            it.children.size() == 1
+            it.children[0].tasks.isEmpty()
+        }
+
+        when:
+        withConfigurationCache("-Dorg.gradle.internal.GradleProjectBuilderOptions=omit_all_tasks")
+        def projectModel = fetchModel(GradleProject)
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 2
+        }
+
+        checkGradleProject(projectModel, expectedProjectModel)
+
+        when:
+        withConfigurationCache("-Dorg.gradle.internal.GradleProjectBuilderOptions=omit_all_tasks")
+        fetchModel(GradleProject)
+
+        then:
+        fixture.assertStateLoaded()
+    }
+
+    def "can fetch GradleProject model for an included build project"() {
+        settingsFile << """
+            rootProject.name = 'root'
+            includeBuild("included1")
+            include("lib1")
+        """
+
+        file("included1/settings.gradle") << """
+            rootProject.name = 'included1'
+            include("lib2")
+        """
+
+        when:
+        // no configuration cache
+        def expectedProjectModel = runBuildAction(new FetchGradleProjectForTarget(":included1"))
+
+        then:
+        fixture.assertNoConfigurationCache()
+
+        // Returned model is for root project even though the target is not the root
+        with(expectedProjectModel) {
+            it.name == "included1"
+            it.children.size() == 1
+            it.children[0].name == "lib2"
+        }
+
+        when:
+        withConfigurationCache()
+        def projectModel = runBuildAction(new FetchGradleProjectForTarget(":included1"))
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 2
+        }
+
+        checkGradleProject(projectModel, expectedProjectModel)
+
+        when:
+        withConfigurationCache()
+        runBuildAction(new FetchGradleProjectForTarget(":included1"))
+
+        then:
+        fixture.assertStateLoaded()
+    }
+
+    def "root GradleProject model is invalidated when a child project configuration changes"() {
+        settingsFile << """
+            rootProject.name = 'root'
+            include("a")
+            include("b")
+        """
+        file("a/build.gradle") << ""
+        file("b/build.gradle") << ""
+
+        when:
+        def originalModel = fetchModel(GradleProject)
+
+        then:
+        fixture.assertNoConfigurationCache()
+
+        when:
+        withConfigurationCache()
+        def model = fetchModel(GradleProject)
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 3
+        }
+
+        checkGradleProject(model, originalModel)
+
+
+        when:
+        file("a/build.gradle") << """
+            tasks.register('something')
+        """
+        def originalUpdatedModel = fetchModel(GradleProject)
+
+        then:
+        fixture.assertNoConfigurationCache()
+
+        originalUpdatedModel.children.path == [":a", ":b"]
+        originalUpdatedModel.children.all[0].tasks.name.contains("something")
+
+
+        when:
+        withConfigurationCache()
+        def updatedModel = fetchModel(GradleProject)
+
+        then:
+        // TODO:isolated unexpected output: Configuration cache entry updated for no projects, no projects up-to-date.
+        fixture.assertStateRecreated {
+            fileChanged("a/build.gradle")
+            projectConfigured = 3
+        }
+
+        and:
+        checkGradleProject(updatedModel, originalUpdatedModel)
+    }
+
+    def "root GradleProject model is reused when models are not dependencies even when child configuration changes"() {
+        settingsFile << """
+            rootProject.name = 'root'
+            include("a")
+            include("b")
+        """
+        file("a/build.gradle") << ""
+        file("b/build.gradle") << ""
+
+        when:
+        withConfigurationCache("-Dorg.gradle.internal.model-project-dependencies=false")
+        fetchModel(GradleProject)
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 3
+        }
+
+
+        when:
+        file("a/build.gradle") << """
+            println("updated :a")
+        """
+        withConfigurationCache("-Dorg.gradle.internal.model-project-dependencies=false")
+        fetchModel(GradleProject)
+
+        then:
+        outputContains("updated :a")
+        // TODO:isolated unexpected output: Configuration cache entry updated for no projects, no projects up-to-date.
+        fixture.assertStateRecreated {
+            fileChanged("a/build.gradle")
+            projectConfigured = 3
+        }
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiGradleProjectIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiGradleProjectIntegrationTest.groovy
@@ -201,7 +201,6 @@ class ConfigurationCacheToolingApiGradleProjectIntegrationTest extends AbstractC
         def updatedModel = fetchModel(GradleProject)
 
         then:
-        // TODO:isolated unexpected output: Configuration cache entry updated for no projects, no projects up-to-date.
         fixture.assertStateRecreated {
             fileChanged("a/build.gradle")
             projectConfigured = 3
@@ -239,7 +238,6 @@ class ConfigurationCacheToolingApiGradleProjectIntegrationTest extends AbstractC
 
         then:
         outputContains("updated :a")
-        // TODO:isolated unexpected output: Configuration cache entry updated for no projects, no projects up-to-date.
         fixture.assertStateRecreated {
             fileChanged("a/build.gradle")
             projectConfigured = 3

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiGradleProjectIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiGradleProjectIntegrationTest.groovy
@@ -46,7 +46,7 @@ class ConfigurationCacheToolingApiGradleProjectIntegrationTest extends AbstractC
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def projectModel = fetchModel(GradleProject)
 
         then:
@@ -57,7 +57,7 @@ class ConfigurationCacheToolingApiGradleProjectIntegrationTest extends AbstractC
         checkGradleProject(projectModel, expectedProjectModel)
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         fetchModel(GradleProject)
 
         then:
@@ -93,7 +93,7 @@ class ConfigurationCacheToolingApiGradleProjectIntegrationTest extends AbstractC
         }
 
         when:
-        withConfigurationCache("-Dorg.gradle.internal.GradleProjectBuilderOptions=omit_all_tasks")
+        withConfigurationCacheForModels("-Dorg.gradle.internal.GradleProjectBuilderOptions=omit_all_tasks")
         def projectModel = fetchModel(GradleProject)
 
         then:
@@ -104,7 +104,7 @@ class ConfigurationCacheToolingApiGradleProjectIntegrationTest extends AbstractC
         checkGradleProject(projectModel, expectedProjectModel)
 
         when:
-        withConfigurationCache("-Dorg.gradle.internal.GradleProjectBuilderOptions=omit_all_tasks")
+        withConfigurationCacheForModels("-Dorg.gradle.internal.GradleProjectBuilderOptions=omit_all_tasks")
         fetchModel(GradleProject)
 
         then:
@@ -138,7 +138,7 @@ class ConfigurationCacheToolingApiGradleProjectIntegrationTest extends AbstractC
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def projectModel = runBuildAction(new FetchGradleProjectForTarget(":included1"))
 
         then:
@@ -149,7 +149,7 @@ class ConfigurationCacheToolingApiGradleProjectIntegrationTest extends AbstractC
         checkGradleProject(projectModel, expectedProjectModel)
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         runBuildAction(new FetchGradleProjectForTarget(":included1"))
 
         then:
@@ -172,7 +172,7 @@ class ConfigurationCacheToolingApiGradleProjectIntegrationTest extends AbstractC
         fixture.assertNoConfigurationCache()
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = fetchModel(GradleProject)
 
         then:
@@ -197,7 +197,7 @@ class ConfigurationCacheToolingApiGradleProjectIntegrationTest extends AbstractC
 
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def updatedModel = fetchModel(GradleProject)
 
         then:
@@ -220,7 +220,7 @@ class ConfigurationCacheToolingApiGradleProjectIntegrationTest extends AbstractC
         file("b/build.gradle") << ""
 
         when:
-        withConfigurationCache("-Dorg.gradle.internal.model-project-dependencies=false")
+        withConfigurationCacheForModels("-Dorg.gradle.internal.model-project-dependencies=false")
         fetchModel(GradleProject)
 
         then:
@@ -233,7 +233,7 @@ class ConfigurationCacheToolingApiGradleProjectIntegrationTest extends AbstractC
         file("a/build.gradle") << """
             println("updated :a")
         """
-        withConfigurationCache("-Dorg.gradle.internal.model-project-dependencies=false")
+        withConfigurationCacheForModels("-Dorg.gradle.internal.model-project-dependencies=false")
         fetchModel(GradleProject)
 
         then:

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiIdeaProjectIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiIdeaProjectIntegrationTest.groovy
@@ -1,0 +1,464 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.tapi
+
+import org.gradle.api.JavaVersion
+import org.gradle.internal.cc.impl.actions.FetchAllIdeaProjects
+import org.gradle.tooling.model.idea.BasicIdeaProject
+import org.gradle.tooling.model.idea.IdeaModuleDependency
+import org.gradle.tooling.model.idea.IdeaProject
+
+import static org.gradle.integtests.tooling.fixture.ToolingApiModelChecker.checkModel
+import static org.gradle.internal.cc.impl.fixtures.ToolingApiIdeaModelChecker.checkIdeaProject
+
+class ConfigurationCacheToolingApiIdeaProjectIntegrationTest extends AbstractConfigurationCacheToolingApiIntegrationTest {
+
+    def "can fetch IdeaProject model"() {
+        settingsFile << """
+            rootProject.name = 'root'
+        """
+
+        when:
+        withConfigurationCache()
+        def ideaModel = fetchModel(IdeaProject)
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 1
+        }
+
+        then:
+        ideaModel.name == "root"
+
+        when:
+        withConfigurationCache()
+        fetchModel(IdeaProject)
+
+        then:
+        fixture.assertStateLoaded()
+    }
+
+    def "can fetch BasicIdeaProject model for root and re-fetch cached"() {
+        settingsFile << """
+            rootProject.name = 'root'
+        """
+
+        when:
+        withConfigurationCache()
+        def ideaModel = fetchModel(BasicIdeaProject)
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 1
+        }
+
+        then:
+        ideaModel.name == "root"
+
+        when:
+        withConfigurationCache()
+        fetchModel(BasicIdeaProject)
+
+        then:
+        fixture.assertStateLoaded()
+    }
+
+    def "can fetch IdeaProject model for empty projects"() {
+        settingsFile << """
+            rootProject.name = 'root'
+            include(":lib1")
+            include(":lib1:lib11")
+        """
+
+        when:
+        // no configuration cache
+        def originalIdeaModel = fetchModel(IdeaProject)
+
+        then:
+        fixture.assertNoConfigurationCache()
+        originalIdeaModel.modules.size() == 3
+        originalIdeaModel.modules.every { it.children.isEmpty() } // IdeaModules are always flattened
+
+        when:
+        withConfigurationCache()
+        def ideaModel = fetchModel(IdeaProject)
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 3
+        }
+
+        checkIdeaProject(ideaModel, originalIdeaModel)
+    }
+
+    def "can fetch IdeaProject model for java projects"() {
+        settingsFile << """
+            rootProject.name = 'root'
+            include(":lib1")
+        """
+
+        file("lib1/build.gradle") << """
+            plugins {
+                id 'java'
+            }
+            java.targetCompatibility = JavaVersion.VERSION_1_9
+            java.sourceCompatibility = JavaVersion.VERSION_1_8
+        """
+
+        when:
+        // no configuration cache
+        def originalIdeaModel = fetchModel(IdeaProject)
+
+        then:
+        fixture.assertNoConfigurationCache()
+        originalIdeaModel.modules.name == ["root", "lib1"]
+        originalIdeaModel.javaLanguageSettings.languageLevel == JavaVersion.VERSION_1_8
+        originalIdeaModel.javaLanguageSettings.targetBytecodeVersion == JavaVersion.VERSION_1_9
+
+        when:
+        withConfigurationCache()
+        def ideaModel = fetchModel(IdeaProject)
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 2
+        }
+
+        checkIdeaProject(ideaModel, originalIdeaModel)
+    }
+
+    def "can fetch IdeaProject model for projects with java and idea plugins"() {
+        settingsFile << """
+            rootProject.name = 'root'
+            include(":lib1")
+            include(":lib2")
+        """
+
+        file("lib1/build.gradle") << """
+            import org.gradle.plugins.ide.idea.model.IdeaLanguageLevel
+            plugins {
+                id 'java'
+                id 'idea'
+            }
+            idea.module.languageLevel = new IdeaLanguageLevel(7)
+            idea.module.targetBytecodeVersion = JavaVersion.VERSION_1_7
+            java.targetCompatibility = JavaVersion.VERSION_1_8
+            java.sourceCompatibility = JavaVersion.VERSION_1_8
+        """
+
+        file("lib2/build.gradle") << """
+            import org.gradle.plugins.ide.idea.model.IdeaLanguageLevel
+            plugins {
+                id 'idea'
+            }
+            idea.module.languageLevel = new IdeaLanguageLevel(21)
+            idea.module.targetBytecodeVersion = JavaVersion.VERSION_21
+        """
+
+        when:
+        // no configuration cache
+        def originalIdeaModel = fetchModel(IdeaProject)
+
+        then:
+        fixture.assertNoConfigurationCache()
+        originalIdeaModel.javaLanguageSettings.languageLevel == JavaVersion.VERSION_1_8
+        originalIdeaModel.javaLanguageSettings.targetBytecodeVersion == JavaVersion.VERSION_1_8
+        originalIdeaModel.modules.name == ["root", "lib1", "lib2"]
+        originalIdeaModel.modules[1].javaLanguageSettings.languageLevel == JavaVersion.VERSION_1_7
+        originalIdeaModel.modules[1].javaLanguageSettings.targetBytecodeVersion == JavaVersion.VERSION_1_7
+        originalIdeaModel.modules[2].javaLanguageSettings == null
+
+        when:
+        withConfigurationCache()
+        def ideaModel = fetchModel(IdeaProject)
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 3
+        }
+
+        checkIdeaProject(ideaModel, originalIdeaModel)
+    }
+
+    def "IdeaProject model is invalidated when a child project configuration changes"() {
+        settingsFile << """
+            rootProject.name = 'root'
+            include("a")
+            include("b")
+        """
+
+        file("a/build.gradle") << """
+            plugins {
+                id 'java'
+            }
+            java.sourceCompatibility = JavaVersion.VERSION_1_8
+        """
+        file("b/build.gradle") << """
+            plugins {
+                id 'java'
+            }
+            java.sourceCompatibility = JavaVersion.VERSION_1_9
+        """
+
+        when:
+        def originalIdeaModel = fetchModel(IdeaProject)
+
+        then:
+        fixture.assertNoConfigurationCache()
+
+        and:
+        originalIdeaModel.javaLanguageSettings.languageLevel == JavaVersion.VERSION_1_9
+
+
+        when:
+        withConfigurationCache()
+        def ideaModel = fetchModel(IdeaProject)
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 3
+        }
+
+        checkIdeaProject(ideaModel, originalIdeaModel)
+
+
+        when:
+        file("a/build.gradle") << """
+            java.sourceCompatibility = JavaVersion.VERSION_11
+        """
+        def originalUpdatedModel = fetchModel(IdeaProject)
+
+        then:
+        fixture.assertNoConfigurationCache()
+
+        and:
+        originalUpdatedModel.javaLanguageSettings.languageLevel == JavaVersion.VERSION_11
+
+        when:
+        withConfigurationCache()
+        def updatedModel = fetchModel(IdeaProject)
+
+        then:
+        fixture.assertStateRecreated {
+            fileChanged("a/build.gradle")
+            projectConfigured = 3
+        }
+
+        and:
+        checkIdeaProject(updatedModel, originalUpdatedModel)
+    }
+
+    def "can fetch BasicIdeaProject model without resolving external dependencies"() {
+        settingsFile << """
+            rootProject.name = 'root'
+            include(":api")
+            include(":impl")
+        """
+
+        file("api/build.gradle") << """
+            plugins {
+                id 'java'
+            }
+        """
+
+        file("impl/build.gradle") << """
+            plugins {
+                id 'java'
+                id 'idea'
+            }
+
+            dependencies {
+                implementation(project(":api"))
+                testImplementation("i.dont:Exist:2.4")
+            }
+        """
+
+        when:
+        // no configuration cache
+        def originalIdeaModel = fetchModel(BasicIdeaProject)
+
+        then:
+        fixture.assertNoConfigurationCache()
+        with(originalIdeaModel.children.find { it.name == "impl" }) { impl ->
+            impl.dependencies.size() == 1
+            def apiDep = impl.dependencies[0] as IdeaModuleDependency
+            apiDep.targetModuleName == "api"
+        }
+
+        when:
+        withConfigurationCache()
+        def ideaModel = fetchModel(BasicIdeaProject)
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 3
+        }
+
+        checkIdeaProject(ideaModel, originalIdeaModel)
+    }
+
+    // This test mostly reproduces `org.gradle.plugins.ide.tooling.r31.PersistentCompositeDependencySubstitutionCrossVersionSpec.ensures unique name for all Idea modules in composite`
+    def "ensures unique name for all Idea modules in composite"() {
+        singleProjectBuildInRootDir("buildA") {
+            buildFile << """
+                apply plugin: 'java'
+                dependencies {
+                    testImplementation "org.test:b1:1.0"
+
+                    testImplementation "org.test:buildC:1.0"
+                    testImplementation "org.buildD:b1:1.0"
+                }
+            """
+            settingsFile << """
+                includeBuild 'buildB'
+                includeBuild 'buildC'
+                includeBuild 'buildD'
+            """
+        }
+
+        multiProjectBuildInSubDir("buildB", ['b1', 'b2']) {
+            buildFile << """
+                apply plugin: 'java'
+            """
+            project("b1").buildFile << """
+                apply plugin: 'java'
+                dependencies {
+                    testImplementation "org.test:buildC:1.0"
+                }
+            """
+            project("b2").buildFile << """
+                apply plugin: 'java'
+            """
+        }
+
+        singleProjectBuildInSubDir("buildC") {
+            buildFile << """
+                apply plugin: 'java'
+            """
+        }
+
+        multiProjectBuildInSubDir("buildD", ["b1", "buildC"]) {
+            buildFile << """
+                apply plugin: 'java'
+                group = 'org.buildD'
+            """
+
+            ["b1", "buildC"].each {
+                project(it).buildFile << """
+                    apply plugin: 'java'
+                    group = 'org.buildD'
+                """
+            }
+        }
+
+        when:
+        // no configuration cache
+        def originalResult = runBuildAction(new FetchAllIdeaProjects())
+
+        then:
+        originalResult.allIdeaProjects.name == ['buildA', 'buildB', 'buildC', 'buildD']
+        originalResult.rootIdeaProject.name == 'buildA'
+        originalResult.rootIdeaProject.modules.name == ['buildA']
+
+        def moduleA = originalResult.rootIdeaProject.modules[0]
+        moduleA.dependencies.each {
+            assert it instanceof IdeaModuleDependency
+        }
+        moduleA.dependencies.targetModuleName == ['buildB-b1', 'buildA-buildC', 'buildD-b1']
+
+        originalResult.getIdeaProject('buildB').modules.name == ['buildB', 'buildB-b1', 'b2']
+        originalResult.getIdeaProject('buildC').modules.name == ['buildA-buildC']
+        originalResult.getIdeaProject('buildD').modules.name == ['buildD', 'buildD-b1', 'buildD-buildC']
+
+
+        when:
+        withConfigurationCache()
+        def result = runBuildAction(new FetchAllIdeaProjects())
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 8
+        }
+
+        checkModel(result, originalResult, [
+            [{ it.allIdeaProjects }, { a, e -> checkIdeaProject(a, e) }]
+        ])
+
+
+        when:
+        withConfigurationCache()
+        def anotherResult = runBuildAction(new FetchAllIdeaProjects())
+
+        then:
+        fixture.assertStateLoaded()
+
+        checkModel(anotherResult, originalResult, [
+            [{ it.allIdeaProjects }, { a, e -> checkIdeaProject(a, e) }]
+        ])
+
+        when:
+        file("buildC/build.gradle") << """
+            println("changed root in buildC")
+        """
+        withConfigurationCache()
+        def afterChangeResult = runBuildAction(new FetchAllIdeaProjects())
+
+        then:
+        fixture.assertStateRecreated {
+            fileChanged("buildC/build.gradle")
+            projectConfigured = 8
+        }
+        outputContains("changed root in buildC")
+
+        checkModel(afterChangeResult, originalResult, [
+            [{ it.allIdeaProjects }, { a, e -> checkIdeaProject(a, e) }]
+        ])
+    }
+
+    def "can fetch IdeaProject model for Scala projects"() {
+        settingsFile << """
+            rootProject.name = 'root'
+            include(":lib1")
+        """
+
+        file("lib1/build.gradle") << """
+            plugins {
+                id 'scala'
+            }
+        """
+
+        when:
+        // no configuration cache
+        def originalIdeaModel = fetchModel(IdeaProject)
+
+        then:
+        fixture.assertNoConfigurationCache()
+        originalIdeaModel.modules.name == ["root", "lib1"]
+
+        when:
+        withConfigurationCache()
+        def ideaModel = fetchModel(IdeaProject)
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 2
+        }
+
+        checkIdeaProject(ideaModel, originalIdeaModel)
+    }
+
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiIdeaProjectIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiIdeaProjectIntegrationTest.groovy
@@ -33,7 +33,7 @@ class ConfigurationCacheToolingApiIdeaProjectIntegrationTest extends AbstractCon
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def ideaModel = fetchModel(IdeaProject)
 
         then:
@@ -45,7 +45,7 @@ class ConfigurationCacheToolingApiIdeaProjectIntegrationTest extends AbstractCon
         ideaModel.name == "root"
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         fetchModel(IdeaProject)
 
         then:
@@ -58,7 +58,7 @@ class ConfigurationCacheToolingApiIdeaProjectIntegrationTest extends AbstractCon
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def ideaModel = fetchModel(BasicIdeaProject)
 
         then:
@@ -70,7 +70,7 @@ class ConfigurationCacheToolingApiIdeaProjectIntegrationTest extends AbstractCon
         ideaModel.name == "root"
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         fetchModel(BasicIdeaProject)
 
         then:
@@ -94,7 +94,7 @@ class ConfigurationCacheToolingApiIdeaProjectIntegrationTest extends AbstractCon
         originalIdeaModel.modules.every { it.children.isEmpty() } // IdeaModules are always flattened
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def ideaModel = fetchModel(IdeaProject)
 
         then:
@@ -130,7 +130,7 @@ class ConfigurationCacheToolingApiIdeaProjectIntegrationTest extends AbstractCon
         originalIdeaModel.javaLanguageSettings.targetBytecodeVersion == JavaVersion.VERSION_1_9
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def ideaModel = fetchModel(IdeaProject)
 
         then:
@@ -183,7 +183,7 @@ class ConfigurationCacheToolingApiIdeaProjectIntegrationTest extends AbstractCon
         originalIdeaModel.modules[2].javaLanguageSettings == null
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def ideaModel = fetchModel(IdeaProject)
 
         then:
@@ -225,7 +225,7 @@ class ConfigurationCacheToolingApiIdeaProjectIntegrationTest extends AbstractCon
 
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def ideaModel = fetchModel(IdeaProject)
 
         then:
@@ -249,7 +249,7 @@ class ConfigurationCacheToolingApiIdeaProjectIntegrationTest extends AbstractCon
         originalUpdatedModel.javaLanguageSettings.languageLevel == JavaVersion.VERSION_11
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def updatedModel = fetchModel(IdeaProject)
 
         then:
@@ -300,7 +300,7 @@ class ConfigurationCacheToolingApiIdeaProjectIntegrationTest extends AbstractCon
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def ideaModel = fetchModel(BasicIdeaProject)
 
         then:
@@ -386,7 +386,7 @@ class ConfigurationCacheToolingApiIdeaProjectIntegrationTest extends AbstractCon
 
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def result = runBuildAction(new FetchAllIdeaProjects())
 
         then:
@@ -400,7 +400,7 @@ class ConfigurationCacheToolingApiIdeaProjectIntegrationTest extends AbstractCon
 
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def anotherResult = runBuildAction(new FetchAllIdeaProjects())
 
         then:
@@ -414,7 +414,7 @@ class ConfigurationCacheToolingApiIdeaProjectIntegrationTest extends AbstractCon
         file("buildC/build.gradle") << """
             println("changed root in buildC")
         """
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def afterChangeResult = runBuildAction(new FetchAllIdeaProjects())
 
         then:
@@ -450,7 +450,7 @@ class ConfigurationCacheToolingApiIdeaProjectIntegrationTest extends AbstractCon
         originalIdeaModel.modules.name == ["root", "lib1"]
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def ideaModel = fetchModel(IdeaProject)
 
         then:

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiInvocationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiInvocationIntegrationTest.groovy
@@ -14,18 +14,11 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.cc.impl
+package org.gradle.internal.cc.impl.tapi
 
 import org.gradle.internal.cc.impl.fixtures.SomeToolingModelBuildAction
-import org.gradle.internal.cc.impl.fixtures.ToolingApiBackedGradleExecuter
-import org.gradle.internal.cc.impl.fixtures.ToolingApiSpec
-import org.gradle.integtests.fixtures.executer.GradleExecuter
 
-class ConfigurationCacheToolingApiInvocationIntegrationTest extends AbstractConfigurationCacheIntegrationTest implements ToolingApiSpec {
-    @Override
-    GradleExecuter createExecuter() {
-        return new ToolingApiBackedGradleExecuter(distribution, temporaryFolder)
-    }
+class ConfigurationCacheToolingApiInvocationIntegrationTest extends AbstractConfigurationCacheToolingApiIntegrationTest {
 
     def "can run tasks via tooling API when configuration cache is enabled"() {
         buildFile << """
@@ -115,7 +108,6 @@ class ConfigurationCacheToolingApiInvocationIntegrationTest extends AbstractConf
     }
 
     def "can use test launcher tooling api"() {
-
         given:
         withConfigurationCacheEnabledInGradleProperties()
         settingsFile << ""
@@ -148,66 +140,88 @@ class ConfigurationCacheToolingApiInvocationIntegrationTest extends AbstractConf
         outputDoesNotContain("script log statement")
     }
 
-    def "configuration cache is disabled for direct model requests"() {
+    def "configuration cache is enabled for direct model requests"() {
         given:
-        withConfigurationCacheEnabledInGradleProperties()
         buildWithSomeToolingModelAndScriptLogStatement()
 
         when:
+        withConfigurationCache()
         def model = fetchModel()
 
         then:
         model.message == "It works from project :"
-        outputContains("script log statement")
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 2
+        }
 
         when:
+        withConfigurationCache()
         def model2 = fetchModel()
 
         then:
         model2.message == "It works from project :"
-        outputContains("script log statement")
+
+        and:
+        fixture.assertStateLoaded()
     }
 
-    def "configuration cache is disabled for client provided build actions"() {
+    def "configuration cache is enabled for client provided build actions"() {
         given:
-        withConfigurationCacheEnabledInGradleProperties()
         buildWithSomeToolingModelAndScriptLogStatement()
 
         when:
+        withConfigurationCache()
         def model = runBuildAction(new SomeToolingModelBuildAction())
 
         then:
         model.message == "It works from project :"
-        outputContains("script log statement")
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 2
+        }
 
         when:
+        withConfigurationCache()
         def model2 = runBuildAction(new SomeToolingModelBuildAction())
 
         then:
         model2.message == "It works from project :"
-        outputContains("script log statement")
+
+        and:
+        fixture.assertStateLoaded()
     }
 
-    def "configuration cache is disabled for client provided phased build actions"() {
+    def "configuration cache is enabled for client provided phased build actions"() {
         given:
         withConfigurationCacheEnabledInGradleProperties()
         buildWithSomeToolingModelAndScriptLogStatement()
 
         when:
+        withConfigurationCache()
         def model = runPhasedBuildAction(new SomeToolingModelBuildAction(), new SomeToolingModelBuildAction())
 
         then:
         model.left.message == "It works from project :"
         model.right.message == "It works from project :"
-        outputContains("script log statement")
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 2
+        }
 
         when:
+        withConfigurationCache()
         def model2 = runPhasedBuildAction(new SomeToolingModelBuildAction(), new SomeToolingModelBuildAction())
 
         then:
         model2.left.message == "It works from project :"
         model2.right.message == "It works from project :"
-        outputContains("script log statement")
+
+        and:
+        fixture.assertStateLoaded()
     }
 
     private void withConfigurationCacheEnabledInGradleProperties() {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiInvocationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiInvocationIntegrationTest.groovy
@@ -145,7 +145,7 @@ class ConfigurationCacheToolingApiInvocationIntegrationTest extends AbstractConf
         buildWithSomeToolingModelAndScriptLogStatement()
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = fetchModel()
 
         then:
@@ -157,7 +157,7 @@ class ConfigurationCacheToolingApiInvocationIntegrationTest extends AbstractConf
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = fetchModel()
 
         then:
@@ -172,7 +172,7 @@ class ConfigurationCacheToolingApiInvocationIntegrationTest extends AbstractConf
         buildWithSomeToolingModelAndScriptLogStatement()
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = runBuildAction(new SomeToolingModelBuildAction())
 
         then:
@@ -184,7 +184,7 @@ class ConfigurationCacheToolingApiInvocationIntegrationTest extends AbstractConf
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = runBuildAction(new SomeToolingModelBuildAction())
 
         then:
@@ -200,7 +200,7 @@ class ConfigurationCacheToolingApiInvocationIntegrationTest extends AbstractConf
         buildWithSomeToolingModelAndScriptLogStatement()
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = runPhasedBuildAction(new SomeToolingModelBuildAction(), new SomeToolingModelBuildAction())
 
         then:
@@ -213,7 +213,7 @@ class ConfigurationCacheToolingApiInvocationIntegrationTest extends AbstractConf
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = runPhasedBuildAction(new SomeToolingModelBuildAction(), new SomeToolingModelBuildAction())
 
         then:

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiInvocationValidationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiInvocationValidationIntegrationTest.groovy
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.tapi
+
+
+class ConfigurationCacheToolingApiInvocationValidationIntegrationTest extends AbstractConfigurationCacheToolingApiIntegrationTest {
+
+    def "reports configuration cache problems in build script when fetching custom tooling model"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        settingsFile << ""
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+            gradle.buildFinished {
+                println("build finished")
+            }
+        """
+
+        when:
+        withConfigurationCache()
+        fetchModelFails()
+
+        then:
+        fixture.assertStateStoredAndDiscarded {
+            projectConfigured = 2
+            problem("Build file 'build.gradle': line 3: registration of listener on 'Gradle.buildFinished' is unsupported")
+        }
+
+        when:
+        withConfigurationCache()
+        fetchModelFails()
+
+        then:
+        fixture.assertStateStoredAndDiscarded {
+            projectConfigured = 2
+            problem("Build file 'build.gradle': line 3: registration of listener on 'Gradle.buildFinished' is unsupported")
+        }
+    }
+
+    def "reports configuration cache problems in model builder while fetching tooling model"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc("""
+            project.gradle.buildFinished {
+                println("build finished")
+            }
+        """)
+        settingsFile << ""
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        withConfigurationCache()
+        fetchModelFails()
+
+        then:
+        fixture.assertStateStoredAndDiscarded {
+            projectConfigured = 2
+            problem("Plugin class 'my.MyPlugin': registration of listener on 'Gradle.buildFinished' is unsupported")
+        }
+
+        when:
+        withConfigurationCache()
+        fetchModelFails()
+
+        then:
+        fixture.assertStateStoredAndDiscarded {
+            projectConfigured = 2
+            problem("Plugin class 'my.MyPlugin': registration of listener on 'Gradle.buildFinished' is unsupported")
+        }
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiInvocationValidationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiInvocationValidationIntegrationTest.groovy
@@ -31,7 +31,7 @@ class ConfigurationCacheToolingApiInvocationValidationIntegrationTest extends Ab
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         fetchModelFails()
 
         then:
@@ -41,7 +41,7 @@ class ConfigurationCacheToolingApiInvocationValidationIntegrationTest extends Ab
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         fetchModelFails()
 
         then:
@@ -64,7 +64,7 @@ class ConfigurationCacheToolingApiInvocationValidationIntegrationTest extends Ab
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         fetchModelFails()
 
         then:
@@ -74,7 +74,7 @@ class ConfigurationCacheToolingApiInvocationValidationIntegrationTest extends Ab
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         fetchModelFails()
 
         then:

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiModelQueryIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiModelQueryIntegrationTest.groovy
@@ -1,0 +1,375 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.tapi
+
+import org.gradle.internal.cc.impl.actions.FetchCustomModelForEachProject
+import org.gradle.internal.cc.impl.fixtures.SomeToolingModel
+import org.gradle.tooling.model.GradleProject
+import org.gradle.tooling.model.gradle.GradleBuild
+
+class ConfigurationCacheToolingApiModelQueryIntegrationTest extends AbstractConfigurationCacheToolingApiIntegrationTest {
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'root'
+        """
+        createDirs("a", "b")
+    }
+
+    def "caches creation of custom tooling model"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+        """
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        withConfigurationCache()
+        def model = fetchModel()
+
+        then:
+        model.message == "It works from project :"
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 4
+        }
+        outputContains("creating model for root project 'root'")
+
+        when:
+        withConfigurationCache()
+        def model2 = fetchModel()
+
+        then:
+        model2.message == "It works from project :"
+
+        and:
+        fixture.assertStateLoaded()
+        outputDoesNotContain("creating model")
+
+        when:
+        buildFile << """
+            myExtension.message = 'this is the root project'
+        """
+
+        withConfigurationCache()
+        def model3 = fetchModel()
+
+        then:
+        model3.message == "this is the root project"
+
+        and:
+        fixture.assertStateRecreated {
+            fileChanged("build.gradle")
+            projectConfigured = 4
+        }
+        outputContains("creating model for root project 'root'")
+
+        when:
+        withConfigurationCache()
+        def model4 = fetchModel()
+
+        then:
+        model4.message == "this is the root project"
+
+        and:
+        fixture.assertStateLoaded()
+    }
+
+    def "can cache models with tasks"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+        """
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+
+            tasks.register("dummyTask") {
+                println("Configuration of dummyTask")
+                doLast {
+                    println("Execution of dummyTask")
+                }
+            }
+        """
+
+        when:
+        withConfigurationCache()
+        fetchModel(SomeToolingModel, ":dummyTask")
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 4
+        }
+        outputContains("Configuration of dummyTask")
+        outputContains("Execution of dummyTask")
+
+        when:
+        withConfigurationCache()
+        fetchModel(SomeToolingModel, ":dummyTask")
+
+        then:
+        fixture.assertStateLoaded()
+        outputDoesNotContain("Configuration of dummyTask")
+        outputDoesNotContain("creating model")
+        outputContains("Execution of dummyTask")
+    }
+
+    def "can skip tasks execution during model building"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+
+            tasks.register("dummyTask")
+        """
+
+        when:
+        withConfigurationCache()
+        fetchModel(SomeToolingModel, "help")
+
+        then:
+        notExecuted("help")
+        fixture.assertStateStored {
+            projectConfigured = 2
+        }
+
+        when:
+        withConfigurationCache()
+        fetchModel(SomeToolingModel, ":dummyTask")
+
+        then:
+        executed(":dummyTask")
+        fixture.assertStateStored {
+            projectConfigured = 2
+        }
+    }
+
+    def "can ignore problems and cache custom model"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+            gradle.buildFinished {
+                println("build finished")
+            }
+        """
+
+        when:
+        withConfigurationCacheLenient()
+        def model = fetchModel()
+
+        then:
+        model.message == "It works from project :"
+        fixture.assertStateStoredWithProblems {
+            projectConfigured = 2
+            problem("Build file 'build.gradle': line 3: registration of listener on 'Gradle.buildFinished' is unsupported")
+        }
+
+        when:
+        withConfigurationCacheLenient()
+        def model2 = fetchModel()
+
+        then:
+        model2.message == "It works from project :"
+        fixture.assertStateLoaded()
+    }
+
+    def "caches calculation of GradleBuild model"() {
+        given:
+        settingsFile << """
+            include("a")
+            include("b")
+            println("configuring build")
+        """
+        buildFile << """
+            throw new RuntimeException("should not be called")
+        """
+
+        when:
+        withConfigurationCache()
+        def model = fetchModel(GradleBuild)
+
+        then:
+        model.rootProject.name == "root"
+        model.projects.size() == 3
+        model.projects[0].name == "root"
+        model.projects[1].name == "a"
+        model.projects[2].name == "b"
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 0
+        }
+        outputContains("configuring build")
+
+        when:
+        withConfigurationCache()
+        def model2 = fetchModel(GradleBuild)
+
+        then:
+        model2.rootProject.name == "root"
+        model2.projects.size() == 3
+        model2.projects[0].name == "root"
+        model2.projects[1].name == "a"
+        model2.projects[2].name == "b"
+
+        and:
+        fixture.assertStateLoaded()
+        outputDoesNotContain("configuring build")
+    }
+
+    def "can query and cache different models"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+            println("configuring build")
+        """
+
+        when:
+        withConfigurationCache()
+        def model = fetchModel()
+
+        then:
+        model.message == "It works from project :"
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 2
+        }
+        outputContains("configuring build")
+        outputContains("creating model for root project 'root'")
+
+        when:
+        withConfigurationCache()
+        def model2 = fetchModel()
+
+        then:
+        model2.message == "It works from project :"
+
+        and:
+        fixture.assertStateLoaded()
+        outputDoesNotContain("configuring build")
+        outputDoesNotContain("creating model")
+
+        when:
+        withConfigurationCache()
+        def model3 = fetchModel(GradleProject)
+
+        then:
+        model3 instanceof GradleProject
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 2
+        }
+        outputContains("configuring build")
+        outputDoesNotContain("creating model")
+
+        when:
+        withConfigurationCache()
+        def model4 = fetchModel(GradleProject)
+
+        then:
+        model4 instanceof GradleProject
+
+        and:
+        fixture.assertStateLoaded()
+        outputDoesNotContain("configuring build")
+        outputDoesNotContain("creating model")
+
+        when:
+        withConfigurationCache()
+        def model5 = fetchModel()
+
+        then:
+        model5 instanceof SomeToolingModel
+        model5.message == "It works from project :"
+
+        and:
+        fixture.assertStateLoaded()
+        outputDoesNotContain("configuring build")
+        outputDoesNotContain("creating model")
+    }
+
+    def "can store fingerprint for reused projects"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+        """
+        // Materializing of `ValueSource` at configuration time is leading to serializing its `Class`
+        file("a/build.gradle") << """
+            import org.gradle.api.provider.ValueSourceParameters
+
+            plugins.apply(my.MyPlugin)
+
+            abstract class MyValueSource implements ValueSource<String, ValueSourceParameters.None> {
+
+                @Override
+                String obtain() {
+                    return "Foo"
+                }
+            }
+
+            def a = providers.of(MyValueSource) {}
+            println(a.get())
+        """
+
+        file("b/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        withConfigurationCache()
+        runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 4
+        }
+
+        when:
+        file("buildSrc/build.gradle") << """
+            // change it
+        """
+
+        and:
+        withConfigurationCache()
+        runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        fixture.assertStateRecreated {
+            fileChanged("buildSrc/build.gradle")
+            projectConfigured = 4
+        }
+
+        and:
+        withConfigurationCache()
+        runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        fixture.assertStateLoaded()
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiModelQueryIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiModelQueryIntegrationTest.groovy
@@ -27,7 +27,7 @@ class ConfigurationCacheToolingApiModelQueryIntegrationTest extends AbstractConf
         settingsFile << """
             rootProject.name = 'root'
         """
-        createDirs("a", "b")
+        createDirs("a", "b") // avoid missing subproject directories warning
     }
 
     def "caches creation of custom tooling model"() {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiModelQueryIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiModelQueryIntegrationTest.groovy
@@ -42,7 +42,7 @@ class ConfigurationCacheToolingApiModelQueryIntegrationTest extends AbstractConf
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = fetchModel()
 
         then:
@@ -55,7 +55,7 @@ class ConfigurationCacheToolingApiModelQueryIntegrationTest extends AbstractConf
         outputContains("creating model for root project 'root'")
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = fetchModel()
 
         then:
@@ -70,7 +70,7 @@ class ConfigurationCacheToolingApiModelQueryIntegrationTest extends AbstractConf
             myExtension.message = 'this is the root project'
         """
 
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model3 = fetchModel()
 
         then:
@@ -84,7 +84,7 @@ class ConfigurationCacheToolingApiModelQueryIntegrationTest extends AbstractConf
         outputContains("creating model for root project 'root'")
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model4 = fetchModel()
 
         then:
@@ -113,7 +113,7 @@ class ConfigurationCacheToolingApiModelQueryIntegrationTest extends AbstractConf
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         fetchModel(SomeToolingModel, ":dummyTask")
 
         then:
@@ -124,7 +124,7 @@ class ConfigurationCacheToolingApiModelQueryIntegrationTest extends AbstractConf
         outputContains("Execution of dummyTask")
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         fetchModel(SomeToolingModel, ":dummyTask")
 
         then:
@@ -144,7 +144,7 @@ class ConfigurationCacheToolingApiModelQueryIntegrationTest extends AbstractConf
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         fetchModel(SomeToolingModel, "help")
 
         then:
@@ -154,7 +154,7 @@ class ConfigurationCacheToolingApiModelQueryIntegrationTest extends AbstractConf
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         fetchModel(SomeToolingModel, ":dummyTask")
 
         then:
@@ -175,7 +175,7 @@ class ConfigurationCacheToolingApiModelQueryIntegrationTest extends AbstractConf
         """
 
         when:
-        withConfigurationCacheLenient()
+        withConfigurationCacheLenientForModels()
         def model = fetchModel()
 
         then:
@@ -186,7 +186,7 @@ class ConfigurationCacheToolingApiModelQueryIntegrationTest extends AbstractConf
         }
 
         when:
-        withConfigurationCacheLenient()
+        withConfigurationCacheLenientForModels()
         def model2 = fetchModel()
 
         then:
@@ -206,7 +206,7 @@ class ConfigurationCacheToolingApiModelQueryIntegrationTest extends AbstractConf
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = fetchModel(GradleBuild)
 
         then:
@@ -223,7 +223,7 @@ class ConfigurationCacheToolingApiModelQueryIntegrationTest extends AbstractConf
         outputContains("configuring build")
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = fetchModel(GradleBuild)
 
         then:
@@ -247,7 +247,7 @@ class ConfigurationCacheToolingApiModelQueryIntegrationTest extends AbstractConf
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = fetchModel()
 
         then:
@@ -261,7 +261,7 @@ class ConfigurationCacheToolingApiModelQueryIntegrationTest extends AbstractConf
         outputContains("creating model for root project 'root'")
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = fetchModel()
 
         then:
@@ -273,7 +273,7 @@ class ConfigurationCacheToolingApiModelQueryIntegrationTest extends AbstractConf
         outputDoesNotContain("creating model")
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model3 = fetchModel(GradleProject)
 
         then:
@@ -287,7 +287,7 @@ class ConfigurationCacheToolingApiModelQueryIntegrationTest extends AbstractConf
         outputDoesNotContain("creating model")
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model4 = fetchModel(GradleProject)
 
         then:
@@ -299,7 +299,7 @@ class ConfigurationCacheToolingApiModelQueryIntegrationTest extends AbstractConf
         outputDoesNotContain("creating model")
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model5 = fetchModel()
 
         then:
@@ -342,7 +342,7 @@ class ConfigurationCacheToolingApiModelQueryIntegrationTest extends AbstractConf
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -356,7 +356,7 @@ class ConfigurationCacheToolingApiModelQueryIntegrationTest extends AbstractConf
         """
 
         and:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -366,7 +366,7 @@ class ConfigurationCacheToolingApiModelQueryIntegrationTest extends AbstractConf
         }
 
         and:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         runBuildAction(new FetchCustomModelForEachProject())
 
         then:

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiParameterizedModelQueryIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiParameterizedModelQueryIntegrationTest.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.tapi
+
+import org.gradle.internal.cc.impl.actions.FetchParameterizedCustomModelForEachProject
+
+class ConfigurationCacheToolingApiParameterizedModelQueryIntegrationTest extends AbstractConfigurationCacheToolingApiIntegrationTest {
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'root'
+        """
+
+        withParameterizedSomeToolingModelBuilderPluginInChildBuild("buildSrc")
+
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+            println("configuring root")
+        """
+    }
+
+    def "can cache parameterized models"() {
+        when:
+        withConfigurationCache()
+        def models = runBuildAction(new FetchParameterizedCustomModelForEachProject(["fetch1", "fetch2"]))
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 2
+        }
+        outputContains("configuring root")
+        outputContains("creating model with parameter='fetch1' for root project 'root'")
+        outputContains("creating model with parameter='fetch2' for root project 'root'")
+
+        and:
+        models.keySet() ==~ [":"]
+        models.values().every { it.size() == 2 }
+
+        models[":"][0].message == "fetch1 It works from project :"
+        models[":"][1].message == "fetch2 It works from project :"
+
+
+        when:
+        withConfigurationCache()
+        runBuildAction(new FetchParameterizedCustomModelForEachProject(["fetch1", "fetch2"]))
+
+        then:
+        fixture.assertStateLoaded()
+        outputDoesNotContain("configuring root")
+        outputDoesNotContain("creating model")
+    }
+
+    def "can cache parameterized models with different parameters"() {
+        when:
+        withConfigurationCache()
+        runBuildAction(new FetchParameterizedCustomModelForEachProject(["fetch1", "fetch2"]))
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 2
+        }
+
+        when:
+        withConfigurationCache()
+        runBuildAction(new FetchParameterizedCustomModelForEachProject(["fetch2", "fetch1"]))
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 2
+        }
+
+        when:
+        withConfigurationCache()
+        def model1 = runBuildAction(new FetchParameterizedCustomModelForEachProject(["fetch1", "fetch2"]))
+
+        then:
+        fixture.assertStateLoaded()
+        outputDoesNotContain("configuring root")
+        outputDoesNotContain("creating model")
+
+        and:
+        model1.keySet() ==~ [":"]
+        model1.values().every { it.size() == 2 }
+        model1[":"][0].message == "fetch1 It works from project :"
+        model1[":"][1].message == "fetch2 It works from project :"
+
+        when:
+        withConfigurationCache()
+        def model2 = runBuildAction(new FetchParameterizedCustomModelForEachProject(["fetch2", "fetch1"]))
+
+        then:
+        fixture.assertStateLoaded()
+        outputDoesNotContain("configuring root")
+        outputDoesNotContain("creating model")
+
+        and:
+        model2.keySet() ==~ [":"]
+        model2.values().every { it.size() == 2 }
+        model2[":"][0].message == "fetch2 It works from project :"
+        model2[":"][1].message == "fetch1 It works from project :"
+    }
+
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiParameterizedModelQueryIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiParameterizedModelQueryIntegrationTest.groovy
@@ -35,7 +35,7 @@ class ConfigurationCacheToolingApiParameterizedModelQueryIntegrationTest extends
 
     def "can cache parameterized models"() {
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def models = runBuildAction(new FetchParameterizedCustomModelForEachProject(["fetch1", "fetch2"]))
 
         then:
@@ -55,7 +55,7 @@ class ConfigurationCacheToolingApiParameterizedModelQueryIntegrationTest extends
 
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         runBuildAction(new FetchParameterizedCustomModelForEachProject(["fetch1", "fetch2"]))
 
         then:
@@ -66,7 +66,7 @@ class ConfigurationCacheToolingApiParameterizedModelQueryIntegrationTest extends
 
     def "can cache parameterized models with different parameters"() {
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         runBuildAction(new FetchParameterizedCustomModelForEachProject(["fetch1", "fetch2"]))
 
         then:
@@ -75,7 +75,7 @@ class ConfigurationCacheToolingApiParameterizedModelQueryIntegrationTest extends
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         runBuildAction(new FetchParameterizedCustomModelForEachProject(["fetch2", "fetch1"]))
 
         then:
@@ -84,7 +84,7 @@ class ConfigurationCacheToolingApiParameterizedModelQueryIntegrationTest extends
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model1 = runBuildAction(new FetchParameterizedCustomModelForEachProject(["fetch1", "fetch2"]))
 
         then:
@@ -99,7 +99,7 @@ class ConfigurationCacheToolingApiParameterizedModelQueryIntegrationTest extends
         model1[":"][1].message == "fetch2 It works from project :"
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = runBuildAction(new FetchParameterizedCustomModelForEachProject(["fetch2", "fetch1"]))
 
         then:

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiPhasedBuildActionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiPhasedBuildActionIntegrationTest.groovy
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.tapi
+
+import org.gradle.internal.cc.impl.actions.FetchCustomModelForEachProject
+import org.gradle.internal.cc.impl.actions.FetchCustomModelForTargetProject
+import org.gradle.internal.cc.impl.actions.FetchPartialCustomModelForEachProject
+
+class ConfigurationCacheToolingApiPhasedBuildActionIntegrationTest extends AbstractConfigurationCacheToolingApiIntegrationTest {
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'root'
+        """
+
+        createDirs("a", "b") // avoid missing subproject directories warning
+    }
+
+    def "caches execution of phased BuildAction that queries custom tooling model"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+        """
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+        """
+        file("a/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        withConfigurationCache()
+        def models = runPhasedBuildAction(new FetchPartialCustomModelForEachProject(), new FetchCustomModelForEachProject())
+
+        then:
+        def messages = models.left
+        messages.size() == 2
+        messages[0] == "It works from project :"
+        messages[1] == "It works from project :a"
+        def model = models.right
+        model.size() == 2
+        model[0].message == "It works from project :"
+        model[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 4
+        }
+        outputContains("creating model for root project 'root'")
+        outputContains("creating model for project ':a'")
+
+        when:
+        withConfigurationCache()
+        def models2 = runPhasedBuildAction(new FetchPartialCustomModelForEachProject(), new FetchCustomModelForEachProject())
+
+        then:
+        def messages2 = models2.left
+        messages2.size() == 2
+        messages2[0] == "It works from project :"
+        messages2[1] == "It works from project :a"
+        def model2 = models2.right
+        model2.size() == 2
+        model2[0].message == "It works from project :"
+        model2[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateLoaded()
+        outputDoesNotContain("creating model")
+
+        when:
+        buildFile << """
+            // some change
+        """
+
+        withConfigurationCache()
+        def models3 = runPhasedBuildAction(new FetchPartialCustomModelForEachProject(), new FetchCustomModelForEachProject())
+
+        then:
+        def messages3 = models3.left
+        messages3.size() == 2
+        messages3[0] == "It works from project :"
+        messages3[1] == "It works from project :a"
+        def model3 = models3.right
+        model3.size() == 2
+        model3[0].message == "It works from project :"
+        model3[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateRecreated {
+            fileChanged("build.gradle")
+            projectConfigured = 4
+        }
+        outputContains("creating model for root project 'root'")
+    }
+
+    def "caches execution of phased BuildAction that queries custom tooling model and that may, but does not actually, run tasks"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+        """
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+        """
+        file("a/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        withConfigurationCache()
+        def models = runPhasedBuildAction(new FetchPartialCustomModelForEachProject(), new FetchCustomModelForEachProject()) {
+            // Empty list means "run tasks defined by build logic or default tasks"
+            forTasks([])
+        }
+
+        then:
+        def messages = models.left
+        messages.size() == 2
+        messages[0] == "It works from project :"
+        messages[1] == "It works from project :a"
+        def model = models.right
+        model.size() == 2
+        model[0].message == "It works from project :"
+        model[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 4
+        }
+        outputContains("creating model for root project 'root'")
+        outputContains("creating model for project ':a'")
+
+        when:
+        withConfigurationCache()
+        def models2 = runPhasedBuildAction(new FetchPartialCustomModelForEachProject(), new FetchCustomModelForEachProject()) {
+            forTasks([])
+        }
+
+        then:
+        def messages2 = models2.left
+        messages2.size() == 2
+        messages2[0] == "It works from project :"
+        messages2[1] == "It works from project :a"
+        def model2 = models2.right
+        model2.size() == 2
+        model2[0].message == "It works from project :"
+        model2[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateLoaded()
+        outputDoesNotContain("creating model")
+    }
+
+    def "caches execution of phased BuildAction that queries custom tooling model and that runs tasks"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+        """
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+        """
+        file("a/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+            task thing { }
+        """
+
+        when:
+        withConfigurationCache()
+        def models = runPhasedBuildAction(new FetchPartialCustomModelForEachProject(), new FetchCustomModelForEachProject()) {
+            forTasks(["thing"])
+        }
+
+        then:
+        def messages = models.left
+        messages.size() == 2
+        messages[0] == "It works from project :"
+        messages[1] == "It works from project :a"
+        def model = models.right
+        model.size() == 2
+        model[0].message == "It works from project :"
+        model[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 4
+        }
+        outputContains("creating model for root project 'root'")
+        outputContains("creating model for project ':a'")
+        result.ignoreBuildSrc.assertTasksExecuted(":a:thing")
+
+        when:
+        withConfigurationCache()
+        def models2 = runPhasedBuildAction(new FetchPartialCustomModelForEachProject(), new FetchCustomModelForEachProject()) {
+            forTasks(["thing"])
+        }
+
+        then:
+        def messages2 = models2.left
+        messages2.size() == 2
+        messages2[0] == "It works from project :"
+        messages2[1] == "It works from project :a"
+        def model2 = models2.right
+        model2.size() == 2
+        model2[0].message == "It works from project :"
+        model2[1].message == "It works from project :a"
+
+        and:
+        fixture.assertStateLoaded()
+        outputDoesNotContain("creating model")
+        result.ignoreBuildSrc.assertTasksExecuted(":a:thing")
+    }
+
+    def "caches execution of phased BuildAction with same component types and different state"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+        """
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+        """
+        file("a/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        withConfigurationCache()
+        def models = runPhasedBuildAction(new FetchCustomModelForTargetProject(":"), new FetchCustomModelForTargetProject(":a"))
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 4
+        }
+        outputContains("creating model for root project 'root'")
+        outputContains("creating model for project ':a'")
+
+        and:
+        models.left.message == "It works from project :"
+        models.right.message == "It works from project :a"
+
+
+        when:
+        withConfigurationCache()
+        def models2 = runPhasedBuildAction(new FetchCustomModelForTargetProject(":a"), new FetchCustomModelForTargetProject(":"))
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 4
+        }
+        outputContains("creating model for project ':a'")
+        outputContains("creating model for root project 'root'")
+
+        and:
+        models2.left.message == "It works from project :a"
+        models2.right.message == "It works from project :"
+
+
+        when:
+        withConfigurationCache()
+        def models3 = runPhasedBuildAction(new FetchCustomModelForTargetProject(":"), new FetchCustomModelForTargetProject(":a"))
+
+        then:
+        fixture.assertStateLoaded()
+        outputDoesNotContain("creating model")
+
+        and:
+        models3.left.message == "It works from project :"
+        models3.right.message == "It works from project :a"
+
+
+        when:
+        withConfigurationCache()
+        def models4 = runPhasedBuildAction(new FetchCustomModelForTargetProject(":a"), new FetchCustomModelForTargetProject(":"))
+
+        then:
+        fixture.assertStateLoaded()
+        outputDoesNotContain("creating model")
+
+        and:
+        models4.left.message == "It works from project :a"
+        models4.right.message == "It works from project :"
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiPhasedBuildActionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiPhasedBuildActionIntegrationTest.groovy
@@ -45,7 +45,7 @@ class ConfigurationCacheToolingApiPhasedBuildActionIntegrationTest extends Abstr
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def models = runPhasedBuildAction(new FetchPartialCustomModelForEachProject(), new FetchCustomModelForEachProject())
 
         then:
@@ -66,7 +66,7 @@ class ConfigurationCacheToolingApiPhasedBuildActionIntegrationTest extends Abstr
         outputContains("creating model for project ':a'")
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def models2 = runPhasedBuildAction(new FetchPartialCustomModelForEachProject(), new FetchCustomModelForEachProject())
 
         then:
@@ -88,7 +88,7 @@ class ConfigurationCacheToolingApiPhasedBuildActionIntegrationTest extends Abstr
             // some change
         """
 
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def models3 = runPhasedBuildAction(new FetchPartialCustomModelForEachProject(), new FetchCustomModelForEachProject())
 
         then:
@@ -124,7 +124,7 @@ class ConfigurationCacheToolingApiPhasedBuildActionIntegrationTest extends Abstr
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def models = runPhasedBuildAction(new FetchPartialCustomModelForEachProject(), new FetchCustomModelForEachProject()) {
             // Empty list means "run tasks defined by build logic or default tasks"
             forTasks([])
@@ -148,7 +148,7 @@ class ConfigurationCacheToolingApiPhasedBuildActionIntegrationTest extends Abstr
         outputContains("creating model for project ':a'")
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def models2 = runPhasedBuildAction(new FetchPartialCustomModelForEachProject(), new FetchCustomModelForEachProject()) {
             forTasks([])
         }
@@ -184,7 +184,7 @@ class ConfigurationCacheToolingApiPhasedBuildActionIntegrationTest extends Abstr
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def models = runPhasedBuildAction(new FetchPartialCustomModelForEachProject(), new FetchCustomModelForEachProject()) {
             forTasks(["thing"])
         }
@@ -208,7 +208,7 @@ class ConfigurationCacheToolingApiPhasedBuildActionIntegrationTest extends Abstr
         result.ignoreBuildSrc.assertTasksExecuted(":a:thing")
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def models2 = runPhasedBuildAction(new FetchPartialCustomModelForEachProject(), new FetchCustomModelForEachProject()) {
             forTasks(["thing"])
         }
@@ -244,7 +244,7 @@ class ConfigurationCacheToolingApiPhasedBuildActionIntegrationTest extends Abstr
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def models = runPhasedBuildAction(new FetchCustomModelForTargetProject(":"), new FetchCustomModelForTargetProject(":a"))
 
         then:
@@ -260,7 +260,7 @@ class ConfigurationCacheToolingApiPhasedBuildActionIntegrationTest extends Abstr
 
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def models2 = runPhasedBuildAction(new FetchCustomModelForTargetProject(":a"), new FetchCustomModelForTargetProject(":"))
 
         then:
@@ -276,7 +276,7 @@ class ConfigurationCacheToolingApiPhasedBuildActionIntegrationTest extends Abstr
 
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def models3 = runPhasedBuildAction(new FetchCustomModelForTargetProject(":"), new FetchCustomModelForTargetProject(":a"))
 
         then:
@@ -289,7 +289,7 @@ class ConfigurationCacheToolingApiPhasedBuildActionIntegrationTest extends Abstr
 
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def models4 = runPhasedBuildAction(new FetchCustomModelForTargetProject(":a"), new FetchCustomModelForTargetProject(":"))
 
         then:

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiStreamingBuildActionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiStreamingBuildActionIntegrationTest.groovy
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.tapi
+
+import org.gradle.internal.cc.impl.actions.CustomModelStreamingBuildAction
+import org.gradle.internal.cc.impl.actions.ModelStreamingBuildAction
+import org.gradle.internal.cc.impl.fixtures.CustomModel
+import org.gradle.internal.cc.impl.isolated.AbstractIsolatedProjectsToolingApiIntegrationTest
+import org.gradle.tooling.StreamedValueListener
+import org.gradle.tooling.model.GradleProject
+import org.gradle.tooling.model.eclipse.EclipseProject
+
+import java.util.concurrent.CopyOnWriteArrayList
+
+class ConfigurationCacheToolingApiStreamingBuildActionIntegrationTest extends AbstractConfigurationCacheToolingApiIntegrationTest {
+
+    def setup() {
+        file("settings.gradle") << 'rootProject.name="hello-world"'
+    }
+
+    def "models are streamed on build action cache hit"() {
+        def listener1 = new TestStreamedValueListener()
+        def listener2 = new TestStreamedValueListener()
+
+        when:
+        withConfigurationCache()
+        def model = runBuildAction(new ModelStreamingBuildAction()) {
+            setStreamedValueListener(listener1)
+        }
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 1
+        }
+
+        and:
+        model.value == 42
+
+        and:
+        def streamedModels = listener1.models
+        streamedModels.size() == 2
+        (streamedModels[0] as GradleProject).name == "hello-world"
+        (streamedModels[1] as EclipseProject).gradleProject.name == "hello-world"
+
+        when:
+        withConfigurationCache()
+        def model2 = runBuildAction(new ModelStreamingBuildAction()) {
+            setStreamedValueListener(listener2)
+        }
+
+        then:
+        fixture.assertStateLoaded()
+
+        and:
+        model2.value == 42
+
+        and:
+        def streamedModels2 = listener2.models
+        streamedModels2.size() == 2
+        (streamedModels2[0] as GradleProject).name == "hello-world"
+        (streamedModels2[1] as EclipseProject).gradleProject.name == "hello-world"
+    }
+
+    def "models are streamed on phased build action cache hit"() {
+        def listener1 = new TestStreamedValueListener()
+        def listener2 = new TestStreamedValueListener()
+
+        when:
+        withConfigurationCache()
+        def model = runPhasedBuildAction(new CustomModelStreamingBuildAction(GradleProject, 1), new CustomModelStreamingBuildAction(EclipseProject, 2)) {
+            setStreamedValueListener(listener1)
+        }
+
+        then:
+        fixture.assertStateStored {
+            projectConfigured = 1
+        }
+
+        and:
+        (model.left as GradleProject).name == "hello-world"
+        (model.right as EclipseProject).gradleProject.name == "hello-world"
+
+        and:
+        def streamedModels = listener1.models as List<CustomModel>
+        streamedModels.size() == 2
+        streamedModels[0].value == 1
+        streamedModels[1].value == 2
+
+
+        when:
+        withConfigurationCache()
+        def model2 = runPhasedBuildAction(new CustomModelStreamingBuildAction(GradleProject, 1), new CustomModelStreamingBuildAction(EclipseProject, 2)) {
+            setStreamedValueListener(listener2)
+        }
+
+        then:
+        fixture.assertStateLoaded()
+
+        and:
+        (model2.left as GradleProject).name == "hello-world"
+        (model2.right as EclipseProject).gradleProject.name == "hello-world"
+
+        and:
+        def streamedModels2 = listener2.models as List<CustomModel>
+        streamedModels2.size() == 2
+        streamedModels2[0].value == 1
+        streamedModels2[1].value == 2
+    }
+
+    private static class TestStreamedValueListener implements StreamedValueListener {
+        def models = new CopyOnWriteArrayList<Object>()
+        @Override
+        void onValue(Object value) {
+            models += value
+        }
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiStreamingBuildActionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiStreamingBuildActionIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.internal.cc.impl.tapi
 import org.gradle.internal.cc.impl.actions.CustomModelStreamingBuildAction
 import org.gradle.internal.cc.impl.actions.ModelStreamingBuildAction
 import org.gradle.internal.cc.impl.fixtures.CustomModel
-import org.gradle.internal.cc.impl.isolated.AbstractIsolatedProjectsToolingApiIntegrationTest
 import org.gradle.tooling.StreamedValueListener
 import org.gradle.tooling.model.GradleProject
 import org.gradle.tooling.model.eclipse.EclipseProject

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiStreamingBuildActionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingApiStreamingBuildActionIntegrationTest.groovy
@@ -36,7 +36,7 @@ class ConfigurationCacheToolingApiStreamingBuildActionIntegrationTest extends Ab
         def listener2 = new TestStreamedValueListener()
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = runBuildAction(new ModelStreamingBuildAction()) {
             setStreamedValueListener(listener1)
         }
@@ -56,7 +56,7 @@ class ConfigurationCacheToolingApiStreamingBuildActionIntegrationTest extends Ab
         (streamedModels[1] as EclipseProject).gradleProject.name == "hello-world"
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = runBuildAction(new ModelStreamingBuildAction()) {
             setStreamedValueListener(listener2)
         }
@@ -79,7 +79,7 @@ class ConfigurationCacheToolingApiStreamingBuildActionIntegrationTest extends Ab
         def listener2 = new TestStreamedValueListener()
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = runPhasedBuildAction(new CustomModelStreamingBuildAction(GradleProject, 1), new CustomModelStreamingBuildAction(EclipseProject, 2)) {
             setStreamedValueListener(listener1)
         }
@@ -101,7 +101,7 @@ class ConfigurationCacheToolingApiStreamingBuildActionIntegrationTest extends Ab
 
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = runPhasedBuildAction(new CustomModelStreamingBuildAction(GradleProject, 1), new CustomModelStreamingBuildAction(EclipseProject, 2)) {
             setStreamedValueListener(listener2)
         }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest.groovy
@@ -50,7 +50,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -66,7 +66,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -83,7 +83,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         file("a/build.gradle") << """
             // some change
         """
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model3 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -119,7 +119,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -134,7 +134,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -152,7 +152,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
                 implementation(project(":b"))
             }
         """
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model3 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -168,7 +168,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model4 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -184,7 +184,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         file("a/build.gradle") << """
             // some change
         """
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model5 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -222,7 +222,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -237,7 +237,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -255,7 +255,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
                 implementation(project(":b"))
             }
         """
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model3 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -271,7 +271,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model4 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -287,7 +287,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         file("a/build.gradle") << """
             // some change
         """
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model5 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -328,7 +328,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -343,7 +343,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -358,7 +358,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         when:
         file("a/build.gradle").replace('implementation(project(":b"))', "")
 
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model3 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -374,7 +374,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model4 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -390,7 +390,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         file("a/build.gradle") << """
             // some change
         """
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model5 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -431,7 +431,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -446,7 +446,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -462,7 +462,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         file("c/build.gradle") << """
             // some change
         """
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model3 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -478,7 +478,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model4 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -494,7 +494,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         file("b/build.gradle") << """
             // some change
         """
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model5 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -542,7 +542,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -558,7 +558,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model2 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -577,7 +577,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
                 implementation(project(":d"))
             }
         """
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def model3 = runBuildAction(new FetchCustomModelForEachProject())
 
         then:
@@ -623,7 +623,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         """
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def models = runPhasedBuildAction(new FetchPartialCustomModelForEachProject(), new FetchCustomModelForEachProject())
 
         then:
@@ -647,7 +647,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         }
 
         when:
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def models2 = runPhasedBuildAction(new FetchPartialCustomModelForEachProject(), new FetchCustomModelForEachProject())
 
         then:
@@ -672,7 +672,7 @@ class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest ext
         file("a/build.gradle") << """
             // some change
         """
-        withConfigurationCache()
+        withConfigurationCacheForModels()
         def models3 = runPhasedBuildAction(new FetchPartialCustomModelForEachProject(), new FetchCustomModelForEachProject())
 
         then:

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/tapi/ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest.groovy
@@ -1,0 +1,699 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.tapi
+
+import org.gradle.internal.cc.impl.actions.FetchCustomModelForEachProject
+import org.gradle.internal.cc.impl.actions.FetchPartialCustomModelForEachProject
+
+class ConfigurationCacheToolingModelsWithDependencyResolutionIntegrationTest extends AbstractConfigurationCacheToolingApiIntegrationTest {
+
+    def "caches BuildAction that queries model that performs dependency resolution"() {
+        given:
+        withSomeToolingModelBuilderPluginThatPerformsDependencyResolutionInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+            include("c")
+            include("d")
+        """
+        file("a/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+            dependencies {
+                implementation(project(":b"))
+            }
+        """
+        file("b/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+            dependencies {
+                implementation(project(":c"))
+            }
+        """
+        file("c/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+        file("d/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        withConfigurationCache()
+        def model = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model.size() == 4
+        model[0].message == "project :a classpath = 2"
+        model[1].message == "project :b classpath = 1"
+        model[2].message == "project :c classpath = 0"
+        model[3].message == "project :d classpath = 0"
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 6
+        }
+
+        when:
+        withConfigurationCache()
+        def model2 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model2.size() == 4
+        model2[0].message == "project :a classpath = 2"
+        model2[1].message == "project :b classpath = 1"
+        model2[2].message == "project :c classpath = 0"
+        model2[3].message == "project :d classpath = 0"
+
+        and:
+        fixture.assertStateLoaded()
+
+        when:
+        file("a/build.gradle") << """
+            // some change
+        """
+        withConfigurationCache()
+        def model3 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model3.size() == 4
+        model3[0].message == "project :a classpath = 2"
+        model3[1].message == "project :b classpath = 1"
+        model3[2].message == "project :c classpath = 0"
+        model3[3].message == "project :d classpath = 0"
+
+        and:
+        fixture.assertStateRecreated {
+            fileChanged("a/build.gradle")
+            projectConfigured = 6
+        }
+    }
+
+    def "updates cached state when project dependency is added to project"() {
+        given:
+        withSomeToolingModelBuilderPluginThatPerformsDependencyResolutionInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+            include("c")
+        """
+        file("a/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+        file("b/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+        file("c/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        withConfigurationCache()
+        def model = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model.size() == 3
+        model[0].message == "project :a classpath = 0"
+        model[1].message == "project :b classpath = 0"
+        model[2].message == "project :c classpath = 0"
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 5
+        }
+
+        when:
+        withConfigurationCache()
+        def model2 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model2.size() == 3
+        model2[0].message == "project :a classpath = 0"
+        model2[1].message == "project :b classpath = 0"
+        model2[2].message == "project :c classpath = 0"
+
+        and:
+        fixture.assertStateLoaded()
+
+        when:
+        file("a/build.gradle") << """
+            dependencies {
+                implementation(project(":b"))
+            }
+        """
+        withConfigurationCache()
+        def model3 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model3.size() == 3
+        model3[0].message == "project :a classpath = 1"
+        model3[1].message == "project :b classpath = 0"
+        model3[2].message == "project :c classpath = 0"
+
+        and:
+        fixture.assertStateRecreated {
+            fileChanged("a/build.gradle")
+            projectConfigured = 5
+        }
+
+        when:
+        withConfigurationCache()
+        def model4 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model4.size() == 3
+        model4[0].message == "project :a classpath = 1"
+        model4[1].message == "project :b classpath = 0"
+        model4[2].message == "project :c classpath = 0"
+
+        and:
+        fixture.assertStateLoaded()
+
+        when:
+        file("a/build.gradle") << """
+            // some change
+        """
+        withConfigurationCache()
+        def model5 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model5.size() == 3
+        model5[0].message == "project :a classpath = 1"
+        model5[1].message == "project :b classpath = 0"
+        model5[2].message == "project :c classpath = 0"
+
+        and:
+        fixture.assertStateRecreated {
+            fileChanged("a/build.gradle")
+            projectConfigured = 5
+        }
+    }
+
+    def "updates cached state when project dependency graph is added to project"() {
+        given:
+        withSomeToolingModelBuilderPluginThatPerformsDependencyResolutionInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+            include("c")
+        """
+        file("a/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+        file("b/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+            dependencies {
+                implementation(project(":c"))
+            }
+        """
+        file("c/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        withConfigurationCache()
+        def model = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model.size() == 3
+        model[0].message == "project :a classpath = 0"
+        model[1].message == "project :b classpath = 1"
+        model[2].message == "project :c classpath = 0"
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 5
+        }
+
+        when:
+        withConfigurationCache()
+        def model2 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model2.size() == 3
+        model2[0].message == "project :a classpath = 0"
+        model2[1].message == "project :b classpath = 1"
+        model2[2].message == "project :c classpath = 0"
+
+        and:
+        fixture.assertStateLoaded()
+
+        when:
+        file("a/build.gradle") << """
+            dependencies {
+                implementation(project(":b"))
+            }
+        """
+        withConfigurationCache()
+        def model3 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model3.size() == 3
+        model3[0].message == "project :a classpath = 2"
+        model3[1].message == "project :b classpath = 1"
+        model3[2].message == "project :c classpath = 0"
+
+        and:
+        fixture.assertStateRecreated {
+            fileChanged("a/build.gradle")
+            projectConfigured = 5
+        }
+
+        when:
+        withConfigurationCache()
+        def model4 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model4.size() == 3
+        model4[0].message == "project :a classpath = 2"
+        model4[1].message == "project :b classpath = 1"
+        model4[2].message == "project :c classpath = 0"
+
+        and:
+        fixture.assertStateLoaded()
+
+        when:
+        file("a/build.gradle") << """
+            // some change
+        """
+        withConfigurationCache()
+        def model5 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model5.size() == 3
+        model5[0].message == "project :a classpath = 2"
+        model5[1].message == "project :b classpath = 1"
+        model5[2].message == "project :c classpath = 0"
+
+        and:
+        fixture.assertStateRecreated {
+            fileChanged("a/build.gradle")
+            projectConfigured = 5
+        }
+    }
+
+    def "updates cached state when project dependency graph is removed from project"() {
+        given:
+        withSomeToolingModelBuilderPluginThatPerformsDependencyResolutionInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+            include("c")
+        """
+        file("a/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+            dependencies {
+                implementation(project(":b"))
+            }
+        """
+        file("b/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+            dependencies {
+                implementation(project(":c"))
+            }
+        """
+        file("c/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        withConfigurationCache()
+        def model = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model.size() == 3
+        model[0].message == "project :a classpath = 2"
+        model[1].message == "project :b classpath = 1"
+        model[2].message == "project :c classpath = 0"
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 5
+        }
+
+        when:
+        withConfigurationCache()
+        def model2 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model2.size() == 3
+        model2[0].message == "project :a classpath = 2"
+        model2[1].message == "project :b classpath = 1"
+        model2[2].message == "project :c classpath = 0"
+
+        and:
+        fixture.assertStateLoaded()
+
+        when:
+        file("a/build.gradle").replace('implementation(project(":b"))', "")
+
+        withConfigurationCache()
+        def model3 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model3.size() == 3
+        model3[0].message == "project :a classpath = 0"
+        model3[1].message == "project :b classpath = 1"
+        model3[2].message == "project :c classpath = 0"
+
+        and:
+        fixture.assertStateRecreated {
+            fileChanged("a/build.gradle")
+            projectConfigured = 5
+        }
+
+        when:
+        withConfigurationCache()
+        def model4 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model4.size() == 3
+        model4[0].message == "project :a classpath = 0"
+        model4[1].message == "project :b classpath = 1"
+        model4[2].message == "project :c classpath = 0"
+
+        and:
+        fixture.assertStateLoaded()
+
+        when:
+        file("a/build.gradle") << """
+            // some change
+        """
+        withConfigurationCache()
+        def model5 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model5.size() == 3
+        model5[0].message == "project :a classpath = 0"
+        model5[1].message == "project :b classpath = 1"
+        model5[2].message == "project :c classpath = 0"
+
+        and:
+        fixture.assertStateRecreated {
+            fileChanged("a/build.gradle")
+            projectConfigured = 5
+        }
+    }
+
+    def "updates cached state when upstream project dependency changes"() {
+        given:
+        withSomeToolingModelBuilderPluginThatPerformsDependencyResolutionInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+            include("c")
+        """
+        file("a/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+            dependencies {
+                implementation project(":b")
+            }
+        """
+        file("b/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+            dependencies {
+                implementation project(":c")
+            }
+        """
+        file("c/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        withConfigurationCache()
+        def model = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model.size() == 3
+        model[0].message == "project :a classpath = 2"
+        model[1].message == "project :b classpath = 1"
+        model[2].message == "project :c classpath = 0"
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 5
+        }
+
+        when:
+        withConfigurationCache()
+        def model2 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model2.size() == 3
+        model2[0].message == "project :a classpath = 2"
+        model2[1].message == "project :b classpath = 1"
+        model2[2].message == "project :c classpath = 0"
+
+        and:
+        fixture.assertStateLoaded()
+
+        when:
+        file("c/build.gradle") << """
+            // some change
+        """
+        withConfigurationCache()
+        def model3 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model3.size() == 3
+        model3[0].message == "project :a classpath = 2"
+        model3[1].message == "project :b classpath = 1"
+        model3[2].message == "project :c classpath = 0"
+
+        and:
+        fixture.assertStateRecreated {
+            fileChanged("c/build.gradle")
+            projectConfigured = 5
+        }
+
+        when:
+        withConfigurationCache()
+        def model4 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model4.size() == 3
+        model4[0].message == "project :a classpath = 2"
+        model4[1].message == "project :b classpath = 1"
+        model4[2].message == "project :c classpath = 0"
+
+        and:
+        fixture.assertStateLoaded()
+
+        when:
+        file("b/build.gradle") << """
+            // some change
+        """
+        withConfigurationCache()
+        def model5 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model5.size() == 3
+        model5[0].message == "project :a classpath = 2"
+        model5[1].message == "project :b classpath = 1"
+        model5[2].message == "project :c classpath = 0"
+
+        and:
+        fixture.assertStateRecreated {
+            fileChanged("b/build.gradle")
+            projectConfigured = 5
+        }
+    }
+
+    def "caches BuildAction when there are cycles in the dependency graph"() {
+        given:
+        withSomeToolingModelBuilderPluginThatPerformsDependencyResolutionInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+            include("c")
+            include("d")
+        """
+        file("a/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+            dependencies {
+                implementation(project(":b"))
+            }
+        """
+        file("b/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+            dependencies {
+                implementation(project(":c"))
+            }
+        """
+        file("c/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+            dependencies {
+                implementation(project(":a"))
+            }
+        """
+        file("d/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        withConfigurationCache()
+        def model = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model.size() == 4
+        model[0].message == "project :a classpath = 3"
+        model[1].message == "project :b classpath = 3"
+        model[2].message == "project :c classpath = 3"
+        model[3].message == "project :d classpath = 0"
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 6
+        }
+
+        when:
+        withConfigurationCache()
+        def model2 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model2.size() == 4
+        model2[0].message == "project :a classpath = 3"
+        model2[1].message == "project :b classpath = 3"
+        model2[2].message == "project :c classpath = 3"
+        model2[3].message == "project :d classpath = 0"
+
+        and:
+        fixture.assertStateLoaded()
+
+        when:
+        file("a/build.gradle") << """
+            dependencies {
+                implementation(project(":d"))
+            }
+        """
+        withConfigurationCache()
+        def model3 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model3.size() == 4
+        model3[0].message == "project :a classpath = 4"
+        model3[1].message == "project :b classpath = 4"
+        model3[2].message == "project :c classpath = 4"
+        model3[3].message == "project :d classpath = 0"
+
+        and:
+        fixture.assertStateRecreated {
+            fileChanged("a/build.gradle")
+            projectConfigured = 6
+        }
+    }
+
+    def "caches phased build action that queries model that performs dependency resolution"() {
+        given:
+        withSomeToolingModelBuilderPluginThatPerformsDependencyResolutionInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+            include("c")
+            include("d")
+        """
+        file("a/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+            dependencies {
+                implementation(project(":b"))
+            }
+        """
+        file("b/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+            dependencies {
+                implementation(project(":c"))
+            }
+        """
+        file("c/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+        file("d/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        withConfigurationCache()
+        def models = runPhasedBuildAction(new FetchPartialCustomModelForEachProject(), new FetchCustomModelForEachProject())
+
+        then:
+        def messages = models.left
+        messages.size() == 4
+        messages[0] == "project :a classpath = 2"
+        messages[1] == "project :b classpath = 1"
+        messages[2] == "project :c classpath = 0"
+        messages[3] == "project :d classpath = 0"
+
+        def model = models.right
+        model.size() == 4
+        model[0].message == "project :a classpath = 2"
+        model[1].message == "project :b classpath = 1"
+        model[2].message == "project :c classpath = 0"
+        model[3].message == "project :d classpath = 0"
+
+        and:
+        fixture.assertStateStored {
+            projectConfigured = 6
+        }
+
+        when:
+        withConfigurationCache()
+        def models2 = runPhasedBuildAction(new FetchPartialCustomModelForEachProject(), new FetchCustomModelForEachProject())
+
+        then:
+        def messages2 = models2.left
+        messages2.size() == 4
+        messages2[0] == "project :a classpath = 2"
+        messages2[1] == "project :b classpath = 1"
+        messages2[2] == "project :c classpath = 0"
+        messages2[3] == "project :d classpath = 0"
+
+        def model2 = models2.right
+        model2.size() == 4
+        model2[0].message == "project :a classpath = 2"
+        model2[1].message == "project :b classpath = 1"
+        model2[2].message == "project :c classpath = 0"
+        model2[3].message == "project :d classpath = 0"
+
+        and:
+        fixture.assertStateLoaded()
+
+        when:
+        file("a/build.gradle") << """
+            // some change
+        """
+        withConfigurationCache()
+        def models3 = runPhasedBuildAction(new FetchPartialCustomModelForEachProject(), new FetchCustomModelForEachProject())
+
+        then:
+        def messages3 = models3.left
+        messages3.size() == 4
+        messages3[0] == "project :a classpath = 2"
+        messages3[1] == "project :b classpath = 1"
+        messages3[2] == "project :c classpath = 0"
+        messages3[3] == "project :d classpath = 0"
+
+        def model3 = models3.right
+        model3.size() == 4
+        model3[0].message == "project :a classpath = 2"
+        model3[1].message == "project :b classpath = 1"
+        model3[2].message == "project :c classpath = 0"
+        model3[3].message == "project :d classpath = 0"
+
+        and:
+        fixture.assertStateRecreated {
+            fileChanged("a/build.gradle")
+            projectConfigured = 6
+        }
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildTreeModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildTreeModelControllerServices.kt
@@ -130,6 +130,7 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
         val options = DefaultInternalOptions(startParameter.systemPropertiesArgs)
         val requiresTasks = requirements.isRunsTasks
         val isolatedProjects = startParameter.isolatedProjects.get()
+        val configurationCache = isolatedProjects || startParameter.configurationCache.get()
         val parallelProjectExecution = isolatedProjects || requirements.startParameter.isParallelProjectExecutionEnabled
         val parallelToolingActions = parallelProjectExecution && options.getOption(parallelBuilding).get()
         val invalidateCoupledProjects = isolatedProjects && options.getOption(invalidateCoupledProjects).get()
@@ -142,7 +143,7 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
                 requiresToolingModels = true,
                 parallelProjectExecution = parallelProjectExecution,
                 configureOnDemand = configureOnDemand,
-                configurationCache = isolatedProjects,
+                configurationCache = configurationCache,
                 isolatedProjects = isolatedProjects,
                 intermediateModelCache = isolatedProjects,
                 parallelToolingApiActions = parallelToolingActions,
@@ -150,7 +151,6 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
                 modelAsProjectDependency = modelAsProjectDependency
             )
         } else {
-            val configurationCache = isolatedProjects || startParameter.configurationCache.get()
             val configureOnDemand =
                 if (isolatedProjects) options.getOption(isolatedProjectsTasksConfigureOnDemand).get()
                 else startParameter.isConfigureOnDemand

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildTreeModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildTreeModelControllerServices.kt
@@ -76,6 +76,9 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
         val modelProjectDependencies = InternalFlag("org.gradle.internal.model-project-dependencies", true)
 
         private
+        val configurationCacheForModels = InternalFlag("org.gradle.configuration-cache.internal.tooling-models", false)
+
+        private
         val isolatedProjectsToolingModelsConfigureOnDemand =
             InternalFlag("org.gradle.internal.isolated-projects.configure-on-demand.tooling", false)
 
@@ -130,7 +133,7 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
         val options = DefaultInternalOptions(startParameter.systemPropertiesArgs)
         val requiresTasks = requirements.isRunsTasks
         val isolatedProjects = startParameter.isolatedProjects.get()
-        val configurationCache = isolatedProjects || startParameter.configurationCache.get()
+        val configurationCacheRequested = startParameter.configurationCache.get()
         val parallelProjectExecution = isolatedProjects || requirements.startParameter.isParallelProjectExecutionEnabled
         val parallelToolingActions = parallelProjectExecution && options.getOption(parallelBuilding).get()
         val invalidateCoupledProjects = isolatedProjects && options.getOption(invalidateCoupledProjects).get()
@@ -139,6 +142,8 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
         return if (requirements.isCreatesModel) {
             val configureOnDemand = isolatedProjects && !requiresTasks &&
                 options.getOption(isolatedProjectsToolingModelsConfigureOnDemand).get()
+            val configurationCacheForModels = configurationCacheRequested && options.getOption(configurationCacheForModels).get()
+            val configurationCache = isolatedProjects || configurationCacheForModels
             DefaultBuildModelParameters(
                 requiresToolingModels = true,
                 parallelProjectExecution = parallelProjectExecution,
@@ -151,6 +156,7 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
                 modelAsProjectDependency = modelAsProjectDependency
             )
         } else {
+            val configurationCache = isolatedProjects || configurationCacheRequested
             val configureOnDemand =
                 if (isolatedProjects) options.getOption(isolatedProjectsTasksConfigureOnDemand).get()
                 else startParameter.isConfigureOnDemand

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildTreeModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildTreeModelControllerServices.kt
@@ -76,7 +76,7 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
         val modelProjectDependencies = InternalFlag("org.gradle.internal.model-project-dependencies", true)
 
         private
-        val configurationCacheForModels = InternalFlag("org.gradle.configuration-cache.internal.tooling-models", false)
+        val configurationCacheToolingModels = InternalFlag("org.gradle.internal.configuration-cache.tooling", false)
 
         private
         val isolatedProjectsToolingModelsConfigureOnDemand =
@@ -143,7 +143,7 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
         return if (requirements.isCreatesModel) {
             val configureOnDemand = isolatedProjects && !requiresTasks &&
                 options.getOption(isolatedProjectsToolingModelsConfigureOnDemand).get()
-            val configurationCacheForModels = configurationCacheRequested && options.getOption(configurationCacheForModels).get()
+            val configurationCacheForModels = configurationCacheRequested && options.getOption(configurationCacheToolingModels).get()
             val configurationCache = isolatedProjects || configurationCacheForModels
             DefaultBuildModelParameters(
                 requiresToolingModels = true,

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildTreeModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildTreeModelControllerServices.kt
@@ -87,6 +87,7 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
             InternalFlag("org.gradle.internal.isolated-projects.configure-on-demand.tasks", false)
     }
 
+    @Suppress("CyclomaticComplexMethod")
     override fun servicesForBuildTree(requirements: BuildActionModelRequirements): BuildTreeModelControllerServices.Supplier {
         val startParameter = requirements.startParameter
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -337,7 +337,8 @@ class DefaultConfigurationCache internal constructor(
                         checkedFingerprint.firstReason.render()
                     )
                     logBootstrapSummary(description)
-                    ConfigurationCacheAction.UPDATE to description
+                    val action = if (startParameter.isIsolatedProjects) ConfigurationCacheAction.UPDATE else ConfigurationCacheAction.STORE
+                    action to description
                 }
 
                 is CheckedFingerprint.Valid -> {

--- a/platforms/core-runtime/build-option/src/main/java/org/gradle/internal/buildoption/Option.java
+++ b/platforms/core-runtime/build-option/src/main/java/org/gradle/internal/buildoption/Option.java
@@ -40,6 +40,11 @@ public interface Option {
                 public T get() {
                     return value;
                 }
+
+                @Override
+                public String toString() {
+                    return "DefaultValue(" + value + ")";
+                }
             };
         }
 
@@ -56,6 +61,11 @@ public interface Option {
                 @Override
                 public T get() {
                     return value;
+                }
+
+                @Override
+                public String toString() {
+                    return "ExplicitValue(" + value + ")";
                 }
             };
         }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
@@ -60,7 +60,7 @@ class ConfigurationCacheFixture {
         closure()
 
         assertStateStored(details)
-        assertHasWarningThatIncubatingFeatureUsed()
+        assertNoWarningThatIncubatingFeatureUsed()
     }
 
     void assertStateStored(HasBuildActions details) {
@@ -83,7 +83,7 @@ class ConfigurationCacheFixture {
         closure()
 
         assertStateStoredWithProblems(details, details)
-        assertHasWarningThatIncubatingFeatureUsed()
+        assertNoWarningThatIncubatingFeatureUsed()
     }
 
     void assertStateStoredWithProblems(HasBuildActions details, HasProblems problemDetails) {
@@ -106,7 +106,7 @@ class ConfigurationCacheFixture {
         closure()
 
         assertStateStoredAndDiscarded(details, details)
-        assertHasWarningThatIncubatingFeatureUsed()
+        assertNoWarningThatIncubatingFeatureUsed()
     }
 
     void assertStateStoredAndDiscarded(HasBuildActions details, HasProblems problemDetails) {
@@ -139,7 +139,7 @@ class ConfigurationCacheFixture {
         closure()
 
         assertStateRecreated(details, details)
-        assertHasWarningThatIncubatingFeatureUsed()
+        assertNoWarningThatIncubatingFeatureUsed()
     }
 
     void assertStateRecreated(HasBuildActions details, HasInvalidationReason invalidationDetails) {
@@ -160,7 +160,7 @@ class ConfigurationCacheFixture {
         closure()
 
         assertStateRecreatedWithProblems(details, details, details)
-        assertHasWarningThatIncubatingFeatureUsed()
+        assertNoWarningThatIncubatingFeatureUsed()
     }
 
     void assertStateRecreatedWithProblems(HasBuildActions details, HasInvalidationReason invalidationDetails, HasProblems problemDetails) {
@@ -177,7 +177,7 @@ class ConfigurationCacheFixture {
      */
     void assertStateLoaded() {
         assertStateLoaded(new LoadDetails())
-        assertHasWarningThatIncubatingFeatureUsed()
+        assertNoWarningThatIncubatingFeatureUsed()
     }
 
     void assertStateLoaded(LoadDetails details) {
@@ -201,7 +201,7 @@ class ConfigurationCacheFixture {
         closure.delegate = details
         closure()
 
-        assertHasWarningThatIncubatingFeatureUsed()
+        assertNoWarningThatIncubatingFeatureUsed()
         assertLoadLogged()
         spec.postBuildOutputContains("Configuration cache entry ${details.storeAction}.")
 
@@ -240,7 +240,7 @@ class ConfigurationCacheFixture {
         }
     }
 
-    private void assertHasWarningThatIncubatingFeatureUsed() {
+    void assertNoWarningThatIncubatingFeatureUsed() {
         if (quietLogging) {
             // Runs in quiet mode, and does not log anything
             return


### PR DESCRIPTION
Fixes: https://github.com/gradle/gradle/issues/29521

Introduces an internal flag that enables opting into using CC for Gradle invocations via Tooling API.

The change itself required almost no modifications to the production code. The test coverage for this has been adopted from all the TAPI testing for Isolated Projects, mainly with simplifications of the assertions as CC is all-or-nothing as opposed to a more incremental IP behavior.