### PR TITLE
Remove binding from SFL4J via ArtifactTransform to clean build output

### DIFF
--- a/build-logic/dependency-modules/src/main/kotlin/gradlebuild/HasBindingAttributeRule.kt
+++ b/build-logic/dependency-modules/src/main/kotlin/gradlebuild/HasBindingAttributeRule.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild
+
+import org.gradle.api.artifacts.CacheableRule
+import org.gradle.api.artifacts.ComponentMetadataContext
+import org.gradle.api.artifacts.ComponentMetadataRule
+import org.gradle.api.attributes.Attribute
+
+
+val SLF4J_ATTRIBUTE = Attribute.of("org.gradle.slf4j", String::class.java)
+
+
+// Must be top-level class (or static or not abstract) or else:
+// > Could not create an instance of type Build_gradle$HasBindingAttributeRule.
+//            > Class Build_gradle.HasBindingAttributeRule is a non-static inner class.
+@CacheableRule
+abstract class HasBindingAttributeRule : ComponentMetadataRule {
+    override fun execute(context: ComponentMetadataContext) {
+        context.details.allVariants() {
+            attributes {
+                attribute(SLF4J_ATTRIBUTE, "has-binding")
+            }
+        }
+    }
+}


### PR DESCRIPTION
We should be able to clean up this noise in the Gradle build:

```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/Users/ttresansky/Projects/gradle-worktrees/master/platforms/core-runtime/logging/build/libs/gradle-logging-8.9.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/Users/ttresansky/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-simple/1.7.36/a41f9cfe6faafb2eb83a1c7dd2d0dfd844e2a936/slf4j-simple-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.gradle.internal.logging.slf4j.OutputEventListenerBackedLoggerContext]
```

By removing the unused `StaticLoggerBinder` class from the SLF4J jar and leaving our own `OutputEventListenerBackedLoggerContext` as the only binding on the classpath.

We should be able to do this via a cached `ArtifactTransform` targeting this particular jar following the example: https://docs.gradle.org/6.7.1/userguide/artifact_transforms.html#artifact_transform_selection_and_execution

However, this transform is not selected when `sanityCheck` is run, resulting in:

```
Could not determine the dependencies of task ':configuration-cache:compileGroovy'.
> Could not resolve all dependencies for configuration ':configuration-cache:compileClasspath'.
   > Could not resolve org.slf4j:slf4j-api.
     Required by:
         project :configuration-cache
         project :configuration-cache > project :dependency-management
         project :configuration-cache > project :logging
         project :configuration-cache > project :logging-api
         project :configuration-cache > project :messaging
         project :configuration-cache > project :execution
         project :configuration-cache > project :file-watching
      > No matching variant of org.slf4j:slf4j-api:1.7.36 was found. The consumer was configured to find a library for use during compile-time, compatible with Java 8, preferably not packaged as a jar, preferably optimized for standard JVMs, and its dependencies declared externally, as well as attribute 'org.gradle.slf4j' with value 'no-binding', attribute 'org.jetbrains.kotlin.platform.type' with value 'jvm' but:
          - Variant 'compile' declares a library for use during compile-time, packaged as a jar:
              - Incompatible because this component declares a component, as well as attribute 'org.gradle.slf4j' with value 'has-binding' and the consumer needed a component, as well as attribute 'org.gradle.slf4j' with value 'no-binding'
              - Other compatible attributes:
                  - Doesn't say anything about how its dependencies are found (required its dependencies declared externally)
                  - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about org.jetbrains.kotlin.platform.type (required 'jvm')
// ... more variants with org.gradle.slf4j=has-binding listed
```