### PR TITLE
Completely remove and exclude slf4j-simple from the gradle build

### DIFF
--- a/build-logic/dependency-modules/src/main/kotlin/gradlebuild.dependency-modules.gradle.kts
+++ b/build-logic/dependency-modules/src/main/kotlin/gradlebuild.dependency-modules.gradle.kts
@@ -44,6 +44,12 @@ dependencies {
         )
         withLibraryDependencies<DependencyRemovalByNameRule>("cglib:cglib", setOf("ant"))
 
+        // SLF4J Simple is an implementation of the SLF4J API, which is not needed in Gradle
+        withLibraryDependencies<DependencyRemovalByNameRule>(libs.sshdCore, setOf("slf4j-simple"))
+        withLibraryDependencies<DependencyRemovalByNameRule>(libs.sshdScp, setOf("slf4j-simple"))
+        withLibraryDependencies<DependencyRemovalByNameRule>(libs.sshdSftp, setOf("slf4j-simple"))
+        withLibraryDependencies<DependencyRemovalByNameRule>(libs.gradleProfiler, setOf("slf4j-simple"))
+
         // asciidoctorj depends on a lot of stuff, which causes `Can't create process, argument list too long` on Windows
         withLibraryDependencies<DependencyRemovalByNameRule>("org.gradle:sample-discovery", setOf("asciidoctorj", "asciidoctorj-api"))
 

--- a/build-logic/dependency-modules/src/main/kotlin/gradlebuild.dependency-modules.gradle.kts
+++ b/build-logic/dependency-modules/src/main/kotlin/gradlebuild.dependency-modules.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
         withLibraryDependencies<DependencyRemovalByNameRule>(libs.sshdScp, setOf("slf4j-simple"))
         withLibraryDependencies<DependencyRemovalByNameRule>(libs.sshdSftp, setOf("slf4j-simple"))
         withLibraryDependencies<DependencyRemovalByNameRule>(libs.gradleProfiler, setOf("slf4j-simple"))
+        withLibraryDependencies<DependencyRemovalByNameRule>(libs.samplesCheck, setOf("slf4j-simple"))
 
         // asciidoctorj depends on a lot of stuff, which causes `Can't create process, argument list too long` on Windows
         withLibraryDependencies<DependencyRemovalByNameRule>("org.gradle:sample-discovery", setOf("asciidoctorj", "asciidoctorj-api"))

--- a/platforms/core-execution/build-cache-example-client/build.gradle.kts
+++ b/platforms/core-execution/build-cache-example-client/build.gradle.kts
@@ -42,7 +42,6 @@ dependencies {
     implementation(libs.guice)
     implementation(libs.jsr305)
     implementation(libs.slf4jApi)
-    implementation(libs.slf4jSimple)
 }
 
 application {

--- a/platforms/core-execution/build-cache-example-client/src/main/java/org/gradle/caching/example/ExampleBuildCacheClient.java
+++ b/platforms/core-execution/build-cache-example-client/src/main/java/org/gradle/caching/example/ExampleBuildCacheClient.java
@@ -168,9 +168,4 @@ public class ExampleBuildCacheClient {
             return updateFunction.update(SnapshotHierarchy.NodeDiffListener.NOOP);
         }
     }
-
-    static {
-        // Workaround to make sure the dependency checker doesn't complain about slf4j-simple being unused
-        Class<?> ignored = org.slf4j.impl.SimpleLoggerFactory.class;
-    }
 }

--- a/platforms/documentation/docs/build.gradle
+++ b/platforms/documentation/docs/build.gradle
@@ -38,12 +38,14 @@ configurations {
     docsTestRuntimeClasspath.extendsFrom(integTestDistributionRuntimeOnly)
 }
 
-configurations.configureEach {
+configurations.docsTestImplementation {
+    // The 'gradlebuild.generate-samples' plugin uses the 'org.gradle.samples' plugin from the old gradle/guides build, which pulls in slf4j-simple, which we don't want.
+    // Because this is done directly by the plugin application logic, we can't use a ComponentMetadataRule to exclude it.
+    // See: https://github.com/gradle/guides/blob/ba018cec535d90f75876bfcca29381d213a956cc/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SamplesDocumentationPlugin.java#L335
     exclude([group: "org.slf4j", module: "slf4j-simple"])
 }
 
 dependencies {
-
     // generate Javadoc for the full Gradle distribution
     runtimeOnly project(":distributions-full")
 

--- a/platforms/documentation/docs/build.gradle
+++ b/platforms/documentation/docs/build.gradle
@@ -38,7 +38,12 @@ configurations {
     docsTestRuntimeClasspath.extendsFrom(integTestDistributionRuntimeOnly)
 }
 
+configurations.configureEach {
+    exclude([group: "slf4j", module: "slf4j-simple"])
+}
+
 dependencies {
+
     // generate Javadoc for the full Gradle distribution
     runtimeOnly project(":distributions-full")
 
@@ -66,10 +71,6 @@ dependencies {
     docsTestImplementation libs.junit
 
     integTestDistributionRuntimeOnly project(":distributions-full")
-}
-
-configurations.docsTestRuntimeClasspath {
-    exclude group: "org.slf4j", module: "slf4j-simple"
 }
 
 asciidoctorj {

--- a/platforms/documentation/docs/build.gradle
+++ b/platforms/documentation/docs/build.gradle
@@ -39,7 +39,7 @@ configurations {
 }
 
 configurations.configureEach {
-    exclude([group: "slf4j", module: "slf4j-simple"])
+    exclude([group: "org.slf4j", module: "slf4j-simple"])
 }
 
 dependencies {

--- a/platforms/documentation/samples/build.gradle.kts
+++ b/platforms/documentation/samples/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
     integTestImplementation(libs.ant)
     integTestImplementation(libs.samplesCheck) {
         exclude(group = "org.codehaus.groovy", module = "groovy-all")
-        exclude(module = "slf4j-simple")
     }
     integTestImplementation(testFixtures(project(":core")))
     integTestImplementation(testFixtures(project(":model-core")))

--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -151,8 +151,7 @@ dependencies {
         api(libs.plist)                 { version { strictly("1.27") }}
         api(libs.servletApi)            { version { strictly("3.1.0") }}
         api(libs.slf4jApi)              { version { strictly(slf4jVersion) }}
-// TODO: Restore this after SLF4J-Simple is removed from docs:docsTestCompileClasspath
-// api(libs.slf4jSimple)           { version { rejectAll(); because("We only need the logging API, we supply our own binding, which cause duplicate binding on class path error") }}
+        api(libs.slf4jSimple)           { version { rejectAll(); because("We only need the logging API, we supply our own binding, which cause duplicate binding on class path error") }}
         api(libs.snakeyaml)             { version { strictly("2.0") }}
         api(libs.testng)                { version { strictly("6.3.1"); because("later versions break test cross-version test filtering") }}
         api(libs.tomlj)                 { version { strictly(tomljVersion) }}

--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -151,7 +151,8 @@ dependencies {
         api(libs.plist)                 { version { strictly("1.27") }}
         api(libs.servletApi)            { version { strictly("3.1.0") }}
         api(libs.slf4jApi)              { version { strictly(slf4jVersion) }}
-        api(libs.slf4jSimple)           { version { rejectAll(); because("We only need the logging API, we supply our own binding, which cause duplicate binding on class path error") }}
+// TODO: Restore this after SLF4J-Simple is removed from docs:docsTestCompileClasspath
+// api(libs.slf4jSimple)           { version { rejectAll(); because("We only need the logging API, we supply our own binding, which cause duplicate binding on class path error") }}
         api(libs.snakeyaml)             { version { strictly("2.0") }}
         api(libs.testng)                { version { strictly("6.3.1"); because("later versions break test cross-version test filtering") }}
         api(libs.tomlj)                 { version { strictly(tomljVersion) }}

--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -151,7 +151,7 @@ dependencies {
         api(libs.plist)                 { version { strictly("1.27") }}
         api(libs.servletApi)            { version { strictly("3.1.0") }}
         api(libs.slf4jApi)              { version { strictly(slf4jVersion) }}
-        api(libs.slf4jSimple)           { version { strictly(slf4jVersion) }}
+        api(libs.slf4jSimple)           { version { rejectAll(); because("We only need the logging API, we supply our own binding, which cause duplicate binding on class path error") }}
         api(libs.snakeyaml)             { version { strictly("2.0") }}
         api(libs.testng)                { version { strictly("6.3.1"); because("later versions break test cross-version test filtering") }}
         api(libs.tomlj)                 { version { strictly(tomljVersion) }}

--- a/testing/integ-test/build.gradle.kts
+++ b/testing/integ-test/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
 
     integTestImplementation(libs.samplesCheck) {
         exclude(group = "org.codehaus.groovy", module = "groovy-all")
-        exclude(module = "slf4j-simple")
     }
     integTestImplementation(testFixtures(project(":model-core")))
 

--- a/testing/internal-integ-testing/build.gradle.kts
+++ b/testing/internal-integ-testing/build.gradle.kts
@@ -69,7 +69,6 @@ dependencies {
     }
     api(libs.samplesCheck) {
         exclude(module = "groovy-all")
-        exclude(module = "slf4j-simple")
     }
     api(libs.samplesDiscovery)
     api(libs.servletApi)


### PR DESCRIPTION
It shouldn't be necessary, we don't need this slf4j implementation at all.

This excludes it via `ComponantMetadataRule`s where possible and a documented `exclude` where necessary.

It adds a `rejectAll` to our dependencies "specification" to ensure it doesn't ever creep back in.

This removes this noise in the build output:
```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/Users/ttresansky/Projects/gradle-worktrees/master/platforms/core-runtime/logging/build/libs/gradle-logging-8.9.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/Users/ttresansky/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-simple/1.7.36/a41f9cfe6faafb2eb83a1c7dd2d0dfd844e2a936/slf4j-simple-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.gradle.internal.logging.slf4j.OutputEventListenerBackedLoggerContext]
```