### PR TITLE
Show incompatible tasks in CC report

### DIFF
--- a/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
+++ b/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
@@ -21,7 +21,7 @@ import gradlebuild.modules.model.License
 abstract class ExternalModulesExtension(isBundleGroovy4: Boolean) {
 
     val groovyVersion = if (isBundleGroovy4) "4.0.20" else "3.0.21"
-    val configurationCacheReportVersion = "1.5"
+    val configurationCacheReportVersion = "1.6"
     val gradleIdeStarterVersion = "0.3"
     val kotlinVersion = "1.9.23"
 

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheIncompatibleTasksIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheIncompatibleTasksIntegrationTest.groovy
@@ -64,9 +64,9 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
     def "configuration cache report includes incompatible tasks"() {
         given:
         buildFile '''
-        task reportedlyIncompatible {
-            notCompatibleWithConfigurationCache("declaring myself as not compatible")
-        }
+            task reportedlyIncompatible {
+                notCompatibleWithConfigurationCache("declaring myself as not compatible")
+            }
         '''
 
         when:

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
@@ -144,7 +144,7 @@ class DefaultConfigurationCacheProblemsListener internal constructor(
     private
     fun problemsListenerFor(task: TaskInternal): ProblemsListener = when {
         task.isCompatibleWithConfigurationCache -> problems
-        else -> problems.forIncompatibleTask(task.identityPath.path)
+        else -> problems.forIncompatibleTask(task.identityPath.path, task.reasonTaskIsIncompatibleWithConfigurationCache.get())
     }
 
     override fun onBuildScopeListenerRegistration(listener: Any, invocationDescription: String, invocationSource: Any) {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
@@ -134,19 +134,28 @@ class DefaultConfigurationCacheProblemsListener internal constructor(
     }
 
     private
-    fun locationForTask(location: PropertyTrace?, task: TaskInternal): PropertyTrace =
-        if (location is PropertyTrace.BuildLogic) {
-            location
-        } else if (location is PropertyTrace.Task) {
-            location
-        } else {
-            PropertyTrace.Task(GeneratedSubclasses.unpackType(task), task.identityPath.path)
+    fun locationForTask(location: PropertyTrace, task: TaskInternal) =
+        when (location) {
+            is PropertyTrace.BuildLogic -> {
+                location
+            }
+
+            is PropertyTrace.Task -> {
+                location
+            }
+
+            else -> {
+                locationForTask(task)
+            }
         }
+
+    private
+    fun locationForTask(task: TaskInternal) = PropertyTrace.Task(GeneratedSubclasses.unpackType(task), task.identityPath.path)
 
     private
     fun problemsListenerFor(task: TaskInternal): ProblemsListener = when {
         task.isCompatibleWithConfigurationCache -> problems
-        else -> problems.forIncompatibleTask(locationForTask(null, task), task.reasonTaskIsIncompatibleWithConfigurationCache.get())
+        else -> problems.forIncompatibleTask(locationForTask(task), task.reasonTaskIsIncompatibleWithConfigurationCache.get())
     }
 
     override fun onBuildScopeListenerRegistration(listener: Any, invocationDescription: String, invocationSource: Any) {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
@@ -134,8 +134,10 @@ class DefaultConfigurationCacheProblemsListener internal constructor(
     }
 
     private
-    fun locationForTask(location: PropertyTrace, task: TaskInternal) =
+    fun locationForTask(location: PropertyTrace?, task: TaskInternal): PropertyTrace =
         if (location is PropertyTrace.BuildLogic) {
+            location
+        } else if (location is PropertyTrace.Task) {
             location
         } else {
             PropertyTrace.Task(GeneratedSubclasses.unpackType(task), task.identityPath.path)
@@ -144,7 +146,7 @@ class DefaultConfigurationCacheProblemsListener internal constructor(
     private
     fun problemsListenerFor(task: TaskInternal): ProblemsListener = when {
         task.isCompatibleWithConfigurationCache -> problems
-        else -> problems.forIncompatibleTask(task.identityPath.path, task.reasonTaskIsIncompatibleWithConfigurationCache.get())
+        else -> problems.forIncompatibleTask(locationForTask(null, task), task.reasonTaskIsIncompatibleWithConfigurationCache.get())
     }
 
     override fun onBuildScopeListenerRegistration(listener: Any, invocationDescription: String, invocationSource: Any) {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
@@ -136,17 +136,9 @@ class DefaultConfigurationCacheProblemsListener internal constructor(
     private
     fun locationForTask(location: PropertyTrace, task: TaskInternal) =
         when (location) {
-            is PropertyTrace.BuildLogic -> {
-                location
-            }
-
-            is PropertyTrace.Task -> {
-                location
-            }
-
-            else -> {
-                locationForTask(task)
-            }
+            is PropertyTrace.BuildLogic -> location
+            is PropertyTrace.Task -> location
+            else -> locationForTask(task)
         }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/AbstractProblemsListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/AbstractProblemsListener.kt
@@ -39,5 +39,5 @@ abstract class AbstractProblemsListener : ProblemsListener {
         )
     }
 
-    override fun forIncompatibleTask(path: String, reason: String): ProblemsListener = this
+    override fun forIncompatibleTask(trace: PropertyTrace, reason: String): ProblemsListener = this
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/AbstractProblemsListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/AbstractProblemsListener.kt
@@ -39,5 +39,5 @@ abstract class AbstractProblemsListener : ProblemsListener {
         )
     }
 
-    override fun forIncompatibleTask(path: String): ProblemsListener = this
+    override fun forIncompatibleTask(path: String, reason: String): ProblemsListener = this
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -168,10 +168,7 @@ class ConfigurationCacheProblems(
             .problem {
                 text("task ")
                 reference(path)
-                text(" is incompatible with the configuration cache. ")
-                text("Reason: ")
-                text(reason)
-                text(".")
+                text(" is incompatible with the configuration cache. Reason: $reason.")
             }
             .mapLocation {
                 PropertyTrace.TaskPath(path)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -103,7 +103,7 @@ class ConfigurationCacheProblems(
     var updatedProjects = 0
 
     private
-    var incompatibleTasks = newConcurrentHashSet<PropertyTrace>()
+    val incompatibleTasks = newConcurrentHashSet<PropertyTrace>()
 
     private
     lateinit var cacheAction: ConfigurationCacheAction

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
@@ -43,7 +43,7 @@ internal
 enum class ProblemSeverity {
     Info,
     Failure,
-
+    Warning,
     /**
      * A problem produced by a task marked as [notCompatibleWithConfigurationCache][Task.notCompatibleWithConfigurationCache].
      */
@@ -106,6 +106,7 @@ class ConfigurationCacheProblemsSummary(
             when (severity) {
                 ProblemSeverity.Failure -> failureCount += 1
                 ProblemSeverity.Suppressed -> suppressedCount += 1
+                ProblemSeverity.Warning -> {}
                 ProblemSeverity.Info -> {}
             }
             if (overflowed) {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheReport.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheReport.kt
@@ -130,7 +130,11 @@ class ConfigurationCacheReport(
 
             override fun onDiagnostic(kind: DiagnosticKind, problem: PropertyProblem): State {
                 executor.submit {
-                    val severity = if (kind == DiagnosticKind.PROBLEM) ProblemSeverity.Failure else ProblemSeverity.Info
+                    val severity = when (kind) {
+                        DiagnosticKind.PROBLEM -> ProblemSeverity.Failure
+                        DiagnosticKind.INCOMPATIBLE_TASK -> ProblemSeverity.Warning
+                        DiagnosticKind.INPUT -> ProblemSeverity.Info
+                    }
                     writer.writeDiagnostic(kind, decorate(problem, severity))
                 }
                 return this
@@ -273,6 +277,12 @@ class ConfigurationCacheReport(
     fun onProblem(problem: PropertyProblem) {
         modifyState {
             onDiagnostic(DiagnosticKind.PROBLEM, problem)
+        }
+    }
+
+    fun onIncompatibleTask(problem: PropertyProblem) {
+        modifyState {
+            onDiagnostic(DiagnosticKind.INCOMPATIBLE_TASK, problem)
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/JsonModelWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/JsonModelWriter.kt
@@ -192,12 +192,6 @@ class JsonModelWriter(val writer: Writer) {
                 property("type", trace.type.name)
             }
 
-            is PropertyTrace.TaskPath -> {
-                property("kind", "TaskPath")
-                comma()
-                property("path", trace.path)
-            }
-
             is PropertyTrace.Bean -> {
                 property("kind", "Bean")
                 comma()

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/JsonModelWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/JsonModelWriter.kt
@@ -34,7 +34,8 @@ import java.io.Writer
 internal
 enum class DiagnosticKind {
     PROBLEM,
-    INPUT
+    INPUT,
+    INCOMPATIBLE_TASK
 }
 
 
@@ -135,6 +136,7 @@ class JsonModelWriter(val writer: Writer) {
     fun keyFor(kind: DiagnosticKind) = when (kind) {
         DiagnosticKind.PROBLEM -> "problem"
         DiagnosticKind.INPUT -> "input"
+        DiagnosticKind.INCOMPATIBLE_TASK -> "incompatibleTask"
     }
 
     private
@@ -188,6 +190,12 @@ class JsonModelWriter(val writer: Writer) {
                 property("path", trace.path)
                 comma()
                 property("type", trace.type.name)
+            }
+
+            is PropertyTrace.TaskPath -> {
+                property("kind", "TaskPath")
+                comma()
+                property("path", trace.path)
             }
 
             is PropertyTrace.Bean -> {

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
@@ -371,7 +371,7 @@ class ConfigurationCacheFingerprintCheckerTest {
         override fun onError(error: Exception, message: StructuredMessageBuilder) =
             undefined()
 
-        override suspend fun forIncompatibleTask(path: String, reason: String, action: suspend () -> Unit) =
+        override suspend fun forIncompatibleTask(trace: PropertyTrace, reason: String, action: suspend () -> Unit) =
             undefined()
 
         override fun push(codec: Codec<Any?>): Unit =
@@ -502,7 +502,7 @@ class ConfigurationCacheFingerprintCheckerTest {
         override fun pop(): Unit =
             undefined()
 
-        override suspend fun forIncompatibleTask(path: String, reason: String, action: suspend () -> Unit) =
+        override suspend fun forIncompatibleTask(trace: PropertyTrace, reason: String, action: suspend () -> Unit) =
             undefined()
 
         override fun readInt(): Int =

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
@@ -371,6 +371,9 @@ class ConfigurationCacheFingerprintCheckerTest {
         override fun onError(error: Exception, message: StructuredMessageBuilder) =
             undefined()
 
+        override suspend fun forIncompatibleTask(path: String, reason: String, action: suspend () -> Unit) =
+            undefined()
+
         override fun push(codec: Codec<Any?>): Unit =
             undefined()
 
@@ -381,9 +384,6 @@ class ConfigurationCacheFingerprintCheckerTest {
             undefined()
 
         override fun pop(): Unit =
-            undefined()
-
-        override suspend fun forIncompatibleType(path: String, action: suspend () -> Unit) =
             undefined()
 
         override fun writeNullableString(value: CharSequence?): Unit =
@@ -502,7 +502,7 @@ class ConfigurationCacheFingerprintCheckerTest {
         override fun pop(): Unit =
             undefined()
 
-        override suspend fun forIncompatibleType(path: String, action: suspend () -> Unit) =
+        override suspend fun forIncompatibleTask(path: String, reason: String, action: suspend () -> Unit) =
             undefined()
 
         override fun readInt(): Int =

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummaryTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummaryTest.kt
@@ -17,6 +17,7 @@
 package org.gradle.internal.cc.impl.problems
 
 import org.gradle.internal.Describables
+import org.gradle.internal.code.DefaultUserCodeSource
 import org.gradle.internal.configuration.problems.PropertyProblem
 import org.gradle.internal.configuration.problems.PropertyTrace
 import org.gradle.internal.configuration.problems.StructuredMessage
@@ -76,7 +77,7 @@ class ConfigurationCacheProblemsSummaryTest {
 
     private
     fun buildLogicProblem(location: String, message: String) = PropertyProblem(
-        PropertyTrace.BuildLogic(Describables.of(location), 1),
+        PropertyTrace.BuildLogic(DefaultUserCodeSource(Describables.of(location), null)),
         StructuredMessage.build { text(message) }
     )
 }

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/DefaultProblemFactory.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/DefaultProblemFactory.kt
@@ -90,7 +90,7 @@ class DefaultProblemFactory(
     fun locationForCaller(consumer: String?, diagnostics: ProblemDiagnostics): PropertyTrace {
         val location = diagnostics.location
         return if (location != null) {
-            PropertyTrace.BuildLogic(location.sourceShortDisplayName, location.lineNumber)
+            PropertyTrace.BuildLogic(location)
         } else {
             locationForCaller(consumer, diagnostics.source)
         }
@@ -99,7 +99,7 @@ class DefaultProblemFactory(
     private
     fun locationForCaller(consumer: String?, source: UserCodeSource?): PropertyTrace {
         return if (source != null) {
-            PropertyTrace.BuildLogic(source.displayName, null)
+            PropertyTrace.BuildLogic(source)
         } else if (consumer != null) {
             PropertyTrace.BuildLogicClass(consumer)
         } else {

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/ProblemsListener.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/ProblemsListener.kt
@@ -27,7 +27,7 @@ interface ProblemsListener {
 
     fun onError(trace: PropertyTrace, error: Exception, message: StructuredMessageBuilder)
 
-    fun forIncompatibleTask(path: String): ProblemsListener
+    fun forIncompatibleTask(path: String, reason: String): ProblemsListener
 }
 
 

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/ProblemsListener.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/ProblemsListener.kt
@@ -27,7 +27,7 @@ interface ProblemsListener {
 
     fun onError(trace: PropertyTrace, error: Exception, message: StructuredMessageBuilder)
 
-    fun forIncompatibleTask(path: String, reason: String): ProblemsListener
+    fun forIncompatibleTask(trace: PropertyTrace, reason: String): ProblemsListener
 }
 
 

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/PropertyProblem.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/PropertyProblem.kt
@@ -44,6 +44,7 @@ enum class DocumentationSection(val anchor: String) {
     NotYetImplementedJavaSerialization("config_cache:not_yet_implemented:java_serialization"),
     NotYetImplementedTestKitJavaAgent("config_cache:not_yet_implemented:testkit_build_with_java_agent"),
     NotYetImplementedBuildServiceInFingerprint("config_cache:not_yet_implemented:build_services_in_fingerprint"),
+    TaskOptOut("config_cache:task_opt_out"),
     RequirementsBuildListeners("config_cache:requirements:build_listeners"),
     RequirementsDisallowedTypes("config_cache:requirements:disallowed_types"),
     RequirementsExternalProcess("config_cache:requirements:external_processes"),
@@ -127,6 +128,10 @@ sealed class PropertyTrace {
         val path: String
     ) : PropertyTrace()
 
+    class TaskPath(
+        val path: String
+    ) : PropertyTrace()
+
     class Bean(
         val type: Class<*>,
         val trace: PropertyTrace
@@ -206,7 +211,10 @@ sealed class PropertyTrace {
                 append(" of type ")
                 quoted(trace.type.name)
             }
-
+            is TaskPath -> {
+                append("task ")
+                quoted(trace.path)
+            }
             is BuildLogic -> {
                 append(trace.source.displayName)
                 trace.lineNumber?.let {

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/PropertyProblem.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/PropertyProblem.kt
@@ -110,62 +110,77 @@ data class StructuredMessage(val fragments: List<Fragment>) {
 
 sealed class PropertyTrace {
 
-    object Unknown : PropertyTrace()
+    object Unknown : PropertyTrace() {
+        override fun toString(): String = asString()
+    }
 
-    object Gradle : PropertyTrace()
+    object Gradle : PropertyTrace() {
+        override fun toString(): String = asString()
+    }
 
-    class BuildLogic(
+    data class BuildLogic(
         val source: DisplayName,
         val lineNumber: Int? = null
-    ) : PropertyTrace()
+    ) : PropertyTrace() {
+        override fun toString(): String = asString()
+    }
 
-    class BuildLogicClass(
+    data class BuildLogicClass(
         val name: String
-    ) : PropertyTrace()
+    ) : PropertyTrace() {
+        override fun toString(): String = asString()
+    }
 
-    class Task(
+    data class Task(
         val type: Class<*>,
         val path: String
-    ) : PropertyTrace()
+    ) : PropertyTrace() {
+        override fun toString(): String = asString()
+    }
 
-    class TaskPath(
-        val path: String
-    ) : PropertyTrace()
-
-    class Bean(
+    data class Bean(
         val type: Class<*>,
         val trace: PropertyTrace
     ) : PropertyTrace() {
         override val containingUserCode: String
             get() = trace.containingUserCode
+
+        override fun toString(): String = asString()
     }
 
-    class Property(
+    data class Property(
         val kind: PropertyKind,
         val name: String,
         val trace: PropertyTrace
     ) : PropertyTrace() {
         override val containingUserCode: String
             get() = trace.containingUserCode
+
+        override fun toString(): String = asString()
     }
 
-    class Project(
+    data class Project(
         val path: String,
         val trace: PropertyTrace
     ) : PropertyTrace() {
         override val containingUserCode: String
             get() = trace.containingUserCode
+
+        override fun toString(): String = asString()
     }
 
-    class SystemProperty(
+    data class SystemProperty(
         val name: String,
         val trace: PropertyTrace
     ) : PropertyTrace() {
         override val containingUserCode: String
             get() = trace.containingUserCode
+
+        override fun toString(): String = asString()
     }
 
-    override fun toString(): String =
+    protected
+    fun asString(): String =
         StringBuilder().apply {
             sequence.forEach {
                 appendStringOf(it)
@@ -210,10 +225,6 @@ sealed class PropertyTrace {
                 quoted(trace.path)
                 append(" of type ")
                 quoted(trace.type.name)
-            }
-            is TaskPath -> {
-                append("task ")
-                quoted(trace.path)
             }
             is BuildLogic -> {
                 append(trace.source.displayName)

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/PropertyProblem.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/PropertyProblem.kt
@@ -127,7 +127,7 @@ sealed class PropertyTrace {
     object Gradle : PropertyTrace() {
         override fun toString(): String = asString()
         override fun equals(other: Any?): Boolean = other === this
-        override fun hashCode(): Int = 0
+        override fun hashCode(): Int = 1
     }
 
     @Suppress("DataClassPrivateConstructor")

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/TaskNodeCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/TaskNodeCodec.kt
@@ -234,7 +234,7 @@ suspend fun <T> T.withTaskOf(
             if (task.isCompatibleWithConfigurationCache) {
                 action()
             } else {
-                forIncompatibleType(task.identityPath.path, action)
+                forIncompatibleTask(task.identityPath.path, task.reasonTaskIsIncompatibleWithConfigurationCache.get(), action)
             }
         }
     }

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/TaskNodeCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/TaskNodeCodec.kt
@@ -230,12 +230,11 @@ suspend fun <T> T.withTaskOf(
     action: suspend () -> Unit
 ) where T : IsolateContext, T : MutableIsolateContext {
     withIsolate(IsolateOwners.OwnerTask(task), codec) {
-        val taskTrace = PropertyTrace.Task(taskType, task.identityPath.path)
-        withPropertyTrace(taskTrace) {
+        withPropertyTrace(PropertyTrace.Task(taskType, task.identityPath.path)) {
             if (task.isCompatibleWithConfigurationCache) {
                 action()
             } else {
-                forIncompatibleTask(taskTrace, task.reasonTaskIsIncompatibleWithConfigurationCache.get(), action)
+                forIncompatibleTask(trace, task.reasonTaskIsIncompatibleWithConfigurationCache.get(), action)
             }
         }
     }

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/TaskNodeCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/TaskNodeCodec.kt
@@ -230,11 +230,12 @@ suspend fun <T> T.withTaskOf(
     action: suspend () -> Unit
 ) where T : IsolateContext, T : MutableIsolateContext {
     withIsolate(IsolateOwners.OwnerTask(task), codec) {
-        withPropertyTrace(PropertyTrace.Task(taskType, task.identityPath.path)) {
+        val taskTrace = PropertyTrace.Task(taskType, task.identityPath.path)
+        withPropertyTrace(taskTrace) {
             if (task.isCompatibleWithConfigurationCache) {
                 action()
             } else {
-                forIncompatibleTask(task.identityPath.path, task.reasonTaskIsIncompatibleWithConfigurationCache.get(), action)
+                forIncompatibleTask(taskTrace, task.reasonTaskIsIncompatibleWithConfigurationCache.get(), action)
             }
         }
     }

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
@@ -160,7 +160,7 @@ interface MutableIsolateContext : IsolateContext {
     fun push(owner: IsolateOwner, codec: Codec<Any?>)
     fun pop()
 
-    suspend fun forIncompatibleTask(path: String, reason: String, action: suspend () -> Unit)
+    suspend fun forIncompatibleTask(trace: PropertyTrace, reason: String, action: suspend () -> Unit)
 }
 
 

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
@@ -160,7 +160,7 @@ interface MutableIsolateContext : IsolateContext {
     fun push(owner: IsolateOwner, codec: Codec<Any?>)
     fun pop()
 
-    suspend fun forIncompatibleType(path: String, action: suspend () -> Unit)
+    suspend fun forIncompatibleTask(path: String, reason: String, action: suspend () -> Unit)
 }
 
 

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
@@ -258,9 +258,9 @@ abstract class AbstractIsolateContext<T>(
         currentProblemsListener.onError(trace, error, message)
     }
 
-    override suspend fun forIncompatibleTask(path: String, reason: String, action: suspend () -> Unit) {
+    override suspend fun forIncompatibleTask(trace: PropertyTrace, reason: String, action: suspend () -> Unit) {
         val previousListener = currentProblemsListener
-        currentProblemsListener = previousListener.forIncompatibleTask(path, reason)
+        currentProblemsListener = previousListener.forIncompatibleTask(trace, reason)
         try {
             action()
         } finally {

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
@@ -258,9 +258,9 @@ abstract class AbstractIsolateContext<T>(
         currentProblemsListener.onError(trace, error, message)
     }
 
-    override suspend fun forIncompatibleType(path: String, action: suspend () -> Unit) {
+    override suspend fun forIncompatibleTask(path: String, reason: String, action: suspend () -> Unit) {
         val previousListener = currentProblemsListener
-        currentProblemsListener = previousListener.forIncompatibleTask(path)
+        currentProblemsListener = previousListener.forIncompatibleTask(path, reason)
         try {
             action()
         } finally {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
@@ -230,6 +230,9 @@ class ConfigurationCacheFixture {
         spec.withUniqueProblems(details.problems.collect {
             it.message.replace('/', File.separator)
         })
+        details.incompatibleTasks.each {
+            spec.withIncompatibleTask(it.task, it.reason)
+        }
     }
 
     private assertHasNoProblems() {
@@ -321,7 +324,28 @@ class ConfigurationCacheFixture {
         }
     }
 
-    trait HasProblems {
+    static class IncompatibleTaskDetails {
+        final String task
+        final String reason
+        IncompatibleTaskDetails(String task, String reason) {
+            this.task = task
+            this.reason = reason
+        }
+    }
+
+    trait HasIncompatibleTasks {
+        final List<IncompatibleTaskDetails> incompatibleTasks = []
+
+        void incompatibleTask(String task, String reason) {
+            incompatibleTasks.add(new IncompatibleTaskDetails(task, reason))
+        }
+
+        int getTotalIncompatibleTasks() {
+            return incompatibleTasks.size()
+        }
+    }
+
+    trait HasProblems extends HasIncompatibleTasks {
         final List<ProblemDetails> problems = []
 
         void problem(String message, int count = 1, boolean hasStackTrace = true) {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsFixture.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.fixtures.configurationcache
 
 import groovy.json.JsonSlurper
 import groovy.transform.PackageScope
+import groovy.transform.ToString
 import junit.framework.AssertionFailedError
 import org.gradle.api.Action
 import org.gradle.api.internal.DocumentationRegistry
@@ -35,7 +36,9 @@ import javax.annotation.Nullable
 import java.nio.file.Paths
 import java.util.regex.Pattern
 
+import static org.hamcrest.CoreMatchers.allOf
 import static org.hamcrest.CoreMatchers.containsString
+import static org.hamcrest.CoreMatchers.endsWith
 import static org.hamcrest.CoreMatchers.equalTo
 import static org.hamcrest.CoreMatchers.not
 import static org.hamcrest.CoreMatchers.notNullValue
@@ -173,8 +176,9 @@ final class ConfigurationCacheProblemsFixture {
         } else {
             assertNoProblemsSummary(result.output)
         }
-        // TODO:bamboo avoid reading jsModel twice when asserting on problems AND inputs
-        assertInputs(result.output, rootDir, spec.inputs)
+        // TODO:bamboo avoid reading jsModel twice when asserting on problems AND inputs AND incompatible tasks
+        assertInputs(result.output, rootDir, spec)
+        assertIncompatibleTasks(result.output, rootDir, spec)
     }
 
     HasConfigurationCacheProblemsSpec newProblemsSpec(
@@ -274,47 +278,67 @@ final class ConfigurationCacheProblemsFixture {
     private static void assertInputs(
         String output,
         File rootDir,
-        InputsSpec spec
+        HasConfigurationCacheProblemsSpec spec
     ) {
-        if (spec == InputsSpec.IGNORING) {
+        assertItems('input', output, rootDir, spec.inputs)
+    }
+
+    private static void assertIncompatibleTasks(
+        String output,
+        File rootDir,
+        HasConfigurationCacheProblemsSpec spec
+    ) {
+        assertItems('incompatibleTask', output, rootDir, spec.incompatibleTasks)
+    }
+
+    private static void assertItems(
+        String kind,
+        String output,
+        File rootDir,
+        ItemSpec spec
+    ) {
+        if (spec == ItemSpec.IGNORING) {
             return
         }
 
-        List<Matcher<String>> expectedInputs = spec instanceof InputsSpec.ExpectingSome
-            ? spec.inputs.collect()
+        List<Matcher<String>> expectedItems = spec instanceof ItemSpec.ExpectingSome
+            ? spec.itemMatchers.collect()
             : []
 
         def reportDir = resolveConfigurationCacheReportDirectory(rootDir, output)
         if (reportDir == null) {
             assertThat(
-                "Expecting inputs but no report was found",
-                expectedInputs,
+                "Expecting '$kind' items but no report was found",
+                expectedItems,
                 equalTo([])
             )
             return
         }
 
         Map<String, Object> jsModel = readJsModelFromReportDir(reportDir)
-        List<Map<String, Object>> inputs = (jsModel.diagnostics as List<Map<String, Object>>).findAll { it['input'] != null }
-        List<String> unexpectedInputs = inputs.collect { formatInputForAssert(it) }.reverse()
-        for (int i in expectedInputs.indices.reverse()) {
-            def expectedInput = expectedInputs[i]
-            for (int j in unexpectedInputs.indices) {
-                if (expectedInput.matches(unexpectedInputs[j])) {
-                    expectedInputs.removeAt(i)
-                    unexpectedInputs.removeAt(j)
+        List<Map<String, Object>> items = (jsModel.diagnostics as List<Map<String, Object>>).findAll { it[kind] != null }
+        List<String> unexpectedItems = items.collect { formatItemForAssert(it, kind) }.reverse()
+        for (int i in expectedItems.indices.reverse()) {
+            def expectedItem = expectedItems[i]
+            for (int j in unexpectedItems.indices) {
+                if (expectedItem.matches(unexpectedItems[j])) {
+                    expectedItems.removeAt(i)
+                    unexpectedItems.removeAt(j)
                     break
                 }
             }
         }
-        if (!(spec instanceof InputsSpec.IgnoreUnexpected)) {
-            assert unexpectedInputs.isEmpty() : "Unexpected inputs $unexpectedInputs found in the report, expecting $expectedInputs"
+        if (!(spec instanceof ItemSpec.IgnoreUnexpected)) {
+            assert unexpectedItems.isEmpty() : "Unexpected '$kind' items $unexpectedItems found in the report, expecting $expectedItems"
         }
-        assert expectedInputs.isEmpty() : "Expecting $expectedInputs in the report, found $unexpectedInputs"
+        assert expectedItems.isEmpty() : "Expecting $expectedItems in the report, found $unexpectedItems"
     }
 
-    static String formatInputForAssert(Map<String, Object> input) {
-        "${formatTrace(input['trace'][0])}: ${formatStructuredMessage(input['input'])}"
+    static String formatItemForAssert(Map<String, Object> item, String kind) {
+        def trace = formatTrace(item['trace'][0])
+        List<Map<String, Object>> itemFragments = item[kind]
+        def message = formatStructuredMessage(itemFragments)
+        "${trace}: ${message}"
     }
 
     static String formatStructuredMessage(List<Map<String, Object>> fragments) {
@@ -325,14 +349,18 @@ final class ConfigurationCacheProblemsFixture {
     }
 
     static String formatTrace(Map<String, Object> trace) {
-        switch (trace['kind']) {
+        def kind = trace['kind']
+        switch (kind) {
             case "Task": return trace['path']
             case "Bean": return trace['type']
             case "Field": return trace['name']
             case "InputProperty": return trace['name']
             case "OutputProperty": return trace['name']
+            // Build file 'build.gradle'
             case "BuildLogic": return trace['location'].toString().capitalize()
             case "BuildLogicClass": return trace['type']
+            // Task :some-task-path
+            case "TaskPath":  return "Task ${trace['path']}"
             default: return "Gradle runtime"
         }
     }
@@ -414,7 +442,7 @@ final class ConfigurationCacheProblemsFixture {
     }
 
     protected static int numberOfProblemsWithStacktraceIn(jsModel) {
-        return (jsModel.diagnostics as List<Object>).count { it['error']?.getAt('parts') != null }
+        return (jsModel.diagnostics as List<Object>).count { it['problem'] != null && it['error']?.getAt('parts') != null }
     }
 
     private static ProblemsSummary extractSummary(String text) {
@@ -465,6 +493,7 @@ ${text}
         return new ProblemsSummary(totalProblems, problems.size(), problems)
     }
 
+    @ToString(includeNames=true)
     private static class ProblemsSummary {
         final int totalProblems
         final int uniqueProblems
@@ -489,83 +518,87 @@ final class HasConfigurationCacheErrorSpec extends HasConfigurationCacheProblems
     }
 }
 
-abstract class InputsSpec {
+abstract class ItemSpec {
 
-    abstract InputsSpec expect(Matcher<String> input)
+    abstract ItemSpec expect(Matcher<String> itemMatcher)
 
-    abstract InputsSpec expectNone()
+    ItemSpec expectPrefix(String prefix) {
+        return expect(startsWith(prefix))
+    }
 
-    abstract InputsSpec ignoreUnexpected()
+    abstract ItemSpec expectNone()
 
-    static final InputsSpec IGNORING = new InputsSpec() {
+    abstract ItemSpec ignoreUnexpected()
+
+    static final ItemSpec IGNORING = new ItemSpec() {
 
         @Override
-        InputsSpec expect(Matcher<String> input) {
-            new ExpectingSome().expect(input)
+        ItemSpec expect(Matcher<String> itemMatcher) {
+            new ExpectingSome().expect(itemMatcher)
         }
 
         @Override
-        InputsSpec expectNone() {
+        ItemSpec expectNone() {
             EXPECTING_NONE
         }
 
         @Override
-        InputsSpec ignoreUnexpected() {
+        ItemSpec ignoreUnexpected() {
             new IgnoreUnexpected([])
         }
     }
 
-    static final InputsSpec EXPECTING_NONE = new InputsSpec() {
+    static final ItemSpec EXPECTING_NONE = new ItemSpec() {
 
         @Override
-        InputsSpec expect(Matcher<String> input) {
-            throw new IllegalStateException("Already expecting no inputs, cannot expect $input")
+        ItemSpec expect(Matcher<String> itemMatcher) {
+            throw new IllegalStateException("Already expecting no items, cannot expect $itemMatcher")
         }
 
         @Override
-        InputsSpec expectNone() {
+        ItemSpec expectNone() {
             this
         }
 
         @Override
-        InputsSpec ignoreUnexpected() {
-            throw new IllegalStateException("Already expecting no inputs, cannot ignore unexpected.")
+        ItemSpec ignoreUnexpected() {
+            throw new IllegalStateException("Already expecting no items, cannot ignore unexpected.")
         }
     }
 
-    static class ExpectingSome extends InputsSpec {
+    static class ExpectingSome extends ItemSpec {
 
-        final List<Matcher<String>> inputs
+        final List<Matcher<String>> itemMatchers
 
-        ExpectingSome(List<Matcher<String>> inputs = []) {
-            this.inputs = inputs
+        ExpectingSome(List<Matcher<String>> itemMatchers = []) {
+            this.itemMatchers = itemMatchers
         }
 
         @Override
-        InputsSpec expect(Matcher<String> input) {
-            inputs.add(input)
+        ItemSpec expect(Matcher<String> itemMatcher) {
+            itemMatchers.add(itemMatcher)
             this
         }
 
         @Override
-        InputsSpec expectNone() {
-            throw new IllegalStateException("Already expecting $inputs, cannot expect none")
+        ItemSpec expectNone() {
+            throw new IllegalStateException("Already expecting $itemMatchers, cannot expect none")
         }
 
         @Override
-        InputsSpec ignoreUnexpected() {
-            return new IgnoreUnexpected(inputs)
+        ItemSpec ignoreUnexpected() {
+            return new IgnoreUnexpected(itemMatchers)
         }
     }
 
     static class IgnoreUnexpected extends ExpectingSome {
 
-        IgnoreUnexpected(List<Matcher<String>> inputs) {
-            super(inputs)
+        IgnoreUnexpected(List<Matcher<String>> itemMatchers) {
+            super(itemMatchers)
         }
 
         @Override
-        InputsSpec ignoreUnexpected() {
+        ItemSpec ignoreUnexpected() {
             this
         }
     }
@@ -577,7 +610,10 @@ class HasConfigurationCacheProblemsSpec {
     final List<Matcher<String>> uniqueProblems = []
 
     @PackageScope
-    InputsSpec inputs = InputsSpec.IGNORING
+    ItemSpec inputs = ItemSpec.IGNORING
+
+    @PackageScope
+    ItemSpec incompatibleTasks = ItemSpec.IGNORING
 
     @Nullable
     @PackageScope
@@ -641,7 +677,7 @@ class HasConfigurationCacheProblemsSpec {
     }
 
     HasConfigurationCacheProblemsSpec withInput(String prefix) {
-        inputs = inputs.expect(startsWith(prefix))
+        inputs = inputs.expectPrefix(prefix)
         return this
     }
 
@@ -652,6 +688,16 @@ class HasConfigurationCacheProblemsSpec {
 
     HasConfigurationCacheProblemsSpec ignoringUnexpectedInputs() {
         inputs = inputs.ignoreUnexpected()
+        return this
+    }
+
+    HasConfigurationCacheProblemsSpec withIncompatibleTask(String task, String reason) {
+        incompatibleTasks = incompatibleTasks.expect(allOf(startsWith("Task ${task}:"), endsWith(reason)))
+        return this
+    }
+
+    HasConfigurationCacheProblemsSpec ignoringUnexpectedIncompatibleTasks() {
+        incompatibleTasks = incompatibleTasks.ignoreUnexpected()
         return this
     }
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsFixture.groovy
@@ -176,7 +176,7 @@ final class ConfigurationCacheProblemsFixture {
         } else {
             assertNoProblemsSummary(result.output)
         }
-        // TODO:bamboo avoid reading jsModel twice when asserting on problems AND inputs AND incompatible tasks
+        // TODO:bamboo avoid reading jsModel more than once when asserting on problems AND inputs AND incompatible tasks        assertInputs(result.output, rootDir, spec)
         assertInputs(result.output, rootDir, spec)
         assertIncompatibleTasks(result.output, rootDir, spec)
     }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsFixture.groovy
@@ -359,8 +359,6 @@ final class ConfigurationCacheProblemsFixture {
             // Build file 'build.gradle'
             case "BuildLogic": return trace['location'].toString().capitalize()
             case "BuildLogicClass": return trace['type']
-            // Task :some-task-path
-            case "TaskPath":  return "Task ${trace['path']}"
             default: return "Gradle runtime"
         }
     }
@@ -568,6 +566,11 @@ abstract class ItemSpec {
 
     static class ExpectingSome extends ItemSpec {
 
+
+        @Override
+        String toString() {
+            return itemMatchers.join(", ")
+        }
         final List<Matcher<String>> itemMatchers
 
         ExpectingSome(List<Matcher<String>> itemMatchers = []) {
@@ -692,7 +695,7 @@ class HasConfigurationCacheProblemsSpec {
     }
 
     HasConfigurationCacheProblemsSpec withIncompatibleTask(String task, String reason) {
-        incompatibleTasks = incompatibleTasks.expect(allOf(startsWith("Task ${task}:"), endsWith(reason)))
+        incompatibleTasks = incompatibleTasks.expect(allOf(startsWith("${task}: task `${task}` of type "), endsWith(reason)))
         return this
     }
 


### PR DESCRIPTION
Issue: #21290
Related: gradle/configuration-cache-report#18

### Summary of changes

- adapted collection of incompatible tasks so reason is also provided, to be included in the report
- include incompatible tasks in the CC report
- changed tracking of incompatible tasks to be based on PropertyTrace (likely a PropertyTrace.Task variant) instead of task paths
- added test coverage to verify incompatible tasks appear in the generated report
- generalized checking of inputs so the verification can be shared between inputs and incompatible tasks


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
