### PR TITLE
Avoid 'classes' task in documentation for --update-locks (#29407)

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/dependency_locking.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/dependency_locking.adoc
@@ -209,7 +209,7 @@ It takes a comma (`,`) separated list of module notations.
 In this mode, the existing lock state is still used as input to resolution, filtering out the modules targeted by the update.
 
 ----
-❯ gradle classes --update-locks org.apache.commons:commons-lang3,org.slf4j:slf4j-api
+❯ gradle dependencies --update-locks org.apache.commons:commons-lang3,org.slf4j:slf4j-api
 ----
 
 Wildcards, indicated with `*`, can be used in the group or module name. They can be the only character or appear at the end of the group or module respectively.


### PR DESCRIPTION
### Context
Fixes #29407 in a way discussed in the issue.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
