### PR TITLE
Preserve task dependencies for transformed incoming elements

### DIFF
--- a/platforms/core-configuration/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
+++ b/platforms/core-configuration/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.api.artifacts.transform.TransformOutputs
 import org.gradle.api.artifacts.transform.TransformParameters
 import org.gradle.api.tasks.TasksWithInputsAndOutputs
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.util.internal.ToBeImplemented
 import spock.lang.Issue
 
 import static org.gradle.util.internal.TextUtil.escapeString
@@ -513,7 +512,6 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec implements T
             " Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#file_collection_to_classpath")
     }
 
-    @ToBeImplemented
     @Issue('https://github.com/gradle/gradle/issues/29147')
     def "can connect transformed incoming elements of a configuration to task input ListProperty"() {
         withZipArtifactProducingSubprojects 'p1', 'p2'
@@ -551,17 +549,14 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec implements T
             }
         '''
 
-        expect:
-        fails 'merge'
-// Expected behavior:
-//        when:
-//        run 'merge'
-//
-//        then:
-//        outputContains 'Transforming p1.zip'
-//        outputContains 'Transforming p2.zip'
-//        result.assertTasksExecuted ':p1:produce', ':p1:zip', ':p2:produce', ':p2:zip', ':merge'
-//        file('merge.txt').text == 'p1.zip,p2.zip'
+        when:
+        run 'merge'
+
+        then:
+        outputContains 'Transforming p1.zip'
+        outputContains 'Transforming p2.zip'
+        result.assertTasksExecuted ':p1:produce', ':p1:zip', ':p2:produce', ':p2:zip', ':merge'
+        file('merge.txt').text == 'p1.zip,p2.zip'
     }
 
     @Issue('https://github.com/gradle/gradle/issues/29147')

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/ProviderBackedFileCollection.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/ProviderBackedFileCollection.java
@@ -50,7 +50,7 @@ public class ProviderBackedFileCollection extends CompositeFileCollection {
     public void visitDependencies(TaskDependencyResolveContext context) {
         ValueSupplier.ValueProducer producer = provider.getProducer();
         if (producer.isKnown()) {
-            producer.visitProducerTasks(context);
+            producer.visitDependencies(context);
         } else {
             // Producer is unknown, so unpack the value
             UnpackingVisitor unpackingVisitor = new UnpackingVisitor(context::add, resolver, taskDependencyFactory, patternSetFactory);

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
@@ -139,7 +139,7 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
     @Override
     public void visitDependencies(TaskDependencyResolveContext context) {
         // When used as an input, add the producing tasks if known
-        getProducer().visitProducerTasks(context);
+        getProducer().visitDependencies(context);
     }
 
     @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/BuildableBackedProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/BuildableBackedProvider.java
@@ -19,6 +19,8 @@ package org.gradle.api.internal.provider;
 import org.gradle.api.Action;
 import org.gradle.api.Buildable;
 import org.gradle.api.Task;
+import org.gradle.api.internal.tasks.TaskDependencyContainer;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.internal.tasks.TaskDependencyUtil;
 import org.gradle.internal.Factory;
 
@@ -48,6 +50,15 @@ public class BuildableBackedProvider<T> extends AbstractProviderWithValue<T> {
         // not a lambda for readability purposes.
         //noinspection Convert2Lambda
         return new ValueProducer() {
+            @Override
+            public void visitDependencies(TaskDependencyResolveContext context) {
+                if (buildable instanceof TaskDependencyContainer) {
+                    ((TaskDependencyContainer) buildable).visitDependencies(context);
+                } else {
+                    ValueProducer.super.visitDependencies(context);
+                }
+            }
+
             @Override
             public void visitProducerTasks(Action<? super Task> visitor) {
                 for (Task dependency : buildableDependencies()) {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
@@ -20,6 +20,8 @@ import com.google.common.collect.ImmutableList;
 import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.api.Transformer;
+import org.gradle.api.internal.tasks.TaskDependencyContainer;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.internal.Cast;
 import org.gradle.internal.DisplayName;
 
@@ -51,12 +53,17 @@ public interface ValueSupplier {
     /**
      * Carries information about the producer of a value.
      */
-    interface ValueProducer {
+    interface ValueProducer extends TaskDependencyContainer {
         NoProducer NO_PRODUCER = new NoProducer();
         UnknownProducer UNKNOWN_PRODUCER = new UnknownProducer();
 
         default boolean isKnown() {
             return true;
+        }
+
+        @Override
+        default void visitDependencies(TaskDependencyResolveContext context) {
+            visitProducerTasks(context);
         }
 
         void visitProducerTasks(Action<? super Task> visitor);

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/AbstractTaskDependencyResolveContext.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/AbstractTaskDependencyResolveContext.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks;
 
+import org.gradle.api.Task;
 import org.gradle.internal.UncheckedException;
 
 public abstract class AbstractTaskDependencyResolveContext implements TaskDependencyResolveContext {
@@ -23,5 +24,10 @@ public abstract class AbstractTaskDependencyResolveContext implements TaskDepend
     public void visitFailure(Throwable failure) {
         // Rethrow
         throw UncheckedException.throwAsUncheckedException(failure);
+    }
+
+    @Override
+    public Task getTask() {
+        return null;
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
@@ -103,7 +103,7 @@ public class DefaultTaskDependency extends AbstractTaskDependency {
                 ProviderInternal<?> provider = (ProviderInternal<?>) dependency;
                 ValueSupplier.ValueProducer producer = provider.getProducer();
                 if (producer.isKnown()) {
-                    producer.visitProducerTasks(context);
+                    producer.visitDependencies(context);
                 } else {
                     // The provider does not know how to produce the value, so use the value instead
                     queue.addFirst(provider.get());

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultArtifactCollection.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultArtifactCollection.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.artifacts.ivyservice.ResolvedArtifactCollectingVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
+import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.provider.BuildableBackedProvider;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
@@ -77,7 +78,7 @@ public class DefaultArtifactCollection implements ArtifactCollectionInternal {
 
     @Override
     public Provider<Set<ResolvedArtifactResult>> getResolvedArtifacts() {
-        return new BuildableBackedProvider<>(getArtifactFiles(), Cast.uncheckedCast(Set.class), new ArtifactCollectionResolvedArtifactsFactory(this));
+        return new BuildableBackedProvider<>((FileCollectionInternal) getArtifactFiles(), Cast.uncheckedCast(Set.class), new ArtifactCollectionResolvedArtifactsFactory(this));
     }
 
     @Override


### PR DESCRIPTION
By making `ValueProducer` extend `TaskDependencyContainer` so all types of producer dependencies, including transforms, can be properly taken into account.

Also make `BuildableBackedProvider` expect and compute dependencies via a given `TaskDependencyContainer`.

This PR doesn't address all situations in which `incoming.elements` dependencies could be lost (for example, when the `incoming.elements` provider is combined with another provider via `orElse`), that work is being tracked as part of #29528. 

Fixes #29147

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
