### PR TITLE
WIP: Highlight of scripts in integration tests with append operator

### DIFF
--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -39,6 +39,7 @@ import org.gradle.integtests.fixtures.problems.ReceivedProblem
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.fixtures.dsl.GradleDsl
 import org.gradle.test.fixtures.file.CleanupTestDirectory
+import org.gradle.test.fixtures.file.GroovyBuildScriptTestFile
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.test.fixtures.file.TestWorkspaceBuilder
@@ -184,11 +185,14 @@ abstract class AbstractIntegrationSpec extends Specification {
         }
     }
 
+    // TODO: might not need this comment, if the IJ issue is fixed
     /**
      * Want syntax highlighting inside of IntelliJ? Consider using {@link AbstractIntegrationSpec#buildFile(String)}
      */
-    TestFile getBuildFile() {
-        testDirectory.file(getDefaultBuildFileName())
+    TestFile getBuildFile() { // TODO: update the return type, and fix in the children classes
+        new GroovyBuildScriptTestFile(testDirectory, getDefaultBuildFileName())
+        // TODO: use a factory method on the `TestFile`
+//        testDirectory.file(getDefaultBuildFileName())
     }
 
     String getTestJunitCoordinates() {
@@ -232,6 +236,7 @@ abstract class AbstractIntegrationSpec extends Specification {
     }
 
     TestFile getBuildKotlinFile() {
+        // TODO: support KotlinBuildScriptTestFile
         testDirectory.file(defaultBuildKotlinFileName)
     }
 
@@ -269,6 +274,7 @@ abstract class AbstractIntegrationSpec extends Specification {
     }
 
 
+    // TODO: introduce a separate Language annotation for the settings scripts
     protected TestFile getSettingsFile() {
         testDirectory.file(settingsFileName)
     }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/file/GroovyBuildScriptTestFile.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/file/GroovyBuildScriptTestFile.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.test.fixtures.file;
+
+import org.gradle.integtests.fixtures.GroovyBuildScriptLanguage;
+
+import java.io.File;
+
+public class GroovyBuildScriptTestFile extends TestFile {
+
+    public GroovyBuildScriptTestFile(File file, Object... path) {
+        super(file, path);
+    }
+
+    public GroovyBuildScriptTestFile leftShift(@GroovyBuildScriptLanguage String content) {
+        super.leftShift(content);
+        return this;
+    }
+}

--- a/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
+++ b/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
@@ -143,6 +143,8 @@ public class TestFile extends File {
         }
     }
 
+    // TODO: have a file() overload that takes a factory and shared the creation logic
+
     public List<TestFile> files(Object... paths) {
         List<TestFile> files = new ArrayList<>();
         for (Object path : paths) {


### PR DESCRIPTION
Code in the integration tests like the following should provide highlighting for the string literal
```
settingsFile << """
    include("a")
    rootProject.name = "root"
"""
```
