### PR TITLE
Fix property lookup tracking in scripts for Isolated Projects

### DIFF
--- a/platforms/core-configuration/configuration-cache-base/src/main/kotlin/org/gradle/internal/cc/base/Logging.kt
+++ b/platforms/core-configuration/configuration-cache-base/src/main/kotlin/org/gradle/internal/cc/base/Logging.kt
@@ -24,3 +24,8 @@ import org.gradle.api.logging.Logging
  * Configuration Cache logger.
  */
 val logger: Logger = Logging.getLogger("org.gradle.configurationcache")
+
+
+inline fun Logger.debug(msg: () -> String) {
+    if (isDebugEnabled) debug(msg())
+}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DynamicCallProblemReporting.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DynamicCallProblemReporting.kt
@@ -68,9 +68,6 @@ class DefaultDynamicCallProblemReporting : DynamicCallProblemReporting {
     }
 
     override fun leaveDynamicCall(entryPoint: Any) {
-        if (currentThreadState.callStack.isEmpty()) {
-            return
-        }
         val innermostCall = currentThreadState.callStack.pop()
         check(entryPoint == innermostCall.entryPoint) { "Mismatched enter-leave calls in DynamicCallProjectIsolationProblemReporting" }
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DynamicCallProblemReporting.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DynamicCallProblemReporting.kt
@@ -66,13 +66,19 @@ class DefaultDynamicCallProblemReporting : DynamicCallProblemReporting {
     }
 
     override fun leaveDynamicCall(entryPoint: Any) {
+        if (currentThreadState.callStack.isEmpty()) {
+            return
+        }
         val innermostCall = currentThreadState.callStack.pop()
         check(entryPoint == innermostCall.entryPoint) { "Mismatched enter-leave calls in DynamicCallProjectIsolationProblemReporting" }
     }
 
     override fun unreportedProblemInCurrentCall(problemKey: Any): Boolean {
         val currentThreadCallStack = currentThreadState.callStack
-        check(currentThreadCallStack.isNotEmpty()) { "Expected unreportedProblemInCurrentCall to be called after enterDynamicCall" }
+        if (currentThreadCallStack.isEmpty()) {
+            return true
+        }
+
         return currentThreadCallStack.peek().problemsReportedInCurrentCall.add(problemKey)
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DynamicCallProblemReporting.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DynamicCallProblemReporting.kt
@@ -85,7 +85,8 @@ class DefaultDynamicCallProblemReporting : DynamicCallProblemReporting {
         return currentThreadCallStack.peek().problemsReportedInCurrentCall.add(problemKey)
     }
 
-    private fun logMissingScope() {
+    private
+    fun logMissingScope() {
         if (logger.isEnabled(LogLevel.DEBUG)) {
             val stackTrace = IllegalStateException("Expected unreportedProblemInCurrentCall to be called after enterDynamicCall").stackTraceToString()
             val shortenedStackTrace = stackTrace.lines().take(15).joinToString("\n")
@@ -98,6 +99,7 @@ class DefaultDynamicCallProblemReporting : DynamicCallProblemReporting {
         get() = threadLocalState.get()
 
     companion object {
-        private val logger = Logging.getLogger(DynamicCallProblemReporting::class.java)
+        private
+        val logger = Logging.getLogger(DynamicCallProblemReporting::class.java)
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DynamicCallProblemReporting.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DynamicCallProblemReporting.kt
@@ -16,8 +16,8 @@
 
 package org.gradle.internal.cc.impl
 
-import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logging
+import org.gradle.internal.cc.base.debug
 import java.util.Stack
 
 
@@ -84,10 +84,9 @@ class DefaultDynamicCallProblemReporting : DynamicCallProblemReporting {
 
     private
     fun logMissingScope() {
-        if (logger.isEnabled(LogLevel.DEBUG)) {
+        logger.debug {
             val stackTrace = IllegalStateException("Expected unreportedProblemInCurrentCall to be called after enterDynamicCall").stackTraceToString()
-            val shortenedStackTrace = stackTrace.lines().take(15).joinToString("\n")
-            logger.log(LogLevel.DEBUG, shortenedStackTrace)
+            "Warning: " + stackTrace.lines().take(15).joinToString("\n")
         }
     }
 


### PR DESCRIPTION
Fixes: https://github.com/gradle/gradle/issues/29519

by making **lenient** the expectation of having a cross-project access scope present at the time of registering violations.