### PR TITLE
Clarify the root project by printing "project : (the root project)" instead of just "project :" in resolution failure messaging

### DIFF
--- a/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-metadataRule/tests/failRuntimeClasspathResolve.out
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-metadataRule/tests/failRuntimeClasspathResolve.out
@@ -1,7 +1,7 @@
 > Could not resolve all files for configuration ':runtimeClasspath'.
    > Could not resolve org.lwjgl:lwjgl:3.2.3.
      Required by:
-         project :
+         project : (the root project)
       > The consumer was configured to find a library for use during runtime, compatible with Java 11, packaged as a jar, preferably optimized for standard JVMs, and its dependencies declared externally, as well as attribute 'org.gradle.native.operatingSystem' with value 'windows'. There are several available matching variants of org.lwjgl:lwjgl:3.2.3
         The only attribute distinguishing these variants is 'org.gradle.native.architecture'. Add this attribute to the consumer's configuration to resolve the ambiguity:
           - Value: 'x86-64' selects variant: 'natives-windows-runtime'

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/variants/GradlePluginWithVariantsPublicationIntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/variants/GradlePluginWithVariantsPublicationIntegrationTest.groovy
@@ -207,7 +207,7 @@ class GradlePluginWithVariantsPublicationIntegrationTest extends AbstractIntegra
         failure.assertHasErrorOutput("""> Could not resolve all artifacts for configuration ':classpath'.
    > Could not resolve com.example:producer:1.0.
      Required by:
-         project : > com.example.greeting:com.example.greeting.gradle.plugin:1.0
+         project : (the root project) > com.example.greeting:com.example.greeting.gradle.plugin:1.0
       > Plugin com.example:producer:1.0 requires at least Gradle 1000.0. This build uses Gradle $currentGradle.""")
         failure.assertHasErrorOutput("Caused by: " + VariantSelectionException.class.getName())
         failure.assertHasResolution("Upgrade to at least Gradle 1000.0. See the instructions at https://docs.gradle.org/$currentGradle/userguide/upgrading_version_8.html#sub:updating-gradle.")

--- a/platforms/jvm/plugins-java-library/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetJvmVersionIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java-library/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetJvmVersionIntegrationTest.groovy
@@ -58,7 +58,7 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
         failure.assertHasErrorOutput("""> Could not resolve all dependencies for configuration ':compileClasspath'.
    > Could not resolve project :producer.
      Required by:
-         project :
+         project : (the root project)
       > Dependency resolution is looking for a library compatible with JVM runtime version 6, but 'project :producer' is only compatible with JVM runtime version 7 or newer.""")
         failure.assertHasResolution("Change the dependency on 'project :producer' to an earlier version that supports JVM runtime version 7.")
     }
@@ -140,7 +140,7 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
 > Could not resolve all dependencies for configuration ':compileClasspath'.
    > Could not resolve project :producer.
      Required by:
-         project :
+         project : (the root project)
       > Dependency resolution is looking for a library compatible with JVM runtime version 6, but 'project :producer' is only compatible with JVM runtime version 7 or newer.""")
         failure.assertHasResolution("Change the dependency on 'project :producer' to an earlier version that supports JVM runtime version 7.")
 

--- a/platforms/jvm/plugins-java-library/src/integTest/groovy/org/gradle/java/JavaLibraryPublishedTargetJvmVersionIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java-library/src/integTest/groovy/org/gradle/java/JavaLibraryPublishedTargetJvmVersionIntegrationTest.groovy
@@ -101,7 +101,7 @@ class JavaLibraryPublishedTargetJvmVersionIntegrationTest extends AbstractHttpDe
         failure.assertHasErrorOutput('''> Could not resolve all files for configuration ':compileClasspath'.
    > Could not resolve org:producer:1.0.
      Required by:
-         project :
+         project : (the root project)
       > Dependency resolution is looking for a library compatible with JVM runtime version 5, but 'org:producer:1.0' is only compatible with JVM runtime version 6 or newer.''')
         failure.assertHasResolution("Change the dependency on 'org:producer:1.0' to an earlier version that supports JVM runtime version 6.")
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/ResolutionFailureHandlerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/ResolutionFailureHandlerIntegrationTest.groovy
@@ -56,8 +56,8 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasCause("Could not resolve project :.")
-        assertFullMessageCorrect("""      > The consumer was configured to find attribute 'color' with value 'blue'. There are several available matching variants of project :
+        failure.assertHasCause("Could not resolve project : (the root project).")
+        assertFullMessageCorrect("""      > The consumer was configured to find attribute 'color' with value 'blue'. There are several available matching variants of project : (the root project)
         The only attribute distinguishing these variants is 'shape'. Add this attribute to the consumer's configuration to resolve the ambiguity:
           - Value: 'round' selects variant: 'blueRoundElements'
           - Value: 'square' selects variant: 'blueSquareElements'
@@ -77,8 +77,8 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasCause("Could not resolve project :.")
-        assertFullMessageCorrect("""      > The consumer was configured to find attribute 'color' with value 'blue'. However we cannot choose between the following variants of project ::
+        failure.assertHasCause("Could not resolve project : (the root project).")
+        assertFullMessageCorrect("""      > The consumer was configured to find attribute 'color' with value 'blue'. However we cannot choose between the following variants of project : (the root project):
           - blueRoundTransparentElements
           - blueSquareOpaqueElements
           - blueSquareTransparentElements
@@ -113,7 +113,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause("Could not resolve com.squareup.okhttp3:okhttp:4.4.0.")
         assertFullMessageCorrect("""   > Could not resolve com.squareup.okhttp3:okhttp:4.4.0.
      Required by:
-         project :
+         project : (the root project)
       > The consumer was configured to find attribute 'org.gradle.category' with value 'documentation'. There are several available matching variants of com.squareup.okhttp3:okhttp:4.4.0
         The only attribute distinguishing these variants is 'org.gradle.docstype'. Add this attribute to the consumer's configuration to resolve the ambiguity:
           - Value: 'javadoc' selects variant: 'javadocElements'
@@ -133,11 +133,11 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasCause("Could not resolve project :.")
-        assertFullMessageCorrect("""   > Could not resolve project :.
+        failure.assertHasCause("Could not resolve project : (the root project).")
+        assertFullMessageCorrect("""   > Could not resolve project : (the root project).
      Required by:
-         project :
-      > No matching variant of project : was found. The consumer was configured to find attribute 'color' with value 'green' but:
+         project : (the root project)
+      > No matching variant of project : (the root project) was found. The consumer was configured to find attribute 'color' with value 'green' but:
           - Variant 'default':
               - Incompatible because this component declares attribute 'color' with value 'blue' and the consumer needed attribute 'color' with value 'green'""")
 
@@ -181,10 +181,10 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasCause("Could not resolve project :.")
+        failure.assertHasCause("Could not resolve project : (the root project).")
         assertFullMessageCorrect("""     Required by:
-         project :
-      > Configuration 'mismatch' in project : does not match the consumer attributes
+         project : (the root project)
+      > Configuration 'mismatch' in project : (the root project) does not match the consumer attributes
         Configuration 'mismatch':
           - Incompatible because this component declares attribute 'color' with value 'blue' and the consumer needed attribute 'color' with value 'green'
 """)
@@ -205,7 +205,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
         failure.assertHasCause("Could not resolve project :producer.")
         assertFullMessageCorrect("""     Required by:
-         project :
+         project : (the root project)
       > No matching variant of project :producer was found. The consumer was configured to find attribute 'color' with value 'green' but:
           - No variants exist.""")
 
@@ -224,10 +224,10 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasCause("Could not resolve project :.")
+        failure.assertHasCause("Could not resolve project : (the root project).")
         assertFullMessageCorrect("""     Required by:
-         project :
-      > A dependency was declared on configuration 'absent' which is not declared in the descriptor for project :.""")
+         project : (the root project)
+      > A dependency was declared on configuration 'absent' which is not declared in the descriptor for project : (the root project).""")
 
         and: "Helpful resolutions are provided"
         assertSuggestsReviewingAlgorithm()
@@ -244,8 +244,8 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasCause("Could not resolve project :.")
-        assertFullMessageCorrect("A dependency was declared on configuration 'absent' which is not declared in the descriptor for project :.")
+        failure.assertHasCause("Could not resolve project : (the root project).")
+        assertFullMessageCorrect("A dependency was declared on configuration 'absent' which is not declared in the descriptor for project : (the root project).")
 
         and: "Helpful resolutions are provided"
         assertSuggestsReviewingAlgorithm()
@@ -265,9 +265,9 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasCause("Could not resolve project :.")
+        failure.assertHasCause("Could not resolve project : (the root project).")
         assertFullMessageCorrect("""     Required by:
-         project :
+         project : (the root project)
       > Multiple incompatible variants of org.example:${temporaryFolder.getTestDirectory().getName()}:1.0 were selected:
            - Variant blueElementsCapability1 has attributes {color=blue}
            - Variant greenElementsCapability2 has attributes {color=green}""")
@@ -286,7 +286,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        assertFullMessageCorrect("""   > No variants of project : match the consumer attributes:
+        assertFullMessageCorrect("""   > No variants of project : (the root project) match the consumer attributes:
        - Configuration ':myElements' declares attribute 'color' with value 'blue':
            - Incompatible because this component declares attribute 'artifactType' with value 'jar' and the consumer needed attribute 'artifactType' with value 'dll'
        - Configuration ':myElements' variant secondary declares attribute 'color' with value 'blue':
@@ -306,7 +306,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        assertFullMessageCorrect("""   > Found multiple transforms that can produce a variant of project : with requested attributes:
+        assertFullMessageCorrect("""   > Found multiple transforms that can produce a variant of project : (the root project) with requested attributes:
        - color 'red'
        - shape 'round'
      Found the following transforms:
@@ -339,7 +339,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        assertFullMessageCorrect("""   > More than one variant of project : matches the consumer attributes:
+        assertFullMessageCorrect("""   > More than one variant of project : (the root project) matches the consumer attributes:
        - Configuration ':default' variant v1
        - Configuration ':default' variant v2""")
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/ResolutionFailureHandlerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/ResolutionFailureHandlerIntegrationTest.groovy
@@ -379,7 +379,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
     // endregion dependencyInsight failures
 
     // region error showcase
-    @spock.lang.Ignore("This test is used to generate a summary of all possible errors, it shouldn't usually be run as part of testing")
+    //@spock.lang.Ignore("This test is used to generate a summary of all possible errors, it shouldn't usually be run as part of testing")
     def "generate resolution failure showcase report"() {
         given:
         // Escape to the root of the dependency-management project, to put these reports in build output dir so it isn't auto-deleted when test completes

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/ResolutionFailureHandlerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/ResolutionFailureHandlerIntegrationTest.groovy
@@ -379,7 +379,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
     // endregion dependencyInsight failures
 
     // region error showcase
-    //@spock.lang.Ignore("This test is used to generate a summary of all possible errors, it shouldn't usually be run as part of testing")
+    @spock.lang.Ignore("This test is used to generate a summary of all possible errors, it shouldn't usually be run as part of testing")
     def "generate resolution failure showcase report"() {
         given:
         // Escape to the root of the dependency-management project, to put these reports in build output dir so it isn't auto-deleted when test completes

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
@@ -75,7 +75,7 @@ class CapabilitiesLocalComponentIntegrationTest extends AbstractIntegrationSpec 
         succeeds 'dependencyInsight', '--configuration', 'compileClasspath', '--dependency', ':'
 
         then:
-        outputContains("Could not resolve project :.")
+        outputContains("Could not resolve project : (the root project).")
     }
 
     def "can lazily define and request capability"() {
@@ -185,4 +185,3 @@ class CapabilitiesLocalComponentIntegrationTest extends AbstractIntegrationSpec 
         succeeds("resolve")
     }
 }
-

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyBrokenRemoteResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyBrokenRemoteResolveIntegrationTest.groovy
@@ -206,13 +206,13 @@ task showMissing { doLast { println configurations.compile.files } }
 Searched in the following locations:
   - ${moduleA.ivy.uri}
 Required by:
-    project : > group:projectC:0.99
-    project : > project :child1 > group:projectD:1.0GA""")
+    project : (the root project) > group:projectC:0.99
+    project : (the root project) > project :child1 > group:projectD:1.0GA""")
             .assertHasCause("""Could not find group:projectB:1.0-milestone-9.
 Searched in the following locations:
   - ${moduleB.ivy.uri}
 Required by:
-    project : > project :child1 > group:projectD:1.0GA""")
+    project : (the root project) > project :child1 > group:projectD:1.0GA""")
         failure.assertHasResolutions(REPOSITORY_HINT,
             STACKTRACE_MESSAGE,
             INFO_DEBUG,

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBrokenRemoteResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBrokenRemoteResolveIntegrationTest.groovy
@@ -209,13 +209,13 @@ task showMissing {
 Searched in the following locations:
   - ${moduleA.pom.uri}
 Required by:
-    project : > group:projectC:0.99
-    project : > project :child1 > group:projectD:1.0GA""")
+    project : (the root project) > group:projectC:0.99
+    project : (the root project) > project :child1 > group:projectD:1.0GA""")
             .assertHasCause("""Could not find group:projectB:1.0-milestone-9.
 Searched in the following locations:
   - ${moduleB.pom.uri}
 Required by:
-    project : > project :child1 > group:projectD:1.0GA""")
+    project : (the root project) > project :child1 > group:projectD:1.0GA""")
         failure.assertHasResolutions(REPOSITORY_HINT,
             STACKTRACE_MESSAGE,
             INFO_DEBUG,

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/VersionConflictResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/VersionConflictResolutionIntegrationTest.groovy
@@ -951,7 +951,7 @@ dependencies {
         runAndFail "resolve"
 
         then:
-        failure.assertResolutionFailure(":conf").assertFailedDependencyRequiredBy("project : > org:d:1.0")
+        failure.assertResolutionFailure(":conf").assertFailedDependencyRequiredBy("project : \\(the root project\\) > org:d:1.0")
     }
 
     def "chooses highest version that is included in both ranges"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/plugin/devel/variants/TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/plugin/devel/variants/TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest.groovy
@@ -104,7 +104,7 @@ class TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest extends Abst
         failure.assertHasErrorOutput("""> Could not resolve all artifacts for configuration ':classpath'.
    > Could not resolve com.example:producer:1.0.
      Required by:
-         project : > com.example.greeting:com.example.greeting.gradle.plugin:1.0
+         project : (the root project) > com.example.greeting:com.example.greeting.gradle.plugin:1.0
       > Dependency requires at least JVM runtime version ${higherVersion.javaVersion.majorVersion}. This build uses a Java ${lowerVersion.javaVersion.majorVersion} JVM.""")
         failure.assertHasErrorOutput("Caused by: " + VariantSelectionException.class.getName())
         failure.assertHasResolution("Run this build using a Java ${higherVersion.javaVersion.majorVersion} or newer JVM.")
@@ -184,7 +184,7 @@ class TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest extends Abst
         failure.assertHasErrorOutput("""> Could not resolve all artifacts for configuration ':classpath'.
    > Could not resolve com.example:producer:1.0.
      Required by:
-         project : > com.example.greeting:com.example.greeting.gradle.plugin:1.0
+         project : (the root project) > com.example.greeting:com.example.greeting.gradle.plugin:1.0
       > Dependency requires at least JVM runtime version $tooHighJava. This build uses a Java $currentJava JVM.""")
         failure.assertHasErrorOutput("Caused by: " + VariantSelectionException.class.getName())
         failure.assertHasResolution("Run this build using a Java $tooHighJava or newer JVM.")
@@ -259,7 +259,7 @@ class TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest extends Abst
         failure.assertHasErrorOutput("""> Could not resolve all dependencies for configuration ':classpath'.
    > Could not resolve project :producer.
      Required by:
-         project :
+         project : (the root project)
       > Dependency requires at least JVM runtime version ${higherVersion.javaVersion.majorVersion}. This build uses a Java ${lowerVersion.javaVersion.majorVersion} JVM.""")
         failure.assertHasErrorOutput("Caused by: " + VariantSelectionException.class.getName())
         failure.assertHasResolution("Run this build using a Java ${higherVersion.javaVersion.majorVersion} or newer JVM.")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/plugin/devel/variants/TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/plugin/devel/variants/TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest.groovy
@@ -331,7 +331,7 @@ class TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest extends Abst
         failure.assertHasErrorOutput("""> Could not resolve all artifacts for configuration ':classpath'.
    > Could not resolve org.springframework.boot:spring-boot-gradle-plugin:3.2.1.
      Required by:
-         project : > org.springframework.boot:org.springframework.boot.gradle.plugin:3.2.1
+         project : (the root project) > org.springframework.boot:org.springframework.boot.gradle.plugin:3.2.1
       > Dependency requires at least JVM runtime version 17. This build uses a Java $currentJava JVM.""")
         failure.assertHasErrorOutput("Caused by: " + VariantSelectionException.class.getName())
         failure.assertHasResolution("Run this build using a Java 17 or newer JVM.")

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -109,7 +109,7 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
      * @param selectedConfiguration the non-consumable configuration that was selected
      */
     private void failDueToNonConsumableConfigurationSelection(Configuration selectedConfiguration) {
-        ConfigurationNotConsumableFailure failure = new ConfigurationNotConsumableFailure(selectedConfiguration.getName(), dependencyProject.getDisplayName());
+        ConfigurationNotConsumableFailure failure = new ConfigurationNotConsumableFailure(selectedConfiguration.getName(), dependencyProject::getDisplayName);
         String message = String.format(
             "Selected configuration '" + failure.getRequestedName() + "' on '" + failure.getRequestedComponentDisplayName() +
             "' but it can't be used as a project dependency because it isn't intended for consumption by other components."

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelector.java
@@ -91,7 +91,7 @@ public class AttributeMatchingArtifactVariantSelector implements ArtifactVariant
             // Request is ambiguous. Rerun matching again, except capture an explanation this time for reporting.
             TraceDiscardedVariants newExpBuilder = new TraceDiscardedVariants();
             matches = matcher.matches(variants, componentRequested, newExpBuilder);
-            throw failureProcessor.ambiguousArtifactVariantsFailure(schema, matcher, producer.asDescribable().getDisplayName(), componentRequested, matches);
+            throw failureProcessor.ambiguousArtifactVariantsFailure(schema, matcher, producer.asDescribable(), componentRequested, matches);
         }
 
         // We found no matches. Attempt to construct artifact transform chains which produce matching variants.
@@ -108,14 +108,14 @@ public class AttributeMatchingArtifactVariantSelector implements ArtifactVariant
         }
 
         if (!transformedVariants.isEmpty()) {
-            throw failureProcessor.ambiguousArtifactTransformationFailure(schema, producer.asDescribable().getDisplayName(), componentRequested, transformedVariants);
+            throw failureProcessor.ambiguousArtifactTransformationFailure(schema, producer.asDescribable(), componentRequested, transformedVariants);
         }
 
         if (allowNoMatchingVariants) {
             return ResolvedArtifactSet.EMPTY;
         }
 
-        throw failureProcessor.noMatchingArtifactVariantFailure(schema, matcher, producer.asDescribable().getDisplayName(), componentRequested, variants);
+        throw failureProcessor.noMatchingArtifactVariantFailure(schema, matcher, producer.asDescribable(), componentRequested, variants);
     }
 
     /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/ResolutionFailureHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/ResolutionFailureHandler.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component;
 
+import org.gradle.api.Describable;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
@@ -85,34 +86,34 @@ public class ResolutionFailureHandler {
     }
 
     // region Artifact Variant Selection Failures
-    public AbstractResolutionFailureException noMatchingArtifactVariantFailure(AttributesSchemaInternal schema, AttributeMatcher matcher, String variantSetName, ImmutableAttributes requestedAttributes, List<? extends ResolvedVariant> candidateVariants) {
+    public AbstractResolutionFailureException noMatchingArtifactVariantFailure(AttributesSchemaInternal schema, AttributeMatcher matcher, Describable variantSet, ImmutableAttributes requestedAttributes, List<? extends ResolvedVariant> candidateVariants) {
         ResolutionCandidateAssessor resolutionCandidateAssessor = new ResolutionCandidateAssessor(requestedAttributes, matcher);
         List<AssessedCandidate> assessedCandidates = resolutionCandidateAssessor.assessResolvedVariants(candidateVariants);
-        IncompatibleResolutionFailure failure = new IncompatibleResolutionFailure(variantSetName, requestedAttributes, assessedCandidates);
+        IncompatibleResolutionFailure failure = new IncompatibleResolutionFailure(variantSet, requestedAttributes, assessedCandidates);
         return describeFailure(schema, failure);
     }
 
-    public AbstractResolutionFailureException ambiguousArtifactVariantsFailure(AttributesSchemaInternal schema, AttributeMatcher matcher, String selectedComponentName, ImmutableAttributes requestedAttributes, List<? extends ResolvedVariant> matchingVariants) {
+    public AbstractResolutionFailureException ambiguousArtifactVariantsFailure(AttributesSchemaInternal schema, AttributeMatcher matcher, Describable selectedComponent, ImmutableAttributes requestedAttributes, List<? extends ResolvedVariant> matchingVariants) {
         ResolutionCandidateAssessor resolutionCandidateAssessor = new ResolutionCandidateAssessor(requestedAttributes, matcher);
         List<AssessedCandidate> assessedCandidates = resolutionCandidateAssessor.assessResolvedVariants(matchingVariants);
-        AmbiguousResolutionFailure failure = new AmbiguousResolutionFailure(selectedComponentName, requestedAttributes, assessedCandidates);
+        AmbiguousResolutionFailure failure = new AmbiguousResolutionFailure(selectedComponent, requestedAttributes, assessedCandidates);
         return describeFailure(schema, failure);
     }
 
-    public AbstractResolutionFailureException ambiguousArtifactTransformationFailure(AttributesSchemaInternal schema, String selectedComponentName, ImmutableAttributes requestedAttributes, List<TransformedVariant> transformedVariants) {
-        AmbiguousArtifactTransformFailure failure = new AmbiguousArtifactTransformFailure(selectedComponentName, requestedAttributes, transformedVariants);
+    public AbstractResolutionFailureException ambiguousArtifactTransformationFailure(AttributesSchemaInternal schema, Describable selectedComponent, ImmutableAttributes requestedAttributes, List<TransformedVariant> transformedVariants) {
+        AmbiguousArtifactTransformFailure failure = new AmbiguousArtifactTransformFailure(selectedComponent, requestedAttributes, transformedVariants);
         return describeFailure(schema, failure);
     }
 
     public AbstractResolutionFailureException unknownArtifactVariantSelectionFailure(AttributesSchemaInternal schema, ResolvedVariantSet producer, Exception cause) {
-        UnknownArtifactSelectionFailure failure = new UnknownArtifactSelectionFailure(producer.asDescribable().getDisplayName(), cause);
+        UnknownArtifactSelectionFailure failure = new UnknownArtifactSelectionFailure(producer.asDescribable(), cause);
         return describeFailure(schema, failure);
     }
 
     public AbstractResolutionFailureException incompatibleArtifactVariantsFailure(AttributesSchemaInternal schema, ComponentState selectedComponent, Set<NodeState> incompatibleNodes) {
         ResolutionCandidateAssessor resolutionCandidateAssessor = new ResolutionCandidateAssessor(ImmutableAttributes.EMPTY, schema.matcher());
         List<AssessedCandidate> assessedCandidates = resolutionCandidateAssessor.assessNodeStates(incompatibleNodes);
-        IncompatibleMultipleNodeSelectionFailure failure = new IncompatibleMultipleNodeSelectionFailure(selectedComponent.toString(), assessedCandidates);
+        IncompatibleMultipleNodeSelectionFailure failure = new IncompatibleMultipleNodeSelectionFailure(selectedComponent::toString, assessedCandidates);
         return describeFailure(schema, failure);
     }
     // endregion Artifact Variant Selection Failures
@@ -126,7 +127,7 @@ public class ResolutionFailureHandler {
     ) {
         ResolutionCandidateAssessor resolutionCandidateAssessor = new ResolutionCandidateAssessor(requestedAttributes, matcher);
         List<AssessedCandidate> assessedCandidates = resolutionCandidateAssessor.assessResolvedVariantStates(matchingVariants);
-        VariantAwareAmbiguousResolutionFailure failure = new VariantAwareAmbiguousResolutionFailure(targetComponent.getId().getDisplayName(), requestedAttributes, assessedCandidates, targetComponent.getModuleVersionId());
+        VariantAwareAmbiguousResolutionFailure failure = new VariantAwareAmbiguousResolutionFailure(targetComponent.getId(), requestedAttributes, assessedCandidates, targetComponent.getModuleVersionId());
         return describeFailure(schema, failure);
     }
 
@@ -139,19 +140,19 @@ public class ResolutionFailureHandler {
     ) {
         ResolutionCandidateAssessor resolutionCandidateAssessor = new ResolutionCandidateAssessor(requestedAttributes, matcher);
         List<AssessedCandidate> assessedCandidates = resolutionCandidateAssessor.assessGraphSelectionCandidates(candidates);
-        IncompatibleGraphVariantFailure failure = new IncompatibleGraphVariantFailure(targetComponent.getId().getDisplayName(), requestedAttributes, assessedCandidates);
+        IncompatibleGraphVariantFailure failure = new IncompatibleGraphVariantFailure(targetComponent.getId(), requestedAttributes, assessedCandidates);
         return describeFailure(schema, failure);
     }
 
     public AbstractResolutionFailureException noMatchingCapabilitiesFailure(AttributesSchemaInternal schema, AttributeMatcher matcher, ImmutableAttributes requestedAttributes, ComponentGraphResolveMetadata targetComponent, Collection<? extends Capability> requestedCapabilities, List<? extends VariantGraphResolveState> candidates) {
         ResolutionCandidateAssessor resolutionCandidateAssessor = new ResolutionCandidateAssessor(requestedAttributes, matcher);
         List<AssessedCandidate> assessedCandidates = resolutionCandidateAssessor.assessResolvedVariantStates(candidates);
-        NoMatchingCapabilitiesFailure failure = new NoMatchingCapabilitiesFailure(targetComponent.getId().getDisplayName(), requestedCapabilities, assessedCandidates, targetComponent.getModuleVersionId());
+        NoMatchingCapabilitiesFailure failure = new NoMatchingCapabilitiesFailure(targetComponent.getId(), requestedCapabilities, assessedCandidates, targetComponent.getModuleVersionId());
         return describeFailure(schema, failure);
     }
 
     public AbstractResolutionFailureException noVariantsExistFailure(AttributesSchemaInternal schema, AttributeContainerInternal requestedAttributes, ComponentIdentifier targetComponent) {
-        IncompatibleGraphVariantFailure failure = new IncompatibleGraphVariantFailure(targetComponent.getDisplayName(), requestedAttributes, Collections.emptyList());
+        IncompatibleGraphVariantFailure failure = new IncompatibleGraphVariantFailure(targetComponent, requestedAttributes, Collections.emptyList());
         return describeFailure(schema, failure);
     }
 
@@ -167,7 +168,7 @@ public class ResolutionFailureHandler {
     ) {
         ResolutionCandidateAssessor resolutionCandidateAssessor = new ResolutionCandidateAssessor(requestedAttributes, matcher);
         List<AssessedCandidate> assessedCandidates = Collections.singletonList(resolutionCandidateAssessor.assessCandidate(targetConfiguration.getName(), targetConfiguration.getCapabilities(), targetConfiguration.getMetadata().getAttributes()));
-        IncompatibleRequestedConfigurationFailure failure = new IncompatibleRequestedConfigurationFailure(targetComponent.getId().getDisplayName(), requestedAttributes, assessedCandidates);
+        IncompatibleRequestedConfigurationFailure failure = new IncompatibleRequestedConfigurationFailure(targetComponent.getId(), requestedAttributes, assessedCandidates);
         return describeFailure(schema, failure);
     }
 
@@ -186,7 +187,7 @@ public class ResolutionFailureHandler {
     ) {
         // We hard-code the exception here since we do not currently support dynamically describing this type of failure.
         // It might make sense to do this for other similar failures that do not have dynamic failure handling.
-        ConfigurationNotConsumableFailure failure = new ConfigurationNotConsumableFailure(configurationName, componentId.getDisplayName());
+        ConfigurationNotConsumableFailure failure = new ConfigurationNotConsumableFailure(configurationName, componentId);
         String message = String.format("Selected configuration '" + failure.getRequestedName() + "' on '" + failure.getRequestedComponentDisplayName() + "' but it can't be used as a project dependency because it isn't intended for consumption by other components.");
         throw new ConfigurationSelectionException(message, failure, Collections.emptyList());
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AbstractConfigurationSelectionFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AbstractConfigurationSelectionFailure.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.resolution.failure.type;
 
+import org.gradle.api.Describable;
 import org.gradle.api.internal.artifacts.ProjectPathClarifyingDescriber;
 
 /**
@@ -26,17 +27,17 @@ public abstract class AbstractConfigurationSelectionFailure implements Resolutio
     private final String requestedConfigurationName;
     private final String requestedComponentName;
 
-    public AbstractConfigurationSelectionFailure(String requestedConfigurationName, String requestedComponentName) {
-        this.requestedConfigurationName = requestedConfigurationName;
-        this.requestedComponentName = requestedComponentName;
+    public AbstractConfigurationSelectionFailure(String requestedConfigurationName, Describable requestedComponent) {
+        this.requestedConfigurationName = ProjectPathClarifyingDescriber.describe(requestedConfigurationName);
+        this.requestedComponentName = ProjectPathClarifyingDescriber.describe(requestedComponent);
     }
 
     @Override
     public String getRequestedName() {
-        return ProjectPathClarifyingDescriber.describe(requestedConfigurationName);
+        return requestedConfigurationName;
     }
 
     public String getRequestedComponentDisplayName() {
-        return ProjectPathClarifyingDescriber.describe(requestedComponentName);
+        return requestedComponentName;
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AbstractConfigurationSelectionFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AbstractConfigurationSelectionFailure.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.component.resolution.failure.type;
 
+import org.gradle.api.internal.artifacts.ProjectPathClarifyingDescriber;
+
 /**
  * An abstract {@link ResolutionFailure} that represents the situation when a configuration is requested
  * by name on a project dependency and does not exist on the target project.
@@ -31,10 +33,10 @@ public abstract class AbstractConfigurationSelectionFailure implements Resolutio
 
     @Override
     public String getRequestedName() {
-        return requestedConfigurationName;
+        return ProjectPathClarifyingDescriber.describe(requestedConfigurationName);
     }
 
     public String getRequestedComponentDisplayName() {
-        return requestedComponentName;
+        return ProjectPathClarifyingDescriber.describe(requestedComponentName);
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AbstractIncompatibleAttributesSelectionFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AbstractIncompatibleAttributesSelectionFailure.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.resolution.failure.type;
 
+import org.gradle.api.Describable;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 
@@ -26,8 +27,8 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
 public abstract class AbstractIncompatibleAttributesSelectionFailure extends AbstractVariantSelectionFailure {
     private final ImmutableAttributes requestedAttributes;
 
-    public AbstractIncompatibleAttributesSelectionFailure(String requestedName, AttributeContainerInternal requestedAttributes) {
-        super(requestedName);
+    public AbstractIncompatibleAttributesSelectionFailure(Describable requested, AttributeContainerInternal requestedAttributes) {
+        super(requested);
         this.requestedAttributes = requestedAttributes.asImmutable();
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AbstractVariantSelectionFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AbstractVariantSelectionFailure.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.resolution.failure.type;
 
+import org.gradle.api.Describable;
 import org.gradle.api.internal.artifacts.ProjectPathClarifyingDescriber;
 
 /**
@@ -25,12 +26,12 @@ import org.gradle.api.internal.artifacts.ProjectPathClarifyingDescriber;
 public abstract class AbstractVariantSelectionFailure implements ResolutionFailure {
     private final String requestedName;
 
-    public AbstractVariantSelectionFailure(String requestedName) {
-        this.requestedName = requestedName;
+    public AbstractVariantSelectionFailure(Describable requested) {
+        this.requestedName = ProjectPathClarifyingDescriber.describe(requested);
     }
 
     @Override
     public String getRequestedName() {
-        return ProjectPathClarifyingDescriber.describe(requestedName);
+        return requestedName;
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AbstractVariantSelectionFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AbstractVariantSelectionFailure.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.component.resolution.failure.type;
 
+import org.gradle.api.internal.artifacts.ProjectPathClarifyingDescriber;
+
 /**
  * An abstract {@link ResolutionFailure} that represents the situation when a requested variant has attributes
  * that are not compatible with any of the available variants.
@@ -29,6 +31,6 @@ public abstract class AbstractVariantSelectionFailure implements ResolutionFailu
 
     @Override
     public String getRequestedName() {
-        return requestedName;
+        return ProjectPathClarifyingDescriber.describe(requestedName);
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AmbiguousArtifactTransformFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AmbiguousArtifactTransformFailure.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.resolution.failure.type;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.Describable;
 import org.gradle.api.internal.artifacts.transform.TransformedVariant;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 
@@ -29,8 +30,8 @@ import java.util.List;
 public final class AmbiguousArtifactTransformFailure extends AbstractIncompatibleAttributesSelectionFailure {
     private final ImmutableList<TransformedVariant> transformedVariants;
 
-    public AmbiguousArtifactTransformFailure(String requestedName, AttributeContainerInternal requestedAttributes, List<TransformedVariant> transformedVariants) {
-        super(requestedName, requestedAttributes);
+    public AmbiguousArtifactTransformFailure(Describable requested, AttributeContainerInternal requestedAttributes, List<TransformedVariant> transformedVariants) {
+        super(requested, requestedAttributes);
         this.transformedVariants = ImmutableList.copyOf(transformedVariants);
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AmbiguousResolutionFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AmbiguousResolutionFailure.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.resolution.failure.type;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.Describable;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 
@@ -29,8 +30,8 @@ import java.util.List;
 public class AmbiguousResolutionFailure extends AbstractIncompatibleAttributesSelectionFailure {
     private final ImmutableList<ResolutionCandidateAssessor.AssessedCandidate> candidates;
 
-    public AmbiguousResolutionFailure(String requestedName, AttributeContainerInternal requestedAttributes, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
-        super(requestedName, requestedAttributes);
+    public AmbiguousResolutionFailure(Describable requested, AttributeContainerInternal requestedAttributes, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
+        super(requested, requestedAttributes);
         this.candidates = ImmutableList.copyOf(candidates);
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/ConfigurationNotConsumableFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/ConfigurationNotConsumableFailure.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.component.resolution.failure.type;
 
+import org.gradle.api.Describable;
+
 /**
  * A {@link ResolutionFailure} that represents the situation when the selected configuration
  * is not consumable.
@@ -23,7 +25,7 @@ package org.gradle.internal.component.resolution.failure.type;
  * This is exclusive to project dependencies when a configuration is requested by name.
  */
 public final class ConfigurationNotConsumableFailure extends AbstractConfigurationSelectionFailure {
-    public ConfigurationNotConsumableFailure(String requestedConfigurationName, String requestedComponentName) {
-        super(requestedConfigurationName, requestedComponentName);
+    public ConfigurationNotConsumableFailure(String requestedConfigurationName, Describable requestedComponent) {
+        super(requestedConfigurationName, requestedComponent);
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/IncompatibleGraphVariantFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/IncompatibleGraphVariantFailure.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.resolution.failure.type;
 
+import org.gradle.api.Describable;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 
@@ -26,8 +27,8 @@ import java.util.List;
  * failure to select a variant for a component when building a dependency resolution graph.
  */
 public final class IncompatibleGraphVariantFailure extends IncompatibleResolutionFailure {
-    public IncompatibleGraphVariantFailure(String requestedName, AttributeContainerInternal requestedAttributes, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
-        super(requestedName, requestedAttributes, candidates);
+    public IncompatibleGraphVariantFailure(Describable requested, AttributeContainerInternal requestedAttributes, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
+        super(requested, requestedAttributes, candidates);
     }
 
     public boolean noCandidatesHaveAttributes() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/IncompatibleMultipleNodeSelectionFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/IncompatibleMultipleNodeSelectionFailure.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.resolution.failure.type;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.Describable;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor.AssessedCandidate;
 
 import java.util.List;
@@ -28,8 +29,8 @@ import java.util.List;
 public final class IncompatibleMultipleNodeSelectionFailure extends AbstractVariantSelectionFailure {
     private final ImmutableList<AssessedCandidate> assessedCandidates;
 
-    public IncompatibleMultipleNodeSelectionFailure(String requestedName, List<AssessedCandidate> assessedCandidates) {
-        super(requestedName);
+    public IncompatibleMultipleNodeSelectionFailure(Describable requested, List<AssessedCandidate> assessedCandidates) {
+        super(requested);
         this.assessedCandidates = ImmutableList.copyOf(assessedCandidates);
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/IncompatibleRequestedConfigurationFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/IncompatibleRequestedConfigurationFailure.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.resolution.failure.type;
 
+import org.gradle.api.Describable;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 
@@ -26,7 +27,7 @@ import java.util.List;
  * requested by name but its attributes are not compatible with the request.
  */
 public final class IncompatibleRequestedConfigurationFailure extends IncompatibleResolutionFailure {
-    public IncompatibleRequestedConfigurationFailure(String requestedName, AttributeContainerInternal requestedAttributes, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
-        super(requestedName, requestedAttributes, candidates);
+    public IncompatibleRequestedConfigurationFailure(Describable requested, AttributeContainerInternal requestedAttributes, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
+        super(requested, requestedAttributes, candidates);
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/IncompatibleResolutionFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/IncompatibleResolutionFailure.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.resolution.failure.type;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.Describable;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 
@@ -29,8 +30,8 @@ import java.util.List;
 public class IncompatibleResolutionFailure extends AbstractIncompatibleAttributesSelectionFailure {
     private final ImmutableList<ResolutionCandidateAssessor.AssessedCandidate> candidates;
 
-    public IncompatibleResolutionFailure(String requestedName, AttributeContainerInternal requestedAttributes, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
-        super(requestedName, requestedAttributes);
+    public IncompatibleResolutionFailure(Describable requested, AttributeContainerInternal requestedAttributes, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
+        super(requested, requestedAttributes);
         this.candidates = ImmutableList.copyOf(candidates);
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/NoMatchingCapabilitiesFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/NoMatchingCapabilitiesFailure.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.resolution.failure.type;
 
+import org.gradle.api.Describable;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor.AssessedCandidate;
@@ -32,8 +33,8 @@ public final class NoMatchingCapabilitiesFailure extends AbstractVariantSelectio
     private final List<AssessedCandidate> candidates;
     private final ModuleVersionIdentifier targetComponentId;
 
-    public NoMatchingCapabilitiesFailure(String requestedName, Collection<? extends Capability> requestedCapabilities, List<AssessedCandidate> candidates, ModuleVersionIdentifier targetComponentId) {
-        super(requestedName);
+    public NoMatchingCapabilitiesFailure(Describable requested, Collection<? extends Capability> requestedCapabilities, List<AssessedCandidate> candidates, ModuleVersionIdentifier targetComponentId) {
+        super(requested);
         this.requestedCapabilities = requestedCapabilities;
         this.candidates = candidates;
         this.targetComponentId = targetComponentId;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/RequestedConfigurationNotFoundFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/RequestedConfigurationNotFoundFailure.java
@@ -24,6 +24,6 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
  */
 public class RequestedConfigurationNotFoundFailure extends AbstractConfigurationSelectionFailure {
     public RequestedConfigurationNotFoundFailure(String requestedConfigurationName, ComponentIdentifier requestedComponent) {
-        super(requestedConfigurationName, requestedComponent.getDisplayName());
+        super(requestedConfigurationName, requestedComponent);
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/UnknownArtifactSelectionFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/UnknownArtifactSelectionFailure.java
@@ -16,14 +16,16 @@
 
 package org.gradle.internal.component.resolution.failure.type;
 
+import org.gradle.api.Describable;
+
 /**
  * A {@link ResolutionFailure} that represents the an unknown, catch-all failure that occurred during variant selection.
  */
 public final class UnknownArtifactSelectionFailure extends AbstractVariantSelectionFailure {
     private final Exception cause;
 
-    public UnknownArtifactSelectionFailure(String requestedName, Exception cause) {
-        super(requestedName);
+    public UnknownArtifactSelectionFailure(Describable requested, Exception cause) {
+        super(requested);
         this.cause = cause;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/VariantAwareAmbiguousResolutionFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/VariantAwareAmbiguousResolutionFailure.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.resolution.failure.type;
 
+import org.gradle.api.Describable;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
@@ -29,8 +30,8 @@ import java.util.List;
 public final class VariantAwareAmbiguousResolutionFailure extends AmbiguousResolutionFailure {
     private final ModuleVersionIdentifier targetComponentId;
 
-    public VariantAwareAmbiguousResolutionFailure(String requestedName, AttributeContainerInternal requestedAttributes, List<ResolutionCandidateAssessor.AssessedCandidate> candidates, ModuleVersionIdentifier targetComponentId) {
-        super(requestedName, requestedAttributes, candidates);
+    public VariantAwareAmbiguousResolutionFailure(Describable requested, AttributeContainerInternal requestedAttributes, List<ResolutionCandidateAssessor.AssessedCandidate> candidates, ModuleVersionIdentifier targetComponentId) {
+        super(requested, requestedAttributes, candidates);
         this.targetComponentId = targetComponentId;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/ModuleVersionResolveException.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/ModuleVersionResolveException.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
+import org.gradle.api.internal.artifacts.ProjectPathClarifyingDescriber;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
 import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
@@ -99,7 +100,7 @@ public class ModuleVersionResolveException extends DefaultMultiCauseExceptionNoS
     }
 
     protected static Factory<String> format(String messageFormat, ComponentSelector selector) {
-        return () -> String.format(messageFormat, selector.getDisplayName());
+        return () -> String.format(messageFormat, ProjectPathClarifyingDescriber.describe(selector));
     }
 
     /**
@@ -130,7 +131,7 @@ public class ModuleVersionResolveException extends DefaultMultiCauseExceptionNoS
     }
 
     private String toString(ComponentIdentifier identifier) {
-        return identifier.getDisplayName();
+        return ProjectPathClarifyingDescriber.describe(identifier);
     }
 
     protected ModuleVersionResolveException createCopy() {

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ComponentIdentifier.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ComponentIdentifier.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.artifacts.component;
 
+import org.gradle.api.Describable;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
@@ -23,12 +24,13 @@ import org.gradle.internal.scan.UsedByScanPlugin;
  * @since 1.10
  */
 @UsedByScanPlugin
-public interface ComponentIdentifier {
+public interface ComponentIdentifier extends Describable {
     /**
      * Returns a human-consumable display name for this identifier.
      *
      * @return Component identifier display name
      * @since 1.10
      */
+    @Override
     String getDisplayName();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ComponentSelector.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ComponentSelector.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.artifacts.component;
 
+import org.gradle.api.Describable;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.internal.scan.UsedByScanPlugin;
@@ -28,13 +29,14 @@ import java.util.List;
  * @since 1.10
  */
 @UsedByScanPlugin
-public interface ComponentSelector {
+public interface ComponentSelector extends Describable {
     /**
      * Returns a human-consumable display name for this selector.
      *
      * @return Display name
      * @since 1.10
      */
+    @Override
     String getDisplayName();
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/ProjectPathClarifyingDescriber.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/ProjectPathClarifyingDescriber.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts;
+
+import org.gradle.api.Describable;
+import org.gradle.util.Path;
+
+/**
+ * Static utility class containing methods for describing a project path with clarifications
+ * that may make it clearer to the reader in error messages.
+ */
+public final class ProjectPathClarifyingDescriber {
+    private static final String PROJECT_PREFIX = "project ";
+
+    private ProjectPathClarifyingDescriber() { /* not instantiable */}
+
+    /**
+     * Describes the given {@link Describable} object, clarifying when it references the root project.
+     *
+     * @param describable the object to describe
+     * @return clarified description of the object
+     */
+    public static String describe(Describable describable) {
+        return describe(describable.getDisplayName());
+    }
+
+    /**
+     * Describes the given display path, clarifying when that path references the root project.
+     *
+     * @param displayPath the path to describe
+     * @return clarified description of the path
+     */
+    public static String describe(String displayPath) {
+        String pathAlone;
+        if (displayPath.startsWith(PROJECT_PREFIX)) {
+            pathAlone = displayPath.substring(PROJECT_PREFIX.length());
+        } else {
+            pathAlone = displayPath;
+        }
+        if (Path.path(pathAlone) == Path.ROOT) {
+            return displayPath + " (the root project)";
+        } else {
+            return displayPath;
+        }
+    }
+}

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DependencyResolutionFailure.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DependencyResolutionFailure.groovy
@@ -21,7 +21,7 @@ import java.util.regex.Pattern
 import static org.gradle.util.Matchers.*;
 import org.hamcrest.Matcher
 
-public class DependencyResolutionFailure {
+class DependencyResolutionFailure {
     private final ExecutionFailure failure
 
     DependencyResolutionFailure(ExecutionFailure failure, String configuration) {
@@ -34,8 +34,8 @@ public class DependencyResolutionFailure {
         this
     }
 
-    DependencyResolutionFailure assertFailedDependencyRequiredBy(String dependency) {
-        failure.assertThatCause(matchesRegexp("(?ms).*Required by:\\s+$dependency.*"))
+    DependencyResolutionFailure assertFailedDependencyRequiredBy(String dependencyRegex) {
+        failure.assertThatCause(matchesRegexp("(?ms).*Required by:\\s+$dependencyRegex.*"))
         this
     }
 


### PR DESCRIPTION
Not a large or complex change, despite 31 files touched.

- Passing `Describable` instead of name String to Failures.
- When abstract Failures are asked for requested name, `ProjectPathClarifyingDescriber` is used to add description.
- Update test expectations.

New message example:

```
FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':forceResolution'.
> Could not resolve all dependencies for configuration ':resolveMe'.
   > Could not resolve project : (the root project).
     Required by:
         project : (the root project)
      > Multiple incompatible variants of org.example:xbdp7:1.0 were selected:
           - Variant blueElementsCapability1 has attributes {color=blue}
           - Variant greenElementsCapability2 has attributes {color=green}
```

Continues #27858