### PR TITLE
Disable file-system watching on macOS 11 and before

### DIFF
--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
@@ -58,6 +58,7 @@ import org.gradle.internal.service.Provides;
 import org.gradle.internal.service.ServiceCreationException;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
+import org.gradle.util.internal.VersionNumber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -515,6 +516,14 @@ public class NativeServices extends DefaultServiceRegistry implements ServiceReg
 
             @Override
             public boolean useFileSystemWatching() {
+                OperatingSystem operatingSystem = OperatingSystem.current();
+                if (operatingSystem.isMacOsX()) {
+                    String version = operatingSystem.getVersion();
+                    if (VersionNumber.parse(version).getMajor() < 12) {
+                        LOGGER.info("Disabling file system watching on macOS {}, as it is only supported for macOS 12+", version);
+                        return false;
+                    }
+                }
                 return isFeatureEnabled(NativeFeatures.FILE_SYSTEM_WATCHING);
             }
         };

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/file_system_watching.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/file_system_watching.adoc
@@ -52,7 +52,7 @@ Gradle supports file system watching on the following operating systems:
 ** CentOS Stream 8 or later
 ** Red Hat Enterprise Linux (RHEL) 8 or later
 ** Amazon Linux 2 or later
-* macOS 10.14 (Mojave) or later on Intel and ARM architectures
+* macOS 12 (Monterey) or later on Intel and ARM architectures
 
 == Supported File Systems
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -71,6 +71,11 @@ However, before this release, the configuration cache subsystem did not follow t
 To address this issue, in the current release, all code originally under the `org.gradle.configurationcache*` packages
 (which was never API) has been moved to new internal packages (`org.gradle.internal.*`).
 
+=== File-system watching on macOS 11 (Big Sur) and earlier is disabled
+
+Since Gradle 8.8 file-system watching has only been supported on macOS 12 (Monterey) and later.
+We've now added a check to disable file-system watching on macOS 11 (Big Sur) and earlier automatically.
+
 [[changes_8.8]]
 == Upgrading from 8.7 and earlier
 


### PR DESCRIPTION
File-system watching only works well on macOS 12+. This updates the documentation and automatically disables it on macOS 11 and earlier.

New native code that breaks on macOS 11 and earlier was introduced in 8.8 in:

- https://github.com/gradle/gradle/pull/28259

*Note:* We don't have macOS 11 or earlier in our CI fleet, so we can't actually test this automatically.

Fixes #29476

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
