### PR TITLE
Refine mirror init script

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
@@ -67,6 +67,9 @@ val propagatedEnvironmentVariables = listOf(
     "BUILD_TYPE_ID",
     "JPROFILER_HOME",
 
+    // Used by mirror init script, see RepoScriptBlockUtil
+    "IGNORE_MIRROR",
+
     "LANG",
     "LANGUAGE",
     // It is possible to have many LC_xxx variables for different aspects of the locale. However, LC_ALL overrides all of them, and it is what CI uses.

--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/AbstractInitIntegrationSpec.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/AbstractInitIntegrationSpec.groovy
@@ -38,6 +38,7 @@ abstract class AbstractInitIntegrationSpec extends AbstractIntegrationSpec {
             // This is here to prevent Gradle searching up to find the build's settings.gradle
         """
         initializeIntoTestDir()
+        executer.withRepositoryMirrors()
     }
 
     void initializeIntoTestDir() {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
@@ -28,6 +28,10 @@ import static org.gradle.test.fixtures.dsl.GradleDsl.KOTLIN
 
 @CompileStatic
 class RepoScriptBlockUtil {
+    static boolean isMirrorEnabled() {
+        return !Boolean.parseBoolean(System.getenv("IGNORE_MIRROR"))
+    }
+
     static String repositoryDefinition(GradleDsl dsl = GROOVY, String type, String name, String url) {
         if (dsl == KOTLIN) {
             """

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -469,7 +469,9 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
 
     @Override
     public GradleExecuter usingInitScript(File initScript) {
-        initScripts.add(initScript);
+        if (RepoScriptBlockUtil.isMirrorEnabled()) {
+            initScripts.add(initScript);
+        }
         return this;
     }
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/mirror/SetMirrorsSampleModifier.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/mirror/SetMirrorsSampleModifier.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import static org.gradle.api.internal.artifacts.BaseRepositoryFactory.PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY;
 import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.gradlePluginRepositoryMirrorUrl;
+import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.isMirrorEnabled;
 
 public class SetMirrorsSampleModifier implements SampleModifier {
 
@@ -34,7 +35,7 @@ public class SetMirrorsSampleModifier implements SampleModifier {
 
     @Override
     public Sample modify(Sample sample) {
-        if (sample.getId().contains("usePluginsInInitScripts")) {
+        if (sample.getId().contains("usePluginsInInitScripts") || !isMirrorEnabled()) {
             // usePluginsInInitScripts asserts using https://repo.gradle.org/gradle/repo
             return sample;
         }

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunner.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunner.groovy
@@ -205,7 +205,12 @@ class CrossVersionPerformanceTestRunner extends PerformanceTestSpec {
                 distribution(new PerformanceTestGradleDistribution(dist, workingDir))
                 tasksToRun(this.tasksToRun as String[])
                 cleanTasks(this.cleanTasks as String[])
-                args((this.args + ['--stacktrace', '-I', RepoScriptBlockUtil.createMirrorInitScript().absolutePath, "-D${PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY}=${gradlePluginRepositoryMirrorUrl()}".toString()]) as String[])
+
+                if (RepoScriptBlockUtil.isMirrorEnabled()) {
+                    args((this.args + ['--stacktrace', '-I', RepoScriptBlockUtil.createMirrorInitScript().absolutePath, "-D${PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY}=${gradlePluginRepositoryMirrorUrl()}".toString()]) as String[])
+                } else {
+                    args((this.args + ['--stacktrace']) as String[])
+                }
                 jvmArgs(gradleOptsInUse as String[])
                 useDaemon(this.useDaemon)
                 useToolingApi(this.useToolingApi)

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -36,6 +36,7 @@ import org.gradle.util.internal.TextUtil
 import spock.lang.Specification
 import spock.lang.TempDir
 
+import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.createMirrorInitScript
 import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.gradlePluginRepositoryMirrorUrl
 import static org.gradle.test.fixtures.dsl.GradleDsl.GROOVY
 import static org.gradle.test.fixtures.server.http.MavenHttpPluginRepository.PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY
@@ -283,9 +284,16 @@ abstract class AbstractSmokeTest extends Specification {
     }
 
     private static List<String> repoMirrorParameters() {
-        return [
-            "-D${PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY}=${gradlePluginRepositoryMirrorUrl()}" as String,
-        ]
+        if (RepoScriptBlockUtil.isMirrorEnabled()) {
+            String mirrorInitScriptPath = createMirrorInitScript().absolutePath
+            return [
+                '--init-script', mirrorInitScriptPath,
+                "-D${PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY}=${gradlePluginRepositoryMirrorUrl()}" as String,
+                "-D${INIT_SCRIPT_LOCATION}=${mirrorInitScriptPath}" as String,
+            ]
+        } else {
+            return []
+        }
     }
 
     private static List<String> toolchainParameters() {


### PR DESCRIPTION
In the past, we used `RepoScriptBlockUtil` to inject an init script into all integration tests. The init script can configure repository mirrors. There are two problems found:

1. [This comparison](https://github.com/gradle/gradle/blob/master/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy#L187) compares plain string: `if (gradle.gradleVersion >= "8.8") {` - i.e. "8.10" < "8.8".
2. When we ran into the problem, we can't disable this mirror init script injection globally. Even though we have `IGNORE_MIRRORS` env varaible, the init scripts are still generated and passed to integration tests via `-I ...`.

This PR fixes problem 1) by doing correct comparison. Also, now `RepoScriptBlockUtil` respects `IGNORE_MIRRORS` - when it exists, skip doing the init script magic.