### PR TITLE
Intercept calls made through Groovy method pointers

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="EntryPointsManager">
-    <list size="2">
+    <list size="4">
       <item index="0" class="java.lang.String" itemvalue="com.tngtech.archunit.junit.ArchTest" />
-      <item index="1" class="java.lang.String" itemvalue="org.gradle.internal.service.Provides" />
       <item index="1" class="java.lang.String" itemvalue="org.gradle.internal.instrumentation.api.annotations.BytecodeUpgrade" />
+      <item index="2" class="java.lang.String" itemvalue="org.gradle.internal.instrumentation.api.annotations.InterceptJvmCalls" />
+      <item index="3" class="java.lang.String" itemvalue="org.gradle.internal.service.Provides" />
     </list>
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/undeclared/MethodReferenceInstrumentationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/undeclared/MethodReferenceInstrumentationIntegrationTest.groovy
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.inputs.undeclared
+
+
+import groovy.transform.MapConstructor
+import org.gradle.internal.cc.impl.AbstractConfigurationCacheIntegrationTest
+
+class MethodReferenceInstrumentationIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+    def "reference #reference is instrumented in dynamic groovy"() {
+        given:
+        testDirectory.file(file().path).text = file().expectedValue
+
+        buildFile """
+            import java.nio.file.*
+            import java.util.function.*
+
+            public String readInputWithReference() {
+                def input = ${input.expr}
+                $referenceType ref = $reference;
+                if (!(ref instanceof Serializable)) {
+                    throw new AssertionError("The lambda should be serializable!");
+                }
+                $consumerStatement
+            }
+
+            tasks.register("echo") {
+                def value = readInputWithReference()
+                doLast {
+                    println("value = \$value")
+                }
+            }
+        """
+
+        when:
+        configurationCacheRun("echo", "-D${systemProperty().path}=${systemProperty().expectedValue}")
+
+        then:
+        outputContains("value = ${input.expectedValue}")
+
+        problems.assertResultHasProblems(result) {
+            withInput("Build file 'build.gradle': ${input.expectedInput}")
+        }
+
+        where:
+        input            | referenceType                       | reference                  | consumerStatement
+        file()           | "Function<String, FileInputStream>" | "FileInputStream::new"     | "try (InputStream in = ref.apply(input)) { return in.text } "
+        file()           | "Closure"                           | "FileInputStream::new"     | "try (InputStream in = ref(input)) { return in.text } "
+        file()           | "Closure"                           | "FileInputStream.&new"     | "try (InputStream in = ref(input)) { return in.text } "
+        systemProperty() | "Function<String, String>"          | "System::getProperty"      | "return ref.apply(input)"
+        systemProperty() | "Closure"                           | "System::getProperty"      | "return ref(input)"
+        systemProperty() | "Closure"                           | "System.&getProperty"      | "return ref(input)"
+        fileEntry()      | "Function<File, Boolean>"           | "File::isFile"             | "return String.valueOf(ref.apply(new File(input)))"
+        fileEntry()      | "Closure"                           | "File::isFile"             | "return String.valueOf(ref(new File(input)))"
+        fileEntry()      | "Closure"                           | "File.&isFile"             | "return String.valueOf(ref(new File(input)))"
+        fileEntry()      | "Supplier<Boolean>"                 | "new File(input)::isFile"  | "return String.valueOf(ref.get())"
+        fileEntry()      | "Closure"                           | "new File(input)::isFile"  | "return String.valueOf(ref())"
+        fileEntry()      | "Closure"                           | "new File(input).&isFile"  | "return String.valueOf(ref())"
+        file()           | "Function<Path, BufferedReader>"    | "Files::newBufferedReader" | "try (BufferedReader in = ref.apply(Paths.get(input))) { return in.readLine() }"
+        file()           | "Closure"                           | "Files::newBufferedReader" | "try (BufferedReader in = ref(Paths.get(input))) { return in.readLine() }"
+        file()           | "Closure"                           | "Files.&newBufferedReader" | "try (BufferedReader in = ref(Paths.get(input))) { return in.readLine() }"
+    }
+
+    def "reference #reference is instrumented in dynamic untyped groovy"() {
+        given:
+        testDirectory.file(file().path).text = file().expectedValue
+
+        buildFile """
+            import java.nio.file.*
+            import java.util.function.*
+
+            public String readInputWithReference() {
+                def input = ${input.expr}
+                def ref = $reference;
+                if (!(ref instanceof Serializable)) {
+                    throw new AssertionError("The lambda should be serializable!");
+                }
+                $consumerStatement
+            }
+
+            tasks.register("echo") {
+                def value = readInputWithReference()
+                doLast {
+                    println("value = \$value")
+                }
+            }
+        """
+
+        when:
+        configurationCacheRun("echo", "-D${systemProperty().path}=${systemProperty().expectedValue}")
+
+        then:
+        outputContains("value = ${input.expectedValue}")
+
+        problems.assertResultHasProblems(result) {
+            withInput("Build file 'build.gradle': ${input.expectedInput}")
+        }
+
+        where:
+        input            | reference                  | consumerStatement
+        file()           | "FileInputStream::new"     | "try (InputStream in = ref(input)) { return in.text } "
+        file()           | "FileInputStream.&new"     | "try (InputStream in = ref(input)) { return in.text } "
+        systemProperty() | "System::getProperty"      | "return ref(input)"
+        systemProperty() | "System.&getProperty"      | "return ref(input)"
+        fileEntry()      | "File::isFile"             | "return String.valueOf(ref(new File(input)))"
+        fileEntry()      | "File.&isFile"             | "return String.valueOf(ref(new File(input)))"
+        fileEntry()      | "new File(input)::isFile"  | "return String.valueOf(ref())"
+        fileEntry()      | "new File(input).&isFile"  | "return String.valueOf(ref())"
+        file()           | "Files::newBufferedReader" | "try (BufferedReader in = ref(Paths.get(input))) { return in.readLine() }"
+        file()           | "Files.&newBufferedReader" | "try (BufferedReader in = ref(Paths.get(input))) { return in.readLine() }"
+    }
+
+    @MapConstructor
+    @SuppressWarnings('GrFinalVariableAccess')
+    private static class Input {
+        final String path
+        final String expr
+        final String expectedValue
+        final String expectedInput
+    }
+
+    private static Input file(String path = "input.txt") {
+        new Input(path: path, expr: "file(\"$path\").absolutePath", expectedValue: "file value", expectedInput: "file '$path'")
+    }
+
+    private static Input systemProperty(String path = "my.system.property") {
+        new Input(path: path, expr: "\"$path\"", expectedValue: "property value", expectedInput: "system property '$path'")
+    }
+
+    private static Input fileEntry(String path = "input.txt") {
+        new Input(path: path, expr: "file(\"$path\").absolutePath", expectedValue: "true", expectedInput: "file system entry '$path'")
+    }
+}

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/groovy/InterceptGroovyCallsGenerator.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/groovy/InterceptGroovyCallsGenerator.java
@@ -220,7 +220,7 @@ public class InterceptGroovyCallsGenerator extends RequestGroupingInstrumentatio
 
         new CodeGeneratingSignatureTreeVisitor(result).visit(tree, -1);
 
-        result.addStatement("return invocation.callOriginal()");
+        result.addStatement("return invocation.callNext()");
         return result.build();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/CallInterceptingMetaClass.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/CallInterceptingMetaClass.java
@@ -24,18 +24,18 @@ import groovy.lang.MetaMethod;
 import groovy.lang.MetaProperty;
 import groovy.lang.MissingMethodException;
 import groovy.lang.MissingPropertyException;
-import org.codehaus.groovy.reflection.CachedClass;
 import groovy.lang.Tuple;
+import org.codehaus.groovy.reflection.CachedClass;
 import org.codehaus.groovy.reflection.ClassInfo;
 import org.codehaus.groovy.runtime.MetaClassHelper;
 import org.gradle.api.NonNullApi;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Pair;
-import org.gradle.internal.classpath.intercept.AbstractInvocation;
 import org.gradle.internal.classpath.intercept.CallInterceptor;
 import org.gradle.internal.classpath.intercept.CallInterceptorResolver;
 import org.gradle.internal.classpath.intercept.InterceptScope;
 import org.gradle.internal.classpath.intercept.Invocation;
+import org.gradle.internal.classpath.intercept.InvocationImpl;
 import org.gradle.internal.classpath.intercept.PropertyAwareCallInterceptor;
 import org.gradle.internal.classpath.intercept.SignatureAwareCallInterceptor;
 import org.gradle.internal.metaobject.InstrumentedMetaClass;
@@ -83,6 +83,7 @@ public class CallInterceptingMetaClass extends MetaClassImpl implements Adapting
     }
 
     @Override
+    @Nullable
     public Object getProperty(Class sender, Object object, String name, boolean useSuper, boolean fromInsideClass) {
         if (useSuper || fromInsideClass) {
             return adaptee.getProperty(sender, object, name, useSuper, fromInsideClass);
@@ -92,6 +93,7 @@ public class CallInterceptingMetaClass extends MetaClassImpl implements Adapting
     }
 
     @Override
+    @Nullable
     public Object getProperty(Object object, String property) {
         return invokeIntercepted(object, GET_PROPERTY, property, NO_ARG, () -> adaptee.getProperty(object, property));
     }
@@ -165,6 +167,7 @@ public class CallInterceptingMetaClass extends MetaClassImpl implements Adapting
     }
 
     @Override
+    @Nullable
     public Object invokeMethod(Object object, String methodName, @Nullable Object arguments) {
         Object[] argsForInterceptor = arguments == null ? MetaClassHelper.EMPTY_ARRAY :
             arguments instanceof Tuple ? ((Tuple<?>) arguments).toArray() :
@@ -175,11 +178,13 @@ public class CallInterceptingMetaClass extends MetaClassImpl implements Adapting
     }
 
     @Override
+    @Nullable
     public Object invokeMethod(Object object, String methodName, Object[] arguments) {
         return invokeIntercepted(object, INVOKE_METHOD, methodName, arguments, () -> adaptee.invokeMethod(object, methodName, arguments));
     }
 
     @Override
+    @Nullable
     public Object invokeMethod(Class sender, Object object, String methodName, Object[] originalArguments, boolean isCallToSuper, boolean fromInsideClass) {
         if (isCallToSuper || fromInsideClass) {
             // Calls to super are not supported by the call interception mechanisms as of now
@@ -189,6 +194,7 @@ public class CallInterceptingMetaClass extends MetaClassImpl implements Adapting
     }
 
     @Override
+    @Nullable
     public MetaMethod pickMethod(String methodName, Class[] arguments) {
         String matchedCaller = callsTracker.findCallerForCurrentCallIfNotIntercepted(methodName, INVOKE_METHOD);
         MetaMethod original = adaptee.pickMethod(methodName, arguments);
@@ -214,6 +220,7 @@ public class CallInterceptingMetaClass extends MetaClassImpl implements Adapting
         return original;
     }
 
+    @Nullable
     private Object invokeIntercepted(Object receiver, InstrumentedGroovyCallsTracker.CallKind kind, String name, Object[] arguments, Callable<Object> invokeOriginal) {
         String matchedCaller = callsTracker.findCallerForCurrentCallIfNotIntercepted(name, kind);
         if (matchedCaller != null) {
@@ -297,6 +304,7 @@ public class CallInterceptingMetaClass extends MetaClassImpl implements Adapting
     }
     //endregion
 
+    @Nullable
     private static Object invokeWithInterceptor(InstrumentedGroovyCallsTracker callsTracker, CallInterceptor interceptor, String name, InstrumentedGroovyCallsTracker.CallKind kind, Object receiver, Object[] arguments, String consumerClass, Callable<Object> doCallOriginal) {
         final InvokedFlag invokedOriginal = new InvokedFlag();
 
@@ -319,19 +327,10 @@ public class CallInterceptingMetaClass extends MetaClassImpl implements Adapting
     }
 
     private static Invocation callOriginalReportingInvocation(Object receiver, Object[] arguments, Callable<Object> doCallOriginal, Runnable reportCallOriginal) {
-        @NonNullApi
-        class InvocationImpl extends AbstractInvocation<Object> {
-            public InvocationImpl(Object receiver, Object[] args) {
-                super(receiver, args);
-            }
-
-            @Override
-            public Object callOriginal() throws Exception {
-                reportCallOriginal.run();
-                return doCallOriginal.call();
-            }
-        }
-        return new InvocationImpl(receiver, arguments);
+        return new InvocationImpl<>(receiver, arguments, () -> {
+            reportCallOriginal.run();
+            return doCallOriginal.call();
+        });
     }
 
     @NonNullApi
@@ -403,6 +402,7 @@ public class CallInterceptingMetaClass extends MetaClassImpl implements Adapting
         }
 
         @Override
+        @Nullable
         public Object getProperty(Object object) {
             if (getterInterceptor != null) {
                 return invokeWithInterceptor(callsTracker, getterInterceptor, name, GET_PROPERTY, object, NO_ARG, consumerClass, () -> {
@@ -468,6 +468,7 @@ public class CallInterceptingMetaClass extends MetaClassImpl implements Adapting
         }
 
         @Override
+        @Nullable
         public Object invoke(Object object, Object[] arguments) {
             return invokeWithInterceptor(callsTracker, callInterceptor, name, INVOKE_METHOD, object, arguments, consumerClass, () -> {
                 if (original != null) {

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/Instrumented.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/Instrumented.java
@@ -497,7 +497,7 @@ public class Instrumented {
                 case 2:
                     return getInteger(invocation.getArgument(0).toString(), (Integer) invocation.getArgument(1), consumer);
             }
-            return invocation.callOriginal();
+            return invocation.callNext();
         }
     }
 
@@ -517,7 +517,7 @@ public class Instrumented {
                 case 2:
                     return getLong(invocation.getArgument(0).toString(), (Long) invocation.getArgument(1), consumer);
             }
-            return invocation.callOriginal();
+            return invocation.callNext();
         }
     }
 
@@ -534,7 +534,7 @@ public class Instrumented {
             if (invocation.getArgsCount() == 1) {
                 return getBoolean(invocation.getArgument(0).toString(), consumer);
             }
-            return invocation.callOriginal();
+            return invocation.callNext();
         }
     }
 
@@ -554,7 +554,7 @@ public class Instrumented {
                 case 2:
                     return systemProperty(invocation.getArgument(0).toString(), convertToString(invocation.getArgument(1)), consumer);
             }
-            return invocation.callOriginal();
+            return invocation.callNext();
         }
     }
 
@@ -571,7 +571,7 @@ public class Instrumented {
             if (invocation.getArgsCount() == 2) {
                 return setSystemProperty(convertToString(invocation.getArgument(0)), convertToString(invocation.getArgument(1)), consumer);
             }
-            return invocation.callOriginal();
+            return invocation.callNext();
         }
     }
 
@@ -590,7 +590,7 @@ public class Instrumented {
             if (invocation.getArgsCount() == 0) {
                 return systemProperties(consumer);
             }
-            return invocation.callOriginal();
+            return invocation.callNext();
         }
     }
 
@@ -608,7 +608,7 @@ public class Instrumented {
                 setSystemProperties((Properties) invocation.getArgument(0), consumer);
                 return null;
             }
-            return invocation.callOriginal();
+            return invocation.callNext();
         }
     }
 
@@ -625,7 +625,7 @@ public class Instrumented {
             if (invocation.getArgsCount() == 1) {
                 return clearSystemProperty(convertToString(invocation.getArgument(0)), consumer);
             }
-            return invocation.callOriginal();
+            return invocation.callNext();
         }
     }
 
@@ -645,7 +645,7 @@ public class Instrumented {
                 case 1:
                     return getenv(convertToString(invocation.getArgument(0)), consumer);
             }
-            return invocation.callOriginal();
+            return invocation.callNext();
         }
     }
 
@@ -670,7 +670,7 @@ public class Instrumented {
                     }
                 }
             }
-            return invocation.callOriginal();
+            return invocation.callNext();
         }
 
         private Optional<Process> tryCallExec(Object runtimeArg, Object commandArg, @Nullable Object envpArg, @Nullable Object fileArg, String consumer) throws Throwable {
@@ -717,7 +717,7 @@ public class Instrumented {
 
             if (nonCommandArgsCount != 0 && nonCommandArgsCount != 2) {
                 // This is an unsupported overload, skip interception.
-                return invocation.callOriginal();
+                return invocation.callNext();
             }
 
             Object commandArg = isStaticCall ? invocation.getArgument(0) : invocation.getReceiver();
@@ -729,7 +729,7 @@ public class Instrumented {
                     return result.get();
                 }
             }
-            return invocation.callOriginal();
+            return invocation.callNext();
         }
 
         private Optional<Process> tryCallExecute(Object commandArg, @Nullable Object envpArg, @Nullable Object fileArg, String consumer) throws Throwable {
@@ -780,7 +780,7 @@ public class Instrumented {
             if (receiver instanceof ProcessBuilder) {
                 return start((ProcessBuilder) receiver, consumer);
             }
-            return invocation.callOriginal();
+            return invocation.callNext();
         }
     }
 
@@ -798,7 +798,7 @@ public class Instrumented {
             if (invocation.getArgsCount() == 1 && invocation.getArgument(0) instanceof List) {
                 return startPipeline((List<ProcessBuilder>) invocation.getArgument(0), consumer);
             }
-            return invocation.callOriginal();
+            return invocation.callNext();
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/declarations/GroovyDynamicDispatchInterceptors.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/declarations/GroovyDynamicDispatchInterceptors.java
@@ -16,7 +16,9 @@
 
 package org.gradle.internal.classpath.declarations;
 
+import groovy.lang.Closure;
 import groovy.lang.GroovyObject;
+import org.codehaus.groovy.runtime.InvokerHelper;
 import org.codehaus.groovy.runtime.ScriptBytecodeAdapter;
 import org.gradle.api.NonNullApi;
 import org.gradle.internal.classpath.InstrumentedClosuresHelper;
@@ -32,6 +34,8 @@ import org.gradle.internal.instrumentation.api.annotations.ParameterKind.InjectV
 import org.gradle.internal.instrumentation.api.annotations.SpecificJvmCallInterceptors;
 import org.gradle.internal.instrumentation.api.declarations.InterceptorDeclaration;
 import org.gradle.internal.instrumentation.api.types.BytecodeInterceptorFilter;
+
+import javax.annotation.Nullable;
 
 import static org.gradle.internal.classpath.InstrumentedGroovyCallsHelper.withEntryPoint;
 import static org.gradle.internal.classpath.InstrumentedGroovyCallsTracker.CallKind.SET_PROPERTY;
@@ -84,5 +88,82 @@ public class GroovyDynamicDispatchInterceptors {
         } else {
             ScriptBytecodeAdapter.setProperty(messageArgument, senderClass, receiver, messageName);
         }
+    }
+
+    @InterceptJvmCalls
+    @CallableKind.StaticMethod(ofClass = ScriptBytecodeAdapter.class)
+    public static Closure<?> intercept_getMethodPointer(
+        Object owner,
+        @Nullable String methodName,
+        @CallerClassName String consumer,
+        @InjectVisitorContext BytecodeInterceptorFilter interceptorFilter
+    ) {
+        Closure<?> originalPointer = ScriptBytecodeAdapter.getMethodPointer(owner, methodName);
+
+        if (methodName == null) {
+            // It isn't clear if "null" is an allowed method name, but we cannot intercept it anyway.
+            return originalPointer;
+        }
+        // TODO(mlopatkin): ClosureCallInterceptorResolver is a strange name for a general interceptor-providing routine.
+        CallInterceptorResolver resolver = ClosureCallInterceptorResolver.of(interceptorFilter);
+        InterceptScope scope = isConstructorMethodRef(owner, methodName)
+            ? InterceptScope.constructorsOf((Class<?>) owner)
+            : InterceptScope.methodsNamed(methodName);
+        CallInterceptor interceptor = resolver.resolveCallInterceptor(scope);
+        if (interceptor == null) {
+            return originalPointer;
+        }
+
+        class MethodRefInterceptorClosure extends Closure<Object> {
+            public MethodRefInterceptorClosure() {
+                super(owner);
+            }
+
+            @SuppressWarnings("unused")  // Called by Groovy runtime
+            @Nullable
+            public Object doCall(Object... arguments) throws Throwable {
+                Object owner = getOwner();
+                // Method pointers and method references may be bound (foo::getBar) or unbound (Foo::getBar).
+                // The bound pointer has the receiver as the owner.
+                // The unbound one has a class as an owner and gets the receiver as a first argument when invoked.
+                // The latter is therefore indistinguishable from a static method that receives an instance of owner as a first argument.
+                // However, the instance method interceptor won't match the arguments of the static-like invocation, and some adaptation is needed.
+                // Let's try to intercept without any preparation first, to avoid extra work on a happy path.
+                // This covers static methods and bound instance invocations.
+                return interceptor.intercept(
+                    new InvocationImpl<>(owner, arguments, () -> {
+                        // If we're here, a static method or bound instance method invocation weren't intercepted.
+                        // We can still try to intercept an unbound invocation.
+                        if (canBeUnboundInstanceMethodInvocation(owner, arguments)) {
+                            Object maybeInstanceReceiver = arguments[0];
+                            Object[] boundCallArguments = subArray(arguments, 1);
+                            // Let's try to intercept instance method and fall back to the original call if it also fails.
+                            return interceptor.intercept(
+                                new InvocationImpl<>(maybeInstanceReceiver, boundCallArguments, () -> InvokerHelper.invokeClosure(originalPointer, arguments)),
+                                consumer
+                            );
+                        }
+                        return InvokerHelper.invokeClosure(originalPointer, arguments);
+                    }),
+                    consumer
+                );
+            }
+
+            private boolean canBeUnboundInstanceMethodInvocation(Object owner, Object[] arguments) {
+                return arguments.length > 0 && owner instanceof Class<?> && ((Class<?>) owner).isInstance(arguments[0]);
+            }
+
+            private Object[] subArray(Object[] array, int pos) {
+                Object[] subArray = new Object[array.length - pos];
+                System.arraycopy(array, pos, subArray, 0, subArray.length);
+                return subArray;
+            }
+        }
+
+        return new MethodRefInterceptorClosure();
+    }
+
+    private static boolean isConstructorMethodRef(Object owner, String methodName) {
+        return "new".equals(methodName) && owner instanceof Class<?>;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/AbstractCallInterceptor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/AbstractCallInterceptor.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSet;
 import org.codehaus.groovy.vmplugin.v8.IndyInterface;
 import org.gradle.api.GradleException;
 
+import javax.annotation.Nullable;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -51,6 +52,7 @@ public abstract class AbstractCallInterceptor implements CallInterceptor {
         return decorated.asCollector(Object[].class, original.type().parameterCount()).asType(original.type());
     }
 
+    @Nullable
     private Object interceptMethodHandle(MethodHandle original, int flags, String consumer, Object[] args) throws Throwable {
         boolean isSpread = (flags & IndyInterface.SPREAD_CALL) != 0;
         return intercept(new MethodHandleInvocation(original, args, isSpread), consumer);

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/CallInterceptor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/CallInterceptor.java
@@ -18,6 +18,7 @@ package org.gradle.internal.classpath.intercept;
 
 import org.codehaus.groovy.runtime.callsite.CallSite;
 
+import javax.annotation.Nullable;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.util.Set;
@@ -43,6 +44,7 @@ public interface CallInterceptor {
      * @return the value to return to the caller
      * @throws Throwable if necessary to propagate it to the caller
      */
+    @Nullable
     Object intercept(Invocation invocation, String consumer) throws Throwable;
 
     MethodHandle decorateMethodHandle(MethodHandle original, MethodHandles.Lookup caller, int flags);

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/ClassBoundCallInterceptor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/ClassBoundCallInterceptor.java
@@ -38,7 +38,7 @@ public abstract class ClassBoundCallInterceptor extends AbstractCallInterceptor 
     @Nullable
     public final Object intercept(Invocation invocation, String consumer) throws Throwable {
         if (!expectedReceiver.equals(invocation.getReceiver())) {
-            return invocation.callOriginal();
+            return invocation.callNext();
         }
         return interceptSafe(invocation, consumer);
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/ClassBoundCallInterceptor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/ClassBoundCallInterceptor.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.classpath.intercept;
 
+import javax.annotation.Nullable;
+
 /**
  * A special case of the CallInterceptor for static methods and static properties.
  * It only intercepts the calls where the receiver is the class of interest.
@@ -33,6 +35,7 @@ public abstract class ClassBoundCallInterceptor extends AbstractCallInterceptor 
     }
 
     @Override
+    @Nullable
     public final Object intercept(Invocation invocation, String consumer) throws Throwable {
         if (!expectedReceiver.equals(invocation.getReceiver())) {
             return invocation.callOriginal();
@@ -49,5 +52,6 @@ public abstract class ClassBoundCallInterceptor extends AbstractCallInterceptor 
      * @return the value to return to the caller
      * @throws Throwable if necessary to propagate it to the caller
      */
+    @Nullable
     protected abstract Object interceptSafe(Invocation invocation, String consumer) throws Throwable;
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/CompositeCallInterceptor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/CompositeCallInterceptor.java
@@ -32,9 +32,11 @@ public class CompositeCallInterceptor extends AbstractCallInterceptor implements
     }
 
     @Override
+    @Nullable
     public Object intercept(Invocation invocation, String consumer) throws Throwable {
         return first.intercept(new Invocation() {
             @Override
+            @Nullable
             public Object getReceiver() {
                 return invocation.getReceiver();
             }
@@ -45,11 +47,13 @@ public class CompositeCallInterceptor extends AbstractCallInterceptor implements
             }
 
             @Override
+            @Nullable
             public Object getArgument(int pos) {
                 return invocation.getArgument(pos);
             }
 
             @Override
+            @Nullable
             public Object callOriginal() throws Throwable {
                 return second.intercept(invocation, consumer);
             }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/CompositeCallInterceptor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/CompositeCallInterceptor.java
@@ -54,7 +54,7 @@ public class CompositeCallInterceptor extends AbstractCallInterceptor implements
 
             @Override
             @Nullable
-            public Object callOriginal() throws Throwable {
+            public Object callNext() throws Throwable {
                 return second.intercept(invocation, consumer);
             }
         }, consumer);

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/DefaultCallSiteDecorator.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/DefaultCallSiteDecorator.java
@@ -61,7 +61,7 @@ public class DefaultCallSiteDecorator implements CallSiteDecorator, CallIntercep
                     return realConstructorInterceptor.intercept(invocation, consumer);
                 }
             }
-            return invocation.callOriginal();
+            return invocation.callNext();
         }
     };
 

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/DefaultCallSiteDecorator.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/DefaultCallSiteDecorator.java
@@ -52,6 +52,7 @@ public class DefaultCallSiteDecorator implements CallSiteDecorator, CallIntercep
     // dedicated MethodHandle decorator method just for constructors.
     private final CallInterceptor dispatchingConstructorInterceptor = new AbstractCallInterceptor() {
         @Override
+        @Nullable
         public Object intercept(Invocation invocation, String consumer) throws Throwable {
             Object receiver = invocation.getReceiver();
             if (receiver instanceof Class) {
@@ -150,55 +151,51 @@ public class DefaultCallSiteDecorator implements CallSiteDecorator, CallIntercep
         }
 
         @Override
+        @Nullable
         public Object call(Object receiver, Object[] args) throws Throwable {
             CallInterceptor interceptor = resolveCallInterceptor(InterceptScope.methodsNamed(getName()));
             if (interceptor != null) {
-                return interceptor.intercept(new AbstractInvocation<Object>(receiver, args) {
-                    @Override
-                    public Object callOriginal() throws Throwable {
-                        return DecoratingCallSite.super.call(receiver, args);
-                    }
-                }, callSiteOwnerClassName());
+                return interceptor.intercept(
+                    new InvocationImpl<>(receiver, args, () -> super.call(receiver, args)),
+                    callSiteOwnerClassName()
+                );
             }
             return super.call(receiver, args);
         }
 
         @Override
+        @Nullable
         public Object callGetProperty(Object receiver) throws Throwable {
             CallInterceptor interceptor = resolveCallInterceptor(InterceptScope.readsOfPropertiesNamed(getName()));
             if (interceptor != null) {
-                return interceptor.intercept(new AbstractInvocation<Object>(receiver, new Object[0]) {
-                    @Override
-                    public Object callOriginal() throws Throwable {
-                        return DecoratingCallSite.super.callGetProperty(receiver);
-                    }
-                }, array.owner.getName());
+                return interceptor.intercept(
+                    new InvocationImpl<>(receiver, new Object[0], () -> super.callGetProperty(receiver)),
+                    callSiteOwnerClassName()
+                );
             }
             return super.callGetProperty(receiver);
         }
 
         @Override
+        @Nullable
         public Object callStatic(Class receiver, Object[] args) throws Throwable {
             CallInterceptor interceptor = resolveCallInterceptor(InterceptScope.methodsNamed(getName()));
             if (interceptor != null) {
-                return interceptor.intercept(new AbstractInvocation<Class<?>>(receiver, args) {
-                    @Override
-                    public Object callOriginal() throws Throwable {
-                        return DecoratingCallSite.super.callStatic(receiver, args);
-                    }
-                }, callSiteOwnerClassName());
+                return interceptor.intercept(
+                    new InvocationImpl<>(receiver, args, () ->super.callStatic(receiver, args)),
+                    callSiteOwnerClassName()
+                );
             }
             return super.callStatic(receiver, args);
         }
 
         @Override
+        @Nullable
         public Object callConstructor(Object receiver, Object[] args) throws Throwable {
-            return dispatchingConstructorInterceptor.intercept(new AbstractInvocation<Object>(receiver, args) {
-                @Override
-                public Object callOriginal() throws Throwable {
-                    return DecoratingCallSite.super.callConstructor(receiver, args);
-                }
-            }, callSiteOwnerClassName());
+            return dispatchingConstructorInterceptor.intercept(
+                new InvocationImpl<>(receiver, args, () -> super.callConstructor(receiver, args)),
+                callSiteOwnerClassName()
+            );
         }
 
         private @Nullable Object maybeInstrumentedDynamicCall(

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/Invocation.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/Invocation.java
@@ -68,11 +68,14 @@ public interface Invocation {
     }
 
     /**
-     * Forwards the call to the original Groovy implementation and returns the result.
+     * Forwards the call to the next handler and returns the result.
+     * Used by interceptors when they decide that this invocation doesn't match their interception criteria or to delegate the actual call.
+     * In simple cases, the next handler just calls the original Groovy implementation.
+     * However, some invocation implementation may delegate to other interceptors.
      *
-     * @return the value produced by the original Groovy implementation
-     * @throws Throwable if the original Groovy implementation throws
+     * @return the value produced by the next handler
+     * @throws Throwable if the next handler throws
      */
     @Nullable
-    Object callOriginal() throws Throwable;
+    Object callNext() throws Throwable;
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/Invocation.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/Invocation.java
@@ -18,6 +18,8 @@ package org.gradle.internal.classpath.intercept;
 
 import org.codehaus.groovy.runtime.callsite.CallSite;
 
+import javax.annotation.Nullable;
+
 /**
  * Represents a single invocation of the intercepted method/constructor/property.
  */
@@ -30,6 +32,7 @@ public interface Invocation {
      * @return the receiver of the method
      * @see CallSite
      */
+    @Nullable
     Object getReceiver();
 
     /**
@@ -45,6 +48,7 @@ public interface Invocation {
      * @param pos the position of the argument
      * @return the unwrapped value of the argument
      */
+    @Nullable
     Object getArgument(int pos);
 
     /**
@@ -58,6 +62,7 @@ public interface Invocation {
      * @param pos the position of the argument
      * @return the unwrapped value of the argument or {@code null} if {@code pos >= getArgsCount()}
      */
+    @Nullable
     default Object getOptionalArgument(int pos) {
         return pos < getArgsCount() ? getArgument(pos) : null;
     }
@@ -68,5 +73,6 @@ public interface Invocation {
      * @return the value produced by the original Groovy implementation
      * @throws Throwable if the original Groovy implementation throws
      */
+    @Nullable
     Object callOriginal() throws Throwable;
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/InvocationImpl.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/InvocationImpl.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
 import static org.gradle.internal.classpath.intercept.InvocationUtils.unwrap;
 
 /**
- * A base implementation of the Invocation that provides everything except {@link #callOriginal()}.
+ * A simple implementation of the Invocation that accepts a lambda for {@link #callNext()} implementation.
  *
  * @param <R> the type of the receiver
  */
@@ -35,10 +35,10 @@ public final class InvocationImpl<R> implements Invocation {
     private final Object[] args;
     private final ThrowingSupplier callOriginal;
 
-    public InvocationImpl(R receiver, Object[] args, ThrowingSupplier callOriginal) {
+    public InvocationImpl(R receiver, Object[] args, ThrowingSupplier callNext) {
         this.receiver = receiver;
         this.args = args;
-        this.callOriginal = callOriginal;
+        this.callOriginal = callNext;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/InvocationImpl.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/InvocationImpl.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.classpath.intercept;
 
+import javax.annotation.Nullable;
+
 import static org.gradle.internal.classpath.intercept.InvocationUtils.unwrap;
 
 /**
@@ -23,17 +25,24 @@ import static org.gradle.internal.classpath.intercept.InvocationUtils.unwrap;
  *
  * @param <R> the type of the receiver
  */
-public abstract class AbstractInvocation<R> implements Invocation {
-    protected final R receiver;
-    protected final Object[] args;
+public final class InvocationImpl<R> implements Invocation {
+    @FunctionalInterface
+    public interface ThrowingSupplier {
+        @Nullable Object get() throws Throwable;
+    }
 
-    public AbstractInvocation(R receiver, Object[] args) {
+    private final R receiver;
+    private final Object[] args;
+    private final ThrowingSupplier callOriginal;
+
+    public InvocationImpl(R receiver, Object[] args, ThrowingSupplier callOriginal) {
         this.receiver = receiver;
         this.args = args;
+        this.callOriginal = callOriginal;
     }
 
     @Override
-    public Object getReceiver() {
+    public R getReceiver() {
         return receiver;
     }
 
@@ -43,8 +52,14 @@ public abstract class AbstractInvocation<R> implements Invocation {
     }
 
     @Override
+    @Nullable
     public Object getArgument(int pos) {
         return unwrap(args[pos]);
     }
 
+    @Override
+    @Nullable
+    public Object callNext() throws Throwable {
+        return callOriginal.get();
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/InvocationUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/InvocationUtils.java
@@ -18,9 +18,12 @@ package org.gradle.internal.classpath.intercept;
 
 import org.codehaus.groovy.runtime.wrappers.Wrapper;
 
+import javax.annotation.Nullable;
+
 class InvocationUtils {
     private InvocationUtils() {}
 
+    @Nullable
     static Object unwrap(Object obj) {
         if (obj instanceof Wrapper) {
             return ((Wrapper) obj).unwrap();

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/MethodHandleInvocation.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/MethodHandleInvocation.java
@@ -60,7 +60,7 @@ class MethodHandleInvocation implements Invocation {
 
     @Override
     @Nullable
-    public Object callOriginal() throws Throwable {
+    public Object callNext() throws Throwable {
         return original.invokeExact(originalArgs);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/MethodHandleInvocation.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/MethodHandleInvocation.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.classpath.intercept;
 
+import javax.annotation.Nullable;
 import java.lang.invoke.MethodHandle;
 
 import static org.gradle.internal.classpath.intercept.InvocationUtils.unwrap;
@@ -52,11 +53,13 @@ class MethodHandleInvocation implements Invocation {
     }
 
     @Override
+    @Nullable
     public Object getArgument(int pos) {
         return unwrap(unspreadArgs[pos + unspreadArgsOffset]);
     }
 
     @Override
+    @Nullable
     public Object callOriginal() throws Throwable {
         return original.invokeExact(originalArgs);
     }


### PR DESCRIPTION
We replace the closure returned by `ScriptBytecodeAdapter.getMethodPointer` with a special implementation that attempts to intercept the invocation when called.

Part of #24713.