### PR TITLE
Cleanup "Upgrading Version 8" page of User Manual page for Gradle 8.9RC1 release

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -41,6 +41,7 @@ The previous step will help you identify potential problems by issuing deprecati
 === Potential breaking changes
 
 ==== Change to toolchain provisioning
+
 In previous versions of Gradle, toolchain provisioning could leave a partially provisioned toolchain in place **with a marker file indicating that the toolchain was fully provisioned**. This could lead to strange behavior with the toolchain. In Gradle 8.9, the toolchain is fully provisioned before the marker file is written. However, to not detect potentially broken toolchains, a different marker file (`.ready`) is used. This means all your existing toolchains will be re-provisioned the first time you use them with Gradle 8.9. Gradle 8.9 also writes the old marker file (`provisioned.ok`) to indicate that the toolchain was fully provisioned. This means that if you return to an older version of Gradle, an 8.9-provisioned toolchain will **not** be re-provisioned.
 
 ==== Upgrade to Kotlin 1.9.23
@@ -48,6 +49,7 @@ In previous versions of Gradle, toolchain provisioning could leave a partially p
 The embedded Kotlin has been updated from 1.9.22 to link:https://github.com/JetBrains/kotlin/releases/tag/v1.9.23[Kotlin 1.9.23].
 
 ==== Change the encoding of daemon log files
+
 In previous versions of Gradle, the daemon log file, located at `$<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>/daemon/{gradleVersion}/`, was encoded with the default JVM encoding.
 This file is now always encoded with UTF-8 to prevent clients who may use different default encodings from reading data incorrectly.
 This change may affect third-party tools trying to read this file.
@@ -672,7 +674,7 @@ Publishing dependencies with an explicit artifact with a name different from the
 This behavior is still permitted when publishing to Ivy repositories.
 It will result in an error in Gradle 9.0.
 
-Currently, when publishing to Maven repositories, Gradle will interpret the dependency below as if it were declared with coordinates `org:notfoo:1.0`.
+When publishing to Maven repositories, Gradle will interpret the dependency below as if it were declared with coordinates `org:notfoo:1.0`:
 
 =====
 [.multi-language-sample]
@@ -732,12 +734,13 @@ dependencies {
 
 [[deprecated_artifact_identifier]]
 ==== Deprecated `ArtifactIdentifier`
+
 The `ArtifactIdentifier` class has been deprecated for removal in Gradle 9.0.
 
 [[dependency_mutate_dependency_collector_after_finalize]]
 ==== Deprecate mutating `DependencyCollector` dependencies after observation
 
-Starting in Gradle 9.0, mutating dependencies sourced from a link:{javadocPath}/org/gradle/api/artifacts/dsl/DependencyCollector.html[DependencyCollector] after those dependencies have been observed will result in an error.
+Starting in Gradle 9.0, mutating dependencies sourced from a link:{javadocPath}/org/gradle/API/artifacts/DSL/DependencyCollector.html[DependencyCollector], after those dependencies have been observed, will result in an error.
 The `DependencyCollector` interface is used to declare dependencies within the test suites DSL.
 
 Consider the following example where a test suite's dependency is mutated after it is observed:
@@ -822,7 +825,7 @@ In general, the `groovy-base` plugin should be applied whenever working with Gro
 
 ==== Provider.filter
 
-The type of the argument passed to `Provider.filter` is changed from `Predicate` to `Spec` for a more consistent API.
+The type of argument passed to `Provider.filter` is changed from `Predicate` to `Spec` for a more consistent API.
 This change should not affect anyone using `Provider.filter` with a lambda expression.
 However, this might affect plugin authors if they don't use SAM conversions to create a lambda.
 
@@ -839,21 +842,21 @@ These members will be removed in Gradle 9.0:
 [[depending_on_root_configuration]]
 ==== Deprecated depending on resolved configuration
 
-When resolving a `Configuration`, it is sometimes possible to select that same configuration as a variant.
+When resolving a `Configuration`, selecting that same configuration as a variant is sometimes possible.
 Configurations should be used for one purpose (resolution, consumption or dependency declarations), so this can only occur when a configuration is marked as both consumable and resolvable.
 
-This can lead to confusing circular dependency graphs, as the configuration being resolved is used for two different purposes.
+This can lead to circular dependency graphs, as the resolved configuration is used for two purposes.
 
 To avoid this problem, plugins should mark all resolvable configurations as `canBeConsumed=false` or use the `resolvable(String)` configuration factory method when creating configurations meant for resolution.
 
-In Gradle 9.0, consuming configurations in this manner will no longer be allowed and will result in an error.
+In Gradle 9.0, consuming configurations in this manner will no longer be allowed and result in an error.
 
 [[deprecated_missing_project_directory]]
 ==== Including projects without an existing directory
 
 Gradle will warn if a project is added to the build where the associated `projectDir` does not exist or is not writable.
 Starting with version 9.0, Gradle will not run builds if a project directory is missing or read-only.
-If you intend to dynamically synthesize projects make sure to create directories for them as well:
+If you intend to dynamically synthesize projects, make sure to create directories for them as well:
 
 =====
 [.multi-language-sample]
@@ -876,7 +879,6 @@ project(":project-without-directory").projectDir.mkdirs()
 ======
 =====
 
-
 [[changes_8.4]]
 == Upgrading from 8.3 and earlier
 
@@ -889,11 +891,11 @@ The embedded Kotlin has been updated to link:https://github.com/JetBrains/kotlin
 ==== XML parsing now requires recent parsers
 
 Gradle 8.4 now configures XML parsers with security features enabled.
-If your build logic has dependencies on old XML parsers that don't support secure parsing, your build may now fail.
+If your build logic depends on old XML parsers that don't support secure parsing, your build may fail.
 If you encounter a failure, check and update or remove any dependency on legacy XML parsers.
 
 If you are unable to upgrade XML parsers coming from your build logic dependencies, you can force the use of the XML parsers built into the JVM.
-For example, in OpenJDK this can be done by adding the following to `gradle.properties`:
+In OpenJDK, for example, this can be done by adding the following to `gradle.properties`:
 ```
 systemProp.javax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl
 systemProp.javax.xml.transform.TransformerFactory=com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl
@@ -945,7 +947,7 @@ ear {
 ======
 =====
 
-If you happen to use `asNode()` instead of `asElement()` then nothing changes given `asNode()` simply ignores external DTDs.
+If you happen to use `asNode()` instead of `asElement()`, then nothing changes, given `asNode()` simply ignores external DTDs.
 
 You can work around this by running your build with the `javax.xml.accessExternalDTD` system property set to `http`.
 
@@ -993,11 +995,11 @@ See <<#project_builddir, the deprecation entry>> for details.
 
 The `TestLauncher` interface is part of the Tooling API, specialized for running tests.
 It is a logical extension of the `BuildLauncher` that can only launch tasks.
-A discrepancy has been reported in their behavior: if the same failing test is executed, `BuildLauncher` will report a build failure but `TestLauncher` won't.
+A discrepancy has been reported in their behavior: if the same failing test is executed, `BuildLauncher` will report a build failure, but `TestLauncher` won't.
 Originally, this was a design decision in order to continue the execution and run the tests in all test tasks and not stop at the first failure.
 At the same time, this behavior can be confusing for users as they can experience a failing test in a successful build.
 To make the two APIs more uniform, we made `TestLauncher` also fail the build, which is a potential breaking change.
-To continue the test execution even if a test task failed, Tooling API clients should explicitly pass `--continue` to the build.
+Tooling API clients should explicitly pass `--continue` to the build to continue the test execution even if a test task fails.
 
 [[legacy_attribute_snapshotting]]
 ==== Fixed variant selection behavior with `ArtifactView` and `ArtifactCollection`
@@ -1005,7 +1007,8 @@ To continue the test execution even if a test task failed, Tooling API clients s
 The dependency resolution APIs for selecting different artifacts or files (`Configuration.getIncoming().artifactView { }` and `Configuration.getIncoming().getArtifacts()`) captured immutable copies of the underlying `Configuration`'s attributes to use for variant selection.
 If the `Configuration`'s attributes were changed after these methods were called, the artifacts selected by these methods could be unexpected.
 
-Consider the case where the set of attributes on a `Configuration` is changed after an `ArtifactView` is created.
+Consider the case where the set of attributes on a `Configuration` is changed after an `ArtifactView` is created:
+
 ====
 [.multi-language-sample]
 =====
@@ -1035,7 +1038,7 @@ configurations {
 ====
 
 The `inputFiles` property of `myTask` uses an artifact view to select a different type of artifact from the configuration `classpath`.
-Since the artifact view was created before the attributes were added to the configuration, Gradle was not able to select the correct artifact.
+Since the artifact view was created before the attributes were added to the configuration, Gradle could not select the correct artifact.
 
 Some builds may have worked around this by also putting the additional attributes into the artifact view. This is no longer necessary.
 
@@ -1043,7 +1046,7 @@ Some builds may have worked around this by also putting the additional attribute
 ==== Upgrade to Kotlin 1.9.0
 
 The embedded Kotlin has been updated from 1.8.20 to link:https://github.com/JetBrains/kotlin/releases/tag/v1.9.0[Kotlin 1.9.0].
-The Kotlin language and API levels for the Kotlin DSL are still set to 1.8 for backwards compatibility.
+The Kotlin language and API levels for the Kotlin DSL are still set to 1.8 for backward compatibility.
 See the release notes for link:https://github.com/JetBrains/kotlin/releases/tag/v1.8.22[Kotlin 1.8.22] and link:https://github.com/JetBrains/kotlin/releases/tag/v1.8.21[Kotlin 1.8.21].
 
 Kotlin 1.9 dropped support for Kotlin language and API level 1.3.
@@ -1063,8 +1066,8 @@ The value for property 'languageVersion' is final and cannot be changed any furt
 The value for property 'vendor' is final and cannot be changed any further.
 ```
 
-This situation may arise when plugins or build logic eagerly queries an existing JVM Configuration's attributes to create a new Configuration with the same attributes.
-Previously, this logic would have omitted the two above noted attributes entirely, while now the same logic will copy the attributes and finalize the project's Java toolchain.
+This situation may arise when plugins or build logic eagerly query an existing JVM Configuration's attributes to create a new Configuration with the same attributes.
+Previously, this logic would have omitted the two above-noted attributes entirely, while now, the same logic will copy the attributes and finalize the project's Java toolchain.
 To avoid early toolchain finalization, attribute-copying logic should be updated to query the source Configuration's attributes lazily:
 
 =====
@@ -1103,7 +1106,6 @@ configurations {
 ======
 =====
 
-
 === Deprecations
 
 [[project_builddir]]
@@ -1117,13 +1119,13 @@ It is replaced by a `link:{javadocPath}/org/gradle/api/file/DirectoryProperty.ht
 See the `link:{groovyDslPath}/org.gradle.api.file.ProjectLayout.html[ProjectLayout]` interface for details.
 
 Note that, at this stage, Gradle will not print deprecation warnings if you still use `Project.buildDir`.
-We know this is a big change and want to give time for authors of major plugins to move away from its usage first.
+We know this is a big change, and we want to give the authors of major plugins time to stop using it.
 
-The switch from a `File` to a `DirectoryProperty` requires adaptations in build logic.
+Switching from a `File` to a `DirectoryProperty` requires adaptations in build logic.
 The main impact is that you cannot use the property inside a `String` to expand it.
-Instead, you should leverage the `dir` and `file` methods to compute the location you want.
+Instead, you should leverage the `dir` and `file` methods to compute your desired location.
 
-Here is an example for creating a file, where the following:
+Here is an example of creating a file where the following:
 
 =====
 [.multi-language-sample]
@@ -1146,7 +1148,7 @@ file("$buildDir/myOutput.txt")
 ======
 =====
 
-should be replaced by:
+Should be replaced by:
 
 =====
 [.multi-language-sample]
@@ -1181,7 +1183,7 @@ output.map { it.asFile.path }
 ======
 =====
 
-Here is another example for creating a directory, where the following:
+Here is another example for creating a directory where the following:
 
 =====
 [.multi-language-sample]
@@ -1204,7 +1206,7 @@ file("$buildDir/outputLocation")
 ======
 =====
 
-should be replaced by:
+Should be replaced by:
 
 =====
 [.multi-language-sample]
@@ -1487,7 +1489,7 @@ Current usages of these methods should migrate to `link:{javadocPath}/org/gradle
 
 Gradle will now warn at runtime when methods of link:{javadocPath}/org/gradle/api/artifacts/Configuration.html--[Configuration] are called inconsistently with the configuration's intended usage.
 
-This change is part of a larger ongoing effort to make the intended behavior of configurations more consistent and predictable, and to unlock further speed and memory improvements.
+This change is part of a larger ongoing effort to make the intended behavior of configurations more consistent and predictable and to unlock further speed and memory improvements.
 
 Currently, the following methods should only be called with these listed allowed usages:
 
@@ -1505,7 +1507,7 @@ This list is likely to grow in future releases.
 
 Starting in Gradle 9.0, using a configuration inconsistently with its intended usage will be prohibited.
 
-Also note that although it is not currently restricted, the `getDependencies()` method is really only intended for use with DECLARABLE configurations.
+Also note that although it is not currently restricted, the `getDependencies()` method is only intended for use with DECLARABLE configurations.
 The `getAllDependencies()` method, which retrieves all declared dependencies on a configuration and any superconfigurations, will not be restricted to any particular usage.
 
 [[deprecated_access_to_conventions]]
@@ -1526,10 +1528,10 @@ Doing so will now emit a deprecation warning.
 This will become an error in Gradle 9.0.
 You should prefer accessing the extensions and their properties instead.
 
-For specific examples see the next sections.
+For specific examples, see the next sections.
 
 Prominent community plugins already migrated to using extensions to provide custom DSLs.
-Some of them still registers conventions for backwards compatibility.
+Some of them still register conventions for backward compatibility.
 Registering conventions does not emit a deprecation warning yet to provide a migration window.
 Future Gradle versions will do.
 
@@ -1540,11 +1542,11 @@ To fix this these plugins should be recompiled with Gradle >= 8.2 or changed to 
 ==== Deprecated `base` plugin conventions
 
 The convention properties contributed by the `base` plugin have been deprecated and scheduled for removal in Gradle 9.0.
-For the wider context see the <<deprecated_access_to_conventions, section about plugin convention deprecation>>.
+For more context, see the <<deprecated_access_to_conventions, section about plugin convention deprecation>>.
 
 The conventions are replaced by the `base { }` configuration block backed by link:{groovyDslPath}/org.gradle.api.plugins.BasePluginExtension.html[BasePluginExtension].
-The old convention object defines the `distsDirName`, `libsDirName` and `archivesBaseName` properties with simple getter and setter methods.
-Those methods are available in the extension only to maintain backwards compatibility.
+The old convention object defines the `distsDirName,` `libsDirName`, and `archivesBaseName` properties with simple getter and setter methods.
+Those methods are available in the extension only to maintain backward compatibility.
 Build scripts should solely use the properties of type `Property`:
 
 ====
@@ -1585,8 +1587,8 @@ base {
 [[application_convention_deprecation]]
 ==== Deprecated `application` plugin conventions
 
-The convention properties contributed by the `application` plugin have been deprecated and scheduled for removal in Gradle 9.0.
-For the wider context see the <<deprecated_access_to_conventions, section about plugin convention deprecation>>.
+The convention properties the `application` plugin contributed have been deprecated and scheduled for removal in Gradle 9.0.
+For more context, see the <<deprecated_access_to_conventions, section about plugin convention deprecation>>.
 
 The following code will now emit deprecation warnings:
 
@@ -1653,8 +1655,8 @@ application {
 [[java_convention_deprecation]]
 ==== Deprecated `java` plugin conventions
 
-The convention properties contributed by the `java` plugin have been deprecated and scheduled for removal in Gradle 9.0.
-For the wider context see the <<deprecated_access_to_conventions, section about plugin convention deprecation>>.
+The convention properties the `java` plugin contributed have been deprecated and scheduled for removal in Gradle 9.0.
+For more context, see the <<deprecated_access_to_conventions, section about plugin convention deprecation>>.
 
 The following code will now emit deprecation warnings:
 
@@ -1724,7 +1726,7 @@ java {
 ==== Deprecated `war` plugin conventions
 
 The convention properties contributed by the `war` plugin have been deprecated and scheduled for removal in Gradle 9.0.
-For the wider context see the <<deprecated_access_to_conventions, section about plugin convention deprecation>>.
+For more context, see the <<deprecated_access_to_conventions, section about plugin convention deprecation>>.
 
 The following code will now emit deprecation warnings:
 
@@ -1757,7 +1759,7 @@ webAppDirName = 'src/main/webapp' // Accessing a convention
 =====
 ====
 
-Clients should configure the `war` task  directly.
+Clients should configure the `war` task directly.
 Also, link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-[tasks.withType(War.class).configureEach(...)] can be used to configure each task of type `War`.
 
 ====
@@ -1795,7 +1797,7 @@ war {
 ==== Deprecated `ear` plugin conventions
 
 The convention properties contributed by the `ear` plugin have been deprecated and scheduled for removal in Gradle 9.0.
-For the wider context see the <<deprecated_access_to_conventions, section about plugin convention deprecation>>.
+For more context, see the <<deprecated_access_to_conventions, section about plugin convention deprecation>>.
 
 The following code will now emit deprecation warnings:
 
@@ -1866,7 +1868,7 @@ ear {
 ==== Deprecated `project-report` plugin conventions
 
 The convention properties contributed by the `project-reports` plugin have been deprecated and scheduled for removal in Gradle 9.0.
-For the wider context see the <<deprecated_access_to_conventions, section about plugin convention deprecation>>.
+For more context, see the <<deprecated_access_to_conventions, section about plugin convention deprecation>>.
 
 The following code will now emit deprecation warnings:
 
@@ -1946,15 +1948,11 @@ Obtain the set of all configurations from the project's `configurations` contain
 [[test_framework_implementation_dependencies]]
 ==== Relying on automatic test framework implementation dependencies
 
-In some cases, Gradle will load JVM test framework dependencies from the Gradle distribution in order to
-execute tests.
-This existing behavior can lead to test framework dependency version conflicts on the test
-classpath.
-To avoid these conflicts, this behavior is deprecated and will be removed in Gradle 9.0. Tests
-using TestNG are unaffected.
+In some cases, Gradle will load JVM test framework dependencies from the Gradle distribution to execute tests.
+This existing behavior can lead to test framework dependency version conflicts on the test classpath.
+To avoid these conflicts, this behavior is deprecated and will be removed in Gradle 9.0. Tests using TestNG are unaffected.
 
-In order to prepare for this change in behavior, either declare the required dependencies explicitly,
-or migrate to link:jvm_test_suite_plugin.html[Test Suites], where these dependencies are managed automatically.
+To prepare for this change in behavior, either declare the required dependencies explicitly or migrate to link:jvm_test_suite_plugin.html[Test Suites], where these dependencies are managed automatically.
 
 ===== Test Suites
 
@@ -2045,6 +2043,7 @@ Use `link:{javadocPath}/org/gradle/api/artifacts/component/ProjectComponentSelec
 
 [[cache_marking]]
 === CACHEDIR.TAG files are created in global cache directories
+
 Gradle now emits a `CACHEDIR.TAG` file in some global cache directories, as specified in <<directory_layout#dir:gradle_user_home:cache_marking>>.
 
 This may cause these directories to no longer be searched or backed up by some tools. To disable it, use the following code in an <<init_scripts#sec:using_an_init_script,init script>> in the Gradle User Home:
@@ -2081,8 +2080,8 @@ beforeSettings { settings ->
 [[configuration_caching_options_renamed]]
 === Configuration cache options renamed
 
-In this release, the configuration cache feature was promoted from incubating to stable, and as such, all properties
-originally mentioned in the feature documentation (which had an `unsafe` part in their names, e.g. `org.gradle.unsafe.configuration-cache`) were renamed, in some cases, by just removing the `unsafe` bit.
+In this release, the configuration cache feature was promoted from incubating to stable.
+As such, all properties originally mentioned in the feature documentation (which had an `unsafe` part in their names, e.g., `org.gradle.unsafe.configuration-cache`) were renamed, in some cases, by removing the `unsafe` part of the name.
 
 [cols="1,1", options="header"]
 |===
@@ -2148,7 +2147,7 @@ Execution failed for task ':compileKotlin'.
 > Kotlin compiler arguments of task ':compileKotlin' do not work for the `kotlin-dsl` plugin. The 'freeCompilerArgs' property has been reassigned. It must instead be appended to. Please use 'freeCompilerArgs.addAll(\"your\", \"args\")' to fix this.
 ----
 
-You must change this to adding your custom compiler arguments to the lazy configuration properties of the Kotlin Gradle Plugin in order for them to be appended to the ones required by the `kotlin-dsl` plugin:
+You must change this to adding your custom compiler arguments to the lazy configuration properties of the Kotlin Gradle Plugin for them to be appended to the ones required by the `kotlin-dsl` plugin:
 
 ====
 [.multi-language-sample]
@@ -2169,11 +2168,11 @@ tasks.withType(KotlinCompile::class).configureEach {
 =====
 ====
 
-If you were already adding to `freeCompilerArgs` instead of setting its value, then you should not experience a build failure.
+If you were already adding to `freeCompilerArgs` instead of setting its value, you should not experience a build failure.
 
 ==== New API introduced may clash with existing Gradle DSL code
 
-When a new property or method is added to an existing type in the Gradle DSL, it may clash with names already in use in user code.
+When a new property or method is added to an existing type in the Gradle DSL, it may clash with names already used in user code.
 
 When a name clash occurs, one solution is to rename the element in user code.
 
@@ -2526,6 +2525,7 @@ See the <<configuration_cache#config_cache:requirements:disallowed_types,configu
 
 [[test_task_fail_on_no_test_executed]]
 ==== Deprecated running test task successfully when no test executed
+
 Running the `Test` task successfully when no test was executed is now deprecated and will become an error in Gradle 9.
 Note that it is not an error when no test sources are present, in this case the `test` task is simply skipped. It is only an error when test sources are present, but no test was selected for execution.
 This is changed to avoid accidental successful test runs due to erroneous configuration.

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -24,13 +24,13 @@ We recommend the following steps for all users:
 +
 image::deprecations.png[Deprecations View of a Gradle Build Scan]
 +
-This is so you can see any deprecation warnings that apply to your build.
+This lets you see any deprecation warnings that apply to your build.
 +
 Alternatively, you can run `gradle help --warning-mode=all` to see the deprecations in the console, though it may not report as much detailed information.
 . Update your plugins.
 +
-Some plugins will break with this new version of Gradle, for example because they use internal APIs that have been removed or changed.
-The previous step will help you identify potential problems by issuing deprecation warnings when a plugin does try to use a deprecated part of the API.
+Some plugins will break with this new version of Gradle because they use internal APIs that have been removed or changed.
+The previous step will help you identify potential problems by issuing deprecation warnings when a plugin tries to use a deprecated part of the API.
 +
 . Run `gradle wrapper --gradle-version {gradleVersion}` to update the project to {gradleVersion}.
 . Try to run the project and debug any errors using the <<troubleshooting.adoc#troubleshooting, Troubleshooting Guide>>.
@@ -41,7 +41,7 @@ The previous step will help you identify potential problems by issuing deprecati
 === Potential breaking changes
 
 ==== Change to toolchain provisioning
-In previous versions of Gradle, toolchain provisioning could leave a partially provisioned toolchain in place **with a marker file indicating that the toolchain was fully provisioned**. This could lead to strange behavior with the toolchain. In Gradle 8.9, the toolchain is now fully provisioned before the marker file is written. However, in order to not detect potentially broken toolchains, a different marker file (`.ready`) is used. This means that all of your existing toolchains will be re-provisioned the first time you use them with Gradle 8.9. Gradle 8.9 also writes the old marker file (`provisioned.ok`) to indicate that the toolchain was fully provisioned. This means that if you go back to an older version of Gradle, a 8.9-provisioned toolchain will **not** be re-provisioned.
+In previous versions of Gradle, toolchain provisioning could leave a partially provisioned toolchain in place **with a marker file indicating that the toolchain was fully provisioned**. This could lead to strange behavior with the toolchain. In Gradle 8.9, the toolchain is fully provisioned before the marker file is written. However, to not detect potentially broken toolchains, a different marker file (`.ready`) is used. This means all your existing toolchains will be re-provisioned the first time you use them with Gradle 8.9. Gradle 8.9 also writes the old marker file (`provisioned.ok`) to indicate that the toolchain was fully provisioned. This means that if you return to an older version of Gradle, an 8.9-provisioned toolchain will **not** be re-provisioned.
 
 ==== Upgrade to Kotlin 1.9.23
 
@@ -49,32 +49,29 @@ The embedded Kotlin has been updated from 1.9.22 to link:https://github.com/JetB
 
 ==== Change the encoding of daemon log files
 In previous versions of Gradle, the daemon log file, located at `$<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>/daemon/{gradleVersion}/`, was encoded with the default JVM encoding.
-To prevent clients that may use different default encoding from reading data incorrectly, this file is now always encoded with UTF-8.
+This file is now always encoded with UTF-8 to prevent clients who may use different default encodings from reading data incorrectly.
 This change may affect third-party tools trying to read this file.
 
 ==== Compiling against Gradle implementation classpath
 
-In previous versions of Gradle, it was possible for Java projects that had no declared dependencies to implicitly compile against Gradle's runtime classes.
-This means it was possible for some projects to compile without any declared dependencies even though they referenced Gradle runtime classes.
-We believe this situation is very unlikely to occur in real projects, as IDE integration and test execution would not work correctly.
-If you need to use the Gradle API, declare a `gradleApi` dependency or use the `java-gradle-plugin` plugin.
+In previous versions of Gradle, Java projects that had no declared dependencies could implicitly compile against Gradle's runtime classes.
+This means that some projects were able to compile without any declared dependencies even though they referenced Gradle runtime classes.
+This situation is unlikely to arise in projects since IDE integration and test execution would be compromised. However, if you need to utilize the Gradle API, declare a `gradleApi` dependency or apply the `java-gradle-plugin` plugin.
 
 ==== Configuration cache implementation packages now under `org.gradle.internal`
 
-References to Gradle types that are not part of the public API should be avoided, as their direct use is unsupported,
-and Gradle internal implementation classes may suffer breaking changes (or be renamed or removed) from one version to another without warning.
+References to Gradle types not part of the public API should be avoided, as their direct use is unsupported. Gradle internal implementation classes may suffer breaking changes (or be renamed or removed) from one version to another without warning.
 
-It is important for users to distinguish between the API and internal parts of the Gradle codebase.
+Users need to distinguish between the API and internal parts of the Gradle codebase.
 This is typically achieved by including `internal` in the implementation package names.
-However, before this release, the configuration cache subsystem did not follow this pattern, potentially causing confusion.
+However, before this release, the configuration cache subsystem did not follow this pattern.
 
-To address this issue, in the current release, all code originally under the `org.gradle.configurationcache*` packages
-(which was never API) has been moved to new internal packages (`org.gradle.internal.*`).
+To address this issue, all code initially under the `org.gradle.configurationcache*` packages has been moved to new internal packages (`org.gradle.internal.*`).
 
 === File-system watching on macOS 11 (Big Sur) and earlier is disabled
 
-Since Gradle 8.8 file-system watching has only been supported on macOS 12 (Monterey) and later.
-We've now added a check to disable file-system watching on macOS 11 (Big Sur) and earlier automatically.
+Since Gradle 8.8, file-system watching has only been supported on macOS 12 (Monterey) and later.
+We added a check to automatically disable file-system watching on macOS 11 (Big Sur) and earlier versions.
 
 [[changes_8.8]]
 == Upgrading from 8.7 and earlier
@@ -86,13 +83,13 @@ We've now added a check to disable file-system watching on macOS 11 (Big Sur) an
 
 To ensure the accuracy of dependency resolution, Gradle checks that Configurations are not mutated after they have been used as part of a dependency graph.
 
-* Resolvable configurations should not have their resolution strategy, dependencies, hierarchy, etc. modified after they have been resolved.
+* Resolvable configurations should not have their resolution strategy, dependencies, hierarchy, etc., modified after they have been resolved.
 * Consumable configurations should not have their dependencies, hierarchy, attributes, etc. modified after they have been published or consumed as a variant.
-* Dependency scope configurations should not have their dependencies, constraints, etc. modified after a configuration that extends from them are observed.
+* Dependency scope configurations should not have their dependencies, constraints, etc., modified after a configuration that extends from them is observed.
 
 In prior versions of Gradle, many of these circumstances were detected and handled by failing the build.
 However, some cases went undetected or did not trigger build failures.
-In Gradle 9.0, all changes to a configuration after it has been observed will become an error.
+In Gradle 9.0, all changes to a configuration, once observed, will become an error.
 After a configuration of any type has been observed, it should be considered immutable.
 This validation covers the following properties of a configuration:
 
@@ -154,7 +151,7 @@ For the following use cases, consider these alternatives when replacing a `befor
 * **Changing dependency versions**: Use <<using_preferred_versions,preferred version constraints>>.
 * **Adding excludes**: Use <<component_metadata_rules.adoc#sec:component_metadata_rules,Component Metadata Rules>>.
 * **Roles**: Configuration roles should be set upon creation and not changed afterward.
-* **Hierarchy**: Configuration hierarchy (`extendsFrom`) should be set upon creation. Mutating the hierarchy prior to resolution is highly discouraged, but is permitted within a `withDependencies` hook.
+* **Hierarchy**: Configuration hierarchy (`extendsFrom`) should be set upon creation. Mutating the hierarchy prior to resolution is highly discouraged but permitted within a `withDependencies` hook.
 * **Resolution Strategy**: Mutating a configuration's ResolutionStrategy is still permitted in a `beforeResolve` hook; however, this is not recommended.
 
 [[deprecate_filtered_configuration_file_and_filecollection_methods]]
@@ -246,7 +243,7 @@ tasks.register("filterDependencies") {
 =====
 ====
 
-Note that contrary to the behavior of the deprecated `Dependency` filtering methods, `componentFilter` does not consider the transitive dependencies of the component being filtered.
+Contrary to the deprecated `Dependency` filtering methods, `componentFilter` does not consider the transitive dependencies of the component being filtered.
 This allows for more granular control over which artifacts are selected.
 
 [[deprecated_namers]]
@@ -257,17 +254,17 @@ Now that these types implement link:{javadocPath}/org/gradle/api/Named.html[`Nam
 They will be removed in Gradle 9.0.
 Use link:{javadocPath}/org/gradle/api/Named.Namer.html#INSTANCE[`Named.Namer.INSTANCE`] instead.
 
-The superinterface, link:{javadocPath}/org/gradle/api/Namer.html[`Namer`], is *not* being deprecated.
+The super interface, link:{javadocPath}/org/gradle/api/Namer.html[`Namer`], is *not* being deprecated.
 
 [[unix_file_permissions_deprecated]]
-==== Unix mode based file permissions deprecated ====
+==== Unix mode-based file permissions deprecated ====
 
 A new API for defining file permissions has been added in Gradle 8.3, see:
 
 - link:{javadocPath}/org/gradle/api/file/FilePermissions.html[FilePermissions].
 - link:{javadocPath}/org/gradle/api/file/ConfigurableFilePermissions.html[ConfigurableFilePermissions].
 
-The new API has now been promoted to stable and the old methods have been deprecated:
+The new API has now been promoted to stable, and the old methods have been deprecated:
 
 - link:{javadocPath}/org/gradle/api/file/CopyProcessingSpec.html#getFileMode--[CopyProcessingSpec.getFileMode]
 - link:{javadocPath}/org/gradle/api/file/CopyProcessingSpec.html#setFileMode-java.lang.Integer-[CopyProcessingSpec.setFileMode]
@@ -283,12 +280,13 @@ In previous versions, cleanup of the local build cache entries ran every 24 hour
 The retention period was configured using `buildCache.local.removeUnusedEntriesAfterDays`.
 
 In Gradle 8.0, link:directory_layout.html#dir:gradle_user_home:configure_cache_cleanup[a new mechanism] was added to configure the cleanup and retention periods for various resources in Gradle User Home.
-In Gradle 8.8, this mechanism was extended to permit configuration of retention of local build cache entries, providing improved control and consistency.
+In Gradle 8.8, this mechanism was extended to permit the retention configuration of local build cache entries, providing improved control and consistency.
 
 - Specifying `Cleanup.DISABLED` or `Cleanup.ALWAYS` will now prevent or force the cleanup of the local build cache
 - Build cache entry retention is now configured via an `init-script`, link:directory_layout.html#dir:gradle_user_home:configure_cache_cleanup[in the same manner as other caches].
 
-E.g. if you want build-cache entries to be retained for 30 days, **remove** any calls to the deprecated method:
+If you want build-cache entries to be retained for 30 days, **remove** any calls to the deprecated method:
+
 ```kotlin
 buildCache {
     local {
@@ -298,7 +296,7 @@ buildCache {
 }
 ```
 
-add a file like this in `~/.gradle/init.d`:
+Add a file like this in `~/.gradle/init.d`:
 ```kotlin
 beforeSettings {
     caches {
@@ -307,13 +305,14 @@ beforeSettings {
 }
 ```
 
-Calling link:{javadocPath}/org/gradle/caching/local/DirectoryBuildCache.html#setRemoveUnusedEntriesAfterDays-int-[buildCache.local.removeUnusedEntriesAfterDays] is deprecated and this method will be removed in Gradle 9.0.
+Calling link:{javadocPath}/org/gradle/caching/local/DirectoryBuildCache.html#setRemoveUnusedEntriesAfterDays-int-[buildCache.local.removeUnusedEntriesAfterDays] is deprecated, and this method will be removed in Gradle 9.0.
 If set to a non-default value, this deprecated setting will take precedence over `Settings.caches.buildCache.setRemoveUnusedEntriesAfterDays()`.
 
 [[gradle_enterprise_extension_deprecated]]
 ==== Deprecated Kotlin DSL gradle-enterprise plugin block extension ====
 
 In `settings.gradle.kts` (Kotlin DSL), you can use `gradle-enterprise` in the plugins block to apply the Gradle Enterprise plugin with the same version as `gradle --scan`.
+
 ```kotlin
 plugins {
     `gradle-enterprise`
@@ -322,31 +321,33 @@ plugins {
 
 There is no equivalent to this in `settings.gradle` (Groovy DSL).
 
-Gradle Enterprise has been renamed to Develocity and the `com.gradle.enterprise` plugin has been renamed to `com.gradle.develocity`.
+Gradle Enterprise has been renamed Develocity, and the `com.gradle.enterprise` plugin has been renamed `com.gradle.develocity`.
 Therefore, the `gradle-enterprise` plugin block extension has been deprecated and will be removed in Gradle 9.0.
 
-The Develocity plugin must be applied with an explicit plugin id and version.
-There is no `develocity` shorthand available in the plugins block.
+The Develocity plugin must be applied with an explicit plugin ID and version.
+There is no `develocity` shorthand available in the plugins block:
+
 ```kotlin
 plugins {
     id("com.gradle.develocity") version "3.17.3"
 }
 ```
 
-If you want to continue using the Gradle Enterprise plugin, you can specify the deprecated plugin id.
+If you want to continue using the Gradle Enterprise plugin, you can specify the deprecated plugin ID:
+
 ```kotlin
 plugins {
     id("com.gradle.enterprise") version "3.17.3"
 }
 ```
 
-We encourage you to use the https://plugins.gradle.org/plugin/com.gradle.develocity[latest released Develocity plugin version], even when you are using an older Gradle version.
+We encourage you to use the https://plugins.gradle.org/plugin/com.gradle.develocity[latest released Develocity plugin version], even when using an older Gradle version.
 
 === Potential breaking changes
 
 ==== Changes in the Problems API
 
-We have implemented several refactorings of the Problems API, including a significant change in the way problem definitions and contextual information are handled.
+We have implemented several refactorings of the Problems API, including a significant change in how problem definitions and contextual information are handled.
 The complete design specification can be found https://docs.google.com/document/d/1T_vM-Upa23aA21sanFTTLZa3j9xV6R32djJk6-muWzI/edit#heading=h.610fausqnpu6[here].
 
 In implementing this spec, we have introduced the following breaking changes to the `ProblemSpec` interface:
@@ -368,7 +369,8 @@ Groovy has been updated to https://groovy-lang.org/changelogs/changelog-3.0.21.h
 
 Since the previous version was 3.0.17, the https://groovy-lang.org/changelogs/changelog-3.0.18.html[3.0.18] and https://groovy-lang.org/changelogs/changelog-3.0.19.html[3.0.19], and https://groovy-lang.org/changelogs/changelog-3.0.20.html[3.0.20] changes are also included.
 
-Some changes in static type checking have resulted in source-code incompatibilities. One of these occurs if you were casting a closure to an `Action` without generics. Starting with 3.0.18, this now results in the parameter of the closure being `Object` instead of any explicit type specified. This can be fixed by adding the appropriate type to the cast, and the redundant parameter declaration can be removed:
+Some changes in static type checking have resulted in source-code incompatibilities. Starting with 3.0.18, if you cast a closure to an `Action` without generics, the closure parameter will be `Object` instead of any explicit type specified. This can be fixed by adding the appropriate type to the cast, and the redundant parameter declaration can be removed:
+
 ```groovy
 // Before
 tasks.create("foo", { Task it -> it.description "Foo task" } as Action)
@@ -447,18 +449,20 @@ tasks {
 The first notation is deprecated and will be removed in Gradle 9.0.
 Instead of using `"name"()` to reference a task or domain object, use `named("name")` or one of the other supported notations.
 
-The above example would be written:
+The above example would be written as:
+
 ```
 tasks {
     named("wrapper") // returns TaskProvider<Task>
 }
 ```
 
-Groovy DSL build scripts and the Gradle API are not impacted by this.
+The Gradle API and Groovy build scripts are not impacted by this.
 
 [[deprecated_invalid_url_decoding]]
 ==== Deprecated invalid URL decoding behavior
-Prior to Gradle 8.3, Gradle would decode a `CharSequence` given to `link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:uri(java.lang.Object)[Project.uri(Object)]` using an algorithm that accepted invalid URLs and improperly decoded others.
+
+Before Gradle 8.3, Gradle would decode a `CharSequence` given to `link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:uri(java.lang.Object)[Project.uri(Object)]` using an algorithm that accepted invalid URLs and improperly decoded others.
 Gradle now uses the `URI` class to parse and decode URLs, but with a fallback to the legacy behavior in the event of an error.
 
 Starting in Gradle 9.0, the fallback will be removed, and an error will be thrown instead.
@@ -576,10 +580,11 @@ Previously, when using the `main` source set, new `implementation`, `compileOnly
 
 Starting in Gradle 9.0, the `main` source set will be treated like any other source set.
 With the `java-library` plugin applied (or any other plugin that applies the `java` plugin), calling `usingSourceSet` with the `main` source set will throw an exception.
-This is because the `java` plugin already configures a main feature.
+This is because the `java` plugin already configures a `main` feature.
 Only if the `java` plugin is not applied will the `main` source set be permitted when calling `usingSourceSet`.
 
-Code that currently registers features with the main source set, like so:
+Code that currently registers features with the main source set, such as:
+
 =====
 [.multi-language-sample]
 ======
@@ -615,7 +620,8 @@ java {
 ======
 =====
 
-Should instead create a separate source set for the feature, and register the feature with that source set:
+Should instead, create a separate source set for the feature and register the feature with that source set:
+
 =====
 [.multi-language-sample]
 ======
@@ -1961,11 +1967,11 @@ See link:jvm_test_suite_plugin.html[the user manual] for further information on 
 
 In the absence of test suites, dependencies must be manually declared on the test runtime classpath:
 
-  * If using JUnit 5, an explicit `runtimeOnly` dependency on `junit-platform-launcher` is required
-  in addition to the existing `implementation` dependency on the test engine.
-  * If using JUnit 4, only the existing `implementation` dependency on `junit` 4 is required.
-  * If using JUnit 3, a test `runtimeOnly` dependency on `junit` 4 is required in addition to a
-  `compileOnly` dependency on `junit` 3.
+* If using JUnit 5, an explicit `runtimeOnly` dependency on `junit-platform-launcher` is required
+in addition to the existing `implementation` dependency on the test engine.
+* If using JUnit 4, only the existing `implementation` dependency on `junit` 4 is required.
+* If using JUnit 3, a test `runtimeOnly` dependency on `junit` 4 is required in addition to a
+`compileOnly` dependency on `junit` 3.
 
 =====
 [.multi-language-sample]


### PR DESCRIPTION
### Details
This is a Documentation change ONLY.

### Context 
This is an update for the User Manual's [Upgrading Version 8](https://github.com/gradle/gradle/blob/3c9b45ac28bedbbbac4751f3d497f4dd9a34aa91/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc) page for Gradle 8.9 RC1. **--> [BUILD LINK FOR REVIEW](https://builds.gradle.org/repository/download/Gradle_Release_Check_BuildDistributions/83552575:id/distributions/gradle-8.9-docs.zip!/gradle-8.9-20240612234831%2B0000/docs/userguide/upgrading_version_8.html) <--**
