### PR TITLE
Merge the Gradle and build scoped `ExecutionEngine` instances into a single build scoped instance

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -112,7 +112,10 @@ class DefaultConfigurationCache internal constructor(
     val loadedSideEffects = mutableListOf<BuildTreeModelSideEffect>()
 
     private
-    val store by lazy { cacheRepository.forKey(cacheKey.string) }
+    val storeDelegate = lazy { cacheRepository.forKey(cacheKey.string) }
+
+    private
+    val store by storeDelegate
 
     private
     val lazyBuildTreeModelSideEffects = lazy { BuildTreeModelSideEffectStore(host, cacheIO, store) }
@@ -343,7 +346,7 @@ class DefaultConfigurationCache internal constructor(
         stoppable.addIfInitialized(lazyBuildTreeModelSideEffects)
         stoppable.addIfInitialized(lazyIntermediateModels)
         stoppable.addIfInitialized(lazyProjectMetadata)
-        stoppable.add(store)
+        stoppable.addIfInitialized(storeDelegate)
         stoppable.stop()
     }
 

--- a/platforms/core-execution/build-cache/src/main/java/org/gradle/caching/internal/controller/BuildCacheController.java
+++ b/platforms/core-execution/build-cache/src/main/java/org/gradle/caching/internal/controller/BuildCacheController.java
@@ -33,7 +33,7 @@ import java.util.Optional;
  *
  * <p>Note that some implementations are mutable and may change behavior over the lifetime of a build.</p>
  */
-@ServiceScope(Scope.Gradle.class)
+@ServiceScope(Scope.Build.class)
 public interface BuildCacheController extends Closeable {
 
     boolean isEnabled();

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/ExecutionEngine.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/ExecutionEngine.java
@@ -32,7 +32,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Optional;
 
-@ServiceScope({Scope.Build.class, Scope.Gradle.class})
+@ServiceScope(Scope.Build.class)
 public interface ExecutionEngine {
     Request createRequest(UnitOfWork work);
 

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/OutputChangeListener.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/OutputChangeListener.java
@@ -21,7 +21,7 @@ import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 @EventScope(Scope.Build.class)
-@ServiceScope(Scope.Gradle.class)
+@ServiceScope(Scope.Build.class)
 public interface OutputChangeListener {
     /**
      * Invoked when some locations on disk have been changed or are about to be changed.

--- a/platforms/core-runtime/build-profile/src/main/java/org/gradle/profile/BuildProfileServices.java
+++ b/platforms/core-runtime/build-profile/src/main/java/org/gradle/profile/BuildProfileServices.java
@@ -40,7 +40,7 @@ public class BuildProfileServices extends AbstractGradleModuleServices {
         registration.addProvider(new ServiceRegistrationProvider() {
             public void configure(ServiceRegistration serviceRegistration, StartParameter startParameter) {
                 if (startParameter.isProfile()) {
-                    serviceRegistration.add(ProfileEventAdapter.class);
+                    serviceRegistration.add(ProfileService.class, ProfileEventAdapter.class);
                 }
             }
         });

--- a/platforms/core-runtime/build-profile/src/main/java/org/gradle/profile/ProfileEventAdapter.java
+++ b/platforms/core-runtime/build-profile/src/main/java/org/gradle/profile/ProfileEventAdapter.java
@@ -37,7 +37,7 @@ import org.gradle.internal.time.Clock;
  * Adapts various events to build a {@link BuildProfile} model.
  */
 @ListenerService
-public class ProfileEventAdapter implements InternalBuildListener, ProjectEvaluationListener, TaskListenerInternal, DependencyResolutionListener, TransformExecutionListener {
+public class ProfileEventAdapter implements ProfileService, InternalBuildListener, ProjectEvaluationListener, TaskListenerInternal, DependencyResolutionListener, TransformExecutionListener {
     private final BuildStartedTime buildStartedTime;
     private final Clock clock;
     @SuppressWarnings("ThreadLocalUsage")

--- a/platforms/core-runtime/build-profile/src/main/java/org/gradle/profile/ProfileService.java
+++ b/platforms/core-runtime/build-profile/src/main/java/org/gradle/profile/ProfileService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.profile;
+
+import org.gradle.internal.service.scopes.ListenerService;
+
+/**
+ * A marker interface to allow the implementation to be registered as a service without exposing the various listener interfaces that it implements for injection into other services.
+ */
+@ListenerService
+public interface ProfileService {
+}

--- a/platforms/core-runtime/concurrent/src/main/java/org/gradle/internal/concurrent/CompositeStoppable.java
+++ b/platforms/core-runtime/concurrent/src/main/java/org/gradle/internal/concurrent/CompositeStoppable.java
@@ -53,6 +53,16 @@ public class CompositeStoppable implements Stoppable {
         return new CompositeStoppable().add(elements);
     }
 
+    public CompositeStoppable addFailure(final Throwable failure) {
+        add(new Closeable() {
+            @Override
+            public void close() {
+                throw UncheckedException.throwAsUncheckedException(failure);
+            }
+        });
+        return this;
+    }
+
     public CompositeStoppable add(Iterable<?> elements) {
         for (Object closeable : elements) {
             add(closeable);

--- a/platforms/core-runtime/concurrent/src/test/groovy/org/gradle/internal/concurrent/CompositeStoppableTest.groovy
+++ b/platforms/core-runtime/concurrent/src/test/groovy/org/gradle/internal/concurrent/CompositeStoppableTest.groovy
@@ -70,6 +70,27 @@ class CompositeStoppableTest extends Specification {
         e == failure1
     }
 
+    def stopsAllElementsWhenClosingInResponseToAnExceptionAndMultipleFailToStop() {
+        RuntimeException original = new RuntimeException()
+
+        Stoppable a = Mock()
+        Stoppable b = Mock()
+        RuntimeException failure1 = new RuntimeException()
+        RuntimeException failure2 = new RuntimeException()
+        stoppable.addFailure(original)
+        stoppable.add(a)
+        stoppable.add(b)
+
+        when:
+        stoppable.stop()
+
+        then:
+        1 * a.stop() >> { throw failure1 }
+        1 * b.stop() >> { throw failure2 }
+        def e = thrown(RuntimeException)
+        e == original
+    }
+
     def closesACloseableElement() {
         Closeable a = Mock()
         Stoppable b = Mock()

--- a/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/scopes/AbstractGradleModuleServices.java
+++ b/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/scopes/AbstractGradleModuleServices.java
@@ -57,11 +57,6 @@ public class AbstractGradleModuleServices implements GradleModuleServices {
     }
 
     @Override
-    public void registerGradleServices(ServiceRegistration registration) {
-
-    }
-
-    @Override
     public void registerProjectServices(ServiceRegistration registration) {
 
     }

--- a/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/scopes/GradleModuleServices.java
+++ b/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/scopes/GradleModuleServices.java
@@ -93,15 +93,6 @@ public interface GradleModuleServices extends ServiceRegistrationProvider {
     void registerSettingsServices(ServiceRegistration registration);
 
     /**
-     * Called once per build invocation on a build, to register any {@link org.gradle.api.invocation.Gradle} scoped services. These services are closed at the end of the build invocation.
-     *
-     * <p>Global, user home, build session, build tree and build scoped services are visible to the gradle scope services, but not vice versa.</p>
-     *
-     * @see Scope.Gradle
-     */
-    void registerGradleServices(ServiceRegistration registration);
-
-    /**
      * Called once per project per build invocation, to register any project scoped services. These services are closed at the end of the build invocation.
      *
      * <p>Global, user home, build session, build tree, build and gradle scoped services are visible to the project scope services, but not vice versa.</p>

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -63,6 +63,7 @@ import org.gradle.api.internal.artifacts.repositories.resolver.DefaultExternalRe
 import org.gradle.api.internal.artifacts.repositories.resolver.ExternalResourceAccessor;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
+import org.gradle.api.internal.artifacts.transform.TransformExecutionListener;
 import org.gradle.api.internal.artifacts.transform.TransformStepNodeDependencyResolver;
 import org.gradle.api.internal.artifacts.verification.signatures.DefaultSignatureVerificationServiceFactory;
 import org.gradle.api.internal.artifacts.verification.signatures.SignatureVerificationServiceFactory;
@@ -449,5 +450,10 @@ class DependencyManagementBuildScopeServices implements ServiceRegistrationProvi
         InputFingerprinter inputFingerprinter
     ) {
         return objectFactory.newInstance(DefaultDependenciesAccessors.class, registry, workspace, factory, featureFlags, executionEngine, fileCollectionFactory, inputFingerprinter, attributesFactory, capabilityNotationParser);
+    }
+
+    @Provides
+    TransformExecutionListener createTransformExecutionListener(ListenerManager listenerManager) {
+        return listenerManager.getBroadcaster(TransformExecutionListener.class);
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -105,28 +105,8 @@ import org.gradle.internal.component.resolution.failure.ResolutionFailureDescrib
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.execution.ExecutionEngine;
 import org.gradle.internal.execution.InputFingerprinter;
-import org.gradle.internal.execution.OutputChangeListener;
-import org.gradle.internal.execution.OutputSnapshotter;
-import org.gradle.internal.execution.history.ImmutableWorkspaceMetadataStore;
-import org.gradle.internal.execution.impl.DefaultExecutionEngine;
-import org.gradle.internal.execution.steps.AssignImmutableWorkspaceStep;
-import org.gradle.internal.execution.steps.BroadcastChangingOutputsStep;
-import org.gradle.internal.execution.steps.CaptureNonIncrementalStateBeforeExecutionStep;
-import org.gradle.internal.execution.steps.CaptureOutputsAfterExecutionStep;
-import org.gradle.internal.execution.steps.ExecuteStep;
-import org.gradle.internal.execution.steps.IdentifyStep;
-import org.gradle.internal.execution.steps.IdentityCacheStep;
-import org.gradle.internal.execution.steps.NeverUpToDateStep;
-import org.gradle.internal.execution.steps.NoInputChangesStep;
-import org.gradle.internal.execution.steps.PreCreateOutputParentsStep;
-import org.gradle.internal.execution.steps.ResolveNonIncrementalCachingStateStep;
-import org.gradle.internal.execution.steps.TimeoutStep;
-import org.gradle.internal.execution.steps.ValidateStep;
-import org.gradle.internal.execution.timeout.TimeoutHandler;
-import org.gradle.internal.file.Deleter;
 import org.gradle.internal.file.RelativeFilePathResolver;
 import org.gradle.internal.hash.ChecksumService;
-import org.gradle.internal.hash.ClassLoaderHierarchyHasher;
 import org.gradle.internal.hash.FileHasher;
 import org.gradle.internal.instantiation.InstanceGenerator;
 import org.gradle.internal.instantiation.InstantiatorFactory;
@@ -134,9 +114,7 @@ import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.management.DefaultDependencyResolutionManagement;
 import org.gradle.internal.management.DependencyResolutionManagementInternal;
 import org.gradle.internal.operations.BuildOperationExecutor;
-import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
 import org.gradle.internal.operations.BuildOperationRunner;
-import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.caching.ComponentMetadataRuleExecutor;
 import org.gradle.internal.resolve.caching.ComponentMetadataSupplierRuleExecutor;
@@ -150,14 +128,11 @@ import org.gradle.internal.resource.local.FileResourceRepository;
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder;
 import org.gradle.internal.resource.local.ivy.LocallyAvailableResourceFinderFactory;
 import org.gradle.internal.resource.transfer.CachingTextUriResourceLoader;
-import org.gradle.internal.scopeids.id.BuildInvocationScopeId;
 import org.gradle.internal.service.Provides;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistrationProvider;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.snapshot.ValueSnapshotter;
-import org.gradle.internal.vfs.FileSystemAccess;
-import org.gradle.internal.vfs.VirtualFileSystem;
 import org.gradle.util.internal.BuildCommencedTimeProvider;
 import org.gradle.util.internal.SimpleMapInterner;
 
@@ -166,8 +141,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
-
-import static org.gradle.internal.execution.steps.AfterExecutionOutputFilter.NO_FILTER;
 
 /**
  * The set of dependency management services that are created per build in the tree.
@@ -476,48 +449,5 @@ class DependencyManagementBuildScopeServices implements ServiceRegistrationProvi
         InputFingerprinter inputFingerprinter
     ) {
         return objectFactory.newInstance(DefaultDependenciesAccessors.class, registry, workspace, factory, featureFlags, executionEngine, fileCollectionFactory, inputFingerprinter, attributesFactory, capabilityNotationParser);
-    }
-
-    /**
-     * Execution engine for usage above Gradle scope
-     *
-     * Currently used for running artifact transforms in buildscript blocks, compiling Kotlin scripts etc.
-     */
-    @Provides
-    ExecutionEngine createExecutionEngine(
-        BuildInvocationScopeId buildInvocationScopeId,
-        BuildOperationRunner buildOperationRunner,
-        BuildOperationProgressEventEmitter buildOperationProgressEventEmitter,
-        ClassLoaderHierarchyHasher classLoaderHierarchyHasher,
-        CurrentBuildOperationRef currentBuildOperationRef,
-        Deleter deleter,
-        FileSystemAccess fileSystemAccess,
-        ListenerManager listenerManager,
-        ImmutableWorkspaceMetadataStore immutableWorkspaceMetadataStore,
-        OutputSnapshotter outputSnapshotter,
-        TimeoutHandler timeoutHandler,
-        ValidateStep.ValidationWarningRecorder validationWarningRecorder,
-        VirtualFileSystem virtualFileSystem
-    ) {
-        OutputChangeListener outputChangeListener = listenerManager.getBroadcaster(OutputChangeListener.class);
-
-        // @formatter:off
-        return new DefaultExecutionEngine(
-            new IdentifyStep<>(buildOperationRunner,
-            new IdentityCacheStep<>(buildOperationProgressEventEmitter,
-            new AssignImmutableWorkspaceStep<>(deleter, fileSystemAccess, immutableWorkspaceMetadataStore, outputSnapshotter,
-            new CaptureNonIncrementalStateBeforeExecutionStep<>(buildOperationRunner, classLoaderHierarchyHasher,
-            new ValidateStep<>(virtualFileSystem, validationWarningRecorder,
-            new ResolveNonIncrementalCachingStateStep<>(
-            new NeverUpToDateStep<>(
-            new NoInputChangesStep<>(
-            new CaptureOutputsAfterExecutionStep<>(buildOperationRunner, buildInvocationScopeId.getId(), outputSnapshotter, NO_FILTER,
-            // TODO Use a shared execution pipeline
-            new BroadcastChangingOutputsStep<>(outputChangeListener,
-            new PreCreateOutputParentsStep<>(
-            new TimeoutStep<>(timeoutHandler, currentBuildOperationRef,
-            new ExecuteStep<>(buildOperationRunner
-        ))))))))))))));
-        // @formatter:on
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyServices.java
@@ -17,11 +17,7 @@
 package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSetToFileCollectionFactory;
-import org.gradle.api.internal.artifacts.transform.TransformExecutionListener;
-import org.gradle.internal.event.ListenerManager;
-import org.gradle.internal.service.Provides;
 import org.gradle.internal.service.ServiceRegistration;
-import org.gradle.internal.service.ServiceRegistrationProvider;
 import org.gradle.internal.service.scopes.AbstractGradleModuleServices;
 
 public class DependencyServices extends AbstractGradleModuleServices {
@@ -54,17 +50,5 @@ public class DependencyServices extends AbstractGradleModuleServices {
     @Override
     public void registerBuildTreeServices(ServiceRegistration registration) {
         registration.addProvider(new DependencyManagementBuildTreeScopeServices());
-    }
-
-    @Override
-    public void registerGradleServices(ServiceRegistration registration) {
-        registration.addProvider(new DependencyManagementGradleServices());
-    }
-
-    private static class DependencyManagementGradleServices implements ServiceRegistrationProvider {
-        @Provides
-        TransformExecutionListener createTransformExecutionListener(ListenerManager listenerManager) {
-            return listenerManager.getBroadcaster(TransformExecutionListener.class);
-        }
     }
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.initialization.exception.ExceptionAnalyser;
+import org.gradle.internal.UncheckedException;
 import org.gradle.internal.build.AbstractBuildState;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.ExecutionResult;
@@ -30,6 +31,7 @@ import org.gradle.internal.buildtree.BuildTreeLifecycleControllerFactory;
 import org.gradle.internal.buildtree.BuildTreeState;
 import org.gradle.internal.buildtree.BuildTreeWorkExecutor;
 import org.gradle.internal.buildtree.DefaultBuildTreeWorkExecutor;
+import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.service.scopes.BuildScopeServices;
 import org.gradle.util.Path;
 
@@ -59,13 +61,18 @@ class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedB
         this.owner = owner;
 
         BuildScopeServices buildScopeServices = getBuildServices();
-        ExceptionAnalyser exceptionAnalyser = buildScopeServices.get(ExceptionAnalyser.class);
-        BuildTreeWorkExecutor workExecutor = new DefaultBuildTreeWorkExecutor();
-        BuildTreeLifecycleControllerFactory buildTreeLifecycleControllerFactory = buildScopeServices.get(BuildTreeLifecycleControllerFactory.class);
+        try {
+            ExceptionAnalyser exceptionAnalyser = buildScopeServices.get(ExceptionAnalyser.class);
+            BuildTreeWorkExecutor workExecutor = new DefaultBuildTreeWorkExecutor();
+            BuildTreeLifecycleControllerFactory buildTreeLifecycleControllerFactory = buildScopeServices.get(BuildTreeLifecycleControllerFactory.class);
 
-        // On completion of the action, do not finish this build. The root build will take care of finishing this build later
-        BuildTreeFinishExecutor finishExecutor = new DoNothingBuildFinishExecutor(exceptionAnalyser);
-        buildTreeLifecycleController = buildTreeLifecycleControllerFactory.createController(getBuildController(), workExecutor, finishExecutor);
+            // On completion of the action, do not finish this build. The root build will take care of finishing this build later
+            BuildTreeFinishExecutor finishExecutor = new DoNothingBuildFinishExecutor(exceptionAnalyser);
+            buildTreeLifecycleController = buildTreeLifecycleControllerFactory.createController(getBuildController(), workExecutor, finishExecutor);
+        } catch (Throwable t) {
+            CompositeStoppable.stoppable().addFailure(t).add(buildScopeServices).stop();
+            throw UncheckedException.throwAsUncheckedException(t);
+        }
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
@@ -26,6 +26,7 @@ import org.gradle.initialization.RunNestedBuildBuildOperationType;
 import org.gradle.initialization.exception.ExceptionAnalyser;
 import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.internal.Pair;
+import org.gradle.internal.UncheckedException;
 import org.gradle.internal.build.AbstractBuildState;
 import org.gradle.internal.build.BuildLifecycleController;
 import org.gradle.internal.build.BuildState;
@@ -39,6 +40,7 @@ import org.gradle.internal.buildtree.BuildTreeWorkExecutor;
 import org.gradle.internal.buildtree.DefaultBuildTreeFinishExecutor;
 import org.gradle.internal.buildtree.DefaultBuildTreeWorkExecutor;
 import org.gradle.internal.composite.IncludedBuildInternal;
+import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationRunner;
@@ -68,13 +70,18 @@ public class RootOfNestedBuildTree extends AbstractBuildState implements NestedR
         this.identityPath = identityPath;
 
         BuildScopeServices buildServices = getBuildServices();
-        BuildLifecycleController buildLifecycleController = getBuildController();
-        BuildTreeLifecycleControllerFactory buildTreeLifecycleControllerFactory = buildServices.get(BuildTreeLifecycleControllerFactory.class);
-        ExceptionAnalyser exceptionAnalyser = buildServices.get(ExceptionAnalyser.class);
-        BuildStateRegistry buildStateRegistry = buildServices.get(BuildStateRegistry.class);
-        BuildTreeWorkExecutor buildTreeWorkExecutor = new DefaultBuildTreeWorkExecutor();
-        BuildTreeFinishExecutor buildTreeFinishExecutor = new DefaultBuildTreeFinishExecutor(buildStateRegistry, exceptionAnalyser, buildLifecycleController);
-        buildTreeLifecycleController = buildTreeLifecycleControllerFactory.createController(buildLifecycleController, buildTreeWorkExecutor, buildTreeFinishExecutor);
+        try {
+            BuildLifecycleController buildLifecycleController = getBuildController();
+            BuildTreeLifecycleControllerFactory buildTreeLifecycleControllerFactory = buildServices.get(BuildTreeLifecycleControllerFactory.class);
+            ExceptionAnalyser exceptionAnalyser = buildServices.get(ExceptionAnalyser.class);
+            BuildStateRegistry buildStateRegistry = buildServices.get(BuildStateRegistry.class);
+            BuildTreeWorkExecutor buildTreeWorkExecutor = new DefaultBuildTreeWorkExecutor();
+            BuildTreeFinishExecutor buildTreeFinishExecutor = new DefaultBuildTreeFinishExecutor(buildStateRegistry, exceptionAnalyser, buildLifecycleController);
+            buildTreeLifecycleController = buildTreeLifecycleControllerFactory.createController(buildLifecycleController, buildTreeWorkExecutor, buildTreeFinishExecutor);
+        } catch (Throwable t) {
+            CompositeStoppable.stoppable().addFailure(t).add(buildServices).stop();
+            throw UncheckedException.throwAsUncheckedException(t);
+        }
     }
 
     public void attach() {

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/BuildCacheServices.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/BuildCacheServices.java
@@ -113,13 +113,6 @@ public final class BuildCacheServices extends AbstractGradleModuleServices {
             BuildCacheServiceRegistration createDirectoryBuildCacheServiceRegistration() {
                 return new DefaultBuildCacheServiceRegistration(DirectoryBuildCache.class, DirectoryBuildCacheServiceFactory.class);
             }
-        });
-    }
-
-    @Override
-    public void registerGradleServices(ServiceRegistration registration) {
-        // Not build scoped because of dependency on GradleInternal for build path
-        registration.addProvider(new ServiceRegistrationProvider() {
 
             @Provides
             TarPackerFileSystemSupport createPackerFileSystemSupport(Deleter deleter) {

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/controller/impl/LifecycleAwareBuildCacheController.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/controller/impl/LifecycleAwareBuildCacheController.java
@@ -26,7 +26,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
  *
  * At some point we aim to better model services who need data from the Gradle model, and this complexity can go away.
  */
-@ServiceScope(Scope.Gradle.class)
+@ServiceScope(Scope.Build.class)
 public interface LifecycleAwareBuildCacheController extends BuildCacheController {
     /**
      * Called when the configuration for this controller is available.

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/services/BuildCacheControllerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/services/BuildCacheControllerFactory.java
@@ -23,7 +23,7 @@ import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.util.Path;
 
-@ServiceScope(Scope.Gradle.class)
+@ServiceScope(Scope.Build.class)
 public interface BuildCacheControllerFactory {
     String REMOTE_CONTINUE_ON_ERROR_PROPERTY = "org.gradle.unsafe.build-cache.remote-continue-on-error";
 

--- a/subprojects/core/src/main/java/org/gradle/execution/commandline/CommandLineTaskConfigurer.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/commandline/CommandLineTaskConfigurer.java
@@ -25,14 +25,11 @@ import org.gradle.cli.CommandLineArgumentException;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
 import org.gradle.cli.ParsedCommandLineOption;
-import org.gradle.internal.service.scopes.Scope;
-import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.typeconversion.TypeConversionException;
 
 import java.util.Collection;
 import java.util.List;
 
-@ServiceScope(Scope.Gradle.class)
 public class CommandLineTaskConfigurer {
     private OptionReader optionReader;
 

--- a/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
@@ -29,7 +29,6 @@ import org.gradle.internal.service.scopes.BuildScopeServices;
 
 import javax.annotation.Nullable;
 import java.io.Closeable;
-import java.io.IOException;
 import java.util.function.Function;
 
 public abstract class AbstractBuildState implements BuildState, Closeable {
@@ -57,7 +56,7 @@ public abstract class AbstractBuildState implements BuildState, Closeable {
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
         buildServices.close();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionBuildServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionBuildServices.java
@@ -95,7 +95,7 @@ import java.util.function.Supplier;
 
 import static org.gradle.internal.execution.steps.AfterExecutionOutputFilter.NO_FILTER;
 
-public class ExecutionGradleServices implements ServiceRegistrationProvider {
+public class ExecutionBuildServices implements ServiceRegistrationProvider {
     @Provides
     ExecutionHistoryCacheAccess createCacheAccess(BuildScopedCacheBuilderFactory cacheBuilderFactory) {
         return new DefaultExecutionHistoryCacheAccess(cacheBuilderFactory);

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionServices.java
@@ -31,7 +31,7 @@ public class ExecutionServices extends AbstractGradleModuleServices {
     }
 
     @Override
-    public void registerGradleServices(ServiceRegistration registration) {
-        registration.addProvider(new ExecutionGradleServices());
+    public void registerBuildServices(ServiceRegistration registration) {
+        registration.addProvider(new ExecutionBuildServices());
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -79,11 +79,6 @@ import java.util.List;
 public class GradleScopeServices extends ScopedServiceRegistry {
     public GradleScopeServices(final ServiceRegistry parent) {
         super(Scope.Gradle.class, "Gradle-scope services", parent);
-        register(registration -> {
-            for (GradleModuleServices services : parent.getAll(GradleModuleServices.class)) {
-                services.registerGradleServices(registration);
-            }
-        });
     }
 
     @Provides


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context

This ensures that there is a single `ExecutionEngine` that will honor the build cache configuration, regardless of which scope the consuming service happens to live in.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
