### PR TITLE
Add support for using JUnit Platform selectors via `--select-tests`

### DIFF
--- a/platforms/jvm/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformSelectorParser.java
+++ b/platforms/jvm/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformSelectorParser.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Will be replaced by JUnit Platform's {@link org.junit.platform.engine.discovery.DiscoverySelectors#parseAll(Collection <String>)} once 5.10.3 is released
+ * Will be replaced by JUnit Platform's {@link org.junit.platform.engine.discovery.DiscoverySelectors#parseAll(Collection <String>)} once 5.11 is released
  * PR https://github.com/junit-team/junit5/pull/3737
  */
 public class JUnitPlatformSelectorParser {

--- a/platforms/jvm/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformSelectorParser.java
+++ b/platforms/jvm/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformSelectorParser.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing.junitplatform;
+
+import org.junit.platform.engine.DiscoverySelector;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Will be replaced by JUnit Platform's {@link org.junit.platform.engine.discovery.DiscoverySelectors#parseAll(Collection <String>)} once 5.10.3 is released
+ * PR https://github.com/junit-team/junit5/pull/3737
+ */
+public class JUnitPlatformSelectorParser {
+    public static List<DiscoverySelector> parse(List<String> selectorPatterns) {
+        return JUnitPlatformSelectorParser.parseSelectors(selectorPatterns);
+    }
+
+    private static List<DiscoverySelector> parseSelectors(List<String> selectorPatterns) {
+        return selectorPatterns.stream().flatMap(JUnitPlatformSelectorParser::parseSelector).collect(Collectors.toList());
+    }
+
+    private static Stream<DiscoverySelector> parseSelector(String selectorPattern) {
+        // A subset of the supported selectors added in https://github.com/junit-team/junit5/pull/3737
+        // for demonstration purposes
+        String[] parts = selectorPattern.split(":", 2);
+        if (parts.length != 2) {
+            return Stream.empty();
+        }
+        switch (parts[0]) {
+            case "class":
+                return Stream.of(DiscoverySelectors.selectClass(parts[1]));
+            case "file":
+                return Stream.of(DiscoverySelectors.selectFile(parts[1]));
+            case "method":
+                return Stream.of(DiscoverySelectors.selectMethod(parts[1]));
+            case "module":
+                return Stream.of(DiscoverySelectors.selectModule(parts[1]));
+            case "package":
+                return Stream.of(DiscoverySelectors.selectPackage(parts[1]));
+            case "uid":
+                return Stream.of(DiscoverySelectors.selectUniqueId(parts[1]));
+            default:
+                return Stream.empty();
+        }
+    }
+}

--- a/platforms/jvm/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessor.java
+++ b/platforms/jvm/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessor.java
@@ -177,11 +177,16 @@ public class JUnitPlatformTestClassProcessor extends AbstractJUnitTestClassProce
     }
 
     private LauncherDiscoveryRequest createLauncherDiscoveryRequest(List<Class<?>> testClasses) {
-        List<DiscoverySelector> classSelectors = testClasses.stream()
-            .map(DiscoverySelectors::selectClass)
-            .collect(Collectors.toList());
+        List<DiscoverySelector> discoverySelectors = null;
+        if (spec.getSelectorPatterns().isEmpty()) {
+            discoverySelectors =testClasses.stream()
+                .map(DiscoverySelectors::selectClass)
+                .collect(Collectors.toList());
+        } else {
+            discoverySelectors = JUnitPlatformSelectorParser.parse(spec.getSelectorPatterns());
+        }
 
-        LauncherDiscoveryRequestBuilder requestBuilder = LauncherDiscoveryRequestBuilder.request().selectors(classSelectors);
+        LauncherDiscoveryRequestBuilder requestBuilder = LauncherDiscoveryRequestBuilder.request().selectors(discoverySelectors);
 
         addTestNameFilters(requestBuilder);
         addEnginesFilter(requestBuilder);

--- a/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformSpec.java
+++ b/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformSpec.java
@@ -28,6 +28,7 @@ public class JUnitPlatformSpec implements Serializable {
     private final Set<String> excludeEngines;
     private final Set<String> includeTags;
     private final Set<String> excludeTags;
+    private final Set<String> selectorPatterns;
     private final boolean isDryRun;
 
     public JUnitPlatformSpec(
@@ -36,6 +37,7 @@ public class JUnitPlatformSpec implements Serializable {
         Set<String> excludeEngines,
         Set<String> includeTags,
         Set<String> excludeTags,
+        Set<String> selectorPatterns,
         boolean isDryRun
     ) {
         this.filter = filter;
@@ -43,6 +45,7 @@ public class JUnitPlatformSpec implements Serializable {
         this.excludeEngines = excludeEngines;
         this.includeTags = includeTags;
         this.excludeTags = excludeTags;
+        this.selectorPatterns = selectorPatterns;
         this.isDryRun = isDryRun;
     }
 
@@ -64,6 +67,10 @@ public class JUnitPlatformSpec implements Serializable {
 
     public List<String> getExcludeTags() {
         return new ArrayList<String>(excludeTags);
+    }
+
+    public List<String> getSelectorPatterns() {
+        return new ArrayList<String>(selectorPatterns);
     }
 
     public boolean isDryRun() {

--- a/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestFramework.java
+++ b/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestFramework.java
@@ -101,8 +101,8 @@ public class JUnitPlatformTestFramework implements TestFramework {
         validateOptions();
         return new JUnitPlatformTestClassProcessorFactory(new JUnitPlatformSpec(
             filter.toSpec(), options.getIncludeEngines(), options.getExcludeEngines(),
-            options.getIncludeTags(), options.getExcludeTags(), dryRun.get()
-        ));
+            options.getIncludeTags(), options.getExcludeTags(),
+            filter.getJunitPlatformSelectorPatterns(), dryRun.get()));
     }
 
     @Override

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/DefaultTestFilter.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/DefaultTestFilter.java
@@ -31,6 +31,7 @@ public class DefaultTestFilter implements TestFilter {
     private final Set<String> includeTestNames = new HashSet<String>();
     private final Set<String> excludeTestNames = new HashSet<String>();
     private final Set<String> commandLineIncludeTestNames = new HashSet<String>();
+    private final Set<String> junitPlatformSelectorPatterns = new HashSet<String>();
     private boolean failOnNoMatching = true;
 
     private void validateName(String name) {
@@ -124,6 +125,20 @@ public class DefaultTestFilter implements TestFilter {
         }
         this.commandLineIncludeTestNames.clear();
         this.commandLineIncludeTestNames.addAll(testNamePatterns);
+        return this;
+    }
+
+    @Input
+    public Set<String> getJunitPlatformSelectorPatterns() {
+        return junitPlatformSelectorPatterns;
+    }
+
+    public TestFilter setJunitPlatformSelectorPatterns(Collection<String> selectorPatterns) {
+        for (String pattern : selectorPatterns) {
+            validateName(pattern);
+        }
+        this.junitPlatformSelectorPatterns.clear();
+        this.junitPlatformSelectorPatterns.addAll(selectorPatterns);
         return this;
     }
 

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -641,6 +641,16 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
         return this;
     }
 
+    /**
+     * Sets the JUnit Platform selector patterns to be used for test discovery.
+     * See the JUnit Platform documentation for more information.
+     */
+    @Option(option = "select-tests", description = "Sets the JUnit Platform selector patterns (requires JUnitPlatform to be used).")
+    public AbstractTestTask setJunitPlatformSelectorPatterns(List<String> junitPlatformSelectorPatterns) {
+        filter.setJunitPlatformSelectorPatterns(junitPlatformSelectorPatterns);
+        return this;
+    }
+
     @Internal
     boolean getFailFast() {
         return failFast;


### PR DESCRIPTION
Fixes #21317, #21302

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

Gradle users can't leverage all of the powerful selectors that the JUnit Platform provides.
Instead, they are limited to class or method filtering.

One glaringly obvious example is data-driven tests. When IntelliJ runs these tests directly, it is capable of re-running individual iterations. However, when delegating the execution to Gradle, the whole method has to be re-run.

The JUnit Platform [added](https://github.com/junit-team/junit5/pull/3737/) standardized string representations of all supported selectors and the ability to parse them.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
