### PR TITLE
Fix javadoc for "resolvable" in JsonProjectDependencyRenderer

### DIFF
--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/internal/JsonProjectDependencyRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/internal/JsonProjectDependencyRenderer.java
@@ -64,7 +64,7 @@ import java.util.Set;
  *                       {
  *                           "module" : "group:name"
  *                           "name" : "...",
- *                           "resolvable" : true|false,
+ *                           "resolvable" : "FAILED" | "RESOLVED" | "RESOLVED_CONSTRAINT" | "UNRESOLVED",
  *                           "alreadyRendered" : true|false
  *                           "hasConflict" : true|false
  *                           "children" : [
@@ -80,7 +80,7 @@ import java.util.Set;
  *                               {
  *                                   "name" : "...",
  *                                   "description" : "...",
- *                                   "resolvable" : true|false,
+ *                                   "resolvable" : "FAILED" | "RESOLVED" | "RESOLVED_CONSTRAINT" | "UNRESOLVED",
  *                                   "hasConflict" : true|false,
  *                                   "children": [
  *                                       {


### PR DESCRIPTION
In the html dependency report's json, the "resolvable" field is not a boolean; it is of type RenderableDependency which is an enum of FAILED, RESOLVED, RESOLVED_CONSTRAINT, UNRESOLVED.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
The javadoc is wrong and that is never good :)

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
