### PR TITLE
Increase to Xmx3000m for now

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Reduce Xmx after https://github.com/gradle/gradle-private/issues/4168 is resolved
-org.gradle.jvmargs=-Xmx2700m -XX:MaxMetaspaceSize=768m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx3000m -XX:MaxMetaspaceSize=768m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true


### PR DESCRIPTION
We've seen build failures and IDE sync failures with current Xmx2700m. While we're investigating let's
increase it to 3000m for now.