### PR TITLE
Allow any new return type for simple custom interceptors for bytecode upgrade

### DIFF
--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
@@ -440,7 +440,7 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
         extras.add(new RequestExtra.OriginatingElement(method));
         extras.add(new RequestExtra.InterceptJvmCalls(interceptorsClassName, BYTECODE_UPGRADE));
         String implementationClass = accessor.generatedClassName;
-        GradleLazyType gradleLazyType = GradleLazyType.from(extractType(method.getReturnType()));
+        Type newReturnType = TypeUtils.extractReturnType(method);
         String propertyName = getPropertyName(method);
         String methodDescriptor = extractMethodDescriptor(method);
         extras.add(new PropertyUpgradeRequestExtra(
@@ -451,7 +451,7 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
             implementationClass,
             accessor.propertyName,
             accessor.methodName,
-            gradleLazyType,
+            newReturnType,
             accessor.deprecationSpec,
             binaryCompatibility,
             accessor.bridgedMethod

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeClassSourceGenerator.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeClassSourceGenerator.java
@@ -149,7 +149,8 @@ public class PropertyUpgradeClassSourceGenerator extends RequestGroupingInstrume
     }
 
     private static List<AnnotationSpec> getAnnotations(PropertyUpgradeRequestExtra implementationExtra) {
-        switch (implementationExtra.getPropertyType()) {
+        GradleLazyType gradleLazyType = GradleLazyType.from(implementationExtra.getNewReturnType());
+        switch (gradleLazyType) {
             case LIST_PROPERTY:
             case SET_PROPERTY:
             case MAP_PROPERTY:
@@ -165,7 +166,7 @@ public class PropertyUpgradeClassSourceGenerator extends RequestGroupingInstrume
         String propertyGetterName = implementationExtra.getMethodName();
         boolean isSetter = implementation.getName().startsWith("access_set_");
         CallableReturnTypeInfo returnType = callableInfo.getReturnType();
-        GradleLazyType upgradedPropertyType = implementationExtra.getPropertyType();
+        GradleLazyType upgradedPropertyType = GradleLazyType.from(implementationExtra.getNewReturnType());
 
         CodeBlock.Builder codeBlockBuilder = CodeBlock.builder();
         if (implementationExtra.getDeprecationSpec().isEnabled()) {

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeRequestExtra.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeRequestExtra.java
@@ -19,7 +19,6 @@ package org.gradle.internal.instrumentation.extensions.property;
 import org.gradle.internal.instrumentation.api.annotations.ReplacesEagerProperty.BinaryCompatibility;
 import org.gradle.internal.instrumentation.extensions.property.PropertyUpgradeAnnotatedMethodReader.DeprecationSpec;
 import org.gradle.internal.instrumentation.model.RequestExtra;
-import org.gradle.internal.instrumentation.processor.codegen.GradleLazyType;
 import org.objectweb.asm.Type;
 
 import javax.lang.model.element.ExecutableElement;
@@ -32,7 +31,7 @@ class PropertyUpgradeRequestExtra implements RequestExtra {
     private final String implementationClassName;
     private final String interceptedPropertyAccessorName;
     private final String methodDescriptor;
-    private final GradleLazyType propertyType;
+    private final Type newReturnType;
     private final DeprecationSpec deprecationSpec;
     private final BinaryCompatibility binaryCompatibility;
     private final String interceptedPropertyName;
@@ -46,7 +45,7 @@ class PropertyUpgradeRequestExtra implements RequestExtra {
         String implementationClassName,
         String interceptedPropertyName,
         String interceptedPropertyAccessorName,
-        GradleLazyType propertyType,
+        Type newReturnType,
         DeprecationSpec deprecationSpec,
         BinaryCompatibility binaryCompatibility,
         ExecutableElement bridgedMethod
@@ -54,7 +53,7 @@ class PropertyUpgradeRequestExtra implements RequestExtra {
         this.propertyName = propertyName;
         this.methodName = methodName;
         this.methodDescriptor = methodDescriptor;
-        this.propertyType = propertyType;
+        this.newReturnType = newReturnType;
         this.returnType = returnType;
         this.implementationClassName = implementationClassName;
         this.interceptedPropertyName = interceptedPropertyName;
@@ -76,8 +75,8 @@ class PropertyUpgradeRequestExtra implements RequestExtra {
         return methodDescriptor;
     }
 
-    public GradleLazyType getPropertyType() {
-        return propertyType;
+    public Type getNewReturnType() {
+        return newReturnType;
     }
 
     public String getImplementationClassName() {

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/GradleLazyType.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/GradleLazyType.java
@@ -69,7 +69,7 @@ public enum GradleLazyType {
                 return gradleType;
             }
         }
-        throw new UnsupportedOperationException("Unknown lazy type: " + type.getClassName());
+        throw new UnsupportedOperationException("Unknown Gradle lazy type: " + type.getClassName());
     }
 
     public static GradleLazyType from(String name) {
@@ -78,6 +78,6 @@ public enum GradleLazyType {
                 return gradleType;
             }
         }
-        throw new UnsupportedOperationException("Unknown lazy type: " + name);
+        throw new UnsupportedOperationException("Unknown Gradle lazy type: " + name);
     }
 }

--- a/platforms/core-runtime/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeCustomInterceptorCodeGenTest.groovy
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeCustomInterceptorCodeGenTest.groovy
@@ -290,7 +290,6 @@ class PropertyUpgradeCustomInterceptorCodeGenTest extends InstrumentationCodeGen
         def newTask = source """
             package org.gradle.test;
 
-            import org.gradle.api.provider.Property;
             import org.gradle.internal.instrumentation.api.annotations.ReplacesEagerProperty;
             import org.gradle.internal.instrumentation.api.annotations.BytecodeUpgrade;
 


### PR DESCRIPTION
Fixes a bug in simple custom interceptors. Basically the bug is, that we allow custom interceptors only for types we support automatic upgrades, e.g. `Property`, but not for other types, e.g. `Provider`. This fixes it, so we can have simple custom inerceptors for any type.

Fixes https://github.com/gradle/gradle/issues/29539
