### PR TITLE
Deprecate running Gradle on < Java 17

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsIntegrationTest.groovy
@@ -51,6 +51,7 @@ class IsolatedProjectsIntegrationTest extends AbstractIsolatedProjectsIntegratio
         """
 
         when:
+        executer.noJavaVersionDeprecationChecks()
         isolatedProjectsFails("thing", "--no-configuration-cache")
 
         then:

--- a/platforms/core-configuration/declarative-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/declarative/dsl/tooling/builders/r89/DeclarativeDslToolingModelsCrossVersionTest.groovy
+++ b/platforms/core-configuration/declarative-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/declarative/dsl/tooling/builders/r89/DeclarativeDslToolingModelsCrossVersionTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.declarative.dsl.tooling.builders.r89
 
-import org.gradle.api.internal.plugins.software.SoftwareType
 import org.gradle.declarative.dsl.tooling.builders.AbstractDeclarativeDslToolingModelsCrossVersionTest
 import org.gradle.declarative.dsl.tooling.models.DeclarativeSchemaModel
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
@@ -34,7 +33,6 @@ import org.gradle.internal.declarativedsl.objectGraph.AssignmentResolver.Assignm
 import org.gradle.internal.declarativedsl.parsing.DefaultLanguageTreeBuilder
 import org.gradle.internal.declarativedsl.parsing.ParserKt
 import org.gradle.test.fixtures.plugin.PluginBuilder
-import org.gradle.tooling.ModelBuilder
 
 @TargetGradleVersion(">=8.9")
 @ToolingApiVersion('>=8.9')
@@ -330,10 +328,8 @@ class DeclarativeDslToolingModelsCrossVersionTest extends AbstractDeclarativeDsl
     }
 
     private <T> T fetchSchemaModel(Class<T> modelType) {
-        toolingApi.withConnection() { connection ->
-            ModelBuilder<T> modelBuilder = connection.model(modelType)
-            collectOutputs(modelBuilder)
-            modelBuilder.get()
+        toolingApi.withConnection { connection ->
+            connection.model(modelType).get()
         }
     }
 

--- a/platforms/core-runtime/build-configuration/src/testFixtures/groovy/org/gradle/internal/buildconfiguration/fixture/DaemonJvmPropertiesFixture.groovy
+++ b/platforms/core-runtime/build-configuration/src/testFixtures/groovy/org/gradle/internal/buildconfiguration/fixture/DaemonJvmPropertiesFixture.groovy
@@ -52,6 +52,7 @@ trait DaemonJvmPropertiesFixture {
     void writeJvmCriteria(Jvm jvm) {
         def otherMetadata = AvailableJavaHomes.getJvmInstallationMetadata(jvm)
         writeJvmCriteria(jvm.javaVersion, otherMetadata.vendor.knownVendor.name())
+        executer.checkJavaVersionDeprecationUsing(jvm)
     }
 
     void writeJvmCriteria(JavaVersion version, String vendor = null, String implementation = null) {

--- a/platforms/core-runtime/daemon-protocol/src/main/java/org/gradle/launcher/daemon/diagnostics/DaemonDiagnostics.java
+++ b/platforms/core-runtime/daemon-protocol/src/main/java/org/gradle/launcher/daemon/diagnostics/DaemonDiagnostics.java
@@ -64,7 +64,7 @@ public class DaemonDiagnostics {
     }
 
     private String formatTail(String tail) {
-        return "----- Last  " + TAIL_SIZE + " lines from daemon log file - " + getDaemonLog().getName() + " -----\n"
+        return "----- Last " + TAIL_SIZE + " lines from daemon log file - " + getDaemonLog().getName() + " -----\n"
             + tail
             + "----- End of the daemon log -----\n";
     }

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/CommandLineIntegrationSpec.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/CommandLineIntegrationSpec.groovy
@@ -33,6 +33,7 @@ class CommandLineIntegrationSpec extends AbstractIntegrationSpec {
     @Requires(IntegTestPreconditions.NotParallelExecutor)
     def "reasonable failure message when --max-workers=#value"() {
         given:
+        executer.noJavaVersionDeprecationChecks()
         executer.requireDaemon().requireIsolatedDaemons()  // otherwise exception gets thrown in testing infrastructure
 
         when:
@@ -50,6 +51,7 @@ class CommandLineIntegrationSpec extends AbstractIntegrationSpec {
 
     def "reasonable failure message when org.gradle.workers.max=#value"() {
         given:
+        executer.noJavaVersionDeprecationChecks()
         executer.requireDaemon().requireIsolatedDaemons() // otherwise exception gets thrown in testing infrastructure
 
         when:
@@ -184,6 +186,7 @@ class CommandLineIntegrationSpec extends AbstractIntegrationSpec {
     @Timeout(30)
     def "reasonable failure message when org.gradle.debug.port=#value"() {
         given:
+        executer.noJavaVersionDeprecationChecks()
         executer.requireDaemon().requireIsolatedDaemons() // otherwise exception gets thrown in testing infrastructure
 
         when:

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/GradleConfigurabilityIntegrationSpec.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/GradleConfigurabilityIntegrationSpec.groovy
@@ -50,6 +50,7 @@ assert java.lang.management.ManagementFactory.runtimeMXBean.inputArguments.conta
         file("gradle.properties").writeProperties(["org.gradle.java.home": dummyJdk.absolutePath])
 
         then:
+        executer.noJavaVersionDeprecationChecks()
         fails()
 
         and:
@@ -102,6 +103,7 @@ assert inputArgs.find { it.contains('-XX:HeapDumpPath=') }
     String useAlternativeJavaPath(Jvm jvm = AvailableJavaHomes.differentJdk) {
         File javaHome = jvm.javaHome
         file("gradle.properties").writeProperties("org.gradle.java.home": javaHome.canonicalPath)
+        executer.checkJavaVersionDeprecationUsing(jvm)
         return javaHome.canonicalPath
     }
 

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/StacktraceIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/StacktraceIntegrationTest.groovy
@@ -69,6 +69,7 @@ class StacktraceIntegrationTest extends AbstractIntegrationSpec {
 
     def "emits actionable message when wrong configuration is used"() {
         setup:
+        executer.noJavaVersionDeprecationChecks()
         executer.requireDaemon().requireIsolatedDaemons()
         file('gradle.properties') << 'org.gradle.logging.stacktrace=suppress'
 

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/SupportedBuildJvmIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/SupportedBuildJvmIntegrationTest.groovy
@@ -74,6 +74,7 @@ class SupportedBuildJvmIntegrationTest extends AbstractIntegrationSpec {
     )
     def "provides reasonable failure message when attempting to run under java #jdk.javaVersion"() {
         given:
+        executer.noJavaVersionDeprecationChecks()
         executer.withJvm(jdk)
 
         expect:
@@ -87,6 +88,7 @@ class SupportedBuildJvmIntegrationTest extends AbstractIntegrationSpec {
     @Requires(IntegTestPreconditions.UnsupportedJavaHomeAvailable)
     def "fails when build is configured to use Java #jdk.javaVersion"() {
         given:
+        executer.noJavaVersionDeprecationChecks()
         file("gradle.properties").writeProperties("org.gradle.java.home": jdk.javaHome.canonicalPath)
 
         expect:

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/cli/NotificationsIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/cli/NotificationsIntegrationTest.groovy
@@ -70,8 +70,11 @@ ${getReleaseNotesDetailsMessage(distribution.version)}
     }
 
     def "show reasonable error message for invalid configuration property"() {
-        when:
+        given:
         propertiesFile << "org.gradle.welcome=foo"
+        executer.noJavaVersionDeprecationChecks()
+
+        when:
         fails()
 
         then:

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/AbstractDaemonLifecycleSpec.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/AbstractDaemonLifecycleSpec.groovy
@@ -137,6 +137,7 @@ class AbstractDaemonLifecycleSpec extends DaemonIntegrationSpec {
 
     void stopDaemonsNow() {
         executer.withArguments("--stop", "--info")
+
         if (jvm) {
             executer.withJvm(jvm)
         }

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonAuthenticationIntegrationSpec.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonAuthenticationIntegrationSpec.groovy
@@ -31,6 +31,7 @@ class DaemonAuthenticationIntegrationSpec extends DaemonIntegrationSpec {
 
         when:
         daemon.changeTokenVisibleToClient()
+        executer.noJavaVersionDeprecationChecks()
         fails()
 
         then:

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonOutputToggleIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonOutputToggleIntegrationTest.groovy
@@ -32,6 +32,7 @@ class DaemonOutputToggleIntegrationTest extends DaemonIntegrationSpec {
 
     def "output is not received when toggle is on"() {
         when:
+        executer.noJavaVersionDeprecationChecks() // Logging is disabled, deprecation warning not emitted
         executer.withBuildJvmOpts("-D$LogToClient.DISABLE_OUTPUT=true").noExtraLogging()
         succeeds "help"
 

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonToolchainIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonToolchainIntegrationTest.groovy
@@ -64,6 +64,7 @@ class DaemonToolchainIntegrationTest extends AbstractIntegrationSpec implements 
         captureJavaHome()
 
         expect:
+        executer.noJavaVersionDeprecationChecks()
         fails("help")
         failure.assertHasDescription("Cannot find a Java installation on your machine")
     }

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonToolchainInvalidCriteriaIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonToolchainInvalidCriteriaIntegrationTest.groovy
@@ -39,6 +39,7 @@ class DaemonToolchainInvalidCriteriaIntegrationTest extends AbstractIntegrationS
         given:
         daemonJvmPropertiesFile.writeProperties((DaemonJvmPropertiesDefaults.TOOLCHAIN_VERSION_PROPERTY): "stringVersion")
         when:
+        executer.noJavaVersionDeprecationChecks()
         fails 'help'
         then:
         failure.assertHasDescription("Value 'stringVersion' given for toolchainVersion is an invalid Java version")
@@ -48,6 +49,7 @@ class DaemonToolchainInvalidCriteriaIntegrationTest extends AbstractIntegrationS
         given:
         daemonJvmPropertiesFile.writeProperties((DaemonJvmPropertiesDefaults.TOOLCHAIN_VERSION_PROPERTY): "-1")
         when:
+        executer.noJavaVersionDeprecationChecks()
         fails 'help'
         then:
         failure.assertHasDescription("Value '-1' given for toolchainVersion is an invalid Java version")

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/ProcessCrashHandlingIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/ProcessCrashHandlingIntegrationTest.groovy
@@ -173,7 +173,7 @@ class ProcessCrashHandlingIntegrationTest extends DaemonIntegrationSpec {
         def failure = build.waitForFailure()
 
         then:
-        failure.assertHasErrorOutput("----- Last  20 lines from daemon log file")
+        failure.assertHasErrorOutput("----- Last 20 lines from daemon log file")
         failure.assertHasDescription(DaemonDisappearedException.MESSAGE)
     }
 
@@ -212,7 +212,7 @@ class ProcessCrashHandlingIntegrationTest extends DaemonIntegrationSpec {
         def failure = executer.runWithFailure()
 
         then:
-        failure.assertHasErrorOutput("----- Last  20 lines from daemon log file")
+        failure.assertHasErrorOutput("----- Last 20 lines from daemon log file")
         failure.assertHasErrorOutput(DaemonMessages.DAEMON_VM_SHUTTING_DOWN)
         failure.assertHasDescription(DaemonDisappearedException.MESSAGE)
 

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/SingleUseDaemonIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/SingleUseDaemonIntegrationTest.groovy
@@ -84,9 +84,11 @@ class SingleUseDaemonIntegrationTest extends AbstractIntegrationSpec implements 
 
     @Requires(IntegTestPreconditions.JavaHomeWithDifferentVersionAvailable)
     def "forks build with default daemon JVM args when java home from gradle properties does not match current process"() {
-        def javaHome = AvailableJavaHomes.differentJdk.javaHome.canonicalFile
+        def jdk = AvailableJavaHomes.differentJdk
+        def javaHome = jdk.javaHome.canonicalFile
 
         file('gradle.properties').writeProperties("org.gradle.java.home": javaHome.path)
+        executer.checkJavaVersionDeprecationUsing(jdk)
 
         file('build.gradle') << """
 println 'javaHome=' + org.gradle.internal.jvm.Jvm.current().javaHome.absolutePath

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/StoppingDaemonIntegrationSpec.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/StoppingDaemonIntegrationSpec.groovy
@@ -55,8 +55,6 @@ task block {
         then:
         stopsSingleDaemon()
         failure.assertHasDescription(DaemonStoppedException.MESSAGE)
-
-        build.waitForFailure()
     }
 
     def "can handle multiple concurrent stop requests"() {

--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/ConsoleTypePersistIntegrationTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/ConsoleTypePersistIntegrationTest.groovy
@@ -36,6 +36,7 @@ class ConsoleTypePersistIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         file('gradle.properties') << 'org.gradle.console=rich'
+        executer.noDeprecationChecks() // Rich consoles mess with deprecation checks
         succeeds('help', "-Pexpected=Rich")
         then:
         assertHasAnsiEscapeSequence()

--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractBasicGroupedTaskLoggingFunctionalTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractBasicGroupedTaskLoggingFunctionalTest.groovy
@@ -222,9 +222,6 @@ abstract class AbstractBasicGroupedTaskLoggingFunctionalTest extends AbstractCon
 
         then:
         result.groupedOutput.task(':log').output == 'Before\nAfter'
-
-        cleanup:
-        gradle?.waitForFinish()
     }
 
     String callFromBuild(String name) {

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/api/internal/DocumentationRegistry.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/api/internal/DocumentationRegistry.java
@@ -26,7 +26,8 @@ import org.gradle.util.GradleVersion;
  */
 @ServiceScope(Scope.Global.class)
 public class DocumentationRegistry {
-    public static final String BASE_URL = "https://docs.gradle.org/" + GradleVersion.current().getVersion();
+    public static final String BASE_URL_WITHOUT_VERSION = "https://docs.gradle.org/";
+    public static final String BASE_URL = BASE_URL_WITHOUT_VERSION + GradleVersion.current().getVersion();
     public static final String DSL_PROPERTY_URL_FORMAT = "%s/dsl/%s.html#%s:%s";
     public static final String KOTLIN_DSL_URL_FORMAT = "%s/kotlin-dsl/gradle/%s";
     public static final String LEARN_MORE_STRING = "Learn more about Gradle by exploring our Samples at ";

--- a/platforms/core-runtime/wrapper-main/src/integTest/groovy/org/gradle/integtests/WrapperBadArchiveTest.groovy
+++ b/platforms/core-runtime/wrapper-main/src/integTest/groovy/org/gradle/integtests/WrapperBadArchiveTest.groovy
@@ -96,6 +96,7 @@ class WrapperBadArchiveTest extends AbstractWrapperIntegrationSpec {
         when:
         def failure = wrapperExecuter
             .withStackTraceChecksDisabled()
+            .noJavaVersionDeprecationChecks()
             .runWithFailure()
 
         then:

--- a/platforms/core-runtime/wrapper-main/src/integTest/groovy/org/gradle/integtests/WrapperChecksumVerificationTest.groovy
+++ b/platforms/core-runtime/wrapper-main/src/integTest/groovy/org/gradle/integtests/WrapperChecksumVerificationTest.groovy
@@ -56,7 +56,7 @@ class WrapperChecksumVerificationTest extends AbstractWrapperIntegrationSpec {
         file(WRAPPER_PROPERTIES_PATH) << 'distributionSha256Sum=bad'
 
         when:
-        def failure = wrapperExecuter.withStackTraceChecksDisabled().runWithFailure()
+        def failure = wrapperExecuter.withStackTraceChecksDisabled().noJavaVersionDeprecationChecks().runWithFailure()
         def f = new File(file("user-home/wrapper/dists/gradle-bin").listFiles()[0], "gradle-bin.zip")
 
         then:

--- a/platforms/core-runtime/wrapper-main/src/integTest/groovy/org/gradle/integtests/WrapperHttpIntegrationTest.groovy
+++ b/platforms/core-runtime/wrapper-main/src/integTest/groovy/org/gradle/integtests/WrapperHttpIntegrationTest.groovy
@@ -93,6 +93,7 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
 
         when:
         wrapperExecuter.withStackTraceChecksDisabled()
+        wrapperExecuter.noJavaVersionDeprecationChecks()
         def failure = wrapperExecuter.runWithFailure()
 
         then:
@@ -117,6 +118,7 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
 
         when:
         wrapperExecuter.withStackTraceChecksDisabled()
+        wrapperExecuter.noJavaVersionDeprecationChecks()
         def failure = wrapperExecuter.runWithFailure()
 
         then:
@@ -133,6 +135,7 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
 
         when:
         wrapperExecuter.withStackTraceChecksDisabled()
+        wrapperExecuter.noJavaVersionDeprecationChecks()
         def failure = wrapperExecuter.runWithFailure()
 
         then:
@@ -153,6 +156,7 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
 
         when:
         wrapperExecuter.withStackTraceChecksDisabled()
+        wrapperExecuter.noJavaVersionDeprecationChecks()
         def failure = wrapperExecuter.runWithFailure()
 
         then:

--- a/platforms/core-runtime/wrapper-main/src/integTest/groovy/org/gradle/integtests/WrapperLoggingIntegrationTest.groovy
+++ b/platforms/core-runtime/wrapper-main/src/integTest/groovy/org/gradle/integtests/WrapperLoggingIntegrationTest.groovy
@@ -111,6 +111,7 @@ class WrapperLoggingIntegrationTest extends AbstractWrapperIntegrationSpec {
         failure = wrapperExecuter
             .withTasks("emptyTask")
             .withStackTraceChecksDisabled()
+            .noJavaVersionDeprecationChecks()
             .runWithFailure()
 
         then:

--- a/platforms/core-runtime/wrapper-main/src/integTest/groovy/org/gradle/integtests/WrapperSupportedBuildJvmIntegrationTest.groovy
+++ b/platforms/core-runtime/wrapper-main/src/integTest/groovy/org/gradle/integtests/WrapperSupportedBuildJvmIntegrationTest.groovy
@@ -47,7 +47,7 @@ class WrapperSupportedBuildJvmIntegrationTest extends AbstractWrapperIntegration
         file("gradle.properties").writeProperties("org.gradle.java.home": jdk.javaHome.canonicalPath)
 
         expect:
-        def failure = wrapperExecuter.withTasks("help").runWithFailure()
+        def failure = wrapperExecuter.withTasks("help").noJavaVersionDeprecationChecks().runWithFailure()
         failure.assertHasErrorOutput("Gradle ${GradleVersion.current().version} requires Java 8 or later to run. Your build is currently configured to use Java ${jdk.javaVersion.majorVersion}.")
 
         where:

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r50/ProjectStateLockingCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r50/ProjectStateLockingCrossVersionTest.groovy
@@ -33,7 +33,6 @@ class ProjectStateLockingCrossVersionTest extends ToolingApiSpecification {
         withConnection {
             def executer = action(new FetchIdeaProject())
             executer.withArguments("--warning-mode", "all")
-            collectOutputs(executer)
             executer.run()
         }
 
@@ -55,7 +54,6 @@ class ProjectStateLockingCrossVersionTest extends ToolingApiSpecification {
         withConnection {
             def executer = action(new FetchEclipseProject())
             executer.withArguments("--warning-mode", "all")
-            collectOutputs(executer)
             executer.run()
         }
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/CompositeBuildTaskExecutionCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/CompositeBuildTaskExecutionCrossVersionSpec.groovy
@@ -389,7 +389,6 @@ class CompositeBuildTaskExecutionCrossVersionSpec extends ToolingApiSpecificatio
         when:
         withConnection { connection ->
             TestLauncher launcher = connection.newTestLauncher().withTests(descriptor)
-            collectOutputs(launcher)
             launcher.run()
         }
 
@@ -429,7 +428,6 @@ class CompositeBuildTaskExecutionCrossVersionSpec extends ToolingApiSpecificatio
         when:
         withConnection { connection ->
             def testLauncher = connection.newTestLauncher()
-            collectOutputs(testLauncher)
             testLauncher.withTaskAndTestClasses(":other-build:sub:test", ["MyIncludedTest"]).run()
         }
 
@@ -440,7 +438,6 @@ class CompositeBuildTaskExecutionCrossVersionSpec extends ToolingApiSpecificatio
     private void executeTaskViaTAPI(String... tasks) {
         withConnection { connection ->
             def build = connection.newBuild()
-            collectOutputs(build)
             build.forTasks(tasks).run()
         }
     }
@@ -451,7 +448,6 @@ class CompositeBuildTaskExecutionCrossVersionSpec extends ToolingApiSpecificatio
             def launchables = findLaunchables(gradleProjects, taskName)
             assert launchables.size == 1
             def build = connection.newBuild()
-            collectOutputs(build)
             build.forLaunchables(launchables[0]).run()
         }
     }
@@ -472,7 +468,6 @@ class CompositeBuildTaskExecutionCrossVersionSpec extends ToolingApiSpecificatio
             def tasks = buildInvocations.collect { it.tasks }.flatten().findAll { it.path.contains(taskName) }
             assert tasks.size == 1
             def build = connection.newBuild()
-            collectOutputs(build)
             build.forLaunchables(tasks[0]).run()
         }
     }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DeferredConfigurationCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DeferredConfigurationCrossVersionSpec.groovy
@@ -31,7 +31,6 @@ class DeferredConfigurationCrossVersionSpec extends ToolingApiSpecification {
         when:
         def model = withConnection {
             def executer = action(new NoOpAction())
-            collectOutputs(executer)
             executer.run()
         }
 
@@ -73,7 +72,6 @@ class DeferredConfigurationCrossVersionSpec extends ToolingApiSpecification {
         when:
         def model = withConnection {
             def executer = action(new FetchGradleBuildAction())
-            collectOutputs(executer)
             executer.run()
         }
 
@@ -117,7 +115,6 @@ class DeferredConfigurationCrossVersionSpec extends ToolingApiSpecification {
         when:
         def model = withConnection {
             def executer = action(new FetchProjectAction())
-            collectOutputs(executer)
             executer.run()
         }
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DeprecationsCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DeprecationsCrossVersionSpec.groovy
@@ -26,6 +26,11 @@ class DeprecationsCrossVersionSpec extends ToolingApiSpecification {
         settingsFile << """
             include("a")
         """
+        file("a/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
+        """
         buildFile << """
             import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
             import org.gradle.tooling.provider.model.ToolingModelBuilder
@@ -37,35 +42,25 @@ class DeprecationsCrossVersionSpec extends ToolingApiSpecification {
                 }
                 Object buildAll(String modelName, Project project) {
                     println("creating model for \$project")
-                    project.allprojects.each { p ->
-                        p.configurations.compileClasspath.files()
+                    project.subprojects.each { p ->
+                        p.configurations.compileClasspath.files
                     }
                     return ["result"]
                 }
             }
 
             project.services.get(ToolingModelBuilderRegistry.class).register(new MyModelBuilder())
-
-            allprojects {
-                apply plugin: 'java-library'
-            }
-            project(':a') {
-                dependencies {
-                    implementation rootProject
-                }
-            }
         """
 
         when:
         withConnection {
             def builder = it.model(List)
             builder.withArguments("--parallel")
-            collectOutputs(builder)
             return builder.get()
         }
 
         then:
-        expectDeprecation("Deprecated Gradle features were used in this build, making it incompatible with Gradle ${targetVersion.compareTo(GradleVersion.version("7.6.4")) > 0 ? "9.0" : "8.0" }.")
+        expectDocumentedDeprecationWarning("Resolution of the configuration :a:compileClasspath was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated. This will fail with an error in Gradle 9.0. For more information, please refer to https://docs.gradle.org/current/userguide/viewing_debugging_dependencies.html#sub:resolving-unsafe-configuration-resolution-errors in the Gradle documentation.")
         assertHasConfigureSuccessfulLogging()
     }
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r76/TestLauncherTaskExecutionCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r76/TestLauncherTaskExecutionCrossVersionSpec.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.tooling.r76
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiConnector
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
 import org.gradle.tooling.ProjectConnection
@@ -211,7 +212,6 @@ class TestLauncherTaskExecutionCrossVersionSpec extends ToolingApiSpecification 
         when:
         withConnection { ProjectConnection connection ->
             TestLauncher testLauncher = connection.newTestLauncher()
-            collectOutputs(testLauncher)
 
             testLauncher.forTasks("setupTest")
                         .withTestsFor(s -> s.forTaskPath(":test")
@@ -226,7 +226,6 @@ class TestLauncherTaskExecutionCrossVersionSpec extends ToolingApiSpecification 
         when:
         withConnection { connection ->
             TestLauncher testLauncher = connection.newTestLauncher()
-            collectOutputs(testLauncher)
             testLauncher.withTestsFor(s -> s.forTaskPath(":test").includeMethod('MyTest', 'pass')).forTasks('setupTest')
             testLauncher.run()
         }
@@ -235,7 +234,7 @@ class TestLauncherTaskExecutionCrossVersionSpec extends ToolingApiSpecification 
         tasksExecutedInOrder(':test', ':setupTest')
     }
 
-    private def launchTestWithTestFilter(connector, @DelegatesTo(TestLauncher) @ClosureParams(value = SimpleType, options = ['org.gradle.tooling.TestLauncher']) Closure testLauncherSpec) {
+    private def launchTestWithTestFilter(ToolingApiConnector connector, @DelegatesTo(TestLauncher) @ClosureParams(value = SimpleType, options = ['org.gradle.tooling.TestLauncher']) Closure testLauncherSpec) {
         withConnection(connector, connectionConfiguration(testLauncherSpec))
     }
 
@@ -247,7 +246,6 @@ class TestLauncherTaskExecutionCrossVersionSpec extends ToolingApiSpecification 
         {   ProjectConnection connection ->
             TestLauncher testLauncher = connection.newTestLauncher()
             testLauncher.withTaskAndTestMethods(':test', 'MyTest', ['pass'])
-            collectOutputs(testLauncher)
             testLauncherSpec(testLauncher)
             testLauncher.run()
         }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r86/StreamingBuildActionCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r86/StreamingBuildActionCrossVersionTest.groovy
@@ -56,7 +56,6 @@ class StreamingBuildActionCrossVersionTest extends ToolingApiSpecification {
 
         withConnection {
             def builder = it.action(new ModelStreamingBuildAction())
-            collectOutputs(builder)
             builder.setStreamedValueListener(listener)
             builder.run(handler)
             finished.await()
@@ -133,7 +132,6 @@ class StreamingBuildActionCrossVersionTest extends ToolingApiSpecification {
 
         withConnection {
             def builder = it.action(new BlockingModelSendingBuildAction(server.uri("action")))
-            collectOutputs(builder)
             builder.setStreamedValueListener(listener)
             builder.run(handler)
 
@@ -155,7 +153,6 @@ class StreamingBuildActionCrossVersionTest extends ToolingApiSpecification {
 
         withConnection {
             def builder = it.action(new ModelStreamingBuildAction())
-            collectOutputs(builder)
             builder.setStreamedValueListener(listener)
             builder.run()
         }
@@ -172,7 +169,6 @@ class StreamingBuildActionCrossVersionTest extends ToolingApiSpecification {
         when:
         withConnection {
             def builder = it.action(new ModelStreamingBuildAction())
-            collectOutputs(builder)
             builder.run()
         }
 
@@ -191,7 +187,6 @@ class StreamingBuildActionCrossVersionTest extends ToolingApiSpecification {
 
         withConnection {
             def builder = it.action(new ModelStreamingBuildAction())
-            collectOutputs(builder)
             builder.setStreamedValueListener(listener)
             builder.run()
         }

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiConnector.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiConnector.groovy
@@ -30,7 +30,7 @@ class ToolingApiConnector {
         this.connector = connector
     }
 
-    def connect() {
+    ProjectConnection connect() {
         new ToolingApiConnection(connector.connect(), stdout, stderr) as ProjectConnection
     }
 

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiConnector.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiConnector.groovy
@@ -34,26 +34,26 @@ class ToolingApiConnector {
         new ToolingApiConnection(connector.connect(), stdout, stderr) as ProjectConnection
     }
 
-    def searchUpwards(boolean searchUpwards) {
+    ToolingApiConnector searchUpwards(boolean searchUpwards) {
         connector.searchUpwards(searchUpwards)
         this
     }
 
-    def methodMissing(String name, args) {
+    void methodMissing(String name, args) {
         connector."$name"(*args)
     }
 
-    def propertyMissing(String name, value) {
+    void propertyMissing(String name, value) {
         connector."$name" = value
     }
 
-    def propertyMissing(String name) {
+    void propertyMissing(String name) {
         connector."$name"
     }
 
-    def forProjectDirectory(File projectDir) {
+    ToolingApiConnector forProjectDirectory(File projectDir) {
         connector.forProjectDirectory(projectDir)
-        connector
+        this
     }
 
     def disconnect() {

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocIntegrationTest.groovy
@@ -17,7 +17,6 @@ package org.gradle.api.tasks.javadoc
 
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.internal.jvm.Jvm
 import org.gradle.test.fixtures.file.TestFile

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocIntegrationTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.api.tasks.javadoc
 
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.internal.jvm.Jvm
 import org.gradle.test.fixtures.file.TestFile

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/UndefinedBuildExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/UndefinedBuildExecutionIntegrationTest.groovy
@@ -33,6 +33,7 @@ class UndefinedBuildExecutionIntegrationTest extends AbstractIntegrationSpec {
 
     def "fails when attempting to execute tasks #tasks in directory with no settings or build file"() {
         when:
+        executer.noJavaVersionDeprecationChecks()
         fails(*tasks)
 
         then:
@@ -134,6 +135,7 @@ class UndefinedBuildExecutionIntegrationTest extends AbstractIntegrationSpec {
         when:
         // the default, if running from user home dir
         def gradleUserHomeDir = file(".gradle")
+        executer.noJavaVersionDeprecationChecks()
         executer.withGradleUserHomeDir(gradleUserHomeDir)
         fails("tasks")
 
@@ -151,6 +153,7 @@ class UndefinedBuildExecutionIntegrationTest extends AbstractIntegrationSpec {
         textFile << "content"
 
         when:
+        executer.noJavaVersionDeprecationChecks()
         fails("tasks")
 
         then:
@@ -219,6 +222,7 @@ class UndefinedBuildExecutionIntegrationTest extends AbstractIntegrationSpec {
         file("buildSrc").createDir()
 
         expect:
+        executer.noJavaVersionDeprecationChecks()
         executer.usingProjectDirectory(file("buildSrc"))
         fails("tasks")
 
@@ -235,6 +239,7 @@ class UndefinedBuildExecutionIntegrationTest extends AbstractIntegrationSpec {
         succeeds("tasks")
 
         executer.usingProjectDirectory(file("buildSrc"))
+        executer.noJavaVersionDeprecationChecks()
         fails("tasks")
 
         file("buildSrc").assertIsEmptyDir()

--- a/subprojects/core/src/integTest/groovy/org/gradle/execution/commandline/CommandLineIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/execution/commandline/CommandLineIntegrationTest.groovy
@@ -104,6 +104,7 @@ class CommandLineIntegrationTest extends AbstractIntegrationSpec {
         String path = String.format('%s%s%s', jvm.javaExecutable.parentFile.canonicalPath, File.pathSeparator, System.getenv('PATH'))
 
         then:
+        executer.checkJavaVersionDeprecationUsing(jvm)
         executer.withEnvironmentVars('PATH': path).withJavaHome('').withArguments(expectedJavaHome).withTasks('checkJavaHome').run()
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/InternalGradleFailuresIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/InternalGradleFailuresIntegrationTest.groovy
@@ -54,6 +54,7 @@ class InternalGradleFailuresIntegrationTest extends AbstractIntegrationSpec {
         cachesDir.touch()
 
         when:
+        executer.noJavaVersionDeprecationChecks()
         fails 'hello'
 
         then:
@@ -67,6 +68,7 @@ class InternalGradleFailuresIntegrationTest extends AbstractIntegrationSpec {
         daemonDir.touch()
 
         when:
+        executer.noJavaVersionDeprecationChecks()
         fails 'hello'
 
         then:
@@ -82,6 +84,7 @@ class InternalGradleFailuresIntegrationTest extends AbstractIntegrationSpec {
         executer.withNoExplicitNativeServicesDir()
 
         when:
+        executer.noJavaVersionDeprecationChecks()
         fails 'hello'
 
         then:

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
@@ -424,6 +424,8 @@ class LoggingBuildOperationProgressIntegTest extends AbstractIntegrationSpec {
             .flatten()
             .with { it as List<BuildOperationRecord.Progress> }
             .findAll { OutputEvent.isAssignableFrom(it.detailsType) }
+            // Ignore deprecations, these are checked by the testing infrastructure elsewhere.
+            .findAll { it.details.get("category") != "org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler" }
 
         // 11 tasks + "\n" + "BUILD SUCCESSFUL" + "2 actionable tasks: 2 executed"
         // when configuration cache is enabled also "Configuration cache entry reused."

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLoadingIntegrationTest.java
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLoadingIntegrationTest.java
@@ -26,6 +26,7 @@ import java.io.File;
 import static org.hamcrest.CoreMatchers.startsWith;
 
 public class ProjectLoadingIntegrationTest extends AbstractIntegrationTest {
+
     @Test
     public void handlesSimilarlyNamedBuildFilesInSameDirectory() {
         TestFile buildFile1 = testFile("similarly-named build.gradle").write("task build");
@@ -119,12 +120,12 @@ public class ProjectLoadingIntegrationTest extends AbstractIntegrationTest {
     public void buildFailsWhenSpecifiedBuildFileIsNotAFile() {
         TestFile file = testFile("unknown");
 
-        ExecutionFailure result = usingBuildFile(file).runWithFailure();
+        ExecutionFailure result = usingBuildFile(file).noJavaVersionDeprecationChecks().runWithFailure();
         result.assertHasDescription("The specified build file '" + file + "' does not exist.");
 
         file.createDir();
 
-        result = usingBuildFile(file).runWithFailure();
+        result = usingBuildFile(file).noJavaVersionDeprecationChecks().runWithFailure();
         result.assertHasDescription("The specified build file '" + file + "' is not a file.");
     }
 
@@ -132,12 +133,12 @@ public class ProjectLoadingIntegrationTest extends AbstractIntegrationTest {
     public void buildFailsWhenSpecifiedProjectDirectoryIsNotADirectory() {
         TestFile file = testFile("unknown");
 
-        ExecutionFailure result = usingProjectDir(file).runWithFailure();
+        ExecutionFailure result = usingProjectDir(file).noJavaVersionDeprecationChecks().runWithFailure();
         result.assertHasDescription("The specified project directory '" + file + "' does not exist.");
 
         file.createFile();
 
-        result = usingProjectDir(file).runWithFailure();
+        result = usingProjectDir(file).noJavaVersionDeprecationChecks().runWithFailure();
         result.assertHasDescription("The specified project directory '" + file + "' is not a directory.");
     }
 
@@ -145,12 +146,12 @@ public class ProjectLoadingIntegrationTest extends AbstractIntegrationTest {
     public void buildFailsWhenSpecifiedSettingsFileIsNotAFile() {
         TestFile file = testFile("unknown");
 
-        ExecutionFailure result = inTestDirectory().usingSettingsFile(file).runWithFailure();
+        ExecutionFailure result = inTestDirectory().usingSettingsFile(file).noJavaVersionDeprecationChecks().runWithFailure();
         result.assertHasDescription("The specified settings file '" + file + "' does not exist.");
 
         file.createDir();
 
-        result = inTestDirectory().usingSettingsFile(file).runWithFailure();
+        result = inTestDirectory().usingSettingsFile(file).noJavaVersionDeprecationChecks().runWithFailure();
         result.assertHasDescription("The specified settings file '" + file + "' is not a file.");
     }
 
@@ -159,12 +160,12 @@ public class ProjectLoadingIntegrationTest extends AbstractIntegrationTest {
     public void buildFailsWhenSpecifiedInitScriptIsNotAFile() {
         TestFile file = testFile("unknown");
 
-        ExecutionFailure result = inTestDirectory().usingInitScript(file).runWithFailure();
+        ExecutionFailure result = inTestDirectory().usingInitScript(file).noJavaVersionDeprecationChecks().runWithFailure();
         result.assertHasDescription("The specified initialization script '" + file + "' does not exist.");
 
         file.createDir();
 
-        result = inTestDirectory().usingInitScript(file).runWithFailure();
+        result = inTestDirectory().usingInitScript(file).noJavaVersionDeprecationChecks().runWithFailure();
         result.assertHasDescription("The specified initialization script '" + file + "' is not a file.");
     }
 
@@ -174,7 +175,7 @@ public class ProjectLoadingIntegrationTest extends AbstractIntegrationTest {
         TestFile initFile1 = testFile("init1").write("// empty");
         TestFile initFile2 = testFile("init2");
 
-        ExecutionFailure result = inTestDirectory().usingInitScript(initFile1).usingInitScript(initFile2).runWithFailure();
+        ExecutionFailure result = inTestDirectory().usingInitScript(initFile1).usingInitScript(initFile2).noJavaVersionDeprecationChecks().runWithFailure();
         result.assertHasDescription("The specified initialization script '" + initFile2 + "' does not exist.");
     }
 

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/environment/BuildEnvironmentIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/environment/BuildEnvironmentIntegrationTest.groovy
@@ -191,6 +191,7 @@ org.gradle.java.home=${TextUtil.escapeString(alternateJavaHome.canonicalPath)}
         file('build.gradle') << "println 'javaHome=' + org.gradle.internal.jvm.Jvm.current().javaHome.absolutePath"
 
         when:
+        executer.checkJavaVersionDeprecationUsing(jvm)
         def out = executer.useOnlyRequestedJvmOpts().run().output
 
         then:

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DocumentationUtils.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DocumentationUtils.java
@@ -16,13 +16,19 @@
 
 package org.gradle.integtests.fixtures.executer;
 
+import org.gradle.util.GradleVersion;
+
 import static org.gradle.api.internal.DocumentationRegistry.BASE_URL;
+import static org.gradle.api.internal.DocumentationRegistry.BASE_URL_WITHOUT_VERSION;
 
 public class DocumentationUtils {
-    public static final String DOCS_GRADLE_ORG = "https://docs.gradle.org/";
-    public static final String PATTERN = DOCS_GRADLE_ORG + "current/";
+    public static final String PATTERN = BASE_URL_WITHOUT_VERSION + "current/";
 
     public static String normalizeDocumentationLink(String message) {
         return message.replace(PATTERN, BASE_URL + "/");
+    }
+
+    public static String normalizeDocumentationLink(String message, GradleVersion version) {
+        return message.replace(PATTERN, BASE_URL_WITHOUT_VERSION + version.getVersion() + "/");
     }
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExpectedDeprecationWarning.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExpectedDeprecationWarning.java
@@ -29,6 +29,9 @@ import java.util.regex.Pattern;
  */
 public abstract class ExpectedDeprecationWarning {
 
+    private static final Pattern DEPRECATION_WARNING_LOG_PREFIX_PATTERN =
+        Pattern.compile("^.* \\[WARN] \\[org\\.gradle\\.internal\\.featurelifecycle\\.LoggingDeprecatedFeatureHandler] ");
+
     private final int numLines;
 
     public ExpectedDeprecationWarning(int numLines) {
@@ -95,6 +98,11 @@ public abstract class ExpectedDeprecationWarning {
         String nextLines = numLines == 1
             ? lines.get(startIndex)
             : String.join("\n", lines.subList(startIndex, Math.min(startIndex + numLines, lines.size())));
+
+        // When info or debug logging is enabled, the line will be prefixed with the log level and timestamp.
+        // We need to strip this out to match the expected message.
+        nextLines = DEPRECATION_WARNING_LOG_PREFIX_PATTERN.matcher(nextLines).replaceAll("");
+
         return matchesNextLines(nextLines);
     }
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
@@ -16,7 +16,6 @@
 
 package org.gradle.integtests.fixtures.executer;
 
-import org.gradle.api.Action;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCachesProvider;
 import org.gradle.api.internal.file.TestFiles;
 import org.gradle.internal.Factory;
@@ -191,8 +190,8 @@ public class NoDaemonGradleExecuter extends AbstractGradleExecuter {
         };
     }
 
-    protected ForkingGradleHandle createForkingGradleHandle(Action<ExecutionResult> resultAssertion, String encoding, Factory<? extends AbstractExecHandleBuilder> execHandleFactory) {
-        return new ForkingGradleHandle(getStdinPipe(), isUseDaemon(), resultAssertion, encoding, execHandleFactory, getDurationMeasurement());
+    protected ForkingGradleHandle createForkingGradleHandle(ResultAssertion resultAssertion, String encoding, Factory<? extends AbstractExecHandleBuilder> execHandleFactory) {
+        return new ForkingGradleHandle(getStdinPipe(), isUseDaemon(), resultAssertion::execute, encoding, execHandleFactory, getDurationMeasurement());
     }
 
     @Override

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ParallelForkingGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ParallelForkingGradleExecuter.java
@@ -16,7 +16,6 @@
 
 package org.gradle.integtests.fixtures.executer;
 
-import org.gradle.api.Action;
 import org.gradle.internal.Factory;
 import org.gradle.process.internal.AbstractExecHandleBuilder;
 import org.gradle.test.fixtures.file.TestDirectoryProvider;
@@ -53,7 +52,7 @@ class ParallelForkingGradleExecuter extends DaemonGradleExecuter {
     }
 
     @Override
-    protected ForkingGradleHandle createForkingGradleHandle(Action<ExecutionResult> resultAssertion, String encoding, Factory<? extends AbstractExecHandleBuilder> execHandleFactory) {
-        return new ParallelForkingGradleHandle(getStdinPipe(), isUseDaemon(), resultAssertion, encoding, execHandleFactory, getDurationMeasurement());
+    protected ForkingGradleHandle createForkingGradleHandle(ResultAssertion resultAssertion, String encoding, Factory<? extends AbstractExecHandleBuilder> execHandleFactory) {
+        return new ParallelForkingGradleHandle(getStdinPipe(), isUseDaemon(), resultAssertion::execute, encoding, execHandleFactory, getDurationMeasurement());
     }
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ResultAssertion.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ResultAssertion.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static java.util.stream.Collectors.joining;
 import static org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult.STACK_TRACE_ELEMENT;
@@ -146,7 +148,10 @@ public class ResultAssertion implements Action<ExecutionResult> {
                 i++;
             } else if (isDeprecationMessageInHelpDescription(line)) {
                 i++;
+            } else if (getNumLinesFromDaemonLogOutput(line) != -1) {
+                i += getNumLinesFromDaemonLogOutput(line);
             } else if (removeFirstExpectedDeprecationWarning(lines, i)) {
+                // Daemon logs may duplicate deprecation warnings
                 i += lastMatchedDeprecationWarning.getNumLines();
                 i = skipStackTrace(lines, i);
             } else if (line.matches(".*\\s+deprecated.*")) {
@@ -166,6 +171,15 @@ public class ResultAssertion implements Action<ExecutionResult> {
                 i++;
             }
         }
+    }
+
+    private static final Pattern DAEMON_LOG_HEADER_PATTERN = Pattern.compile("----- Last (\\d+) lines from daemon log file - .* -----");
+    private static int getNumLinesFromDaemonLogOutput(String line) {
+        Matcher m = DAEMON_LOG_HEADER_PATTERN.matcher(line);
+        if (m.matches()) {
+            return Integer.parseInt(m.group(1)) + 1;
+        }
+        return -1;
     }
 
     private static boolean isInsideVariantDescriptionBlock(boolean insideVariantDescriptionBlock, String line) {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
@@ -82,6 +82,7 @@ class KnownProblemIds {
         'deprecation:buildsrc-script' : 'BuildSrc script has been deprecated.',
         'deprecation:creating-a-configuration-with-a-name-that-starts-with-detachedconfiguration' : 'Creating a configuration with a name that starts with \'detachedConfiguration\' has been deprecated.',
         'deprecation:custom-task-action' : 'Custom Task action has been deprecated.',
+        'deprecation:executing-gradle-on-jvm-versions-and-lower': 'Executing Gradle on JVM versions 16 and lower has been deprecated.',
         'deprecation:missing-java-toolchain-plugin' : 'Using task ValidatePlugins without applying the Java Toolchain plugin.',
         'deprecation:included-build-script' : 'Included build script has been deprecated.',
         'deprecation:included-build-task' : 'Included build task has been deprecated.',


### PR DESCRIPTION
Emit a deprecation warning whenever Gradle is executed on a JVM lower than version 17.

Add automatic checks in integration tests

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
