### PR TITLE
Allow internal service Registration declare multiple types

### DIFF
--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/ValidateStep.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/ValidateStep.java
@@ -30,6 +30,8 @@ import org.gradle.internal.execution.WorkValidationException;
 import org.gradle.internal.execution.history.BeforeExecutionState;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
 import org.gradle.internal.reflect.validation.TypeValidationProblemRenderer;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.snapshot.impl.ImplementationSnapshot;
 import org.gradle.internal.snapshot.impl.UnknownImplementationSnapshot;
 import org.gradle.internal.vfs.VirtualFileSystem;
@@ -172,6 +174,7 @@ public class ValidateStep<C extends BeforeExecutionContext, R extends Result> im
             .get();
     }
 
+    @ServiceScope(Scope.Global.class)
     public interface ValidationWarningRecorder {
         void recordValidationWarnings(UnitOfWork work, Collection<? extends Problem> warnings);
     }

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/AnnotatedServiceLifecycleHandler.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/AnnotatedServiceLifecycleHandler.java
@@ -39,7 +39,11 @@ public interface AnnotatedServiceLifecycleHandler {
     void whenRegistered(Class<? extends Annotation> annotation, Registration registration);
 
     interface Registration {
-        Class<?> getDeclaredType();
+
+        /**
+         * One or more services provided by this registration.
+         */
+        List<Class<?>> getDeclaredTypes();
 
         /**
          * Returns the service instance, creating it if required.

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -613,7 +613,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
 
         @Override
         public List<Class<?>> getDeclaredTypes() {
-            return serviceProvider.declaredServiceTypes;
+            return serviceProvider.getDeclaredServiceTypes();
         }
 
         @Override
@@ -700,9 +700,8 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
     private static abstract class SingletonService extends ManagedObjectServiceProvider {
         private enum BindState {UNBOUND, BINDING, BOUND}
 
-        final Type serviceType;
-        final List<Class<?>> declaredServiceTypes;
-
+        final Type serviceType; // TODO: this should go away and be replaced by the plural version
+        private final List<Class<?>> unwrappedDeclaredServiceTypes;
 
         BindState state = BindState.UNBOUND;
         Class<?> factoryElementType;
@@ -711,12 +710,12 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
             super(owner);
             this.serviceType = serviceType;
             Class<?> serviceClass = unwrap(serviceType);
-            declaredServiceTypes = Cast.uncheckedCast(singletonList(serviceClass));
+            unwrappedDeclaredServiceTypes = Cast.uncheckedCast(singletonList(serviceClass));
         }
 
         @Override
         public List<Class<?>> getDeclaredServiceTypes() {
-            return declaredServiceTypes;
+            return unwrappedDeclaredServiceTypes;
         }
 
         @Override
@@ -772,7 +771,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
 
         @Override
         public Visitor getAll(Class<?> serviceType, ServiceProvider.Visitor visitor) {
-            if (anyTypeIsAssignableFrom(serviceType, declaredServiceTypes)) {
+            if (anyTypeIsAssignableFrom(serviceType, getDeclaredServiceTypes())) {
                 visitor.visit(prepare());
             }
             return visitor;

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.internal.service;
 
-import com.google.common.collect.ImmutableList;
 import org.gradle.api.Action;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
@@ -712,7 +711,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
             super(owner);
             this.serviceType = serviceType;
             serviceClass = unwrap(serviceType);
-            declaredServiceTypes = Cast.uncheckedCast(ImmutableList.of(serviceClass));
+            declaredServiceTypes = Cast.uncheckedCast(Collections.singletonList(serviceClass));
         }
 
         @Override

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -251,7 +251,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
             }
 
             @Override
-            public void add(Class<?> serviceType, Class<?> implementationType) {
+            public <S, I extends S> void add(Class<S> serviceType, Class<I> implementationType) {
                 ownServices.add(new ConstructorService(DefaultServiceRegistry.this, serviceType, implementationType));
             }
 

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -701,6 +701,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
         private enum BindState {UNBOUND, BINDING, BOUND}
 
         final Type serviceType; // TODO: this should go away and be replaced by the plural version
+        final List<Type> rawDeclaredServiceTypes;
         private final List<Class<?>> unwrappedDeclaredServiceTypes;
 
         BindState state = BindState.UNBOUND;
@@ -709,6 +710,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
         SingletonService(DefaultServiceRegistry owner, Type serviceType) {
             super(owner);
             this.serviceType = serviceType;
+            rawDeclaredServiceTypes = Cast.uncheckedCast(singletonList(serviceType));
             Class<?> serviceClass = unwrap(serviceType);
             unwrappedDeclaredServiceTypes = Cast.uncheckedCast(singletonList(serviceClass));
         }
@@ -953,16 +955,16 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
             try {
                 result = method.invoke(target, params);
             } catch (Exception e) {
-                throw new ServiceCreationException(String.format("Could not create service of type %s using %s.%s().",
-                    format(serviceType),
+                throw new ServiceCreationException(String.format("Could not create service of %s using %s.%s().",
+                    format("type", rawDeclaredServiceTypes),
                     method.getOwner().getSimpleName(),
                     method.getName()),
                     e);
             }
             try {
                 if (result == null) {
-                    throw new ServiceCreationException(String.format("Could not create service of type %s using %s.%s() as this method returned null.",
-                        format(serviceType),
+                    throw new ServiceCreationException(String.format("Could not create service of %s using %s.%s() as this method returned null.",
+                        format("type", rawDeclaredServiceTypes),
                         method.getOwner().getSimpleName(),
                         method.getName()));
                 }
@@ -982,7 +984,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
 
         @Override
         public String getDisplayName() {
-            return "Service " + format(serviceType) + " with implementation " + format(getInstance().getClass());
+            return format("Service", rawDeclaredServiceTypes) + " with implementation " + format(getInstance().getClass());
         }
 
         @Override
@@ -1032,15 +1034,15 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
             try {
                 return constructor.newInstance(params);
             } catch (InvocationTargetException e) {
-                throw new ServiceCreationException(String.format("Could not create service of type %s.", format(serviceType)), e.getCause());
+                throw new ServiceCreationException(String.format("Could not create service of %s.", format("type", rawDeclaredServiceTypes)), e.getCause());
             } catch (Exception e) {
-                throw new ServiceCreationException(String.format("Could not create service of type %s.", format(serviceType)), e);
+                throw new ServiceCreationException(String.format("Could not create service of %s.", format("type", rawDeclaredServiceTypes)), e);
             }
         }
 
         @Override
         public String getDisplayName() {
-            return "Service " + format(serviceType);
+            return format("Service", rawDeclaredServiceTypes);
         }
     }
 

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -573,15 +573,6 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
             }
         }
 
-        private boolean anyTypeHasAnnotation(Class<? extends Annotation> annotation, List<Class<?>> types) {
-            for (Class<?> type : types) {
-                if (inspector.hasAnnotation(type, annotation)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
         private boolean anyDeclaredTypeProvides(Class<?> targetType, List<Class<?>> declaredServiceTypes) {
             for (Class<?> declaredType : declaredServiceTypes) {
                 if (targetType.isAssignableFrom(declaredType)) {
@@ -602,12 +593,22 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
             if (annotationHandler.getImplicitAnnotation() != null) {
                 annotationHandler.whenRegistered(annotationHandler.getImplicitAnnotation(), new RegistrationWrapper(candidate));
             } else {
+                List<Class<?>> declaredServiceTypes = candidate.getDeclaredServiceTypes();
                 for (Class<? extends Annotation> annotation : annotationHandler.getAnnotations()) {
-                    if (inspector.hasAnnotation(candidate.serviceClass, annotation)) {
+                    if (anyTypeHasAnnotation(annotation, declaredServiceTypes)) {
                         annotationHandler.whenRegistered(annotation, new RegistrationWrapper(candidate));
                     }
                 }
             }
+        }
+
+        private boolean anyTypeHasAnnotation(Class<? extends Annotation> annotation, List<Class<?>> types) {
+            for (Class<?> type : types) {
+                if (inspector.hasAnnotation(type, annotation)) {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -743,7 +743,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
             return getInstance();
         }
 
-        public Object getPreparedInstance() {
+        private Object getPreparedInstance() {
             return prepare().get();
         }
 

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.internal.service;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.Action;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
@@ -582,14 +583,16 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
 
     private class RegistrationWrapper implements AnnotatedServiceLifecycleHandler.Registration {
         private final SingletonService serviceProvider;
+        private final List<Class<?>> declaredTypes;
 
         public RegistrationWrapper(SingletonService serviceProvider) {
             this.serviceProvider = serviceProvider;
+            declaredTypes = Cast.uncheckedCast(ImmutableList.of(serviceProvider.serviceClass));
         }
 
         @Override
-        public Class<?> getDeclaredType() {
-            return serviceProvider.serviceClass;
+        public List<Class<?>> getDeclaredTypes() {
+            return declaredTypes;
         }
 
         @Override

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -719,6 +719,11 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
 
         SingletonService(DefaultServiceRegistry owner, List<? extends Type> serviceTypes) {
             super(owner);
+
+            if (serviceTypes.isEmpty()) {
+                throw new IllegalArgumentException("Expected at least one declared service type");
+            }
+
             rawDeclaredServiceTypes = serviceTypes;
             unwrappedDeclaredServiceTypes = collect(serviceTypes, new InternalTransformer<Class<?>, Type>() {
                 @Override

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -627,7 +627,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
         @Override
         public Object getInstance() {
             serviceRequested();
-            return serviceProvider.getService(serviceProvider.serviceClass).get();
+            return serviceProvider.getPreparedInstance();
         }
     }
 
@@ -736,6 +736,10 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
         @Override
         public Object get() {
             return getInstance();
+        }
+
+        public Object getPreparedInstance() {
+            return prepare().get();
         }
 
         private Service prepare() {

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -707,7 +707,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
     private static abstract class SingletonService extends ManagedObjectServiceProvider {
         private enum BindState {UNBOUND, BINDING, BOUND}
 
-        final List<Type> rawDeclaredServiceTypes;
+        protected final List<? extends Type> rawDeclaredServiceTypes;
         private final List<Class<?>> unwrappedDeclaredServiceTypes;
 
         BindState state = BindState.UNBOUND;
@@ -717,7 +717,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
         // The value of the field is computed lazily.
         Class<?> factoryElementType;
 
-        SingletonService(DefaultServiceRegistry owner, List<Type> serviceTypes) {
+        SingletonService(DefaultServiceRegistry owner, List<? extends Type> serviceTypes) {
             super(owner);
             rawDeclaredServiceTypes = serviceTypes;
             unwrappedDeclaredServiceTypes = collect(serviceTypes, new InternalTransformer<Class<?>, Type>() {
@@ -831,7 +831,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
         }
 
         @Nullable
-        private static Class<?> findFactoryElementType(List<Type> factoryCandidates) {
+        private static Class<?> findFactoryElementType(List<? extends Type> factoryCandidates) {
             for (Type factoryCandidate : factoryCandidates) {
                 Class<?> factoryElementType = findFactoryElementType(factoryCandidate);
                 if (factoryElementType != null) {
@@ -859,7 +859,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
         private Service[] paramServices;
         private Service decorates;
 
-        protected FactoryService(DefaultServiceRegistry owner, List<Type> serviceTypes) {
+        protected FactoryService(DefaultServiceRegistry owner, List<? extends Type> serviceTypes) {
             super(owner, serviceTypes);
         }
 
@@ -1014,7 +1014,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
 
     private static class FixedInstanceService extends SingletonService {
         public FixedInstanceService(DefaultServiceRegistry owner, Class<?> serviceType, Object serviceInstance) {
-            super(owner, singletonList((Type) serviceType));
+            super(owner, singletonList(serviceType));
             setInstance(serviceInstance);
         }
 
@@ -1041,7 +1041,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
         }
 
         private ConstructorService(DefaultServiceRegistry owner, List<Class<?>> serviceTypes, Class<?> implementationType) {
-            super(owner, Cast.<List<Type>>uncheckedCast(serviceTypes));
+            super(owner, serviceTypes);
 
             if (implementationType.isInterface()) {
                 throw new ServiceValidationException("Cannot register an interface for construction.");
@@ -1280,7 +1280,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
         return false;
     }
 
-    private static boolean isEqualToAnyType(Type targetType, List<Type> candidateTypes) {
+    private static boolean isEqualToAnyType(Type targetType, List<? extends Type> candidateTypes) {
         for (Type candidate : candidateTypes) {
             if (targetType.equals(candidate)) {
                 return true;
@@ -1289,7 +1289,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
         return false;
     }
 
-    private static boolean isSatisfiedByAny(Type expected, List<Type> candidates) {
+    private static boolean isSatisfiedByAny(Type expected, List<? extends Type> candidates) {
         for (Type candidate : candidates) {
             if (isSatisfiedBy(expected, candidate)) {
                 return true;

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -583,16 +583,14 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
 
     private class RegistrationWrapper implements AnnotatedServiceLifecycleHandler.Registration {
         private final SingletonService serviceProvider;
-        private final List<Class<?>> declaredTypes;
 
         public RegistrationWrapper(SingletonService serviceProvider) {
             this.serviceProvider = serviceProvider;
-            declaredTypes = Cast.uncheckedCast(ImmutableList.of(serviceProvider.serviceClass));
         }
 
         @Override
         public List<Class<?>> getDeclaredTypes() {
-            return declaredTypes;
+            return serviceProvider.declaredServiceTypes;
         }
 
         @Override
@@ -680,7 +678,9 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
         private enum BindState {UNBOUND, BINDING, BOUND}
 
         final Type serviceType;
-        final Class<?> serviceClass;
+        final Class<?> serviceClass; // TODO: this should go away and be fully replaced by `declaredServiceTypes`
+        final List<Class<?>> declaredServiceTypes;
+
 
         BindState state = BindState.UNBOUND;
         Class<?> factoryElementType;
@@ -689,6 +689,7 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
             super(owner);
             this.serviceType = serviceType;
             serviceClass = unwrap(serviceType);
+            declaredServiceTypes = Cast.uncheckedCast(ImmutableList.of(serviceClass));
         }
 
         @Override

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -845,8 +845,8 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
                     // A decorating factory
                     Service paramProvider = find(paramType, owner.parentServices);
                     if (paramProvider == null) {
-                        throw new ServiceCreationException(String.format("Cannot create service of type %s using %s as required service of type %s for parameter #%s is not available in parent registries.",
-                            format(serviceType),
+                        throw new ServiceCreationException(String.format("Cannot create service of %s using %s as required service of type %s for parameter #%s is not available in parent registries.",
+                            format("type", rawDeclaredServiceTypes),
                             getFactoryDisplayName(),
                             format(paramType),
                             i + 1));
@@ -858,15 +858,15 @@ public class DefaultServiceRegistry implements ServiceRegistry, Closeable, Conta
                     try {
                         paramProvider = find(paramType, owner.allServices);
                     } catch (ServiceLookupException e) {
-                        throw new ServiceCreationException(String.format("Cannot create service of type %s using %s as there is a problem with parameter #%s of type %s.",
-                            format(serviceType),
+                        throw new ServiceCreationException(String.format("Cannot create service of %s using %s as there is a problem with parameter #%s of type %s.",
+                            format("type", rawDeclaredServiceTypes),
                             getFactoryDisplayName(),
                             i + 1,
                             format(paramType)), e);
                     }
                     if (paramProvider == null) {
-                        throw new ServiceCreationException(String.format("Cannot create service of type %s using %s as required service of type %s for parameter #%s is not available.",
-                            format(serviceType),
+                        throw new ServiceCreationException(String.format("Cannot create service of %s using %s as required service of type %s for parameter #%s is not available.",
+                            format("type", rawDeclaredServiceTypes),
                             getFactoryDisplayName(),
                             format(paramType),
                             i + 1));

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/ServiceScopeValidator.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/ServiceScopeValidator.java
@@ -100,6 +100,7 @@ class ServiceScopeValidator implements AnnotatedServiceLifecycleHandler {
             throw new IllegalArgumentException(missingScopeMessage(serviceType));
         }
 
+        // TODO(alllex): let the registration explicitly provide the Class of the implementation
         Class<?> inferredServiceType = annotatedSupertypes.iterator().next();
         throw new IllegalArgumentException(implementationWithMissingScopeMessage(inferredServiceType, serviceType));
     }

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/ServiceScopeValidator.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/ServiceScopeValidator.java
@@ -64,7 +64,9 @@ class ServiceScopeValidator implements AnnotatedServiceLifecycleHandler {
 
     @Override
     public void whenRegistered(Class<? extends Annotation> annotation, Registration registration) {
-        validateScope(registration.getDeclaredType());
+        for (Class<?> declaredType : registration.getDeclaredTypes()) {
+            validateScope(declaredType);
+        }
     }
 
     private void validateScope(Class<?> serviceType) {

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
@@ -31,7 +31,6 @@ public class ServiceScopeValidatorWorkarounds {
 
         "org.gradle.internal.Factory",
         "org.gradle.internal.serialize.Serializer",
-        "org.gradle.execution.DefaultWorkValidationWarningRecorder",
         "org.gradle.api.internal.classpath.DefaultModuleRegistry",
         "org.gradle.tooling.internal.provider.runner.ToolingApiBuildEventListenerFactory",
         "org.gradle.cache.internal.ProducerGuard",

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
@@ -34,8 +34,6 @@ import org.gradle.internal.resources.ResourceLock;
 import org.gradle.internal.resources.ResourceLockContainer;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
 import org.gradle.internal.resources.TaskExecutionLockRegistry;
-import org.gradle.internal.service.scopes.Scope;
-import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.time.Time;
 import org.gradle.internal.time.Timer;
 import org.gradle.util.Path;
@@ -55,7 +53,6 @@ import static org.gradle.internal.resources.DefaultResourceLockCoordinationServi
 import static org.gradle.internal.resources.DefaultResourceLockCoordinationService.tryLock;
 import static org.gradle.internal.resources.DefaultResourceLockCoordinationService.unlock;
 
-@ServiceScope(Scope.CrossBuildSession.class)
 public class DefaultWorkerLeaseService implements WorkerLeaseService, ProjectParallelExecutionController, Stoppable {
     public static final String PROJECT_LOCK_STATS_PROPERTY = "org.gradle.internal.project.lock.stats";
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultWorkerLeaseService.class);

--- a/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/event/DefaultListenerManager.java
+++ b/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/event/DefaultListenerManager.java
@@ -93,7 +93,8 @@ public class DefaultListenerManager implements ScopedListenerManager {
             }
             pendingServices.clear();
 
-            for (int i = 0; i < pendingRegistrations.size(); ) {
+            int i = 0;
+            while (i < pendingRegistrations.size()) {
                 Registration registration = pendingRegistrations.get(i);
                 if (registrationProvides(type, registration)) {
                     addListener(registration.getInstance());

--- a/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/ServiceRegistration.java
+++ b/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/ServiceRegistration.java
@@ -41,7 +41,7 @@ public interface ServiceRegistration {
      * @param serviceType The service to make visible.
      * @param implementationType The implementation type of the service.
      */
-    void add(Class<?> serviceType, Class<?> implementationType);
+    <S, I extends S> void add(Class<S> serviceType, Class<I> implementationType);
 
     /**
      * Adds a service provider bean to this registry. This provider may define factory and decorator methods. See {@link DefaultServiceRegistry} for details.

--- a/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/ServiceRegistration.java
+++ b/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/ServiceRegistration.java
@@ -22,6 +22,7 @@ package org.gradle.internal.service;
 public interface ServiceRegistration {
     /**
      * Adds a service to this registry. The given object is closed when the associated registry is closed.
+     *
      * @param serviceType The type to make this service visible as.
      * @param serviceInstance The service implementation.
      */

--- a/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/ServiceRegistration.java
+++ b/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/ServiceRegistration.java
@@ -44,6 +44,17 @@ public interface ServiceRegistration {
     <S, I extends S> void add(Class<S> serviceType, Class<I> implementationType);
 
     /**
+     * Adds two services to this registry that share the implementation.
+     * <p>
+     * The implementation class should have a single public constructor, and this constructor can take services to be injected as parameters.
+     *
+     * @param serviceType1 The first service to make visible.
+     * @param serviceType2 The second service to make visible.
+     * @param implementationType The implementation type of the service.
+     */
+    <S, I extends S> void add(Class<S> serviceType1, Class<?> serviceType2, Class<I> implementationType);
+
+    /**
      * Adds a service provider bean to this registry. This provider may define factory and decorator methods. See {@link DefaultServiceRegistry} for details.
      */
     void addProvider(ServiceRegistrationProvider provider);

--- a/subprojects/core/src/main/java/org/gradle/execution/WorkValidationWarningReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/WorkValidationWarningReporter.java
@@ -16,6 +16,10 @@
 
 package org.gradle.execution;
 
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+
+@ServiceScope(Scope.Global.class)
 public interface WorkValidationWarningReporter {
     /**
      * Reports any validation warnings at the end of the build.

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CoreCrossBuildSessionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CoreCrossBuildSessionServices.java
@@ -46,12 +46,15 @@ import org.gradle.internal.service.Provides;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistrationProvider;
 import org.gradle.internal.work.DefaultWorkerLeaseService;
+import org.gradle.internal.work.ProjectParallelExecutionController;
 import org.gradle.internal.work.WorkerLeaseService;
 
 public class CoreCrossBuildSessionServices implements ServiceRegistrationProvider {
+
+    @Provides
     void configure(ServiceRegistration registration) {
         registration.add(ResourceLockCoordinationService.class, DefaultResourceLockCoordinationService.class);
-        registration.add(DefaultWorkerLeaseService.class);
+        registration.add(WorkerLeaseService.class, ProjectParallelExecutionController.class, DefaultWorkerLeaseService.class);
         registration.add(DynamicCallContextTracker.class, DefaultDynamicCallContextTracker.class);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -48,6 +48,7 @@ import org.gradle.cache.internal.InMemoryCacheDecoratorFactory;
 import org.gradle.configuration.DefaultImportsReader;
 import org.gradle.configuration.ImportsReader;
 import org.gradle.execution.DefaultWorkValidationWarningRecorder;
+import org.gradle.execution.WorkValidationWarningReporter;
 import org.gradle.initialization.ClassLoaderRegistry;
 import org.gradle.initialization.DefaultClassLoaderRegistry;
 import org.gradle.initialization.DefaultJdkToolsInitializer;
@@ -65,6 +66,7 @@ import org.gradle.internal.execution.history.OverlappingOutputDetector;
 import org.gradle.internal.execution.history.changes.DefaultExecutionStateChangeDetector;
 import org.gradle.internal.execution.history.changes.ExecutionStateChangeDetector;
 import org.gradle.internal.execution.history.impl.DefaultOverlappingOutputDetector;
+import org.gradle.internal.execution.steps.ValidateStep;
 import org.gradle.internal.installation.GradleRuntimeShadedJarDetector;
 import org.gradle.internal.instantiation.InjectAnnotationHandler;
 import org.gradle.internal.instantiation.InstanceGenerator;
@@ -138,6 +140,7 @@ public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
         super.configure(registration);
         registration.add(DefaultScriptFileResolverListeners.class);
         registration.add(BuildLayoutFactory.class);
+        registration.add(ValidateStep.ValidationWarningRecorder.class, WorkValidationWarningReporter.class, DefaultWorkValidationWarningRecorder.class);
     }
 
     @Provides
@@ -323,11 +326,6 @@ public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
     @Provides
     OverlappingOutputDetector createOverlappingOutputDetector() {
         return new DefaultOverlappingOutputDetector();
-    }
-
-    @Provides
-    DefaultWorkValidationWarningRecorder createValidationWarningReporter() {
-        return new DefaultWorkValidationWarningRecorder();
     }
 
     @Provides


### PR DESCRIPTION
This PR extends the support for explicit separation between Gradle's internal services and their implementations by allowing to explicitly declare that an implementation provides multiple services.

There are at least two examples of internal service implementations that provide more than one actual service: `DefaultWorkerLeaseService` and `DefaultWorkValidationWarningRecorder`. The way all services were exposed for injection was by exposing their actual implementation class for injection, potentially leaking implementation details to the consumers.

The new functionality of the `DefaultServiceFactory` allows to create services that explicitly state the list of service types they implement while forbidding the implementation to get injected.

There is now a new method on the `ServiceRegistration` interface that allows to register two services that share the same implementation. This can be later extended to more services if the need arises.