### PR TITLE
[Issue#27084] Wrapper configs sets networkTimeout property to default…

### DIFF
--- a/platforms/software/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -115,6 +115,7 @@ public abstract class Wrapper extends DefaultTask {
         String jarFileRelativePath = resolver.resolveAsRelativePath(jarFileDestination);
         File propertiesFile = getPropertiesFile();
         Properties existingProperties = propertiesFile.exists() ? GUtil.loadProperties(propertiesFile) : null;
+        Integer propertyTimeout = networkTimeout.getOrElse(WrapperDefaults.NETWORK_TIMEOUT);
 
         checkProperties(existingProperties);
         validateDistributionUrl(propertiesFile.getParentFile());
@@ -128,7 +129,7 @@ public abstract class Wrapper extends DefaultTask {
             unixScript, getBatchScript(),
             getDistributionUrl(),
             getValidateDistributionUrl().get(),
-            networkTimeout.getOrNull()
+            propertyTimeout
         );
     }
 
@@ -472,7 +473,6 @@ public abstract class Wrapper extends DefaultTask {
      * @since 7.6
      */
     @Input
-    @Incubating
     @Optional
     @Option(option = "network-timeout", description = "Timeout in ms to use when the wrapper is performing network operations.")
     public Property<Integer> getNetworkTimeout() {


### PR DESCRIPTION
… if not present

<27084>
<If networkTimeout property is not present, the default value is used. >

### Context
<Users are no longer forced to set this value. If it is not present, the default will be used. >
<https://github.com/gradle/gradle/issues/27084>

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [X] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [X] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [X] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
