### PR TITLE
[Issue#27084] Wrapper configs sets networkTimeout property to default…

### DIFF
--- a/platforms/software/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -115,6 +115,7 @@ public abstract class Wrapper extends DefaultTask {
         String jarFileRelativePath = resolver.resolveAsRelativePath(jarFileDestination);
         File propertiesFile = getPropertiesFile();
         Properties existingProperties = propertiesFile.exists() ? GUtil.loadProperties(propertiesFile) : null;
+        Integer propertyTimeout = networkTimeout.getOrElse(WrapperDefaults.NETWORK_TIMEOUT);
 
         checkProperties(existingProperties);
         validateDistributionUrl(propertiesFile.getParentFile());
@@ -128,7 +129,7 @@ public abstract class Wrapper extends DefaultTask {
             unixScript, getBatchScript(),
             getDistributionUrl(),
             getValidateDistributionUrl().get(),
-            networkTimeout.getOrNull()
+            propertyTimeout
         );
     }
 
@@ -472,7 +473,6 @@ public abstract class Wrapper extends DefaultTask {
      * @since 7.6
      */
     @Input
-    @Incubating
     @Optional
     @Option(option = "network-timeout", description = "Timeout in ms to use when the wrapper is performing network operations.")
     public Property<Integer> getNetworkTimeout() {


### PR DESCRIPTION
… if not present

Fixes #27084

### Context
<!--- Why do you believe many users will benefit from this change? -->
This means users will not have to manually set this value. If the value is not set, the default value of `10000` ms will be used. 
<[!--- Link to relevant issues or forum discussions here --](https://github.com/gradle/gradle/issues/27084)>


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
