### PR TITLE
Support auto upgrades for getter only properties

### DIFF
--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
@@ -16,6 +16,9 @@
 
 package org.gradle.internal.instrumentation.extensions.property;
 
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
 import org.gradle.internal.instrumentation.api.annotations.BytecodeUpgrade;
 import org.gradle.internal.instrumentation.api.annotations.ReplacedDeprecation.RemovedIn;
 import org.gradle.internal.instrumentation.api.annotations.ReplacesEagerProperty;
@@ -76,12 +79,13 @@ import static org.gradle.internal.instrumentation.model.ParameterKindInfo.METHOD
 import static org.gradle.internal.instrumentation.model.ParameterKindInfo.RECEIVER;
 import static org.gradle.internal.instrumentation.processor.AbstractInstrumentationProcessor.PROJECT_NAME_OPTIONS;
 import static org.gradle.internal.instrumentation.processor.codegen.GradleLazyType.FILE_COLLECTION;
+import static org.gradle.internal.instrumentation.processor.codegen.GradleReferencedType.isAssignableToFileSystemLocation;
 import static org.gradle.internal.instrumentation.processor.modelreader.impl.TypeUtils.extractMethodDescriptor;
 import static org.gradle.internal.instrumentation.processor.modelreader.impl.TypeUtils.extractType;
 
 public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodReaderExtension {
 
-    private static final Type DEFAULT_TYPE = Type.getType(DefaultValue.class);
+    private static final TypeName DEFAULT_TYPE = ClassName.get(DefaultValue.class);
 
     private final String projectName;
     private final Elements elements;
@@ -231,7 +235,7 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
         AccessorType accessorType = method.getParameters().size() > 1
             ? AccessorType.SETTER
             : AccessorType.GETTER;
-        Type returnType = extractType(method.getReturnType());
+        TypeName returnType = TypeName.get(method.getReturnType());
         Element innerClass = method.getEnclosingElement();
         Element topClass = innerClass.getEnclosingElement();
         PackageElement packageElement = elements.getPackageOf(innerClass);
@@ -299,18 +303,18 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
         AccessorType accessorType = AnnotationUtils.findAnnotationValue(annotation, "value")
             .map(v -> AccessorType.valueOf(v.getValue().toString()))
             .orElseThrow(() -> new AnnotationReadFailure("Missing 'value' attribute in @ReplacedAccessor"));
-        Type originalType = extractOriginalType(method, annotation);
+        TypeName originalType = extractOriginalType(method, annotation);
         return getAccessorSpec(method, accessorType, methodName, originalType, annotation, parentDeprecationSpec, binaryCompatibility);
     }
 
     private AccessorSpec getAccessorSpec(ExecutableElement method, AccessorType accessorType, AnnotationMirror annotation) {
         String propertyName = getPropertyName(method);
-        Type originalType = extractOriginalType(method, annotation);
+        TypeName originalType = extractOriginalType(method, annotation);
         String methodName;
         switch (accessorType) {
             case GETTER:
                 String capitalize = propertyName.substring(0, 1).toUpperCase(Locale.ROOT) + propertyName.substring(1);
-                methodName = originalType.equals(Type.BOOLEAN_TYPE) ? "is" + capitalize : "get" + capitalize;
+                methodName = originalType.equals(TypeName.BOOLEAN) ? "is" + capitalize : "get" + capitalize;
                 break;
             case SETTER:
                 methodName = method.getSimpleName().toString().replaceFirst("get", "set");
@@ -327,12 +331,12 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
         ExecutableElement method,
         AccessorType accessorType,
         String methodName,
-        Type originalType,
+        TypeName originalType,
         AnnotationMirror annotation,
         DeprecationSpec deprecationSpec,
         BinaryCompatibility binaryCompatibility
     ) {
-        Type returnType;
+        TypeName returnType;
         List<ParameterInfo> parameters;
         switch (accessorType) {
             case GETTER:
@@ -340,11 +344,11 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
                 returnType = originalType;
                 break;
             case SETTER:
-                parameters = Collections.singletonList(new ParameterInfoImpl("arg0", originalType, METHOD_PARAMETER));
+                parameters = Collections.singletonList(new ParameterInfoImpl("arg0", TypeUtils.extractRawType(originalType), METHOD_PARAMETER));
                 boolean isFluentSetter = AnnotationUtils.findAnnotationValueWithDefaults(elements, annotation, "fluentSetter")
                     .map(v -> (Boolean) v.getValue())
                     .orElseThrow(() -> new AnnotationReadFailure("Missing 'fluentSetter' attribute"));
-                returnType = isFluentSetter ? extractType(method.getEnclosingElement().asType()) : Type.VOID_TYPE;
+                returnType = isFluentSetter ? TypeName.get(method.getEnclosingElement().asType()) : ClassName.VOID;
                 break;
             default:
                 throw new IllegalArgumentException("Unsupported accessor type: " + accessorType);
@@ -364,34 +368,52 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
         );
     }
 
-    private static Type extractOriginalType(ExecutableElement method, AnnotationMirror annotation) {
+    private static TypeName extractOriginalType(ExecutableElement method, AnnotationMirror annotation) {
         Optional<? extends AnnotationValue> annotationValue = AnnotationUtils.findAnnotationValue(annotation, "originalType");
-        Type type = annotationValue.map(v -> extractType((TypeMirror) v.getValue())).orElse(DEFAULT_TYPE);
-        if (!type.equals(DEFAULT_TYPE)) {
-            return type;
+        TypeName typeName = annotationValue.map(v -> v.getValue() instanceof DeclaredType
+            // We use DeclaredType.asElement().asType() so if the original type is a parametrized type,
+            // e.g. Iterable<T>, resolved TypeName contains information that it's Iterable<T> and not just Iterable
+            ? TypeName.get(((DeclaredType) annotationValue.get().getValue()).asElement().asType())
+            : TypeName.get((TypeMirror) annotationValue.get().getValue())
+        ).orElse(DEFAULT_TYPE);
+        if (!typeName.equals(DEFAULT_TYPE)) {
+            return typeName;
         }
         return extractOriginalTypeFromGeneric(method, method.getReturnType());
     }
 
-    private static Type extractOriginalTypeFromGeneric(ExecutableElement method, TypeMirror typeMirror) {
+    private static TypeName extractOriginalTypeFromGeneric(ExecutableElement method, TypeMirror typeMirror) {
         String typeName = method.getReturnType() instanceof DeclaredType
             ? ((DeclaredType) method.getReturnType()).asElement().toString()
             : method.getReturnType().toString();
         GradleLazyType gradleLazyType = GradleLazyType.from(typeName);
         switch (gradleLazyType) {
             case CONFIGURABLE_FILE_COLLECTION:
-                return FILE_COLLECTION.asType();
+                return FILE_COLLECTION.asClassName();
             case DIRECTORY_PROPERTY:
             case REGULAR_FILE_PROPERTY:
-                return Type.getType(File.class);
+                return ClassName.get(File.class);
             case LIST_PROPERTY:
-                return Type.getType(List.class);
+                return ParameterizedTypeName.get(ClassName.get(List.class),
+                    TypeName.get(((DeclaredType) typeMirror).getTypeArguments().get(0))
+                );
             case SET_PROPERTY:
-                return Type.getType(Set.class);
+                return ParameterizedTypeName.get(ClassName.get(Set.class),
+                    TypeName.get(((DeclaredType) typeMirror).getTypeArguments().get(0))
+                );
             case MAP_PROPERTY:
-                return Type.getType(Map.class);
+                return ParameterizedTypeName.get(ClassName.get(Map.class),
+                    TypeName.get(((DeclaredType) typeMirror).getTypeArguments().get(0)),
+                    TypeName.get(((DeclaredType) typeMirror).getTypeArguments().get(1))
+                );
             case PROPERTY:
-                return extractType(((DeclaredType) typeMirror).getTypeArguments().get(0));
+                return TypeName.get(((DeclaredType) typeMirror).getTypeArguments().get(0));
+            case PROVIDER: {
+                TypeName extractedType = TypeName.get(((DeclaredType) typeMirror).getTypeArguments().get(0));
+                return isAssignableToFileSystemLocation(extractedType)
+                    ? ClassName.get(File.class)
+                    : extractedType;
+            }
             default:
                 throw new AnnotationReadFailure(String.format("Cannot extract original type for method '%s.%s: %s'. Use explicit @%s#originalType instead.", method.getEnclosingElement(), method, typeMirror, ReplacesEagerProperty.class.getSimpleName()));
         }
@@ -401,7 +423,7 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
         String interceptorsClassName = getGroovyInterceptorsClassName();
         List<RequestExtra> extras = Arrays.asList(new RequestExtra.OriginatingElement(method), new RequestExtra.InterceptGroovyCalls(interceptorsClassName, BYTECODE_UPGRADE));
         List<ParameterInfo> parameters = Collections.singletonList(new ParameterInfoImpl("receiver", extractType(method.getEnclosingElement().asType()), RECEIVER));
-        Type returnType = accessor.returnType;
+        Type returnType = TypeUtils.extractRawType(accessor.returnType);
         return new CallInterceptionRequestImpl(
             extractCallableInfo(GROOVY_PROPERTY_GETTER, method, returnType, accessor.propertyName, parameters),
             extractImplementationInfo(accessor, method, returnType, accessor.methodName, "get", Collections.emptyList()),
@@ -412,7 +434,7 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
     private CallInterceptionRequest createJvmGetterInterceptionRequest(AccessorSpec accessor, ExecutableElement method) {
         List<RequestExtra> extras = getJvmRequestExtras(accessor, method, accessor.binaryCompatibility);
         String callableName = accessor.methodName;
-        Type returnType = accessor.returnType;
+        Type returnType = TypeUtils.extractRawType(accessor.returnType);
         return new CallInterceptionRequestImpl(
             extractCallableInfo(INSTANCE_METHOD, method, returnType, callableName, Collections.emptyList()),
             extractImplementationInfo(accessor, method, returnType, accessor.methodName, "get", Collections.emptyList()),
@@ -421,7 +443,7 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
     }
 
     private CallInterceptionRequest createJvmSetterInterceptionRequest(AccessorSpec accessor, ExecutableElement method) {
-        Type returnType = accessor.returnType;
+        Type returnType = TypeUtils.extractRawType(accessor.returnType);
         String callableName = accessor.methodName;
         List<ParameterInfo> parameters = accessor.parameters;
         BinaryCompatibility binaryCompatibility = accessor.binaryCompatibility;
@@ -440,7 +462,7 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
         extras.add(new RequestExtra.OriginatingElement(method));
         extras.add(new RequestExtra.InterceptJvmCalls(interceptorsClassName, BYTECODE_UPGRADE));
         String implementationClass = accessor.generatedClassName;
-        Type newReturnType = TypeUtils.extractReturnType(method);
+        TypeName newPropertyType = TypeName.get(method.getReturnType());
         String propertyName = getPropertyName(method);
         String methodDescriptor = extractMethodDescriptor(method);
         extras.add(new PropertyUpgradeRequestExtra(
@@ -451,7 +473,7 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
             implementationClass,
             accessor.propertyName,
             accessor.methodName,
-            newReturnType,
+            newPropertyType,
             accessor.deprecationSpec,
             binaryCompatibility,
             accessor.bridgedMethod
@@ -515,7 +537,7 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
         private final String propertyName;
         private final AccessorType accessorType;
         private final String methodName;
-        private final Type returnType;
+        private final TypeName returnType;
         private final List<ParameterInfo> parameters;
         private final BinaryCompatibility binaryCompatibility;
         private final DeprecationSpec deprecationSpec;
@@ -526,7 +548,7 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
             AccessorType accessorType,
             String propertyName,
             String methodName,
-            Type returnType,
+            TypeName returnType,
             List<ParameterInfo> parameters,
             DeprecationSpec deprecationSpec,
             BinaryCompatibility binaryCompatibility,

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
@@ -178,6 +178,11 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
                 .map(annotation -> getAccessorSpec(method, annotation, parentDeprecationSpec, parentBinaryCompatibility))
                 .collect(Collectors.toList());
         }
+
+        // Provider has only a getter, no setter
+        if (GradleLazyType.PROVIDER.isEqualToRawTypeOf(TypeName.get(method.getReturnType()))) {
+            return Collections.singletonList(getAccessorSpec(method, AccessorType.GETTER, annotationMirror));
+        }
         return Arrays.asList(
             getAccessorSpec(method, AccessorType.GETTER, annotationMirror),
             getAccessorSpec(method, AccessorType.SETTER, annotationMirror)

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeClassSourceGenerator.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeClassSourceGenerator.java
@@ -20,6 +20,7 @@ import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.TypeVariableName;
@@ -32,7 +33,6 @@ import org.gradle.internal.instrumentation.processor.codegen.GradleLazyType;
 import org.gradle.internal.instrumentation.processor.codegen.HasFailures;
 import org.gradle.internal.instrumentation.processor.codegen.RequestGroupingInstrumentationClassSourceGenerator;
 import org.gradle.internal.instrumentation.processor.codegen.TypeUtils;
-import org.objectweb.asm.Type;
 
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
@@ -43,15 +43,20 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static org.gradle.internal.instrumentation.processor.codegen.GradleReferencedType.DEPRECATION_LOGGER;
+import static org.gradle.internal.instrumentation.processor.codegen.GradleReferencedType.FILE_SYSTEM_LOCATION;
 import static org.gradle.internal.instrumentation.processor.codegen.GradleReferencedType.GENERATED_ANNOTATION;
 import static org.gradle.internal.instrumentation.processor.codegen.GradleReferencedType.LIST_PROPERTY_LIST_VIEW;
 import static org.gradle.internal.instrumentation.processor.codegen.GradleReferencedType.MAP_PROPERTY_MAP_VIEW;
 import static org.gradle.internal.instrumentation.processor.codegen.GradleReferencedType.SET_PROPERTY_SET_VIEW;
+import static org.gradle.internal.instrumentation.processor.codegen.GradleReferencedType.isAssignableToFileSystemLocation;
 import static org.gradle.internal.instrumentation.processor.codegen.TypeUtils.typeName;
 
 public class PropertyUpgradeClassSourceGenerator extends RequestGroupingInstrumentationClassSourceGenerator {
 
     private static final String SELF_PARAMETER_NAME = "self";
+    private static final AnnotationSpec SUPPRESS_UNCHECKED_AND_RAWTYPES = AnnotationSpec.builder(SuppressWarnings.class)
+        .addMember("value", "$L", "{\"unchecked\", \"rawtypes\"}")
+        .build();
 
     @Override
     protected String classNameForRequest(CallInterceptionRequest request) {
@@ -149,14 +154,16 @@ public class PropertyUpgradeClassSourceGenerator extends RequestGroupingInstrume
     }
 
     private static List<AnnotationSpec> getAnnotations(PropertyUpgradeRequestExtra implementationExtra) {
-        GradleLazyType gradleLazyType = GradleLazyType.from(implementationExtra.getNewReturnType());
+        GradleLazyType gradleLazyType = GradleLazyType.from(implementationExtra.getNewPropertyType());
         switch (gradleLazyType) {
             case LIST_PROPERTY:
             case SET_PROPERTY:
             case MAP_PROPERTY:
-                return Collections.singletonList(AnnotationSpec.builder(SuppressWarnings.class)
-                    .addMember("value", "$L", "{\"unchecked\", \"rawtypes\"}")
-                    .build());
+                return Collections.singletonList(SUPPRESS_UNCHECKED_AND_RAWTYPES);
+            case PROVIDER:
+                return implementationExtra.getReturnType() instanceof ParameterizedTypeName
+                    ? Collections.singletonList(SUPPRESS_UNCHECKED_AND_RAWTYPES)
+                    : Collections.emptyList();
             default:
                 return Collections.emptyList();
         }
@@ -166,7 +173,7 @@ public class PropertyUpgradeClassSourceGenerator extends RequestGroupingInstrume
         String propertyGetterName = implementationExtra.getMethodName();
         boolean isSetter = implementation.getName().startsWith("access_set_");
         CallableReturnTypeInfo returnType = callableInfo.getReturnType();
-        GradleLazyType upgradedPropertyType = GradleLazyType.from(implementationExtra.getNewReturnType());
+        GradleLazyType upgradedPropertyType = GradleLazyType.from(implementationExtra.getNewPropertyType());
 
         CodeBlock.Builder codeBlockBuilder = CodeBlock.builder();
         if (implementationExtra.getDeprecationSpec().isEnabled()) {
@@ -175,7 +182,7 @@ public class PropertyUpgradeClassSourceGenerator extends RequestGroupingInstrume
 
         CodeBlock logic = isSetter
             ? getSetCall(propertyGetterName, implementationExtra, upgradedPropertyType)
-            : getGetCall(propertyGetterName, returnType, upgradedPropertyType);
+            : getGetCall(propertyGetterName, implementationExtra, returnType, upgradedPropertyType);
 
         return codeBlockBuilder.addStatement(logic).build();
     }
@@ -186,7 +193,7 @@ public class PropertyUpgradeClassSourceGenerator extends RequestGroupingInstrume
         DeprecationSpec deprecationSpec = requestExtra.getDeprecationSpec();
 
         CodeBlock.Builder depreactionBuilder = CodeBlock.builder()
-            .add("$T.deprecateProperty($T.class, $S)\n", DEPRECATION_LOGGER.asTypeName(), TypeUtils.typeName(callableInfo.getOwner().getType()), deprecatedPropertyName)
+            .add("$T.deprecateProperty($T.class, $S)\n", DEPRECATION_LOGGER.asClassName(), TypeUtils.typeName(callableInfo.getOwner().getType()), deprecatedPropertyName)
             .add(".withContext($S)\n", "Property was automatically upgraded to the lazy version.");
 
         if (!newPropertyName.equals(deprecatedPropertyName)) {
@@ -216,7 +223,7 @@ public class PropertyUpgradeClassSourceGenerator extends RequestGroupingInstrume
             .build();
     }
 
-    private static CodeBlock getGetCall(String propertyGetterName, CallableReturnTypeInfo returnType, GradleLazyType upgradedPropertyType) {
+    private static CodeBlock getGetCall(String propertyGetterName, PropertyUpgradeRequestExtra implementationExtra, CallableReturnTypeInfo returnType, GradleLazyType upgradedPropertyType) {
         switch (upgradedPropertyType) {
             case REGULAR_FILE_PROPERTY:
             case DIRECTORY_PROPERTY:
@@ -225,15 +232,21 @@ public class PropertyUpgradeClassSourceGenerator extends RequestGroupingInstrume
             case FILE_COLLECTION:
                 return CodeBlock.of("return $N.$N()", SELF_PARAMETER_NAME, propertyGetterName);
             case LIST_PROPERTY:
-                return CodeBlock.of("return new $T<>($N.$N())", LIST_PROPERTY_LIST_VIEW.asTypeName(), SELF_PARAMETER_NAME, propertyGetterName);
+                return CodeBlock.of("return new $T<>($N.$N())", LIST_PROPERTY_LIST_VIEW.asClassName(), SELF_PARAMETER_NAME, propertyGetterName);
             case SET_PROPERTY:
-                return CodeBlock.of("return new $T<>($N.$N())", SET_PROPERTY_SET_VIEW.asTypeName(), SELF_PARAMETER_NAME, propertyGetterName);
+                return CodeBlock.of("return new $T<>($N.$N())", SET_PROPERTY_SET_VIEW.asClassName(), SELF_PARAMETER_NAME, propertyGetterName);
             case MAP_PROPERTY:
-                return CodeBlock.of("return new $T<>($N.$N())", MAP_PROPERTY_MAP_VIEW.asTypeName(), SELF_PARAMETER_NAME, propertyGetterName);
+                return CodeBlock.of("return new $T<>($N.$N())", MAP_PROPERTY_MAP_VIEW.asClassName(), SELF_PARAMETER_NAME, propertyGetterName);
             case PROPERTY:
                 return CodeBlock.of("return $N.$N().getOrElse($L)", SELF_PARAMETER_NAME, propertyGetterName, TypeUtils.getDefaultValue(returnType.getType()));
+            case PROVIDER: {
+                TypeName newPropertyType = implementationExtra.getNewPropertyType();
+                return newPropertyType instanceof ParameterizedTypeName && isAssignableToFileSystemLocation(((ParameterizedTypeName) newPropertyType).typeArguments.get(0))
+                    ? CodeBlock.of("return $N.$N().map($T::getAsFile).getOrNull()", SELF_PARAMETER_NAME, propertyGetterName, FILE_SYSTEM_LOCATION.asClassName())
+                    : CodeBlock.of("return $N.$N().getOrElse($L)", SELF_PARAMETER_NAME, propertyGetterName, TypeUtils.getDefaultValue(returnType.getType()));
+            }
             default:
-                throw new UnsupportedOperationException("Generating get call for type: " + upgradedPropertyType.asType() + " is not supported");
+                throw new UnsupportedOperationException("Generating get call for type: " + upgradedPropertyType.asClassName().reflectionName() + " is not supported");
         }
     }
 
@@ -253,10 +266,11 @@ public class PropertyUpgradeClassSourceGenerator extends RequestGroupingInstrume
             case PROPERTY:
                 assignment = ".set(arg0)";
                 break;
+            case PROVIDER:
             default:
-                throw new UnsupportedOperationException("Generating set call for type: " + upgradedPropertyType.asType() + " is not supported");
+                throw new UnsupportedOperationException("Generating set call for type: " + upgradedPropertyType.asClassName().reflectionName() + " is not supported");
         }
-        if (implementationExtra.getReturnType().equals(Type.VOID_TYPE)) {
+        if (implementationExtra.getReturnType().equals(TypeName.VOID)) {
             return CodeBlock.of("$N.$N()$N", SELF_PARAMETER_NAME, propertyGetterName, assignment);
         } else {
             return CodeBlock.of("$N.$N()$N;\nreturn $N", SELF_PARAMETER_NAME, propertyGetterName, assignment, SELF_PARAMETER_NAME);

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeRequestExtra.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeRequestExtra.java
@@ -16,10 +16,10 @@
 
 package org.gradle.internal.instrumentation.extensions.property;
 
+import com.squareup.javapoet.TypeName;
 import org.gradle.internal.instrumentation.api.annotations.ReplacesEagerProperty.BinaryCompatibility;
 import org.gradle.internal.instrumentation.extensions.property.PropertyUpgradeAnnotatedMethodReader.DeprecationSpec;
 import org.gradle.internal.instrumentation.model.RequestExtra;
-import org.objectweb.asm.Type;
 
 import javax.lang.model.element.ExecutableElement;
 
@@ -27,11 +27,11 @@ class PropertyUpgradeRequestExtra implements RequestExtra {
 
     private final String propertyName;
     private final String methodName;
-    private final Type returnType;
+    private final TypeName returnType;
     private final String implementationClassName;
     private final String interceptedPropertyAccessorName;
     private final String methodDescriptor;
-    private final Type newReturnType;
+    private final TypeName newPropertyType;
     private final DeprecationSpec deprecationSpec;
     private final BinaryCompatibility binaryCompatibility;
     private final String interceptedPropertyName;
@@ -41,11 +41,11 @@ class PropertyUpgradeRequestExtra implements RequestExtra {
         String propertyName,
         String methodName,
         String methodDescriptor,
-        Type returnType,
+        TypeName returnType,
         String implementationClassName,
         String interceptedPropertyName,
         String interceptedPropertyAccessorName,
-        Type newReturnType,
+        TypeName newPropertyType,
         DeprecationSpec deprecationSpec,
         BinaryCompatibility binaryCompatibility,
         ExecutableElement bridgedMethod
@@ -53,8 +53,8 @@ class PropertyUpgradeRequestExtra implements RequestExtra {
         this.propertyName = propertyName;
         this.methodName = methodName;
         this.methodDescriptor = methodDescriptor;
-        this.newReturnType = newReturnType;
         this.returnType = returnType;
+        this.newPropertyType = newPropertyType;
         this.implementationClassName = implementationClassName;
         this.interceptedPropertyName = interceptedPropertyName;
         this.interceptedPropertyAccessorName = interceptedPropertyAccessorName;
@@ -75,8 +75,8 @@ class PropertyUpgradeRequestExtra implements RequestExtra {
         return methodDescriptor;
     }
 
-    public Type getNewReturnType() {
-        return newReturnType;
+    public TypeName getNewPropertyType() {
+        return newPropertyType;
     }
 
     public String getImplementationClassName() {
@@ -92,7 +92,7 @@ class PropertyUpgradeRequestExtra implements RequestExtra {
         return interceptedPropertyAccessorName;
     }
 
-    public Type getReturnType() {
+    public TypeName getReturnType() {
         return returnType;
     }
 

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/GradleLazyType.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/GradleLazyType.java
@@ -60,15 +60,15 @@ public enum GradleLazyType {
     }
 
     public static GradleLazyType from(TypeName typeName) {
-        String canonicalName;
+        String binaryName;
         if (typeName instanceof ClassName) {
-            canonicalName = ((ClassName) typeName).reflectionName();
+            binaryName = ((ClassName) typeName).reflectionName();
         } else if (typeName instanceof ParameterizedTypeName) {
-            canonicalName = ((ParameterizedTypeName) typeName).rawType.reflectionName();
+            binaryName = ((ParameterizedTypeName) typeName).rawType.reflectionName();
         } else {
-            throw new UnsupportedOperationException("Cannot get canonical name from TypeName: " + typeName.getClass());
+            throw new UnsupportedOperationException("Cannot get binary name from TypeName: " + typeName.getClass());
         }
-        return from(canonicalName);
+        return from(binaryName);
     }
 
     public static GradleLazyType from(String name) {

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/GradleLazyType.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/GradleLazyType.java
@@ -16,8 +16,9 @@
 
 package org.gradle.internal.instrumentation.processor.codegen;
 
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
-import org.objectweb.asm.Type;
 
 public enum GradleLazyType {
     CONFIGURABLE_FILE_COLLECTION("org.gradle.api.file.ConfigurableFileCollection"),
@@ -28,53 +29,51 @@ public enum GradleLazyType {
     SET_PROPERTY("org.gradle.api.provider.SetProperty"),
     MAP_PROPERTY("org.gradle.api.provider.MapProperty"),
     PROPERTY("org.gradle.api.provider.Property"),
-    UNSUPPORTED((Type) null) {
+    PROVIDER("org.gradle.api.provider.Provider"),
+    UNSUPPORTED((ClassName) null) {
         @Override
-        public Type asType() {
+        public ClassName asClassName() {
             throw new UnsupportedOperationException("Unsupported type");
         }
     };
 
     @SuppressWarnings("ImmutableEnumChecker")
-    private final Type type;
+    private final ClassName className;
 
     GradleLazyType(String name) {
-        this(Type.getType("L" + name.replace('.', '/') + ";"));
+        this(ClassName.bestGuess(name));
     }
 
-    GradleLazyType(Type type) {
-        this.type = type;
+    GradleLazyType(ClassName className) {
+        this.className = className;
     }
 
-    public Type asType() {
-        return type;
+    public ClassName asClassName() {
+        return className;
     }
 
-    public TypeName asTypeName() {
-        return TypeUtils.typeName(type);
-    }
-
-    public static boolean isAnyOf(Type type) {
-        for (GradleLazyType gradleType : values()) {
-            if (gradleType.type != null && gradleType.type.equals(type)) {
-                return true;
-            }
+    public boolean isEqualToRawTypeOf(TypeName typeName) {
+        if (typeName instanceof ParameterizedTypeName) {
+            typeName = ((ParameterizedTypeName) typeName).rawType;
         }
-        return false;
+        return className.equals(typeName);
     }
 
-    public static GradleLazyType from(Type type) {
-        for (GradleLazyType gradleType : values()) {
-            if (gradleType.type != null && gradleType.type.equals(type)) {
-                return gradleType;
-            }
+    public static GradleLazyType from(TypeName typeName) {
+        String canonicalName;
+        if (typeName instanceof ClassName) {
+            canonicalName = ((ClassName) typeName).reflectionName();
+        } else if (typeName instanceof ParameterizedTypeName) {
+            canonicalName = ((ParameterizedTypeName) typeName).rawType.reflectionName();
+        } else {
+            throw new UnsupportedOperationException("Cannot get canonical name from TypeName: " + typeName.getClass());
         }
-        throw new UnsupportedOperationException("Unknown Gradle lazy type: " + type.getClassName());
+        return from(canonicalName);
     }
 
     public static GradleLazyType from(String name) {
         for (GradleLazyType gradleType : values()) {
-            if (gradleType.type != null && gradleType.type.getClassName().equals(name)) {
+            if (gradleType.className != null && gradleType.className.reflectionName().equals(name)) {
                 return gradleType;
             }
         }

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/GradleReferencedType.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/GradleReferencedType.java
@@ -18,7 +18,6 @@ package org.gradle.internal.instrumentation.processor.codegen;
 
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.TypeName;
-import org.objectweb.asm.Type;
 
 /**
  * Used since we don't want to depend on Gradle types directly, since that way we have to depend on Gradle projects like core-api.
@@ -29,13 +28,16 @@ public enum GradleReferencedType {
     GENERATED_ANNOTATION("org.gradle.api.Generated"),
     LIST_PROPERTY_LIST_VIEW("org.gradle.api.internal.provider.views.ListPropertyListView"),
     SET_PROPERTY_SET_VIEW("org.gradle.api.internal.provider.views.SetPropertySetView"),
-    MAP_PROPERTY_MAP_VIEW("org.gradle.api.internal.provider.views.MapPropertyMapView");
+    MAP_PROPERTY_MAP_VIEW("org.gradle.api.internal.provider.views.MapPropertyMapView"),
+    REGULAR_FILE("org.gradle.api.file.RegularFile"),
+    DIRECTORY("org.gradle.api.file.Directory"),
+    FILE_SYSTEM_LOCATION("org.gradle.api.file.FileSystemLocation");
 
     @SuppressWarnings("ImmutableEnumChecker")
-    private final Type type;
+    private final ClassName className;
 
     GradleReferencedType(String name) {
-        this.type = Type.getType("L" + name.replace('.', '/') + ";");
+        this.className = ClassName.bestGuess(name);
     }
 
     public TypeName asTypeName() {
@@ -43,6 +45,12 @@ public enum GradleReferencedType {
     }
 
     public ClassName asClassName() {
-        return TypeUtils.className(type);
+        return className;
+    }
+
+    public static boolean isAssignableToFileSystemLocation(TypeName typeName) {
+        return typeName.equals(REGULAR_FILE.asTypeName())
+            || typeName.equals(DIRECTORY.asClassName())
+            || typeName.equals(FILE_SYSTEM_LOCATION.asClassName());
     }
 }

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/GradleReferencedType.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/GradleReferencedType.java
@@ -40,16 +40,12 @@ public enum GradleReferencedType {
         this.className = ClassName.bestGuess(name);
     }
 
-    public TypeName asTypeName() {
-        return asClassName();
-    }
-
     public ClassName asClassName() {
         return className;
     }
 
     public static boolean isAssignableToFileSystemLocation(TypeName typeName) {
-        return typeName.equals(REGULAR_FILE.asTypeName())
+        return typeName.equals(REGULAR_FILE.asClassName())
             || typeName.equals(DIRECTORY.asClassName())
             || typeName.equals(FILE_SYSTEM_LOCATION.asClassName());
     }

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/TypeUtils.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/TypeUtils.java
@@ -18,6 +18,7 @@ package org.gradle.internal.instrumentation.processor.codegen;
 
 import com.squareup.javapoet.ArrayTypeName;
 import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import org.gradle.internal.instrumentation.util.NameUtil;
 import org.objectweb.asm.Type;
@@ -25,6 +26,7 @@ import org.objectweb.asm.Type;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 public class TypeUtils {
 
@@ -81,6 +83,13 @@ public class TypeUtils {
             return ArrayTypeName.of(typeName(type.getElementType()));
         }
         return className(type);
+    }
+
+    public static Optional<TypeName> getTypeParameter(TypeName typeName, int index) {
+        if (typeName instanceof ParameterizedTypeName && ((ParameterizedTypeName) typeName).typeArguments.size() > index) {
+            return Optional.of(((ParameterizedTypeName) typeName).typeArguments.get(index));
+        }
+        return Optional.empty();
     }
 
     public static ClassName className(Type type) {

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/groovy/InterceptGroovyCallsResourceGenerator.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/groovy/InterceptGroovyCallsResourceGenerator.java
@@ -59,7 +59,7 @@ public class InterceptGroovyCallsResourceGenerator implements InstrumentationRes
 
             @Override
             public String getName() {
-                return "META-INF/services/" + FILTERABLE_CALL_INTERCEPTOR.canonicalName();
+                return "META-INF/services/" + FILTERABLE_CALL_INTERCEPTOR.reflectionName();
             }
 
             @Override

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/jvmbytecode/InterceptJvmCallsGenerator.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/jvmbytecode/InterceptJvmCallsGenerator.java
@@ -153,10 +153,10 @@ public class InterceptJvmCallsGenerator extends RequestGroupingInstrumentationCl
                 ClassName implementationClassName = NameUtil.getClassName(implementationType.getClassName());
                 String fieldTypeName = knownSimpleNames.add(implementationClassName.simpleName()) ?
                     implementationClassName.simpleName() :
-                    implementationClassName.canonicalName();
+                    implementationClassName.reflectionName();
                 String fullFieldName = camelToKebabCase(fieldTypeName).replace("-", "_").toUpperCase(Locale.US) + "_TYPE";
                 return FieldSpec.builder(String.class, fullFieldName, Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
-                    .initializer("$S", implementationClassName.canonicalName().replace(".", "/"))
+                    .initializer("$S", implementationClassName.reflectionName().replace(".", "/"))
                     .build();
             }, (u, v) -> u, LinkedHashMap::new));
     }

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/modelreader/impl/TypeUtils.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/modelreader/impl/TypeUtils.java
@@ -26,9 +26,11 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -87,6 +89,17 @@ public class TypeUtils {
             extractReturnType(methodElement),
             methodElement.getParameters().stream().map(it -> extractType(it.asType())).toArray(Type[]::new)
         );
+    }
+
+    public static Optional<TypeName> getTypeParameter(TypeMirror typeMirror, int index) {
+        if (typeMirror instanceof DeclaredType && ((DeclaredType) typeMirror).getTypeArguments().size() > index) {
+            return Optional.of(TypeName.get(((DeclaredType) typeMirror).getTypeArguments().get(index)));
+        }
+        return Optional.empty();
+    }
+
+    public static TypeName getTypeParameterOrThrow(TypeMirror typeMirror, int index) {
+        return getTypeParameter(typeMirror, index).orElseThrow(() -> new IllegalArgumentException(String.format("Missing type parameter with index %s for %s", index, typeMirror)));
     }
 
     @Nonnull

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/modelreader/impl/TypeUtils.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/modelreader/impl/TypeUtils.java
@@ -16,6 +16,9 @@
 
 package org.gradle.internal.instrumentation.processor.modelreader.impl;
 
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
 import org.objectweb.asm.Type;
 
 import javax.annotation.Nonnull;
@@ -32,6 +35,47 @@ import java.util.stream.Stream;
 public class TypeUtils {
     public static Type extractType(TypeMirror typeMirror) {
         return typeMirror.accept(new TypeMirrorToType(), null);
+    }
+
+    public static Type extractRawType(TypeName typeName) {
+        if (typeName.isPrimitive()) {
+            if (typeName.equals(TypeName.BOOLEAN)) {
+                return Type.BOOLEAN_TYPE;
+            }
+            if (typeName.equals(TypeName.BYTE)) {
+                return Type.BYTE_TYPE;
+            }
+            if (typeName.equals(TypeName.SHORT)) {
+                return Type.SHORT_TYPE;
+            }
+            if (typeName.equals(TypeName.INT)) {
+                return Type.INT_TYPE;
+            }
+            if (typeName.equals(TypeName.LONG)) {
+                return Type.LONG_TYPE;
+            }
+            if (typeName.equals(TypeName.CHAR)) {
+                return Type.CHAR_TYPE;
+            }
+            if (typeName.equals(TypeName.FLOAT)) {
+                return Type.FLOAT_TYPE;
+            }
+            if (typeName.equals(TypeName.DOUBLE)) {
+                return Type.DOUBLE_TYPE;
+            }
+        } else if (typeName.equals(TypeName.VOID)) {
+            return Type.VOID_TYPE;
+        }
+
+        ClassName className;
+        if (typeName instanceof ParameterizedTypeName) {
+            className = ((ParameterizedTypeName) typeName).rawType;
+        } else if (typeName instanceof ClassName) {
+            className = (ClassName) typeName;
+        } else {
+            throw new IllegalArgumentException("Not supported to extract raw type from: " + typeName);
+        }
+        return Type.getType("L" + className.reflectionName().replace('.', '/') + ";");
     }
 
     public static Type extractReturnType(ExecutableElement methodElement) {

--- a/platforms/core-runtime/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/InstrumentedPropertiesResourceGeneratorTest.groovy
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/InstrumentedPropertiesResourceGeneratorTest.groovy
@@ -119,7 +119,6 @@ class InstrumentedPropertiesResourceGeneratorTest extends InstrumentationCodeGen
             package org.gradle.test;
 
             import org.gradle.api.provider.Property;
-            import org.gradle.internal.instrumentation.api.annotations.VisitForInstrumentation;
             import org.gradle.internal.instrumentation.api.annotations.ReplacesEagerProperty;
 
             public abstract class Task {

--- a/platforms/core-runtime/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeCodeGenTest.groovy
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeCodeGenTest.groovy
@@ -38,11 +38,9 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
             package org.gradle.test;
 
             import org.gradle.api.provider.Property;
-            import org.gradle.internal.instrumentation.api.annotations.VisitForInstrumentation;
             import org.gradle.internal.instrumentation.api.annotations.ReplacesEagerProperty;
             import org.gradle.internal.instrumentation.api.annotations.ReplacedDeprecation;
 
-            @VisitForInstrumentation(value = {Task.class})
             public abstract class Task {
                 @ReplacesEagerProperty(originalType = int.class)
                 public abstract Property<Integer> getMaxErrors();
@@ -82,10 +80,8 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
             package org.gradle.test;
 
             import org.gradle.api.provider.Property;
-            import org.gradle.internal.instrumentation.api.annotations.VisitForInstrumentation;
             import org.gradle.internal.instrumentation.api.annotations.ReplacesEagerProperty;
 
-            @VisitForInstrumentation(value = {Task.class})
             public abstract class Task {
                 @ReplacesEagerProperty(originalType = boolean.class, fluentSetter = true)
                 public abstract Property<Boolean> getIncremental();
@@ -152,10 +148,8 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
 
             import org.gradle.api.provider.*;
             import org.gradle.api.file.*;
-            import org.gradle.internal.instrumentation.api.annotations.VisitForInstrumentation;
             import org.gradle.internal.instrumentation.api.annotations.ReplacesEagerProperty;
 
-            @VisitForInstrumentation(value = {Task.class})
             public abstract class Task {
                 @ReplacesEagerProperty${PRIMITIVE_TYPES.contains(originalType) ? "(originalType = ${originalType}.class)" : ""}
                 public abstract $upgradedType getProperty();
@@ -179,13 +173,13 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
                 ${hasSuppressWarnings ? '@SuppressWarnings({"unchecked", "rawtypes"})' : ''}
                 public static $originalType access_get_${getterPrefix}Property(Task self) {
                     ${getDefaultPropertyUpgradeDeprecation("Task", "property")}
-                    return $getCall;
+                    return $getterBody;
                 }
 
                 ${hasSuppressWarnings ? '@SuppressWarnings({"unchecked", "rawtypes"})' : ''}
                 public static void access_set_setProperty(Task self, $originalType arg0) {
                     ${getDefaultPropertyUpgradeDeprecation("Task", "property")}
-                    self.getProperty()$setCall;
+                    self.getProperty()$setterBody;
                 }
             }
         """
@@ -195,7 +189,7 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
             .containsElementsIn(generatedClass)
 
         where:
-        upgradedType                  | originalType     | getCall                                          | setCall            | imports
+        upgradedType                  | originalType     | getterBody                                       | setterBody         | imports
         "Property<Integer>"           | "int"            | "self.getProperty().getOrElse(0)"                | ".set(arg0)"       | []
         "Property<Boolean>"           | "boolean"        | "self.getProperty().getOrElse(false)"            | ".set(arg0)"       | []
         "Property<Long>"              | "long"           | "self.getProperty().getOrElse(0L)"               | ".set(arg0)"       | []
@@ -243,7 +237,7 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
                 ${hasSuppressWarnings ? '@SuppressWarnings({"unchecked", "rawtypes"})' : ''}
                 public static $originalType access_get_${getterPrefix}Property(Task self) {
                     ${getDefaultPropertyUpgradeDeprecation("Task", "property")}
-                    return $getCall;
+                    return $getterBody;
                 }
             }
         """
@@ -253,7 +247,7 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
             .containsElementsIn(generatedClass)
 
         where:
-        upgradedType                    | originalType | setOriginalType | hasSuppressWarnings | getCall
+        upgradedType                    | originalType | setOriginalType | hasSuppressWarnings | getterBody
         "Provider<Integer>"             | "Integer"    | false           | false               | "self.getProperty().getOrElse(null)"
         "Provider<Integer>"             | "int"        | true            | false               | "self.getProperty().getOrElse(0)"
         "Provider<RegularFile>"         | "File"       | false           | false               | "self.getProperty().map(FileSystemLocation::getAsFile).getOrNull()"
@@ -273,7 +267,6 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
             import org.gradle.api.file.*;
             import org.gradle.internal.instrumentation.api.annotations.*;
 
-            @VisitForInstrumentation(value = {Task.class})
             public abstract class Task {
                 @ReplacesEagerProperty
                 public abstract Property<String> getTargetCompatibility();

--- a/platforms/core-runtime/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeCodeGenTest.groovy
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeCodeGenTest.groovy
@@ -223,11 +223,7 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
             import org.gradle.internal.instrumentation.api.annotations.ReplacedAccessor;
 
             public abstract class Task {
-                @ReplacesEagerProperty(replacedAccessors = @ReplacedAccessor(
-                    value = ReplacedAccessor.AccessorType.GETTER,
-                    ${setOriginalType ? "originalType = ${originalType}.class," : ""}
-                    name = "getProperty"
-                ))
+                @ReplacesEagerProperty(${setOriginalType ? "originalType = ${originalType}.class" : ""})
                 public abstract $upgradedType getProperty();
             }
         """
@@ -260,8 +256,8 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
         upgradedType                    | originalType | setOriginalType | hasSuppressWarnings | getCall
         "Provider<Integer>"             | "Integer"    | false           | false               | "self.getProperty().getOrElse(null)"
         "Provider<Integer>"             | "int"        | true            | false               | "self.getProperty().getOrElse(0)"
-        "Provider<RegularFile>"         | "File"       | false           | false               | "self.getProperty().map(fileSystemLocation -> fileSystemLocation.getAsFile()).getOrNull()"
-        "Provider<Directory>"           | "File"       | false           | false               | "self.getProperty().map(fileSystemLocation -> fileSystemLocation.getAsFile()).getOrNull()"
+        "Provider<RegularFile>"         | "File"       | false           | false               | "self.getProperty().map(FileSystemLocation::getAsFile).getOrNull()"
+        "Provider<Directory>"           | "File"       | false           | false               | "self.getProperty().map(FileSystemLocation::getAsFile).getOrNull()"
         "Provider<File>"                | "File"       | false           | false               | "self.getProperty().getOrElse(null)"
         "Provider<List<String>>"        | "Iterable"   | true            | true                | "self.getProperty().getOrElse(null)"
         "Provider<List<String>>"        | "List"       | false           | true                | "self.getProperty().getOrElse(null)"


### PR DESCRIPTION
We support now automatic upgrades for `@ReplacesEagerProperty` for `Provider<T> getProperty()` like properties.

Fixes https://github.com/gradle/gradle/issues/26540

Tested also with https://github.com/gradle/gradle/pull/29271