### PR TITLE
Make Kotlin generators caching behaviour consistent with Gradle 8.8 

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractKotlinIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractKotlinIntegrationTest.kt
@@ -333,9 +333,9 @@ abstract class AbstractKotlinIntegrationTest : AbstractIntegrationTest() {
         inDirectory(rootDir).withArguments(*arguments)
 
     protected
-    inline fun withOwnGradleUserHomeDir(reason: String, block: () -> Unit) {
+    inline fun <T> withOwnGradleUserHomeDir(reason: String, block: () -> T): T {
         executer.requireOwnGradleUserHomeDir(reason)
-        try {
+        return try {
             block()
         } finally {
             // wait for all daemons to shut down so the test dir can be deleted

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSortedMap;
 import org.gradle.api.Describable;
 import org.gradle.api.file.FileCollection;
 import org.gradle.internal.execution.caching.CachingDisabledReason;
+import org.gradle.internal.execution.caching.CachingDisabledReasonCategory;
 import org.gradle.internal.execution.caching.CachingState;
 import org.gradle.internal.execution.history.OverlappingOutputs;
 import org.gradle.internal.execution.history.changes.InputChangesInternal;
@@ -42,6 +43,8 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 public interface UnitOfWork extends Describable {
+
+    CachingDisabledReason NOT_WORTH_CACHING = new CachingDisabledReason(CachingDisabledReasonCategory.NOT_CACHEABLE, "Not worth caching.");
 
     /**
      * Identifier of the type of the work used in build operations.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultDependenciesAccessors.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultDependenciesAccessors.java
@@ -50,6 +50,8 @@ import org.gradle.internal.execution.ExecutionEngine;
 import org.gradle.internal.execution.ImmutableUnitOfWork;
 import org.gradle.internal.execution.InputFingerprinter;
 import org.gradle.internal.execution.UnitOfWork;
+import org.gradle.internal.execution.caching.CachingDisabledReason;
+import org.gradle.internal.execution.history.OverlappingOutputs;
 import org.gradle.internal.execution.model.InputNormalizer;
 import org.gradle.internal.execution.workspace.ImmutableWorkspaceProvider;
 import org.gradle.internal.file.TreeType;
@@ -413,6 +415,12 @@ public class DefaultDependenciesAccessors implements DependenciesAccessors {
         }
 
         @Override
+        public Optional<CachingDisabledReason> shouldDisableCaching(@Nullable OverlappingOutputs detectedOverlappingOutputs) {
+            // This was a behaviour before 8.9, where we unified ExecutionEngine in https://github.com/gradle/gradle/pull/29534
+            return Optional.of(NOT_WORTH_CACHING);
+        }
+
+        @Override
         protected List<ClassSource> getClassSources() {
             return Arrays.asList(
                 new DependenciesAccessorClassSource(model.getName(), model, getProblemsService()),
@@ -448,6 +456,12 @@ public class DefaultDependenciesAccessors implements DependenciesAccessors {
 
         public ProjectAccessorUnitOfWork(ProjectRegistry<? extends ProjectDescriptor> projectRegistry) {
             this.projectRegistry = projectRegistry;
+        }
+
+        @Override
+        public Optional<CachingDisabledReason> shouldDisableCaching(@Nullable OverlappingOutputs detectedOverlappingOutputs) {
+            // This was a behaviour before 8.9, where we unified ExecutionEngine in https://github.com/gradle/gradle/pull/29534
+            return Optional.of(NOT_WORTH_CACHING);
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/GroovyScriptClassCompiler.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/GroovyScriptClassCompiler.java
@@ -37,7 +37,6 @@ import org.gradle.internal.execution.ExecutionEngine;
 import org.gradle.internal.execution.InputFingerprinter;
 import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.caching.CachingDisabledReason;
-import org.gradle.internal.execution.caching.CachingDisabledReasonCategory;
 import org.gradle.internal.execution.history.OverlappingOutputs;
 import org.gradle.internal.execution.workspace.ImmutableWorkspaceProvider;
 import org.gradle.internal.file.TreeType;
@@ -209,8 +208,6 @@ public class GroovyScriptClassCompiler implements ScriptClassCompiler, Closeable
 
     static class GroovyScriptCompilationAndInstrumentation extends BuildScriptCompilationAndInstrumentation {
 
-        private static final CachingDisabledReason NOT_CACHEABLE = new CachingDisabledReason(CachingDisabledReasonCategory.NOT_CACHEABLE, "Not worth caching.");
-
         private final String templateId;
         private final HashCode sourceHashCode;
         private final ClassLoader classLoader;
@@ -253,7 +250,7 @@ public class GroovyScriptClassCompiler implements ScriptClassCompiler, Closeable
             // Disabled since enabling it introduced negative savings to Groovy script compilation.
             // It's not disabled for Kotlin since Kotlin has better compile avoidance, additionally
             // Kotlin has build cache from the beginning and there was no report of a problem with it.
-            return Optional.of(NOT_CACHEABLE);
+            return Optional.of(NOT_WORTH_CACHING);
         }
 
         @Override

--- a/testing/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/ScriptCachingIntegrationTest.kt
+++ b/testing/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/ScriptCachingIntegrationTest.kt
@@ -18,6 +18,7 @@ package org.gradle.kotlin.dsl.caching
 
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.integtests.fixtures.daemon.DaemonLogsAnalyzer
+import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.kotlin.dsl.caching.fixtures.CachedScript
 import org.gradle.kotlin.dsl.caching.fixtures.KotlinDslCacheFixture
 import org.gradle.kotlin.dsl.caching.fixtures.cachedBuildFile
@@ -274,19 +275,46 @@ class ScriptCachingIntegrationTest : AbstractScriptCachingIntegrationTest() {
 
     @Test
     fun `writes build cache entries`() {
-        expectCacheEntriesWritten(2, false)
+        val result = expectCacheEntriesWritten(6, false)
+        result.assertOutputContains("Stored cache entry for generation of dependency accessors")
+        result.assertOutputContains("Stored cache entry for Kotlin DSL version catalog plugin accessors")
+        result.assertOutputContains("Stored cache entry for Kotlin DSL plugin specs accessors")
+        result.assertOutputContains("Stored cache entry for Kotlin DSL accessors")
+        result.assertOutputContains("Stored cache entry for Kotlin DSL script compilation (Project/TopLevel/stage1)")
+        result.assertOutputContains("Stored cache entry for Kotlin DSL script compilation (Project/TopLevel/stage2)")
     }
 
     @Test
     fun `writes no build cache entries when script caching disabled`() {
-        expectCacheEntriesWritten(0, true)
+        val result = expectCacheEntriesWritten(4, true)
+        result.assertOutputContains("Stored cache entry for generation of dependency accessors")
+        result.assertOutputContains("Stored cache entry for Kotlin DSL version catalog plugin accessors")
+        result.assertOutputContains("Stored cache entry for Kotlin DSL plugin specs accessors")
+        result.assertOutputContains("Stored cache entry for Kotlin DSL accessors")
+        result.assertNotOutput("Stored cache entry for Kotlin DSL script compilation")
     }
 
     private
-    fun expectCacheEntriesWritten(expectedEntryCount: Int, scriptCachingDisabled: Boolean) {
-        withOwnGradleUserHomeDir("verifying local build cache content") {
+    fun expectCacheEntriesWritten(expectedEntryCount: Int, scriptCachingDisabled: Boolean): ExecutionResult {
+        return withOwnGradleUserHomeDir("verifying local build cache content") {
             withSettings(randomScriptContent())
             withBuildScriptIn(".", randomScriptContent())
+            withFolders {
+                "gradle" {
+                    withFile(
+                        "libs.versions.toml",
+                        """
+                            [versions]
+                            groovy = "3.0.5"
+                            checkstyle = "8.37"
+
+                            [libraries]
+                            groovy-core = { module = "org.codehaus.groovy:groovy", version.ref = "groovy" }
+                            groovy-json = { module = "org.codehaus.groovy:groovy-json", version.ref = "groovy" }
+                        """.trimIndent()
+                    )
+                }
+            }
 
             val result = buildForCacheInspection("help", "--build-cache", "--info", "-Dorg.gradle.internal.kotlin-script-caching-disabled=$scriptCachingDisabled")
 
@@ -302,6 +330,7 @@ class ScriptCachingIntegrationTest : AbstractScriptCachingIntegrationTest() {
             val localBuildCacheFiles = localBuildCacheDir.list { _, fileName -> fileName != "gc.properties" && fileName != "build-cache-1.lock" }
 
             assertThat(localBuildCacheFiles).hasSize(expectedEntryCount)
+            result
         }
     }
 

--- a/testing/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/ScriptCachingIntegrationTest.kt
+++ b/testing/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/ScriptCachingIntegrationTest.kt
@@ -275,8 +275,7 @@ class ScriptCachingIntegrationTest : AbstractScriptCachingIntegrationTest() {
 
     @Test
     fun `writes build cache entries`() {
-        val result = expectCacheEntriesWritten(6, false)
-        result.assertOutputContains("Stored cache entry for generation of dependency accessors")
+        val result = expectCacheEntriesWritten(5, false)
         result.assertOutputContains("Stored cache entry for Kotlin DSL version catalog plugin accessors")
         result.assertOutputContains("Stored cache entry for Kotlin DSL plugin specs accessors")
         result.assertOutputContains("Stored cache entry for Kotlin DSL accessors")
@@ -286,8 +285,7 @@ class ScriptCachingIntegrationTest : AbstractScriptCachingIntegrationTest() {
 
     @Test
     fun `writes no build cache entries when script caching disabled`() {
-        val result = expectCacheEntriesWritten(4, true)
-        result.assertOutputContains("Stored cache entry for generation of dependency accessors")
+        val result = expectCacheEntriesWritten(3, true)
         result.assertOutputContains("Stored cache entry for Kotlin DSL version catalog plugin accessors")
         result.assertOutputContains("Stored cache entry for Kotlin DSL plugin specs accessors")
         result.assertOutputContains("Stored cache entry for Kotlin DSL accessors")
@@ -297,7 +295,12 @@ class ScriptCachingIntegrationTest : AbstractScriptCachingIntegrationTest() {
     private
     fun expectCacheEntriesWritten(expectedEntryCount: Int, scriptCachingDisabled: Boolean): ExecutionResult {
         return withOwnGradleUserHomeDir("verifying local build cache content") {
-            withSettings(randomScriptContent())
+            withSettings(
+                """
+                    enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+                    ${randomScriptContent()}
+                """.trimIndent()
+            )
             withBuildScriptIn(".", randomScriptContent())
             withFolders {
                 "gradle" {


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/29458

Relates to https://github.com/gradle/gradle/pull/29534