### PR TITLE
Fix snapshot filtering

### DIFF
--- a/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilter.java
+++ b/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilter.java
@@ -41,7 +41,11 @@ public class FileSystemSnapshotFilter {
     private FileSystemSnapshotFilter() {
     }
 
-    public static Optional<FileSystemLocationSnapshot> filterSnapshot(SnapshottingFilter.FileSystemSnapshotPredicate predicate, FileSystemLocationSnapshot unfiltered) {
+    public static Optional<FileSystemLocationSnapshot> filterSnapshot(SnapshottingFilter filter, FileSystemLocationSnapshot unfiltered) {
+        if (filter.isEmpty()) {
+            return Optional.of(unfiltered);
+        }
+        SnapshottingFilter.FileSystemSnapshotPredicate predicate = filter.getAsSnapshotPredicate();
         DirectorySnapshotBuilder builder = MerkleDirectorySnapshotBuilder.noSortingRequired();
         AtomicBoolean hasBeenFiltered = new AtomicBoolean();
         unfiltered.accept(new RelativePathTracker(), new FilteringVisitor(predicate, builder, hasBeenFiltered));

--- a/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilter.java
+++ b/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilter.java
@@ -23,7 +23,6 @@ import org.gradle.internal.snapshot.DirectorySnapshotBuilder;
 import org.gradle.internal.snapshot.FileSystemLeafSnapshot;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot.FileSystemLocationSnapshotTransformer;
-import org.gradle.internal.snapshot.FileSystemSnapshot;
 import org.gradle.internal.snapshot.MerkleDirectorySnapshotBuilder;
 import org.gradle.internal.snapshot.MissingFileSnapshot;
 import org.gradle.internal.snapshot.RegularFileSnapshot;
@@ -32,6 +31,7 @@ import org.gradle.internal.snapshot.RelativePathTrackingFileSystemSnapshotHierar
 import org.gradle.internal.snapshot.SnapshotVisitResult;
 import org.gradle.internal.snapshot.SnapshottingFilter;
 
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.gradle.internal.snapshot.DirectorySnapshotBuilder.EmptyDirectoryHandlingStrategy.INCLUDE_EMPTY_DIRS;
@@ -41,14 +41,14 @@ public class FileSystemSnapshotFilter {
     private FileSystemSnapshotFilter() {
     }
 
-    public static FileSystemSnapshot filterSnapshot(SnapshottingFilter.FileSystemSnapshotPredicate predicate, FileSystemSnapshot unfiltered) {
+    public static Optional<FileSystemLocationSnapshot> filterSnapshot(SnapshottingFilter.FileSystemSnapshotPredicate predicate, FileSystemLocationSnapshot unfiltered) {
         DirectorySnapshotBuilder builder = MerkleDirectorySnapshotBuilder.noSortingRequired();
         AtomicBoolean hasBeenFiltered = new AtomicBoolean();
         unfiltered.accept(new RelativePathTracker(), new FilteringVisitor(predicate, builder, hasBeenFiltered));
         if (builder.getResult() == null) {
-            return FileSystemSnapshot.EMPTY;
+            return Optional.empty();
         }
-        return hasBeenFiltered.get() ? builder.getResult() : unfiltered;
+        return Optional.of(hasBeenFiltered.get() ? builder.getResult() : unfiltered);
     }
 
     private static class FilteringVisitor implements RelativePathTrackingFileSystemSnapshotHierarchyVisitor {

--- a/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/vfs/VirtualFileSystem.java
+++ b/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/vfs/VirtualFileSystem.java
@@ -55,7 +55,7 @@ public interface VirtualFileSystem {
      * If the snapshotted location is invalidated while snapshotting,
      * then the snapshot is not stored in the VFS to avoid inconsistent state.
      */
-    <T> T store(String baseLocation, StoringAction<T> storingAction);
+    <T> T storeWithAction(String baseLocation, StoringAction<T> storingAction);
 
     /**
      * Snapshotting action which produces possibly more than one snapshot.

--- a/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/vfs/impl/AbstractVirtualFileSystem.java
+++ b/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/vfs/impl/AbstractVirtualFileSystem.java
@@ -85,7 +85,7 @@ public abstract class AbstractVirtualFileSystem implements VirtualFileSystem {
     }
 
     @Override
-    public <T> T store(String baseLocation, StoringAction<T> storingAction) {
+    public <T> T storeWithAction(String baseLocation, StoringAction<T> storingAction) {
         long versionBefore = versionHierarchyRoot.getVersion(baseLocation);
         return storingAction.snapshot(snapshot -> {
             storeIfUnchanged(snapshot.getAbsolutePath(), versionBefore, snapshot);

--- a/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultFileSystemAccess.java
+++ b/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultFileSystemAccess.java
@@ -28,7 +28,6 @@ import org.gradle.internal.hash.FileHasher;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.io.IoRunnable;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
-import org.gradle.internal.snapshot.FileSystemSnapshot;
 import org.gradle.internal.snapshot.MissingFileSnapshot;
 import org.gradle.internal.snapshot.RegularFileSnapshot;
 import org.gradle.internal.snapshot.SnapshottingFilter;
@@ -134,21 +133,15 @@ public class DefaultFileSystemAccess implements FileSystemAccess, FileSystemDefa
         if (filter.isEmpty()) {
             return Optional.of(read(location));
         } else {
-            FileSystemSnapshot filteredSnapshot = readSnapshotFromLocation(location,
+            return readSnapshotFromLocation(location,
                 snapshot -> FileSystemSnapshotFilter.filterSnapshot(filter.getAsSnapshotPredicate(), snapshot),
                 () -> {
                     FileSystemLocationSnapshot snapshot = snapshot(location, filter);
                     return snapshot.getType() == FileType.Directory
                         // Directory snapshots have been filtered while walking the file system
-                        ? snapshot
+                        ? Optional.of(snapshot)
                         : FileSystemSnapshotFilter.filterSnapshot(filter.getAsSnapshotPredicate(), snapshot);
                 });
-
-            if (filteredSnapshot instanceof FileSystemLocationSnapshot) {
-                return Optional.of((FileSystemLocationSnapshot) filteredSnapshot);
-            } else {
-                return Optional.empty();
-            }
         }
     }
 

--- a/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultFileSystemAccess.java
+++ b/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultFileSystemAccess.java
@@ -134,13 +134,13 @@ public class DefaultFileSystemAccess implements FileSystemAccess, FileSystemDefa
             return Optional.of(read(location));
         } else {
             return readSnapshotFromLocation(location,
-                snapshot -> FileSystemSnapshotFilter.filterSnapshot(filter.getAsSnapshotPredicate(), snapshot),
+                snapshot -> FileSystemSnapshotFilter.filterSnapshot(filter, snapshot),
                 () -> {
                     FileSystemLocationSnapshot snapshot = snapshot(location, filter);
                     return snapshot.getType() == FileType.Directory
                         // Directory snapshots have been filtered while walking the file system
                         ? Optional.of(snapshot)
-                        : FileSystemSnapshotFilter.filterSnapshot(filter.getAsSnapshotPredicate(), snapshot);
+                        : FileSystemSnapshotFilter.filterSnapshot(filter, snapshot);
                 });
         }
     }

--- a/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultFileSystemAccess.java
+++ b/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultFileSystemAccess.java
@@ -105,7 +105,7 @@ public class DefaultFileSystemAccess implements FileSystemAccess, FileSystemDefa
                 }
                 return Optional.empty();
             })
-            .orElseGet(() -> virtualFileSystem.store(location, vfsStorer -> {
+            .orElseGet(() -> virtualFileSystem.storeWithAction(location, vfsStorer -> {
                 File file = new File(location);
                 FileMetadata fileMetadata = this.stat.stat(file);
                 switch (fileMetadata.getType()) {
@@ -163,7 +163,7 @@ public class DefaultFileSystemAccess implements FileSystemAccess, FileSystemDefa
         if (knownExactSnapshot != null) {
             return knownExactSnapshot;
         }
-        return virtualFileSystem.store(location, vfsStorer -> {
+        return virtualFileSystem.storeWithAction(location, vfsStorer -> {
             File file = new File(location);
             FileMetadata fileMetadata = this.stat.stat(file);
             switch (fileMetadata.getType()) {

--- a/platforms/core-execution/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilterTest.groovy
+++ b/platforms/core-execution/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilterTest.groovy
@@ -25,7 +25,6 @@ import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.nativeintegration.filesystem.FileSystem
 import org.gradle.internal.snapshot.DirectorySnapshot
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot
-import org.gradle.internal.snapshot.FileSystemSnapshot
 import org.gradle.internal.snapshot.FileSystemSnapshotHierarchyVisitor
 import org.gradle.internal.snapshot.RegularFileSnapshot
 import org.gradle.internal.snapshot.SnapshotVisitResult
@@ -66,11 +65,6 @@ class FileSystemSnapshotFilterTest extends Specification {
         filteredPaths(unfiltered, include("dir1/dirFile1")) == [root, dir1, dirFile1] as Set
     }
 
-    def "filters empty tree"() {
-        expect:
-        FileSystemSnapshotFilter.filterSnapshot(snapshottingFilter(include("**/*")).asSnapshotPredicate, FileSystemSnapshot.EMPTY) == FileSystemSnapshot.EMPTY
-    }
-
     def "root directory is always matched"() {
         def root = temporaryFolder.createFile("root")
         def unfiltered = new DirectorySnapshot(root.absolutePath, root.name, AccessType.DIRECT, TestHashCodes.hashCodeFrom(789), [])
@@ -101,18 +95,20 @@ class FileSystemSnapshotFilterTest extends Specification {
         def filtered = FileSystemSnapshotFilter.filterSnapshot(snapshottingFilter(include("**/*File*")).asSnapshotPredicate, unfiltered)
 
         then:
-        filtered.is(unfiltered)
+        filtered.get().is(unfiltered)
     }
 
-    private Set<File> filteredPaths(FileSystemSnapshot unfiltered, PatternSet patterns) {
+    private Set<File> filteredPaths(FileSystemLocationSnapshot unfiltered, PatternSet patterns) {
         def result = [] as Set
-        def filtered = FileSystemSnapshotFilter.filterSnapshot(snapshottingFilter(patterns).asSnapshotPredicate, unfiltered)
-        filtered.accept(new FileSystemSnapshotHierarchyVisitor() {
-            SnapshotVisitResult visitEntry(FileSystemLocationSnapshot snapshot) {
-                result << new File(snapshot.absolutePath)
-                return CONTINUE
+        FileSystemSnapshotFilter.filterSnapshot(snapshottingFilter(patterns).asSnapshotPredicate, unfiltered)
+            .ifPresent { FileSystemLocationSnapshot filtered ->
+                filtered.accept(new FileSystemSnapshotHierarchyVisitor() {
+                    SnapshotVisitResult visitEntry(FileSystemLocationSnapshot snapshot) {
+                        result << new File(snapshot.absolutePath)
+                        return CONTINUE
+                    }
+                })
             }
-        })
         return result
     }
 

--- a/platforms/core-execution/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilterTest.groovy
+++ b/platforms/core-execution/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilterTest.groovy
@@ -92,7 +92,7 @@ class FileSystemSnapshotFilterTest extends Specification {
         def unfiltered = fileSystemAccess.read(root.getAbsolutePath(), snapshottingFilter(new PatternSet())).get()
 
         when:
-        def filtered = FileSystemSnapshotFilter.filterSnapshot(snapshottingFilter(include("**/*File*")).asSnapshotPredicate, unfiltered)
+        def filtered = FileSystemSnapshotFilter.filterSnapshot(snapshottingFilter(include("**/*File*")), unfiltered)
 
         then:
         filtered.get().is(unfiltered)
@@ -100,7 +100,7 @@ class FileSystemSnapshotFilterTest extends Specification {
 
     private Set<File> filteredPaths(FileSystemLocationSnapshot unfiltered, PatternSet patterns) {
         def result = [] as Set
-        FileSystemSnapshotFilter.filterSnapshot(snapshottingFilter(patterns).asSnapshotPredicate, unfiltered)
+        FileSystemSnapshotFilter.filterSnapshot(snapshottingFilter(patterns), unfiltered)
             .ifPresent { FileSystemLocationSnapshot filtered ->
                 filtered.accept(new FileSystemSnapshotHierarchyVisitor() {
                     SnapshotVisitResult visitEntry(FileSystemLocationSnapshot snapshot) {

--- a/platforms/core-execution/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/AbstractVirtualFileSystemTest.groovy
+++ b/platforms/core-execution/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/AbstractVirtualFileSystemTest.groovy
@@ -17,13 +17,9 @@
 package org.gradle.internal.vfs.impl
 
 import org.gradle.internal.snapshot.CaseSensitivity
-import org.gradle.internal.snapshot.FileSystemLocationSnapshot
 import org.gradle.internal.snapshot.SnapshotHierarchy
 import org.gradle.internal.snapshot.TestSnapshotFixture
-import org.gradle.internal.vfs.VirtualFileSystem
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
-
-import java.util.function.Supplier
 
 class AbstractVirtualFileSystemTest extends ConcurrentSpec implements TestSnapshotFixture {
 
@@ -38,12 +34,12 @@ class AbstractVirtualFileSystemTest extends ConcurrentSpec implements TestSnapsh
         def location = '/my/location/new'
         when:
         start {
-            vfs.store(location, { ->
+            vfs.store(location) { ->
                 instant.snapshottingStarted
                 thread.blockUntil.invalidated
                 instant.snapshottingFinished
                 return directory(location, [])
-            } as Supplier<FileSystemLocationSnapshot>)
+            }
         }
         async {
             thread.blockUntil.snapshottingStarted
@@ -60,7 +56,7 @@ class AbstractVirtualFileSystemTest extends ConcurrentSpec implements TestSnapsh
         def location = '/my/location/new'
         when:
         start {
-            vfs.store(location, { vfsStore ->
+            vfs.storeWithAction(location) { vfsStore ->
                 instant.snapshottingStarted
                 vfsStore.store(regularFile("${location}/some/child"))
                 vfsStore.store(regularFile("${location}/other/child"))
@@ -70,7 +66,7 @@ class AbstractVirtualFileSystemTest extends ConcurrentSpec implements TestSnapsh
                 vfsStore.store(regularFile("${location}/some/child2"))
                 instant.snapshottingFinished
                 return directory(location, [])
-            } as VirtualFileSystem.StoringAction)
+            }
         }
         async {
             thread.blockUntil.partialSnapshotsStored
@@ -92,12 +88,12 @@ class AbstractVirtualFileSystemTest extends ConcurrentSpec implements TestSnapsh
         def location = '/my/location/new'
         when:
         start {
-            vfs.store(location, { ->
+            vfs.store(location) { ->
                 instant.snapshottingStarted
                 thread.blockUntil.invalidated
                 instant.snapshottingFinished
                 return directory(location, [])
-            } as Supplier<FileSystemLocationSnapshot>)
+            }
         }
         async {
             thread.blockUntil.snapshottingStarted
@@ -115,9 +111,9 @@ class AbstractVirtualFileSystemTest extends ConcurrentSpec implements TestSnapsh
 
         when:
         vfs.invalidate(['/my/location/new/something'])
-        vfs.store(location, { ->
-            return directory(location, [])
-        } as Supplier<FileSystemLocationSnapshot>)
+        vfs.store(location) { ->
+            directory(location, [])
+        }
         then:
         vfs.findSnapshot(location).present
     }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #29205

### Context

In some rare cases Gradle could ignore filters while snapshotting inputs or outputs, leading false positives when checking for changes.

The problem lies in how we reuse already taken snapshots. Gradle only stores unfiltered snapshots in the virtual file system, so when reusing these stored snapshots we should make sure to filter them according to whatever is requested. This was not done in one of several branches. The result was that in some highly concurrent builds we'd return the unfiltered snapshot.

I made the code somewhat simpler, this way eliminating some of the branches, and also removed the opportunity for this bug to manifest.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
