### PR TITLE
Handle race condition when storing snapshots in the VFS better

### DIFF
--- a/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultFileSystemAccess.java
+++ b/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultFileSystemAccess.java
@@ -107,7 +107,7 @@ public class DefaultFileSystemAccess implements FileSystemAccess, FileSystemDefa
                         return Optional.empty();
                     case RegularFile:
                         // Avoid snapshotting the same location concurrently
-                        // This is only a performance optimization for a common scenario; the VFS handles its on concurrency
+                        // This is only a performance optimization for a common scenario; the VFS handles its own concurrency
                         return Optional.of(producingSnapshots.guardByKey(location,
                             () -> virtualFileSystem.findSnapshot(location)
                                 .orElseGet(() -> {

--- a/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultFileSystemAccess.java
+++ b/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultFileSystemAccess.java
@@ -148,7 +148,7 @@ public class DefaultFileSystemAccess implements FileSystemAccess, FileSystemDefa
         return virtualFileSystem.findSnapshot(location)
             .map(snapshotProcessor)
             // Avoid snapshotting the same location concurrently
-            // This is only a performance optimization for a common scenario; the VFS handles its on concurrency
+            // This is only a performance optimization for a common scenario; the VFS handles its own concurrency
             .orElseGet(() -> producingSnapshots.guardByKey(location,
                 () -> virtualFileSystem.findSnapshot(location)
                     .map(snapshotProcessor)

--- a/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultFileSystemAccess.java
+++ b/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultFileSystemAccess.java
@@ -106,6 +106,8 @@ public class DefaultFileSystemAccess implements FileSystemAccess, FileSystemDefa
                     case Directory:
                         return Optional.empty();
                     case RegularFile:
+                        // Avoid snapshotting the same location concurrently
+                        // This is only a performance optimization for a common scenario; the VFS handles its on concurrency
                         return Optional.of(producingSnapshots.guardByKey(location,
                             () -> virtualFileSystem.findSnapshot(location)
                                 .orElseGet(() -> {
@@ -145,7 +147,8 @@ public class DefaultFileSystemAccess implements FileSystemAccess, FileSystemDefa
     ) {
         return virtualFileSystem.findSnapshot(location)
             .map(snapshotProcessor)
-            // Avoid snapshotting the same location at the same time
+            // Avoid snapshotting the same location concurrently
+            // This is only a performance optimization for a common scenario; the VFS handles its on concurrency
             .orElseGet(() -> producingSnapshots.guardByKey(location,
                 () -> virtualFileSystem.findSnapshot(location)
                     .map(snapshotProcessor)


### PR DESCRIPTION
This makes it more clear how the VFS is protected against concurrent updates messing up its internal state. The additional locking should not have much practical effect as we should always invalidate things before creating new content. However, for completeness' sake and to make it easier to reason about the code, it's better to fix this.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
