### PR TITLE
Use service registry builder for native services

### DIFF
--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
@@ -29,7 +29,6 @@ import net.rubygrapefruit.platform.file.PosixFiles;
 import net.rubygrapefruit.platform.internal.DefaultProcessLauncher;
 import net.rubygrapefruit.platform.memory.Memory;
 import net.rubygrapefruit.platform.terminal.Terminals;
-import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.file.temp.GradleUserHomeTemporaryFileProvider;
 import org.gradle.initialization.GradleUserHomeDirProvider;
@@ -53,11 +52,12 @@ import org.gradle.internal.nativeintegration.jna.UnsupportedEnvironment;
 import org.gradle.internal.nativeintegration.network.HostnameLookup;
 import org.gradle.internal.nativeintegration.processenvironment.NativePlatformBackedProcessEnvironment;
 import org.gradle.internal.os.OperatingSystem;
-import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.Provides;
 import org.gradle.internal.service.ServiceCreationException;
 import org.gradle.internal.service.ServiceRegistration;
+import org.gradle.internal.service.ServiceRegistrationProvider;
 import org.gradle.internal.service.ServiceRegistry;
+import org.gradle.internal.service.ServiceRegistryBuilder;
 import org.gradle.util.internal.VersionNumber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,7 +78,7 @@ import static org.gradle.internal.nativeintegration.filesystem.services.JdkFallb
 /**
  * Provides various native platform integration services.
  */
-public class NativeServices extends DefaultServiceRegistry implements ServiceRegistry {
+public class NativeServices implements ServiceRegistrationProvider {
     private static final Logger LOGGER = LoggerFactory.getLogger(NativeServices.class);
     private static final NativeServices INSTANCE = new NativeServices();
 
@@ -91,6 +91,8 @@ public class NativeServices extends DefaultServiceRegistry implements ServiceReg
     private File nativeBaseDir;
     private final EnumSet<NativeFeatures> initializedFeatures = EnumSet.noneOf(NativeFeatures.class);
     private final EnumSet<NativeFeatures> enabledFeatures = EnumSet.noneOf(NativeFeatures.class);
+
+    private final ServiceRegistry services;
 
     public enum NativeFeatures {
         FILE_SYSTEM_WATCHING {
@@ -322,28 +324,27 @@ public class NativeServices extends DefaultServiceRegistry implements ServiceReg
         return System.getProperty(NATIVE_DIR_OVERRIDE, System.getenv(NATIVE_DIR_OVERRIDE));
     }
 
-    public static synchronized NativeServices getInstance() {
+    public static synchronized ServiceRegistry getInstance() {
         if (!INSTANCE.initialized) {
             // If this occurs while running gradle or running integration tests, it is indicative of a problem.
             // If this occurs while running unit tests, then either use the NativeServicesTestFixture or the '@UsesNativeServices' annotation.
             throw new IllegalStateException("Cannot get an instance of NativeServices without first calling initialize().");
         }
-        return INSTANCE;
+        return INSTANCE.services;
     }
 
     private NativeServices() {
-        addProvider(new FileSystemServices());
-        register(new Action<ServiceRegistration>() {
-            @Override
-            public void execute(ServiceRegistration registration) {
-                registration.add(GradleUserHomeTemporaryFileProvider.class);
-            }
-        });
-    }
-
-    @Override
-    public void close() {
-        // Don't close
+        services = ServiceRegistryBuilder.builder()
+            .displayName("native services")
+            .provider(new FileSystemServices())
+            .provider(this)
+            .provider(new ServiceRegistrationProvider() {
+                @SuppressWarnings("unused")
+                public void configure(ServiceRegistration registration) {
+                    registration.add(GradleUserHomeTemporaryFileProvider.class);
+                }
+            })
+            .build();
     }
 
     @Provides

--- a/platforms/core-runtime/native/src/test/groovy/org/gradle/internal/nativeintegration/services/NativeServicesTest.groovy
+++ b/platforms/core-runtime/native/src/test/groovy/org/gradle/internal/nativeintegration/services/NativeServicesTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.internal.nativeintegration.ProcessEnvironment
 import org.gradle.internal.nativeintegration.console.ConsoleDetector
 import org.gradle.internal.nativeintegration.filesystem.FileSystem
 import org.gradle.internal.os.OperatingSystem
+import org.gradle.internal.service.ServiceRegistry
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 import org.gradle.util.UsesNativeServices
@@ -34,7 +35,7 @@ import spock.lang.Specification
 
 @UsesNativeServices
 class NativeServicesTest extends Specification {
-    NativeServices services
+    ServiceRegistry services
 
     def setup() {
         services = NativeServices.getInstance()

--- a/subprojects/core/src/integTest/groovy/org/gradle/NativeServicesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/NativeServicesIntegrationTest.groovy
@@ -109,7 +109,7 @@ class NativeServicesIntegrationTest extends AbstractIntegrationSpec {
             import org.gradle.internal.nativeintegration.NativeCapabilities
 
             tasks.register("doWork", WorkerTask)
-            println("Uses native integration in daemon: " + NativeServices.instance.createNativeCapabilities().useNativeIntegrations())
+            println("Uses native integration in daemon: " + NativeServices.INSTANCE.createNativeCapabilities().useNativeIntegrations())
 
             abstract class WorkerTask extends DefaultTask {
                 @Inject
@@ -123,7 +123,7 @@ class NativeServicesIntegrationTest extends AbstractIntegrationSpec {
 
             abstract class NoOpWorkAction implements WorkAction<WorkParameters.None> {
                 void execute() {
-                    println("Uses native integration in worker: " + NativeServices.instance.createNativeCapabilities().useNativeIntegrations())
+                    println("Uses native integration in worker: " + NativeServices.INSTANCE.createNativeCapabilities().useNativeIntegrations())
                 }
             }
         """)
@@ -201,7 +201,7 @@ class NativeServicesIntegrationTest extends AbstractIntegrationSpec {
                     buildFile << \"""
                         println("Build inside a test executor initialized Native services: " + new File("${nativeDirOverride}").exists())
                         println("Build inside a test executor uses Native services: " +
-                            org.gradle.internal.nativeintegration.services.NativeServices.instance.createNativeCapabilities().useNativeIntegrations())
+                            org.gradle.internal.nativeintegration.services.NativeServices.INSTANCE.createNativeCapabilities().useNativeIntegrations())
                     \"""
 
                     when:

--- a/testing/internal-testing/build.gradle.kts
+++ b/testing/internal-testing/build.gradle.kts
@@ -16,7 +16,6 @@ dependencies {
     api(project(":concurrent"))
     api(project(":hashing"))
     api(project(":stdlib-java-extensions"))
-    api(project(":native"))
 
     api(libs.groovy)
     api(libs.groovyXml)
@@ -29,6 +28,7 @@ dependencies {
 
     implementation(project(":build-operations"))
     implementation(project(":functional"))
+    implementation(project(":native"))
     implementation(project(":serialization"))
 
     implementation(libs.ant)

--- a/testing/internal-testing/src/main/groovy/org/gradle/testfixtures/internal/NativeServicesTestFixture.java
+++ b/testing/internal-testing/src/main/groovy/org/gradle/testfixtures/internal/NativeServicesTestFixture.java
@@ -18,6 +18,7 @@ package org.gradle.testfixtures.internal;
 
 import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.internal.nativeintegration.services.NativeServices.NativeServicesMode;
+import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.test.fixtures.file.TestFile;
 
 import java.io.File;
@@ -25,7 +26,7 @@ import java.io.File;
 public class NativeServicesTestFixture {
     // Collect this early, as the process' current directory can change during embedded test execution
     private static final TestFile TEST_DIR = new TestFile(new File(".").toURI());
-    static NativeServices nativeServices;
+    static ServiceRegistry nativeServices;
     static boolean initialized;
 
     public static synchronized void initialize() {
@@ -37,7 +38,7 @@ public class NativeServicesTestFixture {
         }
     }
 
-    public static synchronized NativeServices getInstance() {
+    public static synchronized ServiceRegistry getInstance() {
         if (nativeServices == null) {
             initialize();
             nativeServices = NativeServices.getInstance();


### PR DESCRIPTION
Follow-up for
- https://github.com/gradle/gradle/pull/29566

Migrates the `NativeServices` to not extend a `DefaultServiceRegistry` and use the registry builder instead