### PR TITLE
Improve presentation of task traces for incompatible tasks

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -327,7 +327,7 @@ class DefaultConfigurationCache internal constructor(
                     val description = formatBootstrapSummary(
                         "%s as configuration cache cannot be reused because %s.",
                         buildActionModelRequirements.actionDisplayName.capitalizedDisplayName,
-                        checkedFingerprint.reason.asString()
+                        checkedFingerprint.reason.render()
                     )
                     logBootstrapSummary(description)
                     ConfigurationCacheAction.STORE to description
@@ -337,7 +337,7 @@ class DefaultConfigurationCache internal constructor(
                     val description = formatBootstrapSummary(
                         "%s as configuration cache cannot be reused because %s.",
                         buildActionModelRequirements.actionDisplayName.capitalizedDisplayName,
-                        checkedFingerprint.reason.asString()
+                        checkedFingerprint.reason.render()
                     )
                     logBootstrapSummary(description)
                     ConfigurationCacheAction.UPDATE to description
@@ -634,7 +634,7 @@ class DefaultConfigurationCache internal constructor(
 
     private
     fun logBootstrapSummary(message: StructuredMessage) {
-        logger.log(configurationCacheLogLevel, message.asString())
+        logger.log(configurationCacheLogLevel, message.render())
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -327,7 +327,7 @@ class DefaultConfigurationCache internal constructor(
                     val description = formatBootstrapSummary(
                         "%s as configuration cache cannot be reused because %s.",
                         buildActionModelRequirements.actionDisplayName.capitalizedDisplayName,
-                        checkedFingerprint.reason
+                        checkedFingerprint.reason.asString()
                     )
                     logBootstrapSummary(description)
                     ConfigurationCacheAction.STORE to description
@@ -337,7 +337,7 @@ class DefaultConfigurationCache internal constructor(
                     val description = formatBootstrapSummary(
                         "%s as configuration cache cannot be reused because %s.",
                         buildActionModelRequirements.actionDisplayName.capitalizedDisplayName,
-                        checkedFingerprint.reason
+                        checkedFingerprint.reason.asString()
                     )
                     logBootstrapSummary(description)
                     ConfigurationCacheAction.UPDATE to description
@@ -634,7 +634,7 @@ class DefaultConfigurationCache internal constructor(
 
     private
     fun logBootstrapSummary(message: StructuredMessage) {
-        logger.log(configurationCacheLogLevel, message.toString())
+        logger.log(configurationCacheLogLevel, message.asString())
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/AbstractProblemsListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/AbstractProblemsListener.kt
@@ -34,7 +34,7 @@ abstract class AbstractProblemsListener : ProblemsListener {
             throw error
         }
         throw ConfigurationCacheError(
-            "Configuration cache state could not be cached: $trace: ${StructuredMessage.build(message)}",
+            "Configuration cache state could not be cached: $trace: ${StructuredMessage.build(message).asString()}",
             error.maybeUnwrapInvocationTargetException()
         )
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/AbstractProblemsListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/AbstractProblemsListener.kt
@@ -34,7 +34,7 @@ abstract class AbstractProblemsListener : ProblemsListener {
             throw error
         }
         throw ConfigurationCacheError(
-            "Configuration cache state could not be cached: $trace: ${StructuredMessage.build(message).asString()}",
+            "Configuration cache state could not be cached: $trace: ${StructuredMessage.build(message).render()}",
             error.maybeUnwrapInvocationTargetException()
         )
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -202,7 +202,7 @@ class ConfigurationCacheProblems(
 
     private
     fun InternalProblems.onProblem(problem: PropertyProblem, severity: ProblemSeverity) {
-        val message = problem.message.toString()
+        val message = problem.message.asString()
         internalReporter.create {
             id(
                 DeprecationMessageBuilder.createDefaultDeprecationId(message),

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -175,14 +175,7 @@ class ConfigurationCacheProblems(
 
         val problem = problemFactory
             .problem {
-                if (trace is PropertyTrace.Task) {
-                    text("task ")
-                    reference(trace.path)
-                    text(" of type ")
-                    reference(trace.type)
-                } else {
-                    text(trace.containingUserCode)
-                }
+                message(trace.containingUserCodeMessage)
                 text(" is incompatible with the configuration cache. Reason: $reason.")
             }
             .mapLocation {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -172,9 +172,17 @@ class ConfigurationCacheProblems(
 
     private
     fun reportIncompatibleTask(trace: PropertyTrace, reason: String) {
+
         val problem = problemFactory
             .problem {
-                text(trace.containingUserCode)
+                if (trace is PropertyTrace.Task) {
+                    text("task ")
+                    reference(trace.path)
+                    text(" of type ")
+                    reference(trace.type)
+                } else {
+                    text(trace.containingUserCode)
+                }
                 text(" is incompatible with the configuration cache. Reason: $reason.")
             }
             .mapLocation {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -365,7 +365,7 @@ class ConfigurationCacheProblems(
 
     private
     fun incompatibleTasksSummary() = when {
-        incompatibleTasks.isNotEmpty() -> " because incompatible ${if (incompatibleTasks.size > 1) "tasks were" else "task was"} found: ${incompatibleTasks.joinToString(", ") { "'$it'" }}."
+        incompatibleTasks.isNotEmpty() -> " because incompatible ${if (incompatibleTasks.size > 1) "tasks were" else "task was"} found: ${incompatibleTasks.joinToString(", ") { "'${it.render()}'" }}."
         else -> "."
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -202,7 +202,7 @@ class ConfigurationCacheProblems(
 
     private
     fun InternalProblems.onProblem(problem: PropertyProblem, severity: ProblemSeverity) {
-        val message = problem.message.asString()
+        val message = problem.message.render()
         internalReporter.create {
             id(
                 DeprecationMessageBuilder.createDefaultDeprecationId(message),

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
@@ -237,7 +237,7 @@ data class UniquePropertyProblem(
         fun of(problem: PropertyProblem) = problem.run {
             UniquePropertyProblem(
                 trace.containingUserCode,
-                message.asString(),
+                message.render(),
                 documentationSection?.anchor
             )
         }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
@@ -237,7 +237,7 @@ data class UniquePropertyProblem(
         fun of(problem: PropertyProblem) = problem.run {
             UniquePropertyProblem(
                 trace.containingUserCode,
-                message.toString(),
+                message.asString(),
                 documentationSection?.anchor
             )
         }

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/PropertyProblem.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/PropertyProblem.kt
@@ -61,14 +61,14 @@ typealias StructuredMessageBuilder = StructuredMessage.Builder.() -> Unit
 
 data class StructuredMessage(val fragments: List<Fragment>) {
 
-    fun asString(quote: Char) = fragments.joinToString(separator = "") { fragment ->
+    fun asString(quote: Char = '\'') = fragments.joinToString(separator = "") { fragment ->
         when (fragment) {
             is Fragment.Text -> fragment.text
             is Fragment.Reference -> "$quote${fragment.name}$quote"
         }
     }
 
-    override fun toString(): String = asString('\'')
+    override fun toString(): String = asString()
 
     sealed class Fragment {
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsFixture.groovy
@@ -695,7 +695,7 @@ class HasConfigurationCacheProblemsSpec {
     }
 
     HasConfigurationCacheProblemsSpec withIncompatibleTask(String task, String reason) {
-        incompatibleTasks = incompatibleTasks.expect(allOf(startsWith("${task}: task `${task}` of type "), endsWith(reason)))
+        incompatibleTasks = incompatibleTasks.expect(allOf(startsWith("${task}: task '${task}' of type "), endsWith(reason)))
         return this
     }
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsFixture.groovy
@@ -176,7 +176,7 @@ final class ConfigurationCacheProblemsFixture {
         } else {
             assertNoProblemsSummary(result.output)
         }
-        // TODO:bamboo avoid reading jsModel more than once when asserting on problems AND inputs AND incompatible tasks        assertInputs(result.output, rootDir, spec)
+        // TODO:bamboo avoid reading jsModel more than once when asserting on problems AND inputs AND incompatible tasks
         assertInputs(result.output, rootDir, spec)
         assertIncompatibleTasks(result.output, rootDir, spec)
     }


### PR DESCRIPTION
Related: #21290

> I noticed that the Incompatible tasks tab shows some items in the backticks, possibly not using a StructuredMessage on the gradle/gradle side. Because of this they are not rendered with mono font.  (via @alllex )

![image](https://github.com/gradle/gradle/assets/2187522/c11e78a6-8e70-44e1-9dfe-7932c2672f05)

With these changes:

<img width="1187" alt="Screenshot 2024-06-18 at 13 43 06" src="https://github.com/gradle/gradle/assets/2187522/c56d80d7-2841-4fa4-947a-7b54e5ccdc0f">

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
