### PR TITLE
Avoid failure with IP when phased action involves local dependency resolution

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.cc.impl.fingerprint
 
+import org.gradle.api.internal.artifacts.configurations.ProjectComponentObservationListener
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
@@ -141,6 +142,9 @@ class ConfigurationCacheFingerprintController internal constructor(
         open fun <T> runCollectingFingerprintForProject(project: ProjectIdentityPath, action: () -> T): T =
             illegalStateFor("collectFingerprintForProject")
 
+        open fun projectObserved(consumingProjectPath: Path?, targetProjectPath: Path): Unit =
+            illegalStateFor("projectObserved")
+
         abstract fun dispose(): WritingState
 
         private
@@ -207,6 +211,10 @@ class ConfigurationCacheFingerprintController internal constructor(
             return Paused(fingerprintWriter, buildScopedSpoolFile, projectScopedSpoolFile)
         }
 
+        override fun projectObserved(consumingProjectPath: Path?, targetProjectPath: Path) {
+            fingerprintWriter.projectObserved(consumingProjectPath, targetProjectPath)
+        }
+
         override fun dispose() =
             pause().dispose()
     }
@@ -256,6 +264,10 @@ class ConfigurationCacheFingerprintController internal constructor(
             return Idle()
         }
 
+        override fun projectObserved(consumingProjectPath: Path?, targetProjectPath: Path) {
+            // ignore project dependencies observed outside of fingerprinting
+        }
+
         private
         fun closeStreams() {
             fingerprintWriter.close()
@@ -276,6 +288,13 @@ class ConfigurationCacheFingerprintController internal constructor(
 
     private
     var writingState: WritingState = Idle()
+
+    private
+    val lazyProjectComponentObservationListener = lazy {
+        ProjectComponentObservationListener { consumingProjectPath, targetProjectPath ->
+            this@ConfigurationCacheFingerprintController.writingState.projectObserved(consumingProjectPath, targetProjectPath)
+        }
+    }
 
     // Start fingerprinting if not already started and not already committed
     // This should be strict but currently this method may be called multiple times when a
@@ -312,6 +331,10 @@ class ConfigurationCacheFingerprintController internal constructor(
     }
 
     override fun stop() {
+        if (lazyProjectComponentObservationListener.isInitialized()) {
+            listenerManager.removeListener(lazyProjectComponentObservationListener)
+        }
+
         writingState = writingState.dispose()
     }
 
@@ -334,6 +357,9 @@ class ConfigurationCacheFingerprintController internal constructor(
 
     private
     fun addListener(listener: ConfigurationCacheFingerprintWriter) {
+        // removed when the controller is stopped, because the listener is stateful and cannot be added a second time
+        listenerManager.addListener(lazyProjectComponentObservationListener.value)
+
         listenerManager.addListener(listener)
         workInputListeners.addListener(listener)
         scriptFileResolverListeners.addListener(listener)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -265,7 +265,7 @@ class ConfigurationCacheFingerprintController internal constructor(
         }
 
         override fun projectObserved(consumingProjectPath: Path?, targetProjectPath: Path) {
-            // ignore project dependencies observed outside of fingerprinting
+            error("Unexpected project dependency observed outside of fingerprinting: consumer=$consumingProjectPath, target=$targetProjectPath")
         }
 
         private
@@ -292,7 +292,7 @@ class ConfigurationCacheFingerprintController internal constructor(
     private
     val lazyProjectComponentObservationListener = lazy {
         ProjectComponentObservationListener { consumingProjectPath, targetProjectPath ->
-            this@ConfigurationCacheFingerprintController.writingState.projectObserved(consumingProjectPath, targetProjectPath)
+            writingState.projectObserved(consumingProjectPath, targetProjectPath)
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -21,7 +21,6 @@ import org.gradle.api.Describable
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentSelector
-import org.gradle.api.internal.artifacts.configurations.ProjectComponentObservationListener
 import org.gradle.api.internal.artifacts.configurations.dynamicversion.Expiry
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ChangingValueDependencyResolutionListener
 import org.gradle.api.internal.file.FileCollectionFactory
@@ -100,7 +99,6 @@ class ConfigurationCacheFingerprintWriter(
     ScriptExecutionListener,
     UndeclaredBuildInputListener,
     ChangingValueDependencyResolutionListener,
-    ProjectComponentObservationListener,
     CoupledProjectsListener,
     ToolingModelProjectDependencyListener,
     FileResourceListener,
@@ -538,7 +536,7 @@ class ConfigurationCacheFingerprintWriter(
         }
     }
 
-    override fun projectObserved(consumingProjectPath: Path?, targetProjectPath: Path) {
+    fun projectObserved(consumingProjectPath: Path?, targetProjectPath: Path) {
         if (consumingProjectPath != null) {
             onProjectDependency(consumingProjectPath, targetProjectPath)
         }


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/29540

Adds a workaround for listening for dependencies between projects in the build by not removing the stateful listener, in case fingerprinting is restarted again.

The fingerprinting can be restarted with a phased build action.

