### PR TITLE
Avoid Java 8 in `CollectionUtils`

### DIFF
--- a/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/util/internal/CollectionUtils.java
+++ b/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/util/internal/CollectionUtils.java
@@ -39,7 +39,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 import java.util.Set;
 
 import static org.gradle.internal.Cast.cast;
@@ -95,10 +94,6 @@ public abstract class CollectionUtils {
 
     public static <T> T first(Iterable<? extends T> source) {
         return source.iterator().next();
-    }
-
-    public static <T> Optional<T> firstOrEmpty(Iterable<? extends T> source) {
-        return source == null || !source.iterator().hasNext() ? Optional.<T>empty() : Optional.of(first(source));
     }
 
     public static <T> boolean any(Iterable<? extends T> source, Predicate<? super T> filter) {

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/TestPageGenerator.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/TestPageGenerator.java
@@ -287,8 +287,8 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
     private String getReproductionInstructions(PerformanceTestHistory history) {
         String baseline = "";
         if (history instanceof CrossVersionPerformanceTestHistory) {
-            baseline = ((CrossVersionPerformanceTestHistory) history).getResults().stream().findAny()
-                .flatMap(result -> result.getBaselineVersions().stream().findAny())
+            baseline = ((CrossVersionPerformanceTestHistory) history).getResults().stream().findFirst()
+                .flatMap(result -> result.getBaselineVersions().stream().findFirst())
                 .map(baselineVersion -> "-PperformanceBaselines='" + baselineVersion.getVersion() + "'")
                 .orElse("");
         }

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/TestPageGenerator.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/TestPageGenerator.java
@@ -37,7 +37,6 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.gradle.performance.results.report.AbstractTablePageGenerator.getTeamCityWebUrlFromBuildId;
-import static org.gradle.util.internal.CollectionUtils.firstOrEmpty;
 
 public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory> implements PerformanceExecutionGraphRenderer {
     private final String projectName;
@@ -288,8 +287,8 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
     private String getReproductionInstructions(PerformanceTestHistory history) {
         String baseline = "";
         if (history instanceof CrossVersionPerformanceTestHistory) {
-            baseline = firstOrEmpty(((CrossVersionPerformanceTestHistory) history).getResults())
-                .flatMap(result -> firstOrEmpty(result.getBaselineVersions()))
+            baseline = ((CrossVersionPerformanceTestHistory) history).getResults().stream().findAny()
+                .flatMap(result -> result.getBaselineVersions().stream().findAny())
                 .map(baselineVersion -> "-PperformanceBaselines='" + baselineVersion.getVersion() + "'")
                 .orElse("");
         }


### PR DESCRIPTION
The `CollectionUtils` class is about to be moved to much smaller project that supports Java 6 only.

Given that the only usage of `CollectionUtils.firstOrEmpty()` was in a Java 8-capable subproject, and that it's signature creates an error in the IDE for Java 6-language level, I replaced the usage with functions available in the Java 8.