### PR TITLE
Fix active group rendering in ConfigurationCacheReportIntegrationTest

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheReportIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheReportIntegrationTest.groovy
@@ -59,7 +59,7 @@ class ConfigurationCacheReportIntegrationTest extends AbstractConfigurationCache
             { pageErrors.add(it) }
         )
         pageErrors == []
-        activeGroup == "Problems grouped by message1"
+        activeGroup == "Problems grouped by message (1)"
     }
 
     private String selectInnerTextOf(File configurationCacheReport, String selector, Consumer<String> onPageError) {


### PR DESCRIPTION
Was probably not caught by the original PR checks, because the test is marked as Flaky and runs only on windows.