### PR TITLE
Allow integ tests to specify java home with Jvm

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslJvmTargetIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslJvmTargetIntegrationTest.kt
@@ -111,7 +111,7 @@ class KotlinDslJvmTargetIntegrationTest : AbstractKotlinIntegrationTest() {
         val newerJvm = AvailableJavaHomes.getDifferentVersion { it.languageVersion > currentJvm.javaVersion }
         assumeNotNull(newerJvm)
 
-        val installationPaths = listOf(currentJvm!!, newerJvm!!)
+        val installationPaths = listOf(currentJvm, newerJvm!!)
             .joinToString(",") { it.javaHome.absolutePath }
 
         val utils = withClassJar("utils.jar", JavaClassUtil::class.java)
@@ -148,7 +148,6 @@ class KotlinDslJvmTargetIntegrationTest : AbstractKotlinIntegrationTest() {
         withFile("plugin/src/main/kotlin/some.gradle.kts", printScriptJavaClassFileMajorVersion)
 
         gradleExecuterFor(arrayOf("check", "publish"), rootDir = file("plugin"))
-            .withJavaHome(currentJvm.javaHome)
             .withArgument("-Porg.gradle.java.installations.paths=$installationPaths")
             .run()
 
@@ -169,7 +168,7 @@ class KotlinDslJvmTargetIntegrationTest : AbstractKotlinIntegrationTest() {
         withBuildScriptIn("consumer", """plugins { id("some") }""")
 
         val helpResult = gradleExecuterFor(arrayOf("help"), rootDir = file("consumer"))
-            .withJavaHome(newerJvm.javaHome)
+            .withJvm(newerJvm)
             .run()
 
         assertThat(helpResult.output, containsString(outputFor(supportedKotlinJavaVersion(newerJvm.javaVersion!!))))
@@ -185,7 +184,7 @@ class KotlinDslJvmTargetIntegrationTest : AbstractKotlinIntegrationTest() {
         val newerJvm = AvailableJavaHomes.getJdk22()
         assumeNotNull(newerJvm)
 
-        val installationPaths = listOf(currentJvm!!, newerJvm!!)
+        val installationPaths = listOf(currentJvm, newerJvm!!)
             .joinToString(",") { it.javaHome.absolutePath }
 
         val utils = withClassJar("utils.jar", JavaClassUtil::class.java)
@@ -222,7 +221,6 @@ class KotlinDslJvmTargetIntegrationTest : AbstractKotlinIntegrationTest() {
         withFile("plugin/src/main/kotlin/some.gradle.kts", printScriptJavaClassFileMajorVersion)
 
         val pluginCompile = gradleExecuterFor(arrayOf("check", "publish"), rootDir = file("plugin"))
-            .withJavaHome(currentJvm.javaHome)
             .withArgument("-Porg.gradle.java.installations.paths=$installationPaths")
             .run()
         assertThat(pluginCompile.output, containsString("w: Inconsistent JVM-target compatibility detected for tasks 'compileJava' (22) and 'compileKotlin' (21)."))
@@ -244,7 +242,7 @@ class KotlinDslJvmTargetIntegrationTest : AbstractKotlinIntegrationTest() {
         withBuildScriptIn("consumer", """plugins { id("some") }""")
 
         val helpResult = gradleExecuterFor(arrayOf("help"), rootDir = file("consumer"))
-            .withJavaHome(newerJvm.javaHome)
+            .withJvm(newerJvm)
             .run()
 
         assertThat(helpResult.output, containsString(outputFor(supportedKotlinJavaVersion(newerJvm.javaVersion!!))))

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslJvmTargetIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslJvmTargetIntegrationTest.kt
@@ -148,6 +148,7 @@ class KotlinDslJvmTargetIntegrationTest : AbstractKotlinIntegrationTest() {
         withFile("plugin/src/main/kotlin/some.gradle.kts", printScriptJavaClassFileMajorVersion)
 
         gradleExecuterFor(arrayOf("check", "publish"), rootDir = file("plugin"))
+            .withJvm(currentJvm)
             .withArgument("-Porg.gradle.java.installations.paths=$installationPaths")
             .run()
 
@@ -221,6 +222,7 @@ class KotlinDslJvmTargetIntegrationTest : AbstractKotlinIntegrationTest() {
         withFile("plugin/src/main/kotlin/some.gradle.kts", printScriptJavaClassFileMajorVersion)
 
         val pluginCompile = gradleExecuterFor(arrayOf("check", "publish"), rootDir = file("plugin"))
+            .withJvm(currentJvm)
             .withArgument("-Porg.gradle.java.installations.paths=$installationPaths")
             .run()
         assertThat(pluginCompile.output, containsString("w: Inconsistent JVM-target compatibility detected for tasks 'compileJava' (22) and 'compileKotlin' (21)."))

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/jvm/Jvm.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/jvm/Jvm.java
@@ -19,6 +19,7 @@ package org.gradle.internal.jvm;
 import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
 import org.gradle.api.JavaVersion;
+import org.gradle.api.NonNullApi;
 import org.gradle.api.internal.jvm.JavaVersionParser;
 import org.gradle.internal.FileUtils;
 import org.gradle.internal.SystemProperties;
@@ -35,6 +36,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
+@NonNullApi
 public class Jvm implements JavaInfo {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Jvm.class);
@@ -84,11 +86,11 @@ public class Jvm implements JavaInfo {
     /**
      * Constructs JVM details from the given values
      */
-    Jvm(OperatingSystem os, File suppliedJavaBase, String implementationJavaVersion, Integer javaVersionMajor) {
+    Jvm(OperatingSystem os, File suppliedJavaBase, @Nullable String implementationJavaVersion, @Nullable Integer javaVersionMajor) {
         this(os, suppliedJavaBase, implementationJavaVersion, javaVersionMajor, true);
     }
 
-    private Jvm(OperatingSystem os, File suppliedJavaBase, String implementationJavaVersion, Integer javaVersionMajor, boolean userSupplied) {
+    private Jvm(OperatingSystem os, File suppliedJavaBase, @Nullable String implementationJavaVersion, @Nullable Integer javaVersionMajor, boolean userSupplied) {
         this.os = os;
         this.javaBase = suppliedJavaBase;
         this.implementationJavaVersion = implementationJavaVersion;
@@ -107,7 +109,7 @@ public class Jvm implements JavaInfo {
      * @throws IllegalArgumentException when supplied javaHome is not a valid folder
      */
     public static JavaInfo forHome(File javaHome) throws JavaHomeException, IllegalArgumentException {
-        if (javaHome == null || !javaHome.isDirectory()) {
+        if (!javaHome.isDirectory()) {
             throw new IllegalArgumentException("Supplied javaHome must be a valid directory. You supplied: " + javaHome);
         }
         Jvm jvm = create(javaHome, null, null);
@@ -258,6 +260,9 @@ public class Jvm implements JavaInfo {
      */
     @Nullable
     public JavaVersion getJavaVersion() {
+        if (javaVersionMajor == null) {
+            return null;
+        }
         return JavaVersion.toVersion(javaVersionMajor);
     }
 

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/GradleConfigurabilityIntegrationSpec.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/GradleConfigurabilityIntegrationSpec.groovy
@@ -18,7 +18,6 @@ package org.gradle.launcher
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
-import org.gradle.internal.jvm.JavaInfo
 import org.gradle.internal.jvm.Jvm
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
@@ -100,7 +99,7 @@ assert inputArgs.find { it.contains('-XX:HeapDumpPath=') }
 """
     }
 
-    def String useAlternativeJavaPath(JavaInfo jvm = AvailableJavaHomes.differentJdk) {
+    String useAlternativeJavaPath(Jvm jvm = AvailableJavaHomes.differentJdk) {
         File javaHome = jvm.javaHome
         file("gradle.properties").writeProperties("org.gradle.java.home": javaHome.canonicalPath)
         return javaHome.canonicalPath

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/SupportedBuildJvmIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/SupportedBuildJvmIntegrationTest.groovy
@@ -49,20 +49,20 @@ class SupportedBuildJvmIntegrationTest extends AbstractIntegrationSpec {
     @Requires(UnitTestPreconditions.NotWindows)
     @Issue("https://github.com/gradle/gradle/issues/16816")
     def "can successful start after a running daemon's JDK has been removed"() {
-        def installedJdk = Jvm.current().javaHome
+        def installedJdk = Jvm.current()
         def jdkToRemove = file("removed-jdk")
         jdkToRemove.mkdir()
-        new TestFile(installedJdk).copyTo(jdkToRemove)
+        new TestFile(installedJdk.javaHome).copyTo(jdkToRemove)
 
         // start one JVM with jdk to remove
-        executer.withJavaHome(jdkToRemove)
+        executer.withJavaHome(jdkToRemove.absolutePath)
         succeeds("help")
 
         when:
         // remove the JDK
         jdkToRemove.deleteDir()
         // don't ask for the removed JDK now
-        executer.withJavaHome(installedJdk)
+        executer.withJvm(installedJdk)
         then:
         // try to start another build
         succeeds("help")
@@ -74,7 +74,7 @@ class SupportedBuildJvmIntegrationTest extends AbstractIntegrationSpec {
     )
     def "provides reasonable failure message when attempting to run under java #jdk.javaVersion"() {
         given:
-        executer.withJavaHome(jdk.javaHome)
+        executer.withJvm(jdk)
 
         expect:
         fails("help")

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonLifecycleEncodingSpec.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonLifecycleEncodingSpec.groovy
@@ -25,7 +25,7 @@ class DaemonLifecycleEncodingSpec extends AbstractDaemonLifecycleSpec {
 
     def "if a daemon exists but is using a file encoding, a new compatible daemon will be created and used"() {
         when:
-        startBuild(null, "US-ASCII")
+        startBuild("US-ASCII")
         waitForBuildToWait()
 
         then:
@@ -41,7 +41,7 @@ class DaemonLifecycleEncodingSpec extends AbstractDaemonLifecycleSpec {
         idle()
 
         when:
-        startBuild(null, "UTF-8")
+        startBuild("UTF-8")
         waitForLifecycleLogToContain(1, "1 incompatible")
         waitForBuildToWait()
 

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/SingleUseDaemonIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/SingleUseDaemonIntegrationTest.groovy
@@ -120,14 +120,13 @@ assert java.lang.management.ManagementFactory.runtimeMXBean.inputArguments.conta
 
     @Requires(IntegTestPreconditions.JavaHomeWithDifferentVersionAvailable)
     def "does not fork build when java home from gradle properties matches current process"() {
-        def javaHome = AvailableJavaHomes.differentJdk.javaHome
-
-        file('gradle.properties').writeProperties("org.gradle.java.home": javaHome.canonicalPath)
+        def differentJdk = AvailableJavaHomes.differentJdk
+        file('gradle.properties').writeProperties("org.gradle.java.home": differentJdk.javaHome.canonicalPath)
 
         file('build.gradle') << "println 'javaHome=' + org.gradle.internal.jvm.Jvm.current().javaHome.absolutePath"
 
         when:
-        executer.withJavaHome(javaHome)
+        executer.withJvm(differentJdk)
         succeeds()
 
         then:
@@ -142,7 +141,7 @@ assert java.lang.management.ManagementFactory.runtimeMXBean.inputArguments.conta
         captureJavaHome()
 
         when:
-        executer.withJavaHome(otherJdk.javaHome)
+        executer.withJvm(otherJdk)
         withInstallations(otherJdk).succeeds()
         assertDaemonUsedJvm(otherJdk)
 

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/StoppingDaemonIntegrationSpec.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/StoppingDaemonIntegrationSpec.groovy
@@ -94,7 +94,7 @@ task block {
         daemons.daemon.assertIdle()
 
         when:
-        executer.withJavaHome(AvailableJavaHomes.differentJdk.javaHome)
+        executer.withJvm(AvailableJavaHomes.differentJdk)
         executer.withArguments("--stop").run()
 
         then:

--- a/platforms/core-runtime/wrapper-main/src/crossVersionTest/groovy/org/gradle/integtests/wrapper/WrapperOldJavaCrossVersionIntegrationTest.groovy
+++ b/platforms/core-runtime/wrapper-main/src/crossVersionTest/groovy/org/gradle/integtests/wrapper/WrapperOldJavaCrossVersionIntegrationTest.groovy
@@ -28,7 +28,7 @@ class WrapperOldJavaCrossVersionIntegrationTest extends AbstractWrapperCrossVers
     @Requires(IntegTestPreconditions.UnsupportedJavaHomeAvailable)
     def 'provides reasonable failure message when attempting to run current Version with previous wrapper under java #jdk.javaVersion'() {
         when:
-        GradleExecuter executor = prepareWrapperExecuter(previous, current).withJavaHome(jdk.javaHome)
+        GradleExecuter executor = prepareWrapperExecuter(previous, current).withJvm(jdk)
 
         then:
         def result = executor.usingExecutable('gradlew').withArgument('help').runWithFailure()

--- a/platforms/core-runtime/wrapper-main/src/integTest/groovy/org/gradle/integtests/WrapperSupportedBuildJvmIntegrationTest.groovy
+++ b/platforms/core-runtime/wrapper-main/src/integTest/groovy/org/gradle/integtests/WrapperSupportedBuildJvmIntegrationTest.groovy
@@ -31,7 +31,7 @@ class WrapperSupportedBuildJvmIntegrationTest extends AbstractWrapperIntegration
     def "provides reasonable failure message when attempting to run under java #jdk.javaVersion"() {
         given:
         prepareWrapper()
-        wrapperExecuter.withJavaHome(jdk.javaHome)
+        wrapperExecuter.withJvm(jdk)
 
         expect:
         def failure = wrapperExecuter.withTasks("help").runWithFailure()

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -977,11 +977,11 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
     }
 
     // bootclasspath has been removed in Java 9+
-    @Requires(UnitTestPreconditions.Jdk8OrEarlier)
+    @Requires(IntegTestPreconditions.BestJreAvailable)
     @Issue("https://github.com/gradle/gradle/issues/19817")
     def "fails if bootclasspath is provided as a path instead of a single file"() {
-        def jre = AvailableJavaHomes.getBestJre()
-        def bootClasspath = TextUtil.escapeString(jre.absolutePath) + "/lib/rt.jar${File.pathSeparator}someotherpath"
+        def rtJar = new File(AvailableJavaHomes.bestJre, "lib/rt.jar")
+        def bootClasspath = TextUtil.escapeString(rtJar.absolutePath) + "${File.pathSeparator}someotherpath"
         buildFile << """
             plugins {
                 id 'java'

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileJavaVersionIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileJavaVersionIntegrationTest.groovy
@@ -55,19 +55,19 @@ class JavaCompileJavaVersionIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        executer.withJavaHome AvailableJavaHomes.getLowestSupportedLTS().javaHome
+        executer.withJvm(AvailableJavaHomes.getLowestSupportedLTS())
         succeeds "compileJava"
         then:
         executedAndNotSkipped ":compileJava"
 
         when:
-        executer.withJavaHome AvailableJavaHomes.getLowestSupportedLTS().javaHome
+        executer.withJvm(AvailableJavaHomes.getLowestSupportedLTS())
         succeeds "compileJava"
         then:
         skipped ":compileJava"
 
         when:
-        executer.withJavaHome AvailableJavaHomes.getHighestSupportedLTS().javaHome
+        executer.withJvm(AvailableJavaHomes.getHighestSupportedLTS())
         succeeds "compileJava", "--info"
         then:
         executedAndNotSkipped ":compileJava"
@@ -89,19 +89,19 @@ class JavaCompileJavaVersionIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        executer.withJavaHome highestLTS.javaHome
+        executer.withJvm(highestLTS)
         succeeds "compileJava"
         then:
         executedAndNotSkipped ":compileJava"
 
         when:
-        executer.withJavaHome lowestLTS.javaHome
+        executer.withJvm(lowestLTS)
         succeeds "compileJava"
         then:
         skipped ":compileJava"
 
         when:
-        executer.withJavaHome lowestLTS.javaHome
+        executer.withJvm(lowestLTS)
         buildFile.text = forkedJavaCompilation(highestLTS)
         succeeds "compileJava", "--info"
         then:

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocIntegrationTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.integtests.fixtures.TestResources
 import org.gradle.internal.jvm.Jvm
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.IntegTestPreconditions
 import org.gradle.test.preconditions.UnitTestPreconditions
 import org.gradle.util.internal.TextUtil
 import org.junit.Rule
@@ -510,11 +511,11 @@ Joe!""")
     }
 
     // bootclasspath has been removed in Java 9+
-    @Requires(UnitTestPreconditions.Jdk8OrEarlier)
+    @Requires(IntegTestPreconditions.BestJreAvailable)
     @Issue("https://github.com/gradle/gradle/issues/19817")
     def "shows deprecation if bootclasspath is provided as a path instead of a single file"() {
-        def jre = AvailableJavaHomes.getBestJre()
-        def bootClasspath = TextUtil.escapeString(jre.absolutePath) + "/lib/rt.jar${File.pathSeparator}someotherpath"
+        def rtJar = new File(AvailableJavaHomes.bestJre, "lib/rt.jar")
+        def bootClasspath = TextUtil.escapeString(rtJar.absolutePath) + "${File.pathSeparator}someotherpath"
         buildFile << """
             plugins {
                 id 'java'

--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/java/compile/AbstractJavaCompilerIntegrationSpec.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/java/compile/AbstractJavaCompilerIntegrationSpec.groovy
@@ -459,6 +459,7 @@ abstract class AbstractJavaCompilerIntegrationSpec extends AbstractIntegrationSp
         failure.assertHasErrorOutput("package ${gradleBaseServicesClass.package.name} does not exist")
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/29370")
     def "gradle classpath does not leak onto java compile classpath"() {
         given:
         file("src/main/java/Example.java") << """
@@ -792,7 +793,7 @@ abstract class AbstractJavaCompilerIntegrationSpec extends AbstractIntegrationSp
 
     def configureBoostrapClasspath(Jvm jvm) {
         if (Integer.parseInt(jvm.javaVersion.majorVersion) < 9) {
-            def rtJar = new File(jvm.javaHome, "jre/lib/rt.jar")
+            def rtJar = new File(jvm.jre, "lib/rt.jar")
             def rtJarPath = TextUtil.escapeString(rtJar.absolutePath)
             return """
                 options.bootstrapClasspath = files('${rtJarPath}')

--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/java/compile/daemon/DaemonJavaCompilerIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/java/compile/daemon/DaemonJavaCompilerIntegrationTest.groovy
@@ -16,11 +16,10 @@
 package org.gradle.java.compile.daemon
 
 import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.internal.jvm.Jvm
 import org.gradle.java.compile.AbstractJavaCompilerIntegrationSpec
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
-import org.gradle.test.preconditions.UnitTestPreconditions
-import org.gradle.util.internal.TextUtil
 import spock.lang.Issue
 
 class DaemonJavaCompilerIntegrationTest extends AbstractJavaCompilerIntegrationSpec {
@@ -82,17 +81,12 @@ class DaemonJavaCompilerIntegrationTest extends AbstractJavaCompilerIntegrationS
     }
 
     @Issue("https://github.com/gradle/gradle/issues/3098")
-    @Requires([
-        UnitTestPreconditions.Jdk8OrEarlier,
-        UnitTestPreconditions.JdkOracle
-    ])
+    @Requires(IntegTestPreconditions.BestJreAvailable)
     def "handles -bootclasspath being specified"() {
-        def jre = AvailableJavaHomes.getBestJre()
-        def bootClasspath = TextUtil.escapeString(jre.absolutePath) + "/lib/rt.jar"
         goodCode()
         buildFile << """
             tasks.withType(JavaCompile) {
-                options.bootstrapClasspath = project.layout.files("$bootClasspath")
+                ${configureBoostrapClasspath(Jvm.current())}
             }
         """
 

--- a/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/compile/UpToDateScalaCompileIntegrationTest.groovy
+++ b/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/compile/UpToDateScalaCompileIntegrationTest.groovy
@@ -75,20 +75,20 @@ class UpToDateScalaCompileIntegrationTest extends AbstractIntegrationSpec implem
 
         buildScript(scalaProjectBuildScript(ScalaBasePlugin.DEFAULT_ZINC_VERSION, '2.12.6'))
         when:
-        executer.withJavaHome(jdk8.javaHome)
+        executer.withJvm(jdk8)
         run 'compileScala'
 
         then:
         executedAndNotSkipped(':compileScala')
 
         when:
-        executer.withJavaHome(jdk8.javaHome)
+        executer.withJvm(jdk8)
         run 'compileScala'
         then:
         skipped ':compileScala'
 
         when:
-        executer.withJavaHome(jdk11.javaHome)
+        executer.withJvm(jdk11)
         run 'compileScala', '--info'
         then:
         executedAndNotSkipped(':compileScala')

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/plugin/devel/variants/TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/plugin/devel/variants/TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest.groovy
@@ -86,7 +86,7 @@ class TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest extends Abst
         when:
         projectDir(producer)
         withInstallations(currentJdk, otherJdk)
-        executer.withJavaHome(higherVersion.javaHome)
+        executer.withJvm(higherVersion)
         succeeds 'publish'
 
         then:
@@ -97,7 +97,7 @@ class TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest extends Abst
         when:
         projectDir(consumer)
         withInstallations(currentJdk, otherJdk)
-        executer.withJavaHome(lowerVersion.javaHome)
+        executer.withJvm(lowerVersion)
         fails 'greet', "--stacktrace"
 
         then:
@@ -252,7 +252,7 @@ class TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest extends Abst
         when:
         projectDir(consumer)
         withInstallations(currentJdk, otherJdk)
-        executer.withJavaHome(lowerVersion.javaHome)
+        executer.withJvm(lowerVersion)
         fails 'greet', "--stacktrace"
 
         then:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/JavaExecJavaVersionIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/JavaExecJavaVersionIntegrationSpec.groovy
@@ -37,13 +37,13 @@ class JavaExecJavaVersionIntegrationSpec extends AbstractIntegrationSpec {
         setupRunHelloWorldTask()
 
         when:
-        executer.withJavaHome AvailableJavaHomes.getLowestSupportedLTS().javaHome
+        executer.withJvm(AvailableJavaHomes.getLowestSupportedLTS())
         succeeds "runHelloWorld"
         then:
         executedAndNotSkipped ":runHelloWorld"
 
         when:
-        executer.withJavaHome AvailableJavaHomes.getLowestSupportedLTS().javaHome
+        executer.withJvm(AvailableJavaHomes.getLowestSupportedLTS())
         succeeds "runHelloWorld"
         then:
         skipped ":runHelloWorld"
@@ -56,13 +56,13 @@ class JavaExecJavaVersionIntegrationSpec extends AbstractIntegrationSpec {
         setupRunHelloWorldTask()
 
         when:
-        executer.withJavaHome AvailableJavaHomes.getLowestSupportedLTS().javaHome
+        executer.withJvm(AvailableJavaHomes.getLowestSupportedLTS())
         succeeds "runHelloWorld"
         then:
         executedAndNotSkipped ":runHelloWorld"
 
         when:
-        executer.withJavaHome AvailableJavaHomes.getHighestSupportedLTS().javaHome
+        executer.withJvm(AvailableJavaHomes.getHighestSupportedLTS())
         succeeds "runHelloWorld", "--info"
         then:
         executedAndNotSkipped ":runHelloWorld"
@@ -76,13 +76,13 @@ class JavaExecJavaVersionIntegrationSpec extends AbstractIntegrationSpec {
         setupRunHelloWorldTask()
 
         when:
-        executer.withJavaHome AvailableJavaHomes.getAvailableJdks(VERSION_1_8)[0].javaHome
+        executer.withJvm(AvailableJavaHomes.getAvailableJdks(VERSION_1_8)[0])
         succeeds "runHelloWorld"
         then:
         executedAndNotSkipped ":runHelloWorld"
 
         when:
-        executer.withJavaHome AvailableJavaHomes.getAvailableJdks(VERSION_1_8)[1].javaHome
+        executer.withJvm(AvailableJavaHomes.getAvailableJdks(VERSION_1_8)[1])
         succeeds "runHelloWorld"
         then:
         skipped ":runHelloWorld"

--- a/subprojects/core/src/integTest/groovy/org/gradle/execution/commandline/CommandLineIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/execution/commandline/CommandLineIntegrationTest.groovy
@@ -99,10 +99,9 @@ class CommandLineIntegrationTest extends AbstractIntegrationSpec {
         createProject()
 
         when:
-        String javaHome = Jvm.current().javaHome
-        String expectedJavaHome = "-PexpectedJavaHome=${javaHome}"
-
-        String path = String.format('%s%s%s', Jvm.current().javaExecutable.parentFile, File.pathSeparator, System.getenv('PATH'))
+        def jvm = Jvm.current()
+        String expectedJavaHome = "-PexpectedJavaHome=${(jvm.javaHome.canonicalPath)}"
+        String path = String.format('%s%s%s', jvm.javaExecutable.parentFile.canonicalPath, File.pathSeparator, System.getenv('PATH'))
 
         then:
         executer.withEnvironmentVars('PATH': path).withJavaHome('').withArguments(expectedJavaHome).withTasks('checkJavaHome').run()
@@ -111,7 +110,7 @@ class CommandLineIntegrationTest extends AbstractIntegrationSpec {
     @Requires(IntegTestPreconditions.NotEmbeddedExecutor)
     def "fails when java home does not point to a java installation"() {
         when:
-        def failure = executer.withJavaHome(testDirectory).withTasks('checkJavaHome').runWithFailure()
+        def failure = executer.withJavaHome(testDirectory.absolutePath).withTasks('checkJavaHome').runWithFailure()
 
         then:
         failure.error.contains('ERROR: JAVA_HOME is set to an invalid directory')

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathIntegrationSpec.groovy
@@ -387,18 +387,18 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implem
             }
         """)
 
-        def java8Home = AvailableJavaHomes.getJdk8().javaHome
-        def java11Home = AvailableJavaHomes.getJdk11().javaHome
+        def jdk8 = AvailableJavaHomes.getJdk8()
+        def jdk11 = AvailableJavaHomes.getJdk11()
 
         when:
-        executer.withJavaHome(java8Home).withArguments("-Porg.gradle.java.installations.paths=$java8Home,$java11Home")
+        executer.withJvm(jdk8).withArguments("-Porg.gradle.java.installations.paths=${jdk8.javaHome},${jdk11.javaHome}")
         succeeds("printFoo")
 
         then:
         outputContains("JAR = DEFAULT")
 
         when:
-        executer.withJavaHome(java11Home).withArguments("-Porg.gradle.java.installations.paths=$java8Home,$java11Home")
+        executer.withJvm(jdk11).withArguments("-Porg.gradle.java.installations.paths=${jdk8.javaHome},${jdk11.javaHome}")
         succeeds("printFoo")
 
         then:

--- a/subprojects/core/src/integTest/groovy/org/gradle/normalization/ConfigureRuntimeClasspathNormalizationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/normalization/ConfigureRuntimeClasspathNormalizationIntegrationTest.groovy
@@ -376,7 +376,7 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
 
         when:
         run "clean"
-        executer.withJavaHome(differentJdk.javaHome)
+        executer.withJvm(differentJdk)
         withBuildCache().succeeds project.customTask
         then:
         skipped(project.customTask)

--- a/testing/architecture-test/src/changes/archunit-store/internal-api-nullability.txt
+++ b/testing/architecture-test/src/changes/archunit-store/internal-api-nullability.txt
@@ -2039,7 +2039,6 @@ Class <org.gradle.internal.jvm.JavaHomeException> is not annotated (directly or 
 Class <org.gradle.internal.jvm.JavaInfo> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (JavaInfo.java:0)
 Class <org.gradle.internal.jvm.JavaModuleDetector$ModuleInfoLocator> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (JavaModuleDetector.java:0)
 Class <org.gradle.internal.jvm.JavaModuleDetector> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (JavaModuleDetector.java:0)
-Class <org.gradle.internal.jvm.Jvm> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (Jvm.java:0)
 Class <org.gradle.internal.jvm.UnsupportedJavaRuntimeException> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (UnsupportedJavaRuntimeException.java:0)
 Class <org.gradle.internal.jvm.inspection.CachingJvmMetadataDetector> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (CachingJvmMetadataDetector.java:0)
 Class <org.gradle.internal.jvm.inspection.ConditionalInvalidation> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (ConditionalInvalidation.java:0)

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/environment/BuildEnvironmentIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/environment/BuildEnvironmentIntegrationTest.groovy
@@ -157,7 +157,7 @@ assert classesDir.directory
 
     @Requires(IntegTestPreconditions.JavaHomeWithDifferentVersionAvailable)
     def "java home from environment should be used to run build"() {
-        def alternateJavaHome = AvailableJavaHomes.differentJdk.javaHome
+        def alternateJdk = AvailableJavaHomes.differentJdk
 
         buildFile << """
             task printJavaHome {
@@ -174,15 +174,16 @@ assert classesDir.directory
         out.contains("javaHome=" + Jvm.current().javaHome.canonicalPath)
 
         when:
-        out = executer.withJavaHome(alternateJavaHome).withTasks('printJavaHome').run().output
+        out = executer.withJvm(alternateJdk).withTasks('printJavaHome').run().output
 
         then:
-        out.contains("javaHome=" + alternateJavaHome.canonicalPath)
+        out.contains("javaHome=" + alternateJdk.javaHome.canonicalPath)
     }
 
     @Requires(IntegTestPreconditions.JavaHomeWithDifferentVersionAvailable)
     def "java home from gradle properties should be used to run build"() {
-        def alternateJavaHome = AvailableJavaHomes.differentJdk.javaHome
+        def jvm = AvailableJavaHomes.differentJdk
+        def alternateJavaHome = jvm.javaHome
 
         file('gradle.properties') << """
 org.gradle.java.home=${TextUtil.escapeString(alternateJavaHome.canonicalPath)}

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractProjectRelocationIntegrationTest.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractProjectRelocationIntegrationTest.groovy
@@ -24,13 +24,13 @@ abstract class AbstractProjectRelocationIntegrationTest extends AbstractIntegrat
 
     def "project is relocatable"() {
         def originalDir = file("original-dir")
-        def originalJavaHome = Jvm.current().javaHome
+        def originalJvm = Jvm.current()
         originalDir.file("settings.gradle") << localCacheConfiguration()
         setupProjectIn(originalDir)
 
         def relocatedDir = file("relocated-dir")
         def relocatedJavaHome = file("relocated-java-home")
-        relocatedJavaHome.copyFrom(originalJavaHome)
+        relocatedJavaHome.copyFrom(originalJvm.javaHome)
         relocatedDir.file("settings.gradle") << localCacheConfiguration()
         setupProjectIn(relocatedDir)
 
@@ -39,7 +39,7 @@ abstract class AbstractProjectRelocationIntegrationTest extends AbstractIntegrat
 
         when: "task is built in the original location"
         inDirectory(originalDir)
-        executer.withJavaHome(originalJavaHome)
+        executer.withJvm(originalJvm)
         withBuildCache().run taskName
         def originalResults = extractResultsFrom(originalDir)
         then: "it is executed and cached"
@@ -54,7 +54,7 @@ abstract class AbstractProjectRelocationIntegrationTest extends AbstractIntegrat
         when: "it is executed in the new location"
         prepareForRelocation(relocatedDir)
         inDirectory(relocatedDir)
-        executer.withJavaHome(relocatedJavaHome)
+        executer.withJavaHome(relocatedJavaHome.absolutePath)
         withBuildCache().run taskName
         then: "it is loaded from cache"
         result.assertTaskSkipped taskName

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AvailableJavaHomes.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AvailableJavaHomes.java
@@ -251,17 +251,8 @@ public abstract class AvailableJavaHomes {
      * @return The JRE home directory, or null if not found
      */
     public static File getBestJre() {
-        Jvm jvm = Jvm.current();
-        File jre = jvm.getStandaloneJre();
-        if (jre != null) {
-            return jre;
-        }
-        jre = jvm.getEmbeddedJre();
-        if (jre != null) {
-            return jre;
-        }
-        // Use the JDK instead
-        return jvm.getJavaHome();
+        // TODO: We should improve this to look for any JRE from any JVM installation
+        return Jvm.current().getJre();
     }
 
     public static JvmInstallationMetadata getJvmInstallationMetadata(Jvm jvm) {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -149,6 +149,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
     private TestFile gradleUserHomeDir;
     private File userHomeDir;
     private String javaHome;
+    private Jvm jvm;
     private File buildScript;
     private File projectDir;
     private File settingsFile;
@@ -242,6 +243,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
         dependencyList = false;
         executable = null;
         javaHome = null;
+        jvm = null;
         environmentVars.clear();
         stdinPipe = null;
         defaultCharacterEncoding = null;
@@ -333,6 +335,9 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
         }
         if (javaHome != null) {
             executer.withJavaHome(javaHome);
+        }
+        if (jvm != null) {
+            executer.withJvm(jvm);
         }
         for (File initScript : initScripts) {
             executer.usingInitScript(initScript);
@@ -627,7 +632,13 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
     }
 
     protected String getJavaHome() {
-        return javaHome == null ? Jvm.current().getJavaHome().getAbsolutePath() : javaHome;
+        if (javaHome != null) {
+            return javaHome;
+        }
+        if (jvm != null) {
+            return jvm.getJavaHome().getAbsolutePath();
+        }
+        return Jvm.current().getJavaHome().getAbsolutePath();
     }
 
     protected File getJavaHomeLocation() {
@@ -637,12 +648,22 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
     @Override
     public GradleExecuter withJavaHome(String javaHome) {
         this.javaHome = javaHome;
+        this.jvm = null;
         return this;
     }
 
     @Override
-    public GradleExecuter withJavaHome(File javaHome) {
-        this.javaHome = javaHome == null ? null : javaHome.getAbsolutePath();
+    public GradleExecuter withJvm(Jvm jvm) {
+        if (jvm.getJavaVersion() == null) {
+            throw new IllegalArgumentException(
+                "The provided JVM does not have a version and was likely created with Jvm.forHome(File). " +
+                    "This method should only be used with probed JVMs. " +
+                    "Use withJavaHome(String) instead."
+            );
+        }
+
+        this.jvm = jvm;
+        this.javaHome = null;
         return this;
     }
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -23,6 +23,7 @@ import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.api.logging.configuration.WarningMode;
 import org.gradle.integtests.fixtures.RichConsoleStyling;
 import org.gradle.internal.concurrent.Stoppable;
+import org.gradle.internal.jvm.Jvm;
 import org.gradle.test.fixtures.file.TestDirectoryProvider;
 import org.gradle.test.fixtures.file.TestFile;
 import org.gradle.util.GradleVersion;
@@ -124,14 +125,20 @@ public interface GradleExecuter extends Stoppable {
     GradleExecuter withGradleVersionOverride(GradleVersion gradleVersion);
 
     /**
-     * Sets the java home dir. Setting to null requests that the executer use the real default java home dir rather than the default used for testing.
+     * Sets the java home dir. Replaces any value set by {@link #withJvm(Jvm)}.
+     * <p>
+     * In general, prefer using {@link #withJvm(Jvm)} over this method. This method should be used
+     * when testing non-standard JVMs, like embedded JREs, or those not provided by
+     * {@link org.gradle.integtests.fixtures.AvailableJavaHomes}.
      */
     GradleExecuter withJavaHome(String userHomeDir);
 
     /**
-     * Sets the java home dir. Setting to null requests that the executer use the real default java home dir rather than the default used for testing.
+     * Sets the JVM to execute Gradle with. Replaces any value set by {@link #withJavaHome(String)}.
+     *
+     * @throws IllegalArgumentException If the given JVM is not probed, for example JVMs created by {@link Jvm#forHome(File)}
      */
-    GradleExecuter withJavaHome(File userHomeDir);
+    GradleExecuter withJvm(Jvm jvm);
 
     /**
      * Sets the executable to use. Set to null to use the real default executable (if any) rather than the default used for testing.


### PR DESCRIPTION
The Jvm type is a rich wrapper over an (often probed) JVM installation. It contains extra information about a given java home, including the JVM's version (if probed). This JVM version can prove useful when executing a Gradle build with that JVM. This commit does not _use_ the actual JVM version exposed by this change, but makes it available to future work which _does_ use the JVM version.

We introduce a withJvm(Jvm) to replace the existing withJavaHome(File) method. In most cases, we already had a Jvm object and called withJavaHome(jvm.javaHome). This is now replaced in most places to withJvm(jvm).

In some cases, we still want to to start the gradle build with a non-standard JVM that does not have a probed Jvm wrapper. For these cases, we continue to expose a withJavaHome(String) method.

Along the way, we improve the nullability annotations of the Jvm class, and also improve some tests that test against embedded JREs.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
