### PR TITLE
Strengthen root node selection deprecation

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -398,8 +398,8 @@ public class DependencyGraphBuilder {
                 attachMultipleForceOnPlatformFailureToEdges(module);
             }
         }
-        List<EdgeState> incomingRootEdges = resolveState.getRoot().getIncomingEdges();
-        if (!incomingRootEdges.isEmpty()) {
+
+        if (resolveState.getRoot().wasIncomingEdgeAdded()) {
             String rootNodeName = resolveState.getRoot().getMetadata().getName();
             DeprecationLogger.deprecate(
                     String.format(

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RootNode.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RootNode.java
@@ -30,6 +30,8 @@ class RootNode extends NodeState implements RootGraphNode {
     private final ResolveOptimizations resolveOptimizations;
     private final List<? extends DependencyMetadata> syntheticDependencies;
 
+    boolean incomingEdgeWasAdded = false;
+
     RootNode(long resultId, ComponentState moduleRevision, ResolveState resolveState, List<? extends DependencyMetadata> syntheticDependencies, VariantGraphResolveState root) {
         super(resultId, moduleRevision, resolveState, root, false);
         this.resolveOptimizations = resolveState.getResolveOptimizations();
@@ -44,6 +46,21 @@ class RootNode extends NodeState implements RootGraphNode {
     @Override
     public Set<? extends LocalFileDependencyMetadata> getOutgoingFileEdges() {
         return getMetadata().getFiles();
+    }
+
+    @Override
+    void addIncomingEdge(EdgeState dependencyEdge) {
+        super.addIncomingEdge(dependencyEdge);
+        incomingEdgeWasAdded = true;
+
+        // TODO: We read `incomingEdgeWasAdded` at the end of graph resolution.
+        // If this method is ever called, we trigger a deprecation warning.
+        // In Gradle 9.0, we should fail here immediately if someone tries to
+        // add an incoming edge to a root node.
+    }
+
+    public boolean wasIncomingEdgeAdded() {
+        return incomingEdgeWasAdded;
     }
 
     @Override


### PR DESCRIPTION
The original goal of this deprecation is to prevent the root node from being selected as a variant. This way, for a given resolution, a variant can either be intended for consumption as a variant, or act as a root node, but not both.

Previously, we detected this scenario by checking if there were any incoming edges to the root node by the time the graph was finished resolving.

We update this to trigger a deprecation if an incoming edge is _ever_ added to the root node in any circumstance.

This is stronger than the original deprecation, since this also handles cases where edges temporarilly target the root node but are then later retargeted to another node for some reason.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
