### PR TITLE
Apply snappy compression to Configuration Cache entries

### DIFF
--- a/platforms/core-configuration/configuration-cache/build.gradle.kts
+++ b/platforms/core-configuration/configuration-cache/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("gradlebuild.distribution.implementation-kotlin")
     id("gradlebuild.kotlin-dsl-sam-with-receiver")
     id("gradlebuild.kotlin-experimental-contracts")
+    id("gradlebuild.jmh")
 }
 
 description = "Configuration cache implementation"
@@ -102,6 +103,9 @@ dependencies {
     testImplementation(testFixtures(projects.core))
     testImplementation(libs.mockitoKotlin2)
     testImplementation(libs.kotlinCoroutinesDebug)
+
+    jmhImplementation(projects.beanSerializationServices)
+    jmhImplementation(libs.mockitoKotlin2)
 
     integTestImplementation(projects.jvmServices)
     integTestImplementation(projects.toolingApi)

--- a/platforms/core-configuration/configuration-cache/build.gradle.kts
+++ b/platforms/core-configuration/configuration-cache/build.gradle.kts
@@ -83,6 +83,7 @@ dependencies {
     implementation(projects.stdlibSerializationCodecs)
     implementation(projects.toolingApi)
 
+    implementation(libs.commonsCompress)
     implementation(libs.fastutil)
     implementation(libs.groovyJson)
     implementation(libs.guava)

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEncryptionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEncryptionIntegrationTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 import org.gradle.testfixtures.internal.NativeServicesTestFixture
+import org.junit.Assume
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.FileVisitOption
@@ -73,6 +74,7 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
     }
 
     def "configuration cache encryption enablement is #enabled if kind=#kind"() {
+        Assume.assumeTrue("Compression no longer exposes the raw data", enabled)
         given:
         def configurationCache = newConfigurationCacheFixture()
         buildFile """

--- a/platforms/core-configuration/configuration-cache/src/jmh/kotlin/org/gradle/internal/cc/jmh/BlackholeOutputStream.kt
+++ b/platforms/core-configuration/configuration-cache/src/jmh/kotlin/org/gradle/internal/cc/jmh/BlackholeOutputStream.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.jmh
+
+import org.openjdk.jmh.infra.Blackhole
+import java.io.OutputStream
+
+
+internal
+class BlackholeOutputStream(val bh: Blackhole) : OutputStream() {
+    override fun write(b: Int) {
+        bh.consume(b)
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/jmh/kotlin/org/gradle/internal/cc/jmh/CCStoreBenchmark.kt
+++ b/platforms/core-configuration/configuration-cache/src/jmh/kotlin/org/gradle/internal/cc/jmh/CCStoreBenchmark.kt
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.jmh
+
+import com.nhaarman.mockitokotlin2.mock
+import org.apache.commons.compress.compressors.snappy.FramedSnappyCompressorOutputStream
+import org.apache.commons.compress.compressors.snappy.SnappyCompressorInputStream
+import org.apache.commons.compress.compressors.snappy.SnappyCompressorOutputStream
+import org.gradle.internal.cc.base.serialize.IsolateOwners
+import org.gradle.internal.cc.impl.io.ByteBufferPool
+import org.gradle.internal.cc.impl.io.ParallelOutputStream
+import org.gradle.internal.cc.impl.serialize.Codecs
+import org.gradle.internal.cc.impl.serialize.DefaultClassEncoder
+import org.gradle.internal.configuration.problems.ProblemsListener
+import org.gradle.internal.extensions.stdlib.useToRun
+import org.gradle.internal.serialize.FlushableEncoder
+import org.gradle.internal.serialize.beans.services.DefaultBeanStateWriterLookup
+import org.gradle.internal.serialize.codecs.core.jos.JavaSerializationEncodingLookup
+import org.gradle.internal.serialize.graph.Codec
+import org.gradle.internal.serialize.graph.DefaultWriteContext
+import org.gradle.internal.serialize.graph.MutableIsolateContext
+import org.gradle.internal.serialize.graph.runWriteOperation
+import org.gradle.internal.serialize.graph.withIsolate
+import org.gradle.internal.serialize.kryo.KryoBackedEncoder
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.infra.Blackhole
+import java.io.OutputStream
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.zip.GZIPOutputStream
+
+
+@State(Scope.Benchmark)
+open class CCStoreBenchmark {
+
+    private
+    lateinit var graph: Any
+
+    @Setup
+    fun setup() {
+        graph = (1..1024).map { Peano.fromInt(1024) }
+    }
+
+    @Benchmark
+    fun withSnappyCompression(bh: Blackhole) {
+        writeTo(
+            KryoBackedEncoder(
+                compressorOutputStreamFor(
+                    BlackholeOutputStream(bh)
+                )
+            ),
+            graph
+        )
+    }
+
+    @Benchmark
+    fun withGZIPCompression(bh: Blackhole) {
+        writeTo(
+            KryoBackedEncoder(
+                GZIPOutputStream(
+                    BlackholeOutputStream(bh)
+                )
+            ),
+            graph
+        )
+    }
+
+    @Benchmark
+    fun withParallelSnappyCompression(bh: Blackhole) {
+        writeTo(
+            KryoBackedEncoder(
+                ParallelOutputStream.of {
+                    compressorOutputStreamFor(
+                        BlackholeOutputStream(bh)
+                    )
+                },
+                ParallelOutputStream.recommendedBufferSize
+            ),
+            graph
+        )
+    }
+
+    @Benchmark
+    fun withParallelSnappyCompressionAndArrayBlockingQueue(bh: Blackhole) {
+        writeTo(
+            KryoBackedEncoder(
+                ParallelOutputStream.of(ArrayBlockingQueue(ByteBufferPool.maxChunks)) {
+                    compressorOutputStreamFor(
+                        BlackholeOutputStream(bh)
+                    )
+                },
+                ParallelOutputStream.recommendedBufferSize
+            ),
+            graph
+        )
+    }
+
+    @Benchmark
+    fun withParallelGZIPCompression(bh: Blackhole) {
+        writeTo(
+            KryoBackedEncoder(
+                ParallelOutputStream.of {
+                    GZIPOutputStream(
+                        BlackholeOutputStream(bh)
+                    )
+                },
+                ParallelOutputStream.recommendedBufferSize
+            ),
+            graph
+        )
+    }
+
+    @Benchmark
+    fun withoutCompression(bh: Blackhole) {
+        writeTo(
+            KryoBackedEncoder(BlackholeOutputStream(bh)),
+            graph
+        )
+    }
+
+    private
+    fun compressorOutputStreamFor(outputStream: OutputStream) =
+        FramedSnappyCompressorOutputStream(
+            outputStream,
+            SnappyCompressorOutputStream
+                .createParameterBuilder(SnappyCompressorInputStream.DEFAULT_BLOCK_SIZE)
+                .tunedForSpeed()
+                .build()
+        )
+
+    internal
+    class BlackholeOutputStream(val bh: Blackhole) : OutputStream() {
+        override fun write(b: Int) {
+            bh.consume(b)
+        }
+    }
+
+    private
+    fun writeTo(
+        encoder: KryoBackedEncoder,
+        graph: Any,
+        codec: Codec<Any?> = userTypesCodec(),
+        problemsListener: ProblemsListener = mock(),
+    ) {
+        writeContextFor(encoder, codec, problemsListener).useToRun {
+            withIsolateMock(codec) {
+                runWriteOperation {
+                    write(graph)
+                }
+            }
+        }
+    }
+
+    private
+    fun writeContextFor(encoder: FlushableEncoder, codec: Codec<Any?>, problemHandler: ProblemsListener) =
+        DefaultWriteContext(
+            codec = codec,
+            encoder = encoder,
+            classEncoder = DefaultClassEncoder(mock()),
+            beanStateWriterLookup = DefaultBeanStateWriterLookup(),
+            logger = mock(),
+            tracer = null,
+            problemsListener = problemHandler
+        )
+
+    private
+    inline fun <R> MutableIsolateContext.withIsolateMock(codec: Codec<Any?>, block: () -> R): R =
+        withIsolate(IsolateOwners.OwnerGradle(mock()), codec) {
+            block()
+        }
+
+    private
+    fun userTypesCodec() = codecs().userTypesCodec()
+
+    private
+    fun codecs() = Codecs(
+        directoryFileTreeFactory = mock(),
+        fileCollectionFactory = mock(),
+        artifactSetConverter = mock(),
+        fileLookup = mock(),
+        propertyFactory = mock(),
+        filePropertyFactory = mock(),
+        fileResolver = mock(),
+        objectFactory = mock(),
+        instantiator = mock(),
+        fileSystemOperations = mock(),
+        taskNodeFactory = mock(),
+        ordinalGroupFactory = mock(),
+        inputFingerprinter = mock(),
+        buildOperationRunner = mock(),
+        classLoaderHierarchyHasher = mock(),
+        isolatableFactory = mock(),
+        managedFactoryRegistry = mock(),
+        parameterScheme = mock(),
+        actionScheme = mock(),
+        attributesFactory = mock(),
+        valueSourceProviderFactory = mock(),
+        calculatedValueContainerFactory = mock(),
+        patternSetFactory = mock(),
+        fileOperations = mock(),
+        fileFactory = mock(),
+        includedTaskGraph = mock(),
+        buildStateRegistry = mock(),
+        documentationRegistry = mock(),
+        javaSerializationEncodingLookup = JavaSerializationEncodingLookup(),
+        flowProviders = mock(),
+        transformStepNodeFactory = mock(),
+    )
+
+    internal
+    sealed class Peano {
+
+        companion object {
+
+            fun fromInt(n: Int): Peano = (0 until n).fold(Z as Peano) { acc, _ -> S(acc) }
+        }
+
+        fun toInt(): Int = sequence().count() - 1
+
+        object Z : Peano() {
+            override fun toString() = "Z"
+        }
+
+        data class S(val n: Peano) : Peano() {
+            override fun toString() = "S($n)"
+        }
+
+        private
+        fun sequence() = generateSequence(this) { previous ->
+            when (previous) {
+                is Z -> null
+                is S -> previous.n
+            }
+        }
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/jmh/kotlin/org/gradle/internal/cc/jmh/CCStoreBenchmark.kt
+++ b/platforms/core-configuration/configuration-cache/src/jmh/kotlin/org/gradle/internal/cc/jmh/CCStoreBenchmark.kt
@@ -16,36 +16,22 @@
 
 package org.gradle.internal.cc.jmh
 
-import com.nhaarman.mockitokotlin2.mock
-import org.apache.commons.compress.compressors.snappy.FramedSnappyCompressorOutputStream
-import org.apache.commons.compress.compressors.snappy.SnappyCompressorInputStream
-import org.apache.commons.compress.compressors.snappy.SnappyCompressorOutputStream
-import org.gradle.internal.cc.base.serialize.IsolateOwners
 import org.gradle.internal.cc.impl.io.ByteBufferPool
-import org.gradle.internal.cc.impl.io.ParallelOutputStream
-import org.gradle.internal.cc.impl.serialize.Codecs
-import org.gradle.internal.cc.impl.serialize.DefaultClassEncoder
-import org.gradle.internal.configuration.problems.ProblemsListener
-import org.gradle.internal.extensions.stdlib.useToRun
-import org.gradle.internal.serialize.FlushableEncoder
-import org.gradle.internal.serialize.beans.services.DefaultBeanStateWriterLookup
-import org.gradle.internal.serialize.codecs.core.jos.JavaSerializationEncodingLookup
-import org.gradle.internal.serialize.graph.Codec
-import org.gradle.internal.serialize.graph.DefaultWriteContext
-import org.gradle.internal.serialize.graph.MutableIsolateContext
-import org.gradle.internal.serialize.graph.runWriteOperation
-import org.gradle.internal.serialize.graph.withIsolate
-import org.gradle.internal.serialize.kryo.KryoBackedEncoder
 import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
 import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.Setup
 import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
 import org.openjdk.jmh.infra.Blackhole
-import java.io.OutputStream
 import java.util.concurrent.ArrayBlockingQueue
-import java.util.zip.GZIPOutputStream
+import java.util.concurrent.ConcurrentLinkedQueue
 
 
+@Fork(value = 2)
+@Warmup(iterations = 3)
+@Measurement(iterations = 3)
 @State(Scope.Benchmark)
 open class CCStoreBenchmark {
 
@@ -58,195 +44,32 @@ open class CCStoreBenchmark {
     }
 
     @Benchmark
-    fun withSnappyCompression(bh: Blackhole) {
-        writeTo(
-            KryoBackedEncoder(
-                compressorOutputStreamFor(
-                    BlackholeOutputStream(bh)
-                )
-            ),
-            graph
-        )
+    fun withoutCompression(bh: Blackhole) {
+        CCStoreScenarios.withoutCompression(bh, graph)
     }
 
-    @Benchmark
-    fun withGZIPCompression(bh: Blackhole) {
-        writeTo(
-            KryoBackedEncoder(
-                GZIPOutputStream(
-                    BlackholeOutputStream(bh)
-                )
-            ),
-            graph
-        )
-    }
+//    @Benchmark
+//    fun withSnappyCompression(bh: Blackhole) {
+//        CCStoreScenarios.withSnappyCompression(bh, graph)
+//    }
+//
+//    @Benchmark
+//    fun withGZIPCompression(bh: Blackhole) {
+//        CCStoreScenarios.withGZIPCompression(bh, graph)
+//    }
 
     @Benchmark
-    fun withParallelSnappyCompression(bh: Blackhole) {
-        writeTo(
-            KryoBackedEncoder(
-                ParallelOutputStream.of {
-                    compressorOutputStreamFor(
-                        BlackholeOutputStream(bh)
-                    )
-                },
-                ParallelOutputStream.recommendedBufferSize
-            ),
-            graph
-        )
+    fun withParallelSnappyCompressionAndConcurrentLinkedQueue(bh: Blackhole) {
+        CCStoreScenarios.withParallelSnappyCompression(ConcurrentLinkedQueue(), bh, graph)
     }
 
     @Benchmark
     fun withParallelSnappyCompressionAndArrayBlockingQueue(bh: Blackhole) {
-        writeTo(
-            KryoBackedEncoder(
-                ParallelOutputStream.of(ArrayBlockingQueue(ByteBufferPool.maxChunks)) {
-                    compressorOutputStreamFor(
-                        BlackholeOutputStream(bh)
-                    )
-                },
-                ParallelOutputStream.recommendedBufferSize
-            ),
-            graph
-        )
+        CCStoreScenarios.withParallelSnappyCompression(ArrayBlockingQueue(ByteBufferPool.maxChunks), bh, graph)
     }
 
     @Benchmark
     fun withParallelGZIPCompression(bh: Blackhole) {
-        writeTo(
-            KryoBackedEncoder(
-                ParallelOutputStream.of {
-                    GZIPOutputStream(
-                        BlackholeOutputStream(bh)
-                    )
-                },
-                ParallelOutputStream.recommendedBufferSize
-            ),
-            graph
-        )
-    }
-
-    @Benchmark
-    fun withoutCompression(bh: Blackhole) {
-        writeTo(
-            KryoBackedEncoder(BlackholeOutputStream(bh)),
-            graph
-        )
-    }
-
-    private
-    fun compressorOutputStreamFor(outputStream: OutputStream) =
-        FramedSnappyCompressorOutputStream(
-            outputStream,
-            SnappyCompressorOutputStream
-                .createParameterBuilder(SnappyCompressorInputStream.DEFAULT_BLOCK_SIZE)
-                .tunedForSpeed()
-                .build()
-        )
-
-    internal
-    class BlackholeOutputStream(val bh: Blackhole) : OutputStream() {
-        override fun write(b: Int) {
-            bh.consume(b)
-        }
-    }
-
-    private
-    fun writeTo(
-        encoder: KryoBackedEncoder,
-        graph: Any,
-        codec: Codec<Any?> = userTypesCodec(),
-        problemsListener: ProblemsListener = mock(),
-    ) {
-        writeContextFor(encoder, codec, problemsListener).useToRun {
-            withIsolateMock(codec) {
-                runWriteOperation {
-                    write(graph)
-                }
-            }
-        }
-    }
-
-    private
-    fun writeContextFor(encoder: FlushableEncoder, codec: Codec<Any?>, problemHandler: ProblemsListener) =
-        DefaultWriteContext(
-            codec = codec,
-            encoder = encoder,
-            classEncoder = DefaultClassEncoder(mock()),
-            beanStateWriterLookup = DefaultBeanStateWriterLookup(),
-            logger = mock(),
-            tracer = null,
-            problemsListener = problemHandler
-        )
-
-    private
-    inline fun <R> MutableIsolateContext.withIsolateMock(codec: Codec<Any?>, block: () -> R): R =
-        withIsolate(IsolateOwners.OwnerGradle(mock()), codec) {
-            block()
-        }
-
-    private
-    fun userTypesCodec() = codecs().userTypesCodec()
-
-    private
-    fun codecs() = Codecs(
-        directoryFileTreeFactory = mock(),
-        fileCollectionFactory = mock(),
-        artifactSetConverter = mock(),
-        fileLookup = mock(),
-        propertyFactory = mock(),
-        filePropertyFactory = mock(),
-        fileResolver = mock(),
-        objectFactory = mock(),
-        instantiator = mock(),
-        fileSystemOperations = mock(),
-        taskNodeFactory = mock(),
-        ordinalGroupFactory = mock(),
-        inputFingerprinter = mock(),
-        buildOperationRunner = mock(),
-        classLoaderHierarchyHasher = mock(),
-        isolatableFactory = mock(),
-        managedFactoryRegistry = mock(),
-        parameterScheme = mock(),
-        actionScheme = mock(),
-        attributesFactory = mock(),
-        valueSourceProviderFactory = mock(),
-        calculatedValueContainerFactory = mock(),
-        patternSetFactory = mock(),
-        fileOperations = mock(),
-        fileFactory = mock(),
-        includedTaskGraph = mock(),
-        buildStateRegistry = mock(),
-        documentationRegistry = mock(),
-        javaSerializationEncodingLookup = JavaSerializationEncodingLookup(),
-        flowProviders = mock(),
-        transformStepNodeFactory = mock(),
-    )
-
-    internal
-    sealed class Peano {
-
-        companion object {
-
-            fun fromInt(n: Int): Peano = (0 until n).fold(Z as Peano) { acc, _ -> S(acc) }
-        }
-
-        fun toInt(): Int = sequence().count() - 1
-
-        object Z : Peano() {
-            override fun toString() = "Z"
-        }
-
-        data class S(val n: Peano) : Peano() {
-            override fun toString() = "S($n)"
-        }
-
-        private
-        fun sequence() = generateSequence(this) { previous ->
-            when (previous) {
-                is Z -> null
-                is S -> previous.n
-            }
-        }
+        CCStoreScenarios.withParallelGZIPCompression(bh, graph)
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/jmh/kotlin/org/gradle/internal/cc/jmh/CCStoreScenarios.kt
+++ b/platforms/core-configuration/configuration-cache/src/jmh/kotlin/org/gradle/internal/cc/jmh/CCStoreScenarios.kt
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.jmh
+
+import com.nhaarman.mockitokotlin2.mock
+import org.apache.commons.compress.compressors.snappy.FramedSnappyCompressorOutputStream
+import org.apache.commons.compress.compressors.snappy.SnappyCompressorInputStream
+import org.apache.commons.compress.compressors.snappy.SnappyCompressorOutputStream
+import org.gradle.internal.cc.base.serialize.IsolateOwners
+import org.gradle.internal.cc.impl.io.ParallelOutputStream
+import org.gradle.internal.cc.impl.serialize.Codecs
+import org.gradle.internal.cc.impl.serialize.DefaultClassEncoder
+import org.gradle.internal.configuration.problems.ProblemsListener
+import org.gradle.internal.extensions.stdlib.useToRun
+import org.gradle.internal.serialize.FlushableEncoder
+import org.gradle.internal.serialize.beans.services.DefaultBeanStateWriterLookup
+import org.gradle.internal.serialize.codecs.core.jos.JavaSerializationEncodingLookup
+import org.gradle.internal.serialize.graph.Codec
+import org.gradle.internal.serialize.graph.DefaultWriteContext
+import org.gradle.internal.serialize.graph.MutableIsolateContext
+import org.gradle.internal.serialize.graph.runWriteOperation
+import org.gradle.internal.serialize.graph.withIsolate
+import org.gradle.internal.serialize.kryo.KryoBackedEncoder
+import org.openjdk.jmh.infra.Blackhole
+import java.io.OutputStream
+import java.nio.ByteBuffer
+import java.util.Queue
+import java.util.zip.GZIPOutputStream
+
+
+internal
+object CCStoreScenarios {
+
+    internal
+    fun withSnappyCompression(bh: Blackhole, graph: Any) {
+        writeTo(
+            KryoBackedEncoder(
+                compressorOutputStreamFor(
+                    BlackholeOutputStream(bh)
+                )
+            ),
+            graph
+        )
+    }
+
+    internal
+    fun withGZIPCompression(bh: Blackhole, graph: Any) {
+        writeTo(
+            KryoBackedEncoder(
+                GZIPOutputStream(
+                    BlackholeOutputStream(bh)
+                )
+            ),
+            graph
+        )
+    }
+
+    internal
+    fun withParallelSnappyCompression(queue: Queue<ByteBuffer>, bh: Blackhole, graph: Any) {
+        writeTo(
+            KryoBackedEncoder(
+                ParallelOutputStream.of(queue) {
+                    compressorOutputStreamFor(
+                        BlackholeOutputStream(bh)
+                    )
+                },
+                ParallelOutputStream.recommendedBufferSize
+            ),
+            graph
+        )
+    }
+
+    internal
+    fun withParallelGZIPCompression(bh: Blackhole, graph: Any) {
+        writeTo(
+            KryoBackedEncoder(
+                ParallelOutputStream.of {
+                    GZIPOutputStream(
+                        BlackholeOutputStream(bh),
+                        ParallelOutputStream.recommendedBufferSize
+                    )
+                },
+                ParallelOutputStream.recommendedBufferSize
+            ),
+            graph
+        )
+    }
+
+    internal
+    fun withoutCompression(bh: Blackhole, graph: Any) {
+        writeTo(
+            KryoBackedEncoder(BlackholeOutputStream(bh)),
+            graph
+        )
+    }
+
+    private
+    fun compressorOutputStreamFor(outputStream: OutputStream) =
+        FramedSnappyCompressorOutputStream(
+            outputStream,
+            SnappyCompressorOutputStream.createParameterBuilder(SnappyCompressorInputStream.DEFAULT_BLOCK_SIZE)
+                .tunedForSpeed()
+                .build()
+        )
+
+    private
+    fun writeTo(
+        encoder: KryoBackedEncoder,
+        graph: Any,
+        codec: Codec<Any?> = userTypesCodec(),
+        problemsListener: ProblemsListener = mock(),
+    ) {
+        writeContextFor(encoder, codec, problemsListener).useToRun {
+            withIsolateMock(codec) {
+                runWriteOperation {
+                    write(graph)
+                }
+            }
+        }
+    }
+
+    private
+    fun writeContextFor(encoder: FlushableEncoder, codec: Codec<Any?>, problemHandler: ProblemsListener) =
+        DefaultWriteContext(
+            codec = codec,
+            encoder = encoder,
+            classEncoder = DefaultClassEncoder(mock()),
+            beanStateWriterLookup = DefaultBeanStateWriterLookup(),
+            logger = mock(),
+            tracer = null,
+            problemsListener = problemHandler
+        )
+
+    private
+    inline fun <R> MutableIsolateContext.withIsolateMock(codec: Codec<Any?>, block: () -> R): R =
+        withIsolate(IsolateOwners.OwnerGradle(mock()), codec) {
+            block()
+        }
+
+    private
+    fun userTypesCodec() = codecs().userTypesCodec()
+
+    private
+    fun codecs() = Codecs(
+        directoryFileTreeFactory = mock(),
+        fileCollectionFactory = mock(),
+        artifactSetConverter = mock(),
+        fileLookup = mock(),
+        propertyFactory = mock(),
+        filePropertyFactory = mock(),
+        fileResolver = mock(),
+        objectFactory = mock(),
+        instantiator = mock(),
+        fileSystemOperations = mock(),
+        taskNodeFactory = mock(),
+        ordinalGroupFactory = mock(),
+        inputFingerprinter = mock(),
+        buildOperationRunner = mock(),
+        classLoaderHierarchyHasher = mock(),
+        isolatableFactory = mock(),
+        managedFactoryRegistry = mock(),
+        parameterScheme = mock(),
+        actionScheme = mock(),
+        attributesFactory = mock(),
+        valueSourceProviderFactory = mock(),
+        calculatedValueContainerFactory = mock(),
+        patternSetFactory = mock(),
+        fileOperations = mock(),
+        fileFactory = mock(),
+        includedTaskGraph = mock(),
+        buildStateRegistry = mock(),
+        documentationRegistry = mock(),
+        javaSerializationEncodingLookup = JavaSerializationEncodingLookup(),
+        flowProviders = mock(),
+        transformStepNodeFactory = mock(),
+    )
+}

--- a/platforms/core-configuration/configuration-cache/src/jmh/kotlin/org/gradle/internal/cc/jmh/Peano.kt
+++ b/platforms/core-configuration/configuration-cache/src/jmh/kotlin/org/gradle/internal/cc/jmh/Peano.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.jmh
+
+
+internal
+sealed class Peano {
+
+    companion object {
+
+        fun fromInt(n: Int): Peano = (0 until n).fold(Z as Peano) { acc, _ -> S(acc) }
+    }
+
+    fun toInt(): Int = sequence().count() - 1
+
+    object Z : Peano() {
+        override fun toString() = "Z"
+    }
+
+    data class S(val n: Peano) : Peano() {
+        override fun toString() = "S($n)"
+    }
+
+    private
+    fun sequence() = generateSequence(this) { previous ->
+        when (previous) {
+            is Z -> null
+            is S -> previous.n
+        }
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheIO.kt
@@ -274,7 +274,7 @@ class ConfigurationCacheIO internal constructor(
 
             when (stateType) {
                 StateType.Work -> KryoBackedEncoder(
-                    ParallelOutputStream.of(::compressorStream),
+                    ParallelOutputStream.of(outputStreamFactory = ::compressorStream),
                     ParallelOutputStream.recommendedBufferSize
                 )
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/io/ParallelOutputStream.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/io/ParallelOutputStream.kt
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.io
+
+import org.gradle.internal.cc.base.logger
+import org.gradle.internal.extensions.core.debug
+import java.io.OutputStream
+import java.nio.Buffer
+import java.nio.ByteBuffer
+import java.util.Queue
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import kotlin.concurrent.thread
+import kotlin.math.roundToInt
+
+
+/**
+ * Factory for an [OutputStream] decorator that offloads the writing to a separate thread.
+ */
+internal
+object ParallelOutputStream {
+
+    /**
+     * See [ByteBufferPool.chunkSize].
+     */
+    val recommendedBufferSize: Int
+        get() = ByteBufferPool.chunkSize
+
+    /**
+     * Returns an [OutputStream] that offloads writing to the stream returned by [createOutputStream]
+     * to a separate thread. The returned stream can only be written to from a single thread at a time.
+     *
+     * Note that [createOutputStream] will be called in the writing thread.
+     *
+     * @see QueuedOutputStream
+     * @see ByteBufferPool
+     */
+    fun of(createOutputStream: () -> OutputStream): OutputStream {
+        val chunks = ByteBufferPool()
+        val readyQ = ConcurrentLinkedQueue<ByteBuffer>()
+        val writer = thread(name = "CC writer", isDaemon = true, priority = Thread.NORM_PRIORITY) {
+            try {
+                createOutputStream().use { outputStream ->
+                    while (true) {
+                        val chunk = readyQ.poll()
+                        if (chunk == null) {
+                            // give the producer another chance
+                            Thread.yield()
+                            continue
+                        }
+                        val position = chunk.position()
+                        if (position == 0) {
+                            /** producer is signaling end of stream
+                             * see [QueuedOutputStream.close]
+                             **/
+                            break
+                        }
+                        try {
+                            outputStream.write(chunk.array(), 0, position)
+                        } finally {
+                            // always return the chunk to the pool
+                            rewind(chunk)
+                            chunks.put(chunk)
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                chunks.fail(e)
+            } finally {
+                // in case of failure, this releases some memory until the
+                // producer realizes there was a failure
+                readyQ.clear()
+            }
+            logger.debug {
+                "${javaClass.name} writer ${Thread.currentThread()} finished."
+            }
+        }
+        return QueuedOutputStream(chunks, readyQ) {
+            writer.join()
+        }
+    }
+
+    private
+    fun rewind(chunk: Buffer /* for compatibility with Java 8 */) {
+        chunk.rewind()
+    }
+}
+
+
+/**
+ * An [OutputStream] implementation that writes to buffers taken from a [ByteBufferPool]
+ * and posts them to the given [ready queue][readyQ] when they are full.
+ */
+private
+class QueuedOutputStream(
+    private val chunks: ByteBufferPool,
+    private val readyQ: Queue<ByteBuffer>,
+    private val onClose: () -> Unit,
+) : OutputStream() {
+
+    private
+    var chunk = chunks.take()
+
+    override fun write(b: ByteArray, off: Int, len: Int) {
+        writeByteArray(b, off, len)
+    }
+
+    override fun write(b: Int) {
+        chunk.put(b.toByte())
+        maybeFlush()
+    }
+
+    override fun close() {
+        // send remaining data
+        if (chunk.position() > 0) {
+            sendChunk()
+            takeNextChunk()
+        }
+        // send a last empty chunk to signal the end
+        sendChunk()
+        onClose()
+        chunks.rethrowFailureIfAny()
+        super.close()
+    }
+
+    private
+    tailrec fun writeByteArray(b: ByteArray, off: Int, len: Int) {
+        if (len <= 0) {
+            return
+        }
+        val remaining = chunk.remaining()
+        if (remaining >= len) {
+            putByteArrayAndFlush(b, off, len)
+        } else {
+            putByteArrayAndFlush(b, off, remaining)
+            writeByteArray(b, off + remaining, len - remaining)
+        }
+    }
+
+    private
+    fun putByteArrayAndFlush(b: ByteArray, off: Int, len: Int) {
+        chunk.put(b, off, len)
+        maybeFlush()
+    }
+
+    private
+    fun maybeFlush() {
+        if (!chunk.hasRemaining()) {
+            sendChunk()
+            takeNextChunk()
+        }
+    }
+
+    private
+    fun sendChunk() {
+        readyQ.offer(chunk)
+    }
+
+    private
+    fun takeNextChunk() {
+        chunk = chunks.take()
+    }
+}
+
+
+/**
+ * Manages a pool of chunks of fixed [size][ByteBufferPool.chunkSize] allocated on-demand
+ * upto a [fixed maximum][ByteBufferPool.maxChunks].
+ */
+private
+class ByteBufferPool {
+
+    companion object {
+
+        /**
+         * How many bytes are transferred, at a time, from the producer to the writer thread.
+         *
+         * The smaller the number the more parallelism between producer and writer (but also greater the synchronization overhead).
+         */
+        val chunkSize = System.getProperty("org.gradle.configuration-cache.internal.chunk-size", null)?.toInt()
+            ?: 4096
+
+        /**
+         * Maximum number of chunks to be allocated.
+         *
+         * Determines the maximum memory working set: [maxChunks] * [chunkSize].
+         * The default maximum working set is `16MB`.
+         */
+        val maxChunks = System.getProperty("org.gradle.configuration-cache.internal.max-chunks", null)?.toInt()
+            ?: 4096
+
+        val chunkTimeoutMinutes: Long = System.getProperty("org.gradle.configuration-cache.internal.chunk-timeout-minutes", null)?.toLong()
+            ?: 30L /* stream can be kept open during the whole configuration phase */
+    }
+
+    private
+    val chunks = ArrayBlockingQueue<ByteBuffer>(maxChunks)
+
+    private
+    var chunksToAllocate = maxChunks
+
+    @Volatile
+    private
+    var failure: Exception? = null
+
+    fun put(chunk: ByteBuffer) {
+        require(chunk.position() == 0 && chunk.remaining() == chunk.limit())
+        require(chunks.offer(chunk))
+    }
+
+    private
+    val chunkReuseThreshold = (maxChunks * 0.9).roundToInt()
+
+    fun take(): ByteBuffer {
+        rethrowFailureIfAny()
+        val remainingAllocations = chunksToAllocate
+        if (remainingAllocations > 0) {
+            if (remainingAllocations < chunkReuseThreshold) {
+                // try to reuse chunks past some threshold
+                // to amortize the cost of locking the chunks queue
+                val reused = chunks.poll()
+                if (reused != null) {
+                    return reused
+                }
+            }
+            --chunksToAllocate
+            return ByteBuffer.allocate(chunkSize)
+        }
+        return chunks.poll(chunkTimeoutMinutes, TimeUnit.MINUTES)
+            ?: throw TimeoutException("Timed out while waiting for a chunk.")
+    }
+
+    fun fail(e: Exception) {
+        failure = e
+    }
+
+    fun rethrowFailureIfAny() {
+        failure?.let {
+            throw it
+        }
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/io/ParallelOutputStream.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/io/ParallelOutputStream.kt
@@ -23,7 +23,6 @@ import java.nio.Buffer
 import java.nio.ByteBuffer
 import java.util.Queue
 import java.util.concurrent.ArrayBlockingQueue
-import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import kotlin.concurrent.thread
@@ -52,7 +51,7 @@ object ParallelOutputStream {
      * @see ByteBufferPool
      */
     fun of(
-        readyQ: Queue<ByteBuffer> = ConcurrentLinkedQueue(),
+        readyQ: Queue<ByteBuffer> = ArrayBlockingQueue(ByteBufferPool.maxChunks),
         outputStreamFactory: () -> OutputStream,
     ): OutputStream {
         val chunks = ByteBufferPool()


### PR DESCRIPTION
Apply snappy compression to Configuration Cache entries

Compression and encryption are offloaded to a separate thread, utilizing a pool of byte buffers capped at a maximum memory working set of 16MB.

The resulting files are 1/5th of their original size. Storing might be marginally slower in some cases, but loading is as fast or faster in all tested scenarios.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
