### PR TITLE
Update Resolution Failures to report to Problems API

### DIFF
--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/GradleCoreProblemGroup.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/GradleCoreProblemGroup.java
@@ -25,6 +25,7 @@ public abstract class GradleCoreProblemGroup implements ProblemGroup {
     private static final DefaultValidationProblemGroup VALIDATION_PROBLEM_GROUP = new DefaultValidationProblemGroup("validation", "Validation");
     private static final DefaultProblemGroup TASK_SELECTION_PROBLEM_GROUP = new DefaultProblemGroup("task-selection", "Task selection");
     private static final DefaultProblemGroup VERSION_CATALOG_PROBLEM_GROUP = new DefaultProblemGroup("dependency-version-catalog", "Version catalog");
+    private static final DefaultProblemGroup VARIANT_RESOLUTION_PROBLEM_GROUP = new DefaultProblemGroup("dependency-variant-resolution", "Variant resolution");
 
     public static CompilationProblemGroup compilation() {
         return COMPILATION_PROBLEM_GROUP;
@@ -44,6 +45,10 @@ public abstract class GradleCoreProblemGroup implements ProblemGroup {
 
     public static ProblemGroup versionCatalog() {
         return VERSION_CATALOG_PROBLEM_GROUP;
+    }
+
+    public static ProblemGroup variantResolution() {
+        return VARIANT_RESOLUTION_PROBLEM_GROUP;
     }
 
     public interface CompilationProblemGroup extends ProblemGroup {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/ResolutionFailureHandlerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/ResolutionFailureHandlerIntegrationTest.groovy
@@ -230,6 +230,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
       > A dependency was declared on configuration 'absent' of 'project :' but no variant with that configuration name exists.""")
 
         and: "Helpful resolutions are provided"
+        failure.assertHasResolution("To determine which configurations are available in the target project : run :outgoingVariants.")
         assertSuggestsReviewingAlgorithm()
         // TODO: Nothing specific here
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/ResolutionFailureHandlerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/ResolutionFailureHandlerIntegrationTest.groovy
@@ -63,10 +63,16 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
           - Value: 'round' selects variant: 'blueRoundElements'
           - Value: 'square' selects variant: 'blueSquareElements'
           - Value: 'triangle' selects variant: 'blueTriangleElements'""")
+
         and: "Helpful resolutions are provided"
         assertSuggestsReviewingAlgorithm()
         assertSuggestsViewingDocs("Ambiguity errors are explained in more detail at https://docs.gradle.org/${GradleVersion.current().version}/userguide/variant_model.html#sub:variant-ambiguity.")
         assertSuggestsViewingDocs("Use the dependencyInsight report with the --all-variants option to view all variants of the ambiguous dependency.  This report is described at https://docs.gradle.org/${GradleVersion.current().version}/userguide/viewing_debugging_dependencies.html#sec:identifying_reason_dependency_selection.")
+
+        and: "Problems are reported"
+        verifyAll(receivedProblem(0)) {
+            fqid == 'dependency-variant-resolution:ambiguous-variants'
+        }
     }
 
     def "demonstrate ambiguous graph variant without single disambiguating value selection failure for project"() {
@@ -96,9 +102,15 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
               - Unmatched attributes:
                   - Provides opacity 'transparent' but the consumer didn't ask for it
                   - Provides shape 'square' but the consumer didn't ask for it""")
+
         and: "Helpful resolutions are provided"
         assertSuggestsReviewingAlgorithm()
         assertSuggestsViewingDocs("Ambiguity errors are explained in more detail at https://docs.gradle.org/${GradleVersion.current().version}/userguide/variant_model.html#sub:variant-ambiguity.")
+
+        and: "Problems are reported"
+        verifyAll(receivedProblem(0)) {
+            fqid == 'dependency-variant-resolution:ambiguous-variants'
+        }
     }
 
     @ToBeFixedForConfigurationCache
@@ -123,6 +135,11 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Helpful resolutions are provided"
         assertSuggestsReviewingAlgorithm()
         assertSuggestsViewingDocs("Ambiguity errors are explained in more detail at https://docs.gradle.org/${GradleVersion.current().version}/userguide/variant_model.html#sub:variant-ambiguity.")
+
+        and: "Problems are reported"
+        verifyAll(receivedProblem(0)) {
+            fqid == 'dependency-variant-resolution:ambiguous-variants'
+        }
     }
 
     def "demonstrate no matching graph variants selection failure for project"() {
@@ -145,6 +162,11 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Helpful resolutions are provided"
         assertSuggestsReviewingAlgorithm()
         assertSuggestsViewingDocs("No matching variant errors are explained in more detail at https://docs.gradle.org/${GradleVersion.current().version}/userguide/variant_model.html#sub:variant-no-match.")
+
+        and: "Problems are reported"
+        verifyAll(receivedProblem(0)) {
+            fqid == 'dependency-variant-resolution:no-compatible-variants'
+        }
     }
 
     @ToBeFixedForConfigurationCache
@@ -171,6 +193,11 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Helpful resolutions are provided"
         assertSuggestsReviewingAlgorithm()
         assertSuggestsViewingDocs("No matching variant errors are explained in more detail at https://docs.gradle.org/${GradleVersion.current().version}/userguide/variant_model.html#sub:variant-no-match.")
+
+        and: "Problems are reported"
+        verifyAll(receivedProblem(0)) {
+            fqid == 'dependency-variant-resolution:no-compatible-variants'
+        }
     }
 
     def 'demonstrate incompatible requested configuration failure'() {
@@ -193,6 +220,11 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Helpful resolutions are provided"
         assertSuggestsReviewingAlgorithm()
         assertSuggestsViewingDocs("Incompatible variant errors are explained in more detail at https://docs.gradle.org/${GradleVersion.current().version}/userguide/variant_model.html#sub:variant-incompatible.")
+
+        and: "Problems are reported"
+        verifyAll(receivedProblem(0)) {
+            fqid == 'dependency-variant-resolution:configuration-not-compatible'
+        }
     }
 
     def "demonstrate no variants exist"() {
@@ -213,6 +245,11 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Helpful resolutions are provided"
         assertSuggestsReviewingAlgorithm()
         assertSuggestsViewingDocs("Creating consumable variants is explained in more detail at https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:resolvable-consumable-configs.")
+
+        and: "Problems are reported"
+        verifyAll(receivedProblem(0)) {
+            fqid == 'dependency-variant-resolution:no-compatible-variants'
+        }
     }
 
     def "demonstrate configuration not found selection failure"() {
@@ -232,7 +269,11 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Helpful resolutions are provided"
         failure.assertHasResolution("To determine which configurations are available in the target project : run :outgoingVariants.")
         assertSuggestsReviewingAlgorithm()
-        // TODO: Nothing specific here
+
+        and: "Problems are reported"
+        verifyAll(receivedProblem(0)) {
+            fqid == 'dependency-variant-resolution:configuration-does-not-exist'
+        }
     }
     // endregion Stage 2 - VariantSelectionFailure
 
@@ -259,6 +300,11 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Helpful resolutions are provided"
         assertSuggestsReviewingAlgorithm()
         assertSuggestsViewingDocs("Incompatible variant errors are explained in more detail at https://docs.gradle.org/${GradleVersion.current().version}/userguide/variant_model.html#sub:variant-incompatible.")
+
+        and: "Problems are reported"
+        verifyAll(receivedProblem(0)) {
+            fqid == 'dependency-variant-resolution:incompatible-multiple-nodes'
+        }
     }
 
     def "demonstrate no matching artifact variants exception"() {
@@ -279,6 +325,14 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Helpful resolutions are provided"
         assertSuggestsReviewingAlgorithm()
         assertSuggestsViewingDocs("No matching variant errors are explained in more detail at https://docs.gradle.org/${GradleVersion.current().version}/userguide/variant_model.html#sub:variant-no-match.")
+
+        and: "Problems are reported"
+        verifyAll(receivedProblem(0)) {
+            fqid == 'dependency-variant-resolution:no-compatible-artifact'
+        }
+        verifyAll(receivedProblem(1)) {
+            fqid == 'dependency-variant-resolution:no-compatible-artifact'
+        }
     }
 
     def "demonstrate ambiguous artifact transforms exception"() {
@@ -312,6 +366,14 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Helpful resolutions are provided"
         assertSuggestsReviewingAlgorithm()
         assertSuggestsViewingDocs("Transformation failures are explained in more detail at https://docs.gradle.org/${GradleVersion.current().version}/userguide/variant_model.html#sub:transform-ambiguity.")
+
+        and: "Problems are reported"
+        verifyAll(receivedProblem(0)) {
+            fqid == 'dependency-variant-resolution:ambiguous-artifact-transform'
+        }
+        verifyAll(receivedProblem(1)) {
+            fqid == 'dependency-variant-resolution:ambiguous-artifact-transform'
+        }
     }
 
     def "demonstrate ambiguous artifact variants exception"() {
@@ -330,6 +392,14 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Helpful resolutions are provided"
         assertSuggestsReviewingAlgorithm()
         assertSuggestsViewingDocs("Ambiguity errors are explained in more detail at https://docs.gradle.org/${GradleVersion.current().version}/userguide/variant_model.html#sub:variant-ambiguity.")
+
+        and: "Problems are reported"
+        verifyAll(receivedProblem(0)) {
+            fqid == 'dependency-variant-resolution:ambiguous-artifacts'
+        }
+        verifyAll(receivedProblem(1)) {
+            fqid == 'dependency-variant-resolution:ambiguous-artifacts'
+        }
     }
     // endregion Stage 4 - ArtifactSelectionFailure
 
@@ -358,6 +428,11 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
 
         outputContains(basicOutput)
         outputContains(fullOutput)
+
+        and: "Problems are reported"
+        verifyAll(receivedProblem(0)) {
+            fqid == 'dependency-variant-resolution:no-variants-with-matching-capabilities'
+        }
     }
     // endregion dependencyInsight failures
 
@@ -457,6 +532,10 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
     // endregion error showcase
 
     // region setup
+    def setup() {
+        enableProblemsApiCheck()
+    }
+
     private void setupConfigurationNotFound() {
         buildKotlinFile << """
             configurations {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/ResolutionFailureHandlerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/ResolutionFailureHandlerIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.integtests.internal.component
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.internal.component.resolution.failure.exception.AbstractResolutionFailureException
 import org.gradle.internal.component.resolution.failure.exception.ArtifactSelectionException
 import org.gradle.internal.component.resolution.failure.exception.GraphValidationException
@@ -113,7 +112,6 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         }
     }
 
-    @ToBeFixedForConfigurationCache
     def "demonstrate ambiguous graph variant selection failure with single disambiguating value for externalDep"() {
         ambiguousGraphVariantForExternalDep.prepare()
 
@@ -121,7 +119,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         assertResolutionFailsAsExpected(ambiguousGraphVariantForExternalDep)
 
         and: "Has error output"
-        failure.assertHasDescription("Execution failed for task ':forceResolution'")
+        // This doesn't appear with CC: failure.assertHasDescription("Execution failed for task ':forceResolution'")
         failure.assertHasCause("Could not resolve all files for configuration ':resolveMe'.")
         failure.assertHasCause("Could not resolve com.squareup.okhttp3:okhttp:4.4.0.")
         assertFullMessageCorrect("""   > Could not resolve com.squareup.okhttp3:okhttp:4.4.0.
@@ -169,7 +167,6 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         }
     }
 
-    @ToBeFixedForConfigurationCache
     def "demonstrate no matching graph variants selection failure for externalDep"() {
         noMatchingGraphVariantsForExternalDep.prepare()
 
@@ -177,7 +174,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         assertResolutionFailsAsExpected(noMatchingGraphVariantsForExternalDep)
 
         and: "Has error output"
-        failure.assertHasDescription("Execution failed for task ':forceResolution'.")
+        // This doesn't appear with CC: failure.assertHasDescription("Execution failed for task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all files for configuration ':resolveMe'.")
         failure.assertHasCause("Could not resolve com.squareup.okhttp3:okhttp:4.4.0.")
         assertFullMessageCorrect("""      > No matching variant of com.squareup.okhttp3:okhttp:4.4.0 was found. The consumer was configured to find attribute 'org.gradle.category' with value 'non-existent-format' but:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/ResolutionFailureHandlerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/ResolutionFailureHandlerIntegrationTest.groovy
@@ -267,7 +267,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
       > A dependency was declared on configuration 'absent' of 'project :' but no variant with that configuration name exists.""")
 
         and: "Helpful resolutions are provided"
-        failure.assertHasResolution("To determine which configurations are available in the target project : run :outgoingVariants.")
+        failure.assertHasResolution("To determine which configurations are available in the target project :, run :outgoingVariants.")
         assertSuggestsReviewingAlgorithm()
 
         and: "Problems are reported"

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -800,7 +800,7 @@ project(':b') {
 
         then:
         failure.assertHasCause("A dependency was declared on configuration 'absent' of '${projectDescription}' but no variant with that configuration name exists.")
-        failure.assertHasResolution("To determine which configurations are available in the target project, run ${expectedCommand}")
+        failure.assertHasResolution("To determine which configurations are available in the target ${projectDescription}, run ${expectedCommand}.")
 
         expect:
         succeeds(expectedCommand)

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -111,6 +111,7 @@ import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.provider.PropertyFactory;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.cache.Cache;
 import org.gradle.cache.ManualEvictionInMemoryCache;
@@ -533,10 +534,10 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         }
 
         @Provides
-        ResolutionFailureHandler createResolutionFailureProcessor(InstantiatorFactory instantiatorFactory, ServiceRegistry serviceRegistry) {
+        ResolutionFailureHandler createResolutionFailureProcessor(InstantiatorFactory instantiatorFactory, ServiceRegistry serviceRegistry, InternalProblems problemsService) {
             InstanceGenerator instanceGenerator = instantiatorFactory.inject(serviceRegistry);
             ResolutionFailureDescriberRegistry failureDescriberRegistry = ResolutionFailureDescriberRegistry.standardRegistry(instanceGenerator);
-            return new ResolutionFailureHandler(failureDescriberRegistry);
+            return new ResolutionFailureHandler(failureDescriberRegistry, problemsService);
         }
 
         @Provides

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -84,6 +84,7 @@ import org.gradle.api.internal.runtimeshaded.RuntimeShadedJarFactory;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.BuildTreeObjectFactory;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.cache.internal.CleaningInMemoryCacheDecoratorFactory;
 import org.gradle.cache.internal.GeneratedGradleJarCache;
 import org.gradle.cache.internal.InMemoryCacheDecoratorFactory;
@@ -363,10 +364,10 @@ class DependencyManagementBuildScopeServices implements ServiceRegistrationProvi
     }
 
     @Provides
-    ResolutionFailureHandler createResolutionFailureProcessor(InstantiatorFactory instantiatorFactory, ServiceRegistry serviceRegistry) {
+    ResolutionFailureHandler createResolutionFailureProcessor(InstantiatorFactory instantiatorFactory, ServiceRegistry serviceRegistry, InternalProblems problemsService) {
         InstanceGenerator instanceGenerator = instantiatorFactory.inject(serviceRegistry);
         ResolutionFailureDescriberRegistry failureDescriberRegistry = ResolutionFailureDescriberRegistry.standardRegistry(instanceGenerator);
-        return new ResolutionFailureHandler(failureDescriberRegistry);
+        return new ResolutionFailureHandler(failureDescriberRegistry, problemsService);
     }
 
     @Provides

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionBackedFileCollection.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionBackedFileCollection.java
@@ -77,7 +77,7 @@ public class ResolutionBackedFileCollection extends AbstractFileCollection {
     /**
      * If the file collection is not lenient, rethrow any failures that occurred during the visit.
      *
-     * @throws ArtifactSelectionException subtypes for resolution failures; may throw other exceptions encountered when downloading artifacts
+     * @throws ArtifactSelectionException subtypes
      */
     private void maybeThrowResolutionFailures(ResolvedFileCollectionVisitor collectingVisitor) {
         if (!lenient) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/AmbiguousVariantSelectionException.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/AmbiguousVariantSelectionException.java
@@ -18,6 +18,7 @@ package org.gradle.internal.component;
 
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.catalog.problems.ResolutionFailureProblemId;
 import org.gradle.internal.component.resolution.failure.exception.ArtifactSelectionException;
 import org.gradle.internal.component.resolution.failure.interfaces.ArtifactSelectionFailure;
 import org.gradle.internal.deprecation.DeprecationLogger;
@@ -52,6 +53,11 @@ public abstract class AmbiguousVariantSelectionException extends ArtifactSelecti
         @Override
         public String describeRequestTarget() {
             return "empty target";
+        }
+
+        @Override
+        public ResolutionFailureProblemId getProblemId() {
+            return ResolutionFailureProblemId.UNKNOWN_RESOLUTION_FAILURE;
         }
     };
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/ResolutionFailureHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/ResolutionFailureHandler.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.artifacts.transform.TransformedVariant;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.catalog.problems.ResolutionFailureProblemId;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.api.problems.internal.Problem;
@@ -236,7 +237,8 @@ public class ResolutionFailureHandler {
 
     private AbstractResolutionFailureException reportExceptionAsProblem(AbstractResolutionFailureException exception) {
         Problem problem = problemsService.getInternalReporter().create(builder -> {
-            builder.id(TextUtil.screamingSnakeToKebabCase(exception.getFailure().getProblemId().name()), "variant resolution error", GradleCoreProblemGroup.variantResolution())
+            ResolutionFailureProblemId problemId = exception.getFailure().getProblemId();
+            builder.id(TextUtil.screamingSnakeToKebabCase(problemId.name()), problemId.getDisplayName(), GradleCoreProblemGroup.variantResolution())
                 .contextualLabel(exception.getMessage())
                 .documentedAt(userManual("variant_model", "sec:variant-select-errors"))
                 .severity(ERROR);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/ResolutionFailureHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/ResolutionFailureHandler.java
@@ -24,6 +24,9 @@ import org.gradle.api.internal.artifacts.transform.TransformedVariant;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.problems.internal.GradleCoreProblemGroup;
+import org.gradle.api.problems.internal.InternalProblems;
+import org.gradle.api.problems.internal.Problem;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.model.AttributeMatcher;
 import org.gradle.internal.component.model.ComponentGraphResolveMetadata;
@@ -48,12 +51,16 @@ import org.gradle.internal.component.resolution.failure.type.NoVariantsWithMatch
 import org.gradle.internal.component.resolution.failure.type.ConfigurationDoesNotExistFailure;
 import org.gradle.internal.component.resolution.failure.type.UnknownArtifactSelectionFailure;
 import org.gradle.internal.component.resolution.failure.type.AmbiguousVariantsFailure;
+import org.gradle.util.internal.TextUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+
+import static org.gradle.api.problems.Severity.ERROR;
+import static org.gradle.internal.deprecation.Documentation.userManual;
 
 /**
  * Provides a central location for handling failures encountered during
@@ -78,9 +85,11 @@ public class ResolutionFailureHandler {
     public static final String DEFAULT_MESSAGE_PREFIX = "Review the variant matching algorithm at ";
 
     private final ResolutionFailureDescriberRegistry defaultFailureDescribers;
+    private final InternalProblems problemsService;
 
-    public ResolutionFailureHandler(ResolutionFailureDescriberRegistry failureDescriberRegistry) {
+    public ResolutionFailureHandler(ResolutionFailureDescriberRegistry failureDescriberRegistry, InternalProblems problemsService) {
         this.defaultFailureDescribers = failureDescriberRegistry;
+        this.problemsService = problemsService;
     }
 
     // region Stage 1 - ComponentSelectionFailures
@@ -101,7 +110,6 @@ public class ResolutionFailureHandler {
         ConfigurationNotCompatibleFailure failure = new ConfigurationNotCompatibleFailure(targetComponent.getId(), targetConfiguration.getName(), requestedAttributes, assessedCandidates);
         return describeFailure(schema, failure);
     }
-
     public AbstractResolutionFailureException configurationDoesNotExistFailure(ComponentGraphResolveState targetComponent, String targetConfigurationName) {
         ConfigurationDoesNotExistFailure failure = new ConfigurationDoesNotExistFailure(targetComponent.getId(), targetConfigurationName);
         return describeFailure(failure);
@@ -222,6 +230,19 @@ public class ResolutionFailureHandler {
             .filter(describer -> describer.canDescribeFailure(failure))
             .findFirst()
             .map(describer -> describer.describeFailure(failure, schema))
+            .map(this::reportExceptionAsProblem)
             .orElseThrow(() -> new IllegalStateException("No describer found for failure: " + failure)); // TODO: a default describer at the end of the list that catches everything instead?
+    }
+
+    private AbstractResolutionFailureException reportExceptionAsProblem(AbstractResolutionFailureException exception) {
+        Problem problem = problemsService.getInternalReporter().create(builder -> {
+            builder.id(TextUtil.screamingSnakeToKebabCase(exception.getFailure().getProblemId().name()), "variant resolution error", GradleCoreProblemGroup.variantResolution())
+                .contextualLabel(exception.getMessage())
+                .documentedAt(userManual("variant_model", "sec:variant-select-errors"))
+                .severity(ERROR);
+        });
+        problemsService.getInternalReporter().report(problem);
+
+        return exception;
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ConfigurationDoesNotExistFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ConfigurationDoesNotExistFailureDescriber.java
@@ -39,7 +39,7 @@ public abstract class ConfigurationDoesNotExistFailureDescriber extends Abstract
         if (isLocalComponent) {
             ProjectComponentIdentifierInternal id = (ProjectComponentIdentifierInternal) failure.getTargetComponent();
             Path outgoingVariantsPath = id.getIdentityPath().append(Path.path("outgoingVariants"));
-            resolutions.add("To determine which configurations are available in the target " + failure.getTargetComponent().getDisplayName() + " run " + outgoingVariantsPath.getPath() + ".");
+            resolutions.add("To determine which configurations are available in the target " + failure.getTargetComponent().getDisplayName() + ", run " + outgoingVariantsPath.getPath() + ".");
         }
 
         resolutions.addAll(buildResolutions(suggestReviewAlgorithm()));

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ConfigurationDoesNotExistFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ConfigurationDoesNotExistFailureDescriber.java
@@ -39,7 +39,7 @@ public abstract class ConfigurationDoesNotExistFailureDescriber extends Abstract
         if (isLocalComponent) {
             ProjectComponentIdentifierInternal id = (ProjectComponentIdentifierInternal) failure.getTargetComponent();
             Path outgoingVariantsPath = id.getIdentityPath().append(Path.path("outgoingVariants"));
-            resolutions.add("To determine which configurations are available in the target project, run " + outgoingVariantsPath.getPath());
+            resolutions.add("To determine which configurations are available in the target " + failure.getTargetComponent().getDisplayName() + " run " + outgoingVariantsPath.getPath() + ".");
         }
 
         resolutions.addAll(buildResolutions(suggestReviewAlgorithm()));

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/interfaces/ResolutionFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/interfaces/ResolutionFailure.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.component.resolution.failure.interfaces;
 
+import org.gradle.api.internal.catalog.problems.ResolutionFailureProblemId;
+
 /**
  * Represents any failure that can occur during variant selection and
  * contains contextual information specific to that type of failure.
@@ -38,4 +40,12 @@ public interface ResolutionFailure {
      * {@link org.gradle.internal.component.resolution.failure.interfaces}
      */
     String describeRequestTarget();
+
+    /**
+     * Returns the problem id associated with this failure, for use in identifying the failure and
+     * reporting it to the Problems API.
+     *
+     * @return the problem id
+     */
+    ResolutionFailureProblemId getProblemId();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AbstractArtifactSelectionFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AbstractArtifactSelectionFailure.java
@@ -19,18 +19,20 @@ package org.gradle.internal.component.resolution.failure.type;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.catalog.problems.ResolutionFailureProblemId;
 import org.gradle.internal.component.resolution.failure.interfaces.ArtifactSelectionFailure;
 
 /**
  * An abstract {@link ArtifactSelectionFailure} that represents the situation when an artifact is requested
  * for a variant and this request fails.
  */
-public abstract class AbstractArtifactSelectionFailure implements ArtifactSelectionFailure {
+public abstract class AbstractArtifactSelectionFailure extends AbstractResolutionFailure implements ArtifactSelectionFailure {
     private final ComponentIdentifier targetComponent;
     private final String targetVariant;
     private final ImmutableAttributes requestedAttributes;
 
-    public AbstractArtifactSelectionFailure(ComponentIdentifier targetComponent, String targetVariant, AttributeContainerInternal requestedAttributes) {
+    public AbstractArtifactSelectionFailure(ResolutionFailureProblemId problemId, ComponentIdentifier targetComponent, String targetVariant, AttributeContainerInternal requestedAttributes) {
+        super(problemId);
         this.targetComponent = targetComponent;
         this.targetVariant = targetVariant;
         this.requestedAttributes = requestedAttributes.asImmutable();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AbstractResolutionFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AbstractResolutionFailure.java
@@ -16,18 +16,22 @@
 
 package org.gradle.internal.component.resolution.failure.type;
 
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.catalog.problems.ResolutionFailureProblemId;
-import org.gradle.internal.component.resolution.failure.interfaces.VariantSelectionByNameFailure;
+import org.gradle.internal.component.resolution.failure.interfaces.ResolutionFailure;
 
 /**
- * A {@link VariantSelectionByNameFailure} that represents the situation when the explicitly selected configuration
- * is not consumable.
- *
- * This is exclusive to project dependencies when a configuration is requested by name.
+ * An abstract {@link ResolutionFailure} that represents a resolution failure and can provide
+ * a {@link ResolutionFailureProblemId} identifying the problem to the Problems API.
  */
-public final class ConfigurationNotConsumableFailure extends AbstractVariantSelectionByNameFailure {
-    public ConfigurationNotConsumableFailure(ComponentIdentifier targetComponent, String requestedConfigurationName) {
-        super(ResolutionFailureProblemId.CONFIGURATION_NOT_CONSUMABLE, targetComponent, requestedConfigurationName);
+public abstract class AbstractResolutionFailure implements ResolutionFailure {
+    private final ResolutionFailureProblemId problemId;
+
+    public AbstractResolutionFailure(ResolutionFailureProblemId problemId) {
+        this.problemId = problemId;
+    }
+
+    @Override
+    public ResolutionFailureProblemId getProblemId() {
+        return problemId;
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AbstractVariantSelectionByAttributesFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AbstractVariantSelectionByAttributesFailure.java
@@ -19,6 +19,7 @@ package org.gradle.internal.component.resolution.failure.type;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.catalog.problems.ResolutionFailureProblemId;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.resolution.failure.interfaces.VariantSelectionByAttributesFailure;
 
@@ -26,12 +27,13 @@ import org.gradle.internal.component.resolution.failure.interfaces.VariantSelect
  * An abstract {@link VariantSelectionByAttributesFailure} that represents the situation when a variant
  * was requested via variant-aware matching and that matching failed.
  */
-public abstract class AbstractVariantSelectionByAttributesFailure implements VariantSelectionByAttributesFailure {
+public abstract class AbstractVariantSelectionByAttributesFailure extends AbstractResolutionFailure implements VariantSelectionByAttributesFailure {
     private final ComponentIdentifier targetComponent;
     private final ImmutableAttributes requestedAttributes;
     private final ImmutableCapabilities requestedCapabilities;
 
-    public AbstractVariantSelectionByAttributesFailure(ComponentIdentifier targetComponent, AttributeContainerInternal requestedAttributes, ImmutableCapabilities requestedCapabilities) {
+    public AbstractVariantSelectionByAttributesFailure(ResolutionFailureProblemId problemId, ComponentIdentifier targetComponent, AttributeContainerInternal requestedAttributes, ImmutableCapabilities requestedCapabilities) {
+        super(problemId);
         this.targetComponent = targetComponent;
         this.requestedAttributes = requestedAttributes.asImmutable();
         this.requestedCapabilities = requestedCapabilities;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AbstractVariantSelectionByNameFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AbstractVariantSelectionByNameFailure.java
@@ -17,17 +17,19 @@
 package org.gradle.internal.component.resolution.failure.type;
 
 import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.internal.catalog.problems.ResolutionFailureProblemId;
 import org.gradle.internal.component.resolution.failure.interfaces.VariantSelectionByNameFailure;
 
 /**
  * An abstract {@link VariantSelectionByNameFailure} that represents the situation when a variant is requested
  * via a configuration name and this request fails.
  */
-public abstract class AbstractVariantSelectionByNameFailure implements VariantSelectionByNameFailure {
+public abstract class AbstractVariantSelectionByNameFailure extends AbstractResolutionFailure implements VariantSelectionByNameFailure {
     private final ComponentIdentifier targetComponent;
     private final String requestedConfigurationName;
 
-    public AbstractVariantSelectionByNameFailure(ComponentIdentifier targetComponent, String requestedConfigurationName) {
+    public AbstractVariantSelectionByNameFailure(ResolutionFailureProblemId problemId, ComponentIdentifier targetComponent, String requestedConfigurationName) {
+        super(problemId);
         this.targetComponent = targetComponent;
         this.requestedConfigurationName = requestedConfigurationName;
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AmbiguousArtifactTransformsFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AmbiguousArtifactTransformsFailure.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.transform.TransformedVariant;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.catalog.problems.ResolutionFailureProblemId;
 import org.gradle.internal.component.resolution.failure.interfaces.ArtifactSelectionFailure;
 
 import java.util.List;
@@ -32,7 +33,7 @@ public final class AmbiguousArtifactTransformsFailure extends AbstractArtifactSe
     private final ImmutableList<TransformedVariant> transformedVariants;
 
     public AmbiguousArtifactTransformsFailure(ComponentIdentifier targetComponent, String targetVariant, AttributeContainerInternal requestedAttributes, List<TransformedVariant> transformedVariants) {
-        super(targetComponent, targetVariant, requestedAttributes);
+        super(ResolutionFailureProblemId.AMBIGUOUS_ARTIFACT_TRANSFORM, targetComponent, targetVariant, requestedAttributes);
         this.transformedVariants = ImmutableList.copyOf(transformedVariants);
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AmbiguousArtifactsFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AmbiguousArtifactsFailure.java
@@ -19,6 +19,7 @@ package org.gradle.internal.component.resolution.failure.type;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.catalog.problems.ResolutionFailureProblemId;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 
 import java.util.List;
@@ -31,7 +32,7 @@ public final class AmbiguousArtifactsFailure extends AbstractArtifactSelectionFa
     private final ImmutableList<ResolutionCandidateAssessor.AssessedCandidate> candidates;
 
     public AmbiguousArtifactsFailure(ComponentIdentifier targetComponent, String targetVariant, AttributeContainerInternal requestedAttributes, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
-        super(targetComponent, targetVariant, requestedAttributes);
+        super(ResolutionFailureProblemId.AMBIGUOUS_ARTIFACTS, targetComponent, targetVariant, requestedAttributes);
         this.candidates = ImmutableList.copyOf(candidates);
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AmbiguousVariantsFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AmbiguousVariantsFailure.java
@@ -19,6 +19,7 @@ package org.gradle.internal.component.resolution.failure.type;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.catalog.problems.ResolutionFailureProblemId;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 import org.gradle.internal.component.resolution.failure.interfaces.VariantSelectionByAttributesFailure;
@@ -33,7 +34,7 @@ public final class AmbiguousVariantsFailure extends AbstractVariantSelectionByAt
     private final ImmutableList<ResolutionCandidateAssessor.AssessedCandidate> candidates;
 
     public AmbiguousVariantsFailure(ComponentIdentifier targetComponent, AttributeContainerInternal requestedAttributes, ImmutableCapabilities requestedCapabilities, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
-        super(targetComponent, requestedAttributes, requestedCapabilities);
+        super(ResolutionFailureProblemId.AMBIGUOUS_VARIANTS, targetComponent, requestedAttributes, requestedCapabilities);
         this.candidates = ImmutableList.copyOf(candidates);
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/ConfigurationDoesNotExistFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/ConfigurationDoesNotExistFailure.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.resolution.failure.type;
 
 import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.internal.catalog.problems.ResolutionFailureProblemId;
 import org.gradle.internal.component.resolution.failure.interfaces.VariantSelectionByNameFailure;
 
 /**
@@ -25,6 +26,6 @@ import org.gradle.internal.component.resolution.failure.interfaces.VariantSelect
  */
 public final class ConfigurationDoesNotExistFailure extends AbstractVariantSelectionByNameFailure {
     public ConfigurationDoesNotExistFailure(ComponentIdentifier targetComponent, String requestedConfigurationName) {
-        super(targetComponent, requestedConfigurationName);
+        super(ResolutionFailureProblemId.CONFIGURATION_DOES_NOT_EXIST, targetComponent, requestedConfigurationName);
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/ConfigurationNotCompatibleFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/ConfigurationNotCompatibleFailure.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.catalog.problems.ResolutionFailureProblemId;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 import org.gradle.internal.component.resolution.failure.interfaces.VariantSelectionByNameFailure;
 
@@ -34,7 +35,7 @@ public final class ConfigurationNotCompatibleFailure extends AbstractVariantSele
     private final ImmutableList<ResolutionCandidateAssessor.AssessedCandidate> candidates;
 
     public ConfigurationNotCompatibleFailure(ComponentIdentifier targetComponent, String requestedConfigurationName, AttributeContainerInternal requestedAttributes, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
-        super(targetComponent, requestedConfigurationName);
+        super(ResolutionFailureProblemId.CONFIGURATION_NOT_COMPATIBLE, targetComponent, requestedConfigurationName);
         this.requestedAttributes = requestedAttributes.asImmutable();
         this.candidates = ImmutableList.copyOf(candidates);
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/IncompatibleMultipleNodesValidationFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/IncompatibleMultipleNodesValidationFailure.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.internal.component.model.ComponentGraphResolveMetadata;
 import org.gradle.internal.component.model.VariantGraphResolveMetadata;
+import org.gradle.api.internal.catalog.problems.ResolutionFailureProblemId;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor.AssessedCandidate;
 import org.gradle.internal.component.resolution.failure.interfaces.GraphNodesValidationFailure;
 
@@ -30,12 +31,13 @@ import java.util.Set;
  * A {@link GraphNodesValidationFailure} that represents the situation when multiple incompatible variants of a single component
  * are selected during a request.
  */
-public final class IncompatibleMultipleNodesValidationFailure implements GraphNodesValidationFailure {
+public final class IncompatibleMultipleNodesValidationFailure extends AbstractResolutionFailure implements GraphNodesValidationFailure {
     private final ComponentGraphResolveMetadata selectedComponent;
     private final Set<VariantGraphResolveMetadata> incompatibleNodes;
     private final ImmutableList<AssessedCandidate> assessedCandidates;
 
     public IncompatibleMultipleNodesValidationFailure(ComponentGraphResolveMetadata selectedComponent, Set<VariantGraphResolveMetadata> incompatibleNodes, List<AssessedCandidate> assessedCandidates) {
+        super(ResolutionFailureProblemId.INCOMPATIBLE_MULTIPLE_NODES);
         this.selectedComponent = selectedComponent;
         this.incompatibleNodes = ImmutableSet.copyOf(incompatibleNodes);
         this.assessedCandidates = ImmutableList.copyOf(assessedCandidates);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/NoCompatibleArtifactFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/NoCompatibleArtifactFailure.java
@@ -18,8 +18,8 @@ package org.gradle.internal.component.resolution.failure.type;
 
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.catalog.problems.ResolutionFailureProblemId;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
-import org.gradle.internal.component.resolution.failure.interfaces.ArtifactSelectionFailure;
 
 import java.util.List;
 
@@ -31,7 +31,7 @@ public final class NoCompatibleArtifactFailure extends AbstractArtifactSelection
     private final List<ResolutionCandidateAssessor.AssessedCandidate> candidates;
 
     public NoCompatibleArtifactFailure(ComponentIdentifier targetComponent, String targetVariant, AttributeContainerInternal requestedAttributes, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
-        super(targetComponent, targetVariant, requestedAttributes);
+        super(ResolutionFailureProblemId.NO_COMPATIBLE_ARTIFACT, targetComponent, targetVariant, requestedAttributes);
         this.candidates = candidates;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/NoCompatibleVariantsFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/NoCompatibleVariantsFailure.java
@@ -19,6 +19,7 @@ package org.gradle.internal.component.resolution.failure.type;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.catalog.problems.ResolutionFailureProblemId;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 import org.gradle.internal.component.resolution.failure.interfaces.VariantSelectionByAttributesFailure;
@@ -33,7 +34,7 @@ public final class NoCompatibleVariantsFailure extends AbstractVariantSelectionB
     private final ImmutableList<ResolutionCandidateAssessor.AssessedCandidate> candidates;
 
     public NoCompatibleVariantsFailure(ComponentIdentifier targetComponent, AttributeContainerInternal requestedAttributes, ImmutableCapabilities requestedCapabilities, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
-        super(targetComponent, requestedAttributes, requestedCapabilities);
+        super(ResolutionFailureProblemId.NO_COMPATIBLE_VARIANTS, targetComponent, requestedAttributes, requestedCapabilities);
         this.candidates = ImmutableList.copyOf(candidates);
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/NoVariantsWithMatchingCapabilitiesFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/NoVariantsWithMatchingCapabilitiesFailure.java
@@ -19,6 +19,7 @@ package org.gradle.internal.component.resolution.failure.type;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.catalog.problems.ResolutionFailureProblemId;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor.AssessedCandidate;
@@ -34,7 +35,7 @@ public final class NoVariantsWithMatchingCapabilitiesFailure extends AbstractVar
     private final ImmutableList<AssessedCandidate> candidates;
 
     public NoVariantsWithMatchingCapabilitiesFailure(ComponentIdentifier targetComponent, AttributeContainerInternal requestedAttributes, ImmutableCapabilities requestedCapabilities, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
-        super(targetComponent, requestedAttributes, requestedCapabilities);
+        super(ResolutionFailureProblemId.NO_VARIANTS_WITH_MATCHING_CAPABILITIES, targetComponent, requestedAttributes, requestedCapabilities);
         this.candidates = ImmutableList.copyOf(candidates);
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/UnknownArtifactSelectionFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/UnknownArtifactSelectionFailure.java
@@ -18,6 +18,7 @@ package org.gradle.internal.component.resolution.failure.type;
 
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.catalog.problems.ResolutionFailureProblemId;
 import org.gradle.internal.component.resolution.failure.interfaces.ArtifactSelectionFailure;
 
 /**
@@ -27,7 +28,7 @@ public final class UnknownArtifactSelectionFailure extends AbstractArtifactSelec
     private final Exception cause;
 
     public UnknownArtifactSelectionFailure(ComponentIdentifier targetComponent, String targetVariant, AttributeContainerInternal requestedAttributes, Exception cause) {
-        super(targetComponent, targetVariant, requestedAttributes);
+        super(ResolutionFailureProblemId.UNKNOWN_ARTIFACT_SELECTION_FAILURE, targetComponent, targetVariant, requestedAttributes);
         this.cause = cause;
     }
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -48,6 +48,7 @@ import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact
 import org.gradle.api.internal.attributes.AttributeDesugaring
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.api.problems.internal.InternalProblems
 import org.gradle.api.specs.Spec
 import org.gradle.internal.Describables
 import org.gradle.internal.component.ResolutionFailureHandler
@@ -132,7 +133,7 @@ class DependencyGraphBuilderTest extends Specification {
     )
 
     def failureDescriberRegistry = DependencyManagementTestUtil.standardResolutionFailureDescriberRegistry()
-    def variantSelector = new GraphVariantSelector(new ResolutionFailureHandler(failureDescriberRegistry))
+    def variantSelector = new GraphVariantSelector(new ResolutionFailureHandler(failureDescriberRegistry, Stub(InternalProblems)))
 
     DependencyGraphBuilder builder = new DependencyGraphBuilder(
         moduleExclusions,

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradlePomM
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.notations.ComponentIdentifierParserFactory
 import org.gradle.api.internal.notations.DependencyMetadataNotationParser
+import org.gradle.api.problems.internal.InternalProblems
 import org.gradle.internal.component.ResolutionFailureHandler
 import org.gradle.internal.component.external.descriptor.Configuration
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
@@ -161,7 +162,7 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
         def consumer = new LocalComponentDependencyMetadata(componentSelector, null, [] as List, [], false, false, true, false, false, null)
         def state = DependencyManagementTestUtil.modelGraphResolveFactory().stateFor(immutable)
         def failureDescriberRegistry = DependencyManagementTestUtil.standardResolutionFailureDescriberRegistry()
-        def variantSelector = new GraphVariantSelector(new ResolutionFailureHandler(failureDescriberRegistry))
+        def variantSelector = new GraphVariantSelector(new ResolutionFailureHandler(failureDescriberRegistry, Stub(InternalProblems)))
 
         def variant = consumer.selectVariants(variantSelector, attributes, state, schema, [] as Set).variants[0]
         variant.metadata.dependencies

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelectorSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelectorSpec.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Resol
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariantSet
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.api.problems.internal.InternalProblems
 import org.gradle.internal.Describables
 
 import org.gradle.internal.component.ResolutionFailureHandler
@@ -60,7 +61,7 @@ class AttributeMatchingArtifactVariantSelectorSpec extends Specification {
 
     def factory = Mock(ArtifactVariantSelector.ResolvedArtifactTransformer)
     def failureDescriberRegistry = DependencyManagementTestUtil.standardResolutionFailureDescriberRegistry()
-    def failureProcessor = new ResolutionFailureHandler(failureDescriberRegistry)
+    def failureProcessor = new ResolutionFailureHandler(failureDescriberRegistry, Stub(InternalProblems))
 
     def 'direct match on variant means no finder interaction'() {
         given:

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactVariantSelectorFactoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactVariantSelectorFactoryTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.DefaultMutableAttributeContainer
 import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.api.problems.internal.InternalProblems
 import org.gradle.internal.Describables
 
 import org.gradle.internal.component.ResolutionFailureHandler
@@ -50,7 +51,7 @@ class DefaultArtifactVariantSelectorFactoryTest extends Specification {
     def dependenciesResolverFactory = Stub(TransformUpstreamDependenciesResolverFactory)
     def transformedVariantFactory = Mock(TransformedVariantFactory)
     def failureDescriberRegistry = DependencyManagementTestUtil.standardResolutionFailureDescriberRegistry()
-    def variantSelectionFailureProcessor = new ResolutionFailureHandler(failureDescriberRegistry)
+    def variantSelectionFailureProcessor = new ResolutionFailureHandler(failureDescriberRegistry, Stub(InternalProblems))
     def variantSelectorFactory = new DefaultVariantSelectorFactory(matchingCache, consumerSchema, AttributeTestUtil.attributesFactory(), transformedVariantFactory, variantSelectionFailureProcessor)
 
     def "selects producer variant with requested attributes"() {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependencyM
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.notations.DependencyMetadataNotationParser
+import org.gradle.api.problems.internal.InternalProblems
 import org.gradle.internal.component.ResolutionFailureHandler
 import org.gradle.internal.component.external.descriptor.MavenScope
 import org.gradle.internal.component.external.model.ivy.IvyDependencyDescriptor
@@ -289,7 +290,7 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
         def consumer = new LocalComponentDependencyMetadata(componentSelector, null, [] as List, [], false, false, true, false, false, null)
         def state = DependencyManagementTestUtil.modelGraphResolveFactory().stateFor(immutable)
         def failureDescriberRegistry = DependencyManagementTestUtil.standardResolutionFailureDescriberRegistry()
-        def variantSelector = new GraphVariantSelector(new ResolutionFailureHandler(failureDescriberRegistry))
+        def variantSelector = new GraphVariantSelector(new ResolutionFailureHandler(failureDescriberRegistry, Stub(InternalProblems)))
 
         return consumer.selectVariants(variantSelector, attributes, state, schema, [] as Set).variants[0].metadata
     }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
@@ -32,6 +32,7 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.api.problems.internal.InternalProblems
 import org.gradle.internal.component.ResolutionFailureHandler
 import org.gradle.internal.component.external.descriptor.DefaultExclude
 import org.gradle.internal.component.external.model.ImmutableCapabilities
@@ -48,7 +49,7 @@ import static org.gradle.util.internal.TextUtil.toPlatformLineSeparators
 
 class LocalComponentDependencyMetadataTest extends Specification {
     AttributesSchemaInternal attributesSchema = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
-    GraphVariantSelector variantSelector = new GraphVariantSelector(new ResolutionFailureHandler(DependencyManagementTestUtil.standardResolutionFailureDescriberRegistry()))
+    GraphVariantSelector variantSelector = new GraphVariantSelector(new ResolutionFailureHandler(DependencyManagementTestUtil.standardResolutionFailureDescriberRegistry(), Stub(InternalProblems)))
 
     ComponentIdentifier toComponentId = Stub(ComponentIdentifier) {
         getDisplayName() >> "[target]"

--- a/subprojects/core/src/main/java/org/gradle/api/internal/catalog/problems/ResolutionFailureProblemId.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/catalog/problems/ResolutionFailureProblemId.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.catalog.problems;
+
+import org.gradle.api.NonNullApi;
+
+/**
+ * Problem IDs for Variant Selection resolution failure problems.
+ *
+ * These should correspond with the <em>non-abstract failures classes</em> of the {@code ResolutionFailure} type hierarchy.
+ * in the {@code org.gradle.internal.component.resolution.failure.type} package.
+ */
+@NonNullApi
+public enum ResolutionFailureProblemId {
+    // Stage 2 failures
+    CONFIGURATION_NOT_COMPATIBLE,
+    CONFIGURATION_NOT_CONSUMABLE,
+    CONFIGURATION_DOES_NOT_EXIST,
+    AMBIGUOUS_VARIANTS,
+    NO_COMPATIBLE_VARIANTS,
+    NO_VARIANTS_WITH_MATCHING_CAPABILITIES,
+
+    // Stage 3 failures
+    AMBIGUOUS_ARTIFACT_TRANSFORM,
+    NO_COMPATIBLE_ARTIFACT,
+    AMBIGUOUS_ARTIFACTS,
+    UNKNOWN_ARTIFACT_SELECTION_FAILURE,
+
+    // Stage 4 failures
+    INCOMPATIBLE_MULTIPLE_NODES,
+
+    /**
+     * Indicates that the resolution failed for an unknown reason not enumerated above.
+     */
+    UNKNOWN_RESOLUTION_FAILURE
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/catalog/problems/ResolutionFailureProblemId.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/catalog/problems/ResolutionFailureProblemId.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.catalog.problems;
 
+import org.gradle.api.Describable;
 import org.gradle.api.NonNullApi;
 
 /**
@@ -25,26 +26,37 @@ import org.gradle.api.NonNullApi;
  * in the {@code org.gradle.internal.component.resolution.failure.type} package.
  */
 @NonNullApi
-public enum ResolutionFailureProblemId {
+public enum ResolutionFailureProblemId implements Describable {
     // Stage 2 failures
-    CONFIGURATION_NOT_COMPATIBLE,
-    CONFIGURATION_NOT_CONSUMABLE,
-    CONFIGURATION_DOES_NOT_EXIST,
-    AMBIGUOUS_VARIANTS,
-    NO_COMPATIBLE_VARIANTS,
-    NO_VARIANTS_WITH_MATCHING_CAPABILITIES,
+    CONFIGURATION_NOT_COMPATIBLE("Configuration selected by name is not compatible"),
+    CONFIGURATION_NOT_CONSUMABLE("Configuration selected by name is not consumable"),
+    CONFIGURATION_DOES_NOT_EXIST("Configuration selected by name does not exist"),
+    AMBIGUOUS_VARIANTS("Multiple variants exist that would match the request"),
+    NO_COMPATIBLE_VARIANTS("No variants exist that would match the request"),
+    NO_VARIANTS_WITH_MATCHING_CAPABILITIES("No variants exist with capabilities that would match the request"),
 
     // Stage 3 failures
-    AMBIGUOUS_ARTIFACT_TRANSFORM,
-    NO_COMPATIBLE_ARTIFACT,
-    AMBIGUOUS_ARTIFACTS,
-    UNKNOWN_ARTIFACT_SELECTION_FAILURE,
+    AMBIGUOUS_ARTIFACT_TRANSFORM("Multiple artifacts transforms exist that would satisfy the request"),
+    NO_COMPATIBLE_ARTIFACT("No artifacts exist that would match the request"),
+    AMBIGUOUS_ARTIFACTS("Multiple artifacts exist that would match the request"),
+    UNKNOWN_ARTIFACT_SELECTION_FAILURE("Unknown artifact selection failure"),
 
     // Stage 4 failures
-    INCOMPATIBLE_MULTIPLE_NODES,
+    INCOMPATIBLE_MULTIPLE_NODES("Incompatible nodes of a single component were selected"),
 
     /**
      * Indicates that the resolution failed for an unknown reason not enumerated above.
      */
-    UNKNOWN_RESOLUTION_FAILURE
+    UNKNOWN_RESOLUTION_FAILURE("Unknown resolution failure");
+
+    private final String displayName;
+
+    ResolutionFailureProblemId(String displayName) {
+        this.displayName = displayName;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
@@ -55,6 +55,9 @@ class KnownProblemIds {
         'validation:type-validation' : 'Gradle type validation',
         'validation:configuration-cache' : 'Configuration cache',
 
+        // dependency resolution failures
+        'dependency-variant-resolution' : 'Dependency variant resolution',
+
         // groups from integration tests
         'generic' : 'Generic'
     ]
@@ -124,6 +127,23 @@ class KnownProblemIds {
         'validation:type-validation:invalid-use-of-type-annotation' : 'Incorrect use of type annotation',
         'validation:type-validation:not-cacheable-without-reason' : 'Not cacheable without reason',
         'validation:configuration-cache:cannot-serialize-object-of-type-org-gradle-api-defaulttask-a-subtype-of-org-gradle-api-task-as-these-are-not-supported-with-the-configuration-cache' : 'cannot serialize object of type \'org.gradle.api.DefaultTask\', a subtype of \'org.gradle.api.Task\', as these are not supported with the configuration cache.',
+
+        // dependency resolution failures
+        'dependency-variant-resolution:configuration-not-compatible' : 'Configuration selected by name is not compatible',
+        'dependency-variant-resolution:configuration-not-consumable' : 'Configuration selected by name is not consumable',
+        'dependency-variant-resolution:configuration-does-not-exist' : 'Configuration selected by name does not exist',
+        'dependency-variant-resolution:ambiguous-variants' : 'Multiple variants exist that would match the request',
+        'dependency-variant-resolution:no-compatible-variants' : 'No variants exist that would match the request',
+        'dependency-variant-resolution:no-variants-with-matching-capabilities' : 'No variants exist with capabilities that would match the request',
+
+        'dependency-variant-resolution:ambiguous-artifact-transform' : 'Multiple artifacts transforms exist that would satisfy the request',
+        'dependency-variant-resolution:no-compatible-artifact' : 'No artifacts exist that would match the request',
+        'dependency-variant-resolution:ambiguous-artifacts' : 'Multiple artifacts exist that would match the request',
+        'dependency-variant-resolution:unknown-artifact-selection-failure' : 'Unknown artifact selection failure',
+
+        'dependency-variant-resolution:incompatible-multiple-nodes' : 'Incompatible nodes of a single component were selected',
+
+        'dependency-variant-resolution:unknown-resolution-failure' : 'Unknown resolution failure',
 
         // integration test problems
         'deprecation:some-indirect-deprecation' : 'Some indirect deprecation has been deprecated.',


### PR DESCRIPTION
Replaces https://github.com/gradle/gradle/pull/29520 to incorporate the changes from https://github.com/gradle/gradle/pull/29581.

Adds separate display name for each problem id.

**https://github.com/gradle/gradle/pull/29581 should be merged first**