### PR TITLE
Add context to `NoClassDefFoundError` failures during bootstrapping 

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild.launchable-jar.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.launchable-jar.gradle.kts
@@ -42,6 +42,7 @@ tasks.jar.configure {
             classpathDependency.joinToString(" ") { it.asFile.name }
         }
     }
+    manifest.attributes("Class-Path-Source" to "manifestClasspath")
     manifest.attributes("Class-Path" to classpath)
     if (app.mainClassName.isPresent) {
         manifest.attributes("Main-Class" to app.mainClassName)

--- a/platforms/core-runtime/build-process-services/src/main/java/org/gradle/launcher/bootstrap/ProcessBootstrap.java
+++ b/platforms/core-runtime/build-process-services/src/main/java/org/gradle/launcher/bootstrap/ProcessBootstrap.java
@@ -34,9 +34,9 @@ public class ProcessBootstrap {
      *
      * @param moduleName the name of the Gradle module to use for the main class implementation
      */
-    public static void run(String moduleName, String mainClassName, String[] args) {
+    public static void run(String bootstrapName, String moduleName, String mainClassName, String[] args) {
         try {
-            runNoExit(moduleName, mainClassName, args);
+            runNoExit(bootstrapName, moduleName, mainClassName, args);
             System.exit(0);
         } catch (Throwable throwable) {
             throwable.printStackTrace();
@@ -44,14 +44,23 @@ public class ProcessBootstrap {
         }
     }
 
-    private static void runNoExit(String moduleName, String mainClassName, String[] args) throws Exception {
-        DefaultModuleRegistry moduleRegistry = new DefaultModuleRegistry(CurrentGradleInstallation.get());
-        ClassPathRegistry classPathRegistry = new DefaultClassPathRegistry(new DefaultClassPathProvider(moduleRegistry));
-        ClassLoaderFactory classLoaderFactory = new DefaultClassLoaderFactory();
-        ClassPath antClasspath = classPathRegistry.getClassPath("ANT");
-        ClassPath runtimeClasspath = moduleRegistry.getModule(moduleName).getAllRequiredModulesClasspath();
-        ClassLoader antClassLoader = classLoaderFactory.createIsolatedClassLoader("ant-loader", antClasspath);
-        ClassLoader runtimeClassLoader = VisitableURLClassLoader.fromClassPath("ant-and-gradle-loader", antClassLoader, runtimeClasspath);
+    private static void runNoExit(String bootstrapName, String moduleName, String mainClassName, String[] args) throws Exception {
+        ClassLoader runtimeClassLoader;
+        ClassLoader antClassLoader;
+
+        try {
+            DefaultModuleRegistry moduleRegistry = new DefaultModuleRegistry(CurrentGradleInstallation.get());
+            ClassPathRegistry classPathRegistry = new DefaultClassPathRegistry(new DefaultClassPathProvider(moduleRegistry));
+            ClassLoaderFactory classLoaderFactory = new DefaultClassLoaderFactory();
+            ClassPath antClasspath = classPathRegistry.getClassPath("ANT");
+            ClassPath runtimeClasspath = moduleRegistry.getModule(moduleName).getAllRequiredModulesClasspath();
+            antClassLoader = classLoaderFactory.createIsolatedClassLoader("ant-loader", antClasspath);
+            runtimeClassLoader = VisitableURLClassLoader.fromClassPath("ant-and-gradle-loader", antClassLoader, runtimeClasspath);
+        } catch (NoClassDefFoundError e) {
+            throw new RuntimeException(
+                "Failed to bootstrap Gradle. Check MANIFEST.MF 'Class-Path' of the entry-point " +
+                    "'" + bootstrapName + "' and ensure there are no missing dependencies for the manifest classpath", e);
+        }
 
         ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(runtimeClassLoader);

--- a/platforms/core-runtime/daemon-main/src/main/java/org/gradle/launcher/daemon/bootstrap/GradleDaemon.java
+++ b/platforms/core-runtime/daemon-main/src/main/java/org/gradle/launcher/daemon/bootstrap/GradleDaemon.java
@@ -19,6 +19,6 @@ import org.gradle.launcher.bootstrap.ProcessBootstrap;
 
 public class GradleDaemon {
     public static void main(String[] args) {
-        ProcessBootstrap.run("gradle-daemon-server", "org.gradle.launcher.daemon.bootstrap.DaemonMain", args);
+        ProcessBootstrap.run(GradleDaemon.class.getName(), "gradle-daemon-server", "org.gradle.launcher.daemon.bootstrap.DaemonMain", args);
     }
 }

--- a/platforms/core-runtime/gradle-cli-main/build.gradle.kts
+++ b/platforms/core-runtime/gradle-cli-main/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
     id("gradlebuild.start-scripts")
 }
 
-description = "Java 6-compatible entry point of the `gradle` command. Boostraps the implementation in :gradle-cli."
+description = "Java 6-compatible entry point of the `gradle` command. Bootstraps the implementation in :gradle-cli."
 
 gradlebuildJava.usedForStartup()
 

--- a/platforms/core-runtime/gradle-cli-main/src/main/java/org/gradle/launcher/GradleMain.java
+++ b/platforms/core-runtime/gradle-cli-main/src/main/java/org/gradle/launcher/GradleMain.java
@@ -28,6 +28,6 @@ public class GradleMain {
             System.exit(1);
         }
 
-        ProcessBootstrap.run("gradle-gradle-cli", "org.gradle.launcher.Main", args);
+        ProcessBootstrap.run(GradleMain.class.getName(), "gradle-gradle-cli", "org.gradle.launcher.Main", args);
     }
 }


### PR DESCRIPTION
When moving classes from `:base-services` or potentially other low-level modules into new modules, there might be a need to manually update classpath of Gradle's bootstrapping entry points by adding new modules to the `Class-Path` of the `MANIFEST.MF` file. This is normally done via the `manifestClasspath` configuration.

When new modules are created without updating the classpath, this might lead to obscure `NoClassDefFoundError` failures. This PR adds hints on what to do if that happens.

Currently, there are two modules that correspond to the entry points and need their manifest classpath updated:
- `:gradle-cli-main`
- `:daemon-main`