### PR TITLE
Refine CC codecs with respect to service registries

### DIFF
--- a/platforms/core-configuration/core-serialization-codecs/build.gradle.kts
+++ b/platforms/core-configuration/core-serialization-codecs/build.gradle.kts
@@ -49,7 +49,6 @@ dependencies {
     implementation(projects.publish)
     implementation(projects.serialization)
     implementation(projects.serviceLookup)
-    implementation(projects.serviceRegistryImpl)
     implementation(projects.stdlibKotlinExtensions)
 
     implementation(libs.asm)

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/UnsupportedTypesCodecs.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/UnsupportedTypesCodecs.kt
@@ -56,19 +56,19 @@ import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskDependency
-import org.gradle.internal.serialize.graph.unsupported
 import org.gradle.internal.configuration.problems.DocumentationSection
 import org.gradle.internal.event.AbstractBroadcastDispatch
 import org.gradle.internal.event.ListenerBroadcast
 import org.gradle.internal.flow.services.BuildWorkResultProvider
 import org.gradle.internal.scripts.GradleScript
-import org.gradle.internal.serialize.graph.codecs.BindingsBuilder
 import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.IsolateContext
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext
+import org.gradle.internal.serialize.graph.codecs.BindingsBuilder
 import org.gradle.internal.serialize.graph.logUnsupported
-import org.gradle.internal.service.DefaultServiceRegistry
+import org.gradle.internal.serialize.graph.unsupported
+import org.gradle.internal.service.ServiceRegistry
 import java.io.FileDescriptor
 import java.io.RandomAccessFile
 import java.net.ServerSocket
@@ -145,7 +145,7 @@ fun BindingsBuilder.unsupportedTypes() {
     bind(unsupported<BuildService<*>>())
 
     // Gradle implementation types
-    bind(unsupported<DefaultServiceRegistry>())
+    bind(unsupported<ServiceRegistry>())
 }
 
 

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/UnsupportedTypesCodecs.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/UnsupportedTypesCodecs.kt
@@ -68,7 +68,7 @@ import org.gradle.internal.serialize.graph.WriteContext
 import org.gradle.internal.serialize.graph.codecs.BindingsBuilder
 import org.gradle.internal.serialize.graph.logUnsupported
 import org.gradle.internal.serialize.graph.unsupported
-import org.gradle.internal.service.ServiceRegistry
+import org.gradle.internal.service.ServiceLookup
 import java.io.FileDescriptor
 import java.io.RandomAccessFile
 import java.net.ServerSocket
@@ -145,7 +145,7 @@ fun BindingsBuilder.unsupportedTypes() {
     bind(unsupported<BuildService<*>>())
 
     // Gradle implementation types
-    bind(unsupported<ServiceRegistry>())
+    bind(unsupported<ServiceLookup>())
 }
 
 


### PR DESCRIPTION
There is nothing specific about `DefaultServiceRegistry` that only this implementation should be marked unsupported for storing with Configuration Cache.

The PR changes the unsupported type from `DefaultServiceRegistry` to a more general internal type `ServiceLookup`.