### PR TITLE
Polish internal service framework implementation visibility and docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -69,6 +69,7 @@ platforms/core-runtime/                                     @gradle/bt-core-runt
 platforms/core-runtime/build-operations/                    @gradle/bt-core-runtime-maintainers @gradle/bt-execution @gradle/bt-dv-build-cache
 platforms/core-runtime/functional/                          @gradle/bt-core-runtime-maintainers @gradle/bt-execution @bamboo
 platforms/core-runtime/files/                               @gradle/bt-core-runtime-maintainers @gradle/bt-execution @gradle/bt-dv-build-cache
+platforms/core-runtime/service-*/                           @gradle/bt-core-runtime-maintainers @alllex
 
 # Core automation platform (core/execution)
 platforms/core-execution/                                   @gradle/bt-execution

--- a/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/CloseableServiceRegistry.java
+++ b/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/CloseableServiceRegistry.java
@@ -18,8 +18,25 @@ package org.gradle.internal.service;
 
 import java.io.Closeable;
 
+/**
+ * Managed version of a {@link ServiceRegistry} that controls the lifetime of the registry members,
+ * such as service instances and factories.
+ * <p>
+ * Members created by the registry are stopped and closed when this registry is {@link #close() closed}.
+ * <p>
+ * If a member implements {@link java.io.Closeable#close() Closeable} or
+ * {@link org.gradle.internal.concurrent.Stoppable#stop() Stoppable} then the appropriate
+ * method is called to dispose of it.
+ * <p>
+ * Members are closed in reverse dependency order.
+ */
 public interface CloseableServiceRegistry extends ServiceRegistry, Closeable {
 
+    /**
+     * Closes this registry by stopping and closing all members managed by it.
+     *
+     * @see CloseableServiceRegistry
+     */
     @Override
     void close();
 }

--- a/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/CloseableServiceRegistry.java
+++ b/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/CloseableServiceRegistry.java
@@ -23,17 +23,17 @@ import java.io.Closeable;
  * such as service instances and factories.
  * <p>
  * Members created by the registry are stopped and closed when this registry is {@link #close() closed}.
- * <p>
- * If a member implements {@link java.io.Closeable#close() Closeable} or
- * {@link org.gradle.internal.concurrent.Stoppable#stop() Stoppable} then the appropriate
- * method is called to dispose of it.
- * <p>
- * Members are closed in reverse dependency order.
  */
 public interface CloseableServiceRegistry extends ServiceRegistry, Closeable {
 
     /**
      * Closes this registry by stopping and closing all members managed by it.
+     * <p>
+     * If a member implements {@link java.io.Closeable#close() Closeable} or
+     * {@link org.gradle.internal.concurrent.Stoppable#stop() Stoppable} then the appropriate
+     * method is called to dispose of it.
+     * <p>
+     * Members are closed in reverse dependency order.
      *
      * @see CloseableServiceRegistry
      */

--- a/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/ServiceRegistrationProvider.java
+++ b/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/ServiceRegistrationProvider.java
@@ -25,7 +25,7 @@ package org.gradle.internal.service;
  * The service-declaring methods are
  * <ul>
  * <li> not static and annotated with {@link Provides @Provides}
- * <li> have a name that starts with {@code create}
+ * <li> have a name that starts with {@code create} or {@code decorate}
  * <li> have zero or more parameters declaring dependencies
  * <li> have a non-void return type
  * </ul>
@@ -36,15 +36,15 @@ package org.gradle.internal.service;
  * protected SomeService createSomeService(OtherService otherServiceDependency) { ... }</code></pre>
  *
  * <p>
- * Any other methods will not be considered service declarations.
+ * Any other methods will not be ignored.
  * <p>
  * Factories are declared similarly by having the method return {@code Factory<SomeService>}.
  * The factories are used by {@link ServiceRegistry#getFactory(Class)} and {@link ServiceRegistry#newInstance(Class)} methods.
  *
  * <h3>Registering dynamically</h3>
- * You can register services dynamically using a {@link ServiceRegistration}.
+ * You can register services dynamically by declaring a {@code configure} method with a {@link ServiceRegistration} parameter.
  * <p>
- * The methods for registration are:
+ * The recognized methods are:
  * <ul>
  * <li> not static and called {@code configure}
  * <li> have one of the parameters of type {@link ServiceRegistration}
@@ -103,6 +103,22 @@ package org.gradle.internal.service;
  * When the parameter is of type {@link ServiceRegistry}, it will receive an instance of registry that owns the service.
  * See {@code ServiceRegistry ownerServiceRegistry} in the example.
  * <p>
+ *
+ * <h3>Service lookup order</h3>
+ *
+ * <b>Own services</b> of a registry are services contributed by the service providers.
+ * <p>
+ * <b>All services</b> of a registry are its own services and <em>all services</em> of all its parents.
+ * <p>
+ * The lookup order for dependencies is the following:
+ * <ol>
+ * <li> Own services of the current registry
+ * <li> All services of the first parent
+ * <li> All services of the second parent
+ * <li> ...
+ * </ol>
+ *
+ * The <em>decorator</em> declarations skip the own services, and start the lookup in the parents.
  *
  * <h3>Service lifetime</h3>
  *

--- a/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/ServiceRegistrationProvider.java
+++ b/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/ServiceRegistrationProvider.java
@@ -17,9 +17,100 @@
 package org.gradle.internal.service;
 
 /**
- * Marker interface for service registration providers.
+ * Marker interface for reflection-based service declaration and registration.
  *
- * These are types contain method annotated with {@literal @}{@link Provides} to register services.
+ * <h3>Declaring statically</h3>
+ * You can declare services and factories by adding methods to the implementation of this interface.
+ * <p>
+ * The service-declaring methods are
+ * <ul>
+ * <li> not static and annotated with {@link Provides @Provides}
+ * <li> have a name that starts with {@code create}
+ * <li> have zero or more parameters declaring dependencies
+ * <li> have a non-void return type
+ * </ul>
+ *
+ * For example:
+ * <pre><code class="language-java">
+ * &#64;Provides
+ * protected SomeService createSomeService(OtherService otherServiceDependency) { ... }</code></pre>
+ *
+ * <p>
+ * Any other methods will not be considered service declarations.
+ * <p>
+ * Factories are declared similarly by having the method return {@code Factory<SomeService>}.
+ * The factories are used by {@link ServiceRegistry#getFactory(Class)} and {@link ServiceRegistry#newInstance(Class)} methods.
+ *
+ * <h3>Registering dynamically</h3>
+ * You can register services dynamically using a {@link ServiceRegistration}.
+ * <p>
+ * The methods for registration are:
+ * <ul>
+ * <li> not static and called {@code configure}
+ * <li> have one of the parameters of type {@link ServiceRegistration}
+ * <li> have zero or more parameters declaring dependencies
+ * <li> have a void return type
+ * </ul>
+ *
+ * For example:
+ * <pre><code class="language-java">
+ * protected void configure(ServiceRegistration registration) { ... }</code></pre>
+ *
+ * <p>
+ * The {@code configure} methods can be injected with additional parameters the same way as service-declaring methods.
+ *
+ * <h3>Dependency injection</h3>
+ *
+ * Both service-declaring methods and {@code configure} methods can have parameters
+ * that describe their dependencies.
+ * <p>
+ * On top of the basic case of injecting dependencies, more advanced use-cases are also supported:
+ * decoration, aggregation, owner registry injection.
+ * <p>
+ * <pre><code class="language-java">
+ * &#64;Provides
+ * protected MyService createMyService(
+ *     SomeService someService,
+ *     MyService myServiceFromParent,
+ *     List&lt;OtherService&gt; otherServices,
+ *     ServiceRegistry ownerServiceRegistry
+ * ) { ... }</code></pre>
+ * <p>
+ *
+ * <b>Basic dependency.</b>
+ * As long as the other service is available in the same or one of the parent registries,
+ * it will be injected into the parameter. See {@code SomeService someService} in the example.
+ * <p>
+ * If the service is available in a service registry, the parent registries are not checked.
+ * This can also be used to <b>override</b> services in child registries by providing a service of the same type.
+ * <p>
+ *
+ * <b>Decoration.</b>
+ * If {@code MyService} is available in a parent registry, then it can be decorated in child registries.
+ * When the parameter has the same type as the service type (return-type),
+ * the parameter is injected with an instance of the service from a parent registry.
+ * See {@code MyService myServiceFromParent} in the example.
+ * <p>
+ *
+ * <b>Aggregation.</b>
+ * When the parameter is of type {@code List<T>}, it will receive with all services of type {@code T}
+ * from the current and all parent registries.
+ * If there are no services of this type, the list will be <em>empty</em>.
+ * See <code>List&lt;OtherService&gt; otherServices</code> in the example.
+ * <p>
+ *
+ * <b>Owner dependency.</b>
+ * When the parameter is of type {@link ServiceRegistry}, it will receive an instance of registry that owns the service.
+ * See {@code ServiceRegistry ownerServiceRegistry} in the example.
+ * <p>
+ *
+ * <h3>Service lifetime</h3>
+ *
+ * Services are created lazily and might not be instantiated at all during the lifetime of the owning service registry.
+ * <p>
+ * If a service instance was created and the service implements {@link java.io.Closeable#close() Closeable} or
+ * {@link org.gradle.internal.concurrent.Stoppable#stop() Stoppable} then the appropriate
+ * method is called to dispose of it when the owning service registry is {@link CloseableServiceRegistry#close() closed}.
  */
 public interface ServiceRegistrationProvider {
 }

--- a/platforms/core-runtime/service-registry-builder/src/main/java/org/gradle/internal/service/ServiceRegistryBuilder.java
+++ b/platforms/core-runtime/service-registry-builder/src/main/java/org/gradle/internal/service/ServiceRegistryBuilder.java
@@ -21,7 +21,13 @@ import org.gradle.internal.service.scopes.Scope;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * A builder for a {@link ServiceRegistry}.
+ *
+ * @see ServiceRegistryBuilder#builder()
+ */
 public class ServiceRegistryBuilder {
+
     private final List<ServiceRegistry> parents = new ArrayList<ServiceRegistry>();
     private final List<ServiceRegistrationProvider> providers = new ArrayList<ServiceRegistrationProvider>();
     private String displayName;
@@ -31,25 +37,62 @@ public class ServiceRegistryBuilder {
     private ServiceRegistryBuilder() {
     }
 
+    /**
+     * Creates a new builder.
+     */
     public static ServiceRegistryBuilder builder() {
         return new ServiceRegistryBuilder();
     }
 
+    /**
+     * Sets the display name to be used by the service registry.
+     * <p>
+     * The display name is used for debugging and in the errors messages.
+     * The errors are not user-facing and oriented at troubleshooting.
+     * For instance, errors when services fail validation at registration time,
+     * or when their dependencies are missing at instantiation time.
+     */
     public ServiceRegistryBuilder displayName(String displayName) {
         this.displayName = displayName;
         return this;
     }
 
+    /**
+     * Adds a parent for the service registry.
+     * <p>
+     * Parent registries are used to lookup services not found in the current registry.
+     * <p>
+     * There can be more than one parent.
+     */
     public ServiceRegistryBuilder parent(ServiceRegistry parent) {
         this.parents.add(parent);
         return this;
     }
 
+    /**
+     * Adds a service provider for the service registry.
+     * <p>
+     * Providers are examined for service declarations and service registration logic
+     * at the time of building the registry.
+     * <p>
+     * There can be more than one service provider.
+     *
+     * @see ServiceRegistrationProvider
+     */
     public ServiceRegistryBuilder provider(ServiceRegistrationProvider provider) {
         this.providers.add(provider);
         return this;
     }
 
+    /**
+     * Adds a service provider for the service registry in the form of a registration action.
+     * <p>
+     * The registration action is executed at the time of building the registry.
+     * <p>
+     * There can be more than one registration action.
+     *
+     * @see ServiceRegistrationAction
+     */
     public ServiceRegistryBuilder provider(final ServiceRegistrationAction register) {
         return provider(new ServiceRegistrationProvider() {
             @SuppressWarnings("unused")

--- a/platforms/core-runtime/service-registry-builder/src/main/java/org/gradle/internal/service/ServiceRegistryBuilder.java
+++ b/platforms/core-runtime/service-registry-builder/src/main/java/org/gradle/internal/service/ServiceRegistryBuilder.java
@@ -89,6 +89,14 @@ public class ServiceRegistryBuilder {
         return this;
     }
 
+    /**
+     * Creates a service registry with the provided configuration.
+     * <p>
+     * The registry <b>should be {@link CloseableServiceRegistry#close() closed}</b> when it is no longer required
+     * to cleanly dispose of the resources potentially held by created services.
+     *
+     * @see CloseableServiceRegistry
+     */
     public CloseableServiceRegistry build() {
         ServiceRegistry[] parents = this.parents.toArray(new ServiceRegistry[0]);
 

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/RelevantMethods.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/RelevantMethods.java
@@ -26,7 +26,7 @@ import java.util.concurrent.ConcurrentMap;
 
 import static org.gradle.util.internal.ArrayUtils.contains;
 
-public class RelevantMethods {
+class RelevantMethods {
     private static final ConcurrentMap<Class<?>, RelevantMethods> METHODS_CACHE = new ConcurrentHashMap<Class<?>, RelevantMethods>();
     private static final ServiceMethodFactory SERVICE_METHOD_FACTORY = new DefaultServiceMethodFactory();
 

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ScopedServiceRegistry.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ScopedServiceRegistry.java
@@ -21,7 +21,7 @@ import org.gradle.internal.service.scopes.Scope;
 /**
  * A registry validating that all registered services are annotated with a corresponding {@link Scope}.
  */
-public class ScopedServiceRegistry extends DefaultServiceRegistry {
+class ScopedServiceRegistry extends DefaultServiceRegistry {
 
     public ScopedServiceRegistry(
         Class<? extends Scope> scope,

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceMethod.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceMethod.java
@@ -19,7 +19,7 @@ import javax.annotation.Nullable;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 
-public interface ServiceMethod {
+interface ServiceMethod {
     Class<?> getOwner();
 
     String getName();

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidator.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidator.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.service;
 
-import org.gradle.api.NonNullApi;
 import org.gradle.internal.InternalTransformer;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
@@ -39,7 +38,6 @@ import static org.gradle.util.internal.CollectionUtils.join;
  * <p>
  * Only services that are annotated with {@link ServiceScope} are validated.
  */
-@NonNullApi
 class ServiceScopeValidator implements AnnotatedServiceLifecycleHandler {
 
     private static final List<Class<? extends Annotation>> SCOPE_ANNOTATIONS = Collections.<Class<? extends Annotation>>singletonList(ServiceScope.class);

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
@@ -23,7 +23,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 @NonNullApi
-public class ServiceScopeValidatorWorkarounds {
+class ServiceScopeValidatorWorkarounds {
 
     private static final Set<String> SUPPRESSED_VALIDATION_CLASSES = new HashSet<String>(Arrays.asList(
         "com.google.common.collect.ImmutableList",

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
@@ -16,13 +16,10 @@
 
 package org.gradle.internal.service;
 
-import org.gradle.api.NonNullApi;
-
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-@NonNullApi
 class ServiceScopeValidatorWorkarounds {
 
     private static final Set<String> SUPPRESSED_VALIDATION_CLASSES = new HashSet<String>(Arrays.asList(


### PR DESCRIPTION
Updates javadocs for the [recently decoupled](https://github.com/gradle/gradle/pull/29622) Service Registry framework and reduces the visibility of its implementation classes, which are not used elsewhere.

---

In-IDE rendered version of the main javadoc addition:
<img width="1099" alt="image" src="https://github.com/gradle/gradle/assets/2759152/189c42de-4285-460e-83a6-7bec9c21eacb">

