### PR TITLE
Upgrade ErrorProne Gradle plugin to 4.0.1

### DIFF
--- a/build-logic-commons/gradle-plugin/build.gradle.kts
+++ b/build-logic-commons/gradle-plugin/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
 
     implementation(projects.basics)
     implementation(projects.moduleIdentity)
-    implementation("net.ltgt.gradle:gradle-errorprone-plugin:3.1.0")
+    implementation("net.ltgt.gradle:gradle-errorprone-plugin:4.0.1")
 
     implementation("org.gradle.kotlin.kotlin-dsl:org.gradle.kotlin.kotlin-dsl.gradle.plugin:4.4.0")
     // This Kotlin version should only be updated when updating the above kotlin-dsl version

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -1027,9 +1027,9 @@
             <sha256 value="be5805392060c71474bf6c9a67a099471274d30b83eef84bfc4e0889a4f1dcc0" origin="Verified" reason="Artifact is not signed"/>
          </artifact>
       </component>
-      <component group="net.ltgt.gradle" name="gradle-errorprone-plugin" version="3.1.0">
-         <artifact name="gradle-errorprone-plugin-3.1.0.jar">
-            <sha256 value="10fb66b55747ced1db9c89c8c3d0adb5dbd3f8f12f2a183bee2b5ff818d1fd6c" origin="Verified" reason="Artifact is not signed"/>
+      <component group="net.ltgt.gradle" name="gradle-errorprone-plugin" version="4.0.1">
+         <artifact name="gradle-errorprone-plugin-4.0.1.jar">
+            <sha256 value="4caa671392fd3675171e93c663f2642452819c68d3ef90206d7949bd8fee7d9e" origin="Verified" reason="Artifact is not signed"/>
          </artifact>
       </component>
       <component group="net.openhft" name="zero-allocation-hashing" version="0.10.1">

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,7 +31,6 @@ plugins {
     id("com.gradle.develocity").version("3.17.5") // Sync with `build-logic-commons/build-platform/build.gradle.kts`
     id("io.github.gradle.gradle-enterprise-conventions-plugin").version("0.10.1")
     id("org.gradle.toolchains.foojay-resolver-convention") version ("0.8.0")
-//    id("net.ltgt.errorprone").version("3.1.0")
 }
 
 includeBuild("build-logic-commons")

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -122,7 +122,7 @@ abstract class AbstractSmokeTest extends Specification {
         static playframework = "0.13" // Can't upgrade to 0.14 as it breaks CC compat - see https://github.com/gradle/playframework/issues/184
 
         // https://plugins.gradle.org/plugin/net.ltgt.errorprone
-        static errorProne = "3.1.0"
+        static errorProne = "4.0.1"
 
         // https://plugins.gradle.org/plugin/com.google.protobuf
         static protobufPlugin = "0.9.4"


### PR DESCRIPTION
This unblocks CompileOptions.fork property upgrade.

Relates to https://github.com/gradle/gradle/issues/25836.