### PR TITLE
Say "root project :" instead of just "project :" when describing failures involving the root project

### DIFF
--- a/platforms/documentation/docs/src/samples/writing-tasks/tasks-with-dependency-resolution-result-inputs/tests/dependencyReports.sample.conf
+++ b/platforms/documentation/docs/src/samples/writing-tasks/tasks-with-dependency-resolution-result-inputs/tests/dependencyReports.sample.conf
@@ -1,15 +1,15 @@
 commands: [{
     executable: gradle
-    args: "-q :listResolvedArtifacts"
+    args: "-q :listResolvedArtifacts --no-configuration-cache"
     expected-output-file: listResolvedArtifacts.out
 },
 {
     executable: gradle
-    args: "-q :graphResolvedComponents"
+    args: "-q :graphResolvedComponents --no-configuration-cache"
     expected-output-file: graphResolvedComponents.out
 },
 {
     executable: gradle
-    args: "-q :graphResolvedComponentsAndFiles"
+    args: "-q :graphResolvedComponentsAndFiles --no-configuration-cache"
     expected-output-file: graphResolvedComponentsAndFiles.out
 }]

--- a/platforms/documentation/docs/src/samples/writing-tasks/tasks-with-dependency-resolution-result-inputs/tests/graphResolvedComponents.out
+++ b/platforms/documentation/docs/src/samples/writing-tasks/tasks-with-dependency-resolution-result-inputs/tests/graphResolvedComponents.out
@@ -1,4 +1,4 @@
-project :
+root project :
   org.apache.commons:commons-text -> org.apache.commons:commons-text:1.9
     org.apache.commons:commons-lang3:3.11 -> org.apache.commons:commons-lang3:3.11
   project :utilities -> project :utilities

--- a/platforms/documentation/docs/src/samples/writing-tasks/tasks-with-dependency-resolution-result-inputs/tests/graphResolvedComponentsAndFiles.out
+++ b/platforms/documentation/docs/src/samples/writing-tasks/tasks-with-dependency-resolution-result-inputs/tests/graphResolvedComponentsAndFiles.out
@@ -1,4 +1,4 @@
-project :
+root project :
   org.apache.commons:commons-text -> org.apache.commons:commons-text:1.9 => commons-text-1.9.jar
     org.apache.commons:commons-lang3:3.11 -> org.apache.commons:commons-lang3:3.11 => commons-lang3-3.11.jar
   project :utilities -> project :utilities => utilities.jar

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-metadataRule/tests/failRuntimeClasspathResolve.out
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-metadataRule/tests/failRuntimeClasspathResolve.out
@@ -1,7 +1,7 @@
 > Could not resolve all files for configuration ':runtimeClasspath'.
    > Could not resolve org.lwjgl:lwjgl:3.2.3.
      Required by:
-         project :
+         root project :
       > The consumer was configured to find a library for use during runtime, compatible with Java 11, packaged as a jar, preferably optimized for standard JVMs, and its dependencies declared externally, as well as attribute 'org.gradle.native.operatingSystem' with value 'windows'. There are several available matching variants of org.lwjgl:lwjgl:3.2.3
         The only attribute distinguishing these variants is 'org.gradle.native.architecture'. Add this attribute to the consumer's configuration to resolve the ambiguity:
           - Value: 'x86-64' selects variant: 'natives-windows-runtime'

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/variants/GradlePluginWithVariantsPublicationIntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/variants/GradlePluginWithVariantsPublicationIntegrationTest.groovy
@@ -207,7 +207,7 @@ class GradlePluginWithVariantsPublicationIntegrationTest extends AbstractIntegra
         failure.assertHasErrorOutput("""> Could not resolve all artifacts for configuration ':classpath'.
    > Could not resolve com.example:producer:1.0.
      Required by:
-         project : > com.example.greeting:com.example.greeting.gradle.plugin:1.0
+         root project : > com.example.greeting:com.example.greeting.gradle.plugin:1.0
       > Plugin com.example:producer:1.0 requires at least Gradle 1000.0. This build uses Gradle $currentGradle.""")
         failure.assertHasErrorOutput("Caused by: " + VariantSelectionByAttributesException.class.getName())
         failure.assertHasResolution("Upgrade to at least Gradle 1000.0. See the instructions at https://docs.gradle.org/$currentGradle/userguide/upgrading_version_8.html#sub:updating-gradle.")

--- a/platforms/jvm/plugins-java-library/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetJvmVersionIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java-library/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetJvmVersionIntegrationTest.groovy
@@ -58,7 +58,7 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
         failure.assertHasErrorOutput("""> Could not resolve all dependencies for configuration ':compileClasspath'.
    > Could not resolve project :producer.
      Required by:
-         project :
+         root project :
       > Dependency resolution is looking for a library compatible with JVM runtime version 6, but 'project :producer' is only compatible with JVM runtime version 7 or newer.""")
         failure.assertHasResolution("Change the dependency on 'project :producer' to an earlier version that supports JVM runtime version 7.")
     }
@@ -140,7 +140,7 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
 > Could not resolve all dependencies for configuration ':compileClasspath'.
    > Could not resolve project :producer.
      Required by:
-         project :
+         root project :
       > Dependency resolution is looking for a library compatible with JVM runtime version 6, but 'project :producer' is only compatible with JVM runtime version 7 or newer.""")
         failure.assertHasResolution("Change the dependency on 'project :producer' to an earlier version that supports JVM runtime version 7.")
 

--- a/platforms/jvm/plugins-java-library/src/integTest/groovy/org/gradle/java/JavaLibraryPublishedTargetJvmVersionIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java-library/src/integTest/groovy/org/gradle/java/JavaLibraryPublishedTargetJvmVersionIntegrationTest.groovy
@@ -101,7 +101,7 @@ class JavaLibraryPublishedTargetJvmVersionIntegrationTest extends AbstractHttpDe
         failure.assertHasErrorOutput('''> Could not resolve all files for configuration ':compileClasspath'.
    > Could not resolve org:producer:1.0.
      Required by:
-         project :
+         root project :
       > Dependency resolution is looking for a library compatible with JVM runtime version 5, but 'org:producer:1.0' is only compatible with JVM runtime version 6 or newer.''')
         failure.assertHasResolution("Change the dependency on 'org:producer:1.0' to an earlier version that supports JVM runtime version 6.")
     }

--- a/platforms/jvm/plugins-jvm-test-suite/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesMultiTargetIntegrationTest.groovy
+++ b/platforms/jvm/plugins-jvm-test-suite/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesMultiTargetIntegrationTest.groovy
@@ -153,7 +153,7 @@ class TestSuitesMultiTargetIntegrationTest extends AbstractIntegrationSpec imple
         withInstallations(Jvm.current(), otherJvm).fails("testAggregateTestReport")
 
         then:
-        failure.assertThatCause(containsNormalizedString("There are several available matching variants of project :"))
+        failure.assertThatCause(containsNormalizedString("There are several available matching variants of root project :"))
         failure.assertThatCause(containsNormalizedString("The only attribute distinguishing these variants is 'org.gradle.testsuite.target.name'. Add this attribute to the consumer's configuration to resolve the ambiguity:"))
     }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/ResolutionFailureHandlerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/ResolutionFailureHandlerIntegrationTest.groovy
@@ -56,8 +56,8 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasCause("Could not resolve project :.")
-        assertFullMessageCorrect("""      > The consumer was configured to find attribute 'color' with value 'blue'. There are several available matching variants of project :
+        failure.assertHasCause("Could not resolve root project :.")
+        assertFullMessageCorrect("""      > The consumer was configured to find attribute 'color' with value 'blue'. There are several available matching variants of root project :
         The only attribute distinguishing these variants is 'shape'. Add this attribute to the consumer's configuration to resolve the ambiguity:
           - Value: 'round' selects variant: 'blueRoundElements'
           - Value: 'square' selects variant: 'blueSquareElements'
@@ -83,8 +83,8 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasCause("Could not resolve project :.")
-        assertFullMessageCorrect("""      > The consumer was configured to find attribute 'color' with value 'blue'. However we cannot choose between the following variants of project ::
+        failure.assertHasCause("Could not resolve root project :.")
+        assertFullMessageCorrect("""      > The consumer was configured to find attribute 'color' with value 'blue'. However we cannot choose between the following variants of root project ::
           - blueRoundTransparentElements
           - blueSquareOpaqueElements
           - blueSquareTransparentElements
@@ -124,7 +124,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause("Could not resolve com.squareup.okhttp3:okhttp:4.4.0.")
         assertFullMessageCorrect("""   > Could not resolve com.squareup.okhttp3:okhttp:4.4.0.
      Required by:
-         project :
+         root project :
       > The consumer was configured to find attribute 'org.gradle.category' with value 'documentation'. There are several available matching variants of com.squareup.okhttp3:okhttp:4.4.0
         The only attribute distinguishing these variants is 'org.gradle.docstype'. Add this attribute to the consumer's configuration to resolve the ambiguity:
           - Value: 'javadoc' selects variant: 'javadocElements'
@@ -149,11 +149,11 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasCause("Could not resolve project :.")
-        assertFullMessageCorrect("""   > Could not resolve project :.
+        failure.assertHasCause("Could not resolve root project :.")
+        assertFullMessageCorrect("""   > Could not resolve root project :.
      Required by:
-         project :
-      > No matching variant of project : was found. The consumer was configured to find attribute 'color' with value 'green' but:
+         root project :
+      > No matching variant of root project : was found. The consumer was configured to find attribute 'color' with value 'green' but:
           - Variant 'default':
               - Incompatible because this component declares attribute 'color' with value 'blue' and the consumer needed attribute 'color' with value 'green'""")
 
@@ -206,10 +206,10 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasCause("Could not resolve project :.")
+        failure.assertHasCause("Could not resolve root project :.")
         assertFullMessageCorrect("""     Required by:
-         project :
-      > Configuration 'mismatch' in project : does not match the consumer attributes
+         root project :
+      > Configuration 'mismatch' in root project : does not match the consumer attributes
         Configuration 'mismatch':
           - Incompatible because this component declares attribute 'color' with value 'blue' and the consumer needed attribute 'color' with value 'green'
 """)
@@ -235,7 +235,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
         failure.assertHasCause("Could not resolve project :producer.")
         assertFullMessageCorrect("""     Required by:
-         project :
+         root project :
       > No matching variant of project :producer was found. The consumer was configured to find attribute 'color' with value 'green' but:
           - No variants exist.""")
 
@@ -258,7 +258,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasCause("Could not resolve project :.")
+        failure.assertHasCause("Could not resolve root project :.")
         assertFullMessageCorrect("""Required by:
          project :
       > A dependency was declared on configuration 'absent' of 'project :' but no variant with that configuration name exists.""")
@@ -287,9 +287,9 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasCause("Could not resolve project :.")
+        failure.assertHasCause("Could not resolve root project :.")
         assertFullMessageCorrect("""     Required by:
-         project :
+         root project :
       > Multiple incompatible variants of org.example:${temporaryFolder.getTestDirectory().getName()}:1.0 were selected:
            - Variant blueElementsCapability1 has attributes {color=blue}
            - Variant greenElementsCapability2 has attributes {color=green}""")
@@ -313,7 +313,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        assertFullMessageCorrect("""   > No variants of project : match the consumer attributes:
+        assertFullMessageCorrect("""   > No variants of root project : match the consumer attributes:
        - Configuration ':myElements' declares attribute 'color' with value 'blue':
            - Incompatible because this component declares attribute 'artifactType' with value 'jar' and the consumer needed attribute 'artifactType' with value 'dll'
        - Configuration ':myElements' variant secondary declares attribute 'color' with value 'blue':
@@ -341,7 +341,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        assertFullMessageCorrect("""   > Found multiple transforms that can produce a variant of project : with requested attributes:
+        assertFullMessageCorrect("""   > Found multiple transforms that can produce a variant of root project : with requested attributes:
        - color 'red'
        - shape 'round'
      Found the following transforms:
@@ -382,7 +382,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        assertFullMessageCorrect("""   > More than one variant of project : matches the consumer attributes:
+        assertFullMessageCorrect("""   > More than one variant of root project : matches the consumer attributes:
        - Configuration ':default' variant v1
        - Configuration ':default' variant v2""")
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/ResolutionFailureHandlerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/ResolutionFailureHandlerIntegrationTest.groovy
@@ -260,11 +260,11 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
         failure.assertHasCause("Could not resolve root project :.")
         assertFullMessageCorrect("""Required by:
-         project :
-      > A dependency was declared on configuration 'absent' of 'project :' but no variant with that configuration name exists.""")
+         root project :
+      > A dependency was declared on configuration 'absent' of 'root project :' but no variant with that configuration name exists.""")
 
         and: "Helpful resolutions are provided"
-        failure.assertHasResolution("To determine which configurations are available in the target project :, run :outgoingVariants.")
+        failure.assertHasResolution("To determine which configurations are available in the target root project :, run :outgoingVariants.")
         assertSuggestsReviewingAlgorithm()
 
         and: "Problems are reported"
@@ -434,6 +434,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
     // endregion dependencyInsight failures
 
     // region error showcase
+    @SuppressWarnings('UnnecessaryQualifiedReference')
     @spock.lang.Ignore("This test is used to generate a summary of all possible errors, it shouldn't usually be run as part of testing")
     def "generate resolution failure showcase report"() {
         given:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/ResolutionFailureHandlerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/ResolutionFailureHandlerIntegrationTest.groovy
@@ -38,15 +38,19 @@ import org.gradle.util.GradleVersion
 /**
  * These tests demonstrate the behavior of the [ResolutionFailureHandler] when a project has various
  * variant selection failures.
- *
+ * <p>
  * It can also build a text report demonstrating all these errors in a single place by running
  * the [generateFailureShowcase] method, which is marked with [spock.lang.Ignore] so it doesn't
  * run as part of a typical test run.  It is useful for viewing and comparing the behavior of
  * different types of failures.
+ * <p>
+ * These tests are ordered according to the different categories of
+ * {@link org.gradle.internal.component.resolution.failure.interfaces Resolution failure}.
  */
+@SuppressWarnings('GroovyDocCheck')
 class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
 
-    // region Stage 2 - VariantSelectionFailure
+    // region Variant Selection failures
     def "demonstrate ambiguous graph variant selection failure with single disambiguating value for project"() {
         ambiguousGraphVariantForProjectWithSingleDisambiguatingAttribute.prepare()
 
@@ -272,12 +276,12 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
             fqid == 'dependency-variant-resolution:configuration-does-not-exist'
         }
     }
-    // endregion Stage 2 - VariantSelectionFailure
+    // endregion Variant Selection failure
 
-    // region Stage 3 - GraphValidationFailure
-    // endregion Stage 3 - GraphValidationFailure
+    // region Graph Validation failures
+    // endregion Graph Validation failures
 
-    // region Stage 4 - ArtifactSelectionFailure
+    // region Artifact Selection failures
     def "demonstrate incompatible artifact variants exception"() {
         incompatibleArtifactVariants.prepare()
 
@@ -398,7 +402,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
             fqid == 'dependency-variant-resolution:ambiguous-artifacts'
         }
     }
-    // endregion Stage 4 - ArtifactSelectionFailure
+    // endregion Artifact Selection failures
 
     // region dependencyInsight failures
     /**

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ResolutionFailureHandlerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ResolutionFailureHandlerIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.integtests.internal.component
+package org.gradle.integtests.internal.component.resolution.failure
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.internal.component.resolution.failure.exception.AbstractResolutionFailureException

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
@@ -1145,7 +1145,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         failure.assertHasCause("Could not resolve all dependencies for configuration ':conf'.")
         failure.assertHasCause("""Could not resolve org.utils:impl:1.3.
 Required by:
-    project :""")
+    root project :""")
         failure.assertHasCause("Unhappy :(")
     }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/MetadataArtifactResolveTestFixture.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/MetadataArtifactResolveTestFixture.groovy
@@ -140,10 +140,10 @@ task verify {
         for(component in result.resolvedComponents) {
             def artifacts = component.getArtifacts($requestedArtifact)
             artifacts.each { a ->
-                assert a.id.componentIdentifier.displayName == "${id.displayName}" 
-                assert a.id.componentIdentifier.group == "${id.group}" 
-                assert a.id.componentIdentifier.module == "${id.module}" 
-                assert a.id.componentIdentifier.version == "${id.version}" 
+                assert a.id.componentIdentifier.displayName == "${id.displayName}"
+                assert a.id.componentIdentifier.group == "${id.group}"
+                assert a.id.componentIdentifier.module == "${id.module}"
+                assert a.id.componentIdentifier.version == "${id.version}"
             }
             def resolvedArtifacts = artifacts.findAll { it instanceof ResolvedArtifactResult }
             assert expectedMetadataFileNames.size() == resolvedArtifacts.size()
@@ -205,7 +205,7 @@ task verify {
 
         // Check generic component result
         def componentResult = result.components.iterator().next()
-        assert componentResult.id.displayName == 'project :'
+        assert componentResult.id.displayName == "root project :"
         assert componentResult instanceof $expectedComponentResult.name
 """
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -807,7 +807,7 @@ project(':b') {
 
         where:
         declaredDependency   | projectDescription  | expectedCommand
-        "project(':')"       | "project :"         | ":outgoingVariants"
+        "project(':')"       | "root project :"         | ":outgoingVariants"
         "'org:included:1.0'" | "project :included" | ":included:outgoingVariants"
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
@@ -510,7 +510,7 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
             assert op.result.resolvedDependenciesCount == 3
             def resolvedComponents = op.result.components
             assert resolvedComponents.size() == 8
-            assert resolvedComponents.'project :'.repoId == null
+            assert resolvedComponents.'root project :'.repoId == null
             assert resolvedComponents.'org.foo:direct1:1.0'.repoId == maven1Id
             assert resolvedComponents.'org.foo:direct2:1.0'.repoId == maven2Id
             assert resolvedComponents.'org.foo:transitive1:1.0'.repoId == maven1Id
@@ -580,7 +580,7 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         def repoId = repoId('maven1', op.details)
         def resolvedComponents = op.result.components
         resolvedComponents.size() == 4
-        resolvedComponents.'project :'.repoId == null
+        resolvedComponents.'root project :'.repoId == null
         resolvedComponents.'project :child'.repoId == null
         resolvedComponents.'org.foo:direct1:1.0'.repoId == repoId
         resolvedComponents.'org.foo:transitive1:1.0'.repoId == repoId

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolutionResultApiIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolutionResultApiIntegrationTest.groovy
@@ -637,7 +637,7 @@ testRuntimeClasspath
         fails 'resolve'
 
         then:
-        failure.assertHasCause("Variant 'apiElements' doesn't belong to resolved component 'project :'. There's no resolved variant with the same name. Most likely you are using a variant from another component to get the dependencies of this component.")
+        failure.assertHasCause("Variant 'apiElements' doesn't belong to resolved component 'root project :'. There's no resolved variant with the same name. Most likely you are using a variant from another component to get the dependencies of this component.")
     }
 
     @Issue("https://github.com/gradle/gradle/issues/12643")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
@@ -462,7 +462,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         failure.assertHasCause("""Could not find any version that matches org:test:[1.0,).""")
 
         and:
-        outputContains("Success for project :")
+        outputContains("Success for root project :")
     }
 
     @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
@@ -75,7 +75,7 @@ class CapabilitiesLocalComponentIntegrationTest extends AbstractIntegrationSpec 
         succeeds 'dependencyInsight', '--configuration', 'compileClasspath', '--dependency', ':'
 
         then:
-        outputContains("Could not resolve project :.")
+        outputContains("Could not resolve root project :.")
     }
 
     def "can lazily define and request capability"() {
@@ -185,4 +185,3 @@ class CapabilitiesLocalComponentIntegrationTest extends AbstractIntegrationSpec 
         succeeds("resolve")
     }
 }
-

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyBrokenRemoteResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyBrokenRemoteResolveIntegrationTest.groovy
@@ -55,7 +55,7 @@ task showMissing { doLast { println configurations.missing.files } }
 Searched in the following locations:
   - ${module.ivy.uri}
 Required by:
-    project :""")
+    root project :""")
 
         when:
         module.ivy.expectGetMissing()
@@ -68,7 +68,7 @@ Required by:
 Searched in the following locations:
   - ${module.ivy.uri}
 Required by:
-    project :""")
+    root project :""")
         failure.assertHasResolutions(REPOSITORY_HINT,
             STACKTRACE_MESSAGE,
             INFO_DEBUG,
@@ -122,12 +122,12 @@ task showMissing { doLast { println configurations.missing.files } }
 Searched in the following locations:
   - ${moduleA.ivy.uri}
 Required by:
-    project :""")
+    root project :""")
             .assertHasCause("""Could not find group:projectB:1.0-milestone-9.
 Searched in the following locations:
   - ${moduleB.ivy.uri}
 Required by:
-    project :""")
+    root project :""")
         failure.assertHasResolutions(REPOSITORY_HINT,
             STACKTRACE_MESSAGE,
             INFO_DEBUG,
@@ -206,13 +206,13 @@ task showMissing { doLast { println configurations.compile.files } }
 Searched in the following locations:
   - ${moduleA.ivy.uri}
 Required by:
-    project : > group:projectC:0.99
-    project : > project :child1 > group:projectD:1.0GA""")
+    root project : > group:projectC:0.99
+    root project : > project :child1 > group:projectD:1.0GA""")
             .assertHasCause("""Could not find group:projectB:1.0-milestone-9.
 Searched in the following locations:
   - ${moduleB.ivy.uri}
 Required by:
-    project : > project :child1 > group:projectD:1.0GA""")
+    root project : > project :child1 > group:projectD:1.0GA""")
         failure.assertHasResolutions(REPOSITORY_HINT,
             STACKTRACE_MESSAGE,
             INFO_DEBUG,

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyModuleArtifactResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyModuleArtifactResolutionIntegrationTest.groovy
@@ -85,7 +85,7 @@ repositories {
 
         when:
         fixture.requestComponent('IvyModule').requestArtifact('IvyDescriptorArtifact')
-               .expectUnresolvedComponentResult(new IllegalArgumentException("Cannot query artifacts for a project component (project :)."))
+               .expectUnresolvedComponentResult(new IllegalArgumentException("Cannot query artifacts for a project component (root project :)."))
                .expectNoMetadataFiles()
                .createVerifyTaskForProjectComponentIdentifier()
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyModuleResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyModuleResolveIntegrationTest.groovy
@@ -106,7 +106,7 @@ task retrieve(type: Sync) {
 
         expect:
         fails 'retrieve'
-        failure.assertHasCause("Could not resolve test:target:1.0.\nRequired by:\n    project :")
+        failure.assertHasCause("Could not resolve test:target:1.0.\nRequired by:\n    root project :")
         failure.assertHasCause("A dependency was declared on configuration 'x86_windows' of 'test:target:1.0' but no variant with that configuration name exists.")
     }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBrokenRemoteResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBrokenRemoteResolveIntegrationTest.groovy
@@ -57,7 +57,7 @@ task showMissing {
 Searched in the following locations:
   - ${module.pom.uri}
 Required by:
-    project :""")
+    root project :""")
 
         when:
         module.pom.expectGetMissing()
@@ -69,7 +69,7 @@ Required by:
 Searched in the following locations:
   - ${module.pom.uri}
 Required by:
-    project :""")
+    root project :""")
         failure.assertHasResolutions(REPOSITORY_HINT,
             STACKTRACE_MESSAGE,
             INFO_DEBUG,
@@ -123,12 +123,12 @@ task showMissing {
 Searched in the following locations:
   - ${moduleA.pom.uri}
 Required by:
-    project :""")
+    root project :""")
             .assertHasCause("""Could not find group:projectB:1.0-milestone-9.
 Searched in the following locations:
   - ${moduleB.pom.uri}
 Required by:
-    project :""")
+    root project :""")
         failure.assertHasResolutions(REPOSITORY_HINT,
             STACKTRACE_MESSAGE,
             INFO_DEBUG,
@@ -209,13 +209,13 @@ task showMissing {
 Searched in the following locations:
   - ${moduleA.pom.uri}
 Required by:
-    project : > group:projectC:0.99
-    project : > project :child1 > group:projectD:1.0GA""")
+    root project : > group:projectC:0.99
+    root project : > project :child1 > group:projectD:1.0GA""")
             .assertHasCause("""Could not find group:projectB:1.0-milestone-9.
 Searched in the following locations:
   - ${moduleB.pom.uri}
 Required by:
-    project : > project :child1 > group:projectD:1.0GA""")
+    root project : > project :child1 > group:projectD:1.0GA""")
         failure.assertHasResolutions(REPOSITORY_HINT,
             STACKTRACE_MESSAGE,
             INFO_DEBUG,

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenModuleArtifactResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenModuleArtifactResolutionIntegrationTest.groovy
@@ -84,7 +84,7 @@ repositories {
 
         when:
         fixture.requestComponent('MavenModule').requestArtifact('MavenPomArtifact')
-            .expectUnresolvedComponentResult(new IllegalArgumentException("Cannot query artifacts for a project component (project :)."))
+            .expectUnresolvedComponentResult(new IllegalArgumentException("Cannot query artifacts for a project component (root project :)."))
             .expectNoMetadataFiles()
             .createVerifyTaskForProjectComponentIdentifier()
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -690,7 +690,7 @@ dependencies {
 Searched in the following locations:
   - ${m.pom.uri}
 Required by:
-    project :""")
+    root project :""")
         failure.assertHasResolutions(repositoryHint("Maven POM"),
             STACKTRACE_MESSAGE,
             INFO_DEBUG,

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesIntegrationTest.groovy
@@ -376,7 +376,7 @@ dependencies {
 """
         expect:
         fails 'checkDep'
-        failure.assertHasCause("Could not resolve test:target:1.0.\nRequired by:\n    project :")
+        failure.assertHasCause("Could not resolve test:target:1.0.\nRequired by:\n    root project :")
         failure.assertHasCause("A dependency was declared on configuration 'x86_windows' of 'test:target:1.0' but no variant with that configuration name exists.")
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyResolveRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyResolveRulesIntegrationTest.groovy
@@ -633,7 +633,7 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause("Could not resolve all files for configuration ':conf'.")
         failure.assertHasCause("""Could not resolve org.utils:impl:1.3.
 Required by:
-    project :""")
+    root project :""")
         failure.assertHasCause("Unhappy :(")
     }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/VersionConflictResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/VersionConflictResolutionIntegrationTest.groovy
@@ -951,7 +951,7 @@ dependencies {
         runAndFail "resolve"
 
         then:
-        failure.assertResolutionFailure(":conf").assertFailedDependencyRequiredBy("project : > org:d:1.0")
+        failure.assertResolutionFailure(":conf").assertFailedDependencyRequiredBy("root project : > org:d:1.0")
     }
 
     def "chooses highest version that is included in both ranges"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/plugin/devel/variants/TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/plugin/devel/variants/TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest.groovy
@@ -104,7 +104,7 @@ class TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest extends Abst
         failure.assertHasErrorOutput("""> Could not resolve all artifacts for configuration ':classpath'.
    > Could not resolve com.example:producer:1.0.
      Required by:
-         project : > com.example.greeting:com.example.greeting.gradle.plugin:1.0
+         root project : > com.example.greeting:com.example.greeting.gradle.plugin:1.0
       > Dependency requires at least JVM runtime version ${higherVersion.javaVersion.majorVersion}. This build uses a Java ${lowerVersion.javaVersion.majorVersion} JVM.""")
         failure.assertHasErrorOutput("Caused by: " + VariantSelectionByAttributesException.class.getName())
         failure.assertHasResolution("Run this build using a Java ${higherVersion.javaVersion.majorVersion} or newer JVM.")
@@ -184,7 +184,7 @@ class TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest extends Abst
         failure.assertHasErrorOutput("""> Could not resolve all artifacts for configuration ':classpath'.
    > Could not resolve com.example:producer:1.0.
      Required by:
-         project : > com.example.greeting:com.example.greeting.gradle.plugin:1.0
+         root project : > com.example.greeting:com.example.greeting.gradle.plugin:1.0
       > Dependency requires at least JVM runtime version $tooHighJava. This build uses a Java $currentJava JVM.""")
         failure.assertHasErrorOutput("Caused by: " + VariantSelectionByAttributesException.class.getName())
         failure.assertHasResolution("Run this build using a Java $tooHighJava or newer JVM.")
@@ -259,7 +259,7 @@ class TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest extends Abst
         failure.assertHasErrorOutput("""> Could not resolve all dependencies for configuration ':classpath'.
    > Could not resolve project :producer.
      Required by:
-         project :
+         root project :
       > Dependency requires at least JVM runtime version ${higherVersion.javaVersion.majorVersion}. This build uses a Java ${lowerVersion.javaVersion.majorVersion} JVM.""")
         failure.assertHasErrorOutput("Caused by: " + VariantSelectionByAttributesException.class.getName())
         failure.assertHasResolution("Run this build using a Java ${higherVersion.javaVersion.majorVersion} or newer JVM.")
@@ -331,7 +331,7 @@ class TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest extends Abst
         failure.assertHasErrorOutput("""> Could not resolve all artifacts for configuration ':classpath'.
    > Could not resolve org.springframework.boot:spring-boot-gradle-plugin:3.2.1.
      Required by:
-         project : > org.springframework.boot:org.springframework.boot.gradle.plugin:3.2.1
+         root project : > org.springframework.boot:org.springframework.boot.gradle.plugin:3.2.1
       > Dependency requires at least JVM runtime version 17. This build uses a Java $currentJava JVM.""")
         failure.assertHasErrorOutput("Caused by: " + VariantSelectionByAttributesException.class.getName())
         failure.assertHasResolution("Run this build using a Java 17 or newer JVM.")

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -119,7 +119,7 @@ import org.gradle.internal.authentication.AuthenticationSchemeRegistry;
 import org.gradle.internal.build.BuildModelLifecycleListener;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.buildoption.InternalOptions;
-import org.gradle.internal.component.ResolutionFailureHandler;
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
 import org.gradle.internal.component.external.model.JavaEcosystemVariantDerivationStrategy;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
 import org.gradle.internal.component.model.GraphVariantSelector;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -99,7 +99,7 @@ import org.gradle.internal.buildoption.FeatureFlags;
 import org.gradle.internal.classpath.ClasspathBuilder;
 import org.gradle.internal.classpath.ClasspathWalker;
 import org.gradle.internal.code.UserCodeApplicationContext;
-import org.gradle.internal.component.ResolutionFailureHandler;
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
 import org.gradle.internal.component.model.GraphVariantSelector;
 import org.gradle.internal.component.resolution.failure.ResolutionFailureDescriberRegistry;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -49,7 +49,7 @@ import org.gradle.api.internal.attributes.CompatibilityRule;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.specs.Spec;
-import org.gradle.internal.component.ResolutionFailureHandler;
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
 import org.gradle.internal.component.model.ComponentGraphResolveMetadata;
 import org.gradle.internal.component.model.ComponentIdGenerator;
 import org.gradle.internal.component.model.DefaultCompatibilityCheckResult;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ArtifactVariantSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ArtifactVariantSelector.java
@@ -20,7 +20,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Resol
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariantSet;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.internal.component.ResolutionFailureHandler;
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
 import org.gradle.internal.component.model.GraphVariantSelector;
 
 /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelector.java
@@ -28,7 +28,7 @@ import org.gradle.api.internal.attributes.AttributeValue;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
-import org.gradle.internal.component.ResolutionFailureHandler;
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
 import org.gradle.internal.component.model.AttributeMatcher;
 import org.gradle.internal.component.model.AttributeMatchingExplanationBuilder;
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantSelectorFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantSelectorFactory.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.transform;
 
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
-import org.gradle.internal.component.ResolutionFailureHandler;
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
 
 public class DefaultVariantSelectorFactory implements VariantSelectorFactory {
     private final ConsumerProvidedVariantFinder consumerProvidedVariantFinder;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/ResolutionFailureHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/ResolutionFailureHandler.java
@@ -93,11 +93,12 @@ public class ResolutionFailureHandler {
         this.problemsService = problemsService;
     }
 
-    // region Stage 1 - ComponentSelectionFailures
-    // TODO: Possibly route these failures through this handler to standardize description logic, supply consistent failure data to Problems API, and allow for possible custom descriptions
-    // endregion Stage 1 - ComponentSelectionFailures
+    // region Component Selection failures
+    // TODO: Route these failures through this handler in order to standardize their description logic, supply consistent failure reporting
+    //  via the Problems API, and allow for the possible custom descriptions in specific scenarios
+    // endregion Component Selection failures
 
-    // region Stage 2 - VariantSelectionFailures
+    // region Variant Selection failures
     public AbstractResolutionFailureException configurationNotCompatibleFailure(
         AttributesSchemaInternal schema,
         AttributeMatcher matcher,
@@ -169,18 +170,18 @@ public class ResolutionFailureHandler {
         NoVariantsWithMatchingCapabilitiesFailure failure = new NoVariantsWithMatchingCapabilitiesFailure(targetComponent.getId(), requestedAttributes, requestedCapabilities, assessedCandidates);
         return describeFailure(schema, failure);
     }
-    // endregion Stage 2 - VariantSelectionFailures
+    // endregion Variant Selection failures
 
-    // region State 3 - GraphValidationFailures
+    // region Graph Validation failures
     public AbstractResolutionFailureException incompatibleMultipleNodesValidationFailure(AttributesSchemaInternal schema, ComponentGraphResolveMetadata selectedComponent, Set<VariantGraphResolveMetadata> incompatibleNodes) {
         ResolutionCandidateAssessor resolutionCandidateAssessor = new ResolutionCandidateAssessor(ImmutableAttributes.EMPTY, schema.matcher());
         List<AssessedCandidate> assessedCandidates = resolutionCandidateAssessor.assessNodeMetadatas(incompatibleNodes);
         IncompatibleMultipleNodesValidationFailure failure = new IncompatibleMultipleNodesValidationFailure(selectedComponent, incompatibleNodes, assessedCandidates);
         return describeFailure(schema, failure);
     }
-    // endregion State 3 - GraphValidationFailures
+    // endregion Graph Validation failures
 
-    // region State 4 - ArtifactSelectionFailures
+    // region Artifact Selection failures
     public AbstractResolutionFailureException ambiguousArtifactTransformsFailure(AttributesSchemaInternal schema, ResolvedVariantSet targetVariantSet, ImmutableAttributes requestedAttributes, List<TransformedVariant> transformedVariants) {
         AmbiguousArtifactTransformsFailure failure = new AmbiguousArtifactTransformsFailure(getOrCreateVariantSetComponentIdentifier(targetVariantSet), targetVariantSet.asDescribable().getDisplayName(), requestedAttributes, transformedVariants);
         return describeFailure(schema, failure);
@@ -208,7 +209,7 @@ public class ResolutionFailureHandler {
     private ComponentIdentifier getOrCreateVariantSetComponentIdentifier(ResolvedVariantSet resolvedVariantSet) {
         return resolvedVariantSet.getComponentIdentifier() != null ? resolvedVariantSet.getComponentIdentifier() : () -> resolvedVariantSet.asDescribable().getDisplayName();
     }
-    // endregion State 4 - ArtifactSelectionFailures
+    // endregion Artifact Selection failures
 
     private <FAILURE extends ResolutionFailure> AbstractResolutionFailureException describeFailure(FAILURE failure) {
         @SuppressWarnings("unchecked")

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/IvyDependencyDescriptor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/IvyDependencyDescriptor.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.SetMultimap;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
-import org.gradle.internal.component.ResolutionFailureHandler;
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
 import org.gradle.internal.component.external.descriptor.Artifact;
 import org.gradle.internal.component.external.model.ExternalDependencyDescriptor;
 import org.gradle.internal.component.model.ConfigurationGraphResolveState;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectComponentSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectComponentSelector.java
@@ -59,8 +59,14 @@ public class DefaultProjectComponentSelector implements ProjectComponentSelector
 
     @Override
     public String getDisplayName() {
+        String prefix;
+        if (identityPath == Path.ROOT) {
+            prefix =  "root project";
+        } else {
+            prefix = "project";
+        }
         if (displayName == null) {
-            displayName = "project " + identityPath;
+            displayName = prefix + " " + identityPath;
         }
         return displayName;
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadata.java
@@ -20,7 +20,7 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.internal.component.ResolutionFailureHandler;
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
 
 import javax.annotation.Nullable;
 import java.util.Collection;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/GraphVariantSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/GraphVariantSelector.java
@@ -27,7 +27,7 @@ import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.capabilities.ImmutableCapability;
 import org.gradle.api.internal.capabilities.ShadowedCapability;
-import org.gradle.internal.component.ResolutionFailureHandler;
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
 import org.gradle.internal.deprecation.DeprecationLogger;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/package-info.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/package-info.java
@@ -14,7 +14,5 @@
  * limitations under the License.
  */
 
-@NonNullApi
+@org.gradle.api.NonNullApi
 package org.gradle.internal.component;
-
-import org.gradle.api.NonNullApi;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionCandidateAssessor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionCandidateAssessor.java
@@ -26,7 +26,6 @@ import org.gradle.api.internal.attributes.AttributeValue;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.capabilities.ImmutableCapability;
 import org.gradle.internal.Cast;
-import org.gradle.internal.component.ResolutionFailureHandler;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.model.AttributeMatcher;
 import org.gradle.internal.component.model.GraphSelectionCandidates;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionFailureHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionFailureHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.component;
+package org.gradle.internal.component.resolution.failure;
 
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
@@ -36,9 +36,7 @@ import org.gradle.internal.component.model.GraphSelectionCandidates;
 import org.gradle.internal.component.model.GraphVariantSelector;
 import org.gradle.internal.component.model.VariantGraphResolveMetadata;
 import org.gradle.internal.component.model.VariantGraphResolveState;
-import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor.AssessedCandidate;
-import org.gradle.internal.component.resolution.failure.ResolutionFailureDescriberRegistry;
 import org.gradle.internal.component.resolution.failure.describer.ResolutionFailureDescriber;
 import org.gradle.internal.component.resolution.failure.exception.AbstractResolutionFailureException;
 import org.gradle.internal.component.resolution.failure.interfaces.ResolutionFailure;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/AmbiguousVariantsFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/AmbiguousVariantsFailureDescriber.java
@@ -19,7 +19,7 @@ package org.gradle.internal.component.resolution.failure.describer;
 import org.gradle.api.internal.attributes.AttributeDescriber;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.internal.component.model.AttributeDescriberSelector;
-import org.gradle.internal.component.resolution.failure.CapabilitiesDescriber;
+import org.gradle.internal.component.resolution.failure.formatting.CapabilitiesDescriber;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 import org.gradle.internal.component.resolution.failure.exception.VariantSelectionByAttributesException;
 import org.gradle.internal.component.resolution.failure.type.AmbiguousVariantsFailure;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ConfigurationDoesNotExistFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ConfigurationDoesNotExistFailureDescriber.java
@@ -53,4 +53,9 @@ public abstract class ConfigurationDoesNotExistFailureDescriber extends Abstract
             failure.getTargetComponent().getDisplayName()
         );
     }
+
+    private String quoteNameOnly(String formattedId) {
+        int projectIdIdx = formattedId.indexOf("project ");
+        return projectIdIdx < 0 ? '\'' + formattedId + '\'' : formattedId.substring(0, projectIdIdx + 8) + '\'' + formattedId.substring(projectIdIdx + 8) + '\'';
+    }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/NoCompatibleVariantsFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/NoCompatibleVariantsFailureDescriber.java
@@ -20,7 +20,7 @@ import org.gradle.api.internal.attributes.AttributeDescriber;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.internal.component.model.AttributeDescriberSelector;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
-import org.gradle.internal.component.resolution.failure.StyledAttributeDescriber;
+import org.gradle.internal.component.resolution.failure.formatting.StyledAttributeDescriber;
 import org.gradle.internal.component.resolution.failure.exception.VariantSelectionByAttributesException;
 import org.gradle.internal.component.resolution.failure.type.NoCompatibleVariantsFailure;
 import org.gradle.internal.logging.text.StyledTextOutput;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/NoVariantsWithMatchingCapabilitiesFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/NoVariantsWithMatchingCapabilitiesFailureDescriber.java
@@ -17,7 +17,7 @@
 package org.gradle.internal.component.resolution.failure.describer;
 
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
-import org.gradle.internal.component.resolution.failure.CapabilitiesDescriber;
+import org.gradle.internal.component.resolution.failure.formatting.CapabilitiesDescriber;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 import org.gradle.internal.component.resolution.failure.exception.VariantSelectionByAttributesException;
 import org.gradle.internal.component.resolution.failure.type.NoVariantsWithMatchingCapabilitiesFailure;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/exception/AbstractResolutionFailureException.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/exception/AbstractResolutionFailureException.java
@@ -19,6 +19,7 @@ package org.gradle.internal.component.resolution.failure.exception;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
 import org.gradle.internal.component.resolution.failure.interfaces.ResolutionFailure;
 import org.gradle.internal.exceptions.Contextual;
 import org.gradle.internal.exceptions.ResolutionProvider;
@@ -29,7 +30,7 @@ import java.util.List;
 
 /**
  * Abstract base class for all {@link ResolutionFailure}s occurring during dependency resolution that can be handled
- * by the {@link org.gradle.internal.component.ResolutionFailureHandler ResolutionFailureHandler}.
+ * by the {@link ResolutionFailureHandler ResolutionFailureHandler}.
  * <p>
  * This exception type carries information about the failure, and implements {@link ResolutionProvider} to provide a
  * list of resolutions that may help the user to fix the problem.  This class is meant to be immutable.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/formatting/CapabilitiesDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/formatting/CapabilitiesDescriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.internal.component.resolution.failure;
+package org.gradle.internal.component.resolution.failure.formatting;
 
 import org.gradle.api.capabilities.Capability;
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/formatting/StyledAttributeDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/formatting/StyledAttributeDescriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.internal.component.resolution.failure;
+package org.gradle.internal.component.resolution.failure.formatting;
 
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.attributes.Attribute;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/formatting/package-info.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/formatting/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,7 @@
  */
 
 /**
- * This package exists as a non-intermediate package only to contain the
- * deprecated {@code AmbiguousVariantSelectionException} type.
- * <p>
- * This file should be deleted when that type is removed.
+ * Contains formatting utilities for rendering resolution failure information.
  */
 @org.gradle.api.NonNullApi
-package org.gradle.internal.component;
+package org.gradle.internal.component.resolution.failure.formatting;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/interfaces/package-info.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/interfaces/package-info.java
@@ -20,7 +20,7 @@
  * delineate when during dependency resolution a failure occurred.
  * <p>
  * There are currently 4 different categories of resolution failures processed by the
- * {@link org.gradle.internal.component.ResolutionFailureHandler ResolutionFailureHandler}.  There may be
+ * {@link org.gradle.internal.component.resolution.failure.ResolutionFailureHandler ResolutionFailureHandler}.  There may be
  * more in the future.
  * <p>
  * These categories are represented by the immediate children of

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -51,7 +51,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.problems.internal.InternalProblems
 import org.gradle.api.specs.Spec
 import org.gradle.internal.Describables
-import org.gradle.internal.component.ResolutionFailureHandler
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.internal.component.external.descriptor.DefaultExclude
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.ImmutableCapabilities

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
@@ -27,7 +27,7 @@ import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.notations.ComponentIdentifierParserFactory
 import org.gradle.api.internal.notations.DependencyMetadataNotationParser
 import org.gradle.api.problems.internal.InternalProblems
-import org.gradle.internal.component.ResolutionFailureHandler
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.internal.component.external.descriptor.Configuration
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelectorSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelectorSpec.groovy
@@ -26,7 +26,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.problems.internal.InternalProblems
 import org.gradle.internal.Describables
 
-import org.gradle.internal.component.ResolutionFailureHandler
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.internal.component.model.AttributeMatcher
 import org.gradle.internal.component.resolution.failure.exception.ArtifactSelectionException
 import org.gradle.util.AttributeTestUtil

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactVariantSelectorFactoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactVariantSelectorFactoryTest.groovy
@@ -29,7 +29,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.problems.internal.InternalProblems
 import org.gradle.internal.Describables
 
-import org.gradle.internal.component.ResolutionFailureHandler
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.internal.component.model.AttributeMatcher
 import org.gradle.internal.component.model.AttributeMatchingExplanationBuilder
 import org.gradle.internal.component.resolution.failure.exception.ArtifactSelectionException

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -31,7 +31,7 @@ import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.notations.DependencyMetadataNotationParser
 import org.gradle.api.problems.internal.InternalProblems
-import org.gradle.internal.component.ResolutionFailureHandler
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.internal.component.external.descriptor.MavenScope
 import org.gradle.internal.component.external.model.ivy.IvyDependencyDescriptor
 import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/IvyDependencyDescriptorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/IvyDependencyDescriptorTest.groovy
@@ -27,7 +27,7 @@ import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.PatternMatchers
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ExcludeSpec
-import org.gradle.internal.component.ResolutionFailureHandler
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.internal.component.external.descriptor.Artifact
 import org.gradle.internal.component.external.descriptor.DefaultExclude
 import org.gradle.internal.component.external.model.ivy.IvyComponentGraphResolveState

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
@@ -33,7 +33,7 @@ import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.problems.internal.InternalProblems
-import org.gradle.internal.component.ResolutionFailureHandler
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.internal.component.external.descriptor.DefaultExclude
 import org.gradle.internal.component.external.model.ImmutableCapabilities
 import org.gradle.internal.component.resolution.failure.exception.VariantSelectionByAttributesException

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVersionSelectionIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVersionSelectionIntegrationTest.groovy
@@ -193,7 +193,7 @@ class GitVersionSelectionIntegrationTest extends AbstractIntegrationSpec {
 Searched in the following locations:
   - Git repository at ${repo.url}
 Required by:
-    project :""")
+    root project :""")
 
         when:
         repoSettingsFile.replace("version = '1.1'", "version = '2.0'")
@@ -296,7 +296,7 @@ Required by:
 Searched in the following locations:
   - Git repository at ${repo.url}
 Required by:
-    project :""")
+    root project :""")
 
         when:
         repoSettingsFile.replace("version = '1.0'", "version = '1.1'")
@@ -355,7 +355,7 @@ Required by:
 Searched in the following locations:
   - Git repository at ${repo.url}
 Required by:
-    project :""")
+    root project :""")
 
         where:
         selector  | _
@@ -446,7 +446,7 @@ Required by:
 Searched in the following locations:
   - Git repository at ${repo.url}
 Required by:
-    project :""")
+    root project :""")
 
         when:
         repo.createBranch("release")

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/OfflineSourceDependencyIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/OfflineSourceDependencyIntegrationTest.groovy
@@ -89,6 +89,6 @@ class OfflineSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause("Could not resolve all dependencies for configuration ':compile'.")
         failure.assertHasCause("""Cannot resolve test:test:1.2 from Git repository at ${repo.url} in offline mode.
 Required by:
-    project :""")
+    root project :""")
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectComponentIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectComponentIdentifier.java
@@ -38,8 +38,14 @@ public class DefaultProjectComponentIdentifier implements ProjectComponentIdenti
 
     @Override
     public String getDisplayName() {
+        String prefix;
+        if (identityPath == Path.ROOT) {
+            prefix =  "root project";
+        } else {
+            prefix = "project";
+        }
         if (displayName == null) {
-            displayName = "project " + identityPath.getPath();
+            displayName = prefix + " " + identityPath.getPath();
         }
         return displayName;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/catalog/problems/ResolutionFailureProblemId.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/catalog/problems/ResolutionFailureProblemId.java
@@ -27,7 +27,7 @@ import org.gradle.api.NonNullApi;
  */
 @NonNullApi
 public enum ResolutionFailureProblemId implements Describable {
-    // Stage 2 failures
+    // Variant Selection failures
     CONFIGURATION_NOT_COMPATIBLE("Configuration selected by name is not compatible"),
     CONFIGURATION_NOT_CONSUMABLE("Configuration selected by name is not consumable"),
     CONFIGURATION_DOES_NOT_EXIST("Configuration selected by name does not exist"),
@@ -35,14 +35,14 @@ public enum ResolutionFailureProblemId implements Describable {
     NO_COMPATIBLE_VARIANTS("No variants exist that would match the request"),
     NO_VARIANTS_WITH_MATCHING_CAPABILITIES("No variants exist with capabilities that would match the request"),
 
-    // Stage 3 failures
+    // Graph Validation failures
+    INCOMPATIBLE_MULTIPLE_NODES("Incompatible nodes of a single component were selected"),
+
+    // Artifact Selection failures
     AMBIGUOUS_ARTIFACT_TRANSFORM("Multiple artifacts transforms exist that would satisfy the request"),
     NO_COMPATIBLE_ARTIFACT("No artifacts exist that would match the request"),
     AMBIGUOUS_ARTIFACTS("Multiple artifacts exist that would match the request"),
     UNKNOWN_ARTIFACT_SELECTION_FAILURE("Unknown artifact selection failure"),
-
-    // Stage 4 failures
-    INCOMPATIBLE_MULTIPLE_NODES("Incompatible nodes of a single component were selected"),
 
     /**
      * Indicates that the resolution failed for an unknown reason not enumerated above.

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
@@ -121,7 +121,7 @@ class DefaultProjectDependencyTest extends AbstractProjectBuilderSpec {
 
         then:
         def e = thrown(VariantSelectionByNameException)
-        e.message == "Selected configuration 'conf' on project : but it can't be used as a project dependency because it isn't intended for consumption by other components."
+        e.message == "Selected configuration 'conf' on root project : but it can't be used as a project dependency because it isn't intended for consumption by other components."
     }
 
     void "does not build project dependencies if configured so"() {

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -1642,7 +1642,7 @@ org:leaf2:1.0
 
         then:
         outputContains """
-project :
+root project :
   Variant runtimeClasspath:
     | Attribute Name                 | Provided     | Requested    |
     |--------------------------------|--------------|--------------|
@@ -1662,9 +1662,9 @@ project :
     | org.gradle.usage               | java-runtime | java-runtime |
     | org.gradle.jvm.environment     |              | standard-jvm |
 
-project :
+root project :
 \\--- project :impl
-     \\--- project : (*)
+     \\--- root project : (*)
 """
     }
 

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.tasks.diagnostics
 
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.integtests.resolve.locking.LockfileFixture
 import org.gradle.util.GradleVersion
@@ -1608,6 +1609,7 @@ org:leaf2:1.0
 """
     }
 
+    @ToBeFixedForConfigurationCache(because = "CC component identifiers won't include root prefix in display name")
     def "deals with dependency cycle to root"() {
         given:
         createDirs("impl")

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporter.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporter.java
@@ -38,7 +38,7 @@ import org.gradle.api.tasks.diagnostics.internal.graph.nodes.ResolvedDependencyE
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.Section;
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.UnresolvedDependencyEdge;
 import org.gradle.internal.InternalTransformer;
-import org.gradle.internal.component.ResolutionFailureHandler;
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
 import org.gradle.internal.exceptions.ResolutionProvider;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.util.internal.CollectionUtils;

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DependencyResolutionFailure.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DependencyResolutionFailure.groovy
@@ -21,7 +21,7 @@ import java.util.regex.Pattern
 import static org.gradle.util.Matchers.*;
 import org.hamcrest.Matcher
 
-public class DependencyResolutionFailure {
+/* package */ class DependencyResolutionFailure {
     private final ExecutionFailure failure
 
     DependencyResolutionFailure(ExecutionFailure failure, String configuration) {
@@ -34,8 +34,8 @@ public class DependencyResolutionFailure {
         this
     }
 
-    DependencyResolutionFailure assertFailedDependencyRequiredBy(String dependency) {
-        failure.assertThatCause(matchesRegexp("(?ms).*Required by:\\s+$dependency.*"))
+    DependencyResolutionFailure assertFailedDependencyRequiredBy(String dependencyRegex) {
+        failure.assertThatCause(matchesRegexp("(?ms).*Required by:\\s+$dependencyRegex.*"))
         this
     }
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -24,9 +24,7 @@ import org.gradle.api.artifacts.result.ComponentSelectionCause
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.internal.classloader.ClasspathUtil
 import org.gradle.test.fixtures.file.TestFile
-import org.gradle.util.Path
 import org.junit.ComparisonFailure
-
 /**
  * A test fixture that injects a "checkDeps" task into a build that resolves a dependency configuration and does some validation of the resulting graph, to
  * ensure that the old and new dependency graphs plus the artifacts and files are as expected and well-formed.
@@ -157,7 +155,7 @@ $END_MARKER
         }
 
         def configDetailsFile = getResultFile()
-        def configDetails = configDetailsFile.text.readLines()
+        def configDetails = standardizeRootProjectNodes(configDetailsFile.text.readLines())
 
         def actualRoot = findLines(configDetails, 'root').first()
         def expectedRoot = "[${root.type}][id:${root.id}][mv:${root.moduleVersionId}][reason:${root.reason}]".toString()
@@ -296,6 +294,19 @@ $END_MARKER
             variants << new Variant(name: variant, attributes: attributes)
         }
         new ParsedNode(type: type, id: id, module: module, reasons: reasons, variants: variants)
+    }
+
+    /**
+     * Standardizes the root project nodes in the given configFile lines to maintain the
+     * original "project :" description instead of the new "root project :" description.
+     *
+     * @param lines the lines to standardize
+     * @return the given lines, with every "root project :" replaced by "project :"
+     */
+    private List<String> standardizeRootProjectNodes(List<String> lines) {
+        return lines.collect { line ->
+            line.replaceAll(/root project :/, 'project :')
+        }
     }
 
     static class ParsedNode {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.result.ComponentSelectionCause
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.internal.classloader.ClasspathUtil
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.Path
 import org.junit.ComparisonFailure
 
 /**
@@ -488,7 +489,11 @@ $END_MARKER
         }
 
         private NodeBuilder projectNode(String projectIdentityPath, String moduleVersion) {
-            return node("project:$projectIdentityPath", "project $projectIdentityPath", moduleVersion)
+            if (Path.path(projectIdentityPath) == Path.ROOT) {
+                return node("project:$projectIdentityPath", "root project $projectIdentityPath", moduleVersion)
+            } else {
+                return node("project:$projectIdentityPath", "project $projectIdentityPath", moduleVersion)
+            }
         }
 
         private NodeBuilder moduleNode(String moduleVersionId) {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -489,11 +489,7 @@ $END_MARKER
         }
 
         private NodeBuilder projectNode(String projectIdentityPath, String moduleVersion) {
-            if (Path.path(projectIdentityPath) == Path.ROOT) {
-                return node("project:$projectIdentityPath", "root project $projectIdentityPath", moduleVersion)
-            } else {
-                return node("project:$projectIdentityPath", "project $projectIdentityPath", moduleVersion)
-            }
+            return node("project:$projectIdentityPath", "project $projectIdentityPath", moduleVersion)
         }
 
         private NodeBuilder moduleNode(String moduleVersionId) {


### PR DESCRIPTION
Replaces: https://github.com/gradle/gradle/pull/29504

New message example:

```
FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':forceResolution'.
> Could not resolve all dependencies for configuration ':resolveMe'.
   > Could not resolve root project ':'.
     Required by:
         root project ':'
      > Multiple incompatible variants of org.example:xbdp7:1.0 were selected:
           - Variant blueElementsCapability1 has attributes {color=blue}
           - Variant greenElementsCapability2 has attributes {color=green}
```

Also more minor internal cleanup of `ResolutionFailureHandler` and related types.

**https://github.com/gradle/gradle/pull/29645 should be merged first**