### PR TITLE
Fix link to custom dependencies blocks in JVM test suites

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
@@ -237,7 +237,7 @@ include::sample[dir="snippets/testing/test-suite-multi-configure-each-extracted/
 [[sec:differences_with_top_level_dependencies]]
 == Differences between the test suite `dependencies` and the top-level `dependencies` blocks
 
-See <<jvm_test_suite_plugin.adoc#sec:differences_with_top_level_dependencies,differences with custom `dependencies` blocks>>.
+See <<implementing_gradle_plugins_binary.adoc#sec:differences_with_top_level_dependencies,differences with custom `dependencies` blocks>>.
 
 == Differences between similar methods on link:{groovyDslPath}/org.gradle.api.plugins.jvm.JvmTestSuite.html[JvmTestSuite] and link:{groovyDslPath}/org.gradle.api.tasks.testing.Test.html[Test] task types
 


### PR DESCRIPTION
It was incorrectly linking to itself.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
