### PR TITLE
Add java compiler compatibility fix agains module opens

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -198,10 +198,6 @@ fun Test.configureJvmForTest() {
     }
     javaLauncher = launcher
     if (jvmVersionForTest().canCompileOrRun(9)) {
-        // Required by JdkTools and JdkJavaCompiler
-        jvmArgs(listOf("--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED"))
-        jvmArgs(listOf("--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"))
-
         if (isUnitTest() || usesEmbeddedExecuter()) {
             jvmArgs(org.gradle.internal.jvm.JpmsConfiguration.GRADLE_DAEMON_JPMS_ARGS)
         } else {

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
@@ -44,8 +44,7 @@ public class JpmsConfiguration {
     public static final List<String> GRADLE_DAEMON_JPMS_ARGS;
 
     static {
-        List<String> gradleDaemonJvmArgs = new ArrayList<String>();
-        gradleDaemonJvmArgs.addAll(GROOVY_JPMS_ARGS);
+        List<String> gradleDaemonJvmArgs = new ArrayList<String>(GROOVY_JPMS_ARGS);
 
         List<String> configurationCacheJpmsArgs = Collections.unmodifiableList(Arrays.asList(
             "--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED", // required by JavaObjectSerializationCodec.kt

--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerJavaCompilationIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerJavaCompilationIntegrationTest.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testkit.runner
+
+class GradleRunnerJavaCompilationIntegrationTest extends BaseGradleRunnerIntegrationTest {
+
+    def "can compile Java code through TestKit"() {
+        given:
+        buildScript """
+            plugins {
+                id 'java-library'
+            }
+        """
+        file("src/main/java/Hello.java").text = "public class Hello {}"
+
+        expect:
+        runner("compileJava").build()
+    }
+
+}

--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerConsoleInputEndUserIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerConsoleInputEndUserIntegrationTest.groovy
@@ -32,8 +32,6 @@ class GradleRunnerConsoleInputEndUserIntegrationTest extends BaseTestKitEndUserI
 
     def setup() {
         buildFile << """
-            import org.gradle.internal.jvm.JpmsConfiguration
-
             apply plugin: 'groovy'
 
             dependencies {
@@ -44,17 +42,6 @@ class GradleRunnerConsoleInputEndUserIntegrationTest extends BaseTestKitEndUserI
             testing {
                 suites {
                     test {
-                        targets {
-                            all {
-                                testTask.configure {
-                                    if (JavaVersion.current().isJava9Compatible()) {
-                                        // Normally, test runners are not inheriting the JVM arguments from the Gradle daemon.
-                                        // This case though, we need it, as we are executing a compilation task inside the nested build.
-                                        jvmArgs = JpmsConfiguration.GRADLE_DAEMON_JPMS_ARGS
-                                    }
-                                }
-                            }
-                        }
                         useSpock()
                     }
                 }

--- a/platforms/jvm/language-groovy/build.gradle.kts
+++ b/platforms/jvm/language-groovy/build.gradle.kts
@@ -71,6 +71,12 @@ dependencies {
     integTestDistributionRuntimeOnly(project(":distributions-jvm"))
 }
 
+tasks.withType<Test>().configureEach {
+    if (!javaVersion.isJava9Compatible) {
+        classpath += javaLauncher.get().metadata.installationPath.files("lib/tools.jar")
+    }
+}
+
 packageCycles {
     excludePatterns.add("org/gradle/api/internal/tasks/compile/**")
     excludePatterns.add("org/gradle/api/tasks/javadoc/**")

--- a/platforms/jvm/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/DefaultGroovyJavaJointCompileSpecFactory.java
+++ b/platforms/jvm/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/DefaultGroovyJavaJointCompileSpecFactory.java
@@ -19,11 +19,10 @@ package org.gradle.api.internal.tasks.compile;
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
 
-import javax.annotation.Nullable;
 import java.io.File;
 
 public class DefaultGroovyJavaJointCompileSpecFactory extends AbstractJavaCompileSpecFactory<DefaultGroovyJavaJointCompileSpec> {
-    public DefaultGroovyJavaJointCompileSpecFactory(CompileOptions compileOptions, @Nullable JavaInstallationMetadata javaInstallationMetadata) {
+    public DefaultGroovyJavaJointCompileSpecFactory(CompileOptions compileOptions, JavaInstallationMetadata javaInstallationMetadata) {
         super(compileOptions, javaInstallationMetadata);
     }
 
@@ -38,7 +37,7 @@ public class DefaultGroovyJavaJointCompileSpecFactory extends AbstractJavaCompil
     }
 
     @Override
-    protected DefaultGroovyJavaJointCompileSpec getDefaultSpec() {
+    protected DefaultGroovyJavaJointCompileSpec getInProcessSpec() {
         return new DefaultGroovyJavaJointCompileSpec();
     }
 

--- a/platforms/jvm/language-groovy/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultGroovyJavaJointCompileSpecFactoryTest.groovy
+++ b/platforms/jvm/language-groovy/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultGroovyJavaJointCompileSpecFactoryTest.groovy
@@ -16,12 +16,14 @@
 
 package org.gradle.api.internal.tasks.compile
 
+
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.tasks.compile.CompileOptions
 import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.jvm.toolchain.JavaInstallationMetadata
 import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.internal.JavaToolchain
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
 import org.junit.Rule
@@ -36,7 +38,12 @@ class DefaultGroovyJavaJointCompileSpecFactoryTest extends Specification {
         CompileOptions options = TestUtil.newInstance(CompileOptions.class, TestUtil.objectFactory())
         options.fork = fork
         options.forkOptions.executable = executable ? Jvm.current().javacExecutable.absolutePath : null
-        DefaultGroovyJavaJointCompileSpecFactory factory = new DefaultGroovyJavaJointCompileSpecFactory(options, null)
+
+        def javaToolchain = Mock(JavaToolchain) {
+            getInstallationPath() >> TestFiles.fileFactory().dir(Jvm.current().javaHome)
+            getLanguageVersion() >> JavaLanguageVersion.of("8")
+        }
+        def factory = new DefaultGroovyJavaJointCompileSpecFactory(options, javaToolchain)
 
         when:
         def spec = factory.create()
@@ -48,7 +55,7 @@ class DefaultGroovyJavaJointCompileSpecFactoryTest extends Specification {
 
         where:
         fork  | executable | implementsForking | implementsCommandLine
-        false | false      | false             | false
+        false | false      | true              | false
         true  | false      | true              | false
         true  | true       | false             | true
     }

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AbstractJavaCompileSpecFactory.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AbstractJavaCompileSpecFactory.java
@@ -42,26 +42,24 @@ public abstract class AbstractJavaCompileSpecFactory<T extends JavaCompileSpec> 
         File toolchainJavaHome = toolchain.getInstallationPath().getAsFile();
         if (!toolchain.getLanguageVersion().canCompileOrRun(8)) {
             LOGGER.info("Compilation mode: command line compilation");
-            LOGGER.info("Command line compilation is used, as requested toolchain is below JDK 1.7");
             return getCommandLineSpec(Jvm.forHome(toolchainJavaHome).getJavacExecutable());
         }
 
         if (compileOptions.isFork()) {
-            LOGGER.info("Compilation mode: explicit forking compiler");
             File forkJavaHome = compileOptions.getForkOptions().getJavaHome();
             if (forkJavaHome != null) {
-                LOGGER.info("Forking mode has fork.javaHome set: {}", forkJavaHome);
+                LOGGER.info("Compilation mode: command line compilation");
                 return getCommandLineSpec(Jvm.forHome(forkJavaHome).getJavacExecutable());
             }
 
             String forkExecutable = compileOptions.getForkOptions().getExecutable();
             if (forkExecutable != null) {
-                LOGGER.info("Forking mode has fork.executable set: {}", forkExecutable);
+                LOGGER.info("Compilation mode: command line compilation");
                 return getCommandLineSpec(JavaExecutableUtils.resolveExecutable(forkExecutable));
             }
 
             int languageVersion = toolchain.getLanguageVersion().asInt();
-            LOGGER.info("Forking mode with default executable for language version {}", languageVersion);
+            LOGGER.info("Compilation mode: forking compiler");
             return getForkingSpec(toolchainJavaHome, languageVersion);
         }
 
@@ -69,12 +67,10 @@ public abstract class AbstractJavaCompileSpecFactory<T extends JavaCompileSpec> 
             // Please keep it in mind, that when using TestKit with debug enabled (i.e. in embedded mode), this line won't be reached after Java 16 (JEP 396)
             // If you need this to be executed, add the necessary configs from JPMSConfiguration to the test runner executing Gradle
             LOGGER.info("Compilation mode: in-process compilation");
-            LOGGER.info("In-process compilation is used, as requested toolchain is the same as the current JVM, and all modules are open");
             return getInProcessSpec();
         }
 
-        LOGGER.info("Compilation mode: implicit forking compiler");
-        LOGGER.info("No specific compiler is requested, using default forking compiler for language version {}", toolchain.getLanguageVersion().asInt());
+        LOGGER.info("Compilation mode: default, forking compiler");
         return getForkingSpec(toolchainJavaHome, toolchain.getLanguageVersion().asInt());
     }
 

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpecFactory.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpecFactory.java
@@ -19,11 +19,10 @@ package org.gradle.api.internal.tasks.compile;
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
 
-import javax.annotation.Nullable;
 import java.io.File;
 
 public class DefaultJavaCompileSpecFactory extends AbstractJavaCompileSpecFactory<DefaultJavaCompileSpec> {
-    public DefaultJavaCompileSpecFactory(CompileOptions compileOptions, @Nullable JavaInstallationMetadata toolchain) {
+    public DefaultJavaCompileSpecFactory(CompileOptions compileOptions, JavaInstallationMetadata toolchain) {
         super(compileOptions, toolchain);
     }
 
@@ -38,7 +37,7 @@ public class DefaultJavaCompileSpecFactory extends AbstractJavaCompileSpecFactor
     }
 
     @Override
-    protected DefaultJavaCompileSpec getDefaultSpec() {
+    protected DefaultJavaCompileSpec getInProcessSpec() {
         return new DefaultJavaCompileSpec();
     }
 

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
@@ -131,5 +131,22 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
         spec.withException(ex);
     }
 
+    public static boolean canBeUsed() {
+        try {
+            // Our goal is to check if the class is instantiable
+            // Class loading alone doesn't generate an exception
+            new Context();
+        } catch (IllegalAccessError e) {
+            LOGGER.debug("Expected failure when checking class presence: {}", e.getMessage());
+            return false;
+        } catch (Throwable throwable) {
+            // We don't expect any other exception
+            // Regardless, to make this as robust as possible, we handle it
+            LOGGER.debug("Unexpected failure when checking class presence: {}", throwable.getMessage());
+            return false;
+        }
+
+        return true;
+    }
 
 }

--- a/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpecFactoryTest.groovy
+++ b/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpecFactoryTest.groovy
@@ -51,12 +51,10 @@ class DefaultJavaCompileSpecFactoryTest extends Specification {
         // Where the toolchain == null, we use the current JVM
         fork  | executable | toolchain | implementsForking | implementsCommandLine
         false | false      | null      | false             | false
-        false | false      | null      | false             | false
         false | false      | "11"      | true              | false
         // Below Java 8 toolchain compiler always runs via command-line
         false | false      | "7"       | false             | true
         true  | false      | null      | true              | false
-        true  | true       | null      | false             | true
         true  | true       | null      | false             | true
         true  | true       | "11"      | false             | true
     }

--- a/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpecFactoryTest.groovy
+++ b/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpecFactoryTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,17 +27,15 @@ import spock.lang.Specification
 class DefaultJavaCompileSpecFactoryTest extends Specification {
 
     def "produces correct spec with fork=#fork, executable=#executable, toolchain=#toolchain"() {
+        given:
         CompileOptions options = TestUtil.newInstance(CompileOptions, TestUtil.objectFactory())
         options.fork = fork
         options.forkOptions.executable = executable ? Jvm.current().javacExecutable.absolutePath : null
 
-        def javaToolchain = null
-        if (toolchain != null) {
-            def isCurrent = toolchain == "current"
-            javaToolchain = Mock(JavaToolchain)
-            javaToolchain.installationPath >> TestFiles.fileFactory().dir(Jvm.current().javaHome)
-            javaToolchain.isCurrentJvm() >> isCurrent
-            javaToolchain.languageVersion >> JavaLanguageVersion.of(isCurrent ? "8" : toolchain)
+        def javaToolchain = Mock(JavaToolchain) {
+            getInstallationPath() >> TestFiles.fileFactory().dir(Jvm.current().javaHome)
+            isCurrentJvm() >> (toolchain == null)
+            getLanguageVersion() >> JavaLanguageVersion.of(toolchain ?: "8")
         }
 
         when:
@@ -50,16 +48,16 @@ class DefaultJavaCompileSpecFactoryTest extends Specification {
         CommandLineJavaCompileSpec.isAssignableFrom(spec.getClass()) == implementsCommandLine
 
         where:
+        // Where the toolchain == null, we use the current JVM
         fork  | executable | toolchain | implementsForking | implementsCommandLine
         false | false      | null      | false             | false
-        false | false      | "current" | false             | false
+        false | false      | null      | false             | false
         false | false      | "11"      | true              | false
         // Below Java 8 toolchain compiler always runs via command-line
         false | false      | "7"       | false             | true
-
         true  | false      | null      | true              | false
         true  | true       | null      | false             | true
-        true  | true       | "current" | false             | true
+        true  | true       | null      | false             | true
         true  | true       | "11"      | false             | true
     }
 

--- a/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JdkJavaCompilerTest.groovy
+++ b/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JdkJavaCompilerTest.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile
+
+
+import spock.lang.Specification
+
+class JdkJavaCompilerTest extends Specification {
+
+    def "normally embedded compiler can be used"() {
+        when:
+        def canBeUsed = JdkJavaCompiler.canBeUsed()
+
+        then:
+        canBeUsed == true
+    }
+
+}


### PR DESCRIPTION
Adds a forward and backward compatibility fix caused by some new modules required:
 - The backward direction is done by the compiler, which will switch to forking mode if the required modules are not open.
 - The forward direction is done by adding the missing module declarations in TestKit

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
