### PR TITLE
Fix bugs in integ test deprecation logger scraping

### DIFF
--- a/platforms/core-runtime/daemon-protocol/src/main/java/org/gradle/launcher/daemon/diagnostics/DaemonDiagnostics.java
+++ b/platforms/core-runtime/daemon-protocol/src/main/java/org/gradle/launcher/daemon/diagnostics/DaemonDiagnostics.java
@@ -64,7 +64,7 @@ public class DaemonDiagnostics {
     }
 
     private String formatTail(String tail) {
-        return "----- Last  " + TAIL_SIZE + " lines from daemon log file - " + getDaemonLog().getName() + " -----\n"
+        return "----- Last " + TAIL_SIZE + " lines from daemon log file - " + getDaemonLog().getName() + " -----\n"
             + tail
             + "----- End of the daemon log -----\n";
     }

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/ProcessCrashHandlingIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/ProcessCrashHandlingIntegrationTest.groovy
@@ -173,7 +173,7 @@ class ProcessCrashHandlingIntegrationTest extends DaemonIntegrationSpec {
         def failure = build.waitForFailure()
 
         then:
-        failure.assertHasErrorOutput("----- Last  20 lines from daemon log file")
+        failure.assertHasErrorOutput("----- Last 20 lines from daemon log file")
         failure.assertHasDescription(DaemonDisappearedException.MESSAGE)
     }
 
@@ -212,7 +212,7 @@ class ProcessCrashHandlingIntegrationTest extends DaemonIntegrationSpec {
         def failure = executer.runWithFailure()
 
         then:
-        failure.assertHasErrorOutput("----- Last  20 lines from daemon log file")
+        failure.assertHasErrorOutput("----- Last 20 lines from daemon log file")
         failure.assertHasErrorOutput(DaemonMessages.DAEMON_VM_SHUTTING_DOWN)
         failure.assertHasDescription(DaemonDisappearedException.MESSAGE)
 

--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/ConsoleTypePersistIntegrationTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/ConsoleTypePersistIntegrationTest.groovy
@@ -36,6 +36,7 @@ class ConsoleTypePersistIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         file('gradle.properties') << 'org.gradle.console=rich'
+        executer.noDeprecationChecks() // Rich consoles mess with deprecation checks
         succeeds('help', "-Pexpected=Rich")
         then:
         assertHasAnsiEscapeSequence()

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/api/internal/DocumentationRegistry.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/api/internal/DocumentationRegistry.java
@@ -26,7 +26,8 @@ import org.gradle.util.GradleVersion;
  */
 @ServiceScope(Scope.Global.class)
 public class DocumentationRegistry {
-    public static final String BASE_URL = "https://docs.gradle.org/" + GradleVersion.current().getVersion();
+    public static final String BASE_URL_WITHOUT_VERSION = "https://docs.gradle.org/";
+    public static final String BASE_URL = BASE_URL_WITHOUT_VERSION + GradleVersion.current().getVersion();
     public static final String DSL_PROPERTY_URL_FORMAT = "%s/dsl/%s.html#%s:%s";
     public static final String KOTLIN_DSL_URL_FORMAT = "%s/kotlin-dsl/gradle/%s";
     public static final String LEARN_MORE_STRING = "Learn more about Gradle by exploring our Samples at ";

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DocumentationUtils.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DocumentationUtils.java
@@ -16,13 +16,19 @@
 
 package org.gradle.integtests.fixtures.executer;
 
+import org.gradle.util.GradleVersion;
+
 import static org.gradle.api.internal.DocumentationRegistry.BASE_URL;
+import static org.gradle.api.internal.DocumentationRegistry.BASE_URL_WITHOUT_VERSION;
 
 public class DocumentationUtils {
-    public static final String DOCS_GRADLE_ORG = "https://docs.gradle.org/";
-    public static final String PATTERN = DOCS_GRADLE_ORG + "current/";
+    public static final String PATTERN = BASE_URL_WITHOUT_VERSION + "current/";
 
     public static String normalizeDocumentationLink(String message) {
         return message.replace(PATTERN, BASE_URL + "/");
+    }
+
+    public static String normalizeDocumentationLink(String message, GradleVersion version) {
+        return message.replace(PATTERN, BASE_URL_WITHOUT_VERSION + version.getVersion() + "/");
     }
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExpectedDeprecationWarning.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExpectedDeprecationWarning.java
@@ -29,6 +29,9 @@ import java.util.regex.Pattern;
  */
 public abstract class ExpectedDeprecationWarning {
 
+    private static final Pattern DEPRECATION_WARNING_LOG_PREFIX_PATTERN =
+        Pattern.compile("^.* \\[WARN] \\[org\\.gradle\\.internal\\.featurelifecycle\\.LoggingDeprecatedFeatureHandler] ");
+
     private final int numLines;
 
     public ExpectedDeprecationWarning(int numLines) {
@@ -95,6 +98,11 @@ public abstract class ExpectedDeprecationWarning {
         String nextLines = numLines == 1
             ? lines.get(startIndex)
             : String.join("\n", lines.subList(startIndex, Math.min(startIndex + numLines, lines.size())));
+
+        // When info or debug logging is enabled, the line will be prefixed with the log level and timestamp.
+        // We need to strip this out to match the expected message.
+        nextLines = DEPRECATION_WARNING_LOG_PREFIX_PATTERN.matcher(nextLines).replaceAll("");
+
         return matchesNextLines(nextLines);
     }
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExpectedDeprecationWarning.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExpectedDeprecationWarning.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 public abstract class ExpectedDeprecationWarning {
 
     private static final Pattern DEPRECATION_WARNING_LOG_PREFIX_PATTERN =
-        Pattern.compile("^.* \\[WARN] \\[org\\.gradle\\.internal\\.featurelifecycle\\.LoggingDeprecatedFeatureHandler] ");
+        Pattern.compile("^.* " + Pattern.quote("[WARN] [org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler] "));
 
     private final int numLines;
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -37,9 +37,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import static org.gradle.integtests.fixtures.executer.DocumentationUtils.normalizeDocumentationLink;
-
 public interface GradleExecuter extends Stoppable {
+
     /**
      * Sets the working directory to use. Defaults to the test's temporary directory.
      */
@@ -387,9 +386,7 @@ public interface GradleExecuter extends Stoppable {
     /**
      * Expects the given deprecation warning, allowing to pass documentation url with /current/ version and asserting against the actual current version instead.
      */
-    default GradleExecuter expectDocumentedDeprecationWarning(String warning) {
-        return expectDeprecationWarning(normalizeDocumentationLink(warning));
-    }
+    GradleExecuter expectDocumentedDeprecationWarning(String warning);
 
     /**
      * Expects exactly the given number of deprecation warnings. If fewer or more warnings are produced during


### PR DESCRIPTION
This commit fixes a number of bugs in the infrastructure used to detect deprecation log messages in build outputs.

1. Rich consoles messed with the detection since we can get weird console control characters and progress bars before, after, and in between deprecation log messages. In these cases, we just disable deprecation log checks
2. When the integ test specifies a gradleVesrionOverride, we did not properly normalize documented deprecation URLs. They are now properly normalized to take into account the overridden gradle version.
3. When info or debug logs are enabled, deprecation messages are prfixed with an SLF4J log prefix. We strip this when checking for deprecation messages in a line
4. When a daemon crashes, we print the last ~20 lines of the daemon log. This can include a deprecation, causing the infrastructure to think we emitted the deprecation once and not twice. We strip any daemon log outputs dumps from the deprecation message scraping.

It so happens that none of these cases came up when checking for deprecations. However, if we do come across a build that encounters one of these cases and also emits deprecations, we would have problems.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
