### PR TITLE
Fix docs link for inotify instance limit

### DIFF
--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/FileSystemWatchingDocumentationIndex.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/FileSystemWatchingDocumentationIndex.java
@@ -16,6 +16,6 @@
 
 package org.gradle.internal.watch.registry.impl;
 
-public interface DaemonDocumentationIndex {
+public interface FileSystemWatchingDocumentationIndex {
     String getLinkToSection(String sectionId);
 }

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
@@ -31,7 +31,7 @@ import org.gradle.internal.watch.WatchingNotSupportedException;
 import org.gradle.internal.watch.registry.FileWatcherRegistry;
 import org.gradle.internal.watch.registry.FileWatcherRegistryFactory;
 import org.gradle.internal.watch.registry.WatchMode;
-import org.gradle.internal.watch.registry.impl.DaemonDocumentationIndex;
+import org.gradle.internal.watch.registry.impl.FileSystemWatchingDocumentationIndex;
 import org.gradle.internal.watch.registry.impl.SnapshotCollectingDiffListener;
 import org.gradle.internal.watch.vfs.BuildFinishedFileSystemWatchingBuildOperationType;
 import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem;
@@ -61,7 +61,7 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
     private static final String FILE_WATCHING_ERROR_MESSAGE_AT_END_OF_BUILD = "Gradle was unable to watch the file system for changes";
 
     private final FileWatcherRegistryFactory watcherRegistryFactory;
-    private final DaemonDocumentationIndex daemonDocumentationIndex;
+    private final FileSystemWatchingDocumentationIndex fileSystemWatchingDocumentationIndex;
     private final FileWatchingFilter locationsWrittenByCurrentBuild;
     private final WatchableFileSystemDetector watchableFileSystemDetector;
     private final FileChangeListeners fileChangeListeners;
@@ -80,14 +80,14 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
     public WatchingVirtualFileSystem(
         FileWatcherRegistryFactory watcherRegistryFactory,
         SnapshotHierarchy root,
-        DaemonDocumentationIndex daemonDocumentationIndex,
+        FileSystemWatchingDocumentationIndex fileSystemWatchingDocumentationIndex,
         FileWatchingFilter locationsWrittenByCurrentBuild,
         WatchableFileSystemDetector watchableFileSystemDetector,
         FileChangeListeners fileChangeListeners
     ) {
         super(root);
         this.watcherRegistryFactory = watcherRegistryFactory;
-        this.daemonDocumentationIndex = daemonDocumentationIndex;
+        this.fileSystemWatchingDocumentationIndex = fileSystemWatchingDocumentationIndex;
         this.locationsWrittenByCurrentBuild = locationsWrittenByCurrentBuild;
         this.watchableFileSystemDetector = watchableFileSystemDetector;
         this.fileChangeListeners = fileChangeListeners;
@@ -465,7 +465,7 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
         if (exception instanceof InotifyInstanceLimitTooLowException) {
             warningLogger.warn("{}. The inotify instance limit is too low. {}",
                 fileWatchingErrorMessage,
-                daemonDocumentationIndex.getLinkToSection("sec:inotify_instances_limit")
+                fileSystemWatchingDocumentationIndex.getLinkToSection("sec:inotify_watches_limit")
             );
         } else if (exception instanceof InotifyWatchesLimitTooLowException) {
             warningLogger.warn("{}. The inotify watches limit is too low.", fileWatchingErrorMessage);

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
@@ -465,7 +465,7 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
         if (exception instanceof InotifyInstanceLimitTooLowException) {
             warningLogger.warn("{}. The inotify instance limit is too low. {}",
                 fileWatchingErrorMessage,
-                fileSystemWatchingDocumentationIndex.getLinkToSection("sec:inotify_watches_limit")
+                fileSystemWatchingDocumentationIndex.getLinkToSection("sec:inotify_instances_limit")
             );
         } else if (exception instanceof InotifyWatchesLimitTooLowException) {
             warningLogger.warn("{}. The inotify watches limit is too low.", fileWatchingErrorMessage);

--- a/platforms/core-execution/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystemTest.groovy
+++ b/platforms/core-execution/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystemTest.groovy
@@ -24,7 +24,7 @@ import org.gradle.internal.vfs.impl.DefaultSnapshotHierarchy
 import org.gradle.internal.watch.registry.FileWatcherRegistry
 import org.gradle.internal.watch.registry.FileWatcherRegistryFactory
 import org.gradle.internal.watch.registry.WatchMode
-import org.gradle.internal.watch.registry.impl.DaemonDocumentationIndex
+import org.gradle.internal.watch.registry.impl.FileSystemWatchingDocumentationIndex
 import org.gradle.internal.watch.vfs.FileChangeListeners
 import org.gradle.internal.watch.vfs.VfsLogging
 import org.gradle.internal.watch.vfs.WatchLogging
@@ -38,7 +38,7 @@ class WatchingVirtualFileSystemTest extends Specification {
     def nonEmptySnapshotHierarchy = Stub(SnapshotHierarchy) {
         empty() >> emptySnapshotHierarchy
     }
-    def daemonDocumentationIndex = Mock(DaemonDocumentationIndex)
+    def documentationIndex = Mock(FileSystemWatchingDocumentationIndex)
     def locationsUpdatedByCurrentBuild = Mock(FileWatchingFilter)
     def buildOperationRunner = new TestBuildOperationRunner()
     def watchableFileSystemDetector = Mock(WatchableFileSystemDetector)
@@ -46,7 +46,7 @@ class WatchingVirtualFileSystemTest extends Specification {
     def watchingVirtualFileSystem = new WatchingVirtualFileSystem(
         watcherRegistryFactory,
         nonEmptySnapshotHierarchy,
-        daemonDocumentationIndex,
+        documentationIndex,
         locationsUpdatedByCurrentBuild,
         watchableFileSystemDetector,
         fileChangeListeners

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/file_system_watching.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/file_system_watching.adoc
@@ -149,7 +149,7 @@ If you receive the `java.io.IOException: Too many open files` error on macOS, ra
 See https://superuser.com/a/443168/8117[this post] for more details.
 
 [[sec:inotify_watches_limit]]
-===  Adjust inotify Limits on Linux
+===  Adjust inotify watches limit on Linux
 
 File system watching uses http://en.wikipedia.org/wiki/Inotify[inotify] on Linux.
 Depending on the size of your build, it may be necessary to increase inotify limits.
@@ -177,3 +177,16 @@ sudo sysctl -p --system
 Each used inotify watch takes up to 1KB of memory.
 Assuming inotify uses all the 512K watches then file system watching could use up to 500MB.
 In a memory-constrained environment, you may want to disable file system watching.
+
+[[sec:inotify_instances_limit]]
+===  Inspect inotify instances limit on Linux
+
+File system watching initializes one inotify instance per daemon.
+You can see the current limit of inotify instances per user by running:
+
+[source,bash]
+----
+cat /proc/sys/fs/inotify/max_user_instances
+----
+
+The default per-user instances limit should be high enough, so we don't recommend increasing that value manually.

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -222,7 +222,7 @@ public class VirtualFileSystemServices extends AbstractGradleModuleServices {
                 .<BuildLifecycleAwareVirtualFileSystem>map(watcherRegistryFactory -> new WatchingVirtualFileSystem(
                     watcherRegistryFactory,
                     root,
-                    sectionId -> documentationRegistry.getDocumentationRecommendationFor("details", "gradle_daemon", sectionId),
+                    sectionId -> documentationRegistry.getDocumentationRecommendationFor("details", "file_system_watching", sectionId),
                     fileWatchingFilter,
                     watchableFileSystemDetector,
                     fileChangeListeners


### PR DESCRIPTION
It looks like we link now to:
https://docs.gradle.org/current/userguide/gradle_daemon.html#sec:inotify_instances_limit
but that doesn't exist anymore.

This fix should now link to:
https://docs.gradle.org/current/userguide/file_system_watching.html#sec:inotify_watches_limit 