### PR TITLE
Fix global service validation workarounds

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/InjectAnnotationHandler.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/InjectAnnotationHandler.java
@@ -16,6 +16,9 @@
 
 package org.gradle.internal.instantiation;
 
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+
 import java.lang.annotation.Annotation;
 
 /**
@@ -23,6 +26,7 @@ import java.lang.annotation.Annotation;
  *
  * <p>Implementations must be registered as global scoped services.</p>
  */
+@ServiceScope(Scope.Global.class)
 public interface InjectAnnotationHandler {
     Class<? extends Annotation> getAnnotationType();
 }

--- a/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonServer.java
+++ b/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonServer.java
@@ -22,7 +22,6 @@ import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultClassPathProvider;
 import org.gradle.api.internal.DefaultClassPathRegistry;
 import org.gradle.api.internal.MutationGuards;
-import org.gradle.api.internal.classpath.DefaultModuleRegistry;
 import org.gradle.api.internal.classpath.ModuleRegistry;
 import org.gradle.api.internal.collections.DefaultDomainObjectCollectionFactory;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
@@ -165,7 +164,7 @@ public class WorkerDaemonServer implements RequestHandler<TransportableActionExe
         }
 
         @Provides
-        ClassPathRegistry createClassPathRegistry(DefaultModuleRegistry moduleRegistry) {
+        ClassPathRegistry createClassPathRegistry(ModuleRegistry moduleRegistry) {
             return new DefaultClassPathRegistry(new DefaultClassPathProvider(moduleRegistry));
         }
 

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
@@ -29,7 +29,6 @@ class ServiceScopeValidatorWorkarounds {
         "org.gradle.internal.Factory",
         "org.gradle.internal.serialize.Serializer",
         "org.gradle.api.internal.classpath.DefaultModuleRegistry",
-        "org.gradle.tooling.internal.provider.runner.ToolingApiBuildEventListenerFactory",
         "org.gradle.cache.internal.ProducerGuard",
         "org.gradle.internal.typeconversion.NotationParser",
 

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
@@ -43,14 +43,9 @@ class ServiceScopeValidatorWorkarounds {
 
         "org.gradle.api.reporting.components.internal.TypeAwareBinaryRenderer",
 
-        "org.gradle.nativeplatform.internal.NativeBinaryRenderer",
-        "org.gradle.nativeplatform.internal.SharedLibraryBinaryRenderer",
-        "org.gradle.nativeplatform.internal.StaticLibraryBinaryRenderer",
-        "org.gradle.nativeplatform.internal.NativeExecutableBinaryRenderer",
         "org.gradle.nativeplatform.platform.internal.NativePlatforms",
         "org.gradle.nativeplatform.internal.NativePlatformResolver",
-        "org.gradle.nativeplatform.internal.DefaultTargetMachineFactory",
-        "org.gradle.nativeplatform.test.internal.NativeTestSuiteBinaryRenderer"
+        "org.gradle.nativeplatform.internal.DefaultTargetMachineFactory"
     ));
 
     public static boolean shouldSuppressValidation(Class<?> serviceType) {

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
@@ -41,8 +41,6 @@ class ServiceScopeValidatorWorkarounds {
         "org.gradle.api.internal.tasks.properties.annotations.OutputFilePropertyAnnotationHandler",
         "org.gradle.api.internal.tasks.properties.annotations.OutputFilesPropertyAnnotationHandler",
 
-        "org.gradle.api.reporting.components.internal.TypeAwareBinaryRenderer",
-
         "org.gradle.nativeplatform.platform.internal.NativePlatforms",
         "org.gradle.nativeplatform.internal.NativePlatformResolver",
         "org.gradle.nativeplatform.internal.DefaultTargetMachineFactory"

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
@@ -50,9 +50,7 @@ class ServiceScopeValidatorWorkarounds {
         "org.gradle.nativeplatform.platform.internal.NativePlatforms",
         "org.gradle.nativeplatform.internal.NativePlatformResolver",
         "org.gradle.nativeplatform.internal.DefaultTargetMachineFactory",
-        "org.gradle.nativeplatform.test.internal.NativeTestSuiteBinaryRenderer",
-
-        "org.gradle.internal.scripts.DefaultScriptFileResolverListeners"
+        "org.gradle.nativeplatform.test.internal.NativeTestSuiteBinaryRenderer"
     ));
 
     public static boolean shouldSuppressValidation(Class<?> serviceType) {

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
@@ -33,9 +33,6 @@ class ServiceScopeValidatorWorkarounds {
         "org.gradle.cache.internal.ProducerGuard",
         "org.gradle.internal.typeconversion.NotationParser",
 
-        "org.gradle.api.internal.artifacts.transform.InputArtifactDependenciesAnnotationHandler",
-        "org.gradle.api.internal.artifacts.transform.InputArtifactAnnotationHandler",
-
         "org.gradle.api.internal.tasks.properties.annotations.OutputDirectoryPropertyAnnotationHandler",
         "org.gradle.api.internal.tasks.properties.annotations.OutputDirectoriesPropertyAnnotationHandler",
         "org.gradle.api.internal.tasks.properties.annotations.OutputFilePropertyAnnotationHandler",

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
@@ -52,9 +52,7 @@ class ServiceScopeValidatorWorkarounds {
         "org.gradle.nativeplatform.internal.DefaultTargetMachineFactory",
         "org.gradle.nativeplatform.test.internal.NativeTestSuiteBinaryRenderer",
 
-        "org.gradle.internal.scripts.DefaultScriptFileResolverListeners",
-
-        "org.gradle.plugin.software.internal.SoftwareTypeAnnotationHandler"
+        "org.gradle.internal.scripts.DefaultScriptFileResolverListeners"
     ));
 
     public static boolean shouldSuppressValidation(Class<?> serviceType) {

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/internal/PluginUseServices.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/internal/PluginUseServices.java
@@ -39,6 +39,7 @@ import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.instantiation.InstantiationScheme;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.properties.annotations.MissingPropertyAnnotationHandler;
+import org.gradle.internal.properties.annotations.PropertyAnnotationHandler;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.Provides;
 import org.gradle.internal.service.ServiceRegistration;
@@ -91,7 +92,7 @@ public class PluginUseServices extends AbstractGradleModuleServices {
     @NonNullApi
     private static class GlobalScopeServices implements ServiceRegistrationProvider {
         @Provides
-        SoftwareTypeAnnotationHandler createSoftwareTypeAnnotationHandler() {
+        PropertyAnnotationHandler createSoftwareTypeAnnotationHandler() {
             return new SoftwareTypeAnnotationHandler();
         }
     }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/problems/buildtree/ProblemReporter.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/problems/buildtree/ProblemReporter.java
@@ -26,7 +26,7 @@ import java.io.File;
  * in some form.
  */
 
-@ServiceScope(Scope.BuildTree.class)
+@ServiceScope({Scope.Global.class, Scope.BuildTree.class})
 public interface ProblemReporter {
     interface ProblemConsumer {
         void accept(Throwable throwable);

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ToolingBuilderServices.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ToolingBuilderServices.java
@@ -16,13 +16,15 @@
 
 package org.gradle.tooling.internal.provider.runner;
 
+import org.gradle.internal.build.event.BuildEventListenerFactory;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.scopes.AbstractGradleModuleServices;
+import org.gradle.problems.buildtree.ProblemReporter;
 
 public class ToolingBuilderServices extends AbstractGradleModuleServices {
     @Override
     public void registerGlobalServices(ServiceRegistration registration) {
-        registration.add(ToolingApiBuildEventListenerFactory.class);
+        registration.add(BuildEventListenerFactory.class, ProblemReporter.class, ToolingApiBuildEventListenerFactory.class);
     }
 
     @Override

--- a/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/internal/services/NativeBinaryServices.java
+++ b/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/internal/services/NativeBinaryServices.java
@@ -18,6 +18,7 @@ package org.gradle.nativeplatform.internal.services;
 
 import net.rubygrapefruit.platform.SystemInfo;
 import net.rubygrapefruit.platform.WindowsRegistry;
+import org.gradle.api.reporting.components.internal.AbstractBinaryRenderer;
 import org.gradle.internal.file.RelativeFilePathResolver;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.service.Provides;
@@ -57,10 +58,10 @@ import org.gradle.process.internal.ExecActionFactory;
 public class NativeBinaryServices extends AbstractGradleModuleServices {
     @Override
     public void registerGlobalServices(ServiceRegistration registration) {
-        registration.add(NativeBinaryRenderer.class);
-        registration.add(SharedLibraryBinaryRenderer.class);
-        registration.add(StaticLibraryBinaryRenderer.class);
-        registration.add(NativeExecutableBinaryRenderer.class);
+        registration.add(AbstractBinaryRenderer.class, NativeBinaryRenderer.class);
+        registration.add(AbstractBinaryRenderer.class, SharedLibraryBinaryRenderer.class);
+        registration.add(AbstractBinaryRenderer.class, StaticLibraryBinaryRenderer.class);
+        registration.add(AbstractBinaryRenderer.class, NativeExecutableBinaryRenderer.class);
         registration.add(NativePlatforms.class);
         registration.add(NativePlatformResolver.class);
         registration.add(DefaultTargetMachineFactory.class);

--- a/platforms/native/testing-native/src/main/java/org/gradle/nativeplatform/test/internal/services/NativeTestingServices.java
+++ b/platforms/native/testing-native/src/main/java/org/gradle/nativeplatform/test/internal/services/NativeTestingServices.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.nativeplatform.test.internal.services;
 
+import org.gradle.api.reporting.components.internal.AbstractBinaryRenderer;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.scopes.AbstractGradleModuleServices;
 import org.gradle.nativeplatform.test.internal.NativeTestSuiteBinaryRenderer;
@@ -22,6 +23,6 @@ import org.gradle.nativeplatform.test.internal.NativeTestSuiteBinaryRenderer;
 public class NativeTestingServices extends AbstractGradleModuleServices {
     @Override
     public void registerGlobalServices(ServiceRegistration registration) {
-        registration.add(NativeTestSuiteBinaryRenderer.class);
+        registration.add(AbstractBinaryRenderer.class, NativeTestSuiteBinaryRenderer.class);
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
@@ -58,8 +58,10 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
 import org.gradle.cache.internal.ProducerGuard;
 import org.gradle.internal.component.external.model.PreferJavaRuntimeVariant;
+import org.gradle.internal.instantiation.InjectAnnotationHandler;
 import org.gradle.internal.instantiation.InstantiationScheme;
 import org.gradle.internal.instantiation.InstantiatorFactory;
+import org.gradle.internal.properties.annotations.PropertyAnnotationHandler;
 import org.gradle.internal.properties.annotations.TypeAnnotationHandler;
 import org.gradle.internal.resource.ExternalResourceName;
 import org.gradle.internal.resource.connector.ResourceConnectorFactory;
@@ -80,6 +82,8 @@ class DependencyManagementGlobalScopeServices implements ServiceRegistrationProv
         registration.add(ImmutableModuleIdentifierFactory.class, DefaultImmutableModuleIdentifierFactory.class);
         registration.add(ExcludeRuleConverter.class, DefaultExcludeRuleConverter.class);
         registration.add(LocalVariantMetadataBuilder.class, DefaultLocalVariantMetadataBuilder.class);
+        registration.add(PropertyAnnotationHandler.class, InjectAnnotationHandler.class, InputArtifactAnnotationHandler.class);
+        registration.add(PropertyAnnotationHandler.class, InjectAnnotationHandler.class, InputArtifactDependenciesAnnotationHandler.class);
     }
 
     @Provides
@@ -111,16 +115,6 @@ class DependencyManagementGlobalScopeServices implements ServiceRegistrationProv
     @Provides
     TypeAnnotationHandler createCacheableTransformAnnotationHandler() {
         return new CacheableTransformTypeAnnotationHandler();
-    }
-
-    @Provides
-    InputArtifactAnnotationHandler createInputArtifactAnnotationHandler() {
-        return new InputArtifactAnnotationHandler();
-    }
-
-    @Provides
-    InputArtifactDependenciesAnnotationHandler createInputArtifactDependenciesAnnotationHandler() {
-        return new InputArtifactDependenciesAnnotationHandler();
     }
 
     @Provides

--- a/subprojects/core-api/src/main/java/org/gradle/internal/scripts/ScriptFileResolvedListener.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/scripts/ScriptFileResolvedListener.java
@@ -18,9 +18,11 @@ package org.gradle.internal.scripts;
 
 import org.gradle.internal.service.scopes.EventScope;
 import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.io.File;
 
+@ServiceScope(Scope.Global.class)
 @EventScope(Scope.Global.class)
 public interface ScriptFileResolvedListener {
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/AbstractOutputPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/AbstractOutputPropertyAnnotationHandler.java
@@ -23,11 +23,14 @@ import org.gradle.internal.properties.PropertyValue;
 import org.gradle.internal.properties.PropertyVisitor;
 import org.gradle.internal.properties.annotations.AbstractPropertyAnnotationHandler;
 import org.gradle.internal.properties.annotations.PropertyMetadata;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.lang.annotation.Annotation;
 
 import static org.gradle.internal.execution.model.annotations.ModifierAnnotationCategory.OPTIONAL;
 
+@ServiceScope(Scope.Global.class)
 public abstract class AbstractOutputPropertyAnnotationHandler extends AbstractPropertyAnnotationHandler {
     private final OutputFilePropertyType filePropertyType;
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
@@ -32,6 +32,7 @@ import org.gradle.api.internal.project.taskfactory.TaskClassInfoStore;
 import org.gradle.api.internal.tasks.properties.InspectionScheme;
 import org.gradle.api.internal.tasks.properties.InspectionSchemeFactory;
 import org.gradle.api.internal.tasks.properties.TaskScheme;
+import org.gradle.api.internal.tasks.properties.annotations.AbstractOutputPropertyAnnotationHandler;
 import org.gradle.api.internal.tasks.properties.annotations.CacheableTaskTypeAnnotationHandler;
 import org.gradle.api.internal.tasks.properties.annotations.DestroysPropertyAnnotationHandler;
 import org.gradle.api.internal.tasks.properties.annotations.LocalStatePropertyAnnotationHandler;
@@ -302,22 +303,22 @@ public class ExecutionGlobalServices implements ServiceRegistrationProvider {
     }
 
     @Provides
-    OutputFilePropertyAnnotationHandler createOutputFilePropertyAnnotationHandler() {
+    AbstractOutputPropertyAnnotationHandler createOutputFilePropertyAnnotationHandler() {
         return new OutputFilePropertyAnnotationHandler();
     }
 
     @Provides
-    OutputFilesPropertyAnnotationHandler createOutputFilesPropertyAnnotationHandler() {
+    AbstractOutputPropertyAnnotationHandler createOutputFilesPropertyAnnotationHandler() {
         return new OutputFilesPropertyAnnotationHandler();
     }
 
     @Provides
-    OutputDirectoryPropertyAnnotationHandler createOutputDirectoryPropertyAnnotationHandler() {
+    AbstractOutputPropertyAnnotationHandler createOutputDirectoryPropertyAnnotationHandler() {
         return new OutputDirectoryPropertyAnnotationHandler();
     }
 
     @Provides
-    OutputDirectoriesPropertyAnnotationHandler createOutputDirectoriesPropertyAnnotationHandler() {
+    AbstractOutputPropertyAnnotationHandler createOutputDirectoriesPropertyAnnotationHandler() {
         return new OutputDirectoriesPropertyAnnotationHandler();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -84,7 +84,9 @@ import org.gradle.internal.problems.failure.FailureFactory;
 import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.internal.scripts.DefaultScriptFileResolver;
 import org.gradle.internal.scripts.DefaultScriptFileResolverListeners;
+import org.gradle.internal.scripts.ScriptFileResolvedListener;
 import org.gradle.internal.scripts.ScriptFileResolver;
+import org.gradle.internal.scripts.ScriptFileResolverListeners;
 import org.gradle.internal.service.CachingServiceLocator;
 import org.gradle.internal.service.DefaultServiceLocator;
 import org.gradle.internal.service.Provides;
@@ -138,14 +140,14 @@ public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
     @Override
     void configure(ServiceRegistration registration) {
         super.configure(registration);
-        registration.add(DefaultScriptFileResolverListeners.class);
+        registration.add(ScriptFileResolvedListener.class, ScriptFileResolverListeners.class, DefaultScriptFileResolverListeners.class);
         registration.add(BuildLayoutFactory.class);
         registration.add(ValidateStep.ValidationWarningRecorder.class, WorkValidationWarningReporter.class, DefaultWorkValidationWarningRecorder.class);
     }
 
     @Provides
-    ScriptFileResolver createScriptFileResolver(DefaultScriptFileResolverListeners listeners) {
-        return new DefaultScriptFileResolver(listeners);
+    ScriptFileResolver createScriptFileResolver(ScriptFileResolvedListener listener) {
+        return new DefaultScriptFileResolver(listener);
     }
 
     @Provides

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/components/internal/AbstractBinaryRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/components/internal/AbstractBinaryRenderer.java
@@ -19,6 +19,8 @@ package org.gradle.api.reporting.components.internal;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.tasks.diagnostics.internal.text.TextReportBuilder;
 import org.gradle.internal.logging.text.TreeFormatter;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.language.base.LanguageSourceSet;
 import org.gradle.model.ModelMap;
 import org.gradle.model.internal.manage.schema.ModelProperty;
@@ -36,6 +38,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 // TODO - bust up this hierarchy and compose using interfaces instead
+@ServiceScope(Scope.Global.class)
 public abstract class AbstractBinaryRenderer<T extends BinarySpec> extends ReportRenderer<BinarySpec, TextReportBuilder> {
     private final ModelSchemaStore schemaStore;
 

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/components/internal/TypeAwareBinaryRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/components/internal/TypeAwareBinaryRenderer.java
@@ -17,6 +17,8 @@
 package org.gradle.api.reporting.components.internal;
 
 import org.gradle.api.tasks.diagnostics.internal.text.TextReportBuilder;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.model.ModelElement;
 import org.gradle.platform.base.BinarySpec;
 import org.gradle.reporting.ReportRenderer;
@@ -26,6 +28,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 
+@ServiceScope(Scope.Global.class)
 public class TypeAwareBinaryRenderer extends ReportRenderer<BinarySpec, TextReportBuilder> {
     static final Comparator<BinarySpec> SORT_ORDER = Comparator.comparing(ModelElement::getName);
     private final Map<Class<?>, ReportRenderer<BinarySpec, TextReportBuilder>> renderers = new HashMap<>();

--- a/testing/architecture-test/src/changes/archunit-store/injected-services-should-have-service-scope-applied.txt
+++ b/testing/architecture-test/src/changes/archunit-store/injected-services-should-have-service-scope-applied.txt
@@ -37,7 +37,6 @@ Class <org.gradle.api.provider.ValueSourceParameters> is not annotated with @Ser
 Class <org.gradle.api.publish.ivy.internal.publisher.IvyPublisher> is not annotated with @ServiceScope in (IvyPublisher.java:0)
 Class <org.gradle.api.publish.maven.internal.dependencies.VersionRangeMapper> is not annotated with @ServiceScope in (VersionRangeMapper.java:0)
 Class <org.gradle.api.publish.maven.internal.publisher.MavenPublishers> is not annotated with @ServiceScope in (MavenPublishers.java:0)
-Class <org.gradle.api.reporting.components.internal.TypeAwareBinaryRenderer> is not annotated with @ServiceScope in (TypeAwareBinaryRenderer.java:0)
 Class <org.gradle.api.services.BuildServiceParameters> is not annotated with @ServiceScope in (BuildServiceParameters.java:0)
 Class <org.gradle.api.services.BuildServiceRegistry> is not annotated with @ServiceScope in (BuildServiceRegistry.java:0)
 Class <org.gradle.api.tasks.TaskContainer> is not annotated with @ServiceScope in (TaskContainer.java:0)


### PR DESCRIPTION
Validation for some of the Global services was suppressed because there was no mechanism to explicitly declare that a service implementation could provide multiple services.

Now that it [has become possible](https://github.com/gradle/gradle/pull/29560), the workarounds to suppress validation are no longer needed.

This PR removes some of the workarounds, though not all.