### PR TITLE
Automatically capture tooling API console output in cross version tests

### DIFF
--- a/platforms/core-configuration/declarative-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/declarative/dsl/tooling/builders/r89/DeclarativeDslToolingModelsCrossVersionTest.groovy
+++ b/platforms/core-configuration/declarative-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/declarative/dsl/tooling/builders/r89/DeclarativeDslToolingModelsCrossVersionTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.declarative.dsl.tooling.builders.r89
 
-import org.gradle.api.internal.plugins.software.SoftwareType
 import org.gradle.declarative.dsl.tooling.builders.AbstractDeclarativeDslToolingModelsCrossVersionTest
 import org.gradle.declarative.dsl.tooling.models.DeclarativeSchemaModel
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
@@ -34,7 +33,6 @@ import org.gradle.internal.declarativedsl.objectGraph.AssignmentResolver.Assignm
 import org.gradle.internal.declarativedsl.parsing.DefaultLanguageTreeBuilder
 import org.gradle.internal.declarativedsl.parsing.ParserKt
 import org.gradle.test.fixtures.plugin.PluginBuilder
-import org.gradle.tooling.ModelBuilder
 
 @TargetGradleVersion(">=8.9")
 @ToolingApiVersion('>=8.9')
@@ -330,10 +328,8 @@ class DeclarativeDslToolingModelsCrossVersionTest extends AbstractDeclarativeDsl
     }
 
     private <T> T fetchSchemaModel(Class<T> modelType) {
-        toolingApi.withConnection() { connection ->
-            ModelBuilder<T> modelBuilder = connection.model(modelType)
-            collectOutputs(modelBuilder)
-            modelBuilder.get()
+        toolingApi.withConnection { connection ->
+            connection.model(modelType).get()
         }
     }
 

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/AbstractKotlinScriptModelCrossVersionTest.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/AbstractKotlinScriptModelCrossVersionTest.groovy
@@ -100,7 +100,7 @@ abstract class AbstractKotlinScriptModelCrossVersionTest extends ToolingApiSpeci
         return fetchKotlinBuildScriptModelFor(
             projectDir,
             scriptFile,
-            { selectedProjectDir -> connector().forProjectDirectory(selectedProjectDir) }
+            { selectedProjectDir -> rawConnector().forProjectDirectory(selectedProjectDir) }
         )
     }
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/TestLauncherSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/TestLauncherSpec.groovy
@@ -77,9 +77,7 @@ abstract class TestLauncherSpec extends ToolingApiSpecification implements WithO
             .withCancellationToken(cancellationToken)
             .addProgressListener(events, OperationType.TASK, OperationType.TEST)
 
-        collectOutputs(testLauncher)
-
-        configurationClosure.call(testLauncher)
+        configurationClosure(testLauncher)
 
         events.clear()
         if (resultHandler == null) {

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r23/StandardStreamsCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r23/StandardStreamsCrossVersionSpec.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.integtests.tooling.r23
 
-
 import org.gradle.integtests.tooling.fixture.TestOutputStream
 import org.gradle.integtests.tooling.fixture.ToolingApiLoggingSpecification
 import org.gradle.tooling.ProjectConnection
@@ -45,7 +44,7 @@ task log {
 """
 
         when:
-        withConnection { ProjectConnection connection ->
+        withConnection(connectorWithoutOutputRedirection()) { ProjectConnection connection ->
             def build = connection.newBuild()
             build.forTasks("log")
             build.run()
@@ -75,7 +74,7 @@ task log {
         when:
         def output = new TestOutputStream()
         def error = new TestOutputStream()
-        withConnection { ProjectConnection connection ->
+        withConnection(connectorWithoutOutputRedirection()) { ProjectConnection connection ->
             def build = connection.newBuild()
             build.standardOutput = output
             build.standardError = error
@@ -108,7 +107,7 @@ task log {
 """
 
         when:
-        withConnection { ProjectConnection connection ->
+        withConnection(connectorWithoutOutputRedirection()) { ProjectConnection connection ->
             def build = connection.newBuild()
             build.colorOutput = true
             build.forTasks("log")

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/StandardStreamsCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/StandardStreamsCrossVersionSpec.groovy
@@ -37,7 +37,7 @@ task log {
 
         when:
         def output = new TestOutputStream()
-        withConnection { ProjectConnection connection ->
+        withConnection(connectorWithoutOutputRedirection()) { ProjectConnection connection ->
             def build = connection.newBuild()
             build.standardOutput = output
             build.colorOutput = true

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r48/CancellationCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r48/CancellationCrossVersionSpec.groovy
@@ -21,7 +21,6 @@ import org.gradle.integtests.tooling.fixture.ActionQueriesModelThatRequiresConfi
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.TestResultHandler
 import org.gradle.tooling.GradleConnector
-import org.gradle.tooling.ProjectConnection
 
 @TargetGradleVersion(">=4.8")
 class CancellationCrossVersionSpec extends CancellationSpec {
@@ -33,13 +32,13 @@ class CancellationCrossVersionSpec extends CancellationSpec {
         def resultHandler = new TestResultHandler()
 
         when:
-        withConnection { ProjectConnection connection ->
-            def action = connection.action()
-            action.projectsLoaded(new ActionQueriesModelThatRequiresConfigurationPhase(), Stub(IntermediateResultHandlerCollector))
-            def build = action.build()
-            build.withCancellationToken(cancel.token())
-            collectOutputs(build)
-            build.run(resultHandler)
+        withConnection { connection ->
+            connection.action()
+                .projectsLoaded(new ActionQueriesModelThatRequiresConfigurationPhase(), Stub(IntermediateResultHandlerCollector))
+                .build()
+                .withCancellationToken(cancel.token())
+                .run(resultHandler)
+
             sync.waitForAllPendingCalls(resultHandler)
             cancel.cancel()
             sync.releaseAll()

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r48/PhasedBuildActionCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r48/PhasedBuildActionCrossVersionSpec.groovy
@@ -136,13 +136,11 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
 
         when:
         withConnection { connection ->
-            def action = connection.action()
+            connection.action()
                 .projectsLoaded(new FailAction(), projectsLoadedHandler)
                 .buildFinished(new ActionShouldNotBeCalled(), buildFinishedHandler)
                 .build()
-
-            collectOutputs(action)
-            action.run()
+                .run()
         }
 
         then:
@@ -174,12 +172,11 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
 
         when:
         withConnection { connection ->
-            def action = connection.action()
+            connection.action()
                 .projectsLoaded(new ActionShouldNotBeCalled(), projectsLoadedHandler)
                 .buildFinished(new ActionShouldNotBeCalled(), buildFinishedHandler)
                 .build()
-            collectOutputs(action)
-            action.run()
+                .run()
         }
 
         then:
@@ -206,12 +203,11 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
 
         when:
         withConnection { connection ->
-            def action = connection.action()
+            connection.action()
                 .projectsLoaded(new ActionQueriesModelThatRequiresConfigurationPhase(), projectsLoadedHandler)
                 .buildFinished(new ActionShouldNotBeCalled(), buildFinishedHandler)
                 .build()
-            collectOutputs(action)
-            action.run()
+                .run()
         }
 
         then:
@@ -238,12 +234,11 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
 
         when:
         withConnection { connection ->
-            def action = connection.action()
+            connection.action()
                 .projectsLoaded(new ActionDiscardsConfigurationFailure(), projectsLoadedHandler)
                 .buildFinished(new ActionQueriesModelThatRequiresConfigurationPhase(), buildFinishedHandler)
                 .build()
-            collectOutputs(action)
-            action.run()
+                .run()
         }
 
         then:
@@ -270,13 +265,12 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
 
         when:
         withConnection { connection ->
-            def action = connection.action()
+            connection.action()
                 .projectsLoaded(new CustomProjectsLoadedAction(null), projectsLoadedHandler)
                 .buildFinished(new ActionShouldNotBeCalled(), buildFinishedHandler)
                 .build()
-            collectOutputs(action)
-            action.forTasks("broken")
-            action.run()
+                .forTasks("broken")
+                .run()
         }
 
         then:
@@ -364,11 +358,10 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
 
         when:
         withConnection { connection ->
-            def builder = connection.action()
+            connection.action()
                 .buildFinished(new CustomBuildFinishedAction(), new IntermediateResultHandlerCollector())
                 .build()
-            collectOutputs(builder)
-            builder.run()
+                .run()
         }
 
         then:
@@ -391,8 +384,7 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
             def builder = connection.action()
                 .buildFinished(new CustomBuildFinishedAction(), new IntermediateResultHandlerCollector())
                 .build()
-            action(builder)
-            collectOutputs(builder)
+            taskSelector(builder)
             builder.run()
         }
 
@@ -401,7 +393,7 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
         result.assertTasksExecuted(":help")
 
         where:
-        description                 | action
+        description                 | taskSelector
         "empty array of task names" | { BuildActionExecuter b -> b.forTasks() }
         "empty list of task names"  | { BuildActionExecuter b -> b.forTasks([]) }
     }
@@ -418,8 +410,7 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
             def builder = connection.action()
                 .buildFinished(new CustomBuildFinishedAction(), new IntermediateResultHandlerCollector())
                 .build()
-            action(builder)
-            collectOutputs(builder)
+            taskSelector(builder)
             builder.run()
         }
 
@@ -428,7 +419,7 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
         result.assertTasksExecuted(":thing")
 
         where:
-        description                 | action
+        description                 | taskSelector
         "empty array of task names" | { BuildActionExecuter b -> b.forTasks() }
         "empty list of task names"  | { BuildActionExecuter b -> b.forTasks([]) }
     }
@@ -445,8 +436,7 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
             def builder = connection.action()
                 .buildFinished(new CustomBuildFinishedAction(), new IntermediateResultHandlerCollector())
                 .build()
-            action(builder)
-            collectOutputs(builder)
+            taskSelector(builder)
             builder.run()
         }
 
@@ -456,7 +446,7 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
         result.assertTasksExecuted(":thing")
 
         where:
-        description                 | action
+        description                 | taskSelector
         "empty array of task names" | { BuildActionExecuter b -> b.forTasks() }
         "empty list of task names"  | { BuildActionExecuter b -> b.forTasks([]) }
     }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r50/ProjectStateLockingCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r50/ProjectStateLockingCrossVersionTest.groovy
@@ -30,11 +30,10 @@ class ProjectStateLockingCrossVersionTest extends ToolingApiSpecification {
         }
 
         when:
-        withConnection {
-            def executer = action(new FetchIdeaProject())
-            executer.withArguments("--warning-mode", "all")
-            collectOutputs(executer)
-            executer.run()
+        withConnection { connection ->
+            connection.action(new FetchIdeaProject())
+                .withArguments("--warning-mode", "all")
+                .run()
         }
 
         then:
@@ -52,11 +51,10 @@ class ProjectStateLockingCrossVersionTest extends ToolingApiSpecification {
         }
 
         when:
-        withConnection {
-            def executer = action(new FetchEclipseProject())
-            executer.withArguments("--warning-mode", "all")
-            collectOutputs(executer)
-            executer.run()
+        withConnection { connection ->
+            connection.action(new FetchEclipseProject())
+                .withArguments("--warning-mode", "all")
+                .run()
         }
 
         then:

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/ProjectConfigurationProgressEventCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/ProjectConfigurationProgressEventCrossVersionSpec.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.integtests.tooling.r51
 
-import org.gradle.api.Action
+
 import org.gradle.integtests.tooling.fixture.ProgressEvents
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
@@ -24,7 +24,6 @@ import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.tooling.BuildException
-import org.gradle.tooling.BuildLauncher
 import org.gradle.tooling.events.BinaryPluginIdentifier
 import org.gradle.tooling.events.OperationType
 import org.gradle.tooling.events.ScriptPluginIdentifier
@@ -453,14 +452,12 @@ class ProjectConfigurationProgressEventCrossVersionSpec extends ToolingApiSpecif
         (ProjectConfigurationOperationResult) events.operation("Configure project $displayName").result
     }
 
-    private void runBuild(String task, Set<OperationType> operationTypes = EnumSet.of(OperationType.PROJECT_CONFIGURATION), Action<BuildLauncher> config = {}) {
-        withConnection {
-            def launcher = newBuild()
+    private void runBuild(String task, Set<OperationType> operationTypes = EnumSet.of(OperationType.PROJECT_CONFIGURATION)) {
+        withConnection { connection ->
+            connection.newBuild()
                 .forTasks(task)
                 .addProgressListener(events, operationTypes)
-            collectOutputs(launcher)
-            config.execute(launcher)
-            launcher.run()
+                .run()
         }
     }
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r55/ReservedProjectNamesCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r55/ReservedProjectNamesCrossVersionSpec.groovy
@@ -137,10 +137,8 @@ class ReservedProjectNamesCrossVersionSpec extends ToolingApiSpecification {
         ])
 
         when:
-        def eclipseModels = withConnection { con ->
-            def builder = con.action(new SupplyRuntimeAndLoadCompositeEclipseModels(workspace))
-            collectOutputs(builder)
-            builder.run()
+        def eclipseModels = withConnection { connection ->
+            connection.action(new SupplyRuntimeAndLoadCompositeEclipseModels(workspace)).run()
         }
 
         then:

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r62/CapturingMultipleUserInputCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r62/CapturingMultipleUserInputCrossVersionSpec.groovy
@@ -62,7 +62,7 @@ class CapturingMultipleUserInputCrossVersionSpec extends ToolingApiSpecification
 
     def "can capture multiple user input if standard input was provided"() {
         when:
-        withConnection { ProjectConnection connection ->
+        withConnection { connection ->
             runBuildWithStandardInput(connection, 'something one', 'something two')
         }
 
@@ -75,7 +75,7 @@ class CapturingMultipleUserInputCrossVersionSpec extends ToolingApiSpecification
 
     def "can capture multiple user input if standard input was provided using default values"() {
         when:
-        withConnection { ProjectConnection connection ->
+        withConnection { connection ->
             runBuildWithStandardInput(connection, '', '')
         }
 
@@ -88,7 +88,7 @@ class CapturingMultipleUserInputCrossVersionSpec extends ToolingApiSpecification
 
     def "can default subsequent user input as default values if standard input was provided"() {
         when:
-        withConnection { ProjectConnection connection ->
+        withConnection { connection ->
             runBuildWithStandardInput(connection, 'something', '')
         }
 
@@ -100,17 +100,14 @@ class CapturingMultipleUserInputCrossVersionSpec extends ToolingApiSpecification
     }
 
     private void runBuildWithStandardInput(ProjectConnection connection, String answer1, String answer2) {
-        def build = connection.newBuild()
-        collectOutputs(build)
-        build.forTasks(DUMMY_TASK_NAME)
-
         def stdin = new PipedInputStream()
         def stdinWriter = new PipedOutputStream(stdin)
-
-        build.standardInput = stdin
-
         def resultHandler = new TestResultHandler()
-        build.run(resultHandler)
+
+        connection.newBuild()
+            .forTasks(DUMMY_TASK_NAME)
+            .setStandardInput(stdin)
+            .run(resultHandler)
 
         poll(60) {
             assert getOutput().contains(FOO.prompt)

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/CompositeBuildBuildActionExecuterCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/CompositeBuildBuildActionExecuterCrossVersionSpec.groovy
@@ -18,7 +18,6 @@ package org.gradle.integtests.tooling.r68
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
-import org.gradle.tooling.ProjectConnection
 import org.gradle.tooling.model.GradleProject
 
 @TargetGradleVersion('>=6.8')
@@ -40,11 +39,10 @@ class CompositeBuildBuildActionExecuterCrossVersionSpec extends ToolingApiSpecif
         """
 
         when:
-        toolingApi.withConnection { ProjectConnection connection ->
-            def buildAction = connection.action(new LoadCompositeModel(GradleProject))
-            collectOutputs(buildAction)
-            buildAction.forTasks([':other-build:sub:doSomething'])
-            buildAction.run()
+        toolingApi.withConnection { connection ->
+            connection.action(new LoadCompositeModel(GradleProject))
+                .forTasks([':other-build:sub:doSomething'])
+                .run()
         }
 
         then:

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/CompositeBuildModelBuilderCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/CompositeBuildModelBuilderCrossVersionSpec.groovy
@@ -18,8 +18,6 @@ package org.gradle.integtests.tooling.r68
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
-import org.gradle.tooling.ModelBuilder
-import org.gradle.tooling.ProjectConnection
 import org.gradle.tooling.model.GradleProject
 
 @TargetGradleVersion('>=6.8')
@@ -41,11 +39,10 @@ class CompositeBuildModelBuilderCrossVersionSpec extends ToolingApiSpecification
         """
 
         when:
-        toolingApi.withConnection { ProjectConnection connection ->
-            ModelBuilder<GradleProject> modelBuilder = connection.model(GradleProject.class)
-            collectOutputs(modelBuilder)
-            modelBuilder.forTasks([':other-build:sub:doSomething'])
-            modelBuilder.get()
+        toolingApi.withConnection { connection ->
+            connection.model(GradleProject.class)
+                .forTasks([':other-build:sub:doSomething'])
+                .get()
         }
 
         then:

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/CompositeBuildTaskExecutionCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/CompositeBuildTaskExecutionCrossVersionSpec.groovy
@@ -18,7 +18,6 @@ package org.gradle.integtests.tooling.r68
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
-import org.gradle.tooling.TestLauncher
 import org.gradle.tooling.events.ProgressEvent
 import org.gradle.tooling.events.ProgressListener
 import org.gradle.tooling.events.test.TestFinishEvent
@@ -388,9 +387,7 @@ class CompositeBuildTaskExecutionCrossVersionSpec extends ToolingApiSpecificatio
 
         when:
         withConnection { connection ->
-            TestLauncher launcher = connection.newTestLauncher().withTests(descriptor)
-            collectOutputs(launcher)
-            launcher.run()
+            connection.newTestLauncher().withTests(descriptor).run()
         }
 
         then:
@@ -428,9 +425,9 @@ class CompositeBuildTaskExecutionCrossVersionSpec extends ToolingApiSpecificatio
 
         when:
         withConnection { connection ->
-            def testLauncher = connection.newTestLauncher()
-            collectOutputs(testLauncher)
-            testLauncher.withTaskAndTestClasses(":other-build:sub:test", ["MyIncludedTest"]).run()
+            connection.newTestLauncher()
+                .withTaskAndTestClasses(":other-build:sub:test", ["MyIncludedTest"])
+                .run()
         }
 
         then:
@@ -439,9 +436,9 @@ class CompositeBuildTaskExecutionCrossVersionSpec extends ToolingApiSpecificatio
 
     private void executeTaskViaTAPI(String... tasks) {
         withConnection { connection ->
-            def build = connection.newBuild()
-            collectOutputs(build)
-            build.forTasks(tasks).run()
+            connection.newBuild()
+                .forTasks(tasks)
+                .run()
         }
     }
 
@@ -450,9 +447,10 @@ class CompositeBuildTaskExecutionCrossVersionSpec extends ToolingApiSpecificatio
             def gradleProjects = connection.action(new LoadCompositeModel(GradleProject)).run()
             def launchables = findLaunchables(gradleProjects, taskName)
             assert launchables.size == 1
-            def build = connection.newBuild()
-            collectOutputs(build)
-            build.forLaunchables(launchables[0]).run()
+
+            connection.newBuild()
+                .forLaunchables(launchables[0])
+                .run()
         }
     }
 
@@ -471,9 +469,10 @@ class CompositeBuildTaskExecutionCrossVersionSpec extends ToolingApiSpecificatio
             Collection<BuildInvocations> buildInvocations = connection.action(new LoadCompositeModel(BuildInvocations)).run()
             def tasks = buildInvocations.collect { it.tasks }.flatten().findAll { it.path.contains(taskName) }
             assert tasks.size == 1
-            def build = connection.newBuild()
-            collectOutputs(build)
-            build.forLaunchables(tasks[0]).run()
+
+            connection.newBuild()
+                .forLaunchables(tasks[0])
+                .run()
         }
     }
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/EclipseModelCompositeBuildIncludeCycleCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/EclipseModelCompositeBuildIncludeCycleCrossVersionSpec.groovy
@@ -43,9 +43,7 @@ class EclipseModelCompositeBuildIncludeCycleCrossVersionSpec extends ToolingApiS
         when:
 
         List<String> result = withConnection { connection ->
-            def builder = connection.action(new AccessIncludedBuildProjectBuildAction())
-            collectOutputs(builder)
-            builder.run()
+            connection.action(new AccessIncludedBuildProjectBuildAction()).run()
         }
 
         then:

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/ParallelActionExecutionCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r68/ParallelActionExecutionCrossVersionSpec.groovy
@@ -90,11 +90,10 @@ class ParallelActionExecutionCrossVersionSpec extends ToolingApiSpecification {
 
         expect:
         server.expectConcurrent(1, 'root', 'a', 'b')
-        def models = withConnection {
-            def action = action(new ActionRunsNestedActions())
-            collectOutputs(action)
-            action.addArguments(args)
-            action.run()
+        def models = withConnection { connection ->
+            connection.action(new ActionRunsNestedActions())
+                .addArguments(args)
+                .run()
         }
 
         !models.mayRunInParallel

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DeferredConfigurationCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DeferredConfigurationCrossVersionSpec.groovy
@@ -29,10 +29,8 @@ class DeferredConfigurationCrossVersionSpec extends ToolingApiSpecification {
         setupBuild()
 
         when:
-        def model = withConnection {
-            def executer = action(new NoOpAction())
-            collectOutputs(executer)
-            executer.run()
+        def model = withConnection { connection ->
+            connection.action(new NoOpAction()).run()
         }
 
         then:
@@ -49,13 +47,12 @@ class DeferredConfigurationCrossVersionSpec extends ToolingApiSpecification {
         when:
         def projectsLoadedModel = null
         def buildFinishedModel = null
-        withConnection {
-            def builder = action()
-            builder.projectsLoaded(new NoOpAction()) { projectsLoadedModel = it }
-            builder.buildFinished(new NoOpAction()) { buildFinishedModel = it }
-            def executer = builder.build()
-            collectOutputs(executer)
-            executer.run()
+        withConnection { connection ->
+            connection.action()
+                .projectsLoaded(new NoOpAction()) { projectsLoadedModel = it }
+                .buildFinished(new NoOpAction()) { buildFinishedModel = it }
+                .build()
+                .run()
         }
 
         then:
@@ -71,10 +68,8 @@ class DeferredConfigurationCrossVersionSpec extends ToolingApiSpecification {
         setupBuild()
 
         when:
-        def model = withConnection {
-            def executer = action(new FetchGradleBuildAction())
-            collectOutputs(executer)
-            executer.run()
+        def model = withConnection { connection ->
+            connection.action(new FetchGradleBuildAction()).run()
         }
 
         then:
@@ -92,13 +87,12 @@ class DeferredConfigurationCrossVersionSpec extends ToolingApiSpecification {
         when:
         def projectsLoadedModel = null
         def buildFinishedModel = null
-        withConnection {
-            def builder = action()
-            builder.projectsLoaded(new FetchGradleBuildAction()) { projectsLoadedModel = it }
-            builder.buildFinished(new FetchGradleBuildAction()) { buildFinishedModel = it }
-            def executer = builder.build()
-            collectOutputs(executer)
-            executer.run()
+        withConnection { connection ->
+            connection.action()
+                .projectsLoaded(new FetchGradleBuildAction()) { projectsLoadedModel = it }
+                .buildFinished(new FetchGradleBuildAction()) { buildFinishedModel = it }
+                .build()
+                .run()
         }
 
         then:
@@ -115,10 +109,8 @@ class DeferredConfigurationCrossVersionSpec extends ToolingApiSpecification {
         setupBuild()
 
         when:
-        def model = withConnection {
-            def executer = action(new FetchProjectAction())
-            collectOutputs(executer)
-            executer.run()
+        def model = withConnection { connection ->
+            connection.action(new FetchProjectAction()).run()
         }
 
         then:
@@ -136,13 +128,12 @@ class DeferredConfigurationCrossVersionSpec extends ToolingApiSpecification {
         when:
         def projectsLoadedModel = null
         def buildFinishedModel = null
-        withConnection {
-            def builder = action()
-            builder.projectsLoaded(new FetchProjectAction()) { projectsLoadedModel = it }
-            builder.buildFinished(new FetchProjectAction()) { buildFinishedModel = it }
-            def executer = builder.build()
-            collectOutputs(executer)
-            executer.run()
+        withConnection { connection ->
+            connection.action()
+                .projectsLoaded(new FetchProjectAction()) { projectsLoadedModel = it }
+                .buildFinished(new FetchProjectAction()) { buildFinishedModel = it }
+                .build()
+                .run()
         }
 
         then:

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DependencyArtifactDownloadProgressEventCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DependencyArtifactDownloadProgressEventCrossVersionTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.integtests.tooling.fixture.ProgressEvents
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
 import org.gradle.tooling.BuildException
-import org.gradle.tooling.ProjectConnection
 import org.gradle.tooling.events.OperationType
 import spock.lang.Timeout
 
@@ -38,10 +37,9 @@ class DependencyArtifactDownloadProgressEventCrossVersionTest extends AbstractHt
 
         when:
         def events = ProgressEvents.create()
-        withConnection { ProjectConnection connection ->
-            def build = connection.newBuild()
-            collectOutputs(build)
-            build.addProgressListener(events, OperationType.FILE_DOWNLOAD)
+        withConnection { connection ->
+            connection.newBuild()
+                .addProgressListener(events, OperationType.FILE_DOWNLOAD)
                 .run()
         }
 
@@ -92,10 +90,9 @@ class DependencyArtifactDownloadProgressEventCrossVersionTest extends AbstractHt
 
         when:
         def events = ProgressEvents.create()
-        withConnection { ProjectConnection connection ->
-            def build = connection.newBuild()
-            collectOutputs(build)
-            build.addProgressListener(events, OperationType.FILE_DOWNLOAD)
+        withConnection { connection ->
+            connection.newBuild()
+                .addProgressListener(events, OperationType.FILE_DOWNLOAD)
                 .run()
         }
 
@@ -113,11 +110,10 @@ class DependencyArtifactDownloadProgressEventCrossVersionTest extends AbstractHt
 
         when:
         def events = ProgressEvents.create()
-        withConnection { ProjectConnection connection ->
-            def build = connection.newBuild()
-            collectOutputs(build)
-            build.forTasks("resolve")
-            build.addProgressListener(events, OperationType.FILE_DOWNLOAD)
+        withConnection { connection ->
+            connection.newBuild()
+                .forTasks("resolve")
+                .addProgressListener(events, OperationType.FILE_DOWNLOAD)
                 .run()
         }
 
@@ -139,10 +135,9 @@ class DependencyArtifactDownloadProgressEventCrossVersionTest extends AbstractHt
 
         when:
         def events = ProgressEvents.create()
-        withConnection { ProjectConnection connection ->
-            def build = connection.newBuild()
-            collectOutputs(build)
-            build.addProgressListener(events, OperationType.FILE_DOWNLOAD, OperationType.PROJECT_CONFIGURATION)
+        withConnection { connection ->
+            connection.newBuild()
+                .addProgressListener(events, OperationType.FILE_DOWNLOAD, OperationType.PROJECT_CONFIGURATION)
                 .run()
         }
 
@@ -167,11 +162,10 @@ class DependencyArtifactDownloadProgressEventCrossVersionTest extends AbstractHt
 
         when:
         def events = ProgressEvents.create()
-        withConnection { ProjectConnection connection ->
-            def build = connection.newBuild()
-            collectOutputs(build)
-            build.forTasks("resolve")
-            build.addProgressListener(events, OperationType.FILE_DOWNLOAD, OperationType.TASK)
+        withConnection { connection ->
+            connection.newBuild()
+                .forTasks("resolve")
+                .addProgressListener(events, OperationType.FILE_DOWNLOAD, OperationType.TASK)
                 .run()
         }
 
@@ -195,11 +189,10 @@ class DependencyArtifactDownloadProgressEventCrossVersionTest extends AbstractHt
 
         when:
         def events = ProgressEvents.create()
-        withConnection { ProjectConnection connection ->
-            def build = connection.newBuild()
-            collectOutputs(build)
-            build.forTasks("resolve")
-            build.addProgressListener(events, EnumSet.complementOf(EnumSet.of(OperationType.FILE_DOWNLOAD)))
+        withConnection { connection ->
+            connection.newBuild()
+                .forTasks("resolve")
+                .addProgressListener(events, EnumSet.complementOf(EnumSet.of(OperationType.FILE_DOWNLOAD)))
                 .run()
         }
 
@@ -213,10 +206,9 @@ class DependencyArtifactDownloadProgressEventCrossVersionTest extends AbstractHt
 
         when:
         def events = ProgressEvents.create()
-        withConnection { ProjectConnection connection ->
-            def build = connection.newBuild()
-            collectOutputs(build)
-            build.addProgressListener(events, OperationType.FILE_DOWNLOAD)
+        withConnection { connection ->
+            connection.newBuild()
+                .addProgressListener(events, OperationType.FILE_DOWNLOAD)
                 .run()
         }
 
@@ -230,10 +222,9 @@ class DependencyArtifactDownloadProgressEventCrossVersionTest extends AbstractHt
 
         when:
         def events = ProgressEvents.create()
-        withConnection { ProjectConnection connection ->
-            def build = connection.newBuild()
-            collectOutputs(build)
-            build.addProgressListener(events)
+        withConnection { connection ->
+            connection.newBuild()
+                .addProgressListener(events)
                 .run()
         }
 
@@ -248,10 +239,9 @@ class DependencyArtifactDownloadProgressEventCrossVersionTest extends AbstractHt
 
         when:
         def events = ProgressEvents.create()
-        withConnection { ProjectConnection connection ->
-            def build = connection.newBuild()
-            collectOutputs(build)
-            build.addProgressListener(events, OperationType.GENERIC)
+        withConnection { connection ->
+            connection.newBuild()
+                .addProgressListener(events, OperationType.GENERIC)
                 .run()
         }
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DeprecationsCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DeprecationsCrossVersionSpec.groovy
@@ -57,11 +57,10 @@ class DeprecationsCrossVersionSpec extends ToolingApiSpecification {
         """
 
         when:
-        withConnection {
-            def builder = it.model(List)
-            builder.withArguments("--parallel")
-            collectOutputs(builder)
-            return builder.get()
+        withConnection { connection ->
+            connection.model(List)
+                .withArguments("--parallel")
+                .get()
         }
 
         then:

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r81/DependencyArtifactDownloadProgressEventCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r81/DependencyArtifactDownloadProgressEventCrossVersionTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
 import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.server.http.MavenHttpModule
-import org.gradle.tooling.ProjectConnection
 import org.gradle.tooling.events.OperationType
 import org.gradle.tooling.events.download.internal.DefaultFileDownloadSuccessResult
 import org.gradle.tooling.events.download.internal.NotFoundFileDownloadSuccessResult
@@ -37,10 +36,9 @@ class DependencyArtifactDownloadProgressEventCrossVersionTest extends AbstractHt
 
         when:
         def events = ProgressEvents.create()
-        withConnection { ProjectConnection connection ->
-            def build = connection.newBuild()
-            collectOutputs(build)
-            build.addProgressListener(events, OperationType.FILE_DOWNLOAD)
+        withConnection { connection ->
+            connection.newBuild()
+                .addProgressListener(events, OperationType.FILE_DOWNLOAD)
                 .run()
         }
 
@@ -81,10 +79,9 @@ class DependencyArtifactDownloadProgressEventCrossVersionTest extends AbstractHt
 
         when:
         def events = ProgressEvents.create()
-        withConnection { ProjectConnection connection ->
-            def build = connection.newBuild()
-            collectOutputs(build)
-            build.addProgressListener(events, OperationType.FILE_DOWNLOAD)
+        withConnection { connection ->
+            connection.newBuild()
+                .addProgressListener(events, OperationType.FILE_DOWNLOAD)
                 .run()
         }
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r86/StreamingBuildActionCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r86/StreamingBuildActionCrossVersionTest.groovy
@@ -54,9 +54,8 @@ class StreamingBuildActionCrossVersionTest extends ToolingApiSpecification {
             finished.countDown()
         } as ResultHandler
 
-        withConnection {
-            def builder = it.action(new ModelStreamingBuildAction())
-            collectOutputs(builder)
+        withConnection { connection ->
+            def builder = connection.action(new ModelStreamingBuildAction())
             builder.setStreamedValueListener(listener)
             builder.run(handler)
             finished.await()
@@ -84,12 +83,11 @@ class StreamingBuildActionCrossVersionTest extends ToolingApiSpecification {
         def listener = { model -> models.add(model) } as StreamedValueListener
         def handler = { model -> models.add(model) } as IntermediateResultHandler
 
-        withConnection {
-            def builder = it.action()
+        withConnection { connection ->
+            def builder = connection.action()
                 .projectsLoaded(new CustomModelStreamingBuildAction(GradleProject, 1), handler)
                 .buildFinished(new CustomModelStreamingBuildAction(EclipseProject, 2), handler)
                 .build()
-            collectOutputs(builder)
             builder.setStreamedValueListener(listener)
             builder.run()
         }
@@ -131,9 +129,8 @@ class StreamingBuildActionCrossVersionTest extends ToolingApiSpecification {
             finished.countDown()
         } as ResultHandler
 
-        withConnection {
-            def builder = it.action(new BlockingModelSendingBuildAction(server.uri("action")))
-            collectOutputs(builder)
+        withConnection { connection ->
+            def builder = connection.action(new BlockingModelSendingBuildAction(server.uri("action")))
             builder.setStreamedValueListener(listener)
             builder.run(handler)
 
@@ -153,9 +150,8 @@ class StreamingBuildActionCrossVersionTest extends ToolingApiSpecification {
         when:
         def listener = { throw new RuntimeException("broken") } as StreamedValueListener
 
-        withConnection {
-            def builder = it.action(new ModelStreamingBuildAction())
-            collectOutputs(builder)
+        withConnection { connection ->
+            def builder = connection.action(new ModelStreamingBuildAction())
             builder.setStreamedValueListener(listener)
             builder.run()
         }
@@ -170,10 +166,8 @@ class StreamingBuildActionCrossVersionTest extends ToolingApiSpecification {
 
     def "build fails when build action streams value when no listener is registered"() {
         when:
-        withConnection {
-            def builder = it.action(new ModelStreamingBuildAction())
-            collectOutputs(builder)
-            builder.run()
+        withConnection { connection ->
+            connection.action(new ModelStreamingBuildAction()).run()
         }
 
         then:
@@ -189,9 +183,8 @@ class StreamingBuildActionCrossVersionTest extends ToolingApiSpecification {
         when:
         def listener = { } as StreamedValueListener
 
-        withConnection {
-            def builder = it.action(new ModelStreamingBuildAction())
-            collectOutputs(builder)
+        withConnection { connection ->
+            def builder = connection.action(new ModelStreamingBuildAction())
             builder.setStreamedValueListener(listener)
             builder.run()
         }

--- a/platforms/ide/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ConcurrentToolingApiIntegrationSpec.groovy
+++ b/platforms/ide/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ConcurrentToolingApiIntegrationSpec.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.integtests.tooling
 
+import groovy.transform.stc.ClosureParams
+import groovy.transform.stc.SimpleType
 import org.gradle.initialization.BuildCancellationToken
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.GradleDistribution
@@ -23,6 +25,7 @@ import org.gradle.integtests.fixtures.executer.UnderDevelopmentGradleDistributio
 import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
 import org.gradle.integtests.tooling.fixture.ConfigurableOperation
 import org.gradle.integtests.tooling.fixture.ToolingApi
+import org.gradle.integtests.tooling.fixture.ToolingApiConnector
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
@@ -373,8 +376,8 @@ logger.lifecycle 'this is lifecycle: $idx'
         concurrent.finished()
     }
 
-    def withConnectionInDir(String dir, Closure cl) {
-        def connector = toolingApi.connector(file(dir))
+    <T> T withConnectionInDir(String dir, @DelegatesTo(ProjectConnection) @ClosureParams(value = SimpleType, options = ["org.gradle.tooling.ProjectConnection"]) Closure<T> cl) {
+        ToolingApiConnector connector = toolingApi.connector(file(dir))
         toolingApi.withConnection(connector, cl)
     }
 }

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ContinuousBuildToolingApiSpecification.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ContinuousBuildToolingApiSpecification.groovy
@@ -133,8 +133,6 @@ abstract class ContinuousBuildToolingApiSpecification extends ToolingApiSpecific
                     .forTasks(tasks as String[])
                     .withCancellationToken(token)
 
-                collectOutputs(launcher)
-
                 customizeLauncher(launcher)
 
                 launcher.run(buildResult)

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApi.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApi.groovy
@@ -205,15 +205,35 @@ class ToolingApi implements TestRule {
         assert throwableStack.endsWith(currentThreadStackStr)
     }
 
+    ToolingApiConnector connector() {
+        connector(testWorkDirProvider.testDirectory, true)
+    }
+
+    ToolingApiConnector connectorWithoutOutputRedirection() {
+        connector(testWorkDirProvider.testDirectory, false)
+    }
+
+    ToolingApiConnector connector(File projectDir) {
+        connector(projectDir, true)
+    }
+
     /**
      * Return a wrapper around a {@link GradleConnector} that delegates to the connector
-     * and also forwards all stdout and stderr to this test fixture.
+     * and captures stdout and stderr.
+     * <p>
+     * Optionally, stdout and stderr can be redirected to the system streams so they are visible
+     * in the console.
      */
-    ToolingApiConnector connector(File projectDir = testWorkDirProvider.testDirectory) {
+    ToolingApiConnector connector(File projectDir, boolean redirectOutput) {
         GradleConnector connector = rawConnector(projectDir)
 
-        OutputStream output = new TeeOutputStream(stdout, System.out)
-        OutputStream error = new TeeOutputStream(stderr, System.err)
+        OutputStream output = stdout
+        OutputStream error = stderr
+
+        if (redirectOutput) {
+            output = new TeeOutputStream(stdout, System.out)
+            error = new TeeOutputStream(stderr, System.err)
+        }
 
         return new ToolingApiConnector(connector, output, error)
     }

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApi.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApi.groovy
@@ -15,6 +15,8 @@
  */
 package org.gradle.integtests.tooling.fixture
 
+import groovy.transform.stc.ClosureParams
+import groovy.transform.stc.SimpleType
 import org.apache.commons.io.output.TeeOutputStream
 import org.gradle.integtests.fixtures.daemon.DaemonLogsAnalyzer
 import org.gradle.integtests.fixtures.daemon.DaemonsFixture
@@ -27,7 +29,6 @@ import org.gradle.internal.service.ServiceRegistry
 import org.gradle.test.fixtures.file.TestDirectoryProvider
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.tooling.GradleConnector
-import org.gradle.tooling.LongRunningOperation
 import org.gradle.tooling.ModelBuilder
 import org.gradle.tooling.ProjectConnection
 import org.gradle.tooling.internal.consumer.ConnectorServices
@@ -150,20 +151,24 @@ class ToolingApi implements TestRule {
         connectorConfigurers << cl
     }
 
-    def <T> T withConnection(@DelegatesTo(ProjectConnection) Closure<T> cl) {
+    <T> T withConnection(@DelegatesTo(value = ProjectConnection, strategy = Closure.DELEGATE_FIRST) @ClosureParams(value = SimpleType, options = ["org.gradle.tooling.ProjectConnection"]) Closure<T> cl) {
         def connector = connector()
         withConnection(connector, cl)
     }
 
-    def <T> T withConnection(connector, @DelegatesTo(ProjectConnection) Closure<T> cl) {
-        return withConnectionRaw(connector, cl)
+    <T> T withConnection(ToolingApiConnector connector, @DelegatesTo(value = ProjectConnection, strategy = Closure.DELEGATE_FIRST) @ClosureParams(value = SimpleType, options = ["org.gradle.tooling.ProjectConnection"]) Closure<T> cl) {
+        try (def connection = connector.connect()) {
+            return connection.with(cl)
+        } catch (Throwable t) {
+            validate(t)
+            throw t
+        }
     }
 
     def <T> T loadToolingLeanModel(Class<T> modelClass, @DelegatesTo(ModelBuilder<T>) Closure configurator = {}) {
         withConnection {
             def builder = it.model(modelClass)
             builder.tap(configurator)
-            collectOutputs(builder)
             builder.get()
         }
     }
@@ -172,11 +177,6 @@ class ToolingApi implements TestRule {
         def result = loadToolingLeanModel(modelClass, configurator)
         validateOutput()
         result
-    }
-
-    void collectOutputs(LongRunningOperation op) {
-        op.setStandardOutput(new TeeOutputStream(stdout, System.out))
-        op.setStandardError(new TeeOutputStream(stderr, System.err))
     }
 
     def validateOutput() {
@@ -193,7 +193,7 @@ class ToolingApi implements TestRule {
 
         // Verify that the exception carries the calling thread's stack information
         def currentThreadStack = Thread.currentThread().stackTrace as List
-        while (!currentThreadStack.empty && (currentThreadStack[0].className != ToolingApi.name || currentThreadStack[0].methodName != 'withConnectionRaw')) {
+        while (!currentThreadStack.empty && (currentThreadStack[0].className != ToolingApi.name || currentThreadStack[0].methodName != 'withConnection')) {
             currentThreadStack.remove(0)
         }
         assert currentThreadStack.size() > 1
@@ -205,16 +205,28 @@ class ToolingApi implements TestRule {
         assert throwableStack.endsWith(currentThreadStackStr)
     }
 
-    private <T> T withConnectionRaw(connector, @DelegatesTo(ProjectConnection) Closure<T> cl) {
-        try (def connection = connector.connect()) {
-            return connection.with(cl)
-        } catch (Throwable t) {
-            validate(t)
-            throw t
-        }
+    /**
+     * Return a wrapper around a {@link GradleConnector} that delegates to the connector
+     * and also forwards all stdout and stderr to this test fixture.
+     */
+    ToolingApiConnector connector(File projectDir = testWorkDirProvider.testDirectory) {
+        GradleConnector connector = rawConnector(projectDir)
+
+        OutputStream output = new TeeOutputStream(stdout, System.out)
+        OutputStream error = new TeeOutputStream(stderr, System.err)
+
+        return new ToolingApiConnector(connector, output, error)
     }
 
-    ToolingApiConnector connector(projectDir = testWorkDirProvider.testDirectory) {
+    /**
+     * Get a {@link GradleConnector} that is not wrapped to forward stdout and stderr.
+     * <p>
+     * In general, prefer {@link #connector(File)}. This method should be used when
+     * interfacing with production code that is not {@link ToolingApiConnector}-aware.
+     *
+     * TODO: Can we get rid of this and have ToolingApiConnector implement GradleConnector?
+     */
+    GradleConnector rawConnector(File projectDir = testWorkDirProvider.testDirectory) {
         DefaultGradleConnector connector = createConnector()
 
         connector.forProjectDirectory(projectDir)
@@ -262,7 +274,7 @@ class ToolingApi implements TestRule {
             connector.with(it)
         }
 
-        return new ToolingApiConnector(connector, stdout, stderr)
+        return connector
     }
 
     private createConnector() {

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiConnector.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiConnector.groovy
@@ -30,11 +30,11 @@ class ToolingApiConnector {
         this.connector = connector
     }
 
-    def connect() {
+    ProjectConnection connect() {
         new ToolingApiConnection(connector.connect(), stdout, stderr) as ProjectConnection
     }
 
-    def searchUpwards(boolean searchUpwards) {
+    ToolingApiConnector searchUpwards(boolean searchUpwards) {
         connector.searchUpwards(searchUpwards)
         this
     }
@@ -43,7 +43,7 @@ class ToolingApiConnector {
         connector."$name"(*args)
     }
 
-    def propertyMissing(String name, value) {
+    void propertyMissing(String name, value) {
         connector."$name" = value
     }
 
@@ -51,9 +51,9 @@ class ToolingApiConnector {
         connector."$name"
     }
 
-    def forProjectDirectory(File projectDir) {
+    ToolingApiConnector forProjectDirectory(File projectDir) {
         connector.forProjectDirectory(projectDir)
-        connector
+        this
     }
 
     def disconnect() {

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
@@ -197,6 +197,10 @@ abstract class ToolingApiSpecification extends Specification implements KotlinDs
         toolingApi.connector()
     }
 
+    ToolingApiConnector connectorWithoutOutputRedirection() {
+        toolingApi.connectorWithoutOutputRedirection()
+    }
+
     def <T> T withConnection(@DelegatesTo(ProjectConnection) @ClosureParams(value = SimpleType, options = ["org.gradle.tooling.ProjectConnection"]) Closure<T> cl) {
         try {
             return toolingApi.withConnection(cl)

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
@@ -92,7 +92,7 @@ abstract class ToolingApiSpecification extends Specification implements KotlinDs
     @Delegate
     final ToolingApi toolingApi = new ToolingApi(null, temporaryFolder, stdout, stderr)
 
-    // TODO: react to the isolatedProejcts prop coming from build settings
+    // TODO: react to the isolatedProjects prop coming from build settings
 
     @Rule
     public RuleChain cleanupRule = RuleChain.outerRule(temporaryFolder).around(temporaryDistributionFolder).around(toolingApi)
@@ -184,7 +184,7 @@ abstract class ToolingApiSpecification extends Specification implements KotlinDs
         }
     }
 
-    def <T> T withConnection(connector, @DelegatesTo(ProjectConnection) @ClosureParams(value = SimpleType, options = ["org.gradle.tooling.ProjectConnection"]) Closure<T> cl) {
+    def <T> T withConnection(ToolingApiConnector connector, @DelegatesTo(ProjectConnection) @ClosureParams(value = SimpleType, options = ["org.gradle.tooling.ProjectConnection"]) Closure<T> cl) {
         try {
             return toolingApi.withConnection(connector, cl)
         } catch (GradleConnectionException e) {
@@ -199,7 +199,7 @@ abstract class ToolingApiSpecification extends Specification implements KotlinDs
 
     def <T> T withConnection(@DelegatesTo(ProjectConnection) @ClosureParams(value = SimpleType, options = ["org.gradle.tooling.ProjectConnection"]) Closure<T> cl) {
         try {
-            toolingApi.withConnection(cl)
+            return toolingApi.withConnection(cl)
         } catch (GradleConnectionException e) {
             caughtGradleConnectionException = e
             throw e


### PR DESCRIPTION
Previously, tests called collectOutputs in order to get the tests to collect stdout and stderr. This was the old way to capture these outputs, and new changes -- particularly ToolingApiConnector -- captures these outputs automatically.

Using this manual collect method and also the automatic collection caused the tests to capture duplicate output from the tests.

This change avoids the duplicate output capture, and also simplifes all tests that had to previously manually capture build output.

In addition to this, we improve some questionable cases of dynamic groovy typing by ensuring we are using proper static typing and also properly annotating closure parameters to improve IDE hints.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
