### PR TITLE
Support declaring explicit service types in Provides annotation

### DIFF
--- a/platforms/core-runtime/build-process-services/src/main/java/org/gradle/api/internal/classpath/DefaultModuleRegistry.java
+++ b/platforms/core-runtime/build-process-services/src/main/java/org/gradle/api/internal/classpath/DefaultModuleRegistry.java
@@ -46,7 +46,7 @@ import java.util.zip.ZipFile;
 /**
  * Determines the classpath for a module by looking for a '${module}-classpath.properties' resource with 'name' set to the name of the module.
  */
-public class DefaultModuleRegistry implements ModuleRegistry {
+public class DefaultModuleRegistry implements ModuleRegistry, GlobalCacheRootsProvider {
     private static final Spec<File> SATISFY_ALL = element -> true;
     private static final List<String> JARS_REPLACED_BY_TD_PLUGIN = createJarsReplacedByTdPlugin();
 
@@ -110,6 +110,7 @@ public class DefaultModuleRegistry implements ModuleRegistry {
             : Optional.empty();
     }
 
+    @Override
     public List<File> getGlobalCacheRoots() {
         ImmutableList.Builder<File> builder = ImmutableList.builder();
         if (gradleInstallation != null) {

--- a/platforms/core-runtime/build-process-services/src/main/java/org/gradle/api/internal/classpath/GlobalCacheRootsProvider.java
+++ b/platforms/core-runtime/build-process-services/src/main/java/org/gradle/api/internal/classpath/GlobalCacheRootsProvider.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.classpath;
 
+import org.gradle.api.NonNullApi;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -25,6 +26,7 @@ import java.util.List;
 /**
  * Represents a location for global Gradle caches.
  */
+@NonNullApi
 @ServiceScope(Scope.Global.class)
 public interface GlobalCacheRootsProvider {
 

--- a/platforms/core-runtime/build-process-services/src/main/java/org/gradle/api/internal/classpath/GlobalCacheRootsProvider.java
+++ b/platforms/core-runtime/build-process-services/src/main/java/org/gradle/api/internal/classpath/GlobalCacheRootsProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.classpath;
+
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * Represents a location for global Gradle caches.
+ */
+@ServiceScope(Scope.Global.class)
+public interface GlobalCacheRootsProvider {
+
+    /**
+     * Returns the root directories of the global cache.
+     */
+    List<File> getGlobalCacheRoots();
+}

--- a/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/Provides.java
+++ b/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/Provides.java
@@ -30,4 +30,12 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Keep
 public @interface Provides {
+
+    /**
+     * List of services to expose.
+     * <p>
+     * The return type of the method is used when this is empty.
+     */
+    Class<?>[] value() default {};
+
 }

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -966,7 +966,9 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
     }
 
     private static class FactoryMethodService extends FactoryService {
+
         private final ServiceMethod method;
+        @Nullable
         private Object target;
 
         public FactoryMethodService(DefaultServiceRegistry owner, Object target, ServiceMethod method) {
@@ -996,6 +998,10 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
 
         @Override
         protected Object invokeMethod(Object[] params) {
+            if (target == null) {
+                throw new IllegalStateException("The target of the factory method has been discarded after the first service creation attempt");
+            }
+
             Object result;
             try {
                 result = method.invoke(target, params);
@@ -1006,6 +1012,7 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
                     method.getName()),
                     e);
             }
+
             try {
                 if (result == null) {
                     throw new ServiceCreationException(String.format("Could not create service of %s using %s.%s() as this method returned null.",

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -1056,17 +1056,22 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
             this(owner, Collections.<Class<?>>singletonList(serviceType), implementationType);
         }
 
-        private ConstructorService(DefaultServiceRegistry owner, List<Class<?>> serviceTypes, Class<?> implementationType) {
+        private ConstructorService(DefaultServiceRegistry owner, List<? extends Type> serviceTypes, Class<?> implementationType) {
             super(owner, serviceTypes);
 
             if (implementationType.isInterface()) {
                 throw new ServiceValidationException("Cannot register an interface for construction.");
             }
 
-            for (Class<?> serviceType : serviceTypes) {
-                if (!serviceType.isAssignableFrom(implementationType)) {
-                    throw new ServiceValidationException(String.format("Cannot register implementation '%s' for service '%s', because it does not implement it",
-                        implementationType.getSimpleName(), serviceType.getSimpleName()));
+            for (Type serviceType : serviceTypes) {
+                if (serviceType instanceof Class<?>) {
+                    Class<?> serviceClass = (Class<?>) serviceType;
+                    if (!serviceClass.isAssignableFrom(implementationType)) {
+                        throw new ServiceValidationException(String.format("Cannot register implementation '%s' for service '%s', because it does not implement it",
+                            implementationType.getSimpleName(), serviceClass.getSimpleName()));
+                    }
+                } else {
+                    throw new IllegalArgumentException(String.format("Service type %s is not supported by ConstructorService", serviceType));
                 }
             }
 

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
@@ -28,7 +28,6 @@ class ServiceScopeValidatorWorkarounds {
 
         "org.gradle.internal.Factory",
         "org.gradle.internal.serialize.Serializer",
-        "org.gradle.api.internal.classpath.DefaultModuleRegistry",
         "org.gradle.cache.internal.ProducerGuard",
         "org.gradle.internal.typeconversion.NotationParser",
 

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
@@ -32,11 +32,6 @@ class ServiceScopeValidatorWorkarounds {
         "org.gradle.cache.internal.ProducerGuard",
         "org.gradle.internal.typeconversion.NotationParser",
 
-        "org.gradle.api.internal.tasks.properties.annotations.OutputDirectoryPropertyAnnotationHandler",
-        "org.gradle.api.internal.tasks.properties.annotations.OutputDirectoriesPropertyAnnotationHandler",
-        "org.gradle.api.internal.tasks.properties.annotations.OutputFilePropertyAnnotationHandler",
-        "org.gradle.api.internal.tasks.properties.annotations.OutputFilesPropertyAnnotationHandler",
-
         "org.gradle.nativeplatform.platform.internal.NativePlatforms",
         "org.gradle.nativeplatform.internal.NativePlatformResolver",
         "org.gradle.nativeplatform.internal.DefaultTargetMachineFactory"

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedGlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedGlobalScopeServices.java
@@ -17,6 +17,8 @@
 package org.gradle.internal.service.scopes;
 
 import org.gradle.api.internal.classpath.DefaultModuleRegistry;
+import org.gradle.api.internal.classpath.GlobalCacheRootsProvider;
+import org.gradle.api.internal.classpath.ModuleRegistry;
 import org.gradle.api.internal.file.DefaultFilePropertyFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileFactory;
@@ -165,14 +167,14 @@ public class WorkerSharedGlobalScopeServices extends BasicGlobalScopeServices {
         );
     }
 
-    @Provides
+    @Provides({ModuleRegistry.class, GlobalCacheRootsProvider.class})
     DefaultModuleRegistry createModuleRegistry(CurrentGradleInstallation currentGradleInstallation) {
         return new DefaultModuleRegistry(additionalModuleClassPath, currentGradleInstallation.getInstallation());
     }
 
     @Provides
-    GlobalCache createGlobalCache(DefaultModuleRegistry moduleRegistry) {
-        return moduleRegistry::getGlobalCacheRoots;
+    GlobalCache createGlobalCache(GlobalCacheRootsProvider globalCacheRootsProvider) {
+        return globalCacheRootsProvider::getGlobalCacheRoots;
     }
 
     @Provides


### PR DESCRIPTION
Adds an ability to list the service types in the `@Provides` annotation.

This use case is required, when a multi-service is defined via a factory method, because there can only be single return type.

```java
    @Provides({ServiceOne.class, ServiceTwo.class})
    ServiceImpl createServiceImpl(SomeDependency d) {
        return new ServiceImpl(d);
    }
```