### PR TITLE
More precisely verify tooling API deprecation warnings

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
@@ -35,7 +35,7 @@ class KotlinDslDefaultScriptsModelCrossVersionSpec extends AbstractKotlinDslScri
         def spec = withMultiProjectBuildWithBuildSrc()
 
         when:
-        def model = loadValidatedToolingModel(KotlinDslScriptsModel) {
+        def model = loadToolingModel(KotlinDslScriptsModel) {
             setModelParameters(it, false)
         }
 
@@ -57,7 +57,7 @@ class KotlinDslDefaultScriptsModelCrossVersionSpec extends AbstractKotlinDslScri
         """
 
         when:
-        def model = loadValidatedToolingModel(KotlinDslScriptsModel) {
+        def model = loadToolingModel(KotlinDslScriptsModel) {
             setModelParameters(it, true)
         }
 

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
+import org.gradle.util.GradleVersion
 
 import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinScriptModelParameters.setModelParameters
 
@@ -35,6 +36,7 @@ class KotlinDslDefaultScriptsModelCrossVersionSpec extends AbstractKotlinDslScri
         def spec = withMultiProjectBuildWithBuildSrc()
 
         when:
+        maybeExpectAccessorsDeprecation()
         def model = loadToolingModel(KotlinDslScriptsModel) {
             setModelParameters(it, false)
         }
@@ -57,6 +59,8 @@ class KotlinDslDefaultScriptsModelCrossVersionSpec extends AbstractKotlinDslScri
         """
 
         when:
+        maybeExpectAccessorsDeprecation()
+        withStackTraceChecksDisabled() // This test prints a huge stack trace
         def model = loadToolingModel(KotlinDslScriptsModel) {
             setModelParameters(it, true)
         }
@@ -73,5 +77,11 @@ class KotlinDslDefaultScriptsModelCrossVersionSpec extends AbstractKotlinDslScri
             spec.scripts.a,
             "Unresolved reference: script_body_compilation_error"
         )
+    }
+
+    void maybeExpectAccessorsDeprecation() {
+        if (targetVersion >= GradleVersion.version("7.6") && targetVersion < GradleVersion.version("8.0")) {
+            expectDocumentedDeprecationWarning("Non-strict accessors generation for Kotlin DSL precompiled script plugins has been deprecated. This will change in Gradle X. Strict accessor generation will become the default. To opt in to the strict behavior, set the 'org.gradle.kotlin.dsl.precompiled.accessors.strict' system property to `true`. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#strict-kotlin-dsl-precompiled-scripts-accessors")
+        }
     }
 }

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslGivenScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslGivenScriptsModelCrossVersionSpec.groovy
@@ -35,7 +35,7 @@ class KotlinDslGivenScriptsModelCrossVersionSpec extends AbstractKotlinDslScript
         def requestedScripts = spec.scripts.values() + spec.appliedScripts.some
 
         when:
-        def model = loadValidatedToolingModel(KotlinDslScriptsModel) {
+        def model = loadToolingModel(KotlinDslScriptsModel) {
             setModelParameters(it, false, true, requestedScripts)
         }
 
@@ -61,7 +61,7 @@ class KotlinDslGivenScriptsModelCrossVersionSpec extends AbstractKotlinDslScript
         """
 
         when:
-        def model = loadValidatedToolingModel(KotlinDslScriptsModel) {
+        def model = loadToolingModel(KotlinDslScriptsModel) {
             setModelParameters(it, true, true, requestedScripts)
         }
 

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslGivenScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslGivenScriptsModelCrossVersionSpec.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
+import org.gradle.util.GradleVersion
 
 import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinScriptModelParameters.setModelParameters
 
@@ -35,6 +36,7 @@ class KotlinDslGivenScriptsModelCrossVersionSpec extends AbstractKotlinDslScript
         def requestedScripts = spec.scripts.values() + spec.appliedScripts.some
 
         when:
+        maybeExpectAccessorsDeprecation()
         def model = loadToolingModel(KotlinDslScriptsModel) {
             setModelParameters(it, false, true, requestedScripts)
         }
@@ -61,6 +63,8 @@ class KotlinDslGivenScriptsModelCrossVersionSpec extends AbstractKotlinDslScript
         """
 
         when:
+        maybeExpectAccessorsDeprecation()
+        withStackTraceChecksDisabled() // This test prints a huge stack trace
         def model = loadToolingModel(KotlinDslScriptsModel) {
             setModelParameters(it, true, true, requestedScripts)
         }
@@ -80,5 +84,11 @@ class KotlinDslGivenScriptsModelCrossVersionSpec extends AbstractKotlinDslScript
             spec.scripts.a,
             "Unresolved reference: script_body_compilation_error"
         )
+    }
+
+    void maybeExpectAccessorsDeprecation() {
+        if (targetVersion >= GradleVersion.version("7.6") && targetVersion < GradleVersion.version("8.0")) {
+            expectDocumentedDeprecationWarning("Non-strict accessors generation for Kotlin DSL precompiled script plugins has been deprecated. This will change in Gradle X. Strict accessor generation will become the default. To opt in to the strict behavior, set the 'org.gradle.kotlin.dsl.precompiled.accessors.strict' system property to `true`. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#strict-kotlin-dsl-precompiled-scripts-accessors")
+        }
     }
 }

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslScriptsModelCrossVersionSpec.groovy
@@ -39,8 +39,8 @@ class KotlinDslScriptsModelCrossVersionSpec extends AbstractKotlinDslScriptsMode
         toolingApi.requireIsolatedUserHome()
 
         and:
+        maybeExpectAccessorsDeprecation()
         def spec = withMultiProjectBuildWithBuildSrc()
-
 
         when:
         def model = loadToolingModel(KotlinDslScriptsModel) {
@@ -100,5 +100,11 @@ class KotlinDslScriptsModelCrossVersionSpec extends AbstractKotlinDslScriptsMode
         buildFileKtsModel.implicitImports.isEmpty()
         buildFileKtsModel.editorReports.isEmpty()
         buildFileKtsModel.exceptions.isEmpty()
+    }
+
+    void maybeExpectAccessorsDeprecation() {
+        if (targetVersion >= GradleVersion.version("7.6") && targetVersion < GradleVersion.version("8.0")) {
+            expectDocumentedDeprecationWarning("Non-strict accessors generation for Kotlin DSL precompiled script plugins has been deprecated. This will change in Gradle X. Strict accessor generation will become the default. To opt in to the strict behavior, set the 'org.gradle.kotlin.dsl.precompiled.accessors.strict' system property to `true`. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#strict-kotlin-dsl-precompiled-scripts-accessors")
+        }
     }
 }

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslScriptsModelCrossVersionSpec.groovy
@@ -43,7 +43,7 @@ class KotlinDslScriptsModelCrossVersionSpec extends AbstractKotlinDslScriptsMode
 
 
         when:
-        def model = loadValidatedToolingModel(KotlinDslScriptsModel) {
+        def model = loadToolingModel(KotlinDslScriptsModel) {
             setModelParameters(it, false, true, [])
         }
 
@@ -69,7 +69,7 @@ class KotlinDslScriptsModelCrossVersionSpec extends AbstractKotlinDslScriptsMode
         buildFileKts << ""
 
         when:
-        def model = loadValidatedToolingModel(KotlinDslScriptsModel) {
+        def model = loadToolingModel(KotlinDslScriptsModel) {
             setModelParameters(it, true, true, [buildFileKts])
         }
         def source = Proxy.getInvocationHandler(model).sourceObject

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r68/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r68/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
@@ -34,7 +34,7 @@ class KotlinDslDefaultScriptsModelCrossVersionSpec extends AbstractKotlinDslScri
         def spec = withBuildSrcAndInitScripts()
 
         when:
-        def model = loadValidatedToolingModel(KotlinDslScriptsModel) {
+        def model = loadToolingModel(KotlinDslScriptsModel) {
             setModelParameters(it, false)
         }
 
@@ -56,7 +56,7 @@ class KotlinDslDefaultScriptsModelCrossVersionSpec extends AbstractKotlinDslScri
         """
 
         when:
-        def model = loadValidatedToolingModel(KotlinDslScriptsModel) {
+        def model = loadToolingModel(KotlinDslScriptsModel) {
             setModelParameters(it, true)
         }
 

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r68/KotlinDslGivenScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r68/KotlinDslGivenScriptsModelCrossVersionSpec.groovy
@@ -33,7 +33,7 @@ class KotlinDslGivenScriptsModelCrossVersionSpec extends AbstractKotlinDslScript
         def requestedScripts = spec.scripts.values()
 
         when:
-        def model = loadValidatedToolingModel(KotlinDslScriptsModel) {
+        def model = loadToolingModel(KotlinDslScriptsModel) {
             setModelParameters(it, false, true, requestedScripts)
         }
 
@@ -56,7 +56,7 @@ class KotlinDslGivenScriptsModelCrossVersionSpec extends AbstractKotlinDslScript
         """
 
         when:
-        def model = loadValidatedToolingModel(KotlinDslScriptsModel) {
+        def model = loadToolingModel(KotlinDslScriptsModel) {
             setModelParameters(it, true, true, [buildFileKts])
         }
 

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r68/KotlinDslScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r68/KotlinDslScriptsModelCrossVersionSpec.groovy
@@ -35,7 +35,7 @@ class KotlinDslScriptsModelCrossVersionSpec extends AbstractKotlinDslScriptsMode
 
 
         when:
-        def model = loadValidatedToolingModel(KotlinDslScriptsModel) {
+        def model = loadToolingModel(KotlinDslScriptsModel) {
             setModelParameters(it, false, true, [])
         }
         Map<File, KotlinDslScriptModel> singleRequestModels = model.scriptModels

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r71/KotlinDslScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r71/KotlinDslScriptsModelCrossVersionSpec.groovy
@@ -37,8 +37,8 @@ class KotlinDslScriptsModelCrossVersionSpec extends AbstractKotlinScriptModelCro
         file("src/main/kotlin/myplugin.gradle.kts") << ''
 
         when:
-        def model = loadValidatedToolingModel(KotlinDslScriptsModel) {
-            setModelParameters(it, false)
+        def model = loadToolingModel(KotlinDslScriptsModel) {
+            setModelParameters(it, false, false, [])
         }
 
         then:

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r83/KotlinBuildScriptModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r83/KotlinBuildScriptModelCrossVersionSpec.groovy
@@ -31,7 +31,7 @@ class KotlinBuildScriptModelCrossVersionSpec extends AbstractKotlinScriptModelCr
         propertiesFile << gradleProperties
 
         expect:
-        loadValidatedToolingModel(KotlinDslScriptsModel)
+        loadToolingModel(KotlinDslScriptsModel)
     }
 
     @Issue("https://github.com/gradle/gradle/issues/25555")
@@ -41,7 +41,7 @@ class KotlinBuildScriptModelCrossVersionSpec extends AbstractKotlinScriptModelCr
         propertiesFile << gradleProperties
 
         expect:
-        loadValidatedToolingModel(KotlinDslScriptsModel)
+        loadToolingModel(KotlinDslScriptsModel)
     }
 
     def 'exceptions in different scripts are reported on the corresponding scripts'() {
@@ -55,7 +55,7 @@ class KotlinBuildScriptModelCrossVersionSpec extends AbstractKotlinScriptModelCr
         spec.scripts["b"] << "throw RuntimeException(\"ex2\")"
 
 
-        def model = loadValidatedToolingModel(KotlinDslScriptsModel) {
+        def model = loadToolingModel(KotlinDslScriptsModel) {
             KotlinScriptModelParameters.setModelParameters(it, true, true, [])
         }
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/TapiAgentInstrumentationCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/TapiAgentInstrumentationCrossVersionSpec.groovy
@@ -21,7 +21,6 @@ import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 
 @TargetGradleVersion("current")
 class TapiAgentInstrumentationCrossVersionSpec extends ToolingApiSpecification {
-    private String buildOutput
 
     def setup() {
         // TODO(mlopatkin) Figure a way to have agent-based instrumentation in the embedded TAPI mode.
@@ -63,10 +62,8 @@ class TapiAgentInstrumentationCrossVersionSpec extends ToolingApiSpecification {
     }
 
     private void runDumpTaskWithTapi() {
-        withConnection {
-            buildOutput = withBuild {
-                it.forTasks("hello")
-            }.stdout.toString()
+        withBuild {
+            it.forTasks("hello")
         }
     }
 
@@ -79,7 +76,7 @@ class TapiAgentInstrumentationCrossVersionSpec extends ToolingApiSpecification {
     }
 
     private void agentStatusWas(boolean applied) {
-        assert buildOutput.contains("agent applied = $applied")
+        assert result.output.contains("agent applied = $applied")
     }
 
     private void withAgentEnabledInProperties() {

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/TestLauncherSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/TestLauncherSpec.groovy
@@ -72,6 +72,22 @@ abstract class TestLauncherSpec extends ToolingApiSpecification implements WithO
         }
     }
 
+    void launchFailingTests(Collection<TestOperationDescriptor> testsToLaunch) {
+        launchFailingTests { TestLauncher testLauncher ->
+            testLauncher.withTests(testsToLaunch)
+        }
+    }
+
+    void launchFailingTests(Closure configurationClosure) {
+        launchFailingTests(null, configurationClosure)
+    }
+
+    void launchFailingTests(ResultHandler<Void> resultHandler, Closure configurationClosure) {
+        fails { ProjectConnection connection ->
+            launchTests(connection, resultHandler, cancellationTokenSource.token(), configurationClosure)
+        }
+    }
+
     void launchTests(ProjectConnection connection, ResultHandler<Void> resultHandler, CancellationToken cancellationToken, Closure configurationClosure) {
         TestLauncher testLauncher = connection.newTestLauncher()
             .withCancellationToken(cancellationToken)

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m5/ToolingApiBuildExecutionCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m5/ToolingApiBuildExecutionCrossVersionSpec.groovy
@@ -94,7 +94,7 @@ System.err.println 'this is stderr'
         file('build.gradle') << 'broken'
 
         when:
-        withConnection {
+        fails {
             it.newBuild().forTasks('jar').run()
         }
 
@@ -105,7 +105,6 @@ System.err.println 'this is stderr'
 
         and:
         failure.assertHasDescription('A problem occurred evaluating root project')
-        assertHasBuildFailedLogging()
     }
 
     def "can build the set of tasks for an Eclipse project"() {

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m5/ToolingApiModelCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m5/ToolingApiModelCrossVersionSpec.groovy
@@ -40,7 +40,7 @@ System.err.println 'this is stderr'
         file('build.gradle') << 'broken'
 
         when:
-        withConnection {
+        fails {
             it.model(GradleProject.class).get()
         }
 
@@ -51,6 +51,5 @@ System.err.println 'this is stderr'
 
         and:
         failure.assertHasDescription('A problem occurred evaluating root project')
-        assertHasConfigureFailedLogging()
     }
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ToolingApiLoggingCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ToolingApiLoggingCrossVersionSpec.groovy
@@ -107,11 +107,11 @@ project.logger.debug("debug logging");
         def commandLineResult = runUsingCommandLine()
 
         and:
-        def op = withBuild()
+        withBuild()
 
         then:
-        def out = op.result.output
-        def err = op.result.error
+        def out = result.output
+        def err = result.error
         def commandLineOutput = removeStartupWarnings(commandLineResult.output)
         normaliseOutput(out) == normaliseOutput(commandLineOutput)
         err == commandLineResult.error

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r10rc1/PassingCommandLineArgumentsCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r10rc1/PassingCommandLineArgumentsCrossVersionSpec.groovy
@@ -87,18 +87,18 @@ class PassingCommandLineArgumentsCrossVersionSpec extends ToolingApiSpecificatio
 """
 
         when:
-        String debug = withBuild { it.withArguments('-d') }.standardOutput
-
-        and:
-        String info = withBuild { it.withArguments('-i') }.standardOutput
+        withBuild { it.withArguments('-d') }
 
         then:
-        debug.count("debugging stuff") == 1
-        debug.count("infoing stuff") == 1
+        result.output.count("debugging stuff") == 1
+        result.output.count("infoing stuff") == 1
 
-        and:
-        info.count("debugging stuff") == 0
-        info.count("infoing stuff") == 1
+        when:
+        withBuild { it.withArguments('-i') }
+
+        then:
+        result.output.count("debugging stuff") == 0
+        result.output.count("infoing stuff") == 1
     }
 
     def "gives decent feedback for invalid option"() {

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r14/ToolingApiInitScriptCrossVersionIntegrationTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r14/ToolingApiInitScriptCrossVersionIntegrationTest.groovy
@@ -45,12 +45,12 @@ class ToolingApiInitScriptCrossVersionIntegrationTest extends ToolingApiSpecific
         distro
     }
 
-    String runWithInstallation(TestFile gradleHome) {
+    void runWithInstallation(TestFile gradleHome) {
         toolingApi.requireIsolatedDaemons()
         toolingApi.withConnector { GradleConnector it ->
             it.useInstallation(new File(gradleHome.absolutePath))
         }
-        withBuild { it.forTasks("echo") }.standardOutput
+        withBuild { it.forTasks("echo") }
     }
 
     def "init scripts from client distribution are used, not from the test"() {
@@ -66,18 +66,18 @@ class ToolingApiInitScriptCrossVersionIntegrationTest extends ToolingApiSpecific
         """
 
         when:
-        def distro1Output = runWithInstallation(distro1)
+        runWithInstallation(distro1)
 
         then:
-        distro1Output.contains "from distro 1"
-        distro1Output.contains "runtime gradle home: ${distro1.absolutePath}"
+        result.output.contains "from distro 1"
+        result.output.contains "runtime gradle home: ${distro1.absolutePath}"
 
         when:
-        def distro2Output = runWithInstallation(distro2)
+        runWithInstallation(distro2)
 
         then:
-        distro2Output.contains "from distro 2"
-        distro2Output.contains "runtime gradle home: ${distro1.absolutePath}"
+        result.output.contains "from distro 2"
+        result.output.contains "runtime gradle home: ${distro1.absolutePath}"
     }
 }
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r15/CombiningCommandLineArgumentsCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r15/CombiningCommandLineArgumentsCrossVersionSpec.groovy
@@ -17,6 +17,7 @@ package org.gradle.integtests.tooling.r15
 
 
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.util.GradleVersion
 import spock.lang.Issue
 
 class CombiningCommandLineArgumentsCrossVersionSpec extends ToolingApiSpecification {
@@ -26,10 +27,11 @@ class CombiningCommandLineArgumentsCrossVersionSpec extends ToolingApiSpecificat
         file('buildX.gradle') << "logger.info('info message')"
 
         when:
-        def out = withBuild { it.withArguments('-b', 'buildX.gradle', '-i') }.standardOutput
+        maybeExpectDeprecations()
+        withBuild { it.withArguments('-b', 'buildX.gradle', '-i') }
 
         then:
-        out.contains('info message')
+        result.output.contains('info message')
     }
 
     //below was working as expected
@@ -39,9 +41,16 @@ class CombiningCommandLineArgumentsCrossVersionSpec extends ToolingApiSpecificat
         file('buildX.gradle') << "logger.lifecycle('sys property: ' + System.properties['foo'])"
 
         when:
-        def out = withBuild { it.withArguments('-b', 'buildX.gradle') }.standardOutput
+        maybeExpectDeprecations()
+        withBuild { it.withArguments('-b', 'buildX.gradle') }
 
         then:
-        out.contains('sys property: bar')
+        result.output.contains('sys property: bar')
+    }
+
+    def maybeExpectDeprecations() {
+        if (targetVersion >= GradleVersion.version("7.1")) {
+            expectDocumentedDeprecationWarning("Specifying custom build file location has been deprecated. This is scheduled to be removed in Gradle X. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#configuring_custom_build_layout")
+        }
     }
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r15/ToolingApiConfigurationOnDemandCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r15/ToolingApiConfigurationOnDemandCrossVersionSpec.groovy
@@ -29,6 +29,9 @@ class ToolingApiConfigurationOnDemandCrossVersionSpec extends ToolingApiSpecific
     def "building model evaluates all projects regardless of configuration on demand mode"() {
         given:
         file("settings.gradle") << "include 'api', 'impl', 'other'"
+        file("api/build.gradle").touch()
+        file("impl/build.gradle").touch()
+        file("other/build.gradle").touch()
         file("build.gradle") << """
             rootProject.description = 'Projects configured: '
             allprojects { afterEvaluate {
@@ -48,6 +51,7 @@ class ToolingApiConfigurationOnDemandCrossVersionSpec extends ToolingApiSpecific
         file("settings.gradle") << "include 'api', 'impl', 'other'"
 
         file("build.gradle") << "allprojects { task foo }"
+        file("api/build.gradle").touch()
         file("impl/build.gradle") << "task bar(dependsOn: ':api:foo')"
         file("other/build.gradle") << "assert false: 'should not be evaluated'"
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r26/TestLauncherCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r26/TestLauncherCrossVersionSpec.groovy
@@ -257,8 +257,10 @@ class TestLauncherCrossVersionSpec extends TestLauncherSpec {
         collectDescriptorsFromBuild()
         and:
         buildFile.text = simpleJavaProject()
+
         when:
-        launchTests(testDescriptors("example.MyTest", null, ":secondTest"));
+        launchFailingTests(testDescriptors("example.MyTest", null, ":secondTest"))
+
         then:
         assertTaskNotExecuted(":secondTest")
         assertTaskNotExecuted(":test")
@@ -268,7 +270,6 @@ class TestLauncherCrossVersionSpec extends TestLauncherSpec {
 
         and:
         failure.assertHasDescription("Requested test task with path ':secondTest' cannot be found.")
-        assertHasBuildFailedLogging()
     }
 
     def "fails with meaningful error when passing invalid arguments"() {
@@ -286,17 +287,18 @@ class TestLauncherCrossVersionSpec extends TestLauncherSpec {
     def "fails with BuildException when build fails"() {
         given:
         buildFile << "some invalid build code"
+
         when:
-        launchTests { TestLauncher launcher ->
+        launchFailingTests { TestLauncher launcher ->
             launcher.withJvmTestClasses("example.MyTest")
         }
+
         then:
         def e = thrown(BuildException)
         e.cause.message.contains('A problem occurred evaluating root project')
 
         and:
         failure.assertHasDescription('A problem occurred evaluating root project')
-        assertHasBuildFailedLogging()
     }
 
     def "throws BuildCancelledException when build canceled before request started"() {

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r48/PhasedBuildActionCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r48/PhasedBuildActionCrossVersionSpec.groovy
@@ -264,7 +264,7 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
         """
 
         when:
-        withConnection { connection ->
+        fails { connection ->
             connection.action()
                 .projectsLoaded(new CustomProjectsLoadedAction(null), projectsLoadedHandler)
                 .buildFinished(new ActionShouldNotBeCalled(), buildFinishedHandler)
@@ -282,7 +282,6 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
 
         and:
         failure.assertHasDescription("Execution failed for task ':broken'.")
-        assertHasBuildFailedLogging()
     }
 
     def "build is interrupted immediately if action fails"() {

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r66/CommandLineOptionsCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r66/CommandLineOptionsCrossVersionSpec.groovy
@@ -30,87 +30,87 @@ class CommandLineOptionsCrossVersionSpec extends ToolingApiSpecification {
     def "can specify options using properties file"() {
         when:
         file("gradle.properties") << "org.gradle.workers.max=12"
-        def result = withBuild()
+        withBuild()
 
         then:
-        result.standardOutput.contains("max workers: 12")
+        result.output.contains("max workers: 12")
     }
 
     def "can specify options using command-line arguments"() {
         when:
-        def result = withBuild { BuildLauncher launcher ->
+        withBuild { BuildLauncher launcher ->
             launcher.withArguments("--max-workers", "12")
         }
 
         then:
-        result.standardOutput.contains("max workers: 12")
+        result.output.contains("max workers: 12")
     }
 
     @TargetGradleVersion(">=6.6")
     def "can specify options using system properties defined as command-line arguments"() {
         when:
-        def result = withBuild { BuildLauncher launcher ->
+        withBuild { BuildLauncher launcher ->
             launcher.withArguments("-Dorg.gradle.workers.max=12")
         }
 
         then:
-        result.standardOutput.contains("max workers: 12")
+        result.output.contains("max workers: 12")
     }
 
     @TargetGradleVersion(">=6.6")
     def "can specify options using system properties defined in JVM arguments"() {
         when:
-        def result = withBuild { BuildLauncher launcher ->
+        withBuild { BuildLauncher launcher ->
             launcher.setJvmArguments("-Dorg.gradle.workers.max=12")
         }
 
         then:
-        result.standardOutput.contains("max workers: 12")
+        result.output.contains("max workers: 12")
     }
 
     def "command-line arguments take precedence over system properties"() {
         when:
-        def result = withBuild { BuildLauncher launcher ->
+        withBuild { BuildLauncher launcher ->
             launcher.withArguments("-Dorg.gradle.workers.max=4", "--max-workers=12")
         }
 
         then:
-        result.standardOutput.contains("max workers: 12")
+        result.output.contains("max workers: 12")
     }
 
     @TargetGradleVersion(">=6.6")
     def "command-line system properties take precedence over JVM arg system properties"() {
         when:
-        def result = withBuild { BuildLauncher launcher ->
+        withBuild { BuildLauncher launcher ->
             launcher.withArguments("-Dorg.gradle.workers.max=12")
             launcher.setJvmArguments("-Dorg.gradle.workers.max=4")
         }
 
         then:
-        result.standardOutput.contains("max workers: 12")
+        result.output.contains("max workers: 12")
     }
 
     @TargetGradleVersion(">=6.6")
     def "command-line system properties take precedence over properties file"() {
         when:
         file("gradle.properties") << "org.gradle.workers.max=4"
-        def result = withBuild { BuildLauncher launcher ->
+        withBuild { BuildLauncher launcher ->
             launcher.withArguments("-Dorg.gradle.workers.max=12")
         }
 
         then:
-        result.standardOutput.contains("max workers: 12")
+        result.output.contains("max workers: 12")
     }
 
     @TargetGradleVersion(">=6.6")
     def "JVM arg system properties take precedence over properties file"() {
         when:
         file("gradle.properties") << "org.gradle.workers.max=4"
-        def result = withBuild { BuildLauncher launcher ->
+        withBuild { BuildLauncher launcher ->
             launcher.setJvmArguments("-Dorg.gradle.workers.max=12")
         }
 
         then:
-        result.standardOutput.contains("max workers: 12")
+        result.output.contains("max workers: 12")
     }
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DeprecationsCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DeprecationsCrossVersionSpec.groovy
@@ -52,19 +52,19 @@ class DeprecationsCrossVersionSpec extends ToolingApiSpecification {
             project.services.get(ToolingModelBuilderRegistry.class).register(new MyModelBuilder())
         """
 
-        when:
-        withConnection { connection ->
+        expect:
+        if (GradleVersion.version(targetDist.version.version) < GradleVersion.version("8.0")) {
+            expectDocumentedDeprecationWarning("Resolution of the configuration :a:compileClasspath was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behaviour has been deprecated and is scheduled to be removed in Gradle X. See https://docs.gradle.org/current/userguide/viewing_debugging_dependencies.html#sub:resolving-unsafe-configuration-resolution-errors for more details.")
+        } else if (GradleVersion.version(targetDist.version.version) < GradleVersion.version("8.2")) {
+            expectDocumentedDeprecationWarning("Resolution of the configuration :a:compileClasspath was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated. This will fail with an error in Gradle X. See https://docs.gradle.org/current/userguide/viewing_debugging_dependencies.html#sub:resolving-unsafe-configuration-resolution-errors for more details.")
+        } else {
+            expectDocumentedDeprecationWarning("Resolution of the configuration :a:compileClasspath was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated. This will fail with an error in Gradle X. For more information, please refer to https://docs.gradle.org/current/userguide/viewing_debugging_dependencies.html#sub:resolving-unsafe-configuration-resolution-errors in the Gradle documentation.")
+        }
+
+        succeeds { connection ->
             connection.model(List)
                 .withArguments("--parallel")
                 .get()
         }
-
-        then:
-        if (GradleVersion.version(targetDist.version.version) < GradleVersion.version("8.0")) {
-            expectDocumentedDeprecationWarning("Resolution of the configuration :a:compileClasspath was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behaviour has been deprecated and is scheduled to be removed in Gradle X. See https://docs.gradle.org/current/userguide/viewing_debugging_dependencies.html#sub:resolving-unsafe-configuration-resolution-errors for more details.")
-        } else {
-            expectDocumentedDeprecationWarning("Resolution of the configuration :a:compileClasspath was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated. This will fail with an error in Gradle X. For more information, please refer to https://docs.gradle.org/current/userguide/viewing_debugging_dependencies.html#sub:resolving-unsafe-configuration-resolution-errors in the Gradle documentation.")
-        }
-        assertHasConfigureSuccessfulLogging()
     }
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DeprecationsCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DeprecationsCrossVersionSpec.groovy
@@ -26,6 +26,11 @@ class DeprecationsCrossVersionSpec extends ToolingApiSpecification {
         settingsFile << """
             include("a")
         """
+        file("a/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
+        """
         buildFile << """
             import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
             import org.gradle.tooling.provider.model.ToolingModelBuilder
@@ -37,23 +42,14 @@ class DeprecationsCrossVersionSpec extends ToolingApiSpecification {
                 }
                 Object buildAll(String modelName, Project project) {
                     println("creating model for \$project")
-                    project.allprojects.each { p ->
-                        p.configurations.compileClasspath.files()
+                    project.subprojects.each { p ->
+                        p.configurations.compileClasspath.files
                     }
                     return ["result"]
                 }
             }
 
             project.services.get(ToolingModelBuilderRegistry.class).register(new MyModelBuilder())
-
-            allprojects {
-                apply plugin: 'java-library'
-            }
-            project(':a') {
-                dependencies {
-                    implementation rootProject
-                }
-            }
         """
 
         when:
@@ -64,7 +60,11 @@ class DeprecationsCrossVersionSpec extends ToolingApiSpecification {
         }
 
         then:
-        expectDeprecation("Deprecated Gradle features were used in this build, making it incompatible with Gradle ${targetVersion.compareTo(GradleVersion.version("7.6.4")) > 0 ? "9.0" : "8.0" }.")
+        if (GradleVersion.version(targetDist.version.version) < GradleVersion.version("8.0")) {
+            expectDocumentedDeprecationWarning("Resolution of the configuration :a:compileClasspath was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behaviour has been deprecated and is scheduled to be removed in Gradle X. See https://docs.gradle.org/current/userguide/viewing_debugging_dependencies.html#sub:resolving-unsafe-configuration-resolution-errors for more details.")
+        } else {
+            expectDocumentedDeprecationWarning("Resolution of the configuration :a:compileClasspath was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved. This behavior has been deprecated. This will fail with an error in Gradle X. For more information, please refer to https://docs.gradle.org/current/userguide/viewing_debugging_dependencies.html#sub:resolving-unsafe-configuration-resolution-errors in the Gradle documentation.")
+        }
         assertHasConfigureSuccessfulLogging()
     }
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r82/CustomToolingModelCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r82/CustomToolingModelCrossVersionSpec.groovy
@@ -90,8 +90,8 @@ include 'a', 'b', 'c', 'd', 'e'
         }
 
         then:
-        thrown(GradleConnectionException)
-        caughtGradleConnectionException.cause.cause instanceof OutOfMemoryError
+        def e = thrown(GradleConnectionException)
+        e.cause.cause instanceof OutOfMemoryError
     }
 
     @ToolingApiVersion(">=8.2")

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApi.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApi.groovy
@@ -24,12 +24,10 @@ import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.executer.GradleDistribution
 import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
-import org.gradle.integtests.fixtures.executer.ResultAssertion
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.test.fixtures.file.TestDirectoryProvider
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.tooling.GradleConnector
-import org.gradle.tooling.ModelBuilder
 import org.gradle.tooling.ProjectConnection
 import org.gradle.tooling.internal.consumer.ConnectorServices
 import org.gradle.tooling.internal.consumer.DefaultGradleConnector
@@ -163,27 +161,6 @@ class ToolingApi implements TestRule {
             validate(t)
             throw t
         }
-    }
-
-    def <T> T loadToolingLeanModel(Class<T> modelClass, @DelegatesTo(ModelBuilder<T>) Closure configurator = {}) {
-        withConnection {
-            def builder = it.model(modelClass)
-            builder.tap(configurator)
-            builder.get()
-        }
-    }
-
-    def <T> T loadValidatedToolingModel(Class<T> modelClass, @DelegatesTo(ModelBuilder<T>) Closure configurator = {}) {
-        def result = loadToolingLeanModel(modelClass, configurator)
-        validateOutput()
-        result
-    }
-
-    def validateOutput() {
-        def assertion = new ResultAssertion(0, [], false, true, true)
-        assertion.validate(stdout.toString(), "stdout")
-        assertion.validate(stderr.toString(), "stderr")
-        true
     }
 
     private validate(Throwable throwable) {

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
@@ -23,8 +23,10 @@ import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.integtests.fixtures.build.BuildTestFixture
 import org.gradle.integtests.fixtures.build.KotlinDslTestProjectInitiation
 import org.gradle.integtests.fixtures.daemon.DaemonsFixture
+import org.gradle.integtests.fixtures.executer.DocumentationUtils
 import org.gradle.integtests.fixtures.executer.ExecutionFailure
 import org.gradle.integtests.fixtures.executer.ExecutionResult
+import org.gradle.integtests.fixtures.executer.ExpectedDeprecationWarning
 import org.gradle.integtests.fixtures.executer.GradleDistribution
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 import org.gradle.integtests.fixtures.executer.OutputScrapingExecutionFailure
@@ -89,6 +91,7 @@ abstract class ToolingApiSpecification extends Specification implements KotlinDs
     private GradleDistribution targetGradleDistribution
 
     TestDistributionDirectoryProvider temporaryDistributionFolder = new TestDistributionDirectoryProvider(getClass())
+
     @Delegate
     final ToolingApi toolingApi = new ToolingApi(null, temporaryFolder, stdout, stderr)
 
@@ -121,6 +124,10 @@ abstract class ToolingApiSpecification extends Specification implements KotlinDs
         // this is to avoid the working directory to be the Gradle directory itself
         // which causes isolation problems for tests. This one is for _embedded_ mode
         System.setProperty("user.dir", temporaryFolder.testDirectory.absolutePath)
+
+        // Enable deprecation logging for all tests
+        System.setProperty("org.gradle.warning.mode", "all")
+
         settingsFile.touch()
     }
 
@@ -185,6 +192,7 @@ abstract class ToolingApiSpecification extends Specification implements KotlinDs
     }
 
     def <T> T withConnection(ToolingApiConnector connector, @DelegatesTo(ProjectConnection) @ClosureParams(value = SimpleType, options = ["org.gradle.tooling.ProjectConnection"]) Closure<T> cl) {
+        reset()
         try {
             return toolingApi.withConnection(connector, cl)
         } catch (GradleConnectionException e) {
@@ -202,6 +210,7 @@ abstract class ToolingApiSpecification extends Specification implements KotlinDs
     }
 
     def <T> T withConnection(@DelegatesTo(ProjectConnection) @ClosureParams(value = SimpleType, options = ["org.gradle.tooling.ProjectConnection"]) Closure<T> cl) {
+        reset()
         try {
             return toolingApi.withConnection(cl)
         } catch (GradleConnectionException e) {
@@ -310,56 +319,52 @@ abstract class ToolingApiSpecification extends Specification implements KotlinDs
         rootProjectImplicitTasks
     }
 
+    void assertSuccessful() {
+        def allOutput = stdout.toString()
+        // We get BUILD SUCCESSFUL when we run tasks, and CONFIGURE SUCCESSFUL when we fetch models without requesting tasks
+        assert allOutput.contains("BUILD SUCCESSFUL") || allOutput.contains("CONFIGURE SUCCESSFUL")
+        validateOutput(getResult())
+    }
+
     void assertHasBuildSuccessfulLogging() {
-        assertHasNoUnexpectedDeprecationWarnings()
         assert stdout.toString().contains("BUILD SUCCESSFUL")
+        validateOutput(getResult())
     }
 
     void assertHasBuildFailedLogging() {
-        assertHasNoUnexpectedDeprecationWarnings()
         def failureOutput = targetDist.selectOutputWithFailureLogging(stdout, stderr).toString()
         assert failureOutput.contains("BUILD FAILED")
+        validateOutput(getFailure())
     }
 
     void assertHasConfigureSuccessfulLogging() {
-        assertHasNoUnexpectedDeprecationWarnings()
         if (targetDist.isToolingApiLogsConfigureSummary()) {
             assert stdout.toString().contains("CONFIGURE SUCCESSFUL")
         } else {
             assert stdout.toString().contains("BUILD SUCCESSFUL")
         }
+        validateOutput(getResult())
     }
 
     void assertHasConfigureFailedLogging() {
-        assertHasNoUnexpectedDeprecationWarnings()
         def failureOutput = targetDist.selectOutputWithFailureLogging(stdout, stderr).toString()
         if (targetDist.isToolingApiLogsConfigureSummary()) {
             assert failureOutput.contains("CONFIGURE FAILED")
         } else {
             assert failureOutput.contains("BUILD FAILED")
         }
+        validateOutput(getFailure())
+    }
+
+    private void reset() {
+        stdout.reset()
+        stderr.reset()
+        expectedDeprecations.clear()
     }
 
     def shouldCheckForDeprecationWarnings() {
         // Older versions have deprecations
         GradleVersion.version("6.9") < targetVersion
-    }
-
-    private void assertHasNoUnexpectedDeprecationWarnings() {
-        // Clear all expected warnings first
-        String rawOutput = stdout.toString()
-        if (!expectedDeprecations.isEmpty()) {
-            expectedDeprecations.each { expectedDeprecation ->
-                assert rawOutput.contains(expectedDeprecation)
-                rawOutput = rawOutput.replace(expectedDeprecation, "")
-            }
-        }
-        // Then proceed as before
-        if (shouldCheckForDeprecationWarnings()) {
-            assert !rawOutput
-                .replace("[deprecated]", "IGNORE") // don't check deprecated command-line argument
-                .containsIgnoreCase("deprecated")
-        }
     }
 
     ExecutionResult getResult() {
@@ -370,17 +375,24 @@ abstract class ToolingApiSpecification extends Specification implements KotlinDs
         return OutputScrapingExecutionFailure.from(stdout.toString(), stderr.toString())
     }
 
-    def validateOutput() {
-        def assertion = new ResultAssertion(0, [], false, shouldCheckForDeprecationWarnings(), true)
-        assertion.validate(stdout.toString(), "stdout")
-        assertion.validate(stderr.toString(), "stderr")
-        true
+    void validateOutput(ExecutionResult result) {
+        // Check for deprecation warnings.
+        new ResultAssertion(
+            0,
+            expectedDeprecations.collect { ExpectedDeprecationWarning.withMessage(it) },
+            false,
+            shouldCheckForDeprecationWarnings(),
+            true
+        ).execute(result)
     }
 
     def <T> T loadToolingModel(Class<T> modelClass, @DelegatesTo(ModelBuilder<T>) Closure cl = {}) {
-        def result = loadToolingLeanModel(modelClass, cl)
-        assertHasConfigureSuccessfulLogging()
-        validateOutput()
+        def result = withConnection {
+            def builder = it.model(modelClass)
+            builder.tap(cl)
+            builder.get()
+        }
+        assertSuccessful()
         return result
     }
 
@@ -392,7 +404,16 @@ abstract class ToolingApiSpecification extends Specification implements KotlinDs
         RepoScriptBlockUtil.mavenCentralRepository()
     }
 
-    void expectDeprecation(String message) {
-        expectedDeprecations << message
+    void expectDocumentedDeprecationWarning(String message) {
+        expectedDeprecations << normalizeDeprecationWarning(message)
+    }
+
+    private String normalizeDeprecationWarning(String message) {
+        def nextMajorVersion = Integer.parseInt(targetDist.version.version.split("\\.")[0]) + 1
+
+        def normalizedLink = DocumentationUtils.normalizeDocumentationLink(message, targetDist.version)
+        def normalizedVersion = normalizedLink.replaceAll("Gradle X", "Gradle ${nextMajorVersion}.0")
+
+        return normalizedVersion
     }
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ResultAssertion.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ResultAssertion.java
@@ -96,7 +96,7 @@ public class ResultAssertion implements Action<ExecutionResult> {
         return text;
     }
 
-    public void validate(String output, String displayName) {
+    private void validate(String output, String displayName) {
         List<String> lines = getLines(output);
         int i = 0;
         boolean insideVariantDescriptionBlock = false;


### PR DESCRIPTION
Previously, we would only check for the presence of a generalized deprecation warning message, not the specific deprecation warning emitted.

This is better than what we had, but there are still some shortcomings:

1. The expected deprecation warnings and build outputs are tightly tied to the withConnection methods on ToolingApiSpecification. Any tests directly calling withConnection on the toolingApi fixture itself will not properly reset captured standard output and deprecation expectations across connections. Integ tests handle this by having the executor handle deprecations. That would be very similar to having the toolingApi test fixture track deprecations -- though that was more work than desired here.

2. A single connection can run multiple 'long-running' tasks. The proper soution here would be to have each ToolingApiConfigurableLauncher track its own stdout and stderr instead of merging it with each other launcher's stdout and stderr. It becomes difficult to track which deprecations came from which gradle launch with the way it is currently

3. Emitted deprecations are only checked if the test calls a method that verifies deprecation warnings. These are assertHasBuildSuccessfulLogging and similarly named methods. Many tests do not call these sorts of methods and therefore do not get deprecation checks. In the future, we should work to add tooling to verify that each test actually performs some kind of output verification if they ran a build.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
