### PR TITLE
Rebaseline performance tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ develocity.internal.testdistribution.writeTraceFile=true
 gradle.internal.testdistribution.queryResponseTimeout=PT20S
 develocity.internal.testdistribution.queryResponseTimeout=PT20S
 # Default performance baseline
-defaultPerformanceBaselines=8.10-commit-df3d6a929e4
+defaultPerformanceBaselines=8.10-commit-54c2bd63c39
 
 # Skip dependency analysis for tests
 systemProp.dependency.analysis.test.analysis=false


### PR DESCRIPTION
Because we saw a ~2% regression in some unrelated changes.
