### PR TITLE
Fix NotJava8OnMacOs test precondition

### DIFF
--- a/testing/internal-testing/src/main/groovy/org/gradle/test/preconditions/UnitTestPreconditions.groovy
+++ b/testing/internal-testing/src/main/groovy/org/gradle/test/preconditions/UnitTestPreconditions.groovy
@@ -135,10 +135,17 @@ class UnitTestPreconditions {
         }
     }
 
+    static final class Java8OnMacOs implements TestPrecondition {
+        @Override
+        boolean isSatisfied() {
+            return satisfied(MacOs) && JavaVersion.current() == JavaVersion.VERSION_1_8
+        }
+    }
+
     static final class NotJava8OnMacOs implements TestPrecondition {
         @Override
         boolean isSatisfied() {
-            return notSatisfied(MacOs) && JavaVersion.current() != JavaVersion.VERSION_1_8
+            return notSatisfied(Java8OnMacOs)
         }
     }
 


### PR DESCRIPTION
Fixes the `NotJava8OnMacOs` precondition that was [incorrectly translated](https://github.com/gradle/gradle/commit/ef6a429b1c630053333680434d823a769354f08d#diff-9a925e55327c1030130054b1227c41548a8cf3933d12995021708c9c5f2154c4L31) from the previous `@IgnoreIf` logic.