### PR TITLE
Use equality instead of identity for root path detection

### DIFF
--- a/platforms/documentation/docs/src/samples/writing-tasks/tasks-with-dependency-resolution-result-inputs/tests/dependencyReports.sample.conf
+++ b/platforms/documentation/docs/src/samples/writing-tasks/tasks-with-dependency-resolution-result-inputs/tests/dependencyReports.sample.conf
@@ -1,15 +1,15 @@
 commands: [{
     executable: gradle
-    args: "-q :listResolvedArtifacts --no-configuration-cache"
+    args: "-q :listResolvedArtifacts"
     expected-output-file: listResolvedArtifacts.out
 },
 {
     executable: gradle
-    args: "-q :graphResolvedComponents --no-configuration-cache"
+    args: "-q :graphResolvedComponents"
     expected-output-file: graphResolvedComponents.out
 },
 {
     executable: gradle
-    args: "-q :graphResolvedComponentsAndFiles --no-configuration-cache"
+    args: "-q :graphResolvedComponentsAndFiles"
     expected-output-file: graphResolvedComponentsAndFiles.out
 }]

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectComponentSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectComponentSelector.java
@@ -32,6 +32,7 @@ import org.gradle.util.Path;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class DefaultProjectComponentSelector implements ProjectComponentSelectorInternal {
     private final BuildIdentifier buildIdentifier;
@@ -60,7 +61,7 @@ public class DefaultProjectComponentSelector implements ProjectComponentSelector
     @Override
     public String getDisplayName() {
         String prefix;
-        if (identityPath == Path.ROOT) {
+        if (Objects.equals(identityPath, Path.ROOT)) {
             prefix =  "root project";
         } else {
             prefix = "project";

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectComponentIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectComponentIdentifier.java
@@ -18,6 +18,8 @@ package org.gradle.api.internal.artifacts;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.util.Path;
 
+import java.util.Objects;
+
 public class DefaultProjectComponentIdentifier implements ProjectComponentIdentifierInternal {
     private final BuildIdentifier buildIdentifier;
     private final Path projectPath;
@@ -39,7 +41,7 @@ public class DefaultProjectComponentIdentifier implements ProjectComponentIdenti
     @Override
     public String getDisplayName() {
         String prefix;
-        if (identityPath == Path.ROOT) {
+        if (Objects.equals(identityPath, Path.ROOT)) {
             prefix =  "root project";
         } else {
             prefix = "project";

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.api.tasks.diagnostics
 
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.integtests.resolve.locking.LockfileFixture
 import org.gradle.util.GradleVersion
@@ -1609,7 +1608,6 @@ org:leaf2:1.0
 """
     }
 
-    @ToBeFixedForConfigurationCache(because = "CC component identifiers won't include root prefix in display name")
     def "deals with dependency cycle to root"() {
         given:
         createDirs("impl")

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.result.ComponentSelectionCause
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.internal.classloader.ClasspathUtil
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.Path
 import org.junit.ComparisonFailure
 
 /**
@@ -488,7 +489,11 @@ $END_MARKER
         }
 
         private NodeBuilder projectNode(String projectIdentityPath, String moduleVersion) {
-            return node("project:$projectIdentityPath", "project $projectIdentityPath", moduleVersion)
+            if (Objects.equals(Path.path(projectIdentityPath), Path.ROOT)) {
+                return node("project:$projectIdentityPath", "root project $projectIdentityPath", moduleVersion)
+            } else {
+                return node("project:$projectIdentityPath", "project $projectIdentityPath", moduleVersion)
+            }
         }
 
         private NodeBuilder moduleNode(String moduleVersionId) {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.internal.classloader.ClasspathUtil
 import org.gradle.test.fixtures.file.TestFile
 import org.junit.ComparisonFailure
+
 /**
  * A test fixture that injects a "checkDeps" task into a build that resolves a dependency configuration and does some validation of the resulting graph, to
  * ensure that the old and new dependency graphs plus the artifacts and files are as expected and well-formed.
@@ -155,7 +156,7 @@ $END_MARKER
         }
 
         def configDetailsFile = getResultFile()
-        def configDetails = standardizeRootProjectNodes(configDetailsFile.text.readLines())
+        def configDetails = configDetailsFile.text.readLines()
 
         def actualRoot = findLines(configDetails, 'root').first()
         def expectedRoot = "[${root.type}][id:${root.id}][mv:${root.moduleVersionId}][reason:${root.reason}]".toString()
@@ -294,19 +295,6 @@ $END_MARKER
             variants << new Variant(name: variant, attributes: attributes)
         }
         new ParsedNode(type: type, id: id, module: module, reasons: reasons, variants: variants)
-    }
-
-    /**
-     * Standardizes the root project nodes in the given configFile lines to maintain the
-     * original "project :" description instead of the new "root project :" description.
-     *
-     * @param lines the lines to standardize
-     * @return the given lines, with every "root project :" replaced by "project :"
-     */
-    private List<String> standardizeRootProjectNodes(List<String> lines) {
-        return lines.collect { line ->
-            line.replaceAll(/root project :/, 'project :')
-        }
     }
 
     static class ParsedNode {


### PR DESCRIPTION
This fixes the case where Paths loaded from the CC , and removes some testing infrastructure aimed at standardizing this.  This consistency allows others tests to pass with CC enabled.

Followup to https://github.com/gradle/gradle/pull/29667 to remove workaround.
