### PR TITLE
Fix incorrect comment about when beforeResolve runs

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -129,8 +129,8 @@ plugins {
 }
 
 configurations.runtimeClasspath {
-    // `beforeResolve` is called after the configuration is resolved for task dependencies,
-    // but before it is fully resolved during artifact resolution.
+    // `beforeResolve` is not called before the configuration is partially resolved for 
+    // build dependencies, but only before a full graph resolution.
     // Configurations should not be mutated in this hook
     incoming.beforeResolve {
         // Add a dependency on `com:foo` if not already present


### PR DESCRIPTION
The comment made no sense before. I wonder who wrote this

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
