### PR TITLE
Adjust default params for AdHocPerformanceTest

### DIFF
--- a/.teamcity/src/main/kotlin/util/AdHocPerformanceScenario.kt
+++ b/.teamcity/src/main/kotlin/util/AdHocPerformanceScenario.kt
@@ -42,8 +42,8 @@ abstract class AdHocPerformanceScenario(os: Os, arch: Arch = Arch.AMD64) : Build
         )
         param("channel", "adhoc")
         param("checks", "all")
-        text("runs", "10", display = ParameterDisplay.PROMPT, allowEmpty = false)
-        text("warmups", "3", display = ParameterDisplay.PROMPT, allowEmpty = false)
+        text("runs", "40", display = ParameterDisplay.PROMPT, allowEmpty = false)
+        text("warmups", "10", display = ParameterDisplay.PROMPT, allowEmpty = false)
         text(
             "scenario",
             "",


### PR DESCRIPTION
Warmups 3 -> 10
Runs 10 -> 40

Because they're the default value in performance tests.
