### PR TITLE
Fix problem report url for cc

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/crossVersionTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsCrossVersionTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/crossVersionTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsCrossVersionTest.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl
+
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.BuildException
+import org.gradle.tooling.events.ProgressEvent
+import org.gradle.tooling.events.ProgressListener
+import org.gradle.tooling.events.problems.LineInFileLocation
+import org.gradle.tooling.events.problems.Severity
+import org.gradle.tooling.events.problems.SingleProblemEvent
+import org.gradle.tooling.events.problems.internal.GeneralData
+
+@ToolingApiVersion(">=8.10")
+@TargetGradleVersion(">=8.10")
+class ConfigurationCacheProblemsCrossVersionTest extends ToolingApiSpecification {
+
+    class ProblemProgressListener implements ProgressListener {
+
+        List<SingleProblemEvent> problems = []
+
+        @Override
+        void statusChanged(ProgressEvent event) {
+            if (event instanceof SingleProblemEvent) {
+                this.problems.add(event)
+            }
+        }
+    }
+
+    def "failing executions produce problems"() {
+        setup:
+        buildFile """
+            gradle.buildFinished { }
+
+            task run
+        """
+
+
+        when:
+        def listener = new ProblemProgressListener()
+        withConnection { connection ->
+            connection.newBuild()
+                .forTasks(":run")
+                .addProgressListener(listener)
+                .setStandardError(System.err)
+                .setStandardOutput(System.out)
+                .addArguments("--info", "--configuration-cache")
+                .run()
+        }
+
+        then:
+        thrown(BuildException)
+        listener.problems.size() == 1
+        verifyAll(listener.problems[0]) {
+            definition.id.displayName == "registration of listener on 'Gradle.buildFinished' is unsupported"
+            definition.id.group.displayName == "configuration cache validation"
+            definition.id.group.name == "configuration-cache"
+            definition.severity == Severity.ERROR
+            (locations[0] as LineInFileLocation).path == "build file 'build.gradle'" // FIXME: the path should not contain a prefix nor extra quotes
+            (locations[1] as LineInFileLocation).path == "build file '$buildFile.path'"
+            additionalData instanceof GeneralData
+            additionalData.asMap.isEmpty()
+        }
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsServiceIntegTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsServiceIntegTest.groovy
@@ -69,7 +69,13 @@ class ConfigurationCacheProblemsServiceIntegTest extends AbstractConfigurationCa
             fqid == REGISTRATION_UNSUPPORTED
             contextualLabel == "registration of listener on 'Gradle.buildFinished' is unsupported"
             definition.severity == Severity.WARNING
-            definition.documentationLink != null
+            definition.documentationLink.url.endsWith("/userguide/configuration_cache.html#config_cache:requirements:build_listeners")
+            locations[0].path == "build file 'build.gradle'"
+            locations[0].line == 2
+            locations[1].path == "build file '${buildFile.absolutePath}'"
+            locations[1].line == 2
+            additionalData.asMap.trace == "build file 'build.gradle': line 2"
+
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsServiceIntegTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsServiceIntegTest.groovy
@@ -52,7 +52,7 @@ class ConfigurationCacheProblemsServiceIntegTest extends AbstractConfigurationCa
             fqid == REGISTRATION_UNSUPPORTED
             contextualLabel == "registration of listener on 'Gradle.buildFinished' is unsupported"
             definition.severity == Severity.WARNING
-            definition.documentationLink != null
+            definition.documentationLink.url.endsWith("/userguide/configuration_cache.html#config_cache:requirements:build_listeners")
             locations.size() == 2
             locations[0].path == "build file 'build.gradle'"
             locations[0].line == 2

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -222,7 +222,7 @@ class ConfigurationCacheProblems(
     private
     fun ProblemSpec.documentOfProblem(problem: PropertyProblem) {
         problem.documentationSection?.let {
-            documentedAt(Documentation.userManual("configuration_cache", it.anchor).toString())
+            documentedAt(Documentation.userManual("configuration_cache", it.anchor).url)
         }
     }
 


### PR DESCRIPTION
The doc url supplied to the TAPI was incorrect.

Fixed this by using url and not just `toString()`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
