### PR TITLE
Support providedBy service declarations

### DIFF
--- a/.idea/inspectionProfiles/Gradle.xml
+++ b/.idea/inspectionProfiles/Gradle.xml
@@ -69,7 +69,7 @@
         <constraint name="__context__" within="" contains="" />
         <constraint name="Class" within="" contains="" />
         <constraint name="ReturnType" within="" contains="" />
-        <constraint name="Method" regexp="create.*|decorate.*|configure" target="true" negateName="true" within="" contains="" />
+        <constraint name="Method" regexp="create.*|decorate.*|providedBy.*|configure" target="true" negateName="true" within="" contains="" />
         <constraint name="ParameterType" within="" contains="" />
         <constraint name="Parameter" minCount="0" maxCount="2147483647" within="" contains="" />
         <constraint name="Base" regexp="ServiceRegistrationProvider" withinHierarchy="true" within="" contains="" />
@@ -79,7 +79,7 @@
         <constraint name="__context__" within="" contains="" />
         <constraint name="Class" within="" contains="" />
         <constraint name="ReturnType" within="" contains="" />
-        <constraint name="Method" regexp="(create|decorate).*" target="true" within="" contains="" />
+        <constraint name="Method" regexp="(create|decorate|providedBy).*" target="true" within="" contains="" />
         <constraint name="ParameterType" within="" contains="" />
         <constraint name="Parameter" minCount="0" maxCount="2147483647" within="" contains="" />
         <constraint name="Annotation" regexp="Provides" minCount="0" maxCount="0" within="" contains="" />

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CoreCrossBuildSessionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CoreCrossBuildSessionServices.java
@@ -53,9 +53,17 @@ public class CoreCrossBuildSessionServices implements ServiceRegistrationProvide
 
     @Provides
     void configure(ServiceRegistration registration) {
-        registration.add(ResourceLockCoordinationService.class, DefaultResourceLockCoordinationService.class);
         registration.add(WorkerLeaseService.class, ProjectParallelExecutionController.class, DefaultWorkerLeaseService.class);
-        registration.add(DynamicCallContextTracker.class, DefaultDynamicCallContextTracker.class);
+    }
+
+    @Provides
+    ResourceLockCoordinationService providedBy(DefaultResourceLockCoordinationService service) {
+        return service;
+    }
+
+    @Provides
+    DynamicCallContextTracker providedBy(DefaultDynamicCallContextTracker service) {
+        return service;
     }
 
     @Provides


### PR DESCRIPTION
Adds a new type of methods recognized by `ServiceRegistryBuilder` in implementations of `ServiceRegistrationProvider`.

- The method name must start with `providedBy`.
- The return type represents the exposed service type
- The single parameter type represents the implementation

```java
public class SomeServicesProvider implements ServiceRegistrationProvider {
    @Provides
    MyService providedBy(DefaultMyService service) { return service; }
}
```

## Disadvantages of existing approaches

It was already possible to do a similar thing with `create` methods:
```java
public class SomeServicesProvider implements ServiceRegistrationProvider {
    @Provides
    MyService createMyService() { return new DefaultMyService(); }
}
```

The `create` methods introduce frictions when the services change:
- Whenever the implementation requires a new parameter, it has to be added to the list of parameters of the `create` method with the right name and type
- The `createMyService` method name does not get auto-renamed when services are refactored, so this eventually creates discrepancies

When the logic to create the service is trivial (just call the constructor), the `configure` method can be used instead:
```java
public class SomeServicesProvider implements ServiceRegistrationProvider {
    void configure(ServiceRegistration registration) {
        registration.add(MyService.class, DefaultMyService.class);
    }
}
```

While it does not have the disadvantages of the `create` method, it keeps the need for a completely different-looking and imperative way of registering services.

- This requires developers to expect two different forms of service registration, when exploring or changing the code
- It makes it harder to provide tooling for service wiring navigation (similar to popular Guice and Dagger frameworks)

## The new method

The `providedBy` method solves all of the problems described above

- The method name can stay `providedBy` and does not need updating, because even overloads in the same class will have different implementation as a parameter
- There is no boilerplate of passing parameters
- It encourages to specify the exposed service type separately from the implementation type
- It is declarative, so it stays visually similar to `create` methods
- It is declarative, so tooling for service wiring navigation can be built only on method signatures (does not require method body inspection)
