### PR TITLE
Configurations lacking explicit artifacts should still resolve, should not have secondary variants

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -55,6 +55,15 @@ When this happens, configurations in the substituted project could be selected t
 
 Consuming non-consumable configurations in this manner is deprecated and will result in an error in Gradle 9.0.
 
+[[variants_with_no_artifacts]]
+=== Defining secondary variants for primary variants without artifacts is deprecated
+
+In prior versions of Gradle, it was possible to define [Secondary Variants](https://docs.gradle.org/8.9/userguide/publishing_customization.html#sec:publishing-custom-components) for consumable "primary" variants that lacked artifacts.
+
+As secondary variants are meant to represent "precomputed transformations" of artifacts, this makes no sense for primary variants that lack artifacts.
+
+Defining secondary variants for a primary variant lacking artifacts is deprecated and will result in an error in Gradle 9.0.
+
 [[changes_8.9]]
 == Upgrading from 8.8 and earlier
 
@@ -160,7 +169,7 @@ plugins {
 }
 
 configurations.runtimeClasspath {
-    // `beforeResolve` is not called before the configuration is partially resolved for 
+    // `beforeResolve` is not called before the configuration is partially resolved for
     // build dependencies, but only before a full graph resolution.
     // Configurations should not be mutated in this hook
     incoming.beforeResolve {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/experiments/SecondaryVariantsBreakConsumableConfs.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/experiments/SecondaryVariantsBreakConsumableConfs.groovy
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.experiments
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.file.TestFile
+import spock.lang.Issue
+
+/**
+ * This test is to verify that secondary variants with no artifacts exclude the main
+ * variant from resolution.
+ */
+@Issue("https://github.com/gradle/gradle/issues/29630")
+class SecondaryVariantsBreakConsumableConfs extends AbstractIntegrationSpec {
+    def "no secondary variants works fine for resolution"() {
+        given:
+        setupBuild()
+
+        expect:
+        succeeds("resolve")
+    }
+
+    def "no secondary variants works fine for dependencyInsight"() {
+        given:
+        setupBuild()
+
+        expect:
+        succeeds("dependencyInsight", "--configuration", "resolvableConfiguration", "--dependency", ":")
+    }
+
+    def "secondary variant with no artifacts breaks resolution - THIS SHOULD SUCCEED"() {
+        given:
+        setupBuild()
+
+        expect:
+        fails("resolve", "-PregisterSecondaryVariant=true")
+
+        and:
+        failure.assertHasDescription("Could not determine the dependencies of task ':resolve'.")
+        failure.assertHasCause("Could not resolve all dependencies for configuration ':resolvableConfiguration'.")
+        failure.assertHasErrorOutput("""> Could not resolve all dependencies for configuration ':resolvableConfiguration'.
+   > No variants of root project : match the consumer attributes:
+       - Configuration ':consumableConfiguration' variant myVariant declares attribute 'myAttribute1' with value 'value1':
+           - Incompatible because this component declares attribute 'myAttribute2' with value 'otherValue2' and the consumer needed attribute 'myAttribute2' with value 'value2'""")
+    }
+
+    // Does this not failing indicate the report is unreliable?
+    def "secondary variant with no artifacts works fine for dependencyInsight - SHOULD THIS FAIL?"() {
+        given:
+        setupBuild()
+
+        expect:
+        succeeds("dependencyInsight", "--configuration", "resolvableConfiguration", "--dependency", ":")
+    }
+
+    def "secondary variant with an artifact works fine for resolution"() {
+        given:
+        setupBuild()
+
+        expect:
+        succeeds("resolve", "-PregisterSecondaryVariant=true", "-PregisterArtifacts=true")
+    }
+
+    def "secondary variant with an artifact works fine for dependencyInsight"() {
+        given:
+        setupBuild()
+
+        expect:
+        succeeds("dependencyInsight", "--configuration", "resolvableConfiguration", "--dependency", ":", "-PregisterSecondaryVariant=true", "-PregisterArtifacts=true")
+    }
+
+    private TestFile setupBuild() {
+        buildKotlinFile << """
+            val myAttribute1 = Attribute.of("myAttribute1", String::class.java)
+            val myAttribute2 = Attribute.of("myAttribute2", String::class.java)
+
+            configurations.consumable("consumableConfiguration1") {
+                attributes {
+                    attribute(myAttribute1, "someOtherValue1")
+                    attribute(myAttribute2, "value2")
+                }
+            }
+
+            val consumableConfiguration = configurations.consumable("consumableConfiguration") {
+                attributes {
+                    attribute(myAttribute1, "value1")
+                    attribute(myAttribute2, "value2")
+                }
+
+                if (providers.gradleProperty("registerSecondaryVariant").orNull == "true") {
+                    outgoing.variants.create("myVariant") {
+                        attributes {
+                            attribute(myAttribute1, "value1")
+                            attribute(myAttribute2, "otherValue2")
+                        }
+                    }
+                }
+            }
+
+            if (providers.gradleProperty("registerArtifacts").orNull == "true") {
+                artifacts {
+                    add(consumableConfiguration.name, project.file("build.gradle.kts"))
+                }
+            }
+
+            val dependencyScope = configurations.dependencyScope("dependencyScope")
+            val resolvableConfiguration = configurations.resolvable("resolvableConfiguration") {
+                extendsFrom(dependencyScope.get())
+                attributes {
+                    attribute(myAttribute1, "value1")
+                    attribute(myAttribute2, "value2")
+                }
+            }
+
+            dependencies {
+                attributesSchema.attribute(myAttribute1)
+                attributesSchema.attribute(myAttribute2)
+                dependencyScope(project(":"))
+            }
+
+            tasks.register("resolve") {
+                inputs.files(resolvableConfiguration)
+                doFirst {
+                    println(resolvableConfiguration.get().files)
+                }
+            }
+        """
+    }
+}

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/experiments/SecondaryVariantsBreakConsumableConfs.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/experiments/SecondaryVariantsBreakConsumableConfs.groovy
@@ -51,15 +51,19 @@ class SecondaryVariantsBreakConsumableConfs extends AbstractIntegrationSpec {
     // region Secondary Variant with No Artifacts
     def "adding secondary variant with no artifact fails resolution - THIS SHOULD SUCCEED"() {
         expect:
-        fails("resolve", "-PregisterSecondaryVariant=true")
+        succeeds("resolve")
+        assertResolved([])
 
-        and:
-        failure.assertHasDescription("Could not determine the dependencies of task ':resolve'.")
-        failure.assertHasCause("Could not resolve all dependencies for configuration ':resolvableConfiguration'.")
-        failure.assertHasErrorOutput("""> Could not resolve all dependencies for configuration ':resolvableConfiguration'.
-   > No variants of root project : match the consumer attributes:
-       - Configuration ':consumableConfiguration' variant mySecondaryVariant:
-           - Incompatible because this component declares attribute 'myAttribute' with value 'value2' and the consumer needed attribute 'myAttribute' with value 'value1'""")
+//        expect:
+//        fails("resolve", "-PregisterSecondaryVariant=true")
+//
+//        and:
+//        failure.assertHasDescription("Could not determine the dependencies of task ':resolve'.")
+//        failure.assertHasCause("Could not resolve all dependencies for configuration ':resolvableConfiguration'.")
+//        failure.assertHasErrorOutput("""> Could not resolve all dependencies for configuration ':resolvableConfiguration'.
+//   > No variants of root project : match the consumer attributes:
+//       - Configuration ':consumableConfiguration' variant mySecondaryVariant:
+//           - Incompatible because this component declares attribute 'myAttribute' with value 'value2' and the consumer needed attribute 'myAttribute' with value 'value1'""")
     }
 
     // Does this not failing indicate the report is unreliable?
@@ -105,15 +109,18 @@ class SecondaryVariantsBreakConsumableConfs extends AbstractIntegrationSpec {
     // region Secondary Variant with an Artifact
     def "adding secondary variant with an artifact fails resolution - THIS SHOULD SUCCEED"() {
         expect:
-        fails("resolve", "-PregisterSecondaryVariant=true", "-PregisterSecondaryArtifact=true")
-
-        and:
-        failure.assertHasDescription("Could not determine the dependencies of task ':resolve'.")
-        failure.assertHasCause("Could not resolve all dependencies for configuration ':resolvableConfiguration'.")
-        failure.assertHasErrorOutput("""> Could not resolve all dependencies for configuration ':resolvableConfiguration'.
-   > No variants of root project : match the consumer attributes:
-       - Configuration ':consumableConfiguration' variant mySecondaryVariant:
-           - Incompatible because this component declares attribute 'myAttribute' with value 'value2' and the consumer needed attribute 'myAttribute' with value 'value1'""")
+        succeeds("resolve")
+        assertResolved([])
+//        expect:
+//        fails("resolve", "-PregisterSecondaryVariant=true", "-PregisterSecondaryArtifact=true")
+//
+//        and:
+//        failure.assertHasDescription("Could not determine the dependencies of task ':resolve'.")
+//        failure.assertHasCause("Could not resolve all dependencies for configuration ':resolvableConfiguration'.")
+//        failure.assertHasErrorOutput("""> Could not resolve all dependencies for configuration ':resolvableConfiguration'.
+//   > No variants of root project : match the consumer attributes:
+//       - Configuration ':consumableConfiguration' variant mySecondaryVariant:
+//           - Incompatible because this component declares attribute 'myAttribute' with value 'value2' and the consumer needed attribute 'myAttribute' with value 'value1'""")
     }
 
     def "adding secondary variant with an artifact works fine for dependencyInsight"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ResolutionFailureHandlerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ResolutionFailureHandlerIntegrationTest.groovy
@@ -387,6 +387,9 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
         assertFullMessageCorrect("""   > More than one variant of root project : matches the consumer attributes:
+       - Configuration ':default':
+           - Unmatched attribute:
+               - Provides artifactType 'txt' but the consumer didn't ask for it
        - Configuration ':default' variant v1
        - Configuration ':default' variant v2""")
 
@@ -561,6 +564,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
             configurations {
                 consumable("default") {
                     outgoing {
+                        artifact(file("dummy.txt"))
                         variants {
                             val v1 by creating { }
                             val v2 by creating { }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.extensions.FluidDependenciesResolveTest
 import org.gradle.integtests.fixtures.resolve.ResolveFailureTestFixture
+import org.gradle.util.GradleVersion
 
 @FluidDependenciesResolveTest
 class ArtifactSelectionIntegrationTest extends AbstractHttpDependencyResolutionTest {
@@ -167,6 +168,7 @@ allprojects {
         m1.getArtifact(name: 'some-jar', type: 'jar').expectGet()
 
         expect:
+        executer.expectDeprecationWarning("The configuration ':lib:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'classesFormat', 'dirFormat', 'jarFormat' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         succeeds "resolve"
         // Currently builds all file dependencies
         executed ":lib:jar", ":lib:utilClasses", ":lib:utilDir", ":lib:utilJar", ":ui:jar", ":app:resolve"
@@ -244,6 +246,7 @@ allprojects {
         m2.getArtifact(name: 'some-classes', type: 'classes').expectGet()
 
         expect:
+        executer.expectDeprecationWarning("The configuration ':lib:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'classesFormat', 'dirFormat', 'jarFormat' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         succeeds "resolve"
         // Currently builds all file dependencies
         executed ":lib:classes", ":lib:utilClasses", ":lib:utilDir", ":lib:utilJar", ":ui:classes", ":app:resolve"
@@ -317,6 +320,7 @@ task show {
 }
 """
         when:
+        executer.expectDeprecationWarning("The configuration ':lib:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'var1', 'var2', 'var3' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         run 'show'
 
         then:
@@ -388,6 +392,7 @@ task show {
 }
 """
         when:
+        executer.expectDeprecationWarning("The configuration ':lib:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'var1', 'var2', 'var3' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         run 'show'
 
         then:
@@ -455,6 +460,7 @@ task show {
 }
 """
         when:
+        executer.expectDeprecationWarning("The configuration ':lib:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'var1', 'var2', 'var3' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         run 'show'
 
         then:
@@ -590,12 +596,13 @@ task show {
         when:
         m1.ivy.expectGet()
         m1.jar.expectGet()
+        executer.expectDeprecationWarning("The configuration ':lib:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'var1' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         run 'show'
 
         then:
-        outputContains("files: [test-lib.jar, transformed-a1.jar, transformed-b2.jar, test-1.0.jar]")
-        outputContains("components: [test-lib.jar, project :lib, project :ui, org:test:1.0]")
-        outputContains("variants: [{artifactType=jar}, {artifactType=jar, buildType=debug, flavor=one, usage=transformed}, {artifactType=jar, usage=transformed}, {artifactType=jar, org.gradle.status=integration}]")
+        outputContains("files: [test-lib.jar, transformed-b2.jar, test-1.0.jar]")
+        outputContains("components: [test-lib.jar, project :ui, org:test:1.0]")
+        outputContains("variants: [{artifactType=jar}, {artifactType=jar, usage=transformed}, {artifactType=jar, org.gradle.status=integration}]")
     }
 
     def "can query the content of view before task graph is calculated"() {
@@ -669,6 +676,7 @@ task show {
         m2.getArtifact(name: 'some-classes', type: 'classes').expectGet()
 
         expect:
+        executer.expectDeprecationWarning("The configuration ':lib:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'classesFormat', 'dirFormat', 'jarFormat' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         succeeds "resolve"
         // Currently builds all file dependencies
         executed ":lib:classes", ":lib:utilClasses", ":lib:utilDir", ":lib:utilJar", ":ui:classes", ":app:resolve"
@@ -719,6 +727,7 @@ task show {
         """
 
         expect:
+        executer.expectDeprecationWarning("The configuration ':lib:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'classesFormat', 'dirFormat', 'jarFormat' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         succeeds "resolve"
         result.assertTasksExecuted(":lib:classes", ":app:resolve")
     }
@@ -977,6 +986,8 @@ task show {
         """
 
         expect:
+        executer.expectDeprecationWarning("The configuration ':lib:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'broken1', 'broken2' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
+        executer.expectDeprecationWarning("The configuration ':ui:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'broken1', 'broken2' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         fails(":app:resolve")
         resolve.assertFailurePresent(failure)
         failure.assertHasCause("Could not resolve all files for configuration ':app:compile'.")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationBuildDependenciesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationBuildDependenciesIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.util.GradleVersion
 
 class ConfigurationBuildDependenciesIntegrationTest extends AbstractHttpDependencyResolutionTest {
     def setup() {
@@ -260,11 +261,13 @@ class ConfigurationBuildDependenciesIntegrationTest extends AbstractHttpDependen
 
         expect:
         executer.withArgument("--dry-run")
+        executer.expectDeprecationWarning("The configuration ':child:default' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'v1', 'v2' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         fails("useCompileConfiguration")
         failure.assertHasDescription("Could not determine the dependencies of task ':useCompileConfiguration'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':compile'.")
         failure.assertHasCause("More than one variant of project :child matches the consumer attributes:")
 
+        executer.expectDeprecationWarning("The configuration ':child:default' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'v1', 'v2' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         fails("useCompileConfiguration")
         failure.assertHasDescription("Could not determine the dependencies of task ':useCompileConfiguration'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':compile'.")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantsWithoutArtifactsWithSecondaryVariantsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantsWithoutArtifactsWithSecondaryVariantsIntegrationTest.groovy
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package org.gradle.integtests.experiments
+package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.util.GradleVersion
 import spock.lang.Issue
 
 /**
@@ -24,7 +25,7 @@ import spock.lang.Issue
  * not resolvable.
  */
 @Issue("https://github.com/gradle/gradle/issues/29630")
-class SecondaryVariantsBreakConsumableConfs extends AbstractIntegrationSpec {
+class VariantsWithoutArtifactsWithSecondaryVariantsIntegrationTest extends AbstractIntegrationSpec {
     // region No Secondary Variants
     def "no secondary variants works fine for resolution"() {
         expect:
@@ -49,25 +50,15 @@ class SecondaryVariantsBreakConsumableConfs extends AbstractIntegrationSpec {
     // endregion No Secondary Variants
 
     // region Secondary Variant with No Artifacts
-    def "adding secondary variant with no artifact fails resolution - THIS SHOULD SUCCEED"() {
+    def "adding secondary variant with no artifact is deprecated"() {
         expect:
+        executer.expectDeprecationWarning("The configuration ':consumableConfiguration' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variants: 'mySecondaryVariant' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         succeeds("resolve", "-PregisterSecondaryVariant=true")
         assertResolved([])
-
-//        expect:
-//        fails("resolve", "-PregisterSecondaryVariant=true")
-//
-//        and:
-//        failure.assertHasDescription("Could not determine the dependencies of task ':resolve'.")
-//        failure.assertHasCause("Could not resolve all dependencies for configuration ':resolvableConfiguration'.")
-//        failure.assertHasErrorOutput("""> Could not resolve all dependencies for configuration ':resolvableConfiguration'.
-//   > No variants of root project : match the consumer attributes:
-//       - Configuration ':consumableConfiguration' variant mySecondaryVariant:
-//           - Incompatible because this component declares attribute 'myAttribute' with value 'value2' and the consumer needed attribute 'myAttribute' with value 'value1'""")
     }
 
     // Does this not failing indicate the report is unreliable?
-    def "adding secondary variant with no artifact works fine for dependencyInsight - SHOULD THIS FAIL?"() {
+    def "adding secondary variant with no artifact works fine for dependencyInsight"() {
         expect:
         succeeds("dependencyInsight", "--configuration", "resolvableConfiguration", "--dependency", ":")
     }
@@ -107,20 +98,11 @@ class SecondaryVariantsBreakConsumableConfs extends AbstractIntegrationSpec {
     // endregion Secondary Variant with no Artifacts with an Artifact explicitly added to main variant
 
     // region Secondary Variant with an Artifact
-    def "adding secondary variant with an artifact fails resolution - THIS SHOULD SUCCEED"() {
+    def "adding secondary variant with an artifact is deprecated"() {
         expect:
+        executer.expectDeprecationWarning("The configuration ':consumableConfiguration' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variants: 'mySecondaryVariant' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         succeeds("resolve", "-PregisterSecondaryVariant=true", "-PregisterSecondaryArtifact=true")
         assertResolved([])
-//        expect:
-//        fails("resolve", "-PregisterSecondaryVariant=true", "-PregisterSecondaryArtifact=true")
-//
-//        and:
-//        failure.assertHasDescription("Could not determine the dependencies of task ':resolve'.")
-//        failure.assertHasCause("Could not resolve all dependencies for configuration ':resolvableConfiguration'.")
-//        failure.assertHasErrorOutput("""> Could not resolve all dependencies for configuration ':resolvableConfiguration'.
-//   > No variants of root project : match the consumer attributes:
-//       - Configuration ':consumableConfiguration' variant mySecondaryVariant:
-//           - Incompatible because this component declares attribute 'myAttribute' with value 'value2' and the consumer needed attribute 'myAttribute' with value 'value1'""")
     }
 
     def "adding secondary variant with an artifact works fine for dependencyInsight"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantsWithoutArtifactsWithSecondaryVariantsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantsWithoutArtifactsWithSecondaryVariantsIntegrationTest.groovy
@@ -188,7 +188,7 @@ final class VariantsWithoutArtifactsWithSecondaryVariantsIntegrationTest extends
             tasks.register("resolve") {
                 inputs.files(resolvableConfiguration)
                 doFirst {
-                    println("Resolved: " + resolvableConfiguration.get().files)
+                    println("Resolved: " + inputs.files.files)
                 }
             }
         """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantsWithoutArtifactsWithSecondaryVariantsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantsWithoutArtifactsWithSecondaryVariantsIntegrationTest.groovy
@@ -52,7 +52,7 @@ final class VariantsWithoutArtifactsWithSecondaryVariantsIntegrationTest extends
     // region Secondary Variant with No Artifacts
     def "adding secondary variant with no artifact is deprecated"() {
         expect:
-        executer.expectDeprecationWarning("The configuration ':consumableConfiguration' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variants: 'mySecondaryVariant' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
+        executer.expectDeprecationWarning("The configuration ':consumableConfiguration' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'mySecondaryVariant' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         succeeds("resolve", "-PregisterSecondaryVariant=true")
         assertResolved([])
     }
@@ -100,7 +100,7 @@ final class VariantsWithoutArtifactsWithSecondaryVariantsIntegrationTest extends
     // region Secondary Variant with an Artifact
     def "adding secondary variant with an artifact is deprecated"() {
         expect:
-        executer.expectDeprecationWarning("The configuration ':consumableConfiguration' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variants: 'mySecondaryVariant' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
+        executer.expectDeprecationWarning("The configuration ':consumableConfiguration' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'mySecondaryVariant' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         succeeds("resolve", "-PregisterSecondaryVariant=true", "-PregisterSecondaryArtifact=true")
         assertResolved([])
     }
@@ -195,6 +195,6 @@ final class VariantsWithoutArtifactsWithSecondaryVariantsIntegrationTest extends
     }
 
     private void assertResolved(List<File> artifacts) {
-        result.assertOutputContains("Resolved: " + artifacts*.path.toString())
+        outputContains("Resolved: " + artifacts*.path.toString())
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantsWithoutArtifactsWithSecondaryVariantsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantsWithoutArtifactsWithSecondaryVariantsIntegrationTest.groovy
@@ -21,11 +21,11 @@ import org.gradle.util.GradleVersion
 import spock.lang.Issue
 
 /**
- * This test is to verify that adding a secondary variant with no artifacts makes a main variant
- * not resolvable.
+ * These tests are to verify the behavior when adding a secondary variant to a main variant
+ * without artifacts.
  */
 @Issue("https://github.com/gradle/gradle/issues/29630")
-class VariantsWithoutArtifactsWithSecondaryVariantsIntegrationTest extends AbstractIntegrationSpec {
+final class VariantsWithoutArtifactsWithSecondaryVariantsIntegrationTest extends AbstractIntegrationSpec {
     // region No Secondary Variants
     def "no secondary variants works fine for resolution"() {
         expect:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ArtifactDeclarationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ArtifactDeclarationIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve.api
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+import org.gradle.util.GradleVersion
 
 class ArtifactDeclarationIntegrationTest extends AbstractIntegrationSpec {
     ResolveTestFixture resolve = new ResolveTestFixture(buildFile, "compile")
@@ -273,6 +274,7 @@ classes.attributes.keySet().collect { it.name } == ['usage', 'format']
                 configurations {
                     compile {
                         outgoing {
+                            attributes.attribute(Attribute.of('usage', String), 'other')
                             variants {
                                 classes {
                                     artifact(file('classes')) {
@@ -294,7 +296,7 @@ classes.attributes.keySet().collect { it.name } == ['usage', 'format']
             }
 """
 
-        when:
+        when:executer.expectDeprecationWarning("The configuration ':a:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'classes' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         succeeds ':b:checkDeps'
 
         then:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedArtifactsApiIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedArtifactsApiIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.integtests.resolve.api
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.extensions.FluidDependenciesResolveTest
+import org.gradle.util.GradleVersion
 
 @FluidDependenciesResolveTest
 class ResolvedArtifactsApiIntegrationTest extends AbstractHttpDependencyResolutionTest {
@@ -127,6 +128,11 @@ task show {
 allprojects {
     configurations.compile.attributes.attribute(usage, 'compile')
 }
+configurations {
+    compile {
+        attributes.attribute(Attribute.of('other', String), 'select')
+    }
+}
 dependencies {
     compile project(':a')
 }
@@ -139,6 +145,7 @@ project(':a') {
                     var1 {
                         artifact file('a1.jar')
                         attributes.attribute(flavor, 'one')
+                        attributes.attribute(Attribute.of('other', String), 'select')
                     }
                 }
             }
@@ -156,6 +163,7 @@ project(':b') {
                     var1 {
                         artifact file('b2.jar')
                         attributes.attribute(flavor, 'two')
+                        attributes.attribute(Attribute.of('other', String), 'select')
                     }
                 }
             }
@@ -177,13 +185,15 @@ task show {
 """
 
         when:
+        executer.expectDeprecationWarning("The configuration ':a:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'var1' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
+        executer.expectDeprecationWarning("The configuration ':b:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'var1' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         run 'show'
 
         then:
         outputContains("files: [a1.jar, b2.jar]")
         outputContains("ids: [a1.jar (project :a), b2.jar (project :b)]")
         outputContains("components: [project :a, project :b]")
-        outputContains("variants: [{artifactType=jar, buildType=debug, flavor=one, usage=compile}, {artifactType=jar, flavor=two, usage=compile}]")
+        outputContains("variants: [{artifactType=jar, buildType=debug, flavor=one, other=select, usage=compile}, {artifactType=jar, flavor=two, other=select, usage=compile}]")
 
         where:
         expression                                                    | _
@@ -282,6 +292,8 @@ task show {
 """
 
         when:
+        executer.expectDeprecationWarning("The configuration ':a:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'var1', 'var2' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
+        executer.expectDeprecationWarning("The configuration ':b:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'var1', 'var2' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         run 'show'
 
         then:
@@ -384,6 +396,8 @@ task show {
 """
 
         when:
+        executer.expectDeprecationWarning("The configuration ':a:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'var1', 'var2' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
+        executer.expectDeprecationWarning("The configuration ':b:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'var1', 'var2' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         run 'show'
 
         then:
@@ -408,6 +422,12 @@ allprojects {
     configurations.compile.attributes.attribute(usage, 'compile')
 }
 
+configurations {
+    compile {
+        attributes.attribute(Attribute.of('other', String), 'select')
+    }
+}
+
 dependencies {
     compile project(':a')
 }
@@ -419,14 +439,18 @@ project(':a') {
         compile {
             attributes.attribute(buildType, 'debug')
             outgoing {
+                attributes.attribute(flavor, 'zero')
+                attributes.attribute(Attribute.of('mismatch', String), 'mismatch')
                 variants {
                     var1 {
                         artifact oneJar
                         attributes.attribute(flavor, 'one')
+                        attributes.attribute(Attribute.of('other', String), 'select')
                     }
                     var2 {
                         artifact twoJar
                         attributes.attribute(flavor, 'two')
+                        attributes.attribute(Attribute.of('other', String), 'select')
                     }
                 }
             }
@@ -446,10 +470,12 @@ project(':b') {
                     var1 {
                         artifact oneJar
                         attributes.attribute(flavor, 'one')
+                        attributes.attribute(Attribute.of('other', String), 'select')
                     }
                     var2 {
                         artifact twoJar
                         attributes.attribute(flavor, 'two')
+                        attributes.attribute(Attribute.of('other', String), 'select')
                     }
                 }
             }
@@ -467,16 +493,24 @@ task show {
 """
 
         when:
+        executer.expectDeprecationWarning("The configuration ':a:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'var1', 'var2' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
+        executer.expectDeprecationWarning("The configuration ':b:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'var1', 'var2' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         fails 'show'
 
         then:
-        failure.assertHasCause("""The consumer was configured to find attribute 'usage' with value 'compile'. However we cannot choose between the following variants of project :a:
-  - Configuration ':a:compile' variant var1 declares attribute 'usage' with value 'compile':
+        failure.assertHasCause("""The consumer was configured to find attribute 'other' with value 'select', attribute 'usage' with value 'compile'. However we cannot choose between the following variants of project :a:
+  - Configuration ':a:compile' declares attribute 'usage' with value 'compile':
+      - Unmatched attributes:
+          - Doesn't say anything about other (required 'select')
+          - Provides buildType 'debug' but the consumer didn't ask for it
+          - Provides flavor 'zero' but the consumer didn't ask for it
+          - Provides mismatch 'mismatch' but the consumer didn't ask for it
+  - Configuration ':a:compile' variant var1 declares attribute 'other' with value 'select', attribute 'usage' with value 'compile':
       - Unmatched attributes:
           - Provides artifactType 'jar' but the consumer didn't ask for it
           - Provides buildType 'debug' but the consumer didn't ask for it
           - Provides flavor 'one' but the consumer didn't ask for it
-  - Configuration ':a:compile' variant var2 declares attribute 'usage' with value 'compile':
+  - Configuration ':a:compile' variant var2 declares attribute 'other' with value 'select', attribute 'usage' with value 'compile':
       - Unmatched attributes:
           - Provides artifactType 'jar' but the consumer didn't ask for it
           - Provides buildType 'debug' but the consumer didn't ask for it
@@ -526,13 +560,9 @@ project(':a') {
     configurations {
         compile {
             attributes.attribute(buildType, 'debug')
+            attributes.attribute(flavor, 'one')
             outgoing {
-                variants {
-                    var1 {
-                        artifact file('a1.jar')
-                        attributes.attribute(flavor, 'one')
-                    }
-                }
+                artifact file('a1.jar')
             }
         }
     }
@@ -813,6 +843,7 @@ ${showFailuresTask(expression)}
         m2.artifact.expectGetBroken()
 
         when:
+        executer.expectDeprecationWarning("The configuration ':a:default' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'v1', 'v2' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         fails 'show'
 
         then:
@@ -853,9 +884,11 @@ dependencies {
 configurations.compile.attributes.attribute(usage, "compile")
 
 project(':a') {
-    configurations.default.outgoing.variants {
-        v1 { }
-        v2 { }
+    configurations.default {
+        outgoing.variants {
+            v1 { }
+            v2 { }
+        }
     }
 }
 
@@ -892,6 +925,7 @@ task resolveLenient {
         m3.artifact.expectGet()
 
         expect:
+        executer.expectDeprecationWarning("The configuration ':a:default' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'v1', 'v2' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         succeeds 'resolveLenient'
 
         outputContains("failure 1: Could not find org:missing-module:1.0.")
@@ -902,6 +936,9 @@ Searched in the following locations:
     ${m1.artifact.uri}""")
         outputContains("failure 5: Could not download broken-artifact-1.0.jar (org:broken-artifact:1.0)")
         outputContains("""failure 6: The consumer was configured to find attribute 'usage' with value 'compile'. However we cannot choose between the following variants of project :a:
+  - Configuration ':a:default':
+      - Unmatched attribute:
+          - Doesn't say anything about usage (required 'compile')
   - Configuration ':a:default' variant v1:
       - Unmatched attribute:
           - Doesn't say anything about usage (required 'compile')
@@ -962,7 +999,7 @@ task resolveLenient {
         assert lenientView.files.collect { it.name } == resolvedFiles
         assert lenientView.artifacts.collect { it.file.name } == resolvedFiles
         assert lenientView.artifacts.artifactFiles.collect { it.name } == resolvedFiles
-        assert lenientView.artifacts.failures.size() == 3
+        assert lenientView.artifacts.failures.size() == 2
     }
 }
 """
@@ -972,6 +1009,7 @@ task resolveLenient {
         m0.pom.expectGetMissing()
 
         expect:
+        executer.expectDeprecationWarning("The configuration ':a:default' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'v1', 'v2' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         succeeds 'resolveLenient'
         result.assertTasksExecuted(":c:jar1", ":resolveLenient")
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedFilesApiIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedFilesApiIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve.api
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.util.GradleVersion
 
 class ResolvedFilesApiIntegrationTest extends AbstractHttpDependencyResolutionTest {
     def setup() {
@@ -190,6 +191,8 @@ task show {
 """
         expect:
         2.times { maybeExpectDeprecation(expression) }
+        executer.expectDeprecationWarning("The configuration ':a:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'free', 'paid' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
+        executer.expectDeprecationWarning("The configuration ':b:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'free', 'paid' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         succeeds("show")
         output.contains("files: [a-free.jar, b-paid.jar]")
         result.assertTasksExecuted(':a:freeJar', ':b:paidJar', ':show')
@@ -255,6 +258,8 @@ task show {
 """
         expect:
         2.times { maybeExpectDeprecation(expression) }
+        executer.expectDeprecationWarning("The configuration ':a:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'free', 'paid' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
+        executer.expectDeprecationWarning("The configuration ':b:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'free', 'paid' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         succeeds("show")
         output.contains("files: [a-free.jar, b-paid.jar]")
         result.assertTasksExecuted(':a:freeJar', ':b:paidJar', ':show')
@@ -281,17 +286,24 @@ def flavor = Attribute.of('flavor', String)
 dependencies {
     compile project(':a')
 }
-
 project(':a') {
     dependencies {
         attributesSchema.attribute(flavor)
         compile project(':b')
+    }
+    configurations.compile {
+        attributes.attribute(Attribute.of('flavor', String), 'mismatch')
+        outgoing.artifact file('dummy.txt')
     }
     ${freeAndPaidFlavoredJars('a')}
 }
 project(':b') {
     dependencies {
         attributesSchema.attribute(flavor)
+    }
+    configurations.compile {
+        attributes.attribute(Attribute.of('flavor', String), 'mismatch')
+        outgoing.artifact file('dummy.txt')
     }
     ${freeAndPaidFlavoredJars('b')}
 }
@@ -306,6 +318,10 @@ task show {
         maybeExpectDeprecation(expression)
         fails("show")
         failure.assertHasCause("""The consumer was configured to find attribute 'usage' with value 'compile'. However we cannot choose between the following variants of project :a:
+  - Configuration ':a:compile' declares attribute 'usage' with value 'compile':
+      - Unmatched attributes:
+          - Provides artifactType 'txt' but the consumer didn't ask for it
+          - Provides flavor 'mismatch' but the consumer didn't ask for it
   - Configuration ':a:compile' variant free declares attribute 'usage' with value 'compile':
       - Unmatched attributes:
           - Provides artifactType 'jar' but the consumer didn't ask for it
@@ -377,12 +393,9 @@ task show {
 
         expect:
         maybeExpectDeprecation(expression)
+        executer.expectDeprecationWarning("The configuration ':a:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'free', 'paid' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
+        executer.expectDeprecationWarning("The configuration ':b:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'free', 'paid' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         fails("show")
-        failure.assertHasCause("""No variants of project :a match the consumer attributes:
-  - Configuration ':a:compile' variant free declares attribute 'usage' with value 'compile':
-      - Incompatible because this component declares attribute 'artifactType' with value 'jar', attribute 'flavor' with value 'free' and the consumer needed attribute 'artifactType' with value 'dll', attribute 'flavor' with value 'preview'
-  - Configuration ':a:compile' variant paid declares attribute 'usage' with value 'compile':
-      - Incompatible because this component declares attribute 'artifactType' with value 'jar', attribute 'flavor' with value 'paid' and the consumer needed attribute 'artifactType' with value 'dll', attribute 'flavor' with value 'preview'""")
 
         failure.assertHasCause("""No variants of test:test:1.2 match the consumer attributes:
   - test:test:1.2 configuration default:
@@ -582,6 +595,7 @@ task show {
 
         when:
         maybeExpectDeprecation(expression)
+        executer.expectDeprecationWarning("The configuration ':a:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'v1', 'v2' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         fails 'show'
 
         then:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -517,7 +517,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming lib2.zip to lib2.zip.txt") == 1
 
         when:
-        executer.expectDeprecationWarning("The configuration ':lib:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'files' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
+        executer.noDeprecationChecks() // This isn't the point of this test, and won't be emitted when the result is pulled from the configuration cache
         run "resolve"
 
         then:
@@ -723,7 +723,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming lib1.jar to lib1.jar.red") == 1
 
         when:
-        executer.expectDeprecationWarning("The configuration ':lib:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'java7', 'java8' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
+        executer.noDeprecationChecks() // This isn't the point of this test, and won't be emitted when the result is pulled from the configuration cache
         run "resolve"
 
         then:
@@ -860,7 +860,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming lib1.jar.blue to lib1.jar.blue.red") == 1
 
         when:
-        executer.expectDeprecationWarning("The configuration ':lib:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'java7', 'java8' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
+        executer.noDeprecationChecks() // This isn't the point of this test, and won't be emitted when the result is pulled from the configuration cache
         run "resolve"
 
         then:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.internal.file.FileType
 import org.gradle.operations.dependencies.transforms.ExecutePlannedTransformStepBuildOperationType
 import org.gradle.test.fixtures.maven.MavenFileRepository
+import org.gradle.util.GradleVersion
 import org.hamcrest.Matcher
 import spock.lang.Issue
 
@@ -475,11 +476,14 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                 }
 
                 configurations {
-                    compile.outgoing.variants {
-                        files {
-                            attributes.attribute(Attribute.of('artifactType', String), 'jar')
-                            artifact jar1
-                            artifact zip1
+                    compile {
+                        attributes.attribute(Attribute.of('artifactType', String), 'mismatch')
+                        outgoing.variants {
+                            files {
+                                attributes.attribute(Attribute.of('artifactType', String), 'jar')
+                                artifact jar1
+                                artifact zip1
+                            }
                         }
                     }
                 }
@@ -496,6 +500,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         """
 
         when:
+        executer.expectDeprecationWarning("The configuration ':lib:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'files' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         run "resolve"
 
         then:
@@ -512,6 +517,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming lib2.zip to lib2.zip.txt") == 1
 
         when:
+        executer.expectDeprecationWarning("The configuration ':lib:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'files' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         run "resolve"
 
         then:
@@ -602,6 +608,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         """
 
         when:
+        executer.expectDeprecationWarning("The configuration ':lib:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'files' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         run "resolve"
 
         then:
@@ -640,16 +647,19 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                 }
 
                 configurations {
-                    compile.outgoing.variants {
-                        java7 {
-                            attributes.attribute(Attribute.of('javaVersion', String), '7')
-                            attributes.attribute(Attribute.of('color', String), 'green')
-                            artifact jar1
-                        }
-                        java8 {
-                            attributes.attribute(Attribute.of('javaVersion', String), '8')
-                            attributes.attribute(Attribute.of('color', String), 'red')
-                            artifact jar2
+                    compile {
+                        attributes.attribute(Attribute.of('color', String), 'mismatch')
+                        outgoing.variants {
+                            java7 {
+                                attributes.attribute(Attribute.of('javaVersion', String), '7')
+                                attributes.attribute(Attribute.of('color', String), 'green')
+                                artifact jar1
+                            }
+                            java8 {
+                                attributes.attribute(Attribute.of('javaVersion', String), '8')
+                                attributes.attribute(Attribute.of('color', String), 'red')
+                                artifact jar2
+                            }
                         }
                     }
                 }
@@ -698,6 +708,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         """
 
         when:
+        executer.expectDeprecationWarning("The configuration ':lib:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'java7', 'java8' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         run "resolve"
 
         then:
@@ -712,6 +723,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming lib1.jar to lib1.jar.red") == 1
 
         when:
+        executer.expectDeprecationWarning("The configuration ':lib:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'java7', 'java8' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         run "resolve"
 
         then:
@@ -744,16 +756,19 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                 }
 
                 configurations {
-                    compile.outgoing.variants {
-                        java7 {
-                            attributes.attribute(Attribute.of('javaVersion', String), '7')
-                            attributes.attribute(Attribute.of('color', String), 'green')
-                            artifact jar1
-                        }
-                        java8 {
-                            attributes.attribute(Attribute.of('javaVersion', String), '8')
-                            attributes.attribute(Attribute.of('color', String), 'red')
-                            artifact jar2
+                    compile {
+                        attributes.attribute(Attribute.of('color', String), 'mismatch')
+                        outgoing.variants {
+                            java7 {
+                                attributes.attribute(Attribute.of('javaVersion', String), '7')
+                                attributes.attribute(Attribute.of('color', String), 'green')
+                                artifact jar1
+                            }
+                            java8 {
+                                attributes.attribute(Attribute.of('javaVersion', String), '8')
+                                attributes.attribute(Attribute.of('color', String), 'red')
+                                artifact jar2
+                            }
                         }
                     }
                 }
@@ -824,6 +839,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         """
 
         when:
+        executer.expectDeprecationWarning("The configuration ':lib:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'java7', 'java8' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         run "resolve"
 
         then:
@@ -844,6 +860,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming lib1.jar.blue to lib1.jar.blue.red") == 1
 
         when:
+        executer.expectDeprecationWarning("The configuration ':lib:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'java7', 'java8' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         run "resolve"
 
         then:
@@ -1062,19 +1079,22 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                     archiveFileName = 'lib.jar'
                 }
 
-                configurations.compile.outgoing.variants{
-                    primary {
-                        attributes {
-                            attribute(artifactType, "jar")
-                            attribute(extraAttribute, "preferred")
+                configurations.compile {
+                    attributes.attribute(Attribute.of('artifactType', String), 'mismatch')
+                    outgoing.variants{
+                        primary {
+                            attributes {
+                                attribute(artifactType, "jar")
+                                attribute(extraAttribute, "preferred")
+                            }
+                            artifact jar
                         }
-                        artifact jar
-                    }
-                    secondary {
-                        attributes {
-                            attribute(artifactType, "intermediate")
+                        secondary {
+                            attributes {
+                                attribute(artifactType, "intermediate")
+                            }
+                            artifact jar
                         }
-                        artifact jar
                     }
                 }
             }
@@ -1133,6 +1153,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         """
 
         when:
+        executer.expectDeprecationWarning("The configuration ':lib:compile' has no artifacts and thus should not define any secondary variants. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Secondary variant(s): 'primary', 'secondary' should be made directly consumable. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#variants_with_no_artifacts")
         succeeds ":app:resolve"
 
         then:
@@ -1325,21 +1346,24 @@ Found the following transforms:
                 }
 
                 configurations {
-                    compile.outgoing.variants {
-                        variant1 {
-                            attributes.attribute(buildType, 'release')
-                            attributes.attribute(flavor, 'free')
-                            artifact jar1
-                        }
-                        variant2 {
-                            attributes.attribute(buildType, 'release')
-                            attributes.attribute(flavor, 'paid')
-                            artifact jar1
-                        }
-                        variant3 {
-                            attributes.attribute(buildType, 'debug')
-                            attributes.attribute(flavor, 'free')
-                            artifact jar1
+                    compile {
+                        outgoing.artifact file('dummy.txt')
+                        outgoing.variants {
+                            variant1 {
+                                attributes.attribute(buildType, 'release')
+                                attributes.attribute(flavor, 'free')
+                                artifact jar1
+                            }
+                            variant2 {
+                                attributes.attribute(buildType, 'release')
+                                attributes.attribute(flavor, 'paid')
+                                artifact jar1
+                            }
+                            variant3 {
+                                attributes.attribute(buildType, 'debug')
+                                attributes.attribute(flavor, 'free')
+                                artifact jar1
+                            }
                         }
                     }
                 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
@@ -93,9 +93,9 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
 
     public void collectVariants(ConfigurationInternal.VariantVisitor visitor) {
         PublishArtifactSet allArtifactSet = allArtifacts.getPublishArtifactSet();
-        if (variants == null || variants.isEmpty() || !allArtifactSet.isEmpty()) {
+//        if (variants == null || variants.isEmpty() || !allArtifactSet.isEmpty()) {
             visitor.visitOwnVariant(displayName, attributes.asImmutable(), allArtifactSet);
-        }
+//        }
         if (variants != null) {
             for (ConfigurationVariantInternal variant : variants.withType(ConfigurationVariantInternal.class)) {
                 visitor.visitChildVariant(variant.getName(), variant.getDisplayName(), variant.getAttributes().asImmutable(), variant.getArtifacts());

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
@@ -103,7 +103,7 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
         // a new primary variant instead.
         if (allArtifactSet.isEmpty() && secondaryVariantsExist) {
             DeprecationLogger.deprecateBehaviour("The " + displayName + " has no artifacts and thus should not define any secondary variants.")
-                .withAdvice("Secondary variants: " + variants.stream().map(ConfigurationVariant::getName).collect(Collectors.joining(", ", "'", "'")) + " should be made directly consumable.")
+                .withAdvice("Secondary variant(s): " + variants.stream().map(v -> "'" + v.getName() + "'").collect(Collectors.joining(", ")) + " should be made directly consumable.")
                 .willBeRemovedInGradle9()
                 .withUpgradeGuideSection(8, "variants_with_no_artifacts")
                 .nagUser();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalVariantMetadataBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalVariantMetadataBuilder.java
@@ -164,7 +164,8 @@ public class DefaultLocalVariantMetadataBuilder implements LocalVariantMetadataB
                     result.add(new PublishArtifactLocalArtifactMetadata(componentId, inheritedArtifact));
                 }
             }
-            return result.build().asList();
+            ImmutableSet<LocalComponentArtifactMetadata> artifactMetadatas = result.build();
+            return artifactMetadatas.asList();
         }));
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalComponentGraphResolveStateFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalComponentGraphResolveStateFactory.java
@@ -211,7 +211,7 @@ public class LocalComponentGraphResolveStateFactory {
 
                 configurationsProvider.visitAll(configuration -> {
                     if (configuration.isCanBeConsumed()) {
-                    visitor.accept(createVariantMetadata(configuration));
+                        visitor.accept(createVariantMetadata(configuration));
                     }
                 });
             });

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublicationsTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublicationsTest.groovy
@@ -122,12 +122,17 @@ class DefaultConfigurationPublicationsTest extends Specification {
 
         expect:
         def variants = getOutgoingVariants(publications)
-        variants.size() == 1
+        variants.size() == 2
 
-        def child = variants.first()
-        child.displayName.displayName == '<config> variant child'
-        child.attributes == AttributeTestUtil.attributes(["thing": "value"])
-        child.artifacts == variantDef.artifacts
+        def child1 = variants.first() // Implicit variant
+        child1.displayName.displayName == '<config>'
+        child1.attributes == AttributeTestUtil.attributes([:])
+        child1.artifacts == [] as Set
+
+        def child2 = variants[1]
+        child2.displayName.displayName == '<config> variant child'
+        child2.attributes == AttributeTestUtil.attributes(["thing": "value"])
+        child2.artifacts == variantDef.artifacts
     }
 
     def "converts to OutgoingVariant when explicit variant and artifacts defined"() {


### PR DESCRIPTION
Fixes/clarifies https://github.com/gradle/gradle/issues/29630 by:

- Never removing the primary variant from consideration during artifact selection, even if it is empty of artifacts and there are secondary variants.
- Adding a new deprecation warning (which would then become an error in Gradle 9.0) when you add a secondary variant to a primary variant that lacks artifacts.
