### PR TITLE
Private services visible only within the same service provider

### DIFF
--- a/platforms/core-runtime/messaging/src/test/groovy/org/gradle/internal/event/DefaultListenerManagerInServiceRegistryTest.groovy
+++ b/platforms/core-runtime/messaging/src/test/groovy/org/gradle/internal/event/DefaultListenerManagerInServiceRegistryTest.groovy
@@ -311,7 +311,7 @@ class DefaultListenerManagerInServiceRegistryTest extends Specification {
 
         then:
         def e = thrown(IllegalStateException)
-        e.message == 'Service ListenerManager at DefaultListenerManagerInServiceRegistryTest$.createListenerManager() implements AnnotatedServiceLifecycleHandler but is not declared as a service of this type. This service is declared as having type ListenerManager.'
+        e.message == 'Service ListenerManager at DefaultListenerManagerInServiceRegistryTest$<anonymous>.createListenerManager() implements AnnotatedServiceLifecycleHandler but is not declared as a service of this type. This service is declared as having type ListenerManager.'
     }
 
     def "fails when listener service is not declared as listener type"() {
@@ -328,7 +328,7 @@ class DefaultListenerManagerInServiceRegistryTest extends Specification {
 
         then:
         def e = thrown(IllegalStateException)
-        e.message == 'Service Runnable at DefaultListenerManagerInServiceRegistryTest$.createListener() is annotated with @StatefulListener but is not declared as a service with this annotation. This service is declared as having type Runnable.'
+        e.message == 'Service Runnable at DefaultListenerManagerInServiceRegistryTest$<anonymous>.createListener() is annotated with @StatefulListener but is not declared as a service with this annotation. This service is declared as having type Runnable.'
     }
 
     def "fails when stateful listener registered after first event"() {

--- a/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/PrivateService.java
+++ b/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/PrivateService.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service;
+
+import com.google.errorprone.annotations.Keep;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Can be added to {@link Provides @Provides} methods
+ * to make them visible only within the declaring service provider.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Keep
+public @interface PrivateService {
+
+}

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceAccessToken.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceAccessToken.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service;
+
+class DefaultServiceAccessToken implements ServiceAccessToken {
+
+    private final int id;
+    private final String ownerDisplayName;
+
+    public DefaultServiceAccessToken(int id, String ownerDisplayName) {
+        this.id = id;
+        this.ownerDisplayName = ownerDisplayName;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DefaultServiceAccessToken)) {
+            return false;
+        }
+
+        DefaultServiceAccessToken that = (DefaultServiceAccessToken) o;
+        return id == that.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return id;
+    }
+
+    @Override
+    public String toString() {
+        return "AccessToken(id=" + id + ", owner=" + ownerDisplayName + ")";
+    }
+}

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceAccess.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceAccess.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service;
+
+
+import javax.annotation.Nullable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Factory for {@link ServiceAccessToken} and {@link ServiceAccessScope}.
+ */
+class ServiceAccess {
+
+    private ServiceAccess() {}
+
+    private static final ServiceAccessScope PUBLIC = new ServiceAccessScope() {
+        @Override
+        public boolean contains(@Nullable ServiceAccessToken token) {
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "Public";
+        }
+    };
+
+    private static final AtomicInteger NEXT_ID = new AtomicInteger(0);
+
+    /**
+     * Creates a new unique token.
+     */
+    public static ServiceAccessToken createToken(String ownerDisplayName) {
+        return new DefaultServiceAccessToken(NEXT_ID.incrementAndGet(), ownerDisplayName);
+    }
+
+    /**
+     * Returns a scope that assumes to contain every possible token.
+     */
+    public static ServiceAccessScope getPublicScope() {
+        return PUBLIC;
+    }
+
+    /**
+     * Returns a scope that contains only the provided token.
+     */
+    public static ServiceAccessScope getPrivateScope(ServiceAccessToken token) {
+        return new PrivateAccessScope(token);
+    }
+
+    private static class PrivateAccessScope implements ServiceAccessScope {
+        private final ServiceAccessToken ownerToken;
+
+        public PrivateAccessScope(ServiceAccessToken ownerToken) {
+            this.ownerToken = ownerToken;
+        }
+
+        @Override
+        public boolean contains(@Nullable ServiceAccessToken token) {
+            return ownerToken.equals(token);
+        }
+
+        @Override
+        public String toString() {
+            return "Private(" + ownerToken + ")";
+        }
+    }
+}

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceAccessScope.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceAccessScope.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service;
+
+import javax.annotation.Nullable;
+
+/**
+ * Scopes determine which services can be accessed on the level of individual service providers.
+ *
+ * @see ServiceAccess
+ */
+interface ServiceAccessScope {
+
+    /**
+     * Return true if the given token can access services in this scope.
+     * <p>
+     * The null token value represents access without a token.
+     */
+    boolean contains(@Nullable ServiceAccessToken token);
+
+}

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceAccessToken.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceAccessToken.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service;
+
+/**
+ * Tokens are evaluated by {@link ServiceAccessScope scopes}
+ * to determine which services can be accessed.
+ *
+ * @see ServiceAccess
+ */
+interface ServiceAccessToken {
+
+    @Override
+    boolean equals(Object o);
+
+    @Override
+    int hashCode();
+
+}

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceProvider.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceProvider.java
@@ -29,19 +29,19 @@ interface ServiceProvider extends Stoppable {
     /**
      * Locates a service instance of the given type. Returns null if this provider does not provide a service of this type.
      */
-    @Nullable Service getService(Type serviceType);
+    @Nullable Service getService(Type serviceType, @Nullable ServiceAccessToken token);
 
     /**
      * Locates a factory for services of the given type. Returns null if this provider does not provide any services of this type.
      */
-    @Nullable Service getFactory(Class<?> type);
+    @Nullable Service getFactory(Class<?> type, @Nullable ServiceAccessToken token);
 
     /**
      * Collects all services of the given type.
      *
      * @return A visitor that should be used for all subsequent services.
      */
-    Visitor getAll(Class<?> serviceType, Visitor visitor);
+    Visitor getAll(Class<?> serviceType, @Nullable ServiceAccessToken token, Visitor visitor);
 
     interface Visitor {
         void visit(Service service);

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/TypeStringFormatter.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/TypeStringFormatter.java
@@ -26,7 +26,8 @@ class TypeStringFormatter {
             Class<?> aClass = (Class) type;
             Class<?> enclosingClass = aClass.getEnclosingClass();
             if (enclosingClass != null) {
-                return format(enclosingClass) + "$" + aClass.getSimpleName();
+                String ownName = aClass.isAnonymousClass() ? "<anonymous>" : aClass.getSimpleName();
+                return format(enclosingClass) + "$" + ownName;
             } else {
                 return aClass.getSimpleName();
             }

--- a/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryServiceAccessTest.groovy
+++ b/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryServiceAccessTest.groovy
@@ -1,0 +1,340 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service
+
+import spock.lang.Specification
+
+class DefaultServiceRegistryServiceAccessTest extends Specification {
+
+    TestRegistry registry = new TestRegistry()
+
+    def "can use private service as a dependency within the same service provider"() {
+        given:
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            @PrivateService
+            TestService create() { new TestServiceImpl() }
+
+            @Provides
+            ServiceWithDependency create(TestService ts) { new ServiceWithDependency(ts) }
+        })
+
+        when:
+        def service1 = registry.get(ServiceWithDependency)
+        then:
+        service1 instanceof ServiceWithDependency
+
+        when:
+        registry.get(TestService)
+        then:
+        def e = thrown(UnknownServiceException)
+        withoutTestClassName(e.message) == "No service of type TestService available in TestRegistry."
+    }
+
+    def "can use private service as a dependency in constructor-based injection within the same service provider"() {
+        given:
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            @PrivateService
+            TestService create() { new TestServiceImpl() }
+
+            void configure(ServiceRegistration registration) {
+                registration.add(ServiceWithDependency)
+            }
+        })
+
+        when:
+        def service1 = registry.get(ServiceWithDependency)
+        then:
+        service1 instanceof ServiceWithDependency
+
+        when:
+        registry.get(TestService)
+        then:
+        def e = thrown(UnknownServiceException)
+        withoutTestClassName(e.message) == "No service of type TestService available in TestRegistry."
+    }
+
+    def "private service is reused within the same service provider"() {
+        given:
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            @PrivateService
+            TestService create() { new TestServiceImpl() }
+
+            @Provides
+            ServiceWithDependency create1(TestService ts) { new ServiceWithDependency(ts) }
+
+            @Provides
+            ServiceWithDependency create2(TestService ts) { new ServiceWithDependency(ts) }
+        })
+
+        when:
+        def services = registry.getAll(ServiceWithDependency)
+        then:
+        services.size() == 2
+        services[0].service === services[1].service
+    }
+
+    def "private services are closed when the registry is closed"() {
+        given:
+        def closeableService = new CloseableService()
+
+        when:
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            @PrivateService
+            CloseableService create() { closeableService }
+
+            @SuppressWarnings('unused')
+            @Provides
+            TestService create(CloseableService s) { new TestServiceImpl() }
+        })
+        then:
+        !closeableService.closed
+
+        when:
+        def service = registry.get(TestService)
+        then:
+        service instanceof TestServiceImpl
+        !closeableService.closed
+
+        when:
+        registry.close()
+        then:
+        closeableService.closed
+    }
+
+    def "cannot lookup services declared as private"() {
+        given:
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            @PrivateService
+            TestService create() { new TestServiceImpl() }
+        })
+
+        when:
+        registry.get(TestService)
+        then:
+        def e = thrown(UnknownServiceException)
+        withoutTestClassName(e.message) == "No service of type TestService available in TestRegistry."
+    }
+
+    def "cannot use private services as dependencies in sibling providers"() {
+        given:
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            @PrivateService
+            TestService create() { new TestServiceImpl() }
+        })
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            ServiceWithDependency create(TestService ts) { new ServiceWithDependency(ts) }
+        })
+
+        when:
+        registry.get(ServiceWithDependency)
+        then:
+        def e = thrown(ServiceCreationException)
+        withoutTestClassName(e.message) == "Cannot create service of type ServiceWithDependency using method <anonymous>.create() as required service of type TestService for parameter #1 is not available."
+    }
+
+    def "cannot use private services as dependencies in service providers added via configure"() {
+        given:
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            @PrivateService
+            TestService create() { new TestServiceImpl() }
+
+            void configure(ServiceRegistration registration) {
+                registration.addProvider(new ServiceRegistrationProvider() {
+                    @Provides
+                    ServiceWithDependency create(TestService ts) { new ServiceWithDependency(ts) }
+                })
+            }
+        })
+
+        when:
+        registry.get(ServiceWithDependency)
+        then:
+        def e = thrown(ServiceCreationException)
+        withoutTestClassName(e.message) == 'Cannot create service of type ServiceWithDependency using method <anonymous>$<anonymous>.create() as required service of type TestService for parameter #1 is not available.'
+    }
+
+    def "cannot use private services as dependencies in child registries"() {
+        given:
+        def parentRegistry = registry
+        parentRegistry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            @PrivateService
+            TestService create() { new TestServiceImpl() }
+        })
+
+        def registry = new TestRegistry(parentRegistry)
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            ServiceWithDependency create(TestService ts) { new ServiceWithDependency(ts) }
+        })
+
+        when:
+        registry.get(ServiceWithDependency)
+        then:
+        def e = thrown(ServiceCreationException)
+        withoutTestClassName(e.message) == "Cannot create service of type ServiceWithDependency using method <anonymous>.create() as required service of type TestService for parameter #1 is not available."
+    }
+
+    def "can collect private services from the same service provider"() {
+        given:
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            @PrivateService
+            Integer create1() { 1 }
+
+            @Provides
+            @PrivateService
+            Integer create2() { 2 }
+
+            @Provides
+            Integer create3() { 3 }
+
+            @Provides
+            String create(List<Integer> list) { list.toSorted().join("-") }
+        })
+
+        when:
+        def service = registry.get(String)
+        then:
+        service == "1-2-3"
+    }
+
+    def "private services are not collected with external getAll"() {
+        given:
+        def parentRegistry = registry
+        parentRegistry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            @PrivateService
+            Integer create1() { 1 }
+
+            @Provides
+            Integer create2() { 2 }
+        })
+
+        def registry = new TestRegistry(parentRegistry)
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            @PrivateService
+            Integer create1() { 3 }
+
+            @Provides
+            Integer create2() { 4 }
+
+            void configure(ServiceRegistration registration) {
+                registration.addProvider(new ServiceRegistrationProvider() {
+                    @Provides
+                    @PrivateService
+                    Integer create1() { 5 }
+
+                    @Provides
+                    Integer create2() { 6 }
+                })
+            }
+        })
+
+        when:
+        def services = registry.getAll(Integer)
+        then:
+        services.toSorted() == [2, 4, 6]
+    }
+
+    def "can declare a private service together with a private one"() {
+        given:
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            @PrivateService
+            Integer create1() { 1 }
+
+            @Provides
+            Integer create2() { 2 }
+        })
+
+        when:
+        def result = registry.get(Integer)
+        then:
+        result == 2
+    }
+
+    def "private and non-private service declarations conflict for a dependency"() {
+        given:
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            @PrivateService
+            Integer create1() { 1 }
+
+            @Provides
+            Integer create2() { 2 }
+
+            @Provides
+            TestService create(Integer i) { throw new IllegalStateException("Unreachable") }
+        })
+
+        when:
+        registry.get(TestService)
+        then:
+        def e = thrown(ServiceCreationException)
+        withoutTestClassName(e.message) == 'Cannot create service of type TestService using method <anonymous>.create() as there is a problem with parameter #1 of type Integer.'
+        def cause = e.cause
+        cause instanceof ServiceLookupException
+        withoutTestClassName(cause.message).contains('Multiple services of type Integer available in TestRegistry:')
+        withoutTestClassName(cause.message).contains('- Service Integer at <anonymous>.create1()')
+        withoutTestClassName(cause.message).contains('- Service Integer at <anonymous>.create2()')
+    }
+
+    private interface TestService {
+    }
+
+    private static class TestServiceImpl implements TestService {
+    }
+
+    private static class ServiceWithDependency {
+        final TestService service
+
+        ServiceWithDependency(TestService service) {
+            this.service = service
+        }
+    }
+
+    static class CloseableService implements Closeable {
+        boolean closed
+
+        void close() {
+            closed = true
+        }
+    }
+
+    private static class TestRegistry extends DefaultServiceRegistry {
+        TestRegistry() {
+        }
+
+        TestRegistry(ServiceRegistry parent) {
+            super(parent)
+        }
+    }
+
+    private String withoutTestClassName(String s) {
+        s.replaceAll(this.class.simpleName + "\\\$", "")
+    }
+}

--- a/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
+++ b/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.internal.concurrent.Stoppable
 import org.gradle.util.internal.TextUtil
 import spock.lang.Specification
 
+import javax.annotation.Nullable
 import java.lang.annotation.Annotation
 import java.lang.reflect.Type
 import java.util.concurrent.Callable
@@ -1684,7 +1685,7 @@ class DefaultServiceRegistryTest extends Specification {
         }
 
         @Override
-        Service getService(Type serviceType) {
+        Service getService(Type serviceType, @Nullable ServiceAccessToken token) {
             def object = parentServices.get((Class) serviceType)
             if (object == null) {
                 return null
@@ -1693,7 +1694,7 @@ class DefaultServiceRegistryTest extends Specification {
         }
 
         @Override
-        Service getFactory(Class<?> type) {
+        Service getFactory(Class<?> type, @Nullable ServiceAccessToken token) {
             def factory = parentServices.getFactory(type)
             if (factory == null) {
                 return factory
@@ -1702,7 +1703,7 @@ class DefaultServiceRegistryTest extends Specification {
         }
 
         @Override
-        Visitor getAll(Class<?> serviceType, Visitor visitor) {
+        Visitor getAll(Class<?> serviceType, ServiceAccessToken token, Visitor visitor) {
             parentServices.getAll(serviceType).forEach {
                 visitor.visit(serviceFor(it))
             }

--- a/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
+++ b/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
@@ -309,7 +309,7 @@ class DefaultServiceRegistryTest extends Specification {
 
         then:
         def e = thrown(IllegalArgumentException)
-        e.message == 'Cannot define a service of type ServiceRegistry: Service ServiceRegistry at DefaultServiceRegistryTest$.createServices()'
+        e.message == 'Cannot define a service of type ServiceRegistry: Service ServiceRegistry at DefaultServiceRegistryTest$<anonymous>.createServices()'
     }
 
     def failsWhenProviderFactoryMethodRequiresUnknownService() {

--- a/subprojects/core/src/main/java/org/gradle/internal/scopeids/ScopeIdsServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scopeids/ScopeIdsServices.java
@@ -21,13 +21,14 @@ import org.gradle.cache.scopes.BuildTreeScopedCacheBuilderFactory;
 import org.gradle.cache.scopes.GlobalScopedCacheBuilderFactory;
 import org.gradle.internal.file.Chmod;
 import org.gradle.internal.id.UniqueId;
+import org.gradle.internal.service.PrivateService;
 import org.gradle.internal.service.Provides;
 import org.gradle.internal.service.ServiceRegistrationProvider;
 
 public class ScopeIdsServices implements ServiceRegistrationProvider {
 
     @Provides
-    protected PersistentScopeIdLoader createPersistentScopeIdLoader(
+    PersistentScopeIdLoader createPersistentScopeIdLoader(
         GlobalScopedCacheBuilderFactory globalScopedCacheBuilderFactory,
         BuildTreeScopedCacheBuilderFactory buildTreeScopedCacheBuilderFactory,
         PersistentScopeIdStoreFactory persistentScopeIdStoreFactory
@@ -36,7 +37,8 @@ public class ScopeIdsServices implements ServiceRegistrationProvider {
     }
 
     @Provides
-    protected PersistentScopeIdStoreFactory createPersistentScopeIdStoreFactory(
+    @PrivateService
+    PersistentScopeIdStoreFactory createPersistentScopeIdStoreFactory(
         FileLockManager fileLockManager,
         Chmod chmod
     ) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -75,6 +75,7 @@ import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.serialize.HashCodeSerializer;
+import org.gradle.internal.service.PrivateService;
 import org.gradle.internal.service.Provides;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistrationProvider;
@@ -160,6 +161,7 @@ public class VirtualFileSystemServices extends AbstractGradleModuleServices {
     static class GradleUserHomeServices implements ServiceRegistrationProvider {
 
         @Provides
+        @PrivateService
         CrossBuildFileHashCache createCrossBuildFileHashCache(GlobalScopedCacheBuilderFactory cacheBuilderFactory, InMemoryCacheDecoratorFactory inMemoryCacheDecoratorFactory) {
             return new CrossBuildFileHashCache(cacheBuilderFactory, inMemoryCacheDecoratorFactory, CrossBuildFileHashCache.Kind.FILE_HASHES);
         }
@@ -320,6 +322,7 @@ public class VirtualFileSystemServices extends AbstractGradleModuleServices {
         }
 
         @Provides
+        @PrivateService
         CrossBuildFileHashCache createCrossBuildFileHashCache(BuildTreeScopedCacheBuilderFactory cacheBuilderFactory, InMemoryCacheDecoratorFactory inMemoryCacheDecoratorFactory) {
             return new CrossBuildFileHashCache(cacheBuilderFactory, inMemoryCacheDecoratorFactory, CrossBuildFileHashCache.Kind.FILE_HASHES);
         }


### PR DESCRIPTION
Adds support to annotate services with `@PrivateService`, which makes them visible only within the same service provider (instance of `ServiceRegistrationProvider`).

```java
class SomeServices implements ServiceRegistrationProvider {
    @Provides
    @PrivateService
    MyService create() {
        return new MyServiceImpl();
    }
    
    // can consume within the same service provider
    @Provides
    MyPublicService create(MyService myService) {
        return new MyPublicServiceImpl(mySevice);
    }
    
}
```