### PR TITLE
WIP: Support injection via constructor for service dependencies

### DIFF
--- a/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/FromConstructor.java
+++ b/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/FromConstructor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service;
+
+import com.google.errorprone.annotations.Keep;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that a service factory method parameter must be injected via the type's constructor instead of lookup.
+ * <p>
+ * Used to mark parameters in service factory methods on a {@link ServiceRegistrationProvider}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@Keep
+public @interface FromConstructor {
+}

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.internal.service;
 
+import org.gradle.api.specs.Spec;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
 import org.gradle.internal.InternalTransformer;
@@ -27,6 +28,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Member;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -49,6 +51,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.singletonList;
 import static org.gradle.util.internal.CollectionUtils.collect;
+import static org.gradle.util.internal.CollectionUtils.findFirst;
 import static org.gradle.util.internal.CollectionUtils.join;
 
 /**
@@ -865,11 +868,14 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
     }
 
     private static abstract class FactoryService extends SingletonService {
+        @Nullable
+        private final ServiceProvider[] paramServiceProviders;
         private Service[] paramServices;
         private Service decorates;
 
-        protected FactoryService(DefaultServiceRegistry owner, List<? extends Type> serviceTypes) {
+        protected FactoryService(DefaultServiceRegistry owner, List<? extends Type> serviceTypes, @Nullable ServiceProvider[] paramServiceProviders) {
             super(owner, serviceTypes);
+            this.paramServiceProviders = paramServiceProviders;
         }
 
         protected abstract Type[] getParameterTypes();
@@ -886,8 +892,18 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
             paramServices = new Service[parameterTypes.length];
             for (int i = 0; i < parameterTypes.length; i++) {
                 Type paramType = parameterTypes[i];
-                if (isEqualToAnyType(paramType, serviceTypes)) {
+                if (paramServiceProviders != null && paramServiceProviders[i] != null) {
+                    paramServices[i] = paramServiceProviders[i].getService(paramType);
+                } else if (isEqualToAnyType(paramType, serviceTypes)) {
                     // A decorating factory
+                    if (decorates != null) {
+                        throw new ServiceCreationException(String.format("Cannot create service of %s using %s as required service of type %s for parameter #%s is a repeated decoration target",
+                            format("type", serviceTypes),
+                            getFactoryDisplayName(),
+                            format(paramType),
+                            i + 1));
+                    }
+
                     Service paramProvider = find(paramType, owner.parentServices);
                     if (paramProvider == null) {
                         throw new ServiceCreationException(String.format("Cannot create service of %s using %s as required service of type %s for parameter #%s is not available in parent registries.",
@@ -976,7 +992,7 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
         }
 
         private FactoryMethodService(DefaultServiceRegistry owner, List<? extends Type> serviceTypes, Object target, ServiceMethod method) {
-            super(owner, serviceTypes);
+            super(owner, serviceTypes, findDirectParamServiceProviders(owner, method.getMethod()));
             validateImplementationForServiceTypes(serviceTypes, method.getServiceType());
             this.target = target;
             this.method = method;
@@ -1067,7 +1083,7 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
         }
 
         private ConstructorService(DefaultServiceRegistry owner, List<? extends Type> serviceTypes, Class<?> implementationType) {
-            super(owner, serviceTypes);
+            super(owner, serviceTypes, null);
 
             if (implementationType.isInterface()) {
                 throw new ServiceValidationException("Cannot register an interface for construction.");
@@ -1079,6 +1095,11 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
             if (InjectUtil.isPackagePrivate(match.getModifiers()) || Modifier.isPrivate(match.getModifiers())) {
                 match.setAccessible(true);
             }
+
+            if (findDirectParamServiceProviders(owner, match) != null) {
+                throw new ServiceValidationException("Cannot register a constructor with direct service provider injection for type " + format(match.getDeclaringClass()));
+            }
+
             this.constructor = match;
         }
 
@@ -1209,6 +1230,42 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
         public String toString() {
             return parent.toString();
         }
+    }
+
+    @Nullable
+    private static ServiceProvider[] findDirectParamServiceProviders(DefaultServiceRegistry owner, Method method) {
+        return findDirectParamServiceProviders(owner, method.getParameterTypes(), method.getParameterAnnotations());
+    }
+
+    @Nullable
+    private static ServiceProvider[] findDirectParamServiceProviders(DefaultServiceRegistry owner, Constructor<?> constructor) {
+        return findDirectParamServiceProviders(owner, constructor.getParameterTypes(), constructor.getParameterAnnotations());
+    }
+
+    @Nullable
+    private static ServiceProvider[] findDirectParamServiceProviders(DefaultServiceRegistry owner, Class<?>[] parameterTypes, Annotation[][] parameterAnnotations) {
+        // Boilerplate due to Java 6
+        ServiceProvider[] predefinedParamServices = null;
+        int parameterCount = parameterTypes.length;
+        for (int i = 0; i < parameterCount; i++) {
+            Annotation[] paramAnnotations = parameterAnnotations[i];
+            Annotation fromConstructor = findFirst(paramAnnotations, new Spec<Annotation>() {
+                @Override
+                public boolean isSatisfiedBy(Annotation element) {
+                    return FromConstructor.class.equals(element.annotationType());
+                }
+            });
+            if (fromConstructor != null) {
+                Class<?> paramType = parameterTypes[i];
+                ConstructorService constructorService = new ConstructorService(owner, paramType);
+                if (predefinedParamServices == null) {
+                    predefinedParamServices = new ServiceProvider[parameterCount];
+                }
+                predefinedParamServices[i] = constructorService;
+            }
+        }
+
+        return predefinedParamServices;
     }
 
     @Nullable

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/RelevantMethods.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/RelevantMethods.java
@@ -15,6 +15,9 @@
  */
 package org.gradle.internal.service;
 
+import org.gradle.api.specs.Spec;
+
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -24,7 +27,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import static org.gradle.util.internal.ArrayUtils.contains;
+import static org.gradle.util.internal.CollectionUtils.any;
 
 class RelevantMethods {
     private static final ConcurrentMap<Class<?>, RelevantMethods> METHODS_CACHE = new ConcurrentHashMap<Class<?>, RelevantMethods>();
@@ -86,7 +89,7 @@ class RelevantMethods {
                 if (method.getReturnType().equals(Void.TYPE)) {
                     throw new ServiceValidationException(String.format("Method %s.%s() must not return void.", type.getName(), method.getName()));
                 }
-                if (takesReturnTypeAsParameter(method)) {
+                if (isDecorating(method)) {
                     add(decorators, method);
                 } else {
                     add(factories, method);
@@ -108,8 +111,30 @@ class RelevantMethods {
             }
         }
 
-        private static boolean takesReturnTypeAsParameter(Method method) {
-            return contains(method.getParameterTypes(), method.getReturnType());
+        private static boolean isDecorating(Method method) {
+            // Boilerplate due to Java 6 constraint
+            int parameterCount = method.getParameterCount();
+            Class<?>[] parameterTypes = method.getParameterTypes();
+            Annotation[][] parameterAnnotations = method.getParameterAnnotations();
+
+            for (int i = 0; i < parameterCount; i++) {
+                if (parameterTypes[i].equals(method.getReturnType())) {
+                    boolean isFromConstructor = any(parameterAnnotations[i], new Spec<Annotation>() {
+                        @Override
+                        public boolean isSatisfiedBy(Annotation element) {
+                            return FromConstructor.class.equals(element.annotationType());
+                        }
+                    });
+
+                    if (isFromConstructor) {
+                        continue;
+                    }
+
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CoreCrossBuildSessionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CoreCrossBuildSessionServices.java
@@ -40,8 +40,8 @@ import org.gradle.internal.operations.notify.BuildOperationNotificationValve;
 import org.gradle.internal.operations.trace.BuildOperationTrace;
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
+import org.gradle.internal.service.FromConstructor;
 import org.gradle.internal.service.Provides;
-import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistrationProvider;
 import org.gradle.internal.work.DefaultWorkerLeaseService;
 import org.gradle.internal.work.DefaultWorkerLimits;
@@ -52,10 +52,18 @@ import org.gradle.internal.work.WorkerLimits;
 public class CoreCrossBuildSessionServices implements ServiceRegistrationProvider {
 
     @Provides
-    void configure(ServiceRegistration registration) {
-        registration.add(ResourceLockCoordinationService.class, DefaultResourceLockCoordinationService.class);
-        registration.add(WorkerLeaseService.class, ProjectParallelExecutionController.class, DefaultWorkerLeaseService.class);
-        registration.add(DynamicCallContextTracker.class, DefaultDynamicCallContextTracker.class);
+    ResourceLockCoordinationService create(@FromConstructor DefaultResourceLockCoordinationService service) {
+        return service;
+    }
+
+    @Provides
+    DynamicCallContextTracker create(@FromConstructor DefaultDynamicCallContextTracker service) {
+        return service;
+    }
+
+    @Provides({WorkerLeaseService.class, ProjectParallelExecutionController.class})
+    DefaultWorkerLeaseService create(@FromConstructor DefaultWorkerLeaseService service) {
+        return service;
     }
 
     @Provides


### PR DESCRIPTION
Allows to avoid boilerplate when services are declared through factory methods but only pass parameters to the constructor.

```java
    @Provides
    DynamicCallContextTracker create(@FromConstructor DefaultDynamicCallContextTracker service) {
        return service;
    }
```

The new `FromConstructor` annotation indicates that this parameter must be create directly from the constructor of the corresponding type, instead of being looked up.


This allows replacing the imperative `configure` setups:
```java
    void configure(ServiceRegistration registration) {
        registration.add(DynamicCallContextTracker.class, DefaultDynamicCallContextTracker.class);
    }
```