### PR TITLE
Gradle no longer fails when a plugin coming from an included build has different version than the requested

### DIFF
--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginRequestApplicator.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginRequestApplicator.java
@@ -107,14 +107,7 @@ public class DefaultPluginRequestApplicator implements PluginRequestApplicator {
                 pluginApplyActions.add(new ApplyAction(request, resolved));
             }
 
-            String pluginVersion = resolved.getPluginVersion();
-            if (pluginVersion != null) {
-                pluginVersionTracker.setPluginVersionAt(
-                    classLoaderScope,
-                    resolved.getPluginId().getId(),
-                    pluginVersion
-                );
-            }
+            pluginVersionTracker.setPluginVersionAt(classLoaderScope, resolved.getPluginId().getId(), resolved.getPluginVersion(), resolved.isLocal());
         }
 
         // Configure the resolution

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/resolve/internal/AlreadyOnClasspathPluginResolver.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/resolve/internal/AlreadyOnClasspathPluginResolver.java
@@ -83,7 +83,15 @@ public class AlreadyOnClasspathPluginResolver implements PluginResolver {
             );
         }
 
-        String existingVersion = pluginVersionTracker.findPluginVersionAt(parentLoaderScope, pluginId.getId());
+        PluginVersionTracker.VersionDef existingVersionDef = pluginVersionTracker.findPluginVersionAt(parentLoaderScope, pluginId.getId());
+        if (existingVersionDef != null && existingVersionDef.isLocal()) {
+            PluginResolutionResult resolved = delegate.resolve(pluginRequest);
+            if (resolved.isFound() && resolved.getFound(pluginRequest).isLocal()) {
+                return resolved;
+            }
+        }
+
+        String existingVersion = existingVersionDef != null ? existingVersionDef.getVersion() : null;
         if (existingVersion == null) {
             throw new InvalidPluginRequestException(
                 pluginRequest,

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/resolve/internal/PluginResolution.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/resolve/internal/PluginResolution.java
@@ -49,4 +49,11 @@ public interface PluginResolution {
     default String getPluginVersion() {
         return null;
     }
+
+    /**
+     * Returns {@code true}, if the plugin is from a local build.
+     */
+    default boolean isLocal() {
+        return false;
+    }
 }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/plugins/PluginBuildsMultiPluginApplicationIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/plugins/PluginBuildsMultiPluginApplicationIntegrationTest.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.composite.plugins
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.file.LeaksFileHandles
+import spock.lang.Issue
+
+@LeaksFileHandles("Kotlin Compiler Daemon working directory")
+@Issue("https://github.com/gradle/gradle/issues/29652")
+class PluginBuildsMultiPluginApplicationIntegrationTest extends AbstractIntegrationSpec {
+    def "can apply plugin from included build with version"() {
+        settingsKotlinFile << """
+include("child-project")
+includeBuild(rootDir.resolve("other-build"))
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        register("libs") {
+            plugin("otherBuildPlugin", "internal.integTest.other-build-plugin")
+                .version("1.0")
+        }
+    }
+}
+"""
+
+        buildKotlinFile << """
+plugins {
+    alias(libs.plugins.otherBuildPlugin)
+}
+"""
+
+        file("child-project", "build.gradle.kts") << """
+plugins {
+    alias(libs.plugins.otherBuildPlugin)
+}
+"""
+
+        file("other-build", "settings.gradle.kts") << """
+rootProject.name = "other-build"
+dependencyResolutionManagement.repositories.gradlePluginPortal()
+"""
+
+        file("other-build", "build.gradle.kts") << """
+plugins {
+    `kotlin-dsl`
+}
+
+group = "internal.integTest.\${rootProject.name}"
+version = "1.1"
+"""
+
+        file("other-build", "src", "main", "kotlin", "internal.integTest.other-build-plugin.gradle.kts") << """
+tasks.register("otherBuildPluginTask") {
+    doLast {
+        println("Hello from \$path")
+    }
+}
+"""
+
+        when:
+        succeeds "otherBuildPluginTask"
+
+        then:
+        outputContains "Hello from :otherBuildPluginTask"
+        outputContains "Hello from :child-project:otherBuildPluginTask"
+    }
+}

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/plugins/CompositeBuildPluginResolverContributor.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/plugins/CompositeBuildPluginResolverContributor.java
@@ -194,6 +194,11 @@ public class CompositeBuildPluginResolverContributor implements PluginResolverCo
         public void applyTo(PluginManagerInternal pluginManager) {
             pluginManager.apply(pluginId.getId());
         }
+
+        @Override
+        public boolean isLocal() {
+            return true;
+        }
     }
 
 }


### PR DESCRIPTION
Fixes #29652. This PR makes sure that Gradle doesn't care about the version number of plugins coming from an included build. As is now (Gradle 8.8), Gradle works if the plugin is applied to only a single subproject, but fails if it is applied to two, because it doesn't realize that while the requested version is different than what is on the classpath, that is not an issue because it is coming from an included build. That is, applying to multiple subprojects should not be an issue (because it is the exact same source despite the version number difference).

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
