### PR TITLE
Consider `configure` methods as entry-points to avoid 'unused' warnings in IDE

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -7,6 +7,7 @@
       <item index="2" class="java.lang.String" itemvalue="org.gradle.internal.instrumentation.api.annotations.InterceptJvmCalls" />
       <item index="3" class="java.lang.String" itemvalue="org.gradle.internal.service.Provides" />
     </list>
+    <pattern value="org.gradle.internal.service.ServiceRegistrationProvider" hierarchically="true" method="configure" />
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">


### PR DESCRIPTION
The `configure` methods declared in `ServiceRegistrationProvider` and its descendants are no longer considered "unused" in IntelliJ IDEA.

These methods currently allow imperative configuration of the service providers:
```java
public class BuildProcessScopeServices implements ServiceRegistrationProvider {
    void configure(ServiceRegistration registration, ClassLoaderRegistry classLoaderRegistry) {
		// ...
    }
```

The service provider registration will validate all non-static `configure` methods (with any parameters), so the name-based filtering of entry-points is appropriate.

However, the caveat is that the static `configure` methods in such classes will be considered unused as well. They are completely ignored during registration, and so they should be still marked unused. At the same time, the problem is not new. For instance, any static methods annotated with `@Provides` will also be not marked unused.