### PR TITLE
Allow injecting directly from constructor in provider methods

### DIFF
--- a/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/FromConstructor.java
+++ b/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/FromConstructor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service;
+
+import com.google.errorprone.annotations.Keep;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that a service factory method parameter must be injected via the type's constructor instead of lookup.
+ * <p>
+ * Used to mark parameters in service factory methods on a {@link ServiceRegistrationProvider}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@Keep
+public @interface FromConstructor {
+}

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -302,7 +302,7 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
      */
     public DefaultServiceRegistry addProvider(ServiceRegistrationProvider provider) {
         assertMutable();
-        ServiceAccessToken token = org.gradle.internal.service.ServiceAccess.createToken(format(provider.getClass()));
+        ServiceAccessToken token = ServiceAccess.createToken(format(provider.getClass()));
         findProviderMethods(provider, token);
         return this;
     }

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -534,6 +534,7 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
             stoppable.stop();
         }
 
+        // TODO: we are currently not adding FromConstructor service providers here
         public void add(SingletonService serviceProvider) {
             assertMutable();
             stoppable.add(serviceProvider);
@@ -990,6 +991,8 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
             Object result = invokeMethod(params);
             // Can discard the state required to create instance
             paramServiceProviders = null;
+            // TODO: we should not discard param services if they are not managed elsewhere;
+            //       currently, they are not added to the ownServices
             paramServices = null;
             return result;
         }
@@ -1348,6 +1351,9 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
             });
             if (fromConstructor != null) {
                 Class<?> paramType = parameterTypes[i];
+                // TODO: using a constructor service to create a parameter that is expected to be returned from the provider method
+                //       introduces an explicit pattern of "duplicate" services, which are currently both reported to annotation handlers
+                //       and also will be closed more than once
                 ConstructorService constructorService = new ConstructorService(owner, accessScope, accessToken, paramType);
                 if (predefinedParamServices == null) {
                     predefinedParamServices = new ServiceProvider[parameterCount];

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -897,12 +897,17 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
 
     private static abstract class FactoryService extends SingletonService {
         private final ServiceAccessToken accessToken;
-        @Nullable
-        private final ServiceProvider[] paramServiceProviders;
+        private ServiceProvider[] paramServiceProviders;
         private Service[] paramServices;
         private Service decorates;
 
-        protected FactoryService(DefaultServiceRegistry owner, ServiceAccessScope accessScope, ServiceAccessToken accessToken, List<? extends Type> serviceTypes, @Nullable ServiceProvider[] paramServiceProviders) {
+        protected FactoryService(
+            DefaultServiceRegistry owner,
+            ServiceAccessScope accessScope,
+            ServiceAccessToken accessToken,
+            List<? extends Type> serviceTypes,
+            @Nullable ServiceProvider[] paramServiceProviders
+        ) {
             super(owner, accessScope, serviceTypes);
             this.accessToken = accessToken;
             this.paramServiceProviders = paramServiceProviders;
@@ -974,6 +979,7 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
             Object[] params = assembleParameters();
             Object result = invokeMethod(params);
             // Can discard the state required to create instance
+            paramServiceProviders = null;
             paramServices = null;
             return result;
         }

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/RelevantMethods.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/RelevantMethods.java
@@ -15,6 +15,9 @@
  */
 package org.gradle.internal.service;
 
+import org.gradle.api.specs.Spec;
+
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -24,7 +27,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import static org.gradle.util.internal.ArrayUtils.contains;
+import static org.gradle.util.internal.CollectionUtils.any;
 
 class RelevantMethods {
     private static final ConcurrentMap<Class<?>, RelevantMethods> METHODS_CACHE = new ConcurrentHashMap<Class<?>, RelevantMethods>();
@@ -86,7 +89,7 @@ class RelevantMethods {
                 if (method.getReturnType().equals(Void.TYPE)) {
                     throw new ServiceValidationException(String.format("Method %s.%s() must not return void.", type.getName(), method.getName()));
                 }
-                if (takesReturnTypeAsParameter(method)) {
+                if (isDecorating(method)) {
                     add(decorators, method);
                 } else {
                     add(factories, method);
@@ -108,8 +111,30 @@ class RelevantMethods {
             }
         }
 
-        private static boolean takesReturnTypeAsParameter(Method method) {
-            return contains(method.getParameterTypes(), method.getReturnType());
+        private static boolean isDecorating(Method method) {
+            // Boilerplate due to Java 6 constraint
+            int parameterCount = method.getParameterCount();
+            Class<?>[] parameterTypes = method.getParameterTypes();
+            Annotation[][] parameterAnnotations = method.getParameterAnnotations();
+
+            for (int i = 0; i < parameterCount; i++) {
+                if (parameterTypes[i].equals(method.getReturnType())) {
+                    boolean isFromConstructor = any(parameterAnnotations[i], new Spec<Annotation>() {
+                        @Override
+                        public boolean isSatisfiedBy(Annotation element) {
+                            return FromConstructor.class.equals(element.annotationType());
+                        }
+                    });
+
+                    if (isFromConstructor) {
+                        continue;
+                    }
+
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/RelevantMethods.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/RelevantMethods.java
@@ -113,8 +113,8 @@ class RelevantMethods {
 
         private static boolean isDecorating(Method method) {
             // Boilerplate due to Java 6 constraint
-            int parameterCount = method.getParameterCount();
             Class<?>[] parameterTypes = method.getParameterTypes();
+            int parameterCount = parameterTypes.length;
             Annotation[][] parameterAnnotations = method.getParameterAnnotations();
 
             for (int i = 0; i < parameterCount; i++) {

--- a/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryFromConstructorInjectionTest.groovy
+++ b/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryFromConstructorInjectionTest.groovy
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service
+
+import spock.lang.Specification
+
+class DefaultServiceRegistryFromConstructorInjectionTest extends Specification {
+
+    TestRegistry registry = new TestRegistry()
+
+    def "can inject implementation via constructor"() {
+        given:
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            TestService create(@FromConstructor TestServiceImpl service) { service }
+        })
+
+        when:
+        def service1 = registry.get(TestService)
+        then:
+        service1 instanceof TestServiceImpl
+
+        when:
+        registry.get(TestServiceImpl)
+        then:
+        def e = thrown(UnknownServiceException)
+        withoutTestClassName(e.message) == "No service of type TestServiceImpl available in TestRegistry."
+    }
+
+    def "can inject implementation with dependency via constructor"() {
+        given:
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            TestService createTestService() { new TestServiceImpl() }
+
+            @Provides
+            ServiceWithDependency create(@FromConstructor ServiceWithDependency service) { service }
+        })
+
+        when:
+        def service1 = registry.get(ServiceWithDependency)
+        then:
+        service1 instanceof ServiceWithDependency
+    }
+
+    def "can inject overloads when implementations are injected via constructor"() {
+        given:
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            TestService create(@FromConstructor TestServiceImpl service) { service }
+
+            @Provides
+            ServiceWithDependency create(@FromConstructor ServiceWithDependency service) { service }
+        })
+
+        when:
+        def service1 = registry.get(TestService)
+        then:
+        service1 instanceof TestService
+
+        when:
+        def service2 = registry.get(ServiceWithDependency)
+        then:
+        service2 instanceof ServiceWithDependency
+    }
+
+    def "cannot inject implementation with a missing dependency via constructor"() {
+        given:
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            ServiceWithDependency create(@FromConstructor ServiceWithDependency service) { service }
+        })
+
+        when:
+        registry.get(ServiceWithDependency)
+        then:
+        def e = thrown(ServiceCreationException)
+        withoutTestClassName(e.message) ==
+            "Cannot create service of type ServiceWithDependency using ServiceWithDependency constructor as required service of type TestService for parameter #1 is not available."
+    }
+
+    def "can inject dependencies when using injection via constructor"() {
+        given:
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            Integer createInt() { 12 }
+
+            @Provides
+            TestService create(@FromConstructor StatefulTestServiceImpl service, Integer dependency) {
+                service.value = dependency
+                service
+            }
+        })
+
+        when:
+        def service1 = registry.get(TestService) as StatefulTestServiceImpl
+        then:
+        service1.value == 12
+    }
+
+    def "can inject multiple implementation instances via constructor in the same factory method"() {
+        given:
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            ServiceWithDependency create(@FromConstructor TestServiceImpl service1, @FromConstructor TestServiceImpl service2) {
+                if (service1 == service2) {
+                    throw new IllegalStateException("Unreachable")
+                }
+                new ServiceWithDependency(service2)
+            }
+        })
+
+        when:
+        def service = registry.get(ServiceWithDependency)
+        then:
+        service instanceof ServiceWithDependency
+    }
+
+    def "can inject independent implementation instances via constructor"() {
+        given:
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            TestService create1(@FromConstructor TestServiceImpl service) { service }
+
+            @Provides
+            TestService create2(@FromConstructor TestServiceImpl service) { service }
+        })
+
+        when:
+        def services = registry.getAll(TestService)
+        then:
+        services.size() == 2
+        services[0] instanceof TestServiceImpl
+        services[1] instanceof TestServiceImpl
+        services[0] !== services[1]
+    }
+
+    def "cannot inject implementation via constructor in injected constructors"() {
+        when:
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @SuppressWarnings('unused')
+            void configure(ServiceRegistration registration) {
+                registration.add(ServiceWithConstructorParameterUsingFromConstructor)
+            }
+        })
+
+        then:
+        def e = thrown(ServiceLookupException)
+        e.message == "Could not configure services using .configure()."
+
+        def cause = e.cause
+        cause instanceof ServiceValidationException
+        withoutTestClassName(cause.message) ==
+            "Cannot register a constructor with direct service provider injection for type ServiceWithConstructorParameterUsingFromConstructor"
+    }
+
+    private interface TestService {
+    }
+
+    private static class TestServiceImpl implements TestService {
+    }
+
+    private static class StatefulTestServiceImpl implements TestService {
+        int value = 0
+    }
+
+    private static class ServiceWithDependency {
+        final TestService service
+
+        ServiceWithDependency(TestService service) {
+            this.service = service
+        }
+    }
+
+    private static class TestRegistry extends DefaultServiceRegistry {
+        TestRegistry() {
+        }
+    }
+
+    private static class ServiceWithConstructorParameterUsingFromConstructor extends ServiceWithDependency {
+        ServiceWithConstructorParameterUsingFromConstructor(@FromConstructor TestServiceImpl ts) {
+            super(ts)
+        }
+    }
+
+    private String withoutTestClassName(String s) {
+        s.replaceAll(this.class.simpleName + "\\\$", "")
+    }
+}

--- a/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryFromConstructorInjectionTest.groovy
+++ b/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryFromConstructorInjectionTest.groovy
@@ -216,6 +216,8 @@ class DefaultServiceRegistryFromConstructorInjectionTest extends Specification {
         capturedService.closed == 0
     }
 
+    // TODO: annotation handler tests
+
     private interface TestService {
     }
 

--- a/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
+++ b/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
@@ -2149,6 +2149,12 @@ class DefaultServiceRegistryTest extends Specification {
         }
     }
 
+    static class BrokenServiceWithDependencyWithConstructor extends ServiceWithDependency {
+        BrokenServiceWithDependencyWithConstructor(@FromConstructor TestServiceImpl ts) {
+            super(ts)
+        }
+    }
+
     private String withoutTestClassName(String s) {
         s.replaceAll(this.class.simpleName + "\\\$", "")
     }

--- a/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
+++ b/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
@@ -2149,12 +2149,6 @@ class DefaultServiceRegistryTest extends Specification {
         }
     }
 
-    static class BrokenServiceWithDependencyWithConstructor extends ServiceWithDependency {
-        BrokenServiceWithDependencyWithConstructor(@FromConstructor TestServiceImpl ts) {
-            super(ts)
-        }
-    }
-
     private String withoutTestClassName(String s) {
         s.replaceAll(this.class.simpleName + "\\\$", "")
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CoreCrossBuildSessionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CoreCrossBuildSessionServices.java
@@ -40,8 +40,8 @@ import org.gradle.internal.operations.notify.BuildOperationNotificationValve;
 import org.gradle.internal.operations.trace.BuildOperationTrace;
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
+import org.gradle.internal.service.FromConstructor;
 import org.gradle.internal.service.Provides;
-import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistrationProvider;
 import org.gradle.internal.work.DefaultWorkerLeaseService;
 import org.gradle.internal.work.DefaultWorkerLimits;
@@ -52,10 +52,18 @@ import org.gradle.internal.work.WorkerLimits;
 public class CoreCrossBuildSessionServices implements ServiceRegistrationProvider {
 
     @Provides
-    void configure(ServiceRegistration registration) {
-        registration.add(ResourceLockCoordinationService.class, DefaultResourceLockCoordinationService.class);
-        registration.add(WorkerLeaseService.class, ProjectParallelExecutionController.class, DefaultWorkerLeaseService.class);
-        registration.add(DynamicCallContextTracker.class, DefaultDynamicCallContextTracker.class);
+    ResourceLockCoordinationService create(@FromConstructor DefaultResourceLockCoordinationService service) {
+        return service;
+    }
+
+    @Provides
+    DynamicCallContextTracker create(@FromConstructor DefaultDynamicCallContextTracker service) {
+        return service;
+    }
+
+    @Provides({WorkerLeaseService.class, ProjectParallelExecutionController.class})
+    DefaultWorkerLeaseService create(@FromConstructor DefaultWorkerLeaseService service) {
+        return service;
     }
 
     @Provides


### PR DESCRIPTION
Allows to avoid boilerplate when services are declared through factory methods and only need to pass parameters to the constructor.

```java
    @Provides
    DynamicCallContextTracker create(@FromConstructor DefaultDynamicCallContextTracker service) {
        return service;
    }
```

The new `FromConstructor` annotation indicates that this parameter must be created directly from the constructor of the corresponding type, instead of being looked up in this or parent registries.

This complements the imperative `configure` setups:
```java
    void configure(ServiceRegistration registration) {
        registration.add(DynamicCallContextTracker.class, DefaultDynamicCallContextTracker.class);
    }
```