### PR TITLE
fix arguments for suiteThreadPoolSize option

### DIFF
--- a/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessor.java
+++ b/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessor.java
@@ -213,13 +213,13 @@ public class TestNGTestClassProcessor implements TestClassProcessor {
         }
     }
 
-    private void setSuiteThreadPoolSize(TestNG testNg, int suiteThreadPoolSize) {
+    private void setSuiteThreadPoolSize(TestNG testNg, Integer suiteThreadPoolSize) {
         if (suiteThreadPoolSize < 1) {
             throw new InvalidUserDataException("suiteThreadPoolSize must be greater than or equal to 1.");
         }
 
         try {
-            JavaMethod.of(TestNG.class, Object.class, "setSuiteThreadPoolSize", int.class).invoke(testNg, suiteThreadPoolSize);
+            JavaMethod.of(TestNG.class, Object.class, "setSuiteThreadPoolSize", Integer.class).invoke(testNg, suiteThreadPoolSize);
         } catch (NoSuchMethodException e) {
             if (suiteThreadPoolSize != 1) {
                 throw new InvalidUserDataException("The version of TestNG used does not support setting thread pool size.");

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGParallelBySuitesIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGParallelBySuitesIntegrationTest.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.testng
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.DefaultTestExecutionResult
+
+import static org.hamcrest.CoreMatchers.containsString
+
+class TestNGParallelBySuitesIntegrationTest extends AbstractIntegrationSpec {
+
+    def "run tests using the TestNG version that supports changing the suiteThreadPoolSize"() {
+        given:
+        buildFile << """
+            apply plugin: 'java'
+            ${mavenCentralRepository()}
+            dependencies { testImplementation 'org.testng:testng:6.0.1' }
+            test { useTestNG { suiteThreadPoolSize = 5 } }
+        """
+
+        file("src/test/java/SimpleTest.java") << """
+            import org.testng.annotations.Test;
+
+            public class SimpleTest {
+
+                @Test
+                public void test() {}
+           }
+        """
+
+        expect:
+        succeeds('test')
+    }
+}

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGParallelBySuitesIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGParallelBySuitesIntegrationTest.groovy
@@ -17,9 +17,6 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.DefaultTestExecutionResult
-
-import static org.hamcrest.CoreMatchers.containsString
 
 class TestNGParallelBySuitesIntegrationTest extends AbstractIntegrationSpec {
 


### PR DESCRIPTION

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
In [this](https://github.com/gradle/gradle/pull/29211) pull request, we added the ability to change the testng `suiteThreadPoolSize` option through Gradle. After the release of 8.9-rc1, I noticed that the ability to change this option is present, but it always throws the exception `The version of TestNG used does not support setting thread pool size.` regardless of which version of TestNG is installed. I noticed that there was another pull request https://github.com/gradle/gradle/pull/29470 for this feature, after which, probably, `suiteThreadPoolSize` stopped working. I conducted a small investigation and realized that the problem lies in the types passed to the `setSuiteThreadPoolSize()` method in `TestNGTestClassProcessor`: it should receive `Integer`, not `int`. In the case of `int`, the exception I mentioned at the beginning is thrown, which is entirely fair in such a case. I didn’t notice this during the development of the first iteration (although at that time it worked correctly with int, which is strange), so I’m coming back with a fix and an additional test to cover the positive usage scenario.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
