### PR TITLE
Honours task dependencies on default source/privateHeaders/publicHeaders properties

### DIFF
--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppGeneratedPublicHeadersIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppGeneratedPublicHeadersIntegrationTest.groovy
@@ -92,6 +92,62 @@ class CppGeneratedPublicHeadersIntegrationTest extends AbstractInstalledToolChai
         result.assertTasksExecuted(":log:generatePublicHeaders", ":app:compileDebugCpp")
     }
 
+    @ToBeFixedForConfigurationCache
+    @Issue("https://github.com/gradle/gradle-native/issues/994")
+    def "can generate library's conventional public headers"() {
+        given:
+        writeHelloLibrary { TestFile libraryPath ->
+            app.greeterLib.publicHeaders.writeToSourceDir(testDirectory.file("staging-includes"))
+            app.greeterLib.privateHeaders.writeToSourceDir(libraryPath.file("src/main/headers"))
+            app.greeterLib.sources.writeToSourceDir(libraryPath.file("src/main/cpp"))
+            libraryPath.file('build.gradle') << '''
+                library {
+                    def generatorTask = tasks.register('generatePublicHeaders', Sync) {
+                        from(rootProject.file('staging-includes'))
+                        into('src/main/public')
+                    }
+
+                    publicHeaders.builtBy(generatorTask)
+                }
+            '''
+        }
+        writeLogLibrary()
+
+        when:
+        succeeds ":app:linkDebug"
+        then:
+        result.assertTaskExecuted(":hello:generatePublicHeaders")
+        result.assertTaskExecuted(":hello:compileDebugCpp")
+    }
+
+    @ToBeFixedForConfigurationCache
+    @Issue("https://github.com/gradle/gradle-native/issues/994")
+    def "can generate library's conventional private headers"() {
+        given:
+        writeHelloLibrary { TestFile libraryPath ->
+            app.greeterLib.publicHeaders.writeToSourceDir(libraryPath.file("src/main/public"))
+            app.greeterLib.privateHeaders.writeToSourceDir(testDirectory.file("staging-includes"))
+            app.greeterLib.sources.writeToSourceDir(libraryPath.file("src/main/cpp"))
+            libraryPath.file('build.gradle') << '''
+                library {
+                    def generatorTask = tasks.register('generatePrivateHeaders', Sync) {
+                        from(rootProject.file('staging-includes'))
+                        into('src/main/headers')
+                    }
+
+                    privateHeaders.builtBy(generatorTask)
+                }
+            '''
+        }
+        writeLogLibrary()
+
+        when:
+        succeeds ":app:linkDebug"
+        then:
+        result.assertTaskExecuted(":hello:generatePrivateHeaders")
+        result.assertTaskExecuted(":hello:compileDebugCpp")
+    }
+
     private writeApp() {
         app.main.writeToProject(file("app"))
         file("app/build.gradle") << """

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppGeneratedSourceIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppGeneratedSourceIntegrationTest.groovy
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.cpp
+
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
+import org.gradle.nativeplatform.fixtures.app.CppApp
+import org.gradle.nativeplatform.fixtures.app.CppLib
+import spock.lang.Issue
+
+class CppGeneratedSourceIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
+    @ToBeFixedForConfigurationCache
+    @Issue("https://github.com/gradle/gradle/issues/29767")
+    def "can generate application's conventional sources"() {
+        def app = new CppApp()
+
+        given:
+        app.sources.writeToSourceDir(file('staging-sources'))
+        app.headers.writeToSourceDir(file('src/main/headers'))
+
+        and:
+        buildFile << '''
+            apply plugin: 'cpp-application'
+
+            def generatorTask = tasks.register('generateSources', Sync) {
+                from(rootProject.file('staging-sources'))
+                into('src/main/cpp')
+            }
+
+            application.source.builtBy(generatorTask)
+        '''
+
+        when:
+        succeeds ":compileDebugCpp"
+        then:
+        result.assertTasksExecuted(":generateSources", ":compileDebugCpp")
+    }
+
+    @ToBeFixedForConfigurationCache
+    @Issue("https://github.com/gradle/gradle/issues/29767")
+    def "can generate library's conventional sources"() {
+        def lib = new CppLib()
+
+        given:
+        lib.sources.writeToSourceDir(file('staging-sources'))
+        lib.publicHeaders.writeToSourceDir(file('src/main/public'))
+        lib.privateHeaders.writeToSourceDir(file('src/main/headers'))
+
+        and:
+        buildFile << '''
+            apply plugin: 'cpp-library'
+
+            def generatorTask = tasks.register('generateSources', Sync) {
+                from(rootProject.file('staging-sources'))
+                into('src/main/cpp')
+            }
+
+            library.source.builtBy(generatorTask)
+        '''
+
+        when:
+        succeeds ":compileDebugCpp"
+        then:
+        result.assertTasksExecuted(":generateSources", ":compileDebugCpp")
+    }
+}

--- a/platforms/native/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppComponent.java
+++ b/platforms/native/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppComponent.java
@@ -71,7 +71,7 @@ public abstract class DefaultCppComponent extends DefaultNativeComponent impleme
     }
 
     protected FileCollection createDirView(final ConfigurableFileCollection dirs, final String conventionLocation) {
-        return getProjectLayout().files(new Callable<Object>() {
+        return getObjects().fileCollection().from(new Callable<Object>() {
             @Override
             public Object call() {
                 if (dirs.getFrom().isEmpty()) {
@@ -79,7 +79,7 @@ public abstract class DefaultCppComponent extends DefaultNativeComponent impleme
                 }
                 return dirs;
             }
-        });
+        }).builtBy(dirs);
     }
 
     @Override

--- a/platforms/native/language-native/src/main/java/org/gradle/language/nativeplatform/internal/DefaultNativeComponent.java
+++ b/platforms/native/language-native/src/main/java/org/gradle/language/nativeplatform/internal/DefaultNativeComponent.java
@@ -57,6 +57,11 @@ public abstract class DefaultNativeComponent {
         throw new UnsupportedOperationException();
     }
 
+    @Inject
+    protected ObjectFactory getObjects() {
+        throw new UnsupportedOperationException();
+    }
+
     // TODO - this belongs with the 'var' data structure
     protected FileCollection createSourceView(final String defaultLocation, List<String> sourceExtensions) {
         final PatternSet patternSet = new PatternSet();
@@ -68,7 +73,7 @@ public abstract class DefaultNativeComponent {
             public Object call() {
                 FileTree tree;
                 if (source.getFrom().isEmpty()) {
-                    tree = getProjectLayout().getProjectDirectory().dir(defaultLocation).getAsFileTree();
+                    tree = getObjects().fileTree().setDir(getProjectLayout().getProjectDirectory().dir(defaultLocation)).builtBy(source);
                 } else {
                     tree = source.getAsFileTree();
                 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->
Fixes https://github.com/gradle/gradle/issues/29767

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
Ensure the task dependencies are propagated correctly when using conventional source layout.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
