### PR TITLE
fixes gradle#23580: Replace property with explicit regex to ensure compatibility below Java 15.

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/util/internal/NameMatcher.java
+++ b/subprojects/core/src/main/java/org/gradle/util/internal/NameMatcher.java
@@ -147,7 +147,7 @@ public class NameMatcher {
                 builder.append(Pattern.quote(prefix));
             }
             builder.append(Pattern.quote(matcher.group()));
-            builder.append("[\\p{javaLowerCase}\\p{Digit}]*");
+            builder.append("[a-z\\u00DF-\\u00F6\\u00F8-\\u00FF\\p{Digit}]*");
             pos = matcher.end();
         }
         builder.append(Pattern.quote(name.substring(pos)));

--- a/subprojects/core/src/main/java/org/gradle/util/internal/NameMatcher.java
+++ b/subprojects/core/src/main/java/org/gradle/util/internal/NameMatcher.java
@@ -123,7 +123,7 @@ public class NameMatcher {
 
         if (!caseInsensitiveMatches.isEmpty()) {
             matches.addAll(caseInsensitiveMatches);
-        }else if (!caseSensitiveCamelCaseMatches.isEmpty()) {
+        } else if (!caseSensitiveCamelCaseMatches.isEmpty()) {
             matches.addAll(caseSensitiveCamelCaseMatches);
         } else if (!caseInsensitivePrefixMatches.isEmpty()) {
             matches.addAll(caseInsensitivePrefixMatches);

--- a/subprojects/core/src/main/java/org/gradle/util/internal/NameMatcher.java
+++ b/subprojects/core/src/main/java/org/gradle/util/internal/NameMatcher.java
@@ -147,8 +147,15 @@ public class NameMatcher {
                 builder.append(Pattern.quote(prefix));
             }
             builder.append(Pattern.quote(matcher.group()));
-            // Using explicit character selection instead of properties to select lowercase characters
+            // Manually extend character class instead of properties
+            // (\p{Ll}, \p{javaLowerCase}) to select lowercase characters
             // due to a known issue in regex below Java 15.
+            // Reference of fix made on java 15 - https://bugs.openjdk.org/browse/JDK-8239887.
+            // \u00DF-\u00F6(ß-ö) - Covers extended Latin lowercase letters including German
+            //  Eszett and various accented characters.
+            // \u00F8-\u00FF(ø-ÿ) - Covers extended Latin lowercase letters including ø,
+            //  accented vowels, and the thorn.
+            // Note: this approach is not as comprehensive as properties.
             builder.append("[a-z\\u00DF-\\u00F6\\u00F8-\\u00FF\\p{Digit}]*");
             pos = matcher.end();
         }

--- a/subprojects/core/src/main/java/org/gradle/util/internal/NameMatcher.java
+++ b/subprojects/core/src/main/java/org/gradle/util/internal/NameMatcher.java
@@ -147,6 +147,8 @@ public class NameMatcher {
                 builder.append(Pattern.quote(prefix));
             }
             builder.append(Pattern.quote(matcher.group()));
+            // Using explicit character selection instead of properties to select lowercase characters
+            // due to a known issue in regex below Java 15.
             builder.append("[a-z\\u00DF-\\u00F6\\u00F8-\\u00FF\\p{Digit}]*");
             pos = matcher.end();
         }

--- a/subprojects/core/src/main/java/org/gradle/util/internal/NameMatcher.java
+++ b/subprojects/core/src/main/java/org/gradle/util/internal/NameMatcher.java
@@ -83,6 +83,7 @@ public class NameMatcher {
         Pattern kebabCasePrefixPattern = Pattern.compile(kebabCasePattern.pattern() + "[\\p{javaLowerCase}\\p{Digit}-]*");
 
         Set<String> caseInsensitiveMatches = new TreeSet<>();
+        Set<String> caseInsensitivePrefixMatches = new TreeSet<>();
         Set<String> caseSensitiveCamelCaseMatches = new TreeSet<>();
         Set<String> caseInsensitiveCamelCaseMatches = new TreeSet<>();
         Set<String> kebabCaseMatches = new TreeSet<>();
@@ -97,6 +98,10 @@ public class NameMatcher {
             }
             if (camelCasePattern.matcher(candidate).matches()) {
                 caseSensitiveCamelCaseMatches.add(candidate);
+                found = true;
+            }
+            if (camelCasePattern.matcher(candidate).lookingAt()) {
+                caseInsensitivePrefixMatches.add(candidate);
                 found = true;
             }
             if (normalisedCamelCasePattern.matcher(candidate).lookingAt()) {
@@ -118,8 +123,10 @@ public class NameMatcher {
 
         if (!caseInsensitiveMatches.isEmpty()) {
             matches.addAll(caseInsensitiveMatches);
-        } else if (!caseSensitiveCamelCaseMatches.isEmpty()) {
+        }else if (!caseSensitiveCamelCaseMatches.isEmpty()) {
             matches.addAll(caseSensitiveCamelCaseMatches);
+        } else if (!caseInsensitivePrefixMatches.isEmpty()) {
+            matches.addAll(caseInsensitivePrefixMatches);
         } else if (kebabCaseMatches.isEmpty() && kebabCasePrefixMatches.isEmpty()) {
             matches.addAll(caseInsensitiveCamelCaseMatches);
         }

--- a/subprojects/core/src/test/groovy/org/gradle/util/internal/NameMatcherTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/internal/NameMatcherTest.groovy
@@ -133,6 +133,13 @@ class NameMatcherTest extends Specification {
         matches("na1", "name1", "Name1", "NAME1")
     }
 
+    def "prefers case sensitive prefix match over case insensitive camelcase match"() {
+        expect:
+        matches("someNameWith", "someNameWithExtra", "someNameOtherWithExtra")
+        matches("someNameWith", "someNameWithExtra", "somenamewithextra")
+        matches("sNW", "someNameWithExtra", "someNameOtherWithExtra")
+    }
+
     def "prefers sequential camel case match over non-sequential camel case match"() {
         expect:
         matches("sNW", "someNameWithExtra", "someNameOtherWithExtra")

--- a/subprojects/core/src/test/groovy/org/gradle/util/internal/NameMatcherTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/internal/NameMatcherTest.groovy
@@ -44,7 +44,7 @@ class NameMatcherTest extends Specification {
         matches("somena", "SomeName")
         matches("somena", "SomeName")
         matches("some na", "Some Name")
-        matches("someNameWith", "someNameWithExtra", "someNameOtherWithExtra")
+        matches("somenamew", "someNameWithExtra")
     }
 
     def "selects item with matching camel case prefix"() {
@@ -140,6 +140,11 @@ class NameMatcherTest extends Specification {
         matches("sNW", "someNameWithExtra", "someNameOtherWithExtra")
     }
 
+    def "prefers case insensitive exact match over case sensitive prefix match"() {
+        expect:
+        matches("someNameWith", "somenamewith", "someNameWithExtra")
+    }
+
     def "prefers sequential camel case match over non-sequential camel case match"() {
         expect:
         matches("sNW", "someNameWithExtra", "someNameOtherWithExtra")
@@ -172,6 +177,8 @@ class NameMatcherTest extends Specification {
     def "does not select items when multiple camel case matches"() {
         expect:
         matcher.find("sN", ["someName", "soNa", "other"]) == null
+        matcher.find("sNE", ["someNameWithExtraStuff", "someNameWithOtherExtraStuff"]) == null
+        matcher.matches == ["someNameWithExtraStuff", "someNameWithOtherExtraStuff"] as Set
     }
 
     def "does not select items when multiple kebab case matches"() {

--- a/subprojects/core/src/test/groovy/org/gradle/util/internal/NameMatcherTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/internal/NameMatcherTest.groovy
@@ -136,6 +136,8 @@ class NameMatcherTest extends Specification {
         matches("soNa", "someName", "somename")
         matches("SN", "SomeName", "someName")
         matches("na1", "name1", "Name1", "NAME1")
+        matches("soNaWiEx", "someNameWithExtra", "someNameRandomWithExtra", "other")
+        matches("sNRWE", "someNameRandomWithExtra", "someNameWithExtra", "other")
     }
 
     def "prefers case insensitive match over camel case match"() {

--- a/subprojects/core/src/test/groovy/org/gradle/util/internal/NameMatcherTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/internal/NameMatcherTest.groovy
@@ -64,12 +64,6 @@ class NameMatcherTest extends Specification {
         matches("a9n", "abc9Name")
     }
 
-    def "does not select items when multiple camel case match with one containing unmatched word in between"() {
-        expect:
-        matcher.find("someNameWith", ["someNameWithExtra", "someNameRandomWithExtra", "other"]) == null
-            && matcher.matches == ["someNameWithExtra", "someNameRandomWithExtra"] as Set
-    }
-
     def "selects item with matching kebab case prefix"() {
         expect:
         matches("sN", "some-name")
@@ -136,8 +130,8 @@ class NameMatcherTest extends Specification {
         matches("soNa", "someName", "somename")
         matches("SN", "SomeName", "someName")
         matches("na1", "name1", "Name1", "NAME1")
-        matches("soNaWiEx", "someNameWithExtra", "someNameRandomWithExtra", "other")
-        matches("sNRWE", "someNameRandomWithExtra", "someNameWithExtra", "other")
+        matches("sNW", "someNameWithExtra", "someNameWordWithExtra")
+        matches("someNameWith", "someNameWithExtra", "someNameWordWithExtra")
     }
 
     def "prefers case insensitive match over camel case match"() {

--- a/subprojects/core/src/test/groovy/org/gradle/util/internal/NameMatcherTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/internal/NameMatcherTest.groovy
@@ -64,7 +64,7 @@ class NameMatcherTest extends Specification {
         matches("a9n", "abc9Name")
     }
 
-    def "does not select items when multiple camel case match with one containing word in between"() {
+    def "does not select items when multiple camel case match with one containing unmatched word in between"() {
         expect:
         matcher.find("someNameWith", ["someNameWithExtra", "someNameRandomWithExtra", "other"]) == null
             && matcher.matches == ["someNameWithExtra", "someNameRandomWithExtra"] as Set

--- a/subprojects/core/src/test/groovy/org/gradle/util/internal/NameMatcherTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/internal/NameMatcherTest.groovy
@@ -64,6 +64,12 @@ class NameMatcherTest extends Specification {
         matches("a9n", "abc9Name")
     }
 
+    def "does not select items when multiple camel case match with one containing word in between"() {
+        expect:
+        matcher.find("someNameWith", ["someNameWithExtra", "someNameRandomWithExtra", "other"]) == null
+            && matcher.matches == ["someNameWithExtra", "someNameRandomWithExtra"] as Set
+    }
+
     def "selects item with matching kebab case prefix"() {
         expect:
         matches("sN", "some-name")
@@ -159,6 +165,7 @@ class NameMatcherTest extends Specification {
     def "does not select items when multiple camel case matches"() {
         expect:
         matcher.find("sN", ["someName", "soNa", "other"]) == null
+        matcher.matches == ["someName", "soNa"] as Set
     }
 
     def "does not select items when multiple kebab case matches"() {

--- a/subprojects/core/src/test/groovy/org/gradle/util/internal/NameMatcherTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/internal/NameMatcherTest.groovy
@@ -44,6 +44,7 @@ class NameMatcherTest extends Specification {
         matches("somena", "SomeName")
         matches("somena", "SomeName")
         matches("some na", "Some Name")
+        matches("someNameWith", "someNameWithExtra", "someNameOtherWithExtra")
     }
 
     def "selects item with matching camel case prefix"() {
@@ -130,8 +131,11 @@ class NameMatcherTest extends Specification {
         matches("soNa", "someName", "somename")
         matches("SN", "SomeName", "someName")
         matches("na1", "name1", "Name1", "NAME1")
-        matches("sNW", "someNameWithExtra", "someNameWordWithExtra")
-        matches("someNameWith", "someNameWithExtra", "someNameWordWithExtra")
+    }
+
+    def "prefers sequential camel case match over non-sequential camel case match"() {
+        expect:
+        matches("sNW", "someNameWithExtra", "someNameOtherWithExtra")
     }
 
     def "prefers case insensitive match over camel case match"() {
@@ -161,7 +165,6 @@ class NameMatcherTest extends Specification {
     def "does not select items when multiple camel case matches"() {
         expect:
         matcher.find("sN", ["someName", "soNa", "other"]) == null
-        matcher.matches == ["someName", "soNa"] as Set
     }
 
     def "does not select items when multiple kebab case matches"() {


### PR DESCRIPTION
Fixes [gradle#23580](https://github.com/gradle/gradle/issues/23580)

### Context
Due to issues with regex in java when properties are used, the Task abbreviation working was inconsistent in gradle when used with different version of java (<15 vs >=15).

Related Bug Reports in JDK : https://bugs.openjdk.org/browse/JDK-8239887 

In addition, from a user perspective, you can argue that - using extreme short names - invoking `./gradlew pRB ` should select `publishReleaseBundlePublicationToTempPublishRepository (pRBPTTPR)` over `publishReleaseObfuscatedBundlePublicationToTempPublishRepository (pROBPTTPR)`. The key difference is the additional O. which is fixed.


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
