### PR TITLE
Add performance comparison for Build Scan resource insights capturing

### DIFF
--- a/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
+++ b/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
@@ -72,11 +72,11 @@ class BuildScanPluginPerformanceTest extends AbstractBuildScanPluginPerformanceT
         println(speedStats)
 
         where:
-        scenario                                                | expectedMedianPercentageShift | tasks                              | withFailure | scenarioArgs                                                  | manageCacheState
-        "clean build - 50 projects"                             | MEDIAN_PERCENTAGES_SHIFT      | ['clean', 'build']                 | true        | ['--build-cache']                                             | true
-        "clean build - 20 projects - slow tasks - less console" | MEDIAN_PERCENTAGES_SHIFT      | ['clean', 'project20:buildNeeded'] | true        | ['--build-cache', '-DreducedOutput=true', '-DslowTasks=true'] | true
-        "help"                                                  | MEDIAN_PERCENTAGES_SHIFT      | ['help']                           | false       | []                                                            | false
-        "help - no console output"                              | MEDIAN_PERCENTAGES_SHIFT      | ['help']                           | false       | ['-DreducedOutput=true']                                      | false
+        scenario                                                | tasks                              | withFailure | scenarioArgs                                                  | manageCacheState
+        "clean build - 50 projects"                             | ['clean', 'build']                 | true        | ['--build-cache']                                             | true
+        "clean build - 20 projects - slow tasks - less console" | ['clean', 'project20:buildNeeded'] | true        | ['--build-cache', '-DreducedOutput=true', '-DslowTasks=true'] | true
+        "help"                                                  | ['help']                           | false       | []                                                            | false
+        "help - no console output"                              | ['help']    | false                                                         | ['-DreducedOutput=true']                                      | false
     }
 
     @Override

--- a/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
+++ b/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
@@ -29,7 +29,7 @@ class BuildScanPluginPerformanceTest extends AbstractBuildScanPluginPerformanceT
 
     def "with and without plugin application (#scenario)"() {
         given:
-        def jobArgs = ['--continue', '-Dscan.capture-task-input-files'] + scenarioArgs
+        def jobArgs = ['--continue', '--no-scan', '-Dscan.capture-file-fingerprints'] + scenarioArgs
 
         runner.baseline {
             displayName(WITHOUT_PLUGIN_LABEL)

--- a/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
+++ b/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
@@ -16,14 +16,7 @@
 
 package org.gradle.performance
 
-import org.apache.commons.io.FileUtils
-import org.gradle.profiler.BuildContext
-import org.gradle.profiler.BuildMutator
-import org.gradle.profiler.InvocationSettings
-import org.gradle.profiler.Phase
-import org.gradle.profiler.ScenarioContext
-import org.gradle.test.fixtures.file.TestFile
-import org.gradle.util.internal.VersionNumber
+import org.gradle.performance.fixture.GradleBuildExperimentSpec
 
 class BuildScanPluginPerformanceTest extends AbstractBuildScanPluginPerformanceTest {
 
@@ -39,43 +32,33 @@ class BuildScanPluginPerformanceTest extends AbstractBuildScanPluginPerformanceT
         def jobArgs = ['--continue', '-Dscan.capture-task-input-files'] + scenarioArgs
 
         runner.baseline {
-            warmUpCount WARMUPS
-            invocationCount INVOCATIONS
             displayName(WITHOUT_PLUGIN_LABEL)
             invocation {
-                // Increase client VM heap memory because of a huge amount of output events
-                clientJvmArgs("-Xmx256m", "-Xms256m")
                 args(*jobArgs)
                 tasksToRun(*tasks)
                 if (withFailure) {
                     expectFailure()
                 }
-                addBuildMutator { invocationSettings -> new InjectDevelocityPlugin(invocationSettings.projectDir, pluginVersionNumber) }
-                addBuildMutator { invocationSettings -> new SaveScanSpoolFile(invocationSettings, scenario) }
-                if (manageCacheState) {
-                    addBuildMutator { new ManageLocalCacheState(it.projectDir) }
-                }
+            }
+            addBuildMutator { invocationSettings -> new SaveScanSpoolFile(invocationSettings, scenario) }
+            if (manageCacheState) {
+                addBuildMutator { new ManageLocalCacheState(it.projectDir) }
             }
         }
 
         runner.buildSpec {
-            warmUpCount WARMUPS
-            invocationCount INVOCATIONS
             displayName(WITH_PLUGIN_LABEL)
             invocation {
-                // Increase client VM heap memory because of a huge amount of output events
-                clientJvmArgs("-Xmx256m", "-Xms256m")
                 args(*jobArgs)
                 args("-DenableScan=true")
                 tasksToRun(*tasks)
                 if (withFailure) {
                     expectFailure()
                 }
-                addBuildMutator { invocationSettings -> new InjectDevelocityPlugin(invocationSettings.projectDir, pluginVersionNumber) }
-                addBuildMutator { invocationSettings -> new SaveScanSpoolFile(invocationSettings, scenario) }
-                if (manageCacheState) {
-                    addBuildMutator { new ManageLocalCacheState(it.projectDir) }
-                }
+            }
+            addBuildMutator { invocationSettings -> new SaveScanSpoolFile(invocationSettings, scenario) }
+            if (manageCacheState) {
+                addBuildMutator { new ManageLocalCacheState(it.projectDir) }
             }
         }
 
@@ -96,124 +79,15 @@ class BuildScanPluginPerformanceTest extends AbstractBuildScanPluginPerformanceT
         "help - no console output"                              | MEDIAN_PERCENTAGES_SHIFT      | ['help']                           | false       | ['-DreducedOutput=true']                                      | false
     }
 
-    static class ManageLocalCacheState implements BuildMutator {
-        final File projectDir
-
-        ManageLocalCacheState(File projectDir) {
-            this.projectDir = projectDir
+    @Override
+    protected void configureGradleSpec(GradleBuildExperimentSpec.GradleBuilder builder) {
+        super.configureGradleSpec(builder)
+        builder.warmUpCount = WARMUPS
+        builder.invocationCount = INVOCATIONS
+        builder.invocation {
+            // Increase client VM heap memory because of a huge amount of output events
+            clientJvmArgs("-Xmx256m", "-Xms256m")
         }
-
-        @Override
-        void beforeBuild(BuildContext context) {
-            def projectTestDir = new TestFile(projectDir)
-            def cacheDir = projectTestDir.file('local-build-cache')
-            def settingsFile = projectTestDir.file('settings.gradle')
-            settingsFile << """
-                    buildCache {
-                        local {
-                            directory = '${cacheDir.absoluteFile.toURI()}'
-                        }
-                    }
-                """.stripIndent()
-        }
-
-        @Override
-        void afterBuild(BuildContext context, Throwable t) {
-            assert !new File(projectDir, 'error.log').exists()
-            def buildCacheDirectory = new TestFile(projectDir, 'local-build-cache')
-            def cacheEntries = buildCacheDirectory.listFiles()
-            if (cacheEntries == null) {
-                throw new IllegalStateException("Cache dir doesn't exist, did the build succeed? Please check the build log.")
-            }
-
-            cacheEntries.sort().eachWithIndex { TestFile entry, int i ->
-                if (i % 2 == 0) {
-                    entry.delete()
-                }
-            }
-        }
-    }
-
-    static class SaveScanSpoolFile implements BuildMutator {
-        final InvocationSettings invocationSettings
-        final String testId
-
-        SaveScanSpoolFile(InvocationSettings invocationSettings, String testId) {
-            this.invocationSettings = invocationSettings
-            this.testId = testId.replaceAll(/[- ]/, '_')
-        }
-
-        @Override
-        void beforeBuild(BuildContext context) {
-            spoolDir().deleteDir()
-        }
-
-        @Override
-        void afterBuild(BuildContext context, Throwable t) {
-            def spoolDir = this.spoolDir()
-            if (context.phase == Phase.MEASURE && (context.iteration == invocationSettings.buildCount) && spoolDir.exists()) {
-                def targetDirectory = new File("build/scan-dumps/$testId")
-                targetDirectory.deleteDir()
-                FileUtils.moveToDirectory(spoolDir, targetDirectory, true)
-            }
-        }
-
-        private File spoolDir() {
-            new File(invocationSettings.gradleUserHome, "build-scan-data")
-        }
-    }
-
-    static class InjectDevelocityPlugin implements BuildMutator {
-        private static final VersionNumber DEVELOCITY_PLUGIN_RENAME_VERSION = VersionNumber.parse("3.17")
-
-        final File projectDir
-        final String develocityPluginVersion
-        final boolean isDevelocity
-
-        InjectDevelocityPlugin(File projectDir, String develocityPluginVersion) {
-            this.projectDir = projectDir
-            this.develocityPluginVersion = develocityPluginVersion
-            this.isDevelocity = VersionNumber.parse(develocityPluginVersion).baseVersion >= DEVELOCITY_PLUGIN_RENAME_VERSION
-            println "InjectDevelocityPlugin develocityPluginVersion = $develocityPluginVersion"
-        }
-
-        private String getDevelocityPluginArtifactName() {
-            isDevelocity ? 'develocity-gradle-plugin' : 'gradle-enterprise-gradle-plugin'
-        }
-
-        private String getDevelocityPluginId() {
-            isDevelocity ? 'com.gradle.develocity' : 'com.gradle.enterprise'
-        }
-
-        @Override
-        void beforeScenario(ScenarioContext context) {
-            def projectTestDir = new TestFile(projectDir)
-            def settingsScript = projectTestDir.file('settings.gradle')
-            settingsScript.text = """
-                    buildscript {
-                        repositories {
-                            maven {
-                                name 'gradleInternalRepository'
-                                url '${System.getenv("GRADLE_INTERNAL_REPO_URL")}/enterprise-libs-snapshots-local/'
-                                credentials {
-                                    username = System.getenv("GRADLE_INTERNAL_REPO_USERNAME")
-                                    password = System.getenv("GRADLE_INTERNAL_REPO_PASSWORD")
-                                }
-                                authentication {
-                                    basic(BasicAuthentication)
-                                }
-                            }
-                        }
-
-                        dependencies {
-                            classpath "com.gradle:${develocityPluginArtifactName}:${develocityPluginVersion}"
-                        }
-                    }
-
-                    if (System.getProperty('enableScan')) {
-                        apply plugin: '${develocityPluginId}'
-                    }
-                    """ + settingsScript.text
-        }
+        builder.addBuildMutator { invocationSettings -> new InjectDevelocityPlugin(invocationSettings.projectDir, pluginVersionNumber) }
     }
 }

--- a/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginResourceCapturingPerformanceTest.groovy
+++ b/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginResourceCapturingPerformanceTest.groovy
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance
+
+import org.gradle.performance.fixture.GradleBuildExperimentSpec
+
+class BuildScanPluginResourceCapturingPerformanceTest extends AbstractBuildScanPluginPerformanceTest {
+
+    private final String WITH_RESOURCE_CAPTURING_LABEL = "With resource capturing"
+    private final String WITHOUT_RESOURCE_CAPTURING_LABEL = "Without resource capturing"
+
+    def "with and without resource capturing (#scenario)"() {
+        given:
+        def jobArgs = ['--continue', '-DenableScan=true', '--no-scan', '-Dscan.capture-file-fingerprints', '-Dscan.resource-insights.internal.capturingStats=true'] + scenarioArgs
+
+        runner.baseline {
+            displayName(WITHOUT_RESOURCE_CAPTURING_LABEL)
+            invocation {
+                // Increase client VM heap memory because of a huge amount of output events
+                clientJvmArgs("-Xmx256m", "-Xms256m")
+                args(*jobArgs)
+                args("-Dscan.capture-resource-insights=false")
+                tasksToRun(*tasks)
+                if (withFailure) {
+                    expectFailure()
+                }
+                addBuildMutator { invocationSettings -> new SaveScanSpoolFile(invocationSettings, scenario) }
+                if (manageCacheState) {
+                    addBuildMutator { new ManageLocalCacheState(it.projectDir) }
+                }
+            }
+        }
+
+        runner.buildSpec {
+            displayName(WITH_RESOURCE_CAPTURING_LABEL)
+            invocation {
+                // Increase client VM heap memory because of a huge amount of output events
+                clientJvmArgs("-Xmx256m", "-Xms256m")
+                args(*jobArgs)
+                args("-Dscan.capture-resource-insights=true")
+                tasksToRun(*tasks)
+                if (withFailure) {
+                    expectFailure()
+                }
+                addBuildMutator { invocationSettings -> new SaveScanSpoolFile(invocationSettings, scenario) }
+                if (manageCacheState) {
+                    addBuildMutator { new ManageLocalCacheState(it.projectDir) }
+                }
+            }
+        }
+
+        when:
+        def results = runner.run()
+
+        then:
+        def withoutResults = buildBaselineResults(results, WITHOUT_RESOURCE_CAPTURING_LABEL)
+        def withResults = results.buildResult(WITH_RESOURCE_CAPTURING_LABEL)
+        def speedStats = withoutResults.getSpeedStatsAgainst(withResults.name, withResults)
+        println(speedStats)
+        !withoutResults.significantlyFasterThan(withResults)
+
+        where:
+        scenario                     | tasks                              | withFailure | scenarioArgs                                      | manageCacheState
+        "clean build - 20 projects"  | ['clean', 'project20:buildNeeded'] | true        | ['--build-cache', '-DreducedOutput=true']         | true
+        "help - configuration cache" | ['help']                           | false       | ['--configuration-cache', '-DreducedOutput=true'] | false
+        "help - no console output"   | ['help']                           | false       | ['-DreducedOutput=true']                          | false
+    }
+
+    @Override
+    protected void configureGradleSpec(GradleBuildExperimentSpec.GradleBuilder builder) {
+        super.configureGradleSpec(builder)
+        builder.warmUpCount = 5
+        builder.invocationCount = 10
+        builder.addBuildMutator { invocationSettings -> new InjectDevelocityPlugin(invocationSettings.projectDir, pluginVersionNumber) }
+    }
+}

--- a/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginResourceCapturingPerformanceTest.groovy
+++ b/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginResourceCapturingPerformanceTest.groovy
@@ -20,8 +20,8 @@ import org.gradle.performance.fixture.GradleBuildExperimentSpec
 
 class BuildScanPluginResourceCapturingPerformanceTest extends AbstractBuildScanPluginPerformanceTest {
 
-    private final String WITH_RESOURCE_CAPTURING_LABEL = "With resource capturing"
-    private final String WITHOUT_RESOURCE_CAPTURING_LABEL = "Without resource capturing"
+    private static final String WITH_RESOURCE_CAPTURING_LABEL = "With resource capturing"
+    private static final String WITHOUT_RESOURCE_CAPTURING_LABEL = "Without resource capturing"
 
     def "with and without resource capturing (#scenario)"() {
         given:

--- a/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/InjectDevelocityPlugin.groovy
+++ b/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/InjectDevelocityPlugin.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance
+
+import org.gradle.profiler.BuildMutator
+import org.gradle.profiler.ScenarioContext
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.internal.VersionNumber
+
+class InjectDevelocityPlugin implements BuildMutator {
+    private static final VersionNumber DEVELOCITY_PLUGIN_RENAME_VERSION = VersionNumber.parse("3.17")
+
+    final File projectDir
+    final String develocityPluginVersion
+    final boolean isDevelocity
+
+    InjectDevelocityPlugin(File projectDir, String develocityPluginVersion) {
+        this.projectDir = projectDir
+        this.develocityPluginVersion = develocityPluginVersion
+        this.isDevelocity = VersionNumber.parse(develocityPluginVersion).baseVersion >= DEVELOCITY_PLUGIN_RENAME_VERSION
+        println "InjectDevelocityPlugin develocityPluginVersion = $develocityPluginVersion"
+    }
+
+    private String getDevelocityPluginArtifactName() {
+        isDevelocity ? 'develocity-gradle-plugin' : 'gradle-enterprise-gradle-plugin'
+    }
+
+    private String getDevelocityPluginId() {
+        isDevelocity ? 'com.gradle.develocity' : 'com.gradle.enterprise'
+    }
+
+    @Override
+    void beforeScenario(ScenarioContext context) {
+        def projectTestDir = new TestFile(projectDir)
+        def settingsScript = projectTestDir.file('settings.gradle')
+        settingsScript.text = """
+                buildscript {
+                    repositories {
+                        maven {
+                            name 'gradleInternalRepository'
+                            url '${System.getenv("GRADLE_INTERNAL_REPO_URL")}/enterprise-libs-snapshots-local/'
+                            credentials {
+                                username = System.getenv("GRADLE_INTERNAL_REPO_USERNAME")
+                                password = System.getenv("GRADLE_INTERNAL_REPO_PASSWORD")
+                            }
+                            authentication {
+                                basic(BasicAuthentication)
+                            }
+                        }
+                    }
+
+                    dependencies {
+                        classpath "com.gradle:${develocityPluginArtifactName}:${develocityPluginVersion}"
+                    }
+                }
+
+                if (System.getProperty('enableScan')) {
+                    apply plugin: '${develocityPluginId}'
+                }
+                """ + settingsScript.text
+    }
+}

--- a/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/ManageLocalCacheState.groovy
+++ b/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/ManageLocalCacheState.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance
+
+import org.gradle.profiler.BuildContext
+import org.gradle.profiler.BuildMutator
+import org.gradle.test.fixtures.file.TestFile
+
+class ManageLocalCacheState implements BuildMutator {
+    final File projectDir
+
+    ManageLocalCacheState(File projectDir) {
+        this.projectDir = projectDir
+    }
+
+    @Override
+    void beforeBuild(BuildContext context) {
+        def projectTestDir = new TestFile(projectDir)
+        def cacheDir = projectTestDir.file('local-build-cache')
+        def settingsFile = projectTestDir.file('settings.gradle')
+        settingsFile << """
+                buildCache {
+                    local {
+                        directory = '${cacheDir.absoluteFile.toURI()}'
+                    }
+                }
+            """.stripIndent()
+    }
+
+    @Override
+    void afterBuild(BuildContext context, Throwable t) {
+        assert !new File(projectDir, 'error.log').exists()
+        def buildCacheDirectory = new TestFile(projectDir, 'local-build-cache')
+        def cacheEntries = buildCacheDirectory.listFiles()
+        if (cacheEntries == null) {
+            throw new IllegalStateException("Cache dir doesn't exist, did the build succeed? Please check the build log.")
+        }
+
+        cacheEntries.sort().eachWithIndex { TestFile entry, int i ->
+            if (i % 2 == 0) {
+                entry.delete()
+            }
+        }
+    }
+}

--- a/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/SaveScanSpoolFile.groovy
+++ b/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/SaveScanSpoolFile.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance
+
+import org.apache.commons.io.FileUtils
+import org.gradle.profiler.BuildContext
+import org.gradle.profiler.BuildMutator
+import org.gradle.profiler.InvocationSettings
+import org.gradle.profiler.Phase
+
+class SaveScanSpoolFile implements BuildMutator {
+    final InvocationSettings invocationSettings
+    final String testId
+
+    SaveScanSpoolFile(InvocationSettings invocationSettings, String testId) {
+        this.invocationSettings = invocationSettings
+        this.testId = testId.replaceAll(/[- ]/, '_')
+    }
+
+    @Override
+    void beforeBuild(BuildContext context) {
+        spoolDir().deleteDir()
+    }
+
+    @Override
+    void afterBuild(BuildContext context, Throwable t) {
+        def spoolDir = this.spoolDir()
+        if (context.phase == Phase.MEASURE && (context.iteration == invocationSettings.buildCount) && spoolDir.exists()) {
+            def targetDirectory = new File("build/scan-dumps/$testId")
+            targetDirectory.deleteDir()
+            FileUtils.moveToDirectory(spoolDir, targetDirectory, true)
+        }
+    }
+
+    private File spoolDir() {
+        new File(invocationSettings.gradleUserHome, "build-scan-data")
+    }
+}

--- a/platforms/enterprise/enterprise-plugin-performance/src/templates/root/build.gradle
+++ b/platforms/enterprise/enterprise-plugin-performance/src/templates/root/build.gradle
@@ -14,21 +14,49 @@
  * limitations under the License.
  */
 
+
+import org.gradle.api.flow.BuildWorkResult
+import org.gradle.api.flow.FlowAction
+import org.gradle.api.flow.FlowParameters
+import org.gradle.api.flow.FlowProviders
+import org.gradle.api.flow.FlowScope
+
 // We want to double check that a build failure is
 // only caused by failing test executions
-gradle.buildFinished { result ->
-    buildDir.mkdirs()
-    if(result.failure) {
-        def unexpectedFailure = (result.failure instanceof org.gradle.execution.MultipleBuildFailures && result.failure.causes.every { cause ->
-            def failureMessage = cause?.cause?.cause?.message
-            !failureMessage?.contains("There were failing tests")
-        }
-        )
-        if(unexpectedFailure) {
-            StringWriter errors = new StringWriter();
-            result.failure.printStackTrace(new PrintWriter(errors));
+abstract class CheckResult implements FlowAction<Parameters> {
+    interface Parameters extends FlowParameters {
+        @Input
+        Property<BuildWorkResult> getBuildResult()
+        @Input
+        Property<File> getBuildDirectory()
+    }
+
+    @Override
+    void execute(Parameters parameters) throws Exception {
+        BuildWorkResult result = parameters.getBuildResult().get()
+        if(result.failure.isPresent()) {
+            File buildDir = parameters.getBuildDirectory().get()
             buildDir.mkdirs()
-            new File(buildDir, "error.log").text = errors.toString()
+            def failure = result.failure.get()
+            def unexpectedFailure = (failure instanceof org.gradle.execution.MultipleBuildFailures && failure.causes.every { cause ->
+                def failureMessage = cause?.cause?.cause?.message
+                !failureMessage?.contains("There were failing tests")
+            })
+            if(unexpectedFailure) {
+                StringWriter errors = new StringWriter();
+                failure.printStackTrace(new PrintWriter(errors));
+                new File(buildDir, "error.log").text = errors.toString()
+            }
         }
+    }
+}
+
+FlowProviders flowProviders = gradle.services.get(FlowProviders)
+FlowScope flowScope = gradle.services.get(FlowScope)
+
+flowScope.always(CheckResult) {
+    parameters {
+        buildResult = flowProviders.buildWorkResult
+        buildDirectory = project.layout.buildDirectory.asFile
     }
 }

--- a/platforms/enterprise/enterprise-plugin-performance/src/testFixtures/groovy/org/gradle/performance/AbstractBuildScanPluginPerformanceTest.groovy
+++ b/platforms/enterprise/enterprise-plugin-performance/src/testFixtures/groovy/org/gradle/performance/AbstractBuildScanPluginPerformanceTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
 import org.gradle.performance.fixture.BuildExperimentSpec
 import org.gradle.performance.fixture.BuildScanPerformanceTestRunner
 import org.gradle.performance.fixture.GradleBuildExperimentRunner
+import org.gradle.performance.fixture.GradleBuildExperimentSpec
 import org.gradle.performance.fixture.GradleInvocationSpec
 import org.gradle.performance.fixture.PerformanceTestIdProvider
 import org.gradle.performance.measure.Amount
@@ -90,8 +91,17 @@ class AbstractBuildScanPluginPerformanceTest extends AbstractPerformanceTest {
                 invocation.buildLog(new File(builder.workingDirectory, "build.log"))
                 invocation.distribution(distribution)
             }
+
+            @Override
+            protected void configureGradleSpec(GradleBuildExperimentSpec.GradleBuilder builder) {
+                super.configureGradleSpec(builder)
+                AbstractBuildScanPluginPerformanceTest.this.configureGradleSpec(builder)
+            }
         }
         performanceTestIdProvider.setTestSpec(runner)
+    }
+
+    protected void configureGradleSpec(GradleBuildExperimentSpec.GradleBuilder builder) {
     }
 
     private static resolvePluginVersion() {


### PR DESCRIPTION
We want to test the overhead of resource insights capturing done by the Build Scan plugin. This PR adds a comparison build to check that there isn't any significant overhead.