### PR TITLE
Override https://repo.gradle.org/gradle/list/libs-releases via Gradle properties (with optional credentials)

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/build_environment.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/build_environment.adoc
@@ -344,6 +344,18 @@ This does not affect the JVM settings for the Gradle client VM.
 +
 _Default is `-Xmx512m "-XX:MaxMetaspaceSize=384m"`._
 
+`org.gradle.libraries.sourceRepository.credentialsProperties=(colon separated Gradle property names)`::
+Specifies the Gradle property names for username and the password for the repository set in `org.gradle.libraries.sourceRepository.url`.
+The property names must be separated by a single colon. For example, the value can be `myRepoUserKey:myRepoPasswordKey`. In which case,
+the username will be read from the Gradle property `myRepoUserKey` and the password will be read from the Gradle property `myRepoPasswordKey`.
++
+_Default is no credentials._
+
+`org.gradle.libraries.sourceRepository.url=(Maven repository URL)`::
+Overrides for the default Gradle library repository. The value of this property takes precedence over the `GRADLE_LIBS_REPO_OVERRIDE` environment variable.
++
+_Default is the value of the `GRADLE_LIBS_REPO_OVERRIDE` environment variable otherwise a hardwired URL to the public repository._
+
 `org.gradle.logging.level=(quiet,warn,lifecycle,info,debug)`::
 When set to quiet, warn, info, or debug, Gradle will use this <<logging.adoc#sec:choosing_a_log_level,log level>>.
 The values are not case-sensitive.

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
@@ -621,7 +621,11 @@ public abstract class IdeaModule {
     public Set<Dependency> resolveDependencies() {
         ProjectInternal projectInternal = (ProjectInternal) project;
         IdeArtifactRegistry ideArtifactRegistry = projectInternal.getServices().get(IdeArtifactRegistry.class);
-        IdeaDependenciesProvider ideaDependenciesProvider = new IdeaDependenciesProvider(projectInternal, ideArtifactRegistry, new DefaultGradleApiSourcesResolver(projectInternal.newDetachedResolver()));
+        IdeaDependenciesProvider ideaDependenciesProvider = new IdeaDependenciesProvider(
+            projectInternal,
+            ideArtifactRegistry,
+            new DefaultGradleApiSourcesResolver(project.getProviders(), projectInternal.newDetachedResolver())
+        );
         return ideaDependenciesProvider.provide(this);
     }
 

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
@@ -357,7 +357,12 @@ public abstract class EclipseClasspath {
     public List<ClasspathEntry> resolveDependencies() {
         ProjectInternal projectInternal = (ProjectInternal) this.project;
         IdeArtifactRegistry ideArtifactRegistry = projectInternal.getServices().get(IdeArtifactRegistry.class);
-        ClasspathFactory classpathFactory = new ClasspathFactory(this, ideArtifactRegistry, new DefaultGradleApiSourcesResolver(projectInternal.newDetachedResolver()), EclipseClassPathUtil.isInferModulePath(this.project));
+        ClasspathFactory classpathFactory = new ClasspathFactory(
+            this,
+            ideArtifactRegistry,
+            new DefaultGradleApiSourcesResolver(project.getProviders(), projectInternal.newDetachedResolver()),
+            EclipseClassPathUtil.isInferModulePath(this.project)
+        );
         return classpathFactory.createEntries();
     }
 

--- a/platforms/ide/ide/src/test/groovy/org/gradle/plugins/ide/internal/resolver/DefaultGradleApiSourcesResolverTest.groovy
+++ b/platforms/ide/ide/src/test/groovy/org/gradle/plugins/ide/internal/resolver/DefaultGradleApiSourcesResolverTest.groovy
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.internal.resolver
+
+import org.gradle.api.Action
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.api.artifacts.repositories.PasswordCredentials
+import org.gradle.api.internal.provider.DefaultProviderFactory
+import org.gradle.api.internal.provider.Providers
+import org.gradle.api.provider.Provider
+import org.gradle.internal.credentials.DefaultPasswordCredentials
+import spock.lang.Specification
+
+class DefaultGradleApiSourcesResolverTest extends Specification {
+    StoredRepositoryRef resultRef
+
+    MavenArtifactRepository repository
+
+    def setup() {
+        resultRef = new StoredRepositoryRef()
+        repository = Mock()
+
+        repository.setUrl(_ as Object) >> { args ->
+            resultRef.url = args[0] as String
+        }
+
+        repository.setUrl(_ as URI) >> { args ->
+            resultRef.url = args[0].toString()
+        }
+
+        repository.credentials(_ as Action) >> { args ->
+            def storedCredentials = new DefaultPasswordCredentials()
+            resultRef.credentials = storedCredentials
+            args[0].execute(storedCredentials)
+        }
+    }
+
+    def "configureLibsRepo with default values"() {
+        def providers = new FixedTestProviderFactory([:], [:])
+
+        when:
+        DefaultGradleApiSourcesResolver.configureLibsRepo(repository, providers)
+
+        then:
+        resultRef.url == DefaultGradleApiSourcesResolver.GRADLE_LIBS_REPO_URL
+        resultRef.credentials == null
+    }
+
+    def "configureLibsRepo with default url ignores credentials "() {
+        def providers = new FixedTestProviderFactory([:], [
+            'org.gradle.libraries.sourceRepository.credentialsProperties' : 'testUser:testPassword',
+            'testUser' : 'test-secret-user',
+            'testPassword' : 'test-secret-password',
+        ])
+
+        when:
+        DefaultGradleApiSourcesResolver.configureLibsRepo(repository, providers)
+
+        then:
+        resultRef.url == DefaultGradleApiSourcesResolver.GRADLE_LIBS_REPO_URL
+        resultRef.credentials == null
+    }
+
+    def "configureLibsRepo with environment without credentials"() {
+        def expectedUrl = 'https://example.com/test'
+        def providers = new FixedTestProviderFactory(['GRADLE_LIBS_REPO_OVERRIDE' : expectedUrl], [:])
+
+        when:
+        DefaultGradleApiSourcesResolver.configureLibsRepo(repository, providers)
+
+        then:
+        resultRef.url == expectedUrl
+        resultRef.credentials == null
+    }
+
+    def "configureLibsRepo with environment with credentials"() {
+        def expectedUrl = 'https://example.com/test'
+        def expectedUser = 'expected-test-user'
+        def expectedPassword = 'expected-test-password'
+        def providers = new FixedTestProviderFactory(['GRADLE_LIBS_REPO_OVERRIDE' : expectedUrl], [
+            'org.gradle.libraries.sourceRepository.credentialsProperties' : 'testUser:testPassword',
+            'testUser' : expectedUser,
+            'testPassword' : expectedPassword,
+        ])
+
+        when:
+        DefaultGradleApiSourcesResolver.configureLibsRepo(repository, providers)
+
+        then:
+        resultRef.url == expectedUrl
+        resultRef.credentials != null
+        resultRef.credentials.username == expectedUser
+        resultRef.credentials.password == expectedPassword
+    }
+
+    def "configureLibsRepo with Gradle properties without credentials"() {
+        def expectedUrl = 'https://example.com/test'
+        def providers = new FixedTestProviderFactory([:], ['org.gradle.libraries.sourceRepository.url' : expectedUrl])
+
+        when:
+        DefaultGradleApiSourcesResolver.configureLibsRepo(repository, providers)
+
+        then:
+        resultRef.url == expectedUrl
+        resultRef.credentials == null
+    }
+
+    def "configureLibsRepo with Gradle properties with credentials"() {
+        def expectedUrl = 'https://example.com/test'
+        def expectedUser = 'expected-test-user'
+        def expectedPassword = 'expected-test-password'
+        def providers = new FixedTestProviderFactory([:], [
+            'org.gradle.libraries.sourceRepository.url' : expectedUrl,
+            'org.gradle.libraries.sourceRepository.credentialsProperties' : 'testUser:testPassword',
+            'testUser' : expectedUser,
+            'testPassword' : expectedPassword,
+        ])
+
+        when:
+        DefaultGradleApiSourcesResolver.configureLibsRepo(repository, providers)
+
+        then:
+        resultRef.url == expectedUrl
+        resultRef.credentials != null
+        resultRef.credentials.username == expectedUser
+        resultRef.credentials.password == expectedPassword
+    }
+
+    def "configureLibsRepo with Gradle properties takes precedence"() {
+        def expectedUrl = 'https://example.com/correct'
+        def providers = new FixedTestProviderFactory(
+            ['GRADLE_LIBS_REPO_OVERRIDE' : 'https://example.com/wrong'],
+            ['org.gradle.libraries.sourceRepository.url' : expectedUrl]
+        )
+
+        when:
+        DefaultGradleApiSourcesResolver.configureLibsRepo(repository, providers)
+
+        then:
+        resultRef.url == expectedUrl
+        resultRef.credentials == null
+    }
+
+    class StoredRepositoryRef {
+        String url
+        PasswordCredentials credentials
+    }
+
+    class FixedTestProviderFactory extends DefaultProviderFactory {
+        private final Map<String, String> environmentVariables
+        private final Map<String, String> gradleProperties
+
+        FixedTestProviderFactory(Map<String, String> environmentVariables, Map<String, String> gradleProperties) {
+            this.environmentVariables = environmentVariables
+            this.gradleProperties = gradleProperties
+        }
+
+        @Override
+        Provider<String> environmentVariable(String variableName) {
+            return Providers.ofNullable(environmentVariables[variableName])
+        }
+
+        @Override
+        Provider<String> environmentVariable(Provider<String> variableName) {
+            return environmentVariable(variableName.get())
+        }
+
+        @Override
+        Provider<String> gradleProperty(String propertyName) {
+            return Providers.ofNullable(gradleProperties[propertyName])
+        }
+
+        @Override
+        Provider<String> gradleProperty(Provider<String> propertyName) {
+            return gradleProperty(propertyName.get())
+        }
+    }
+}


### PR DESCRIPTION
Fixes #25840. This PR will let users to change the <https://repo.gradle.org/gradle/list/libs-releases> with the `org.gradle.libraries.sourceRepository.url` Gradle property (with a fallback to `GRADLE_LIBS_REPO_OVERRIDE` environment variable). In addition to the URL, it is possible to override the credentials via the `org.gradle.libraries.sourceRepository.credentialsProperties` Gradle property which may contain the Gradle properties pointing to the username and password.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
