### PR TITLE
Apply develocity and gradle-enterprise-conventions-plugin to included build

### DIFF
--- a/build-logic-commons/build-platform/build.gradle.kts
+++ b/build-logic-commons/build-platform/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     constraints {
         api("org.gradle.guides:gradle-guides-plugin:0.23")
         api("org.apache.ant:ant:1.10.14") // Bump the version brought in transitively by gradle-guides-plugin
-        api("com.gradle:develocity-gradle-plugin:3.17.5") // Sync with `settings.gradle.kts`
+        api("com.gradle:develocity-gradle-plugin:3.17.5") // Run `build-logic-settings/update-develocity-plugin-version.sh <new-version>` to update
         api("com.gradle.publish:plugin-publish-plugin:1.2.1")
         api("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:1.0.1")
         api("me.champeau.gradle:japicmp-gradle-plugin:0.4.1")

--- a/build-logic-settings/settings.gradle.kts
+++ b/build-logic-settings/settings.gradle.kts
@@ -22,7 +22,9 @@ dependencyResolutionManagement {
 }
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version("0.8.0")
+    id("com.gradle.develocity").version("3.17.5") // Run `build-logic-settings/update-develocity-plugin-version.sh <new-version>` to update
+    id("io.github.gradle.gradle-enterprise-conventions-plugin").version("0.10.1")
+    id("org.gradle.toolchains.foojay-resolver-convention").version("0.8.0")
 }
 
 include("build-environment")

--- a/build-logic-settings/update-develocity-plugin-version.sh
+++ b/build-logic-settings/update-develocity-plugin-version.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <new-version>"
+  exit 1
+fi
+
+NEW_VERSION=$1
+
+FILES=(
+  "build-logic-commons/build-platform/build.gradle.kts"
+  "build-logic-settings/settings.gradle.kts"
+  "settings.gradle.kts"
+)
+
+for FILE in "${FILES[@]}"; do
+  if [ -f "$FILE" ]; then
+    sed -i "" "s/com.gradle:develocity-gradle-plugin:[0-9]*\.[0-9]*\.[0-9]*/com.gradle:develocity-gradle-plugin:${NEW_VERSION}/" "$FILE"
+    sed -i "" "s/id(\"com.gradle.develocity\").version(\"[0-9]*\.[0-9]*\.[0-9]*\")/id(\"com.gradle.develocity\").version(\"${NEW_VERSION}\")/" "$FILE"
+    echo "Updated $FILE to version $NEW_VERSION"
+  else
+    echo "File $FILE not found"
+  fi
+done
+
+echo "All files updated successfully."

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,9 +28,9 @@ pluginManagement {
 
 plugins {
     id("gradlebuild.build-environment")
-    id("com.gradle.develocity").version("3.17.5") // Sync with `build-logic-commons/build-platform/build.gradle.kts`
+    id("com.gradle.develocity").version("3.17.5") // Run `build-logic-settings/update-develocity-plugin-version.sh <new-version>` to update
     id("io.github.gradle.gradle-enterprise-conventions-plugin").version("0.10.1")
-    id("org.gradle.toolchains.foojay-resolver-convention") version ("0.8.0")
+    id("org.gradle.toolchains.foojay-resolver-convention").version ("0.8.0")
 }
 
 includeBuild("build-logic-commons")


### PR DESCRIPTION
Otherwise it complains:

> The build cache configuration of the root build differs from the
> build cache configuration of the early evaluated ':build-logic-settings'
> included build. It is recommended to keep them consistent.
