### PR TITLE
Fix wrong TeamCity service message

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -126,7 +126,7 @@ fun BaseGradleBuildType.gradleRunnerStep(
             listOf(extraParameters) +
             buildScanTags.map { buildScanTag(it) } +
             functionalTestParameters(os, arch)
-        ).joinToString(separator = " ")
+        ).joinToString(separator = " ") + if (isRetry) " -PretryBuild" else ""
 
     steps {
         gradleWrapper(this@gradleRunnerStep) {

--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -51,6 +51,7 @@ import gradlebuild.basics.BuildParams.PERFORMANCE_MAX_PROJECTS
 import gradlebuild.basics.BuildParams.PERFORMANCE_TEST_VERBOSE
 import gradlebuild.basics.BuildParams.PREDICTIVE_TEST_SELECTION_ENABLED
 import gradlebuild.basics.BuildParams.RERUN_ALL_TESTS
+import gradlebuild.basics.BuildParams.RETRY_BUILD
 import gradlebuild.basics.BuildParams.RUN_ANDROID_STUDIO_IN_HEADLESS_MODE
 import gradlebuild.basics.BuildParams.RUN_BROKEN_CONFIGURATION_CACHE_DOCS_TESTS
 import gradlebuild.basics.BuildParams.STUDIO_HOME
@@ -118,6 +119,7 @@ object BuildParams {
     const val PERFORMANCE_DEPENDENCY_BUILD_IDS = "org.gradle.performance.dependencyBuildIds"
     const val PERFORMANCE_MAX_PROJECTS = "maxProjects"
     const val RERUN_ALL_TESTS = "rerunAllTests"
+    const val RETRY_BUILD = "retryBuild"
     const val PREDICTIVE_TEST_SELECTION_ENABLED = "enablePredictiveTestSelection"
     const val TEST_DISTRIBUTION_ENABLED = "enableTestDistribution"
     const val TEST_DISTRIBUTION_PARTITION_SIZE = "testDistributionPartitionSizeInSeconds"
@@ -242,6 +244,10 @@ val Project.buildServerUrl: Provider<String>
 
 val Project.buildMilestoneNumber: Provider<String>
     get() = gradleProperty(BUILD_MILESTONE_NUMBER)
+
+
+val Project.isRetryBuild: Boolean
+    get() = gradleProperty(RETRY_BUILD).isPresent
 
 
 val Project.buildTimestamp: Provider<String>

--- a/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
+++ b/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
@@ -24,6 +24,7 @@ import gradlebuild.basics.BuildEnvironment.isTravis
 import gradlebuild.basics.buildBranch
 import gradlebuild.basics.environmentVariable
 import gradlebuild.basics.isPromotionBuild
+import gradlebuild.basics.isRetryBuild
 import gradlebuild.basics.kotlindsl.execAndGetStdoutIgnoringError
 import gradlebuild.basics.logicalBranch
 import gradlebuild.basics.predictiveTestSelectionEnabled
@@ -121,7 +122,7 @@ fun Project.extractCiData() {
             }
             buildFinished {
                 println("##teamcity[setParameter name='env.GRADLE_RUNNER_FINISHED' value='true']")
-                if (failures.isEmpty()) {
+                if (failures.isEmpty() && isRetryBuild) {
                     println("##teamcity[buildStatus status='SUCCESS' text='Retried build succeeds']")
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-private/issues/4239

The functional test builds have two build steps: `GRADLE_RUNNER` and `GRADLE_RETRY_RUNNER`. When `GRADLE_RETRY_RUNNER` succeeds, we want to output a service message to mark the build as successful, regardless of previous build status. The old implementation prints this service message unconditionally, which hides the failures in FlakyTestQuarantine build.

This PR adds a `-PretryBuild` param to the build and only outputs the service message in retried build.