### PR TITLE
Mark `DaemonInitialCommunicationFailureIntegrationSpec` as `@LocalOnly`

### DIFF
--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonInitialCommunicationFailureIntegrationSpec.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonInitialCommunicationFailureIntegrationSpec.groovy
@@ -17,6 +17,7 @@
 package org.gradle.launcher.daemon
 
 
+import com.gradle.develocity.testing.annotations.LocalOnly
 import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
 import org.gradle.internal.remote.internal.inet.InetAddressFactory
 import org.gradle.launcher.daemon.logging.DaemonMessages
@@ -34,6 +35,7 @@ import java.nio.channels.SocketChannel
 import static org.gradle.test.fixtures.ConcurrentTestUtil.poll
 
 @Requires(IntegTestPreconditions.CanKillProcess)
+@LocalOnly
 class DaemonInitialCommunicationFailureIntegrationSpec extends DaemonIntegrationSpec {
 
     @Rule TestServer server = new TestServer()


### PR DESCRIPTION
We've seen quite some failures running on remote executors, let's mark it as `@LocalOnly` for now.

https://ge.gradle.org/scans/tests?search.relativeStartTime=P28D&search.timeZoneId=Asia%2FShanghai&tests.container=org.gradle.launcher.daemon.DaemonInitialCommunicationFailureIntegrationSpec