### PR TITLE
Add an explicit Settings scope

### DIFF
--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileResolver.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileResolver.java
@@ -25,7 +25,7 @@ import org.gradle.internal.typeconversion.NotationParser;
 import java.io.File;
 import java.net.URI;
 
-@ServiceScope({Scope.Global.class, Scope.BuildSession.class, Scope.Project.class})
+@ServiceScope({Scope.Global.class, Scope.BuildSession.class, Scope.Settings.class, Scope.Project.class})
 public interface FileResolver extends RelativeFilePathResolver, PathToFileResolver {
     File resolve(Object path, PathValidation validation);
 

--- a/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/scopes/GradleModuleServices.java
+++ b/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/scopes/GradleModuleServices.java
@@ -78,9 +78,10 @@ public interface GradleModuleServices extends ServiceRegistrationProvider {
     void registerBuildServices(ServiceRegistration registration);
 
     /**
-     * Called once per build invocation on a build, to register any {@link org.gradle.api.initialization.Settings} scoped services. These services are closed at the end of the build invocation.
+     * Called to register services in the {@link Scope.Settings Settings} scope.
      *
-     * <p>Global, user home, build session, build tree and build scoped services are visible to the settings scope services, but not vice versa.</p>
+     * @see Scope
+     * @see Scope.Settings
      */
     void registerSettingsServices(ServiceRegistration registration);
 

--- a/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/service/scopes/Scope.java
+++ b/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/service/scopes/Scope.java
@@ -174,7 +174,10 @@ public interface Scope {
     interface Build extends BuildTree {}
 
     /**
-     * The scope of the {@code org.gradle.api.invocation.Gradle} instance state.
+     * The scope of the {@code org.gradle.api.invocation.Gradle} instance of a build.
+     * <p>
+     * The state and the services are created at the same time the {@code Gradle} instance
+     * is initialized for a given <em>build</em>, and they are discarded at the end of the build execution.
      * <p>
      * The <em>Gradle state</em> is being merged into the {@link Build build state} and is mostly empty.
      * <p>

--- a/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/service/scopes/Scope.java
+++ b/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/service/scopes/Scope.java
@@ -42,8 +42,8 @@ package org.gradle.internal.service.scopes;
  *            Build
  *              │
  *            Gradle
- *              │
- *           Project
+ *         ┌────┴────┐
+ *      Project   Settings
  * </pre>
  *
  * Each scope roughly corresponds to the following user-facing concepts:
@@ -55,6 +55,7 @@ package org.gradle.internal.service.scopes;
  * <li>{@link BuildTree}         — composite build
  * <li>{@link Build}             — build in a composite build
  * <li>{@link Gradle}            — exists for historical reasons, almost empty
+ * <li>{@link Settings}          — settings script
  * <li>{@link Project}           — project in a build
  * </ul>
  *
@@ -180,6 +181,17 @@ public interface Scope {
      * {@link Build} and parent services are visible to {@link Gradle} services and descendant scopes, but not vice versa.
      */
     interface Gradle extends Build {}
+
+    /**
+     * The scope that owns {@code Settings} instance state.
+     * <p>
+     * The build state is managed by the {@code SettingsState} class.
+     * An instance is created for each build in the build definition,
+     * once per build execution and is discarded at the end of that execution.
+     * <p>
+     * {@link Gradle} and parent services are visible to {@link Settings} scope services, but not vice versa.
+     */
+    interface Settings extends Gradle {}
 
     /**
      * The scope of a single project within a {@link Build build}.

--- a/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/service/scopes/Scope.java
+++ b/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/service/scopes/Scope.java
@@ -55,7 +55,7 @@ package org.gradle.internal.service.scopes;
  * <li>{@link BuildTree}         — composite build
  * <li>{@link Build}             — build in a composite build
  * <li>{@link Gradle}            — exists for historical reasons, almost empty
- * <li>{@link Settings}          — settings script
+ * <li>{@link Settings}          — init scripts, settings script
  * <li>{@link Project}           — project in a build
  * </ul>
  *
@@ -183,11 +183,13 @@ public interface Scope {
     interface Gradle extends Build {}
 
     /**
-     * The scope that owns {@code Settings} instance state.
+     * The scope that owns the settings of a build.
      * <p>
-     * The build state is managed by the {@code SettingsState} class.
-     * An instance is created for each build in the build definition,
-     * once per build execution and is discarded at the end of that execution.
+     * The settings state is managed by the {@code SettingsState} class.
+     * The creation of that state implies evaluation of init scripts and settings scripts
+     * of the owner-build and any builds that are included as part of a composite build.
+     * <p>
+     * The state is discarded at the end of the build execution.
      * <p>
      * {@link Gradle} and parent services are visible to {@link Settings} scope services, but not vice versa.
      */

--- a/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/service/scopes/Scope.java
+++ b/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/service/scopes/Scope.java
@@ -72,7 +72,7 @@ package org.gradle.internal.service.scopes;
  *     └── project
  * </pre>
  *
- * <h4>Services and their visibility</h4>
+ * <h3>Services and their visibility</h3>
  * The state in each scope is created and managed by services registered in that scope.
  * All services of a scope are assembled in a {@code ServiceRegistry}.
  * When the registry is closed all its services are closed as well and the state is discarded.

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/BuildLayout.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/BuildLayout.java
@@ -33,7 +33,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
  * @since 8.5
  */
 @Incubating
-@ServiceScope(Scope.Build.class)
+@ServiceScope(Scope.Settings.class)
 public interface BuildLayout {
     /**
      * Returns the settings directory.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
@@ -43,7 +43,7 @@ import java.util.function.Supplier;
  * consumption.
  */
 @UsedByScanPlugin
-@ServiceScope(Scope.Build.class)
+@ServiceScope({Scope.Build.class, Scope.Settings.class})
 public interface GradleInternal extends Gradle, PluginAwareInternal {
     /**
      * {@inheritDoc}

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -104,8 +104,8 @@ import org.gradle.normalization.internal.DefaultInputNormalizationHandler;
 import org.gradle.normalization.internal.DefaultRuntimeClasspathNormalization;
 import org.gradle.normalization.internal.InputNormalizationHandlerInternal;
 import org.gradle.normalization.internal.RuntimeClasspathNormalizationInternal;
-import org.gradle.plugin.software.internal.SoftwareTypeConventionApplicator;
 import org.gradle.plugin.software.internal.PluginScheme;
+import org.gradle.plugin.software.internal.SoftwareTypeConventionApplicator;
 import org.gradle.process.internal.ExecFactory;
 import org.gradle.tooling.provider.model.internal.DefaultToolingModelBuilderRegistry;
 import org.gradle.util.Path;
@@ -124,6 +124,7 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
         Factory<LoggingManagerInternal> loggingManagerInternalFactory
     ) {
         return ServiceRegistryBuilder.builder()
+            .scope(Scope.Project.class)
             .displayName("project services")
             .parent(parent)
             .provider(new ProjectScopeServices(project, loggingManagerInternalFactory))

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/SettingsScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/SettingsScopeServices.java
@@ -56,6 +56,7 @@ public class SettingsScopeServices implements ServiceRegistrationProvider {
 
     public static CloseableServiceRegistry create(ServiceRegistry parent, SettingsInternal settings) {
         return ServiceRegistryBuilder.builder()
+            .scope(Scope.Settings.class)
             .displayName("settings services")
             .parent(parent)
             .provider(new SettingsScopeServices(settings))


### PR DESCRIPTION
Adds the `Settings` scope, which marks the services corresponding to init script and settings script evaluation.
It is not a new concept, but rather a scope that has already existed yet did not have an appropriate `Scope`-extending class.