### PR TITLE
It is now possible to override the Gradle distributions repository via a Gradle property

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionResolverTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionResolverTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.resolver
+
+import org.gradle.api.internal.provider.DefaultProviderFactory
+import org.gradle.api.internal.provider.Providers
+import org.gradle.api.provider.Provider
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.notNullValue
+import org.hamcrest.CoreMatchers.nullValue
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+
+class SourceDistributionResolverTest {
+    private fun distributionRepositoryConfig(gradleVersion: String, vararg gradleProperties: Pair<String, String>) =
+        SourceDistributionResolver.distributionRepositoryConfig(gradleVersion, FixedGradlePropertiesProviderFactory(gradleProperties.toMap()))
+
+    @Test
+    fun `check default values repository config`() {
+        val config = distributionRepositoryConfig("8.9")
+        assertThat(config.url, equalTo("${SourceDistributionResolver.SERVICES_BASE_URL}/${SourceDistributionResolver.RELEASES_REPOSITORY_NAME}"))
+        assertThat(config.credentials, nullValue())
+        assertThat(config.repoName, equalTo(SourceDistributionResolver.RELEASES_REPOSITORY_NAME))
+    }
+
+    @Test
+    fun `check default values repository config with snapshot version`() {
+        val config = distributionRepositoryConfig("8.9-20240702011213+0000")
+        assertThat(config.url, equalTo("${SourceDistributionResolver.SERVICES_BASE_URL}/${SourceDistributionResolver.SNAPSHOTS_REPOSITORY_NAME}"))
+        assertThat(config.credentials, nullValue())
+        assertThat(config.repoName, equalTo(SourceDistributionResolver.SNAPSHOTS_REPOSITORY_NAME))
+    }
+
+    @Test
+    fun `check only credentials override repository config`() {
+        val config = distributionRepositoryConfig("8.9",
+            SourceDistributionResolver.DISTRIBUTIONS_REPO_USER_OVERRIDE_KEY to "test-user",
+            SourceDistributionResolver.DISTRIBUTIONS_REPO_PASSWORD_OVERRIDE_KEY to "test-password"
+        )
+        assertThat(config.url, equalTo("${SourceDistributionResolver.SERVICES_BASE_URL}/${SourceDistributionResolver.RELEASES_REPOSITORY_NAME}"))
+        assertThat(config.credentials, nullValue())
+        assertThat(config.repoName, equalTo(SourceDistributionResolver.RELEASES_REPOSITORY_NAME))
+    }
+
+    @Test
+    fun `check URL only override repository config`() {
+        val urlOverride = "https://test.com/distributions-override"
+        val config = distributionRepositoryConfig("8.9",
+            SourceDistributionResolver.DISTRIBUTIONS_REPO_URL_OVERRIDE_KEY to urlOverride
+        )
+        assertThat(config.url, equalTo(urlOverride))
+        assertThat(config.credentials, nullValue())
+        assertThat(config.repoName, equalTo(SourceDistributionResolver.RELEASES_REPOSITORY_NAME))
+    }
+
+    @Test
+    fun `check URL only override repository config with snapshot version`() {
+        val urlOverride = "https://test.com/distributions-override"
+        val config = distributionRepositoryConfig("8.9-20240702011213+0000",
+            SourceDistributionResolver.DISTRIBUTIONS_REPO_URL_OVERRIDE_KEY to urlOverride
+        )
+        assertThat(config.url, equalTo(urlOverride))
+        assertThat(config.credentials, nullValue())
+        assertThat(config.repoName, equalTo(SourceDistributionResolver.SNAPSHOTS_REPOSITORY_NAME))
+    }
+
+    @Test
+    fun `check override repository config with credentials`() {
+        val urlOverride = "https://test.com/distributions-override"
+        val testUser = "test-user"
+        val testPassword = "test-password"
+        val config = distributionRepositoryConfig("8.9",
+            SourceDistributionResolver.DISTRIBUTIONS_REPO_URL_OVERRIDE_KEY to urlOverride,
+            SourceDistributionResolver.DISTRIBUTIONS_REPO_USER_OVERRIDE_KEY to testUser,
+            SourceDistributionResolver.DISTRIBUTIONS_REPO_PASSWORD_OVERRIDE_KEY to testPassword
+        )
+        assertThat(config.url, equalTo(urlOverride))
+        assertThat(config.credentials, notNullValue())
+        assertThat(config.credentials!!.username, equalTo(testUser))
+        assertThat(config.credentials.password, equalTo(testPassword))
+        assertThat(config.repoName, equalTo(SourceDistributionResolver.RELEASES_REPOSITORY_NAME))
+    }
+
+    class FixedGradlePropertiesProviderFactory(
+        private val gradleProperties: Map<String, String>
+    ) : DefaultProviderFactory() {
+        override fun gradleProperty(propertyName: Provider<String>): Provider<String> = gradleProperty(propertyName.get())
+
+        override fun gradleProperty(propertyName: String): Provider<String> = Providers.ofNullable(gradleProperties[propertyName])
+    }
+}

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/build_environment.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/build_environment.adoc
@@ -328,6 +328,24 @@ Note that this is equivalent to adding `-agentlib:jdwp=transport=dt_socket,serve
 +
 _Default is `false`._
 
+`org.gradle.distributionsRepository.password=(username)`::
+Sets the password to be used for the Gradle distributions repository. The credentials are only used if the distributions
+repository is overridden via `org.gradle.distributionsRepository.url
++
+_Default is no credentials._
+
+`org.gradle.distributionsRepository.url=(URL)`::
+Overrides the default Gradle distribution repository URL. This repository is used for example when
+the IDE wants to download the source distribution of Gradle.
++
+_Default is `https://services.gradle.org/distributions` or `https://services.gradle.org/distributions-snapshots` depending on the version of Gradle._
+
+`org.gradle.distributionsRepository.user=(username)`::
+Sets the user to be used for the Gradle distributions repository. The credentials are only used if the distributions
+repository is overridden via `org.gradle.distributionsRepository.url
++
+_Default is no credentials._
+
 `org.gradle.java.home=(path to JDK home)`::
 Specifies the Java home for the Gradle build process.
 The value can be set to either a `jdk` or `jre` location; however, using a JDK is safer depending on what your build does.


### PR DESCRIPTION
Fixes #18249. The distributions repository URL now can be overridden via the `org.gradle.distributionsRepository.url` Gradle property. Credentials can also be set for the overridden repository via the `org.gradle.distributionsRepository.user` and `org.gradle.distributionsRepository.password` properties.

Note: I didn't add integration tests for this though I have a working one locally. The reason I didn't push it with this PR is because mimicking <https://services.gradle.org> felt a little fragile. And with the unit tests added the integration test would just basically test if the credentials are set for the repository (which is not that much). Another reason while the integration test is brittle is because currently `SourceDistributionResolver` uses `project.gradle.gradleVersion` making the test do different things under the common scenario compared to a release build.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
