### PR TITLE
Deprecate mutating a dependency after adding it to a configuration

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractDependencyConstraint.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractDependencyConstraint.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.dependencies;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.internal.ImmutableActionSet;
+import org.gradle.internal.deprecation.DeprecationLogger;
 
 public abstract class AbstractDependencyConstraint implements DependencyConstraintInternal {
     private ImmutableActionSet<DependencyConstraint> onMutate = ImmutableActionSet.empty();
@@ -29,6 +30,15 @@ public abstract class AbstractDependencyConstraint implements DependencyConstrai
     }
 
     protected void validateMutation() {
+
+        if (!onMutate.isEmpty()) {
+            // Somebody is trying to mutate a constraint after it has been added to a configuration.
+            DeprecationLogger.deprecateAction("Mutating a dependency after declaration")
+                .willBecomeAnErrorInGradle9()
+                .undocumented()
+                .nagUser();
+        }
+
         onMutate.execute(this);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
@@ -34,6 +34,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.ImmutableActionSet;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.typeconversion.NotationParser;
 
 import javax.annotation.Nullable;
@@ -306,12 +307,20 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
         this.attributes = attributes;
     }
 
-    @SuppressWarnings("unchecked")
     public void addMutationValidator(Action<? super ModuleDependency> action) {
         this.onMutate = onMutate.add(action);
     }
 
     protected void validateMutation() {
+
+        if (!onMutate.isEmpty()) {
+            // Somebody is trying to mutate a dependency after it has been added to a configuration.
+            DeprecationLogger.deprecateAction("Mutating a dependency after declaration")
+                .willBecomeAnErrorInGradle9()
+                .undocumented()
+                .nagUser();
+        }
+
         onMutate.execute(this);
     }
 


### PR DESCRIPTION
Lets see how much this breaks. 

Deprecating this would allow us to get rid of a lot of housekeeping logic.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
