### PR TITLE
Fix failure in FlakyTestQuarantine

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
+++ b/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
@@ -64,7 +64,9 @@ class FlakyTestQuarantine(model: CIBuildModel, stage: Stage, os: Os, arch: Arch 
         steps {
             gradleWrapper {
                 name = "FLAKY_TEST_QUARANTINE_${testCoverage.testType.name.uppercase()}_${testCoverage.testJvmVersion.name.uppercase()}"
-                tasks = "${if (index == 0) "clean " else ""}${testCoverage.testType.name}Test"
+                val testTaskName =
+                    if (testCoverage.testType == TestType.isolatedProjects) "isolatedProjectsIntegTest" else "${testCoverage.testType.name}Test"
+                tasks = "${if (index == 0) "clean " else ""}$testTaskName"
                 gradleParams = parameters
                 executionMode = BuildStep.ExecutionMode.ALWAYS
             }


### PR DESCRIPTION
`isolatedProjectsTest` -> `isolatedProjectsIntegTest`

Otherwise it complains:

```
Task 'isolatedProjectsTest' not found in root project 'gradle' and its subprojects.
```