### PR TITLE
Enable flaky TaskCacheabilityReasonIntegrationTest

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/TaskCacheabilityReasonIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/TaskCacheabilityReasonIntegrationTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.api.tasks.OutputFiles
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
-import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.operations.execution.CachingDisabledReasonCategory
 import org.gradle.test.fixtures.Flaky
 import org.gradle.test.precondition.Requires
@@ -255,7 +254,6 @@ class TaskCacheabilityReasonIntegrationTest extends AbstractIntegrationSpec impl
         annotation << [OutputFiles.simpleName, OutputDirectories.simpleName]
     }
 
-    @ToBeFixedForIsolatedProjects(because = "Investigate")
     @Flaky(because = "https://github.com/gradle/gradle-private/issues/4206")
     def "cacheability for a task with overlapping outputs is OVERLAPPING_OUTPUTS"() {
         buildFile """


### PR DESCRIPTION
It's failing because "the expected result is failure": https://builds.gradle.org/buildConfiguration/Gradle_Release_Check_FlakyQuarantine_Linux_Amd64/84542059

Now let's just accept the passed status.