### PR TITLE
Align Scope javadocs with architecture build state model

### DIFF
--- a/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/scopes/GradleModuleServices.java
+++ b/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/scopes/GradleModuleServices.java
@@ -26,61 +26,33 @@ import org.gradle.internal.service.ServiceRegistrationProvider;
  */
 @ServiceScope(Scope.Global.class)
 public interface GradleModuleServices extends ServiceRegistrationProvider {
+
     /**
-     * Called once per process, to register any globally scoped services. These services are reused across builds in the same process.
-     * The services are closed when the process finishes.
-     *
-     * <p>Global services are visible to all other services.</p>
-     *
      * @see Scope.Global
      */
     void registerGlobalServices(ServiceRegistration registration);
 
     /**
-     * Called to register any services scoped to the Gradle user home directory. These services are reused across builds in the same process while the Gradle user home directory remains unchanged. The services are closed when the Gradle user home directory changes.
-     *
-     * <p>These services are "mostly global" as there is usually only a single Gradle user home directory used for a given process. Some processes, such as test processes, may run builds with different user home directories.</p>
-     *
-     * <p>Global services are visible to these shared services, but not vice versa.</p>
-     *
      * @see Scope.UserHome
      */
     void registerGradleUserHomeServices(ServiceRegistration registration);
 
     /**
-     * Called once per "main" build session to register any cross build session scoped services.  These services are reused across build invocations when in
-     * continuous mode. They are closed at the end of the build session.
-     *
-     * <p>Global and shared services are visible to build session scope services, but not vice versa</p>
-     *
      * @see Scope.CrossBuildSession
      */
     void registerCrossBuildSessionServices(ServiceRegistration registration);
 
     /**
-     * Called once per build session to register any build session scoped services.  These services are reused across build invocations when in
-     * continuous mode. They are closed at the end of the build session.
-     *
-     * <p>Global and shared services are visible to build session scope services, but not vice versa</p>
-     *
      * @see Scope.BuildSession
      */
     void registerBuildSessionServices(ServiceRegistration registration);
 
     /**
-     * Called once per build invocation on a build tree to register any build tree scoped services to use during that build invocation.  These services are recreated when in continuous mode and shared across all nested builds. They are closed when the build invocation is completed.
-     *
-     * <p>Global, user home and build session services are visible to build tree scope services, but not vice versa.</p>
-     *
      * @see Scope.BuildTree
      */
     void registerBuildTreeServices(ServiceRegistration registration);
 
     /**
-     * Called once per build invocation on a build, to register any build scoped services to use during that build invocation. These services are closed at the end of the build invocation.
-     *
-     * <p>Global, user home, build session and build tree services are visible to the build scope services, but not vice versa.</p>
-     *
      * @see Scope.Build
      */
     void registerBuildServices(ServiceRegistration registration);
@@ -93,10 +65,6 @@ public interface GradleModuleServices extends ServiceRegistrationProvider {
     void registerSettingsServices(ServiceRegistration registration);
 
     /**
-     * Called once per project per build invocation, to register any project scoped services. These services are closed at the end of the build invocation.
-     *
-     * <p>Global, user home, build session, build tree, build and gradle scoped services are visible to the project scope services, but not vice versa.</p>
-     *
      * @see Scope.Project
      */
     void registerProjectServices(ServiceRegistration registration);

--- a/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/scopes/GradleModuleServices.java
+++ b/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/scopes/GradleModuleServices.java
@@ -21,38 +21,58 @@ import org.gradle.internal.service.ServiceRegistrationProvider;
 
 /**
  * Can be implemented by Gradle modules to provide services in various scopes.
+ * <p>
+ * Implementations are discovered using the JAR service locator mechanism (see {@link org.gradle.internal.service.ServiceLocator}).
  *
- * <p>Implementations are discovered using the JAR service locator mechanism (see {@link org.gradle.internal.service.ServiceLocator}).
+ * @see Scope
  */
 @ServiceScope(Scope.Global.class)
 public interface GradleModuleServices extends ServiceRegistrationProvider {
 
     /**
+     * Called to register services in the {@link Scope.Global Global} scope.
+     *
+     * @see Scope
      * @see Scope.Global
      */
     void registerGlobalServices(ServiceRegistration registration);
 
     /**
+     * Called to register services in the {@link Scope.UserHome UserHome} scope.
+     *
+     * @see Scope
      * @see Scope.UserHome
      */
     void registerGradleUserHomeServices(ServiceRegistration registration);
 
     /**
+     * Called to register services in the {@link Scope.CrossBuildSession CrossBuildSession} scope.
+     *
+     * @see Scope
      * @see Scope.CrossBuildSession
      */
     void registerCrossBuildSessionServices(ServiceRegistration registration);
 
     /**
+     * Called to register services in the {@link Scope.BuildSession BuildSession} scope.
+     *
+     * @see Scope
      * @see Scope.BuildSession
      */
     void registerBuildSessionServices(ServiceRegistration registration);
 
     /**
+     * Called to register services in the {@link Scope.BuildTree BuildTree} scope.
+     *
+     * @see Scope
      * @see Scope.BuildTree
      */
     void registerBuildTreeServices(ServiceRegistration registration);
 
     /**
+     * Called to register services in the {@link Scope.Build Build} scope.
+     *
+     * @see Scope
      * @see Scope.Build
      */
     void registerBuildServices(ServiceRegistration registration);
@@ -65,6 +85,9 @@ public interface GradleModuleServices extends ServiceRegistrationProvider {
     void registerSettingsServices(ServiceRegistration registration);
 
     /**
+     * Called to register services in the {@link Scope.Project Project} scope.
+     *
+     * @see Scope
      * @see Scope.Project
      */
     void registerProjectServices(ServiceRegistration registration);

--- a/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/service/scopes/Scope.java
+++ b/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/service/scopes/Scope.java
@@ -28,6 +28,22 @@ package org.gradle.internal.service.scopes;
  * over a given <em>user build</em> to do some work.
  * It can be a command-line invocation or a Tooling API client request (e.g. an IDE sync).
  *
+ * <pre>
+ *            Global
+ *     ┌────────┴─────────┐
+ *  UserHome      CrossBuildSession
+ *     └────────┬─────────┘
+ *         BuildSession
+ *              │
+ *          BuildTree
+ *              │
+ *            Build
+ *              │
+ *            Gradle
+ *              │
+ *           Project
+ * </pre>
+ *
  * @see ServiceScope
  */
 public interface Scope {

--- a/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/service/scopes/Scope.java
+++ b/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/service/scopes/Scope.java
@@ -100,10 +100,8 @@ public interface Scope {
      * The scope of a Gradle invocation with a specific Gradle user home directory.
      * <p>
      * When the user-home directory changes between subsequent Gradle invocations in the same <em>build process</em>,
-     * this state is discarded and recreated. Otherwise, the state is reused between invocations.
-     * <p>
-     * A regular Gradle invocation deals with a single user home directory,
-     * but the daemon can be potentially reused for invocations with other directories as well.
+     * the state of this scope is discarded and recreated.
+     * Otherwise, the state is reused between invocations.
      * <p>
      * The related state is created per Gradle invocation.
      * <p>
@@ -114,13 +112,14 @@ public interface Scope {
     /**
      * The scope of the state shared across {@link BuildSession build sessions}.
      * <p>
-     * A regular Gradle invocation requires only one build session.
+     * A regular Gradle invocation requires only one "main" build session.
      * However, when the {@code GradleBuild} task is involved, it can create "nested" build sessions.
-     * Having the {@code GradleBuild} task reuse the outer session is complicated because
+     * Having the {@code GradleBuild} task reuse the "main" build session is complicated because
      * it <a href="https://github.com/gradle/gradle/issues/4559">can use a different Gradle user home</a>.
      * <p>
      * The cross build session state is managed by the {@code CrossBuildSessionState} class.
      * An instance is created per Gradle invocation.
+     * Unlike the {@code UserHome} or {@code Global} state, this state is discarded at the end of each invocation.
      *
      * <p>{@link Global} services are visible to {@link CrossBuildSession} services and descendant scopes, but not vice versa.
      */

--- a/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/service/scopes/Scope.java
+++ b/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/service/scopes/Scope.java
@@ -17,75 +17,131 @@
 package org.gradle.internal.service.scopes;
 
 /**
+ * Scopes represent the state, services and lifetime of each activity performed by Gradle as part of
+ * executing a <em>Gradle invocation</em> against a <em>user build</em>.
+ * <p>
+ * <b>User build</b> is a collection of files on disk that constitutes the user's software project,
+ * building of which is orchestrated by Gradle.
+ * It can be a Java library, a backend microservice, or an enterprise monorepo.
+ * <p>
+ * <b>Gradle invocation</b> is a direct or indirect request of the user to invoke Gradle
+ * over a given <em>user build</em> to do some work.
+ * It can be a command-line invocation or a Tooling API client request (e.g. an IDE sync).
+ *
  * @see ServiceScope
  */
 public interface Scope {
 
     /**
-     * These services are reused across builds in the same process.
-     *
-     * <p>Global services are visible to all other services.</p>
+     * Scope of the entire <em>build process</em>, e.g. a long-lived Gradle daemon.
+     * <p>
+     * The build process can potentially serve multiple Gradle invocations.
+     * The <em>build process state</em> holds the global state of the build process and manages all the other state.
+     * <p>
+     * The build process state is managed by the {@code BuildProcessState} class.
+     * An instance is created once for a given process.
+     * <p>
+     * Global services are visible to all other services.
      */
     interface Global extends Scope {}
 
     /**
-     * These services are reused across builds in the same process while the Gradle user home directory remains unchanged.
-     * The services are closed when the Gradle user home directory changes.
-     *
-     * <p>{@link Global} and parent scope services are visible to {@link UserHome} scope services, but not vice versa.</p>
+     * The scope of a Gradle invocation particular Gradle user home directory.
+     * <p>
+     * When that directory changes between Gradle invocations, the state is discarded and recreated.
+     * Otherwise, the state is reused between invocations.
+     * <p>
+     * A regular Gradle invocation deals with a single user home directory,
+     * but the daemon can be potentially reused for invocations with other directories as well.
+     * <p>
+     * The related state is created per Gradle invocation.
+     * <p>
+     * {@link Global} services are visible to {@link UserHome} services and descendant scopes, but not vice versa.
      */
     interface UserHome extends Global {}
 
     /**
-     * These services are reused across build sessions.
+     * The scope of the state shared across {@link BuildSession build sessions}.
      * <p>
-     * Generally, one regular Gradle invocation is conceptually a session.
-     * However, the GradleBuild task is currently implemented in such a way that it uses a discrete session.
-     * Having the GradleBuild task reuse the outer session is complicated because it <a href="https://github.com/gradle/gradle/issues/4559">may use a different Gradle user home</a>.
+     * A regular Gradle invocation requires only one build session.
+     * However, when the {@code GradleBuild} task is involved, it can create "nested" build sessions.
+     * Having the {@code GradleBuild} task reuse the outer session is complicated because
+     * it <a href="https://github.com/gradle/gradle/issues/4559">can use a different Gradle user home</a>.
+     * <p>
+     * The cross build session state is managed by the {@code CrossBuildSessionState} class.
+     * An instance is created per Gradle invocation.
      *
-     * <p>{@link Global} and parent scope services are visible to {@link CrossBuildSession} scope services, but not vice versa.</p>
+     * <p>{@link Global} services are visible to {@link CrossBuildSession} services and descendant scopes, but not vice versa.
      */
     interface CrossBuildSession extends Global {}
 
     /**
-     * These services are reused across build invocations in a session.
-     *
-     * A build session can be long-lived in a continuous build (where these services would be reused) or short-lived in a
-     * regular, single build.
-     *
-     * <p>{@link UserHome}, {@link CrossBuildSession} and parent scope services are visible to {@link BuildSession} scope services, but not vice versa.</p>
+     * The scope of a build session.
+     * <p>
+     * A <em>build session</em> represents a single invocation of Gradle, for example when you run {@code gradlew build}.
+     * A session runs the build one or more times.
+     * For example, when continuous build is enabled, the session may run the build many times,
+     * but when it is disabled, the session will run the build only once.
+     * <p>
+     * The build session state is managed by the {@code BuildSessionState} class.
+     * An instance is created at the start of a Gradle invocation and discarded at the end of that invocation.
+     * <p>
+     * {@link UserHome}, {@link CrossBuildSession} and their parent services are visible to
+     * {@link BuildSession} services and descendant scopes, but not vice versa.
      */
     interface BuildSession extends UserHome, CrossBuildSession {}
 
     /**
-     * These services are recreated when in continuous build and shared across all nested builds.
-     * They are closed when the build invocation is completed.
-     *
-     * <p>{@link BuildSession} and parent scope services are visible to {@link BuildTree} scope services, but not vice versa.</p>
+     * The scope of a single <em>build execution</em> within a {@link BuildSession build session}.
+     * <p>
+     * <em>Build tree</em> is another name for the build definition ({@code BuildDefinition}),
+     * which corresponds to composite build.
+     * <p>
+     * The <em>build tree state</em> holds the state for the entire build definition for a single build execution within a session.
+     * The build tree state is managed by the {@code BuildTreeState} class.
+     * An instance is created at the start of a build execution and discarded at the end of that execution.
+     * <p>
+     * {@link BuildSession} and its parent services are visible to {@link BuildTree} services and descendant scopes, but not vice versa.
      */
     interface BuildTree extends BuildSession {}
 
     /**
-     * These services are created once per {@code org.gradle.api.initialization.Settings} the beginning of the build invocation
-     * These services are closed at the end of the build invocation.
-     *
-     * <p>{@link BuildTree} and parent scope services are visible to {@link Build} scope services, but not vice versa.</p>
+     * The scope of a single <em>build</em> within a {@link BuildTree build tree}.
+     * <p>
+     * The <em>build state</em> holds the state for a <em>build</em> within the <em>build definition</em> for a single <em>build execution</em>,
+     * and is contained by the <em>build tree state</em>.
+     * <p>
+     * The build state is managed by the {@code BuildState} class.
+     * An instance is created for each build in the build definition, once per build execution and is discarded at the end of that execution.
+     * <p>
+     * There is one-to-one correspondence between a <em>build</em> and its {@code Settings}.
+     * However, the build state also contains the state exposed to init scripts,
+     * evaluation of which happens prior to the evaluation of settings.
+     * <p>
+     * {@link BuildTree} and parent services are visible to {@link Build} services and descendant scopes, but not vice versa.
      */
     interface Build extends BuildTree {}
 
     /**
-     * These services are created once per {@code org.gradle.api.invocation.Gradle} at the beginning of the build invocation.
-     * These services are closed at the end of the build invocation.
-     *
-     * <p>{@link Build} and parent scope services are visible to {@link Gradle} scope services, but not vice versa.</p>
+     * The scope of the {@code org.gradle.api.invocation.Gradle} instance state.
+     * <p>
+     * The <em>Gradle state</em> is being merged into the {@link Build build state} and is mostly empty.
+     * <p>
+     * {@link Build} and parent services are visible to {@link Gradle} services and descendant scopes, but not vice versa.
      */
     interface Gradle extends Build {}
 
     /**
-     * These services are created once per project per build invocation.
-     * These services are closed at the end of the build invocation.
-     *
-     * <p>{@link Gradle} and parent scope services are visible to {@link Project} scope services, but not vice versa.</p>
+     * The scope of a single project within a {@link Build build}.
+     * <p>
+     * The <em>project state</em> holds the state for a project for a single build execution,
+     * and is contained by the build state (and not the state of the parent project).
+     * <p>
+     * The project state is managed by the {@code ProjectState} class.
+     * It is created for each project in the build definition,
+     * once per build execution and is discarded at the end of the execution.
+     * <p>
+     * {@link Gradle} and parent scope services are visible to {@link Project} scope services, but not vice versa.
      */
     interface Project extends Gradle {}
 }


### PR DESCRIPTION
Updates the javadoc for `Scope` class and all its descendants, aligning it with the "[build state model](https://github.com/gradle/gradle/blob/900b8ca52663d2b9af26995dce5f2bda71f461fa/architecture/build-state-model.md)" described in the architecture docs.