### PR TITLE
Introduce lazy injection of internal services

### DIFF
--- a/platforms/core-configuration/configuration-cache/build.gradle.kts
+++ b/platforms/core-configuration/configuration-cache/build.gradle.kts
@@ -14,7 +14,6 @@ tasks.configCacheIntegTest {
 dependencies {
     api(projects.baseServices)
     api(projects.buildOption)
-    api(projects.concurrent)
     api(projects.configurationCacheBase)
     api(projects.configurationProblemsBase)
     api(projects.core)
@@ -38,6 +37,7 @@ dependencies {
     // TODO - it might be good to allow projects to contribute state to save and restore, rather than have this project know about everything
     implementation(projects.buildEvents)
     implementation(projects.buildOperations)
+    implementation(projects.concurrent)
     implementation(projects.coreKotlinExtensions)
     implementation(projects.coreSerializationCodecs)
     implementation(projects.dependencyManagementSerializationCodecs)

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEncryptionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEncryptionIntegrationTest.groovy
@@ -208,7 +208,7 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
         fails(*(["help", "--configuration-cache"] + encryptionOptions))
 
         then:
-        failureDescriptionStartsWith "Could not open Gradle Configuration Cache keystore (${keyStoreDir}"
+        failureCauseContains "Could not open Gradle Configuration Cache keystore (${keyStoreDir}"
 
         cleanup:
         fs.chmod(keyStoreDir, 0666)
@@ -269,7 +269,7 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
 
         then:
         // since the key is not fully validated until needed, we only get an error when encrypting
-        failure.assertHasDescription("Error loading encryption key from GRADLE_ENCRYPTION_KEY environment variable")
+        failure.assertHasCause("Error loading encryption key from GRADLE_ENCRYPTION_KEY environment variable")
         failure.assertHasCause("Illegal base64 character ${Integer.toHexString((int) invalidBase64Char)}")
     }
 
@@ -281,7 +281,7 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
         runWithEncryption(EncryptionKind.ENV_VAR, ["help"], [], [(GRADLE_ENCRYPTION_KEY_ENV_KEY): insufficientlyLongEncryptionKey], this::configurationCacheFails)
 
         then:
-        failure.assertHasDescription("Error loading encryption key from GRADLE_ENCRYPTION_KEY environment variable")
+        failure.assertHasCause("Error loading encryption key from GRADLE_ENCRYPTION_KEY environment variable")
         failure.assertHasCause("Encryption key length is 8 bytes, but must be at least 16 bytes long")
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeIO.kt
@@ -24,10 +24,13 @@ import org.gradle.internal.cc.impl.cacheentry.ModelKey
 import org.gradle.internal.cc.impl.serialize.Codecs
 import org.gradle.internal.serialize.graph.CloseableWriteContext
 import org.gradle.internal.serialize.graph.MutableReadContext
+import org.gradle.internal.service.scopes.Scope
+import org.gradle.internal.service.scopes.ServiceScope
 import org.gradle.util.Path
 import java.io.InputStream
 import java.io.OutputStream
 
+@ServiceScope(Scope.BuildTree::class)
 internal
 interface ConfigurationCacheBuildTreeIO : ConfigurationCacheOperationIO {
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheStateStore.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheStateStore.kt
@@ -17,9 +17,12 @@
 package org.gradle.internal.cc.impl
 
 import org.gradle.cache.internal.streams.ValueStore
+import org.gradle.internal.service.scopes.Scope
+import org.gradle.internal.service.scopes.ServiceScope
 import java.io.File
 
 
+@ServiceScope(Scope.BuildTree::class)
 internal
 interface ConfigurationCacheStateStore {
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -55,6 +55,7 @@ import org.gradle.internal.serialize.graph.IsolateOwner
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.withIsolate
 import org.gradle.internal.service.LazyService
+import org.gradle.internal.service.extensions.getValue
 import org.gradle.internal.vfs.FileSystemAccess
 import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem
 import org.gradle.tooling.provider.model.internal.ToolingModelParameterCarrier
@@ -99,7 +100,7 @@ class DefaultConfigurationCache internal constructor(
     var cacheEntryRequiresCommit = false
 
     private
-    val host by lazy { host.instance }
+    val host by host
 
     private
     val isolateOwnerHost: IsolateOwner by lazy { IsolateOwners.OwnerHost(this.host) }
@@ -108,19 +109,19 @@ class DefaultConfigurationCache internal constructor(
     val loadedSideEffects = mutableListOf<BuildTreeModelSideEffect>()
 
     private
-    val store by lazy { store.instance }
+    val store by store
 
     private
-    val cacheIO by lazy { cacheIO.instance }
+    val cacheIO by cacheIO
 
     private
-    val buildTreeModelSideEffects by lazy { buildTreeModelSideEffects.instance }
+    val buildTreeModelSideEffects by buildTreeModelSideEffects
 
     private
-    val intermediateModels by lazy { intermediateModels.instance }
+    val intermediateModels by intermediateModels
 
     private
-    val projectMetadata by lazy { projectMetadata.instance }
+    val projectMetadata by projectMetadata
 
     private
     val gradlePropertiesController: GradlePropertiesController

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -47,6 +47,7 @@ import org.gradle.internal.cc.impl.services.DeferredRootBuildGradle
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveState
 import org.gradle.internal.configuration.inputs.InstrumentedInputs
 import org.gradle.internal.configuration.problems.StructuredMessage
+import org.gradle.internal.extensions.service.getValue
 import org.gradle.internal.extensions.stdlib.toDefaultLowerCase
 import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.operations.BuildOperationRunner
@@ -55,7 +56,6 @@ import org.gradle.internal.serialize.graph.IsolateOwner
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.withIsolate
 import org.gradle.internal.service.LazyService
-import org.gradle.internal.service.extensions.getValue
 import org.gradle.internal.vfs.FileSystemAccess
 import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem
 import org.gradle.tooling.provider.model.internal.ToolingModelParameterCarrier

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/services/ConfigurationCacheBuildTreeModelSideEffectExecutor.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/services/ConfigurationCacheBuildTreeModelSideEffectExecutor.kt
@@ -16,15 +16,18 @@
 
 package org.gradle.internal.cc.impl.services
 
-import org.gradle.internal.cc.impl.models.BuildTreeModelSideEffectStore
 import org.gradle.internal.buildtree.BuildTreeModelSideEffect
 import org.gradle.internal.buildtree.BuildTreeModelSideEffectExecutor
+import org.gradle.internal.cc.impl.models.BuildTreeModelSideEffectStore
+import org.gradle.internal.service.LazyService
 
 
 internal
-class ConfigurationCacheBuildTreeModelSideEffectExecutor : BuildTreeModelSideEffectExecutor {
+class ConfigurationCacheBuildTreeModelSideEffectExecutor(
+    sideEffectStore: LazyService<BuildTreeModelSideEffectStore>
+) : BuildTreeModelSideEffectExecutor {
 
-    lateinit var sideEffectStore: BuildTreeModelSideEffectStore
+    private val sideEffectStore by lazy { sideEffectStore.instance }
 
     override fun runIsolatableSideEffect(sideEffect: BuildTreeModelSideEffect) {
         sideEffect.runSideEffect()

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/services/ConfigurationCacheBuildTreeModelSideEffectExecutor.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/services/ConfigurationCacheBuildTreeModelSideEffectExecutor.kt
@@ -19,8 +19,8 @@ package org.gradle.internal.cc.impl.services
 import org.gradle.internal.buildtree.BuildTreeModelSideEffect
 import org.gradle.internal.buildtree.BuildTreeModelSideEffectExecutor
 import org.gradle.internal.cc.impl.models.BuildTreeModelSideEffectStore
+import org.gradle.internal.extensions.service.getValue
 import org.gradle.internal.service.LazyService
-import org.gradle.internal.service.extensions.getValue
 
 
 internal

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/services/ConfigurationCacheBuildTreeModelSideEffectExecutor.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/services/ConfigurationCacheBuildTreeModelSideEffectExecutor.kt
@@ -20,6 +20,7 @@ import org.gradle.internal.buildtree.BuildTreeModelSideEffect
 import org.gradle.internal.buildtree.BuildTreeModelSideEffectExecutor
 import org.gradle.internal.cc.impl.models.BuildTreeModelSideEffectStore
 import org.gradle.internal.service.LazyService
+import org.gradle.internal.service.extensions.getValue
 
 
 internal
@@ -27,7 +28,7 @@ class ConfigurationCacheBuildTreeModelSideEffectExecutor(
     sideEffectStore: LazyService<BuildTreeModelSideEffectStore>
 ) : BuildTreeModelSideEffectExecutor {
 
-    private val sideEffectStore by lazy { sideEffectStore.instance }
+    private val sideEffectStore by sideEffectStore
 
     override fun runIsolatableSideEffect(sideEffect: BuildTreeModelSideEffect) {
         sideEffect.runSideEffect()

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/extensions/service/lazyService.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/extensions/service/lazyService.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.service.extensions
+package org.gradle.internal.extensions.service
 
 import org.gradle.internal.service.LazyService
 import kotlin.reflect.KProperty

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/extensions/service/lazyService.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/extensions/service/lazyService.kt
@@ -32,5 +32,6 @@ import kotlin.reflect.KProperty
  * @see LazyService
  * @see org.gradle.internal.service.ServiceRegistrationProvider
  */
+internal
 operator fun <T : Any> LazyService<T>.getValue(thisRef: Any?, property: KProperty<*>): T =
     instance

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/service/extensions/lazyService.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/service/extensions/lazyService.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service.extensions
+
+import org.gradle.internal.service.LazyService
+import kotlin.reflect.KProperty
+
+
+/**
+ * Allows using instances of [LazyService] as delegated properties.
+ *
+ * ```kotlin
+ * class SomeService(myService: LazyService<MyService>) {
+ *     private val myService: MyService by myService
+ * }
+ * ```
+ *
+ * @see LazyService
+ * @see org.gradle.internal.service.ServiceRegistrationProvider
+ */
+operator fun <T : Any> LazyService<T>.getValue(thisRef: Any?, property: KProperty<*>): T =
+    instance

--- a/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/DefaultEncryptionService.kt
+++ b/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/DefaultEncryptionService.kt
@@ -19,6 +19,7 @@ package org.gradle.internal.encryption.impl
 import org.gradle.api.InvalidUserDataException
 import org.gradle.cache.scopes.GlobalScopedCacheBuilderFactory
 import org.gradle.internal.buildoption.InternalOptions
+import org.gradle.internal.exceptions.encryption.EncryptionException
 import org.gradle.internal.encryption.EncryptionService
 import org.gradle.internal.extensions.core.getInternalFlag
 import org.gradle.internal.extensions.core.getInternalString

--- a/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/DefaultEncryptionService.kt
+++ b/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/DefaultEncryptionService.kt
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.encryption.impl
 
-import org.gradle.api.GradleException
 import org.gradle.api.InvalidUserDataException
 import org.gradle.cache.scopes.GlobalScopedCacheBuilderFactory
 import org.gradle.internal.buildoption.InternalOptions
@@ -65,7 +64,7 @@ class DefaultEncryptionService(
                     assertKeyLength(key)
                 }
             } catch (e: Exception) {
-                throw GradleException("Error loading encryption key from ${keySource.sourceDescription}", e)
+                throw EncryptionException("Error loading encryption key from ${keySource.sourceDescription}", e)
             }
         }
 

--- a/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/EncryptionException.kt
+++ b/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/EncryptionException.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.encryption.impl
+
+import org.gradle.api.GradleException
+import org.gradle.internal.exceptions.Contextual
+
+/**
+ * This exception can be thrown when an error occurs during the setup or execution of encryption work.
+ */
+@Contextual
+internal
+class EncryptionException(message: String, cause: Throwable? = null) : GradleException(message, cause)

--- a/platforms/core-runtime/service-lookup/src/main/java/org/gradle/internal/service/LazyService.java
+++ b/platforms/core-runtime/service-lookup/src/main/java/org/gradle/internal/service/LazyService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,18 +17,21 @@
 package org.gradle.internal.service;
 
 /**
- * Wraps a single service instance. Implementations must be thread safe.
+ * A lazy service can be consumed as a dependency
+ * to avoid instantiation at the injection time.
  */
-interface Service {
-
-    String getDisplayName();
+public interface LazyService<T> {
 
     /**
-     * Returns the instance of the underlying service.
+     * Returns the instance of the service.
+     * <p>
+     * The service will be created lazily on the first invocation.
+     * All subsequent calls will return the same instance of the service.
+     * <p>
+     * Calling this method is <em>thread-safe</em>.
+     *
+     * @return service instance
      */
-    Object get();
+    T getInstance();
 
-    <T> LazyService<T> asLazyService();
-
-    void requiredBy(ServiceProvider serviceProvider);
 }

--- a/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/ServiceRegistrationProvider.java
+++ b/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/ServiceRegistrationProvider.java
@@ -73,6 +73,7 @@ package org.gradle.internal.service;
  *     SomeService someService,
  *     MyService myServiceFromParent,
  *     List&lt;OtherService&gt; otherServices,
+ *     LazyService&lt;ExpensiveService&gt; lazyService,
  *     ServiceRegistry ownerServiceRegistry
  * ) { ... }</code></pre>
  * <p>
@@ -97,6 +98,12 @@ package org.gradle.internal.service;
  * from the current and all parent registries.
  * If there are no services of this type, the list will be <em>empty</em>.
  * See <code>List&lt;OtherService&gt; otherServices</code> in the example.
+ * <p>
+ *
+ * <b>Lazy dependency.</b>
+ * When the parameter is of type {@link LazyService LazyService&lt;T&gt;},
+ * it will receive a lazily instantiated dependency.
+ * See <code>LazyService&lt;ExpensiveService&gt; lazyService</code> in the example.
  * <p>
  *
  * <b>Owner dependency.</b>

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/LazyServiceWrapper.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/LazyServiceWrapper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service;
+
+class LazyServiceWrapper implements Service {
+
+    private final Service delegate;
+
+    public LazyServiceWrapper(Service delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "LazyService(" + delegate.getDisplayName() + ")";
+    }
+
+    @Override
+    public Object get() {
+        return asLazyService();
+    }
+
+    @Override
+    public <T> LazyService<T> asLazyService() {
+        return delegate.asLazyService();
+    }
+
+    @Override
+    public void requiredBy(ServiceProvider serviceProvider) {
+        delegate.requiredBy(serviceProvider);
+    }
+
+    @Override
+    public String toString() {
+        return getDisplayName();
+    }
+}

--- a/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryLazyServiceTest.groovy
+++ b/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryLazyServiceTest.groovy
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service
+
+import spock.lang.Specification
+
+class DefaultServiceRegistryLazyServiceTest extends Specification {
+
+    TestRegistry registry = new TestRegistry()
+
+    def "lazy dependencies are not created until requested"() {
+        given:
+        def lazyServiceImpl = new TestServiceImpl()
+        lazyServiceImpl.value = 10
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            TestService create() {
+                lazyServiceImpl.value = 20
+                lazyServiceImpl
+            }
+
+            @Provides
+            ServiceWithLazyDependency create(LazyService<TestService> ts) { new ServiceWithLazyDependency(ts) }
+        })
+
+        when:
+        def serviceWithDependency = registry.get(ServiceWithLazyDependency)
+        then:
+        serviceWithDependency.lazyService != null
+        lazyServiceImpl.value == 10
+
+        when:
+        def actualLazyService = serviceWithDependency.lazyService.instance
+        then:
+        actualLazyService === lazyServiceImpl
+        lazyServiceImpl.value == 20
+    }
+
+    def "lazy dependencies can be injected into constructors"() {
+        given:
+        def lazyServiceImpl = new TestServiceImpl()
+        lazyServiceImpl.value = 10
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @SuppressWarnings('unused')
+            void configure(ServiceRegistration registration) {
+                registration.add(ServiceWithLazyDependency)
+            }
+
+            @Provides
+            TestService create() {
+                lazyServiceImpl.value = 20
+                lazyServiceImpl
+            }
+        })
+
+        when:
+        def serviceWithDependency = registry.get(ServiceWithLazyDependency)
+        then:
+        serviceWithDependency.lazyService != null
+        lazyServiceImpl.value == 10
+
+        when:
+        def actualLazyService = serviceWithDependency.lazyService.instance
+        then:
+        actualLazyService === lazyServiceImpl
+        lazyServiceImpl.value == 20
+    }
+
+    def "lazy services are reused"() {
+        given:
+        def lazyServiceImpl = new TestServiceImpl()
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            TestService create() {
+                lazyServiceImpl
+            }
+
+            @Provides
+            ServiceWithLazyDependency create1(LazyService<TestService> ts) { new ServiceWithLazyDependency(ts) }
+
+            @Provides
+            ServiceWithLazyDependency create2(LazyService<TestService> ts) { new ServiceWithLazyDependency(ts) }
+        })
+
+        when:
+        def services = registry.getAll(ServiceWithLazyDependency)
+        then:
+        services.size() == 2
+        services[0].lazyService.instance === lazyServiceImpl
+        services[1].lazyService.instance === lazyServiceImpl
+    }
+
+    def "lazy service is unavailable when underlying service is unavailable"() {
+        given:
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            ServiceWithLazyDependency create(LazyService<TestService> ts) { unreachable() }
+        })
+
+        when:
+        registry.get(ServiceWithLazyDependency)
+        then:
+        def e = thrown(ServiceCreationException)
+        withoutTestClassName(e.message) ==
+            "Cannot create service of type ServiceWithLazyDependency using method <anonymous>.create() as required service of type LazyService<TestService> for parameter #1 is not available."
+    }
+
+    def "lazy service cannot be a return type of a provider method"() {
+        when:
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            LazyService<TestService> create() { unreachable() }
+        })
+
+        then:
+        true
+        def e = thrown(ServiceValidationException)
+        withoutTestClassName(e.message) ==
+            "Cannot register service of type LazyService<TestService>, use the actual service type instead"
+    }
+
+    def "aggregation of lazy services is not supported"() {
+        given:
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            ServiceWithLazyDependency create(List<LazyService<TestService>> services) { unreachable() }
+        })
+
+        when:
+        registry.get(ServiceWithLazyDependency)
+        then:
+        def e = thrown(ServiceCreationException)
+        withoutTestClassName(e.message) ==
+            "Cannot create service of type ServiceWithLazyDependency using method <anonymous>.create() as there is a problem with parameter #1 of type List<LazyService<TestService>>."
+
+        def cause = e.cause as ServiceValidationException
+        withoutTestClassName(cause.message) ==
+            "Locating services with type LazyService<TestService> is not supported."
+    }
+
+    def "lazy services aggregation is not supported"() {
+        given:
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            ServiceWithLazyDependency create(LazyService<List<TestService>> services) { unreachable() }
+        })
+
+        when:
+        registry.get(ServiceWithLazyDependency)
+        then:
+        def e = thrown(ServiceCreationException)
+        withoutTestClassName(e.message) ==
+            "Cannot create service of type ServiceWithLazyDependency using method <anonymous>.create() as there is a problem with parameter #1 of type LazyService<List<TestService>>."
+
+        def cause = e.cause as ServiceValidationException
+        withoutTestClassName(cause.message) ==
+            "Locating services with type List<TestService> is not supported."
+    }
+
+    private interface TestService {
+    }
+
+    private static class TestServiceImpl implements TestService {
+        int value = 0
+    }
+
+    private static class ServiceWithLazyDependency {
+        LazyService<TestService> lazyService
+
+        ServiceWithLazyDependency(LazyService<TestService> lazyService) {
+            this.lazyService = lazyService
+        }
+    }
+
+    private static class TestRegistry extends DefaultServiceRegistry {
+        TestRegistry() {
+        }
+
+        TestRegistry(ServiceRegistry parent) {
+            super(parent)
+        }
+    }
+
+    private String withoutTestClassName(String s) {
+        s.replaceAll(this.class.simpleName + "\\\$", "")
+    }
+
+    private static <T> T unreachable() {
+        throw new IllegalStateException("unreachable")
+    }
+}

--- a/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryLazyServiceTest.groovy
+++ b/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryLazyServiceTest.groovy
@@ -171,6 +171,19 @@ class DefaultServiceRegistryLazyServiceTest extends Specification {
             "Locating services with type List<TestService> is not supported."
     }
 
+    def "lazy service decoration is not supported"() {
+        when:
+        registry.addProvider(new ServiceRegistrationProvider() {
+            @Provides
+            TestService create(LazyService<TestService> service) { unreachable() }
+        })
+
+        then:
+        def e = thrown(ServiceValidationException)
+        withoutTestClassName(e.message) ==
+            "Method <anonymous>.create() cannot decorate a lazy service"
+    }
+
     private interface TestService {
     }
 
@@ -188,10 +201,6 @@ class DefaultServiceRegistryLazyServiceTest extends Specification {
 
     private static class TestRegistry extends DefaultServiceRegistry {
         TestRegistry() {
-        }
-
-        TestRegistry(ServiceRegistry parent) {
-            super(parent)
         }
     }
 

--- a/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryLazyServiceTest.groovy
+++ b/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryLazyServiceTest.groovy
@@ -174,7 +174,7 @@ class DefaultServiceRegistryLazyServiceTest extends Specification {
             "Locating services with type LazyService<TestService> is not supported."
     }
 
-    def "lazy services aggregation is not supported"() {
+    def "aggregation wrapped with lazy is not supported"() {
         given:
         registry.addProvider(new ServiceRegistrationProvider() {
             @Provides

--- a/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
+++ b/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
@@ -1672,6 +1672,11 @@ class DefaultServiceRegistryTest extends Specification {
         }
 
         @Override
+        <T> LazyService<T> asLazyService() {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
         void requiredBy(ServiceProvider serviceProvider) {
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/exceptions/encryption/EncryptionException.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/exceptions/encryption/EncryptionException.java
@@ -14,14 +14,20 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.encryption.impl
+package org.gradle.internal.exceptions.encryption;
 
-import org.gradle.api.GradleException
-import org.gradle.internal.exceptions.Contextual
+import org.gradle.api.GradleException;
+import org.gradle.internal.exceptions.Contextual;
+
+import javax.annotation.Nullable;
 
 /**
  * This exception can be thrown when an error occurs during the setup or execution of encryption work.
  */
 @Contextual
-internal
-class EncryptionException(message: String, cause: Throwable? = null) : GradleException(message, cause)
+public class EncryptionException extends GradleException {
+
+    public EncryptionException(String message, @Nullable Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/exceptions/encryption/package-info.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/exceptions/encryption/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@org.gradle.api.NonNullApi
+package org.gradle.internal.exceptions.encryption;

--- a/testing/architecture-test/src/test/java/org/gradle/architecture/test/ArchUnitFixture.java
+++ b/testing/architecture-test/src/test/java/org/gradle/architecture/test/ArchUnitFixture.java
@@ -80,6 +80,7 @@ public interface ArchUnitFixture {
         "org.gradle.internal.encryption..",
         "org.gradle.internal.extensions.core..",
         "org.gradle.internal.extensions.stdlib..",
+        "org.gradle.internal.extensions.service..",
         "org.gradle.internal.flow.services..",
         "org.gradle.internal.serialize.beans..",
         "org.gradle.internal.serialize.codecs..",


### PR DESCRIPTION
Allows the declaration of service dependencies without initializing services until they are actually needed.

This can be desirable from the architectural point of view: the services required as dependencies may not be ready to be consumed at the injection time. It can also be used as a performance optimization to avoid the initialization of services that are not used in all scenarios.

Wrapping the dependency service type with a new `LazyService<T>` interface is all that is required to defer service initialization:

```java
@Provides
protected MyService createMyService(
    LazyService<ExpensiveService> lazyService
) {
    // sometime later in the implementation
    lazyService.getInstance();
}
```

In Kotlin, leveraging the delegated properties, it's possible to consumer the lazy service transparently:
```kotlin
class MyService(
    store: LazyService<ConfigurationCacheStateStore>
) {

    // the first call to the getter will initialize the backing service
    val store: ConfigurationCacheStateStore by store

}
```


---

This capability is present in other DI frameworks, such as [`Lazy` in Dagger](https://dagger.dev/api/2.13/dagger/Lazy.html).

---

This PR also demonstrates the new functionality on the `DefaultConfigurationCache`, by making it avoid manual management of dependent services for state storage and removing imperative late bindings between the services.