### PR TITLE
Rename teardown method to cleanup

### DIFF
--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/TransformBackedProviderTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/TransformBackedProviderTest.groovy
@@ -50,7 +50,7 @@ class TransformBackedProviderTest extends Specification {
         DeprecationLogger.init(WarningMode.All, progressEventEmitter, new DefaultProblems(problemEmitter), Stub(ProblemStream))
     }
 
-    def teardown() {
+    def cleanup() {
         DeprecationLogger.reset()
     }
 


### PR DESCRIPTION
I assume this method should be named `cleanup` to do the cleanup
and just was accidentally named `teardown`.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- n/a Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- n/a Provide unit tests (under `<subproject>/src/test`) to verify logic.
- n/a Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
