### PR TITLE
Deprecate premature artifact transformation of not-yet-built artifacts (#27372)

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -150,6 +150,23 @@ Since Gradle 8.5, the same information can be obtained via the `BuildFeatures` s
 
 Starting in 8.0, adding an artifact to a configuration that is neither resolvable nor consumable was deprecated.  This deprecation was overly broad and also captured certain valid usages.  It has been removed in Gradle 8.14.
 
+==== Executing a transform before the input task has completed
+
+Executing an artifact transform that needs to transform a locally built artifact before the task has completed can cause strange build failures because it indicates stale or non-existent outputs may be used by mistake. This behavior is deprecated and will emit a deprecation warning. This will become an error in Gradle 9.0.
+
+The following example demonstrates this problem where the producer's output file is transformed before the producer was executed:
+```kotlin
+configurations.runtimeClasspath { attributes.attribute(transformed, true) }
+dependencies { implementation(project(":child")) }
+
+tasks.register<Sync>("copyRT") {
+    from(configurations.runtimeClasspath.map { it.files })
+    destinationDir = layout.buildDirectory.dir("out").get().asFile
+}
+```
+
+Querying the value of `files` will produce a deprecation warning if done prior to `:child:jar` completing, as the output file has not yet been generated.
+
 [[changes_8.13]]
 == Upgrading from 8.12 and earlier
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/TransformLoggingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/TransformLoggingIntegrationTest.groovy
@@ -249,4 +249,18 @@ class TransformLoggingIntegrationTest extends AbstractConsoleGroupedTaskFunction
         result.groupedOutput.subjectsFor('GreenMultiplier') == initialSubjects
         result.groupedOutput.subjectsFor('BlueMultiplier') == initialSubjects
     }
+
+    def "warns when a transform is executed prematurely"() {
+        buildFile << '''project(':util') { resolveGreen.inputs.files.files }'''
+        consoleType = ConsoleOutput.Plain
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Executing the transform GreenMultiplier before task ':lib:jar1' has completed has been deprecated. " +
+            'This will fail with an error in Gradle 9.0. ' +
+            'Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#executing_a_transform_before_the_input_task_has_completed')
+        executer.expectDocumentedDeprecationWarning("Executing the transform GreenMultiplier before task ':lib:jar2' has completed has been deprecated. " +
+            'This will fail with an error in Gradle 9.0. ' +
+            'Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#executing_a_transform_before_the_input_task_has_completed')
+        runAndFail(":util:resolveBlue", "-DshowOutput")
+    }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AbstractTransformExecution.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AbstractTransformExecution.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.internal.tasks.properties.DefaultInputFilePropertySpec;
 import org.gradle.api.internal.tasks.properties.InputFilePropertySpec;
 import org.gradle.api.provider.Provider;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.execution.InputFingerprinter;
 import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.caching.CachingDisabledReason;
@@ -135,6 +136,14 @@ abstract class AbstractTransformExecution implements UnitOfWork {
     public WorkOutput execute(ExecutionRequest executionRequest) {
         transformExecutionListener.beforeTransformExecution(transform, subject);
         try {
+            subject.getProducerTasks().forEach(producerTask -> {
+                if (!producerTask.getState().getExecuted()) {
+                    DeprecationLogger.deprecateAction(String.format("Executing the transform %s before %s has completed", transform.getDisplayName(), producerTask))
+                        .willBecomeAnErrorInGradle9()
+                        .withUpgradeGuideSection(8, "executing_a_transform_before_the_input_task_has_completed")
+                        .nagUser();
+                }
+            });
             return executeWithinTransformerListener(executionRequest);
         } finally {
             transformExecutionListener.afterTransformExecution(transform, subject);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformStepSubject.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformStepSubject.java
@@ -18,10 +18,16 @@ package org.gradle.api.internal.artifacts.transform;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.Describable;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
 
 /**
  * Transform subject is either an initial artifact for the transform chain or a result of a previous transform step.
@@ -30,6 +36,10 @@ public abstract class TransformStepSubject implements Describable {
 
     public static TransformStepSubject initial(ResolvableArtifact artifact) {
         return new Initial(artifact);
+    }
+
+    public Collection<Task> getProducerTasks() {
+        return emptyList();
     }
 
     /**
@@ -54,6 +64,13 @@ public abstract class TransformStepSubject implements Describable {
 
         public Initial(ResolvableArtifact artifact) {
             this.artifact = artifact;
+        }
+
+        @Override
+        public Collection<Task> getProducerTasks() {
+            List<Task> tasks = new ArrayList<>();
+            artifact.visitProducerTasks(tasks::add);
+            return tasks;
         }
 
         @Override


### PR DESCRIPTION
Fixes #27372

### Context
Just like with transform backed providers, if an artifact transform depends on a locally
built artifact but is executed before the task was run this is in practially no case the
intended result and many transforms even break then as they require the artifact to be present
and recent and not absent or stale, so this PR deprecates this behavior.

I'm not sure whether the way I get the task dependencies is appropriate, or whether there is some better way I did not find.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
