### PR TITLE
Script-specific syntax highlighting of snippets in integration tests

### DIFF
--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/action/AnnotationGeneratorWorkAction.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/action/AnnotationGeneratorWorkAction.kt
@@ -51,9 +51,17 @@ abstract class AnnotationGeneratorWorkAction : WorkAction<AnnotationGeneratorWor
             throw IOException("Failed to create directory `$packageDirectory`")
         }
 
-        writeAnnotationFile(packageDirectory, packageName, "GroovyBuildScriptLanguage") { groovyReceiverAccessors<Project>() }
-        writeAnnotationFile(packageDirectory, packageName, "GroovySettingsScriptLanguage") { groovyReceiverAccessors<Settings>() }
-        writeAnnotationFile(packageDirectory, packageName, "GroovyInitScriptLanguage") { groovyReceiverAccessors<Gradle>() }
+        writeAnnotationFile(packageDirectory, packageName, "GroovyBuildScriptLanguage") {
+            groovyReceiverAccessors<Project>() + "\n" + PLUGINS_BLOCK_SIGNATURE
+        }
+
+        writeAnnotationFile(packageDirectory, packageName, "GroovySettingsScriptLanguage") {
+            groovyReceiverAccessors<Settings>() + "\n" + PLUGINS_BLOCK_SIGNATURE
+        }
+
+        writeAnnotationFile(packageDirectory, packageName, "GroovyInitScriptLanguage") {
+            groovyReceiverAccessors<Gradle>()
+        }
     }
 
     private fun writeAnnotationFile(packageDirectory: File, packageName: String, name: String, scriptReceiverAccessors: () -> String) {
@@ -176,6 +184,10 @@ abstract class AnnotationGeneratorWorkAction : WorkAction<AnnotationGeneratorWor
     companion object {
         private
         const val RESOURCE = "/default-imports.txt"
+
+        private
+        const val PLUGINS_BLOCK_SIGNATURE =
+            "void plugins(@groovy.transform.stc.ClosureParams(value = groovy.transform.stc.SimpleType.class, options = 'org.gradle.plugin.use.PluginDependenciesSpec') Closure configuration) {}"
 
         /**
          * Logic duplicated from [org.gradle.configuration.DefaultImportsReader].

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
@@ -643,13 +643,13 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
             project.extensions.extraProperties["projectProperty"] = "hello"
         """
 
-        groovyFile "a/aa/myscript.gradle", """
+        buildFile "a/aa/myscript.gradle", """
             // Using `withPlugin` as an example of a configure action
             project.pluginManager.withPlugin('base', {
                 println("My property: " + projectProperty)
             })
         """
-        groovyFile "a/aa/build.gradle", """
+        buildFile "a/aa/build.gradle", """
             plugins {
                 id "base"
             }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiParallelConfigurationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiParallelConfigurationIntegrationTest.groovy
@@ -238,7 +238,7 @@ class IsolatedProjectsToolingApiParallelConfigurationIntegrationTest extends Abs
         '''
 
         def buildScriptA = file('a/build.gradle')
-        groovyFile buildScriptA, '''
+        buildFile buildScriptA, '''
             plugins {
                 id("my.plugin-1")
                 id("my.plugin-2")
@@ -248,7 +248,7 @@ class IsolatedProjectsToolingApiParallelConfigurationIntegrationTest extends Abs
         configuring(buildScriptA)
 
         def buildScriptB = file('b/build.gradle')
-        groovyFile buildScriptB, '''
+        buildFile buildScriptB, '''
             plugins {
                 id("my.plugin")
                 id("my.plugin-2")

--- a/platforms/core-configuration/flow-services/src/integTest/groovy/org/gradle/internal/flow/services/FlowScopeIntegrationTest.groovy
+++ b/platforms/core-configuration/flow-services/src/integTest/groovy/org/gradle/internal/flow/services/FlowScopeIntegrationTest.groovy
@@ -135,7 +135,7 @@ class FlowScopeIntegrationTest extends AbstractIntegrationSpec {
 
     def '#scriptTarget action can use injectable #simpleServiceTypeName'() {
         given:
-        groovyFile scriptTarget.fileName, """
+        file(scriptTarget.fileName) << """
             import org.gradle.api.flow.*
 
             class FlowActionInjectionPlugin implements Plugin<$targetType> {

--- a/platforms/core-runtime/process-services/src/integTest/groovy/org/gradle/process/internal/health/memory/MemoryStatusUpdateIntegrationTest.groovy
+++ b/platforms/core-runtime/process-services/src/integTest/groovy/org/gradle/process/internal/health/memory/MemoryStatusUpdateIntegrationTest.groovy
@@ -35,7 +35,7 @@ class MemoryStatusUpdateIntegrationTest extends AbstractIntegrationSpec {
     }
 
     private static String waitForMemoryEventsTask() {
-        return groovyScript('''
+        return buildScriptSnippet('''
             import java.util.concurrent.CountDownLatch
             import org.gradle.process.internal.health.memory.*
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/BuildLayoutIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/BuildLayoutIntegrationTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.integtests.fixtures.build.BuildTestFile
 
 class BuildLayoutIntegrationTest extends AbstractIntegrationSpec {
     private String printLocations() {
-        groovyScript """
+        settingsScriptSnippet """
             println "settings root dir: " + layout.rootDirectory + "."
             println "settings dir: " + layout.settingsDirectory + "."
             println "settings source file: " + layout.settingsDirectory.file(providers.provider { buildscript.sourceFile.name }).get() + "."

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/BuildLayoutIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/BuildLayoutIntegrationTest.groovy
@@ -76,10 +76,10 @@ class BuildLayoutIntegrationTest extends AbstractIntegrationSpec {
         def customSettingsDir = customSettingsFile.parentFile
         // setting a custom settings location is deprecated
         executer.noDeprecationChecks()
-        groovyFile(customSettingsFile, """
+        settingsFile customSettingsFile, """
             rootProject.projectDir = file('..')
             ${printLocations()}
-        """)
+        """
 
         when:
         run("help", "--settings-file", customSettingsPath)
@@ -93,15 +93,15 @@ class BuildLayoutIntegrationTest extends AbstractIntegrationSpec {
     def "locations are as expected in an included build"() {
         buildTestFixture.withBuildInSubDir()
         def buildB = singleProjectBuild("buildB") { BuildTestFile build ->
-            groovyFile(build.settingsFile, """
+            settingsFile build.settingsFile, """
                 ${printLocations()}
-            """)
+            """
         }
 
         def rootBuild = singleProjectBuild("buildA") { BuildTestFile build ->
-            groovyFile(build.settingsFile, """
+            settingsFile build.settingsFile, """
                 includeBuild "${buildB.toURI()}"
-            """)
+            """
         }
 
         when:
@@ -120,9 +120,9 @@ class BuildLayoutIntegrationTest extends AbstractIntegrationSpec {
 
         def buildSrcDir = file("buildSrc")
         def buildSrcSettingsFile = buildSrcDir.file("settings.gradle")
-        groovyFile(buildSrcSettingsFile, """
+        settingsFile buildSrcSettingsFile, """
             ${printLocations()}
-        """)
+        """
 
         when:
         run("project")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleLifecycleIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleLifecycleIntegrationTest.groovy
@@ -89,7 +89,7 @@ class GradleLifecycleIntegrationTest extends AbstractIntegrationSpec {
         withSettingsPluginInBuildLogic()
 
         createDir('build-logic') {
-            groovyFile file('build.gradle'), '''
+            buildFile file('build.gradle'), '''
                 plugins {
                     id 'java'
                     id 'java-gradle-plugin'
@@ -163,7 +163,7 @@ class GradleLifecycleIntegrationTest extends AbstractIntegrationSpec {
             subprojects { println("lifecycle: <root>.subprojects '\${it.path}'") }
         """
 
-        groovyFile "a/build.gradle", """
+        buildFile "a/build.gradle", """
             println("lifecycle: <evaluating> " + project)
         """
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleLifecycleIsolationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleLifecycleIsolationIntegrationTest.groovy
@@ -52,7 +52,7 @@ class GradleLifecycleIsolationIntegrationTest extends AbstractIntegrationSpec {
             version = 'from script'
         '''
         buildFile script
-        groovyFile 'sub/build.gradle', script
+        buildFile 'sub/build.gradle', script
 
         when:
         succeeds 'help'
@@ -204,12 +204,12 @@ class GradleLifecycleIsolationIntegrationTest extends AbstractIntegrationSpec {
 
     def 'lifecycle actions preserve user code application context for plugins'() {
         given:
-        groovyFile "build-logic/build.gradle", '''
+        buildFile "build-logic/build.gradle", '''
             plugins {
                 id 'groovy-gradle-plugin'
             }
         '''
-        groovyFile "build-logic/src/main/groovy/my-settings-plugin.settings.gradle", """
+        buildFile "build-logic/src/main/groovy/my-settings-plugin.settings.gradle", """
             gradle.lifecycle.beforeProject {
                 println("before:" + $currentApplication)
             }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
@@ -879,8 +879,8 @@ service: closed with value 12
         include 'subproject2'
         """
         // plugin 1 declares a service
-        groovyFile(file("plugin1/build.gradle"), "plugins { id 'groovy-gradle-plugin' }")
-        groovyFile(file("plugin1/src/main/groovy/my.plugin1.gradle"), """
+        buildFile(file("plugin1/build.gradle"), "plugins { id 'groovy-gradle-plugin' }")
+        buildFile(file("plugin1/src/main/groovy/my.plugin1.gradle"), """
             import org.gradle.api.services.BuildService
             import org.gradle.api.services.BuildServiceParameters
             abstract class MyService implements BuildService<BuildServiceParameters.None> {
@@ -900,16 +900,16 @@ service: closed with value 12
             }
         """)
         // plugin 2
-        groovyFile(file("plugin2/build.gradle"), "plugins { id 'groovy-gradle-plugin' }")
-        groovyFile(file("plugin2/src/main/groovy/my.plugin2.gradle"), "/* no code needed */")
+        buildFile(file("plugin2/build.gradle"), "plugins { id 'groovy-gradle-plugin' }")
+        buildFile(file("plugin2/src/main/groovy/my.plugin2.gradle"), "/* no code needed */")
         // subproject1 and subproject2 apply different sets of plugins, so get different classloaders
-        groovyFile(file("subproject1/build.gradle"), """
+        buildFile(file("subproject1/build.gradle"), """
         plugins {
             id 'my.plugin1'
             id 'my.plugin2'
         }
         """)
-        groovyFile(file("subproject2/build.gradle"), """
+        buildFile(file("subproject2/build.gradle"), """
         plugins {
             // must include the plugin contributing the build service,
             // and must be a different ordered set than the other project
@@ -945,8 +945,8 @@ Hello, subproject1
         include 'subproject2'
         """
         // plugin 1 declares a service
-        groovyFile(file("plugin1/build.gradle"), "plugins { id 'groovy-gradle-plugin' }")
-        groovyFile(file("plugin1/src/main/groovy/my.plugin1.gradle"), """
+        buildFile(file("plugin1/build.gradle"), "plugins { id 'groovy-gradle-plugin' }")
+        buildFile(file("plugin1/src/main/groovy/my.plugin1.gradle"), """
             import org.gradle.api.services.BuildService
             import org.gradle.api.services.BuildServiceParameters
             abstract class MyService implements BuildService<BuildServiceParameters.None> {
@@ -979,16 +979,16 @@ Hello, subproject1
         """)
 
         // plugin 2
-        groovyFile(file("plugin2/build.gradle"), "plugins { id 'groovy-gradle-plugin' }")
-        groovyFile(file("plugin2/src/main/groovy/my.plugin2.gradle"), "/* no code needed */")
+        buildFile(file("plugin2/build.gradle"), "plugins { id 'groovy-gradle-plugin' }")
+        buildFile(file("plugin2/src/main/groovy/my.plugin2.gradle"), "/* no code needed */")
         // subproject1 and subproject2 apply different sets of plugins, so get different classloaders
-        groovyFile(file("subproject1/build.gradle"), """
+        buildFile(file("subproject1/build.gradle"), """
         plugins {
             id 'my.plugin1'
             id 'my.plugin2'
         }
         """)
-        groovyFile(file("subproject2/build.gradle"), """
+        buildFile(file("subproject2/build.gradle"), """
         plugins {
             // must include the plugin contributing the build service,
             // and must be a different ordered set than the other project

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -276,25 +276,6 @@ abstract class AbstractIntegrationSpec extends Specification {
         initScriptFile << append
     }
 
-    /**
-     * Provides best-effort groovy script syntax highlighting.
-     * The highlighting is imperfect since {@link GroovyBuildScriptLanguage} uses stub methods to create a simulated script target environment.
-     *
-     * @deprecated Use a more specific method, e.g {@link #buildFile(java.lang.String, java.lang.String)} or {@link #settingsFile(java.lang.String, java.lang.String)}
-     */
-    @Deprecated
-    void groovyFile(String targetBuildFile, @GroovyBuildScriptLanguage String script) {
-        groovyFile(file(targetBuildFile), script)
-    }
-
-    /**
-     * @deprecated Use a more specific method, e.g {@link #buildFile(org.gradle.test.fixtures.file.TestFile, java.lang.String)} or {@link #settingsFile(org.gradle.test.fixtures.file.TestFile, java.lang.String)}
-     */
-    @Deprecated
-    void groovyFile(TestFile targetBuildFile, @GroovyBuildScriptLanguage String script) {
-        targetBuildFile << script
-    }
-
     void javaFile(String targetBuildFile, @Language('JAVA') String code) {
         javaFile(file(targetBuildFile), code)
     }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -303,8 +303,31 @@ abstract class AbstractIntegrationSpec extends Specification {
         targetBuildFile << code
     }
 
-    static String groovyScript(@GroovyBuildScriptLanguage String script) {
-        script
+    /**
+     * Provides syntax highlighting for the snippet of the build script code.
+     *
+     * @return the same snippet
+     */
+    static String buildScriptSnippet(@GroovyBuildScriptLanguage String snippet) {
+        snippet
+    }
+
+    /**
+     * Provides syntax highlighting for the snippet of the settings script code.
+     *
+     * @return the same snippet
+     */
+    static String settingsScriptSnippet(@GroovySettingsScriptLanguage String snippet) {
+        snippet
+    }
+
+    /**
+     * Provides syntax highlighting for the snippet of the init script code.
+     *
+     * @return the same snippet
+     */
+    static String initScriptSnippet(@GroovyInitScriptLanguage String snippet) {
+        snippet
     }
 
     void versionCatalogFile(@Language("toml") String script) {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -133,7 +133,7 @@ abstract class AbstractIntegrationSpec extends Specification {
                 KnownProblemIds.assertIsKnown(it)
             }
 
-            if (getReceivedProblems().every {it == null }) {
+            if (getReceivedProblems().every { it == null }) {
                 receivedProblems = null
             } else {
                 println "Problems that were not accessed during test execution:"
@@ -897,7 +897,7 @@ tmpdir is currently ${System.getProperty("java.io.tmpdir")}""")
         if (!enableProblemsApiCheck) {
             throw new IllegalStateException('Problems API check is not enabled')
         }
-        return buildOperationsFixture.all().collectMany {operation ->
+        return buildOperationsFixture.all().collectMany { operation ->
             operation.progress(DefaultProblemProgressDetails.class).collect {
                 def problemDetails = it.details.get("problem") as Map<String, Object>
                 return new ReceivedProblem(operation.id, problemDetails)

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -276,12 +276,32 @@ abstract class AbstractIntegrationSpec extends Specification {
         initScriptFile << append
     }
 
-    void javaFile(String targetBuildFile, @Language('JAVA') String code) {
-        javaFile(file(targetBuildFile), code)
+    /**
+     * <b>Appends</b> provided code to the given Java file.
+     */
+    void javaFile(String targetBuildFile, @Language('java') String append) {
+        file(targetBuildFile) << append
     }
 
-    void javaFile(TestFile targetBuildFile, @Language('JAVA') String code) {
-        targetBuildFile << code
+    /**
+     * <b>Appends</b> provided code to the given Java file.
+     */
+    void javaFile(TestFile targetBuildFile, @Language('java') String append) {
+        targetBuildFile << append
+    }
+
+    /**
+     * <b>Appends</b> provided code to the given Groovy file.
+     */
+    void groovyFile(String targetBuildFile, @Language('groovy') String append) {
+        file(targetBuildFile) << append
+    }
+
+    /**
+     * <b>Appends</b> provided code to the given Groovy file.
+     */
+    void groovyFile(TestFile targetBuildFile, @Language('groovy') String append) {
+        targetBuildFile << append
     }
 
     /**

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -279,11 +279,18 @@ abstract class AbstractIntegrationSpec extends Specification {
     /**
      * Provides best-effort groovy script syntax highlighting.
      * The highlighting is imperfect since {@link GroovyBuildScriptLanguage} uses stub methods to create a simulated script target environment.
+     *
+     * @deprecated Use a more specific method, e.g {@link #buildFile(java.lang.String, java.lang.String)} or {@link #settingsFile(java.lang.String, java.lang.String)}
      */
+    @Deprecated
     void groovyFile(String targetBuildFile, @GroovyBuildScriptLanguage String script) {
         groovyFile(file(targetBuildFile), script)
     }
 
+    /**
+     * @deprecated Use a more specific method, e.g {@link #buildFile(org.gradle.test.fixtures.file.TestFile, java.lang.String)} or {@link #settingsFile(org.gradle.test.fixtures.file.TestFile, java.lang.String)}
+     */
+    @Deprecated
     void groovyFile(TestFile targetBuildFile, @GroovyBuildScriptLanguage String script) {
         targetBuildFile << script
     }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -292,6 +292,13 @@ abstract class AbstractIntegrationSpec extends Specification {
 
     /**
      * <b>Appends</b> provided code to the given Groovy file.
+     * <p>
+     * Consider specialized methods for Gradle scripts:
+     * <ul>
+     * <li>{@link #buildFile(java.lang.String, java.lang.String)}
+     * <li>{@link #settingsFile(java.lang.String, java.lang.String)}
+     * <li>{@link #initScriptFile(java.lang.String, java.lang.String)}
+     * </ul>
      */
     void groovyFile(String targetBuildFile, @Language('groovy') String append) {
         file(targetBuildFile) << append
@@ -299,6 +306,13 @@ abstract class AbstractIntegrationSpec extends Specification {
 
     /**
      * <b>Appends</b> provided code to the given Groovy file.
+     * <p>
+     * Consider specialized methods for Gradle scripts:
+     * <ul>
+     * <li>{@link #buildFile(org.gradle.test.fixtures.file.TestFile, java.lang.String)}
+     * <li>{@link #settingsFile(org.gradle.test.fixtures.file.TestFile, java.lang.String)}
+     * <li>{@link #initScriptFile(org.gradle.test.fixtures.file.TestFile, java.lang.String)}
+     * </ul>
      */
     void groovyFile(TestFile targetBuildFile, @Language('groovy') String append) {
         targetBuildFile << append

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -279,15 +279,15 @@ abstract class AbstractIntegrationSpec extends Specification {
     /**
      * <b>Appends</b> provided code to the given Java file.
      */
-    void javaFile(String targetBuildFile, @Language('java') String append) {
-        file(targetBuildFile) << append
+    void javaFile(String targetFile, @Language('java') String append) {
+        file(targetFile) << append
     }
 
     /**
      * <b>Appends</b> provided code to the given Java file.
      */
-    void javaFile(TestFile targetBuildFile, @Language('java') String append) {
-        targetBuildFile << append
+    void javaFile(TestFile targetFile, @Language('java') String append) {
+        targetFile << append
     }
 
     /**
@@ -300,8 +300,8 @@ abstract class AbstractIntegrationSpec extends Specification {
      * <li>{@link #initScriptFile(java.lang.String, java.lang.String)}
      * </ul>
      */
-    void groovyFile(String targetBuildFile, @Language('groovy') String append) {
-        file(targetBuildFile) << append
+    void groovyFile(String targetFile, @Language('groovy') String append) {
+        file(targetFile) << append
     }
 
     /**
@@ -314,8 +314,8 @@ abstract class AbstractIntegrationSpec extends Specification {
      * <li>{@link #initScriptFile(org.gradle.test.fixtures.file.TestFile, java.lang.String)}
      * </ul>
      */
-    void groovyFile(TestFile targetBuildFile, @Language('groovy') String append) {
-        targetBuildFile << append
+    void groovyFile(TestFile targetFile, @Language('groovy') String append) {
+        targetFile << append
     }
 
     /**

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -195,12 +195,85 @@ abstract class AbstractIntegrationSpec extends Specification {
         return "junit:junit:4.13"
     }
 
-    void buildFile(@GroovyBuildScriptLanguage String script) {
-        groovyFile(buildFile, script)
+    /**
+     * <b>Appends</b> provided code to the {@link #getBuildFile() default build file}.
+     * <p>
+     * Use {@link #buildScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
+     */
+    void buildFile(@GroovyBuildScriptLanguage String append) {
+        buildFile << append
     }
 
-    void settingsFile(@GroovyBuildScriptLanguage String script) {
-        groovyFile(settingsFile, script)
+    /**
+     * <b>Appends</b> provided code to the given build file.
+     * <p>
+     * Use {@link #buildScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
+     */
+    void buildFile(String buildFile, @GroovyBuildScriptLanguage String append) {
+        file(buildFile) << append
+    }
+
+    /**
+     * <b>Appends</b> provided code to the given build file.
+     * <p>
+     * Use {@link #buildScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
+     */
+    void buildFile(TestFile buildFile, @GroovyBuildScriptLanguage String append) {
+        buildFile << append
+    }
+
+    /**
+     * <b>Appends</b> provided code to the {@link #getSettingsFile() default settings file}.
+     * <p>
+     * Use {@link #settingsScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
+     */
+    void settingsFile(@GroovySettingsScriptLanguage String append) {
+        settingsFile << append
+    }
+
+    /**
+     * <b>Appends</b> provided code to the given settings file.
+     * <p>
+     * Use {@link #settingsScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
+     */
+    void settingsFile(String settingsFile, @GroovySettingsScriptLanguage String append) {
+        file(settingsFile) << append
+    }
+
+    /**
+     * <b>Appends</b> provided code to the given settings file.
+     * <p>
+     * Use {@link #settingsScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
+     */
+    void settingsFile(TestFile settingsFile, @GroovySettingsScriptLanguage String append) {
+        settingsFile << append
+    }
+
+    /**
+     * <b>Appends</b> provided code to the {@link #getInitScriptFile() default init script file}.
+     * <p>
+     * Use {@link #initScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
+     */
+    void initScriptFile(@GroovyInitScriptLanguage String append) {
+        initScriptFile << append
+    }
+
+    /**
+     * <b>Appends</b> provided code to the given init script file.
+     * <p>
+     * Use {@link #initScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
+     */
+    void initScriptFile(String initScriptFile, @GroovyInitScriptLanguage String append) {
+        file(initScriptFile) << append
+    }
+
+    /**
+     * <b>Appends</b> provided code to the given init script file.
+     * <p>
+     * Use {@link #initScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
+     */
+    void initScriptFile(TestFile initScriptFile, @GroovyInitScriptLanguage String append) {
+        initScriptFile << append
     }
 
     /**


### PR DESCRIPTION
We already have a `@GroovyBuildScriptLanguage` language annotation that allows IntelliJ IDEA to highlight snippets of build script code used in integration tests. Not only highlighting, it also provides in-string-literal auto-complete, making it nicer to write or edit the tests.
```groovy
buildFile """
     dependencies { ... }       // <--- This is auto-highlighted and with auto-completion in IntelliJ IDEA
"""
```

However, that annotation provided the stubs only for the methods available in the build script. It means using the highlighting for settings or init scripts was much less precise.

This PR adds two new flavors to this language annotation:
- `GroovySettingsScriptLanguage`
- `GroovyInitScriptLanguage`

Combined with new / updated helper functions from `AbstractIntegrationSpec`, it provides the same goodness, but tailored for the corresponding script types.

All string-literals in this example are now highlighted and with auto-complete:
```groovy
settingsFile '''
    pluginManagement {
        includeBuild 'build-logic'
    }
'''

initScriptFile '''
    gradle.lifecycle.beforeProject {
    }
'''
```

---

Also fixes the warnings of the `plugins` block being unresolvable in the highlighted snippets.

It previously looked like this:
![image](https://github.com/gradle/gradle/assets/2759152/80908332-27cc-46c8-8466-cb696b723b36)
