### PR TITLE
Enable load-after-store in documentation platform

### DIFF
--- a/platforms/documentation/docs/build.gradle
+++ b/platforms/documentation/docs/build.gradle
@@ -693,7 +693,6 @@ tasks.named("docsTest") { task ->
 
     if (isConfigurationCacheEnabledForDocsTests(project)) {
         systemProperty("org.gradle.integtest.samples.cleanConfigurationCacheOutput", "true")
-        systemProperty("org.gradle.integtest.samples.checkLoadingFromConfigurationCache", "true")
         systemProperty("org.gradle.integtest.executer", "configCache")
 
         filter {

--- a/platforms/documentation/docs/src/docsTest/java/org/gradle/docs/samples/IntegrationTestSamplesExecutor.java
+++ b/platforms/documentation/docs/src/docsTest/java/org/gradle/docs/samples/IntegrationTestSamplesExecutor.java
@@ -27,7 +27,6 @@ import org.gradle.integtests.fixtures.executer.GradleDistribution;
 import org.gradle.integtests.fixtures.executer.GradleExecuter;
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext;
 import org.gradle.integtests.fixtures.executer.UnderDevelopmentGradleDistribution;
-import org.gradle.integtests.fixtures.executer.UnexpectedBuildFailure;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider;
 
@@ -43,8 +42,6 @@ import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toMap;
 
 class IntegrationTestSamplesExecutor extends CommandExecutor {
-
-    private static final String CHECK_LOADING_FROM_CONFIGURATION_CACHE = "org.gradle.integtest.samples.checkLoadingFromConfigurationCache";
 
     private static final String WARNING_MODE_FLAG_PREFIX = "--warning-mode=";
 
@@ -75,26 +72,10 @@ class IntegrationTestSamplesExecutor extends CommandExecutor {
             } else {
                 ExecutionResult result = executer.run();
                 outputStream.write(result.getOutput().getBytes());
-
-                if (shouldCheckLoadingFromConfigurationCache()) {
-                    rerunReusingStoredConfigurationCacheEntry(args, flags);
-                }
             }
             return expectFailure ? 1 : 0;
         } catch (IOException e) {
             throw new UncheckedIOException(e);
-        }
-    }
-
-    private void rerunReusingStoredConfigurationCacheEntry(List<String> args, List<String> flags) {
-        // Rerun tasks. If the task is up-to-date, then its actions aren't executed.
-        // This might hide issues with Groovy closures, as the methods referenced inside the closure are resolved dynamically.
-        try {
-            createExecuter(args, flags).withArgument("--rerun-tasks").run();
-        } catch (UnexpectedBuildFailure e) {
-            UnexpectedBuildFailure tweakedException = new UnexpectedBuildFailure("Failed to rerun the build when reusing the configuration cache entry.\n" + e.getMessage());
-            tweakedException.setStackTrace(e.getStackTrace());
-            throw tweakedException;
         }
     }
 
@@ -139,9 +120,5 @@ class IntegrationTestSamplesExecutor extends CommandExecutor {
 
     private static String capitalize(String s) {
         return s.substring(0, 1).toUpperCase() + s.substring(1);
-    }
-
-    private static boolean shouldCheckLoadingFromConfigurationCache() {
-        return Boolean.parseBoolean(System.getProperty(CHECK_LOADING_FROM_CONFIGURATION_CACHE));
     }
 }

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/workingWithDependencies-accessMetadataArtifact/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/workingWithDependencies-accessMetadataArtifact/groovy/build.gradle
@@ -14,17 +14,21 @@ dependencies {
 tasks.register('printGuavaMetadata') {
     dependsOn configurations.compileClasspath
 
-    doLast {
-        ArtifactResolutionQuery query = dependencies.createArtifactResolutionQuery()
+    ArtifactResolutionQuery query = dependencies.createArtifactResolutionQuery()
             .forModule('com.google.guava', 'guava', '18.0')
             .withArtifacts(MavenModule, MavenPomArtifact)
-        ArtifactResolutionResult result = query.execute()
+    ArtifactResolutionResult result = query.execute()
 
-        for(component in result.resolvedComponents) {
-            Set<ArtifactResult> mavenPomArtifacts = component.getArtifacts(MavenPomArtifact)
-            ArtifactResult guavaPomArtifact = mavenPomArtifacts.find { it.file.name == 'guava-18.0.pom' }
-            def xml = new groovy.xml.XmlSlurper().parse(guavaPomArtifact.file)
-            println guavaPomArtifact.file.name
+    def artifactFiles = result.resolvedComponents.collect { component ->
+        Set<ArtifactResult> mavenPomArtifacts = component.getArtifacts(MavenPomArtifact)
+        ArtifactResult guavaPomArtifact = mavenPomArtifacts.find { it.file.name == 'guava-18.0.pom' }
+        guavaPomArtifact.file
+    }
+
+    doLast {
+        artifactFiles.each {
+            def xml = new groovy.xml.XmlSlurper().parse(it)
+            println it.name
             println xml.name
             println xml.description
         }

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/workingWithDependencies-accessMetadataArtifact/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/workingWithDependencies-accessMetadataArtifact/kotlin/build.gradle.kts
@@ -16,18 +16,22 @@ dependencies {
 tasks.register("printGuavaMetadata") {
     dependsOn(configurations.compileClasspath)
 
-    doLast {
-        val query: ArtifactResolutionQuery = dependencies.createArtifactResolutionQuery()
-            .forModule("com.google.guava", "guava", "18.0")
-            .withArtifacts(MavenModule::class, MavenPomArtifact::class)
-        val result: ArtifactResolutionResult = query.execute()
+    val query: ArtifactResolutionQuery = dependencies.createArtifactResolutionQuery()
+        .forModule("com.google.guava", "guava", "18.0")
+        .withArtifacts(MavenModule::class, MavenPomArtifact::class)
+    val result: ArtifactResolutionResult = query.execute()
 
-        result.resolvedComponents.forEach { component ->
-            val mavenPomArtifacts: Set<ArtifactResult> = component.getArtifacts(MavenPomArtifact::class)
-            val guavaPomArtifact =
-                mavenPomArtifacts.find { it is ResolvedArtifactResult && it.file.name == "guava-18.0.pom" } as ResolvedArtifactResult
-            val xml = XmlSlurper().parse(guavaPomArtifact.file)
-            println(guavaPomArtifact.file.name)
+    val artifactPomFiles = result.resolvedComponents.map { component ->
+        val mavenPomArtifacts: Set<ArtifactResult> = component.getArtifacts(MavenPomArtifact::class)
+        val guavaPomArtifact =
+            mavenPomArtifacts.find { it is ResolvedArtifactResult && it.file.name == "guava-18.0.pom" } as ResolvedArtifactResult
+        guavaPomArtifact.file
+    }
+
+    doLast {
+        artifactPomFiles.forEach { artifactFile ->
+            val xml = XmlSlurper().parse(artifactFile)
+            println(artifactFile.name)
             println(xml.getProperty("name"))
             println(xml.getProperty("description"))
         }

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/workingWithDependencies-iterateArtifacts/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/workingWithDependencies-iterateArtifacts/groovy/build.gradle
@@ -15,8 +15,9 @@ dependencies {
 tasks.register('iterateResolvedArtifacts') {
     dependsOn configurations.scm
 
+    def scm = configurations.scm
     doLast {
-        configurations.scm.each {
+        scm.each {
             logger.quiet it.absolutePath
         }
     }

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/workingWithDependencies-iterateArtifacts/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/workingWithDependencies-iterateArtifacts/kotlin/build.gradle.kts
@@ -14,9 +14,11 @@ tasks.register("iterateResolvedArtifacts") {
     val scm = configurations["scm"]
     dependsOn(scm)
 
+    val scmArtifacts = scm.map { it.absolutePath }
+    val logger = logger
     doLast {
-        scm.forEach {
-            logger.quiet(it.absolutePath)
+        scmArtifacts.forEach {
+            logger.quiet(it)
         }
     }
 }

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/workingWithDependencies-iterateArtifacts/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/workingWithDependencies-iterateArtifacts/kotlin/build.gradle.kts
@@ -15,7 +15,6 @@ tasks.register("iterateResolvedArtifacts") {
     dependsOn(scm)
 
     val scmArtifacts = scm.map { it.absolutePath }
-    val logger = logger
     doLast {
         scmArtifacts.forEach {
             logger.quiet(it)

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/workingWithDependencies-iterateDependencies/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/workingWithDependencies-iterateDependencies/groovy/build.gradle
@@ -13,10 +13,16 @@ dependencies {
 
 // tag::iteration-task[]
 tasks.register('iterateDeclaredDependencies') {
+    def dependencySet = configurations.scm.dependencies
+    def artifactInfo = dependencySet.collect {
+        [
+            group: it.group,
+            name: it.name,
+            version: it.version
+        ]
+    }
     doLast {
-        DependencySet dependencySet = configurations.scm.dependencies
-
-        dependencySet.each {
+        artifactInfo.each {
             logger.quiet "$it.group:$it.name:$it.version"
         }
     }

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/workingWithDependencies-iterateDependencies/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/workingWithDependencies-iterateDependencies/kotlin/build.gradle.kts
@@ -11,11 +11,14 @@ dependencies {
 
 // tag::iteration-task[]
 tasks.register("iterateDeclaredDependencies") {
+    val dependencySet = configurations["scm"].dependencies
+    val artifactInfo = dependencySet.map {
+        Triple(it.group, it.name, it.version)
+    }
+    val logger = logger
     doLast {
-        val dependencySet = configurations["scm"].dependencies
-
-        dependencySet.forEach {
-            logger.quiet("${it.group}:${it.name}:${it.version}")
+        artifactInfo.forEach { (group, name, version) ->
+            logger.quiet("$group:$name:$version")
         }
     }
 }

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/workingWithDependencies-iterateDependencies/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/workingWithDependencies-iterateDependencies/kotlin/build.gradle.kts
@@ -15,7 +15,6 @@ tasks.register("iterateDeclaredDependencies") {
     val artifactInfo = dependencySet.map {
         Triple(it.group, it.name, it.version)
     }
-    val logger = logger
     doLast {
         artifactInfo.forEach { (group, name, version) ->
             logger.quiet("$group:$name:$version")

--- a/platforms/documentation/samples/build.gradle.kts
+++ b/platforms/documentation/samples/build.gradle.kts
@@ -23,8 +23,3 @@ dependencies {
 }
 
 testFilesCleanup.reportOnly = true
-
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/platforms/documentation/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesWorkingWithDependenciesIntegrationTest.groovy
+++ b/platforms/documentation/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesWorkingWithDependenciesIntegrationTest.groovy
@@ -34,7 +34,6 @@ class SamplesWorkingWithDependenciesIntegrationTest extends AbstractIntegrationS
     }
 
     @UsesSample("dependencyManagement/workingWithDependencies-iterateDependencies")
-    @ToBeFixedForConfigurationCache(iterationMatchers = ".*kotlin dsl")
     def "can iterate over dependencies assigned to a configuration with #dsl dsl"() {
         executer.inDirectory(sample.dir.file(dsl))
 
@@ -50,7 +49,6 @@ commons-codec:commons-codec:1.7""")
     }
 
     @UsesSample("dependencyManagement/workingWithDependencies-iterateArtifacts")
-    @ToBeFixedForConfigurationCache(iterationMatchers = ".*kotlin dsl")
     def "can iterate over artifacts resolved for a module with #dsl dsl"() {
         executer.inDirectory(sample.dir.file(dsl))
 
@@ -97,7 +95,6 @@ commons-codec:commons-codec:1.7""")
     }
 
     @UsesSample("dependencyManagement/workingWithDependencies-accessMetadataArtifact")
-    @ToBeFixedForConfigurationCache(iterationMatchers = ".*kotlin dsl")
     def "can accessing a module's metadata artifact with #dsl dsl"() {
         executer.inDirectory(sample.dir.file(dsl))
 

--- a/platforms/documentation/samples/src/integTest/groovy/org/gradle/integtests/samples/java/SamplesJavaTestingIntegrationTest.groovy
+++ b/platforms/documentation/samples/src/integTest/groovy/org/gradle/integtests/samples/java/SamplesJavaTestingIntegrationTest.groovy
@@ -19,14 +19,12 @@ package org.gradle.integtests.samples.java
 import groovy.xml.XmlSlurper
 import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
 import org.gradle.integtests.fixtures.Sample
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.UsesSample
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 import org.junit.Rule
-
-import static org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache.Skip.INVESTIGATE
 
 class SamplesJavaTestingIntegrationTest extends AbstractSampleIntegrationTest {
 
@@ -313,7 +311,6 @@ class SamplesJavaTestingIntegrationTest extends AbstractSampleIntegrationTest {
 
     @Requires(UnitTestPreconditions.Jdk9OrLater)
     @UsesSample("java/basic")
-    @ToBeFixedForConfigurationCache(skip = INVESTIGATE, because = "Task order is non-deterministic in CC")
     def "can run simple Java integration tests with #dsl dsl"() {
         given:
         configureExecuterForToolchains('17')
@@ -324,7 +321,10 @@ class SamplesJavaTestingIntegrationTest extends AbstractSampleIntegrationTest {
         def result = succeeds("test", "integrationTest")
 
         then:
-        result.assertTaskOrder(":test", ":integrationTest")
+        // Task order is non-deterministic in CC
+        if (!GradleContextualExecuter.isConfigCache()) {
+            result.assertTaskOrder(":test", ":integrationTest")
+        }
 
         and:
         assertTestsRunCount(

--- a/platforms/documentation/samples/src/integTest/groovy/org/gradle/integtests/samples/java/SamplesJavaTestingIntegrationTest.groovy
+++ b/platforms/documentation/samples/src/integTest/groovy/org/gradle/integtests/samples/java/SamplesJavaTestingIntegrationTest.groovy
@@ -19,11 +19,14 @@ package org.gradle.integtests.samples.java
 import groovy.xml.XmlSlurper
 import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
 import org.gradle.integtests.fixtures.Sample
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.UsesSample
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 import org.junit.Rule
+
+import static org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache.Skip.INVESTIGATE
 
 class SamplesJavaTestingIntegrationTest extends AbstractSampleIntegrationTest {
 
@@ -310,6 +313,7 @@ class SamplesJavaTestingIntegrationTest extends AbstractSampleIntegrationTest {
 
     @Requires(UnitTestPreconditions.Jdk9OrLater)
     @UsesSample("java/basic")
+    @ToBeFixedForConfigurationCache(skip = INVESTIGATE, because = "Task order is non-deterministic in CC")
     def "can run simple Java integration tests with #dsl dsl"() {
         given:
         configureExecuterForToolchains('17')


### PR DESCRIPTION
Enable load-after-store for documentation and sample tests.

* Skips assertions that are not compatible with CC 
* Collect dependency metadata at config time as DependencySets cannot be stored in CC
* Obtain SCM configuration at config time as accessing project objects at execution time is incompatible with the configuration cache
* Extract artifact metadata in a CC-friendly way at config time

Fixes: #28951