### PR TITLE
Enable load-after-store in tests of the Extensibility platform

### DIFF
--- a/platforms/extensibility/plugin-use/build.gradle.kts
+++ b/platforms/extensibility/plugin-use/build.gradle.kts
@@ -42,8 +42,3 @@ dependencies {
 testFilesCleanup.reportOnly = true
 
 description = """Provides functionality for resolving and managing plugins during their application to projects."""
-
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/NonDeclarativePluginUseIntegrationSpec.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/NonDeclarativePluginUseIntegrationSpec.groovy
@@ -163,8 +163,11 @@ class NonDeclarativePluginUseIntegrationSpec extends AbstractPluginSpec {
 
         when:
         def pluginModule = publishPlugin """
-            project.task('pluginTask').doLast {
-                println "pluginTask - " + this.getClass().classLoader.getResource('d/v.txt').text
+            project.tasks.register("pluginTask") {
+                def resource = this.getClass().classLoader.getResource('d/v.txt')
+                doLast {
+                    println "pluginTask - " + resource.text
+                }
             }
         """
 
@@ -184,8 +187,9 @@ class NonDeclarativePluginUseIntegrationSpec extends AbstractPluginSpec {
             $USE
 
             task scriptTask {
+                def resource = this.getClass().classLoader.getResource('d/v.txt')
                 doLast {
-                    println "scriptTask - " + this.getClass().classLoader.getResource('d/v.txt').text
+                    println "scriptTask - " + resource.text
                 }
             }
 

--- a/platforms/extensibility/test-kit/build.gradle.kts
+++ b/platforms/extensibility/test-kit/build.gradle.kts
@@ -72,11 +72,6 @@ tasks.integMultiVersionTest {
     systemProperty("org.gradle.integtest.testkit.compatibility", "all")
 }
 
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}
-
 tasks {
     withType<Test>().configureEach {
         if (project.isBundleGroovy4) {

--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerPluginClasspathInjectionEndUserIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerPluginClasspathInjectionEndUserIntegrationTest.groovy
@@ -32,13 +32,15 @@ class GradleRunnerPluginClasspathInjectionEndUserIntegrationTest extends BaseTes
         buildFile << """
             task createClasspathManifest {
                 def outputDir = file("\$buildDir/\$name")
+                def outputFile = file("\$outputDir/plugin-classpath.txt")
 
-                inputs.files sourceSets.main.runtimeClasspath
+                def mainRuntimeClasspath = sourceSets.main.runtimeClasspath
+                inputs.files mainRuntimeClasspath
                 outputs.dir outputDir
 
                 doLast {
                     outputDir.mkdirs()
-                    file("\$outputDir/plugin-classpath.txt").text = sourceSets.main.runtimeClasspath.join("\\n")
+                    outputFile.text = mainRuntimeClasspath.join("\\n")
                 }
             }
 


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/28954

by updating the build logic in offending tests