### PR TITLE
Ignore flaky JavaCleanAssemblePerformanceTest

### DIFF
--- a/.teamcity/performance-tests-ci.json
+++ b/.teamcity/performance-tests-ci.json
@@ -653,29 +653,6 @@
       }
     } ]
   }, {
-    "testId" : "org.gradle.performance.regression.java.JavaCleanAssemblePerformanceTest.clean assemble",
-    "groups" : [ {
-      "testProject" : "largeJavaMultiProject",
-      "coverage" : {
-        "per_commit" : [ "linux" ]
-      }
-    }, {
-      "testProject" : "largeMonolithicJavaProject",
-      "coverage" : {
-        "per_commit" : [ "linux" ]
-      }
-    }, {
-      "testProject" : "mediumJavaCompositeBuild",
-      "coverage" : {
-        "per_commit" : [ "linux" ]
-      }
-    }, {
-      "testProject" : "mediumJavaPredefinedCompositeBuild",
-      "coverage" : {
-        "per_day" : [ "linux" ]
-      }
-    } ]
-  }, {
     "testId" : "org.gradle.performance.regression.java.JavaConfigurationCachePerformanceTest.assemble loading configuration cache state with cold daemon",
     "groups" : [ {
       "testProject" : "largeJavaMultiProjectNoBuildSrc",

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -249,6 +249,7 @@ class PerformanceTestPlugin : Plugin<Project> {
             classpath = performanceSourceSet.runtimeClasspath
             maxParallelForks = 1
             systemProperty("org.gradle.performance.scenario.json", outputJson.absolutePath)
+            systemProperty("org.gradle.performance.develocity.plugin.infoDir", projectDir.absolutePath)
 
             project.toolchainInstallationPaths?.apply {
                 systemProperty(JAVA_INSTALLATIONS_PATHS_PROPERTY, this)

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaCleanAssemblePerformanceTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaCleanAssemblePerformanceTest.groovy
@@ -23,11 +23,13 @@ import org.gradle.performance.annotations.Scenario
 import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
 import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
+import spock.lang.Ignore
 
 @RunFor([
     @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject", "mediumJavaCompositeBuild"]),
     @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["mediumJavaPredefinedCompositeBuild"])
 ])
+@Ignore("https://github.com/gradle/gradle-private/issues/4245")
 class JavaCleanAssemblePerformanceTest extends AbstractCrossVersionPerformanceTest {
 
     def "clean assemble"() {


### PR DESCRIPTION
While we're investigating https://github.com/gradle/gradle-private/issues/4245, let's ignore it to avoid breaking developers' builds.
