### PR TITLE
Standardize on file-appending methods in integration tests

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheBuildServiceIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheBuildServiceIntegrationTest.groovy
@@ -736,13 +736,13 @@ class ConfigurationCacheBuildServiceIntegrationTest extends AbstractConfiguratio
             """
         }
 
-        settingsScript("""
+        settingsFile """
             includeBuild("included-build")
-        """)
+        """
 
-        buildScript("""
+        buildFile """
             tasks.register("check") {}
-        """)
+        """
 
         when:
         configurationCacheRun "check"

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheBuildServiceIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheBuildServiceIntegrationTest.groovy
@@ -554,7 +554,7 @@ class ConfigurationCacheBuildServiceIntegrationTest extends AbstractConfiguratio
         given:
         def configurationCache = newConfigurationCacheFixture()
 
-        buildScript("""
+        buildFile("""
             ${constantServiceImpl("ConstantBuildService", "constant")}
             def serviceProvider = gradle.sharedServices.registerIfAbsent("constant", ConstantBuildService) {}
 
@@ -621,7 +621,7 @@ class ConfigurationCacheBuildServiceIntegrationTest extends AbstractConfiguratio
     @Issue("https://github.com/gradle/gradle/issues/22337")
     def "build service cannot be used in ValueSource if it is obtained at configuration time"() {
         given:
-        buildScript("""
+        buildFile("""
             ${constantServiceImpl("ConstantBuildService", "constant")}
 
             ${convertingValueSourceImpl("ConvertingValueSource", "ConstantBuildService", "String", "parameters.input.get().value")}
@@ -650,7 +650,7 @@ class ConfigurationCacheBuildServiceIntegrationTest extends AbstractConfiguratio
         given:
         def configurationCache = newConfigurationCacheFixture()
 
-        buildScript("""
+        buildFile("""
             ${constantServiceImpl("ConstantBuildService", "constant")}
 
             ${convertingValueSourceImpl("ConvertingValueSource", "ConstantBuildService", "String", "parameters.input.get().value")}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheDependencyResolutionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheDependencyResolutionIntegrationTest.groovy
@@ -1375,7 +1375,7 @@ dependencies {
     def 'can use ListProperty of ComponentArtifactIdentifier as task input'() {
         given:
         def configurationCache = newConfigurationCacheFixture()
-        buildScript '''
+        buildFile '''
             plugins {
                 id 'java-library'
             }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheMultiProjectIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheMultiProjectIntegrationTest.groovy
@@ -23,7 +23,7 @@ class ConfigurationCacheMultiProjectIntegrationTest extends AbstractConfiguratio
         settingsFile << """
             include 'a', 'b'
         """
-        buildScript """
+        buildFile """
             task ok
         """
         def a = createDir('a')
@@ -57,7 +57,7 @@ class ConfigurationCacheMultiProjectIntegrationTest extends AbstractConfiguratio
         settingsFile << """
             include 'a', 'b'
         """
-        buildScript """
+        buildFile """
             allprojects {
                 task ok
             }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/process/instrument/AbstractProcessInstrumentationInDynamicGroovyIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/process/instrument/AbstractProcessInstrumentationInDynamicGroovyIntegrationTest.groovy
@@ -16,8 +16,6 @@
 
 package org.gradle.internal.cc.impl.inputs.process.instrument
 
-import org.gradle.integtests.fixtures.GroovyBuildScriptLanguage
-import org.gradle.test.fixtures.file.TestFile
 import spock.lang.Shared
 
 /**

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/process/instrument/AbstractProcessInstrumentationInDynamicGroovyIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/process/instrument/AbstractProcessInstrumentationInDynamicGroovyIntegrationTest.groovy
@@ -76,11 +76,4 @@ abstract class AbstractProcessInstrumentationInDynamicGroovyIntegrationTest exte
         title = processCreator.replace("command", varInitializer.description)
         indyStatus = enableIndy ? "with indy" : "without indy"
     }
-
-
-    // Lift the visibility of the method to make it available for the mixin
-    @Override
-    TestFile buildScript(@GroovyBuildScriptLanguage String script) {
-        super.buildScript(script)
-    }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/process/instrument/DynamicGroovyPluginMixin.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/process/instrument/DynamicGroovyPluginMixin.groovy
@@ -20,7 +20,6 @@ import groovy.transform.SelfType
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.GroovyBuildScriptLanguage
 import org.gradle.test.fixtures.file.TestFile
 
 /**

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/process/instrument/DynamicGroovyPluginMixin.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/process/instrument/DynamicGroovyPluginMixin.groovy
@@ -16,8 +16,10 @@
 
 package org.gradle.internal.cc.impl.inputs.process.instrument
 
+import groovy.transform.SelfType
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.GroovyBuildScriptLanguage
 import org.gradle.test.fixtures.file.TestFile
 
@@ -25,6 +27,7 @@ import org.gradle.test.fixtures.file.TestFile
  * A set of helpers to generate a Groovy plugin with provided code in buildSrc and apply it to the project under test.
  * The trait is intended to be mixed into something that extends {@link org.gradle.integtests.fixtures.AbstractIntegrationSpec}.
  */
+@SelfType(AbstractIntegrationSpec)
 trait DynamicGroovyPluginMixin {
     void withPluginCode(String imports, String codeUnderTest, boolean enableIndy) {
         file("buildSrc/src/main/groovy/SomePlugin.groovy") << """
@@ -48,12 +51,10 @@ trait DynamicGroovyPluginMixin {
         }
         """
 
-        buildScript("""
+        buildFile("""
             apply plugin: SomePlugin
         """)
     }
 
     abstract TestFile file(Object... path)
-
-    abstract TestFile buildScript(@GroovyBuildScriptLanguage String script)
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/process/instrument/UnrelatedMethodInstrumentationInDynamicGroovyIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/process/instrument/UnrelatedMethodInstrumentationInDynamicGroovyIntegrationTest.groovy
@@ -16,9 +16,6 @@
 
 package org.gradle.internal.cc.impl.inputs.process.instrument
 
-import org.gradle.integtests.fixtures.GroovyBuildScriptLanguage
-import org.gradle.test.fixtures.file.TestFile
-
 class UnrelatedMethodInstrumentationInDynamicGroovyIntegrationTest extends AbstractProcessInstrumentationIntegrationTest implements DynamicGroovyPluginMixin {
     def "calling an unrelated method is allowed in groovy build script #indyStatus"() {
         given:

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/process/instrument/UnrelatedMethodInstrumentationInDynamicGroovyIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/process/instrument/UnrelatedMethodInstrumentationInDynamicGroovyIntegrationTest.groovy
@@ -77,10 +77,4 @@ class UnrelatedMethodInstrumentationInDynamicGroovyIntegrationTest extends Abstr
         enableIndy << [true, false]
         indyStatus = enableIndy ? "with indy" : "without indy"
     }
-
-    // Lift the visibility of the method to make it available for the mixin
-    @Override
-    TestFile buildScript(@GroovyBuildScriptLanguage String script) {
-        super.buildScript(script)
-    }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/undeclared/SystemPropertyInstrumentationInDynamicGroovyIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/undeclared/SystemPropertyInstrumentationInDynamicGroovyIntegrationTest.groovy
@@ -46,7 +46,7 @@ class SystemPropertyInstrumentationInDynamicGroovyIntegrationTest extends Abstra
             }
         """
 
-        buildScript("""
+        buildFile("""
             apply plugin: SomePlugin
         """)
 
@@ -111,7 +111,7 @@ class SystemPropertyInstrumentationInDynamicGroovyIntegrationTest extends Abstra
             }
         """
 
-        buildScript("""
+        buildFile("""
             apply plugin: SomePlugin
         """)
 

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/undeclared/SystemPropertyInstrumentationInJavaIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/undeclared/SystemPropertyInstrumentationInJavaIntegrationTest.groovy
@@ -38,7 +38,7 @@ class SystemPropertyInstrumentationInJavaIntegrationTest extends AbstractConfigu
             }
         """
 
-        buildScript("""
+        buildFile("""
             apply plugin: SomePlugin
         """)
 
@@ -80,7 +80,7 @@ class SystemPropertyInstrumentationInJavaIntegrationTest extends AbstractConfigu
             }
         """
 
-        buildScript("""
+        buildFile("""
             apply plugin: SomePlugin
 
              tasks.register("printProperty") {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/undeclared/SystemPropertyInstrumentationInKotlinIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/undeclared/SystemPropertyInstrumentationInKotlinIntegrationTest.groovy
@@ -47,7 +47,7 @@ class SystemPropertyInstrumentationInKotlinIntegrationTest extends AbstractConfi
             ${mavenCentralRepository(GradleDsl.KOTLIN)}
         """
 
-        buildScript("""
+        buildFile("""
             apply plugin: SomePlugin
         """)
 

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/undeclared/SystemPropertyInstrumentationInStaticGroovyIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/undeclared/SystemPropertyInstrumentationInStaticGroovyIntegrationTest.groovy
@@ -47,7 +47,7 @@ class SystemPropertyInstrumentationInStaticGroovyIntegrationTest extends Abstrac
             }
         """
 
-        buildScript("""
+        buildFile("""
             apply plugin: SomePlugin
         """)
 
@@ -80,7 +80,7 @@ class SystemPropertyInstrumentationInStaticGroovyIntegrationTest extends Abstrac
         def configurationCache = newConfigurationCacheFixture()
 
         given:
-        buildScript("""
+        buildFile("""
             import ${CompileStatic.name}
             import static ${System.name}.setProperties
 

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/ConfigurationCycleIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/ConfigurationCycleIntegrationTest.groovy
@@ -24,7 +24,7 @@ class ConfigurationCycleIntegrationTest extends AbstractIntegrationSpec {
 
     def "configuration cycle error contains information useful for troubleshooting"() {
         when:
-        buildScript '''
+        buildFile '''
             class Rules extends RuleSource {
                 @Model
                 String first(@Path("second") String second) {
@@ -71,7 +71,7 @@ first
 
     def "cycles involving multiple rules of same phase are detected"() {
         when:
-        buildScript '''
+        buildFile '''
             class Rules extends RuleSource {
                 @Model List<String> m1() { [] }
                 @Model List<String> m2() { [] }
@@ -108,7 +108,7 @@ m1
 
     def "cycles involving multiple rules of different phase are detected"() {
         when:
-        buildScript '''
+        buildFile '''
             class Rules extends RuleSource {
                 @Model List<String> m1() { [] }
                 @Model List<String> m2() { [] }

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/ModelMapIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/ModelMapIntegrationTest.groovy
@@ -27,7 +27,7 @@ import spock.lang.Issue
 class ModelMapIntegrationTest extends AbstractIntegrationSpec {
     def "provides basic meta-data for map"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Thing {
             }
@@ -65,7 +65,7 @@ class ModelMapIntegrationTest extends AbstractIntegrationSpec {
 
     def "can view as ModelElement"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Thing {
             }

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/ModelRuleBindingFailureIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/ModelRuleBindingFailureIntegrationTest.groovy
@@ -29,7 +29,7 @@ class ModelRuleBindingFailureIntegrationTest extends AbstractIntegrationSpec {
 
     def "unbound rule by-type subject and inputs are reported"() {
         given:
-        buildScript """
+        buildFile """
             class MyPlugin {
                 static class MyThing1 {}
                 static class MyThing2 {}
@@ -79,7 +79,7 @@ class ModelRuleBindingFailureIntegrationTest extends AbstractIntegrationSpec {
 
     def "unbound rule by-path subject and inputs are reported"() {
         given:
-        buildScript """
+        buildFile """
             class MyPlugin {
                 static class MyThing1 {}
                 static class MyThing2 {}
@@ -121,7 +121,7 @@ class ModelRuleBindingFailureIntegrationTest extends AbstractIntegrationSpec {
 
     def "unbound dsl rule by-path subject and inputs are reported"() {
         given:
-        buildScript '''
+        buildFile '''
             @Managed interface Thing { }
 
             model {
@@ -156,7 +156,7 @@ class ModelRuleBindingFailureIntegrationTest extends AbstractIntegrationSpec {
 
     def "suggestions are provided for unbound by-path references"() {
         given:
-        buildScript """
+        buildFile """
             class MyPlugin {
                 static class Rules extends RuleSource {
                     @Mutate
@@ -189,7 +189,7 @@ class ModelRuleBindingFailureIntegrationTest extends AbstractIntegrationSpec {
 
     def "fails on ambiguous by-type reference"() {
         given:
-        buildScript """
+        buildFile """
             class Plugin1 {
                 static class Rules extends RuleSource {
                     @Model
@@ -235,7 +235,7 @@ class ModelRuleBindingFailureIntegrationTest extends AbstractIntegrationSpec {
 
     def "fails on incompatible by-type reference"() {
         given:
-        buildScript """
+        buildFile """
             class Plugin1 {
                 static class Rules extends RuleSource {
                     @Mutate
@@ -261,7 +261,7 @@ This element was created by Project.<init>.tasks() and can be mutated as the fol
 
     def "reports failure to bind subject or input due to null reference"() {
         given:
-        buildScript """
+        buildFile """
 @Managed interface Person extends Named {
     Person getParent()
     void setParent(Person p)
@@ -322,7 +322,7 @@ model {
 
     def "partially bound rules are reported and the report includes the elements bound to"() {
         given:
-        buildScript """
+        buildFile """
             class MyPlugin {
                 static class MyThing1 {}
                 static class MyThing2 {}

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/ModelRuleBindingValidationIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/ModelRuleBindingValidationIntegrationTest.groovy
@@ -50,7 +50,7 @@ class ModelRuleBindingValidationIntegrationTest extends AbstractIntegrationSpec 
 
     def "entire model is validated, not just what is 'needed'"() {
         when:
-        buildScript """
+        buildFile """
             class Rules extends RuleSource {
               @Model
               String s1(Integer iDontExist) {

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/ModelRuleValidationIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/ModelRuleValidationIntegrationTest.groovy
@@ -24,7 +24,7 @@ class ModelRuleValidationIntegrationTest extends AbstractIntegrationSpec {
 
     def "invalid model name produces error message"() {
         when:
-        buildScript """
+        buildFile """
             class MyPlugin {
                 static class Rules extends RuleSource {
                     @Model(" ")
@@ -48,7 +48,7 @@ class ModelRuleValidationIntegrationTest extends AbstractIntegrationSpec {
 
     def "model name can be at nested path"() {
         when:
-        buildScript """
+        buildFile """
             class MyPlugin {
                 static class Rules extends RuleSource {
                     @Model("foo. bar")

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/MutationRuleApplicationOrderIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/MutationRuleApplicationOrderIntegrationTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 class MutationRuleApplicationOrderIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {
-        buildScript '''
+        buildFile '''
             class MutationRecorder {
                 def mutations = []
             }

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/RuleSourceAppliedAsProjectPluginIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/RuleSourceAppliedAsProjectPluginIntegrationTest.groovy
@@ -24,7 +24,7 @@ class RuleSourceAppliedAsProjectPluginIntegrationTest extends AbstractIntegratio
 
     def "plugin class can expose model rules"() {
         when:
-        buildScript '''
+        buildFile '''
             class MyPlugin {
                 static class Rules extends RuleSource {
                     @Model
@@ -100,7 +100,7 @@ model {
 
     def "configuration in script is not executed if not needed"() {
         given:
-        buildScript '''
+        buildFile '''
             class MyPlugin {
                 static class Rules extends RuleSource {
                     @Model
@@ -127,7 +127,7 @@ model {
 
     def "informative error message when rules are invalid"() {
         when:
-        buildScript """
+        buildFile """
             class MyPlugin {
                 class Rules extends RuleSource {
                 }
@@ -148,7 +148,7 @@ model {
 
     def "informative error message when two plugins declare model at the same path"() {
         when:
-        buildScript """
+        buildFile """
             class MyPlugin {
                 static class Rules extends RuleSource {
                     @Model
@@ -177,7 +177,7 @@ model {
 
     def "informative error message when two plugins declare model at the same path and model is already created"() {
         when:
-        buildScript '''
+        buildFile '''
             class MyPlugin {
                 static class Rules extends RuleSource {
                     @Model
@@ -217,7 +217,7 @@ model {
 
     def "informative error message when creation rule throws"() {
         when:
-        buildScript '''
+        buildFile '''
             class MyPlugin {
                 static class Rules extends RuleSource {
                     @Model
@@ -244,7 +244,7 @@ model {
 
     def "informative error message when mutation rule throws"() {
         when:
-        buildScript '''
+        buildFile '''
             class MyPlugin {
                 static class Rules extends RuleSource {
                     @Model
@@ -276,7 +276,7 @@ model {
 
     def "model registration must provide instance"() {
         when:
-        buildScript '''
+        buildFile '''
             class MyPlugin {
                 static class Rules extends RuleSource {
                     @Model
@@ -304,7 +304,7 @@ model {
 
     def "plugin applied by plugin can contribute rules"() {
         when:
-        buildScript '''
+        buildFile '''
             class MyBasePlugin {
                 static class Rules extends RuleSource {
                     @Mutate
@@ -348,7 +348,7 @@ model {
 
     def "configuration made to a project extension during afterEvaluate() is visible to rule sources"() {
         when:
-        buildScript '''
+        buildFile '''
             class MyExtension {
                 String value = "original"
             }
@@ -396,7 +396,7 @@ model {
 
     def "rule can depend on a concrete task type"() {
         when:
-        buildScript '''
+        buildFile '''
             class MyPlugin {
                 static class Rules extends RuleSource {
                     @Mutate
@@ -424,7 +424,7 @@ model {
 
     def "reports rule execution failure when rule source constructor throws exception"() {
         when:
-        buildScript '''
+        buildFile '''
             class Rules extends RuleSource {
                 Rules() {
                     throw new RuntimeException("failing constructor")

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/RuleSourceAppliedByRuleMethodIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/RuleSourceAppliedByRuleMethodIntegrationTest.groovy
@@ -558,7 +558,7 @@ class RuleSourceAppliedByRuleMethodIntegrationTest extends AbstractIntegrationSp
     }
 
     def "reports unbound parameters for rules on applied RuleSource"() {
-        buildScript '''
+        buildFile '''
             class UnboundRuleSource extends RuleSource {
                 @Mutate
                 void unboundRule(String string, Integer integer, @Path("some.inner.path") String withPath) {

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/RuleSourceAppliedToModelMapElementIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/RuleSourceAppliedToModelMapElementIntegrationTest.groovy
@@ -24,7 +24,7 @@ class RuleSourceAppliedToModelMapElementIntegrationTest extends AbstractIntegrat
 
     def "rule source can be applied to ModelMap element"() {
         when:
-        buildScript '''
+        buildFile '''
             class MessageTask extends DefaultTask {
                 @Internal
                 String message = "default"
@@ -67,7 +67,7 @@ class RuleSourceAppliedToModelMapElementIntegrationTest extends AbstractIntegrat
 
     def "scoped rule execution failure yields useful error message"() {
         when:
-        buildScript '''
+        buildFile '''
             class ThrowingRule extends RuleSource {
                 @Mutate
                 void badRule(Task echo) {
@@ -96,7 +96,7 @@ class RuleSourceAppliedToModelMapElementIntegrationTest extends AbstractIntegrat
 
     def "invalid rule definitions of scoped rules are reported with a message helping to identify the faulty rule"() {
         when:
-        buildScript '''
+        buildFile '''
             class InvalidRuleSource extends RuleSource {
                 @Mutate
                 String invalidRule(Task echo) {
@@ -125,7 +125,7 @@ class RuleSourceAppliedToModelMapElementIntegrationTest extends AbstractIntegrat
 
     def "unbound inputs of scoped rules are reported and their scope is shown"() {
         when:
-        buildScript '''
+        buildFile '''
             class UnboundRuleSource extends RuleSource {
                 @Mutate
                 void unboundRule(String string, Integer integer, @Path("some.inner.path") String withInnerPath) {

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/AbstractClassBackedManagedTypeIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/AbstractClassBackedManagedTypeIntegrationTest.groovy
@@ -24,7 +24,7 @@ class AbstractClassBackedManagedTypeIntegrationTest extends AbstractIntegrationS
 
     def "rule can provide a managed model element backed by an abstract class"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             abstract class Person {
                 abstract String getName()
@@ -59,7 +59,7 @@ class AbstractClassBackedManagedTypeIntegrationTest extends AbstractIntegrationS
 
     def "managed type implemented as abstract class can have generative getters"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             abstract class Person {
                 abstract String getFirstName()
@@ -101,7 +101,7 @@ class AbstractClassBackedManagedTypeIntegrationTest extends AbstractIntegrationS
 
     def "managed type implemented as abstract class can have a custom toString() implementation"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             abstract class CustomToString {
                 abstract String getStringRepresentation()
@@ -254,7 +254,7 @@ class AbstractClassBackedManagedTypeIntegrationTest extends AbstractIntegrationS
 
     def "reports managed abstract type in missing property error message"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             abstract class Person {
                 abstract String getName()

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/CyclicalManagedTypeIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/CyclicalManagedTypeIntegrationTest.groovy
@@ -24,7 +24,7 @@ class CyclicalManagedTypeIntegrationTest extends AbstractIntegrationSpec {
 
     def "managed types can have cyclical managed type references"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Parent {
                 String getName()
@@ -68,7 +68,7 @@ class CyclicalManagedTypeIntegrationTest extends AbstractIntegrationSpec {
 
     def "managed types can have cyclical managed type references where more than two types constitute the cycle"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface A {
                 String getName()

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/EnumsInManagedModelIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/EnumsInManagedModelIntegrationTest.groovy
@@ -24,7 +24,7 @@ class EnumsInManagedModelIntegrationTest extends AbstractIntegrationSpec {
 
     def "can use enums in managed model elements"() {
         when:
-        buildScript '''
+        buildFile '''
             enum Gender {
                 FEMALE, MALE, OTHER
             }

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/InterfaceBackedManagedTypeIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/InterfaceBackedManagedTypeIntegrationTest.groovy
@@ -31,7 +31,7 @@ class InterfaceBackedManagedTypeIntegrationTest extends AbstractIntegrationSpec 
 
     def "rule method can define a managed model element backed by an interface"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person {
                 String getName()
@@ -87,7 +87,7 @@ class InterfaceBackedManagedTypeIntegrationTest extends AbstractIntegrationSpec 
 
     def "can view a managed element as ModelElement"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person {
                 String getName()
@@ -125,7 +125,7 @@ class InterfaceBackedManagedTypeIntegrationTest extends AbstractIntegrationSpec 
 
     def "rule method can apply defaults to a managed model element"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person {
                 String getName()
@@ -218,7 +218,7 @@ class InterfaceBackedManagedTypeIntegrationTest extends AbstractIntegrationSpec 
             }
         '''
 
-        buildScript '''
+        buildFile '''
             apply type: RulePlugin
         '''
 
@@ -262,7 +262,7 @@ class InterfaceBackedManagedTypeIntegrationTest extends AbstractIntegrationSpec 
             }
         '''
 
-        buildScript '''
+        buildFile '''
             apply type: RulePlugin
         '''
 
@@ -297,7 +297,7 @@ class InterfaceBackedManagedTypeIntegrationTest extends AbstractIntegrationSpec 
             }
         '''
 
-        buildScript '''
+        buildFile '''
             apply type: RulePlugin
         '''
 
@@ -332,7 +332,7 @@ class InterfaceBackedManagedTypeIntegrationTest extends AbstractIntegrationSpec 
             }
         '''
 
-        buildScript '''
+        buildFile '''
             apply type: RulePlugin
         '''
 
@@ -346,7 +346,7 @@ class InterfaceBackedManagedTypeIntegrationTest extends AbstractIntegrationSpec 
 
     def "two views of the same element are equal"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Address {
                 String getCity()
@@ -386,7 +386,7 @@ class InterfaceBackedManagedTypeIntegrationTest extends AbstractIntegrationSpec 
 
     def "reports managed interface type in missing property error message"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person {
                 String getName()

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/InvalidManagedModelMutationIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/InvalidManagedModelMutationIntegrationTest.groovy
@@ -24,7 +24,7 @@ class InvalidManagedModelMutationIntegrationTest extends AbstractIntegrationSpec
 
     def "mutating managed inputs of a rule is not allowed"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person {
                 String getName()
@@ -59,7 +59,7 @@ class InvalidManagedModelMutationIntegrationTest extends AbstractIntegrationSpec
 
     def "mutating subject of a validate rule is not allowed"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person {
                 String getName()
@@ -94,7 +94,7 @@ class InvalidManagedModelMutationIntegrationTest extends AbstractIntegrationSpec
 
     def "mutating composite managed inputs of a rule is not allowed"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Pet {
                 String getName()
@@ -130,7 +130,7 @@ class InvalidManagedModelMutationIntegrationTest extends AbstractIntegrationSpec
 
     def "mutating managed inputs of a dsl rule is not allowed"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person {
                 String getName()
@@ -162,7 +162,7 @@ class InvalidManagedModelMutationIntegrationTest extends AbstractIntegrationSpec
 
     def "mutating managed objects outside of a creation rule is not allowed"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person {
                 String getName()
@@ -198,7 +198,7 @@ class InvalidManagedModelMutationIntegrationTest extends AbstractIntegrationSpec
 
     def "mutating composite managed objects outside of a creation rule is not allowed"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Pet {
                 String getName()
@@ -239,7 +239,7 @@ class InvalidManagedModelMutationIntegrationTest extends AbstractIntegrationSpec
 
     def "mutating managed objects referenced by another managed object outside of a creation rule is not allowed"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Pet {
                 String getName()

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/InvalidManagedModelRuleIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/InvalidManagedModelRuleIntegrationTest.groovy
@@ -24,7 +24,7 @@ class InvalidManagedModelRuleIntegrationTest extends AbstractIntegrationSpec {
 
     def "provides a useful error message when setting an incompatible type on a managed instance in Groovy"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person {
                 int getThumbCount()
@@ -78,7 +78,7 @@ class InvalidManagedModelRuleIntegrationTest extends AbstractIntegrationSpec {
                 }
             }
         '''
-        buildScript '''
+        buildFile '''
             apply type: RulePlugin
         '''
 
@@ -92,7 +92,7 @@ class InvalidManagedModelRuleIntegrationTest extends AbstractIntegrationSpec {
 
     def "cannot assign a non-managed instance to a property of a managed type"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Platform {
                 OperatingSystem getOperatingSystem()
@@ -138,7 +138,7 @@ class InvalidManagedModelRuleIntegrationTest extends AbstractIntegrationSpec {
 
     def "cannot use value type as subject of void model rule"() {
         when:
-        buildScript '''
+        buildFile '''
             class Rules extends RuleSource {
               @Model
               void s(String s) {}
@@ -157,7 +157,7 @@ class InvalidManagedModelRuleIntegrationTest extends AbstractIntegrationSpec {
 
     def "cannot use unknown type as subject of void model rule"() {
         when:
-        buildScript '''
+        buildFile '''
             interface Thing { }
 
             class Rules extends RuleSource {
@@ -178,7 +178,7 @@ class InvalidManagedModelRuleIntegrationTest extends AbstractIntegrationSpec {
 
     def "provides a useful error message when an invalid managed type is used in a rule"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person {
                 String getName()

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedModelMapIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedModelMapIntegrationTest.groovy
@@ -24,7 +24,7 @@ class ManagedModelMapIntegrationTest extends AbstractIntegrationSpec {
 
     def "rule can create a map of model elements"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Thing extends Named {
               void setValue(String value)
@@ -75,7 +75,7 @@ class ManagedModelMapIntegrationTest extends AbstractIntegrationSpec {
 
     def "rule can create a map of abstract class backed managed model elements"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             abstract class Thing implements Named {
               abstract String getName()
@@ -128,7 +128,7 @@ class ManagedModelMapIntegrationTest extends AbstractIntegrationSpec {
     def "rule can create a map of various supported types"() {
         // TODO - can't actually add anything to these maps yet
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Thing extends Named {
               void setValue(String value)
@@ -179,7 +179,7 @@ class ManagedModelMapIntegrationTest extends AbstractIntegrationSpec {
 
     def "fails when rule creates a map of unsupported type"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Container {
               ModelMap<InputStream> getThings()
@@ -209,7 +209,7 @@ A managed collection can not contain 'java.io.InputStream's""")
 
     def "reports failure that occurs in collection item initializer"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person extends Named {
               String getValue()
@@ -242,7 +242,7 @@ A managed collection can not contain 'java.io.InputStream's""")
 
     def "cannot read when mutable"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person extends Named {
               String getValue()
@@ -273,7 +273,7 @@ A managed collection can not contain 'java.io.InputStream's""")
 
     def "cannot mutate when used as an input"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person extends Named {
               String getValue()
@@ -303,7 +303,7 @@ A managed collection can not contain 'java.io.InputStream's""")
 
     def "cannot mutate when used as subject of validate rule"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person extends Named {
               String getValue()
@@ -338,7 +338,7 @@ A managed collection can not contain 'java.io.InputStream's""")
 
     def "can read children of map when used as input"() {
         when:
-        buildScript """
+        buildFile """
             @Managed
             interface Parent {
                 String getName();
@@ -409,7 +409,7 @@ parent
 
     def "can read children of map when used as subject of validate rule"() {
         given:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person extends Named {
               String getValue()
@@ -446,7 +446,7 @@ parent
 
     def "name is not populated when entity is not named"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Thing {
               String getName()

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedModelPropertyTargetingRuleIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedModelPropertyTargetingRuleIntegrationTest.groovy
@@ -24,7 +24,7 @@ class ManagedModelPropertyTargetingRuleIntegrationTest extends AbstractIntegrati
 
     def "rule can target nested element of managed element as input"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Platform {
                 OperatingSystem getOperatingSystem()
@@ -84,7 +84,7 @@ class ManagedModelPropertyTargetingRuleIntegrationTest extends AbstractIntegrati
 
     def "rule can target nested element of managed element as subject"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Platform {
                 OperatingSystem getOperatingSystem()
@@ -145,7 +145,7 @@ class ManagedModelPropertyTargetingRuleIntegrationTest extends AbstractIntegrati
 
     def "rule can target managed element as input through a reference"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Platform {
                 OperatingSystem getOperatingSystem()
@@ -206,7 +206,7 @@ class ManagedModelPropertyTargetingRuleIntegrationTest extends AbstractIntegrati
 
     def "rule can target nested element of managed element as input through a reference to managed element"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Platform {
                 OperatingSystem getOperatingSystem()
@@ -272,7 +272,7 @@ class ManagedModelPropertyTargetingRuleIntegrationTest extends AbstractIntegrati
 
     def "rule can target managed element via a series of references"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Platform {
                 OperatingSystem getOperatingSystem()
@@ -344,7 +344,7 @@ class ManagedModelPropertyTargetingRuleIntegrationTest extends AbstractIntegrati
 
     def "target of reference is realized when used as an input"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Platforms {
                 OperatingSystem getCurrent()
@@ -414,7 +414,7 @@ class ManagedModelPropertyTargetingRuleIntegrationTest extends AbstractIntegrati
 
     def "rule can target scalar property of managed element as input"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Platform {
                 String getName()
@@ -460,7 +460,7 @@ class ManagedModelPropertyTargetingRuleIntegrationTest extends AbstractIntegrati
 
     def "rule can configure scalar property of managed element"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Platform {
                 OperatingSystem getOperatingSystem()
@@ -510,7 +510,7 @@ class ManagedModelPropertyTargetingRuleIntegrationTest extends AbstractIntegrati
 
     def "creation rule can target scalar property of managed element as input"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface OperatingSystem {
                 String getName()

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedScalarCollectionsIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedScalarCollectionsIntegrationTest.groovy
@@ -26,7 +26,7 @@ class ManagedScalarCollectionsIntegrationTest extends AbstractIntegrationSpec {
 
     def "rule can mutate a managed type with a #type of scalar read-only property"() {
         given:
-        buildScript """
+        buildFile """
 
         @Managed
         interface Container {
@@ -62,7 +62,7 @@ class ManagedScalarCollectionsIntegrationTest extends AbstractIntegrationSpec {
 
     def "rule can mutate a managed type with a #type of scalar read-write property"() {
         given:
-        buildScript """
+        buildFile """
 
         @Managed
         interface Container {
@@ -104,7 +104,7 @@ class ManagedScalarCollectionsIntegrationTest extends AbstractIntegrationSpec {
 
     def "rule can nullify a managed type with a #type of scalar read-write property"() {
         given:
-        buildScript """
+        buildFile """
 
         @Managed
         interface Container {
@@ -145,7 +145,7 @@ class ManagedScalarCollectionsIntegrationTest extends AbstractIntegrationSpec {
 
     def "rule can overwrite value of a managed type with a #type of scalar read-write property"() {
         given:
-        buildScript """
+        buildFile """
 
         @Managed
         interface Container {
@@ -188,7 +188,7 @@ class ManagedScalarCollectionsIntegrationTest extends AbstractIntegrationSpec {
 
     def "rule can nullify and set value of a managed type #type in the same mutation block"() {
         given:
-        buildScript """
+        buildFile """
 
         @Managed
         interface Container {
@@ -230,7 +230,7 @@ class ManagedScalarCollectionsIntegrationTest extends AbstractIntegrationSpec {
 
     def "rule cannot mutate a managed type with a #type of scalar property when a rule input"() {
         when:
-        buildScript """
+        buildFile """
 
         @Managed
         interface Container {
@@ -267,7 +267,7 @@ class ManagedScalarCollectionsIntegrationTest extends AbstractIntegrationSpec {
 
     def "cannot mutate #type subject of a validation rule"() {
         when:
-        buildScript """
+        buildFile """
 
         @Managed
         interface Container {
@@ -303,7 +303,7 @@ class ManagedScalarCollectionsIntegrationTest extends AbstractIntegrationSpec {
 
     def "rule cannot mutate rule input even using iterator on #type"() {
         when:
-        buildScript """
+        buildFile """
 
         @Managed
         interface Container {
@@ -343,7 +343,7 @@ class ManagedScalarCollectionsIntegrationTest extends AbstractIntegrationSpec {
 
     def "reports problem when managed type declares a #type of managed type"() {
         when:
-        buildScript """
+        buildFile """
         @Managed
         interface Thing { }
 
@@ -373,7 +373,7 @@ A valid scalar collection takes the form of List<T> or Set<T> where 'T' is one o
 
     def "reports problem when managed type declares a #type of subtype of scalar type"() {
         when:
-        buildScript """
+        buildFile """
         class Thing extends File {
             Thing(String s) { super(s) }
         }

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedTypeImplementationClassCachingSpec.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedTypeImplementationClassCachingSpec.groovy
@@ -24,7 +24,7 @@ class ManagedTypeImplementationClassCachingSpec extends AbstractIntegrationSpec 
 
     def "managed type implementation class is generated once for each type and reused"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Named {
                 String getName()

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedTypeReferencesIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedTypeReferencesIntegrationTest.groovy
@@ -24,7 +24,7 @@ class ManagedTypeReferencesIntegrationTest extends AbstractIntegrationSpec {
 
     def "rule can provide a managed model element that references another managed model element"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Platform {
                 String getDisplayName()
@@ -95,7 +95,7 @@ class ManagedTypeReferencesIntegrationTest extends AbstractIntegrationSpec {
 
     def "reference can have null value when parent model element is realized"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Platform {
                 String getDisplayName()

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedTypeWithUnmanagedPropertiesIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedTypeWithUnmanagedPropertiesIntegrationTest.groovy
@@ -24,7 +24,7 @@ class ManagedTypeWithUnmanagedPropertiesIntegrationTest extends AbstractIntegrat
 
     def "can have unmanaged property of unsupported types"() {
         when:
-        buildScript '''
+        buildFile '''
             class UnmanagedThing {
               String value
             }
@@ -71,7 +71,7 @@ class ManagedTypeWithUnmanagedPropertiesIntegrationTest extends AbstractIntegrat
 
     def "unmanaged property of managed type can be targeted by rules"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Platform {
                 @Unmanaged
@@ -126,7 +126,7 @@ class ManagedTypeWithUnmanagedPropertiesIntegrationTest extends AbstractIntegrat
 
     def "can view unmanaged property as ModelElement"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Platform {
                 @Unmanaged

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ModelSetIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ModelSetIntegrationTest.groovy
@@ -24,7 +24,7 @@ class ModelSetIntegrationTest extends AbstractIntegrationSpec {
 
     def "provides basic meta-data for set"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person {
             }
@@ -62,7 +62,7 @@ class ModelSetIntegrationTest extends AbstractIntegrationSpec {
 
     def "can view as ModelElement"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person {
             }
@@ -98,7 +98,7 @@ class ModelSetIntegrationTest extends AbstractIntegrationSpec {
 
     def "rule can create a managed collection of interface backed managed model elements"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person {
               String getName()
@@ -156,7 +156,7 @@ class ModelSetIntegrationTest extends AbstractIntegrationSpec {
 
     def "rule can create a managed collection of abstract class backed managed model elements"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             abstract class Person {
               abstract String getName()
@@ -195,7 +195,7 @@ class ModelSetIntegrationTest extends AbstractIntegrationSpec {
 
     def "rule can create a set of various supported types"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Thing extends Named {
               void setValue(String value)
@@ -262,7 +262,7 @@ class ModelSetIntegrationTest extends AbstractIntegrationSpec {
 
     def "managed model type has property of collection of managed types"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person {
               String getName()
@@ -313,7 +313,7 @@ class ModelSetIntegrationTest extends AbstractIntegrationSpec {
 
     def "managed model cannot have a reference to a model set"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person {
               String getName()
@@ -349,7 +349,7 @@ class ModelSetIntegrationTest extends AbstractIntegrationSpec {
 
     def "rule method can apply defaults to a managed set"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person {
               String getName()
@@ -402,7 +402,7 @@ finalize
 
     def "creation and configuration of managed set elements is deferred until required"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             abstract class Person {
               Person() {
@@ -473,7 +473,7 @@ configure p3
 
     def "reports failure that occurs in collection item initializer"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person {
               String getName()
@@ -506,7 +506,7 @@ configure p3
 
     def "read methods of ModelSet throw exceptions when used in a creation rule"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person {
             }
@@ -535,7 +535,7 @@ configure p3
 
     def "read methods of ModelSet throw exceptions when used in a mutation rule"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person {
             }
@@ -568,7 +568,7 @@ configure p3
 
     def "mutating a managed set that is an input of a rule is not allowed"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person {
             }
@@ -596,7 +596,7 @@ configure p3
 
     def "mutating a managed set that is the subject of a validation rule is not allowed"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person {
             }
@@ -628,7 +628,7 @@ configure p3
 
     def "mutating a managed set outside of a creation rule is not allowed"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person {
             }
@@ -662,7 +662,7 @@ configure p3
 
     def "mutating managed set which is an input of a DSL rule is not allowed"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Person {
             }

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/NestedManagedTypeIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/NestedManagedTypeIntegrationTest.groovy
@@ -24,7 +24,7 @@ class NestedManagedTypeIntegrationTest extends AbstractIntegrationSpec {
 
     def "rule can provide a managed model tree"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Platform {
                 String getDisplayName()
@@ -96,7 +96,7 @@ class NestedManagedTypeIntegrationTest extends AbstractIntegrationSpec {
 
     def "rule can apply defaults to a nested managed model element"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Platform {
                 String getDisplayName()

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/PolymorphicManagedTypeIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/PolymorphicManagedTypeIntegrationTest.groovy
@@ -24,7 +24,7 @@ class PolymorphicManagedTypeIntegrationTest extends AbstractIntegrationSpec {
 
     def "rule can provide a managed model element backed by an abstract class that implements interfaces"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Named {
                 String getName()
@@ -63,7 +63,7 @@ class PolymorphicManagedTypeIntegrationTest extends AbstractIntegrationSpec {
 
     def "rule can provide a managed model element backed by an abstract class that extends other classes"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             abstract class Named {
                 abstract String getName()
@@ -102,7 +102,7 @@ class PolymorphicManagedTypeIntegrationTest extends AbstractIntegrationSpec {
 
     def "managed model interface can extend other interface"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Named {
                 String getName()
@@ -144,7 +144,7 @@ class PolymorphicManagedTypeIntegrationTest extends AbstractIntegrationSpec {
 
     def "can depend on managed super type as input and subject"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Named {
                 String getName()
@@ -187,7 +187,7 @@ class PolymorphicManagedTypeIntegrationTest extends AbstractIntegrationSpec {
 
     def "two managed types can extend the same parent"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Named {
                 String getName()

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ScalarTypesInManagedModelIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ScalarTypesInManagedModelIntegrationTest.groovy
@@ -25,7 +25,7 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
 
     def "values of primitive types and boxed primitive types are widened as usual when using groovy"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface PrimitiveTypes {
                 Long getLongPropertyFromInt()
@@ -63,7 +63,7 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
 
     def "can view property with scalar type as ModelElement"() {
         given:
-        buildScript '''
+        buildFile '''
             @Managed
             interface PrimitiveTypes {
                 int getIntProp()
@@ -106,7 +106,7 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
 
     def "mismatched types error in managed type are propagated to the user"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface PrimitiveTypes {
                 Long getLongProperty()
@@ -176,7 +176,7 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
             }
         '''
 
-        buildScript '''
+        buildFile '''
             apply type: RulePlugin
         '''
 
@@ -186,7 +186,7 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
 
     def "can set/get properties of all supported scalar types using Groovy"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface AllSupportedUnmanagedTypes {
                 Boolean getBooleanProperty()
@@ -361,7 +361,7 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
         '''
 
         when:
-        buildScript '''
+        buildFile '''
             apply type: RulePlugin
         '''
 
@@ -371,7 +371,7 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
 
     def "can specify managed models with file types"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface FileContainer {
                 File getFile()
@@ -428,7 +428,7 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
              check     : "assert p.$propName == $value"]
         }
 
-        buildScript """
+        buildFile """
             import org.gradle.api.artifacts.Configuration.State
 
             @Managed
@@ -531,7 +531,7 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
             }
         """
 
-        buildScript '''
+        buildFile '''
             apply type: RulePlugin
         '''
 
@@ -580,7 +580,7 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
                     }"""]
         }
 
-        buildScript """
+        buildFile """
             import org.gradle.api.artifacts.Configuration.State
 
             @Managed
@@ -616,7 +616,7 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
 
     def "read-only backing set preserves order of insertion"() {
         given: "a managed type that uses a Set of strings"
-        buildScript '''
+        buildFile '''
             @Managed
             interface User {
                 Set<String> getGroups()
@@ -654,7 +654,7 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
 
     def "read-write backing set preserves order of insertion"() {
         given: "a managed type that uses a read-write Set of strings"
-        buildScript '''
+        buildFile '''
             @Managed
             interface User {
                 Set<String> getGroups()
@@ -693,7 +693,7 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "read-write backing set retains null value"() {
-        buildScript '''
+        buildFile '''
             @Managed
             interface User {
                 Set<String> getGroups()
@@ -726,7 +726,7 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
 
     def "cannot mutate read-write scalar collection when not target of a rule"() {
         given: "a managed type that uses a read-write Set of strings"
-        buildScript '''
+        buildFile '''
             @Managed
             interface User {
                 Set<String> getGroups()

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/UnmanagedCollectionPropertyIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/UnmanagedCollectionPropertyIntegrationTest.groovy
@@ -24,7 +24,7 @@ class UnmanagedCollectionPropertyIntegrationTest extends AbstractIntegrationSpec
 
     def "managed type can have unmanaged properties of collection type with types that are not scalar types"() {
         given:
-        buildScript """
+        buildFile """
 
         class Widget {
             String name

--- a/platforms/core-configuration/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ModelDslCreationIntegrationTest.groovy
+++ b/platforms/core-configuration/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ModelDslCreationIntegrationTest.groovy
@@ -24,7 +24,7 @@ class ModelDslCreationIntegrationTest extends AbstractIntegrationSpec {
 
     def "can create and initialize elements"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Thing {
                 String getName()
@@ -52,7 +52,7 @@ class ModelDslCreationIntegrationTest extends AbstractIntegrationSpec {
 
     def "creator closure can reference inputs"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Thing {
                 String getName()
@@ -83,7 +83,7 @@ class ModelDslCreationIntegrationTest extends AbstractIntegrationSpec {
 
     def "reports failure in initialization closure"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Thing {
                 String getName()
@@ -112,7 +112,7 @@ class ModelDslCreationIntegrationTest extends AbstractIntegrationSpec {
 
     def "can create elements without mutating"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Thing {
                 String getName()
@@ -138,7 +138,7 @@ class ModelDslCreationIntegrationTest extends AbstractIntegrationSpec {
 
     def "can apply defaults before creator closure is invoked"() {
         when:
-        buildScript '''
+        buildFile '''
             @Managed
             interface Thing {
                 String getName()
@@ -175,7 +175,7 @@ class ModelDslCreationIntegrationTest extends AbstractIntegrationSpec {
 
     def "cannot create non managed types"() {
         when:
-        buildScript '''
+        buildFile '''
             apply plugin: 'language-base'
             interface Thing {
                 String getName()
@@ -204,7 +204,7 @@ It must be one of:
 
     def "cannot create non managed types and provide an initialization closure"() {
         when:
-        buildScript '''
+        buildFile '''
             apply plugin: 'language-base'
             interface Thing {
                 String getName()

--- a/platforms/core-configuration/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ModelDslIntegrationTest.groovy
+++ b/platforms/core-configuration/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ModelDslIntegrationTest.groovy
@@ -29,7 +29,7 @@ class ModelDslIntegrationTest extends AbstractIntegrationSpec {
 
     def "can reference rule inputs using dollar method syntax"() {
         when:
-        buildScript '''
+        buildFile '''
             class MyPlugin extends RuleSource {
                 @Model
                 String foo() {
@@ -66,7 +66,7 @@ class ModelDslIntegrationTest extends AbstractIntegrationSpec {
 
     def "rule inputs can be referenced in closures that are not executed during rule execution"() {
         when:
-        buildScript '''
+        buildFile '''
             class MyPlugin extends RuleSource {
                 @Model
                 String foo() {
@@ -104,7 +104,7 @@ class ModelDslIntegrationTest extends AbstractIntegrationSpec {
 
     def "inputs are fully configured when used in rules"() {
         when:
-        buildScript '''
+        buildFile '''
             class MyPlugin extends RuleSource {
                 @Model
                 List<String> strings() {
@@ -138,7 +138,7 @@ class ModelDslIntegrationTest extends AbstractIntegrationSpec {
 
     def "the same input can be referenced more than once, and refers to the same object"() {
         when:
-        buildScript '''
+        buildFile '''
             class MyPlugin extends RuleSource {
                 @Model
                 List<String> strings() {
@@ -173,7 +173,7 @@ class ModelDslIntegrationTest extends AbstractIntegrationSpec {
 
     def "reports on the first reference to unknown input"() {
         when:
-        buildScript '''
+        buildFile '''
             model {
               tasks {
                 $.unknown
@@ -197,7 +197,7 @@ class ModelDslIntegrationTest extends AbstractIntegrationSpec {
 
     def "reports on configuration action failure"() {
         when:
-        buildScript '''
+        buildFile '''
             model {
               tasks {
                 unknown = 12
@@ -215,7 +215,7 @@ class ModelDslIntegrationTest extends AbstractIntegrationSpec {
         settingsFile << "include 'a'; include 'b'"
         when:
 
-        buildScript '''
+        buildFile '''
             class MyPlugin extends RuleSource {
                 @Model
                 String foo() {

--- a/platforms/core-configuration/model-groovy/src/integTest/groovy/org/gradle/model/dsl/internal/transform/ModelDslRuleDetectionIntegrationSpec.groovy
+++ b/platforms/core-configuration/model-groovy/src/integTest/groovy/org/gradle/model/dsl/internal/transform/ModelDslRuleDetectionIntegrationSpec.groovy
@@ -29,7 +29,7 @@ class ModelDslRuleDetectionIntegrationSpec extends AbstractIntegrationSpec {
         def normalisedPath = path.replace('"', '').replaceAll("'", "")
 
         when:
-        buildScript """
+        buildFile """
             @Managed
             interface Item {
                 String getValue()
@@ -94,7 +94,7 @@ class ModelDslRuleDetectionIntegrationSpec extends AbstractIntegrationSpec {
 
     def "only literal property paths are allowed - #pathCode"() {
         when:
-        buildScript """
+        buildFile """
             model {
                 $pathCode {
 
@@ -120,7 +120,7 @@ class ModelDslRuleDetectionIntegrationSpec extends AbstractIntegrationSpec {
 
     def "only rules are allowed in the model block - #code"() {
         when:
-        buildScript """
+        buildFile """
             model {
                 $code
             }
@@ -142,7 +142,7 @@ class ModelDslRuleDetectionIntegrationSpec extends AbstractIntegrationSpec {
 
     def "only closure literals can be used as rules"() {
         when:
-        buildScript """
+        buildFile """
             class MyPlugin extends RuleSource {
                 @Model
                 String foo() {

--- a/platforms/core-configuration/model-groovy/src/integTest/groovy/org/gradle/model/dsl/internal/transform/ModelDslRuleInputDetectionIntegrationSpec.groovy
+++ b/platforms/core-configuration/model-groovy/src/integTest/groovy/org/gradle/model/dsl/internal/transform/ModelDslRuleInputDetectionIntegrationSpec.groovy
@@ -26,7 +26,7 @@ class ModelDslRuleInputDetectionIntegrationSpec extends AbstractIntegrationSpec 
 
     def "can reference input using dollar method expression - #syntax"() {
         when:
-        buildScript """
+        buildFile """
           @Managed
           interface Thing {
             String getValue(); void setValue(String str)
@@ -68,7 +68,7 @@ class ModelDslRuleInputDetectionIntegrationSpec extends AbstractIntegrationSpec 
 
     def "can reference input using dollar var expression - #syntax"() {
         when:
-        buildScript """
+        buildFile """
           @Managed
           interface Thing {
             String getValue(); void setValue(String str)
@@ -107,7 +107,7 @@ class ModelDslRuleInputDetectionIntegrationSpec extends AbstractIntegrationSpec 
 
     def "can inject input as parameter of rule closure - #syntax"() {
         when:
-        buildScript """
+        buildFile """
           @Managed
           interface Thing {
             String getValue(); void setValue(String str)
@@ -142,7 +142,7 @@ class ModelDslRuleInputDetectionIntegrationSpec extends AbstractIntegrationSpec 
 
     def "input reference can be used as expression statement - #syntax"() {
         when:
-        buildScript """
+        buildFile """
           @Managed
           interface Thing {
             String getValue(); void setValue(String str)
@@ -174,7 +174,7 @@ tasks configured
 
     def "dollar var must be followed by property expression - #code"() {
         when:
-        buildScript """
+        buildFile """
         model {
           foo {
             $code
@@ -202,7 +202,7 @@ tasks configured
 
     def "path for dollar var expression ends with first non-property reference"() {
         when:
-        buildScript '''
+        buildFile '''
         @Managed
         interface Thing {
             List<String> getValues()
@@ -229,7 +229,7 @@ tasks configured
 
     def "only literal strings can be given to dollar method - #code"() {
         when:
-        buildScript """
+        buildFile """
         model {
           foo {
             $code
@@ -258,7 +258,7 @@ tasks configured
 
     def "dollar method is only detected with no explicit receiver - #code"() {
         when:
-        buildScript """
+        buildFile """
             class MyPlugin {
               static class Rules extends RuleSource {
                 @Model
@@ -290,7 +290,7 @@ tasks configured
 
     def "dollar var is only detected with no explicit receiver - #code"() {
         when:
-        buildScript """
+        buildFile """
             class MyPlugin {
               static class Rules extends RuleSource {
                 @Model
@@ -322,7 +322,7 @@ tasks configured
 
     def "input references are found in nested code - #code"() {
         when:
-        buildScript """
+        buildFile """
             class MyPlugin {
                 static class Rules extends RuleSource {
                     @Mutate void addPrintTask(ModelMap<Task> tasks, List<String> strings) {
@@ -387,7 +387,7 @@ cl.call()
 
     def "input model path must be valid"() {
         when:
-        buildScript """
+        buildFile """
             class MyPlugin {
               static class Rules extends RuleSource {
                 @Model
@@ -416,7 +416,7 @@ cl.call()
 
     def "location and suggestions are provided for unbound rule subject specified using a name"() {
         given:
-        buildScript '''
+        buildFile '''
             class MyPlugin extends RuleSource {
                 @Model
                 String foobar() {
@@ -464,7 +464,7 @@ cl.call()
 
     def "location and suggestions are provided for unbound rule inputs specified using a name"() {
         given:
-        buildScript '''
+        buildFile '''
             class MyPlugin {
                 static class Rules extends RuleSource {
                     @Mutate
@@ -507,7 +507,7 @@ cl.call()
     // This is temporary. Will be closed once more progress on DSL has been made
     def "can access project and script from rule"() {
         when:
-        buildScript """
+        buildFile """
             def a = '12'
             model {
                 tasks {

--- a/platforms/core-configuration/model-groovy/src/integTest/groovy/org/gradle/model/dsl/internal/transform/NestedModelDslUsageIntegrationSpec.groovy
+++ b/platforms/core-configuration/model-groovy/src/integTest/groovy/org/gradle/model/dsl/internal/transform/NestedModelDslUsageIntegrationSpec.groovy
@@ -31,7 +31,7 @@ class NestedModelDslUsageIntegrationSpec extends AbstractIntegrationSpec {
         settingsFile << "include 'a', 'b'"
 
         when:
-        buildScript """
+        buildFile """
             ${testPluginImpl()}
 
             allprojects { apply type: TestPlugin }
@@ -86,7 +86,7 @@ class NestedModelDslUsageIntegrationSpec extends AbstractIntegrationSpec {
         settingsFile << "include 'a', 'b'"
 
         when:
-        buildScript """
+        buildFile """
             allprojects { apply type: TestPlugin }
 
             $code {
@@ -119,7 +119,7 @@ class NestedModelDslUsageIntegrationSpec extends AbstractIntegrationSpec {
         settingsFile << "include 'a', 'b'"
 
         when:
-        buildScript """
+        buildFile """
             allprojects { apply type: TestPlugin }
 
             $code {
@@ -171,7 +171,7 @@ class NestedModelDslUsageIntegrationSpec extends AbstractIntegrationSpec {
 
     def "model block must receive transformed closure"() {
         when:
-        buildScript """
+        buildFile """
             ${testPluginImpl()}
             apply type: TestPlugin
 

--- a/platforms/core-execution/execution-e2e-tests/src/integTest/groovy/org/gradle/integtests/FileSystemRootUpToDateIntegrationTest.groovy
+++ b/platforms/core-execution/execution-e2e-tests/src/integTest/groovy/org/gradle/integtests/FileSystemRootUpToDateIntegrationTest.groovy
@@ -48,7 +48,7 @@ class FileSystemRootUpToDateIntegrationTest extends AbstractIntegrationSpec {
             }
         """
         when:
-        buildScript script
+        buildFile script
 
         then:
         succeeds taskName
@@ -85,7 +85,7 @@ class FileSystemRootUpToDateIntegrationTest extends AbstractIntegrationSpec {
             }
         """
         when:
-        buildScript script
+        buildFile script
 
         then:
         succeeds taskName

--- a/platforms/core-execution/execution-e2e-tests/src/integTest/groovy/org/gradle/integtests/StaleOutputIntegrationTest.groovy
+++ b/platforms/core-execution/execution-e2e-tests/src/integTest/groovy/org/gradle/integtests/StaleOutputIntegrationTest.groovy
@@ -29,7 +29,7 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
     def 'stale output file is removed after input source directory is emptied.'() {
         def taskWithSources = new TaskWithSources()
         taskWithSources.createInputs()
-        buildScript(taskWithSources.buildScript)
+        buildFile(taskWithSources.buildScript)
 
         when:
         succeeds(taskWithSources.taskPath)
@@ -67,7 +67,7 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
     def "only files owned by the build are deleted"() {
         def taskWithSources = new TaskWithSources(outputDir: 'unsafe-dir/output')
         taskWithSources.createInputs()
-        buildScript(taskWithSources.buildScript)
+        buildFile(taskWithSources.buildScript)
 
         when:
         succeeds(taskWithSources.taskPath)
@@ -233,7 +233,7 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
         fixture.createInputs()
         creationCommand(fixture.outputDir)
         creationCommand(fixture.outputFile)
-        buildScript(fixture.buildScript)
+        buildFile(fixture.buildScript)
 
         expect:
         succeeds(fixture.taskPath, '-PassertRemoved=true')
@@ -253,7 +253,7 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
     def "unregistered stale outputs (#nonRegisteredDirectory) are not removed before task executes"() {
         def fixture = new StaleOutputFixture(buildDir: nonRegisteredDirectory)
         fixture.createInputs()
-        buildScript(fixture.buildScript)
+        buildFile(fixture.buildScript)
         fixture.createStaleOutputs()
 
         when:
@@ -269,7 +269,7 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
     def "stale outputs are cleaned in #outputDir"() {
         def fixture = new StaleOutputFixture(buildDir: outputDir)
         fixture.createInputs()
-        buildScript(fixture.buildScript)
+        buildFile(fixture.buildScript)
         fixture.createStaleOutputs()
 
         when:
@@ -286,7 +286,7 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
         def operations = new BuildOperationsFixture(executer, testDirectoryProvider)
         def fixture = new StaleOutputFixture()
         fixture.createInputs()
-        buildScript(fixture.buildScript)
+        buildFile(fixture.buildScript)
         fixture.createStaleOutputs()
 
         when:
@@ -301,7 +301,7 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
         def operations = new BuildOperationsFixture(executer, testDirectoryProvider)
         def fixture = new StaleOutputFixture()
         fixture.createInputs()
-        buildScript(fixture.buildScript)
+        buildFile(fixture.buildScript)
 
         when:
         succeeds(fixture.taskPath, '-PassertRemoved=true')
@@ -314,7 +314,7 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
     def "overlapping outputs between 'build/outputs' and '#overlappingOutputDir' are not cleaned up"() {
         def fixture = new StaleOutputFixture(buildDir: 'build/outputs', overlappingOutputDir: overlappingOutputDir)
         fixture.createInputs()
-        buildScript(fixture.buildScript)
+        buildFile(fixture.buildScript)
 
         when:
         succeeds fixture.taskPath, fixture.taskWritingOverlappingOutputs
@@ -329,7 +329,7 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
 
     def "relative paths canonicalized for cleanup registry"() {
         def fixture = new StaleOutputFixture(buildDir: 'build/../some-dir')
-        buildScript(fixture.buildScript)
+        buildFile(fixture.buildScript)
         fixture.createInputs()
         fixture.createStaleOutputs()
 
@@ -342,7 +342,7 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
 
     def "relative paths are canonicalized for output files"() {
         def fixture = new StaleOutputFixture(buildDir: 'build/output/../other-output')
-        buildScript(fixture.buildScript)
+        buildFile(fixture.buildScript)
         buildFile << """
             task writeToRealOutput() {
                 outputs.dir 'build/other-output'
@@ -421,7 +421,7 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
     def "stale local state file is removed after input source directory is emptied"() {
         def taskWithLocalState = new TaskWithLocalState()
         taskWithLocalState.createInputs()
-        buildScript(taskWithLocalState.buildScript)
+        buildFile(taskWithLocalState.buildScript)
 
         when:
         succeeds(taskWithLocalState.taskPath)

--- a/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
+++ b/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
@@ -859,7 +859,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
             includeBuild 'ext-lib'
             includeBuild 'build-logic'
         """
-        buildScript "plugins { id 'my-plugin' }"
+        buildFile "plugins { id 'my-plugin' }"
 
         when:
         succeeds 'buildEnvironment'

--- a/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
+++ b/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
@@ -855,7 +855,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
 
 
         and:
-        settingsScript """
+        settingsFile """
             includeBuild 'ext-lib'
             includeBuild 'build-logic'
         """

--- a/platforms/core-runtime/build-profile/src/integTest/groovy/org/gradle/profile/ProfilingIntegrationTest.groovy
+++ b/platforms/core-runtime/build-profile/src/integTest/groovy/org/gradle/profile/ProfilingIntegrationTest.groovy
@@ -71,7 +71,7 @@ allprojects {
         def pluginJar = file("plugin.jar")
         pluginBuilder.publishTo(executer, pluginJar)
 
-        initScript """
+        initScriptFile """
             initscript {
                 dependencies {
                     classpath files("${pluginJar.name}")

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/ContinueIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/ContinueIntegrationTest.groovy
@@ -69,7 +69,7 @@ class ContinueIntegrationTest extends AbstractIntegrationSpec {
     }
 
     private TestFile buildScript() {
-        buildScript """
+        buildFile """
             def failing = tasks.register("failTask") {
                 doFirst {
                     throw new RuntimeException("failTask failed")

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/cli/TaskOptionsSpec.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/cli/TaskOptionsSpec.groovy
@@ -43,7 +43,7 @@ class TaskOptionsSpec extends AbstractIntegrationSpec {
 
     def "will prioritize built-in option over a task option with a conflicting name"() {
         when:
-        buildScript """
+        buildFile """
             ${defineTaskWithProfileOption()}
 
             tasks.register('mytask', MyTask.class)
@@ -57,7 +57,7 @@ class TaskOptionsSpec extends AbstractIntegrationSpec {
 
     def "can use -- to specify a task option with same name as a built-in option"() {
         when:
-        buildScript """
+        buildFile """
             ${defineTaskWithProfileOption()}
 
             tasks.register('mytask', MyTask.class)
@@ -71,7 +71,7 @@ class TaskOptionsSpec extends AbstractIntegrationSpec {
 
     def "task options apply to most recent task"() {
         when:
-        buildScript """
+        buildFile """
             ${defineTaskWithProfileOption()}
 
             tasks.register('mytaskA', MyTask.class)
@@ -86,7 +86,7 @@ class TaskOptionsSpec extends AbstractIntegrationSpec {
 
     def "task options apply to most recent task -- first task only"() {
         when:
-        buildScript """
+        buildFile """
             ${defineTaskWithProfileOption()}
 
             tasks.register('mytaskA', MyTask.class)
@@ -100,7 +100,7 @@ class TaskOptionsSpec extends AbstractIntegrationSpec {
 
     def "task options apply to most recent task -- second task only"() {
         when:
-        buildScript """
+        buildFile """
             ${defineTaskWithProfileOption()}
 
             tasks.register('mytaskA', MyTask.class)
@@ -114,7 +114,7 @@ class TaskOptionsSpec extends AbstractIntegrationSpec {
 
     def "runs built-in and task options when both are supplied"() {
         when:
-        buildScript """
+        buildFile """
             ${defineTaskWithProfileOption()}
 
             tasks.register('mytask', MyTask.class)
@@ -150,7 +150,7 @@ class TaskOptionsSpec extends AbstractIntegrationSpec {
                 }
             }
         """
-        buildScript """
+        buildFile """
             import MyTask
             tasks.register('mytask', MyTask.class)
         """
@@ -172,7 +172,7 @@ class TaskOptionsSpec extends AbstractIntegrationSpec {
 
             tasks.register('mytask', MyTask.class)
         """
-        buildScript """
+        buildFile """
             // no content needed
         """
 

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/continuous/BuildSrcContinuousIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/continuous/BuildSrcContinuousIntegrationTest.groovy
@@ -33,7 +33,7 @@ class BuildSrcContinuousIntegrationTest extends AbstractContinuousIntegrationTes
 
     def "can build and reload a project with buildSrc when buildSrc changes"() {
         when:
-        buildScript """
+        buildFile """
             task a {
               inputs.files "a"
               doLast {

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/continuous/SmokeContinuousIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/continuous/SmokeContinuousIntegrationTest.groovy
@@ -405,7 +405,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
 
     def "failure to determine inputs has a reasonable message"() {
         when:
-        buildScript """
+        buildFile """
             task a {
                 inputs.files files({ throw new Exception("boom") })
                 outputs.files "build/marker"
@@ -420,7 +420,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
 
     def "failure to determine inputs has a reasonable message when an earlier task succeeds"() {
         when:
-        buildScript """
+        buildFile """
             task a {
                 inputs.files file("inputA")
                 outputs.files "build/outputA"
@@ -443,7 +443,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         when:
         def bFlag = file("bFlag")
         file("inputA").createFile()
-        buildScript """
+        buildFile """
             task a {
                 inputs.files file("inputA")
                 outputs.files "build/outputA"
@@ -478,7 +478,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
     def "ignores non source when source is empty"() {
         when:
         file("source").createDir()
-        buildScript """
+        buildFile """
             task myTask {
               inputs.files(fileTree("source"))
                 .skipWhenEmpty()
@@ -567,7 +567,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
     def "exit hint does not mention enter when not on windows"() {
         when:
         file("a").touch()
-        buildScript "task a { inputs.file 'a'; outputs.file 'b'; doLast {} }"
+        buildFile "task a { inputs.file 'a'; outputs.file 'b'; doLast {} }"
 
         then:
         succeeds "a"
@@ -578,7 +578,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
     def "exit hint mentions enter when on windows"() {
         when:
         file("a").touch()
-        buildScript """
+        buildFile """
             task a {
                 inputs.file 'a'
                 outputs.file 'build/b'

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonJvmSettingsIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonJvmSettingsIntegrationTest.groovy
@@ -63,7 +63,7 @@ assert java.lang.management.ManagementFactory.runtimeMXBean.inputArguments.conta
         executer.requireDaemon().requireIsolatedDaemons()
         boolean java9orAbove = JavaVersion.current().java9Compatible
 
-        buildScript """
+        buildFile """
             import java.lang.management.ManagementFactory
             import java.lang.management.MemoryMXBean
 

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonLifecycleEncodingSpec.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonLifecycleEncodingSpec.groovy
@@ -61,7 +61,7 @@ class DaemonLifecycleEncodingSpec extends AbstractDaemonLifecycleSpec {
     @Requires(IntegTestPreconditions.NotEmbeddedExecutor) // need to start Gradle process from command line to use GRADLE_OPTS
     def "forks new daemon when file encoding is set to different value via GRADLE_OPTS"() {
         setup:
-        buildScript """
+        buildFile """
             println "GRADLE_VERSION: " + gradle.gradleVersion
 
             task verify {

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonSystemPropertiesIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonSystemPropertiesIntegrationTest.groovy
@@ -57,7 +57,7 @@ task verify {
 
     def "forks new daemon when file encoding set to different value via commandline"() {
         setup:
-        buildScript """
+        buildFile """
             task verify {
                 doFirst {
                     println "verified = " + java.nio.charset.Charset.defaultCharset().name()
@@ -83,7 +83,7 @@ task verify {
 
     def "forks new daemon when tmpdir is set to different value via commandline"() {
         setup:
-        buildScript """
+        buildFile """
             task verify {
                 doFirst {
                     println "verified = \${File.createTempFile('pre', 'post')}"
@@ -112,7 +112,7 @@ task verify {
     @Requires(IntegTestPreconditions.NotEmbeddedExecutor) // need to start Gradle process from command line to use GRADLE_OPTS
     def "forks new daemon when tmpdir is set to different value via GRADLE_OPTS"() {
         setup:
-        buildScript """
+        buildFile """
             println "GRADLE_VERSION: " + gradle.gradleVersion
 
             task verify {
@@ -143,7 +143,7 @@ task verify {
     @Requires(IntegTestPreconditions.NotEmbeddedExecutor) // need to start Gradle process from command line to use GRADLE_OPTS
     def "forks new daemon for changed javax.net.ssl sys properties"() {
         setup:
-        buildScript """
+        buildFile """
             println "GRADLE_VERSION: " + gradle.gradleVersion
 
             task verify {
@@ -174,7 +174,7 @@ task verify {
     @Requires(IntegTestPreconditions.NotEmbeddedExecutor) // need to start Gradle process from command line to use GRADLE_OPTS
     def "forks new daemon for changed cache reserved space sys property"() {
         setup:
-        buildScript """
+        buildFile """
             println "GRADLE_VERSION: " + gradle.gradleVersion
 
             task verify {

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/LocaleSupportDaemonIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/LocaleSupportDaemonIntegrationTest.groovy
@@ -35,7 +35,7 @@ class LocaleSupportDaemonIntegrationTest extends DaemonIntegrationSpec {
 
     def "custom locale is applied to daemon"() {
 
-        buildScript """
+        buildFile """
             task printLocale {
                 doFirst {
                     println "defaultLocale: " + Locale.default
@@ -62,7 +62,7 @@ class LocaleSupportDaemonIntegrationTest extends DaemonIntegrationSpec {
         def startLocale = locales[0]
         def changeLocale = locales[1]
 
-        buildScript """
+        buildFile """
             task printLocale {
                 doFirst {
                     Locale.setDefault(new Locale("$changeLocale.language", "$changeLocale.country", "$changeLocale.variant"))
@@ -89,7 +89,7 @@ class LocaleSupportDaemonIntegrationTest extends DaemonIntegrationSpec {
     @Issue("https://github.com/gradle/gradle/issues/4973")
     def "can use a locale without region (#overrideVersion)"() {
         Locale locale = Locale.ENGLISH
-        buildScript """
+        buildFile """
             import org.gradle.util.GradleVersion
 
             task printLocale {

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/SingleUseDaemonIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/SingleUseDaemonIntegrationTest.groovy
@@ -187,7 +187,7 @@ assert System.getProperty('some-prop') == 'some-value'
         def encoding = Charset.defaultCharset().name()
 
         given:
-        buildScript """
+        buildFile """
             task encoding {
                 doFirst { println "encoding = " + java.nio.charset.Charset.defaultCharset().name() }
             }

--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/DeprecatedUsageBuildOperationProgressIntegrationTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/DeprecatedUsageBuildOperationProgressIntegrationTest.groovy
@@ -34,7 +34,7 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
         when:
         settingsFile "rootProject.name = 'root'"
 
-        initScript  """
+        initScriptFile """
             org.gradle.internal.deprecation.DeprecationLogger.deprecate('Init script')
                 .willBeRemovedInGradle9()
                 .undocumented()

--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/DeprecatedUsageBuildOperationProgressIntegrationTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/DeprecatedUsageBuildOperationProgressIntegrationTest.groovy
@@ -49,7 +49,7 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
             org.gradle.internal.deprecation.DeprecationLogger.deprecate('Plugin script').willBeRemovedInGradle9().undocumented().nagUser();
         """
 
-        buildScript """
+        buildFile """
             apply from: 'script.gradle'
             apply plugin: SomePlugin
 

--- a/platforms/core-runtime/process-services/src/integTest/groovy/org/gradle/process/internal/health/memory/MemoryStatusUpdateIntegrationTest.groovy
+++ b/platforms/core-runtime/process-services/src/integTest/groovy/org/gradle/process/internal/health/memory/MemoryStatusUpdateIntegrationTest.groovy
@@ -34,7 +34,7 @@ class MemoryStatusUpdateIntegrationTest extends AbstractIntegrationSpec {
         file("osReceived").exists()
     }
 
-    private static String waitForMemoryEventsTask() {
+    private String waitForMemoryEventsTask() {
         return buildScriptSnippet('''
             import java.util.concurrent.CountDownLatch
             import org.gradle.process.internal.health.memory.*

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/legacy/BuildScanScopeIdsIntegrationTest.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/legacy/BuildScanScopeIdsIntegrationTest.groovy
@@ -28,7 +28,7 @@ class BuildScanScopeIdsIntegrationTest extends AbstractIntegrationSpec {
 
     def "exposes scans view of scope IDs"() {
         when:
-        buildScript """
+        buildFile """
             def ids = project.gradle.services.get($BuildScanScopeIds.name)
             println "ids: [buildInvocation: \$ids.buildInvocationId, workspace: \$ids.workspaceId, user: \$ids.userId]"
         """

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/AuthenticatedPluginRepositorySpec.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/AuthenticatedPluginRepositorySpec.groovy
@@ -76,7 +76,7 @@ class AuthenticatedPluginRepositorySpec extends AbstractHttpDependencyResolution
     def "can resolve plugin from Ivy repo with #authSchemeName and #serverAuthScheme"() {
         given:
         def pluginResults = publishTestPlugin(IVY)
-        buildScript """
+        buildFile """
           plugins {
               id "org.example.plugin" version "1.0"
           }
@@ -111,7 +111,7 @@ class AuthenticatedPluginRepositorySpec extends AbstractHttpDependencyResolution
     def "can resolve plugin from Maven repo with #authSchemeName and #serverAuthScheme"() {
         given:
         def pluginResults = publishTestPlugin(MAVEN)
-        buildScript """
+        buildFile """
           plugins {
               id "org.example.plugin" version "1.0"
           }

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/PluginManagementDslSpec.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/PluginManagementDslSpec.groovy
@@ -127,7 +127,7 @@ class PluginManagementDslSpec extends AbstractIntegrationSpec {
 
     def "pluginManagement block is not supported in ProjectScripts"() {
         given:
-        buildScript """
+        buildFile """
             pluginManagement {}
         """
 

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/PluginManagementWithSettingsPluginIntegrationTest.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/PluginManagementWithSettingsPluginIntegrationTest.groovy
@@ -158,7 +158,7 @@ class PluginManagementWithSettingsPluginIntegrationTest extends AbstractIntegrat
             }
         """
 
-        buildScript("""
+        buildFile("""
             buildscript {
                 repositories {
                     exclusiveContent {

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/RepositoryOrderingIntegrationSpec.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/RepositoryOrderingIntegrationSpec.groovy
@@ -33,7 +33,7 @@ class RepositoryOrderingIntegrationSpec extends AbstractIntegrationSpec {
         overridePluginPortalUri(pluginPortalUri)
 
         and:
-        buildScript """
+        buildFile """
             buildscript {
                 repositories { maven { url "$buildscriptRepoUri" } }
                 dependencies { classpath "my:plugin:1.0" }

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingFromMultipleCustomPluginRepositorySpec.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingFromMultipleCustomPluginRepositorySpec.groovy
@@ -89,7 +89,7 @@ class ResolvingFromMultipleCustomPluginRepositorySpec extends AbstractDependency
     def "#repoType repositories are queried in declaration order"() {
         given:
         publishPlugins(repoType)
-        buildScript """
+        buildFile """
           plugins {
               id "$pluginAB" version "1.0"
           }
@@ -109,7 +109,7 @@ class ResolvingFromMultipleCustomPluginRepositorySpec extends AbstractDependency
     def "Tries next #repoType repository if first didn't match"() {
         given:
         publishPlugins(repoType)
-        buildScript """
+        buildFile """
           plugins {
               id "$pluginA" version "1.0"
           }
@@ -129,7 +129,7 @@ class ResolvingFromMultipleCustomPluginRepositorySpec extends AbstractDependency
     def "Order of plugin requests does not affect order of #repoType repositories queried"() {
         given:
         publishPlugins(repoType)
-        buildScript """
+        buildFile """
           plugins {
               id "$pluginA" version "1.0"
               id "$pluginAB" version "1.0"
@@ -150,7 +150,7 @@ class ResolvingFromMultipleCustomPluginRepositorySpec extends AbstractDependency
     def "Resolution failures for #repoType are reported in declaration order"() {
         given:
         publishPlugins(repoType)
-        buildScript """
+        buildFile """
           plugins {
               id "org.example.foo" version "1.1"
           }
@@ -181,7 +181,7 @@ class ResolvingFromMultipleCustomPluginRepositorySpec extends AbstractDependency
     def "Does not fall through to plugin portal if custom #repoType repos are defined"(String repoType) {
         given:
         publishPlugins(repoType)
-        buildScript """
+        buildFile """
             plugins {
                 id "org.gradle.hello-world" version "0.2" //exits in the plugin portal
             }
@@ -208,7 +208,7 @@ class ResolvingFromMultipleCustomPluginRepositorySpec extends AbstractDependency
         given:
         publishPlugins(MAVEN)
         requireOwnGradleUserHomeDir()
-        buildScript """
+        buildFile """
             plugins {
                 id "org.gradle.hello-world" version "0.2" //exists in the plugin portal
             }
@@ -234,7 +234,7 @@ class ResolvingFromMultipleCustomPluginRepositorySpec extends AbstractDependency
         given:
         publishPlugins(MAVEN)
         requireOwnGradleUserHomeDir()
-        buildScript """
+        buildFile """
             //this simulates pluginA having a dependency on the hello world plugin
             buildscript {
                 dependencies {

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingFromSingleCustomPluginRepositorySpec.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingFromSingleCustomPluginRepositorySpec.groovy
@@ -69,7 +69,7 @@ class ResolvingFromSingleCustomPluginRepositorySpec extends AbstractDependencyRe
     def "can resolve plugin from #pathType #repoType repo"() {
         given:
         publishTestPlugin(repoType)
-        buildScript """
+        buildFile """
           plugins {
               id "org.example.plugin" version "1.0"
           }
@@ -95,7 +95,7 @@ class ResolvingFromSingleCustomPluginRepositorySpec extends AbstractDependencyRe
     def "can access classes from plugin from #repoType repo"() {
         given:
         publishTestPlugin(repoType)
-        buildScript """
+        buildFile """
           plugins {
               id "org.example.plugin" version "1.0"
           }
@@ -120,7 +120,7 @@ class ResolvingFromSingleCustomPluginRepositorySpec extends AbstractDependencyRe
     def "can apply plugin from #repoType repo to subprojects"() {
         given:
         publishTestPlugin(repoType)
-        buildScript """
+        buildFile """
           plugins {
               id "org.example.plugin" version "1.0" apply false
           }
@@ -147,7 +147,7 @@ class ResolvingFromSingleCustomPluginRepositorySpec extends AbstractDependencyRe
     def "custom #repoType repo is not mentioned in plugin resolution errors if none is defined"() {
         given:
         publishTestPlugin(repoType)
-        buildScript """
+        buildFile """
           plugins {
               id "org.example.plugin"
           }
@@ -167,7 +167,7 @@ class ResolvingFromSingleCustomPluginRepositorySpec extends AbstractDependencyRe
     def "Fails gracefully if a plugin is not found in #repoType repo"() {
         given:
         publishTestPlugin(repoType)
-        buildScript """
+        buildFile """
           plugins {
               id "org.example.foo" version "1.1"
           }
@@ -224,7 +224,7 @@ class ResolvingFromSingleCustomPluginRepositorySpec extends AbstractDependencyRe
     def "Can specify repo in init script."() {
         given:
         publishTestPlugin(MAVEN)
-        buildScript """
+        buildFile """
            plugins {
              id "org.example.plugin" version "1.0"
            }
@@ -253,7 +253,7 @@ class ResolvingFromSingleCustomPluginRepositorySpec extends AbstractDependencyRe
     def "can resolve plugins even if buildscript block contains wrong repo with same name"() {
         given:
         publishTestPlugin(MAVEN)
-        buildScript """
+        buildFile """
           buildscript {
             repositories {
                 maven {
@@ -279,7 +279,7 @@ class ResolvingFromSingleCustomPluginRepositorySpec extends AbstractDependencyRe
     def "Does not fall through to Plugin Portal if custom repo is defined"() {
         given:
         publishTestPlugin(MAVEN)
-        buildScript """
+        buildFile """
             plugins {
                 id "org.gradle.hello-world" version "0.2" //this exists in the plugin portal
             }

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingSnapshotFromPluginRepositorySpec.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingSnapshotFromPluginRepositorySpec.groovy
@@ -48,7 +48,7 @@ class ResolvingSnapshotFromPluginRepositorySpec extends AbstractDependencyResolu
     def 'Can specify snapshot version'() {
         given:
         publishTestPlugin()
-        buildScript """
+        buildFile """
           plugins {
               id "org.example.plugin" version '1.0-SNAPSHOT'
           }
@@ -70,7 +70,7 @@ class ResolvingSnapshotFromPluginRepositorySpec extends AbstractDependencyResolu
     def 'setting different snapshot version in resolutionStrategy will affect plugin choice'() {
         given:
         publishTestPlugin()
-        buildScript """
+        buildFile """
           plugins {
               id "org.example.plugin" version '1000'
           }
@@ -98,7 +98,7 @@ class ResolvingSnapshotFromPluginRepositorySpec extends AbstractDependencyResolu
     def 'can specify a snapshot artifact to use'() {
         given:
         publishTestPlugin()
-        buildScript """
+        buildFile """
           plugins {
               id "org.example.plugin"
           }

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingWithPluginManagementSpec.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingWithPluginManagementSpec.groovy
@@ -61,7 +61,7 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
     def 'setting different version in resolutionStrategy will affect plugin choice'() {
         given:
         publishTestPlugin()
-        buildScript """
+        buildFile """
           plugins {
               id "org.example.plugin" version '1000'
           }
@@ -89,7 +89,7 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
     def 'when no version is specified, resolution fails'() {
         given:
         publishTestPlugin()
-        buildScript """
+        buildFile """
           plugins {
               id "org.example.plugin" version '1.2'
           }
@@ -117,7 +117,7 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
     def 'when invalid version is specified, resolution fails'() {
         given:
         publishTestPlugin()
-        buildScript """
+        buildFile """
           plugins {
               id "org.example.plugin" version '1.2'
           }
@@ -145,7 +145,7 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
     def 'when version range is specified, resolution succeeds'() {
         given:
         publishTestPlugin()
-        buildScript """
+        buildFile """
           plugins {
               id "org.example.plugin" version '1.2'
           }
@@ -173,7 +173,7 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
     def 'when invalid artifact version is specified, resolution fails'() {
         given:
         publishTestPlugin()
-        buildScript """
+        buildFile """
           plugins {
               id "org.example.plugin" version '1.2'
           }
@@ -201,7 +201,7 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
     def 'when artifact version range is specified, resolution succeeds'() {
         given:
         publishTestPlugin()
-        buildScript """
+        buildFile """
           plugins {
               id "org.example.plugin" version '1.2'
           }
@@ -229,7 +229,7 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
     def 'can specify an artifact to use'() {
         given:
         publishTestPlugin()
-        buildScript """
+        buildFile """
           plugins {
               id "org.example.plugin"
           }
@@ -257,7 +257,7 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
     def 'rules are executed in declaration order'() {
         given:
         publishTestPlugin()
-        buildScript """
+        buildFile """
           plugins {
               id "org.example.plugin"
           }
@@ -290,7 +290,7 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
     def 'Build fails when a rule throws an exception'() {
         given:
         publishTestPlugin()
-        buildScript """
+        buildFile """
           plugins {
               id "org.example.plugin"
           }
@@ -315,7 +315,7 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
     def "Can specify repo in init script."() {
         given:
         publishTestPlugin()
-        buildScript """
+        buildFile """
            plugins {
              id "org.example.plugin" version "1.0"
            }
@@ -366,7 +366,7 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
 
     def "fails build for unresolvable custom artifact"() {
         given:
-        buildScript helloWorldPlugin('0.2')
+        buildFile helloWorldPlugin('0.2')
 
         settingsFile << """
             pluginManagement {
@@ -390,7 +390,7 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
 
     def "succeeds build for resolvable custom artifact"() {
         given:
-        buildScript helloWorldPlugin('0.2')
+        buildFile helloWorldPlugin('0.2')
 
         settingsFile << """
             pluginManagement {
@@ -416,7 +416,7 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
         given:
         def repo = new IvyFileRepository(file("ivy-repo"), true, '[organisation]/[module]/[revision]', '[module]-[revision].ivy', '[artifact]-[revision](-[classifier]).[ext]')
         publishTestPlugin(repo)
-        buildScript """
+        buildFile """
             plugins {
               id "org.example.plugin" version '1.0'
           }

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/CorePluginUseIntegrationSpec.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/CorePluginUseIntegrationSpec.groovy
@@ -27,7 +27,7 @@ class CorePluginUseIntegrationSpec extends AbstractIntegrationSpec {
 
     void "can resolve core plugins"() {
         when:
-        buildScript """
+        buildFile """
             plugins {
               id 'java'
             }
@@ -39,7 +39,7 @@ class CorePluginUseIntegrationSpec extends AbstractIntegrationSpec {
 
     void "can resolve qualified core plugins"() {
         when:
-        buildScript """
+        buildFile """
             plugins {
               id 'org.gradle.java'
             }
@@ -51,7 +51,7 @@ class CorePluginUseIntegrationSpec extends AbstractIntegrationSpec {
 
     void "core plugins cannot have a version number"() {
         given:
-        buildScript """
+        buildFile """
             plugins {
                 id "java" version "1.0"
             }
@@ -69,7 +69,7 @@ class CorePluginUseIntegrationSpec extends AbstractIntegrationSpec {
 
     void "qualified core plugins cannot have a version number"() {
         given:
-        buildScript """
+        buildFile """
             plugins {
                 id "org.gradle.java" version "1.0"
             }
@@ -87,7 +87,7 @@ class CorePluginUseIntegrationSpec extends AbstractIntegrationSpec {
 
     void "core plugins cannot be used with apply false"() {
         given:
-        buildScript """
+        buildFile """
             plugins {
                 id "java" apply false
             }
@@ -105,7 +105,7 @@ class CorePluginUseIntegrationSpec extends AbstractIntegrationSpec {
 
     def "cant ask for same plugin twice"() {
         given:
-        buildScript """
+        buildFile """
             plugins {
                 id "java"
                 id "java"
@@ -123,7 +123,7 @@ class CorePluginUseIntegrationSpec extends AbstractIntegrationSpec {
 
     def "cant ask for same plugin twice with other plugins applied"() {
         given:
-        buildScript """
+        buildFile """
             plugins {
                 id "base"
                 id "java"
@@ -142,7 +142,7 @@ class CorePluginUseIntegrationSpec extends AbstractIntegrationSpec {
 
     def "can reapply core plugin applied via plugins block"() {
         when:
-        buildScript """
+        buildFile """
             plugins {
                 id "java"
             }
@@ -158,7 +158,7 @@ class CorePluginUseIntegrationSpec extends AbstractIntegrationSpec {
 
     def "can reapply core plugin applied via qualified id in plugins block"() {
         when:
-        buildScript """
+        buildFile """
             plugins {
                 id "org.gradle.java"
             }
@@ -174,7 +174,7 @@ class CorePluginUseIntegrationSpec extends AbstractIntegrationSpec {
 
     def "can use qualified and unqualified ids to detect core plugins"() {
         when:
-        buildScript """
+        buildFile """
             plugins {
                 id "$pluginId"
             }
@@ -201,7 +201,7 @@ class CorePluginUseIntegrationSpec extends AbstractIntegrationSpec {
 
     def "can use apply method to load core plugins qualified or unqualified"() {
         when:
-        buildScript """
+        buildFile """
             apply plugin: "${pluginId}"
         """
 
@@ -214,7 +214,7 @@ class CorePluginUseIntegrationSpec extends AbstractIntegrationSpec {
 
     def "can use apply method with other form of core plugin without problem"() {
         when:
-        buildScript """
+        buildFile """
             plugins {
                 id "${plugins[0]}"
             }

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/DeployedPortalIntegrationSpec.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/DeployedPortalIntegrationSpec.groovy
@@ -37,7 +37,7 @@ class DeployedPortalIntegrationSpec extends AbstractIntegrationSpec {
 
     def "Can access plugin classes when resolved but not applied"() {
         when:
-        buildScript """
+        buildFile """
             plugins {
                 id "$HELLO_WORLD_PLUGIN_ID" version "$HELLO_WORLD_PLUGIN_VERSION" apply false
             }
@@ -61,7 +61,7 @@ class DeployedPortalIntegrationSpec extends AbstractIntegrationSpec {
         settingsFile << """
             include 'sub'
         """
-        buildScript """
+        buildFile """
             plugins {
                 id "$HELLO_WORLD_PLUGIN_ID" version "$HELLO_WORLD_PLUGIN_VERSION" apply false
             }
@@ -81,7 +81,7 @@ class DeployedPortalIntegrationSpec extends AbstractIntegrationSpec {
 
     def "can resolve and apply a plugin from portal"() {
         when:
-        buildScript """
+        buildFile """
             plugins {
                 id "$HELLO_WORLD_PLUGIN_ID" version "$HELLO_WORLD_PLUGIN_VERSION"
             }
@@ -96,7 +96,7 @@ class DeployedPortalIntegrationSpec extends AbstractIntegrationSpec {
 
     def "resolving a non-existing plugin results in an informative error message"() {
         when:
-        buildScript """
+        buildFile """
             plugins {
                 id "org.gradle.non-existing" version "1.0"
             }
@@ -120,7 +120,7 @@ class DeployedPortalIntegrationSpec extends AbstractIntegrationSpec {
         def helloWorldName = 'gradle-hello-world-plugin'
 
         when:
-        buildScript """
+        buildFile """
             buildscript {
                 repositories {
                     gradlePluginPortal()
@@ -142,7 +142,7 @@ class DeployedPortalIntegrationSpec extends AbstractIntegrationSpec {
 
     def "resolution fails if Gradle is in offline mode"() {
         given:
-        buildScript """
+        buildFile """
             plugins {
                 id "$HELLO_WORLD_PLUGIN_ID" version "$HELLO_WORLD_PLUGIN_VERSION"
             }
@@ -161,7 +161,7 @@ class DeployedPortalIntegrationSpec extends AbstractIntegrationSpec {
         mavenRepo.module('com.android.tools', 'r8', '1.5.70').publish()
 
         when:
-        buildScript """
+        buildFile """
             buildscript {
                 repositories {
                     exclusiveContent {
@@ -196,7 +196,7 @@ class DeployedPortalIntegrationSpec extends AbstractIntegrationSpec {
         given:
         mavenRepo.module('com.android.tools', 'r8', '1.5.70').publish()
 
-        buildScript """
+        buildFile """
             buildscript {
                 repositories {
                     exclusiveContent {

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/NonDeclarativePluginUseIntegrationSpec.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/NonDeclarativePluginUseIntegrationSpec.groovy
@@ -52,7 +52,7 @@ class NonDeclarativePluginUseIntegrationSpec extends AbstractPluginSpec {
         """
 
         when:
-        buildScript USE
+        buildFile USE
 
         then:
         succeeds("pluginTask")
@@ -79,7 +79,7 @@ class NonDeclarativePluginUseIntegrationSpec extends AbstractPluginSpec {
         pluginRepo.module(GROUP, ARTIFACT, VERSION).dependsOn(GROUP, ARTIFACT + "2", VERSION).publishPom()
 
         when:
-        buildScript """
+        buildFile """
             $USE
 
             def ops = []
@@ -127,7 +127,7 @@ class NonDeclarativePluginUseIntegrationSpec extends AbstractPluginSpec {
         publishPlugin("").dependsOn(GROUP, ARTIFACT + "2", VERSION).publishPom()
 
         when:
-        buildScript """
+        buildFile """
             buildscript {
               dependencies {
                 classpath "$GROUP:${ARTIFACT + 2}:$VERSION"
@@ -171,7 +171,7 @@ class NonDeclarativePluginUseIntegrationSpec extends AbstractPluginSpec {
         pluginModule.dependsOn("test", "test", "2").publishPom()
 
         and:
-        buildScript """
+        buildFile """
             buildscript {
                 repositories {
                     maven { url "$pluginRepo.uri" }
@@ -220,7 +220,7 @@ class NonDeclarativePluginUseIntegrationSpec extends AbstractPluginSpec {
         }
 
         and:
-        buildScript """
+        buildFile """
             $USE
         """
 
@@ -245,7 +245,7 @@ class NonDeclarativePluginUseIntegrationSpec extends AbstractPluginSpec {
         }
 
         and:
-        buildScript """
+        buildFile """
             $USE
         """
 
@@ -266,7 +266,7 @@ class NonDeclarativePluginUseIntegrationSpec extends AbstractPluginSpec {
         }
 
         and:
-        buildScript """
+        buildFile """
             $USE
         """
 
@@ -285,7 +285,7 @@ class NonDeclarativePluginUseIntegrationSpec extends AbstractPluginSpec {
         publishPlugin "throw new Exception('throwing plugin')"
 
         and:
-        buildScript """
+        buildFile """
             $USE
         """
 

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/PluginApplicationOrderIntegrationSpec.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/PluginApplicationOrderIntegrationSpec.groovy
@@ -29,7 +29,7 @@ class PluginApplicationOrderIntegrationSpec extends AbstractPluginSpec {
         """
 
         when:
-        buildScript """
+        buildFile """
             plugins {
                 id 'java'
                 id '$PLUGIN_ID' version '$VERSION'

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/PluginUseClassLoadingIntegrationSpec.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/PluginUseClassLoadingIntegrationSpec.groovy
@@ -34,7 +34,7 @@ class PluginUseClassLoadingIntegrationSpec extends AbstractPluginSpec {
         file("p1/build.gradle") << USE
         file("p2/build.gradle") << USE
 
-        buildScript """
+        buildFile """
             evaluationDependsOnChildren()
             task verify {
                 def p1PluginClass = project(":p1").pluginClass
@@ -57,7 +57,7 @@ class PluginUseClassLoadingIntegrationSpec extends AbstractPluginSpec {
             project.task("verify")
         """)
 
-        buildScript USE
+        buildFile USE
 
         expect:
         succeeds("verify")

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/PluginUseDslIntegrationSpec.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/PluginUseDslIntegrationSpec.groovy
@@ -28,7 +28,7 @@ class PluginUseDslIntegrationSpec extends AbstractIntegrationSpec {
 
     def "can use plugins block in project build scripts"() {
         when:
-        buildScript """
+        buildFile """
           plugins {
             id "java"
             id "noop" version "1.0"
@@ -41,7 +41,7 @@ class PluginUseDslIntegrationSpec extends AbstractIntegrationSpec {
 
     def "buildscript blocks are allowed before plugin statements"() {
         when:
-        buildScript """
+        buildFile """
             buildscript {}
             plugins {}
         """
@@ -52,7 +52,7 @@ class PluginUseDslIntegrationSpec extends AbstractIntegrationSpec {
 
     def "buildscript blocks are not allowed after plugin blocks"() {
         when:
-        buildScript """
+        buildFile """
             plugins {}
             buildscript {}
         """
@@ -73,7 +73,7 @@ class PluginUseDslIntegrationSpec extends AbstractIntegrationSpec {
 
     def "build logic cannot precede plugins block"() {
         when:
-        buildScript """
+        buildFile """
             someThing()
             plugins {}
         """
@@ -90,7 +90,7 @@ class PluginUseDslIntegrationSpec extends AbstractIntegrationSpec {
 
     def "build logic cannot precede any plugins block"() {
         when:
-        buildScript """
+        buildFile """
             plugins {}
             someThing()
             plugins {}
@@ -139,7 +139,7 @@ class PluginUseDslIntegrationSpec extends AbstractIntegrationSpec {
 
         when:
         scriptPlugin << "plugins {}"
-        buildScript "apply from: 'plugin.gradle'"
+        buildFile "apply from: 'plugin.gradle'"
 
         then:
         fails "help"
@@ -155,7 +155,7 @@ class PluginUseDslIntegrationSpec extends AbstractIntegrationSpec {
 
         when:
         scriptPlugin << "plugins {}"
-        buildScript "task foo; apply from: 'plugin.gradle', to: foo"
+        buildFile "task foo; apply from: 'plugin.gradle', to: foo"
 
         then:
         fails "help"
@@ -168,7 +168,7 @@ class PluginUseDslIntegrationSpec extends AbstractIntegrationSpec {
 
     def "illegal syntax in plugins block - #code"() {
         when:
-        buildScript("""plugins {\n$code\n}""")
+        buildFile("""plugins {\n$code\n}""")
 
         then:
         fails "help"
@@ -210,7 +210,7 @@ class PluginUseDslIntegrationSpec extends AbstractIntegrationSpec {
     def "allowed syntax in plugins block - #code"() {
         given:
         when:
-        buildScript("""plugins {\n$code\n}""")
+        buildFile("""plugins {\n$code\n}""")
 
         then:
         succeeds "help"
@@ -236,7 +236,7 @@ class PluginUseDslIntegrationSpec extends AbstractIntegrationSpec {
 
     def "illegal value in plugins block - #code"() {
         when:
-        buildScript("""plugins {\n$code\n}""")
+        buildFile("""plugins {\n$code\n}""")
 
         then:
         fails "help"
@@ -263,7 +263,7 @@ class PluginUseDslIntegrationSpec extends AbstractIntegrationSpec {
     bar = 444
     foo.bar = 555
 """
-        buildScript("""plugins {\n$code\n}""")
+        buildFile("""plugins {\n$code\n}""")
 
         then:
         succeeds "help"
@@ -302,7 +302,7 @@ class PluginUseDslIntegrationSpec extends AbstractIntegrationSpec {
 
     def "fails to interpolate unknown property in project plugins block"() {
         when:
-        buildScript("""plugins {\n$code\n}""")
+        buildFile("""plugins {\n$code\n}""")
 
         then:
         fails "help"

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/PostPluginResolutionFailuresIntegrationSpec.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/PostPluginResolutionFailuresIntegrationSpec.groovy
@@ -45,7 +45,7 @@ class PostPluginResolutionFailuresIntegrationSpec extends AbstractIntegrationSpe
         pluginBuilder.addUnloadablePlugin(PLUGIN_ID)
         pluginBuilder.publishAs(GROUP, ARTIFACT, VERSION, pluginRepo, executer).allowAll()
 
-        buildScript applyPlugin()
+        buildFile applyPlugin()
 
         expect:
         fails("verify")
@@ -58,7 +58,7 @@ class PostPluginResolutionFailuresIntegrationSpec extends AbstractIntegrationSpe
         pluginBuilder.addNonConstructiblePlugin(PLUGIN_ID)
         pluginBuilder.publishAs(GROUP, ARTIFACT, VERSION, pluginRepo, executer).allowAll()
 
-        buildScript applyPlugin()
+        buildFile applyPlugin()
 
         expect:
         fails("verify")
@@ -72,7 +72,7 @@ class PostPluginResolutionFailuresIntegrationSpec extends AbstractIntegrationSpe
         pluginBuilder.addPlugin("throw new Exception('throwing plugin')", PLUGIN_ID)
         pluginBuilder.publishAs(GROUP, ARTIFACT, VERSION, pluginRepo, executer).allowAll()
 
-        buildScript applyPlugin()
+        buildFile applyPlugin()
 
         expect:
         fails("verify")

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/RuleSourcePluginUseIntegrationSpec.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/RuleSourcePluginUseIntegrationSpec.groovy
@@ -47,7 +47,7 @@ class RuleSourcePluginUseIntegrationSpec extends AbstractIntegrationSpec {
         }
 
         and:
-        buildScript """
+        buildFile """
             plugins { id '$PLUGIN_ID' version '$VERSION' }
         """
 

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/VersionInSettingsPluginUseIntegrationTest.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/VersionInSettingsPluginUseIntegrationTest.groovy
@@ -47,7 +47,7 @@ class VersionInSettingsPluginUseIntegrationTest extends AbstractIntegrationSpec 
 
     def "can define plugin version in settings script"() {
         when:
-        buildScript "plugins { id '$PLUGIN_ID' }"
+        buildFile "plugins { id '$PLUGIN_ID' }"
 
         then:
         verifyPluginApplied('1.0')
@@ -87,7 +87,7 @@ class VersionInSettingsPluginUseIntegrationTest extends AbstractIntegrationSpec 
                 }
             }
         """
-        buildScript "plugins { id '$PLUGIN_ID' }"
+        buildFile "plugins { id '$PLUGIN_ID' }"
 
         then:
         verifyPluginApplied('1.0')
@@ -103,7 +103,7 @@ class VersionInSettingsPluginUseIntegrationTest extends AbstractIntegrationSpec 
                 }
             }
         """
-        buildScript "plugins { id '$PLUGIN_ID' }"
+        buildFile "plugins { id '$PLUGIN_ID' }"
 
         then:
         verifyPluginApplied('2.0')
@@ -111,7 +111,7 @@ class VersionInSettingsPluginUseIntegrationTest extends AbstractIntegrationSpec 
 
     def "can override plugin version in settings script"() {
         when:
-        buildScript "plugins { id '$PLUGIN_ID' version '2.0' }"
+        buildFile "plugins { id '$PLUGIN_ID' version '2.0' }"
 
         then:
         verifyPluginApplied('2.0')

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/VersionedPluginUseIntegrationTest.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/VersionedPluginUseIntegrationTest.groovy
@@ -49,7 +49,7 @@ class VersionedPluginUseIntegrationTest extends AbstractIntegrationSpec {
 
     def "can specify plugin version"() {
         when:
-        buildScript "plugins { id '$PLUGIN_ID' version '1.0' }"
+        buildFile "plugins { id '$PLUGIN_ID' version '1.0' }"
 
         then:
         verifyPluginApplied('1.0')
@@ -58,7 +58,7 @@ class VersionedPluginUseIntegrationTest extends AbstractIntegrationSpec {
     def "can specify plugin version using gradle properties"() {
         when:
         file("gradle.properties") << "myPluginVersion=2.0"
-        buildScript """
+        buildFile """
             plugins {
                 id '$PLUGIN_ID' version "\${myPluginVersion}"
             }
@@ -70,7 +70,7 @@ class VersionedPluginUseIntegrationTest extends AbstractIntegrationSpec {
 
     def "can specify plugin version using command-line project property"() {
         when:
-        buildScript """
+        buildFile """
             plugins {
                 id '$PLUGIN_ID' version "\${myPluginVersion}"
             }
@@ -89,7 +89,7 @@ class VersionedPluginUseIntegrationTest extends AbstractIntegrationSpec {
                 public static final String MY_PLUGIN_VERSION = "2.0";
             }
 """
-        buildScript """
+        buildFile """
             import static MyVersions.*
             plugins {
                 id '$PLUGIN_ID' version "\${MY_PLUGIN_VERSION}"
@@ -107,7 +107,7 @@ class VersionedPluginUseIntegrationTest extends AbstractIntegrationSpec {
                 public static final String MY_PLUGIN_VERSION = "2.0";
             }
 """
-        buildScript """
+        buildFile """
             import static MyVersions.*
             plugins {
                 id '$PLUGIN_ID' version "\${MY_PLUGIN_VERSION}"

--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/TestKitDependencyClassVisibilityIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/TestKitDependencyClassVisibilityIntegrationTest.groovy
@@ -24,7 +24,7 @@ class TestKitDependencyClassVisibilityIntegrationTest extends AbstractIntegratio
 
     def "test kit dependency is not implicitly put on the test compile classpath"() {
         when:
-        buildScript """
+        buildFile """
             plugins { id "org.gradle.java" }
         """
 
@@ -40,7 +40,7 @@ class TestKitDependencyClassVisibilityIntegrationTest extends AbstractIntegratio
 
     def "gradle implementation dependencies are not visible to gradleTestKit() users"() {
         when:
-        buildScript """
+        buildFile """
             plugins { id "org.gradle.java" }
             dependencies { testImplementation gradleTestKit() }
         """
@@ -57,7 +57,7 @@ class TestKitDependencyClassVisibilityIntegrationTest extends AbstractIntegratio
 
     def "gradle implementation dependencies do not conflict with user classes"() {
         when:
-        buildScript """
+        buildFile """
             plugins { id "org.gradle.java" }
             ${mavenCentralRepository()}
             dependencies {

--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerArgumentsIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerArgumentsIntegrationTest.groovy
@@ -20,7 +20,7 @@ class GradleRunnerArgumentsIntegrationTest extends BaseGradleRunnerIntegrationTe
 
     def "can execute build without specifying any arguments"() {
         given:
-        buildScript """
+        buildFile """
             help {
                 doLast {
                     file('out.txt').text = "help"
@@ -37,7 +37,7 @@ class GradleRunnerArgumentsIntegrationTest extends BaseGradleRunnerIntegrationTe
 
     def "can execute build with multiple tasks"() {
         given:
-        buildScript """
+        buildFile """
             task t1 {
                 doLast {
                     file("out.txt").text = "t1"
@@ -59,7 +59,7 @@ class GradleRunnerArgumentsIntegrationTest extends BaseGradleRunnerIntegrationTe
 
     def "can provide non task arguments"() {
         given:
-        buildScript """
+        buildFile """
             task writeValue {
                 doLast {
                     file("out.txt").text = project.value
@@ -76,7 +76,7 @@ class GradleRunnerArgumentsIntegrationTest extends BaseGradleRunnerIntegrationTe
 
     def "can enable parallel execution via --parallel property"() {
         given:
-        buildScript """
+        buildFile """
             task writeValue {
                 doLast {
                     file("out.txt").text = gradle.startParameter.parallelProjectExecutionEnabled

--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerBuildFailureIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerBuildFailureIntegrationTest.groovy
@@ -37,7 +37,7 @@ class GradleRunnerBuildFailureIntegrationTest extends BaseGradleRunnerIntegratio
 
     def "does not throw exception when build fails expectantly"() {
         given:
-        buildScript """
+        buildFile """
             task helloWorld {
                 doLast {
                     throw new GradleException('Expected exception')
@@ -56,7 +56,7 @@ class GradleRunnerBuildFailureIntegrationTest extends BaseGradleRunnerIntegratio
     @InspectsExecutedTasks
     def "exposes result when build fails expectantly"() {
         given:
-        buildScript """
+        buildFile """
             task helloWorld {
                 doLast {
                     throw new GradleException('Expected exception')
@@ -74,7 +74,7 @@ class GradleRunnerBuildFailureIntegrationTest extends BaseGradleRunnerIntegratio
 
     def "throws when build is expected to fail but does not"() {
         given:
-        buildScript helloWorldTask()
+        buildFile helloWorldTask()
 
         when:
         runner('helloWorld').buildAndFail()
@@ -89,7 +89,7 @@ class GradleRunnerBuildFailureIntegrationTest extends BaseGradleRunnerIntegratio
     @InspectsExecutedTasks
     def "exposes result when build is expected to fail but does not"() {
         given:
-        buildScript helloWorldTask()
+        buildFile helloWorldTask()
 
         when:
         def runner = gradleVersion >= GradleVersion.version("4.5")
@@ -114,7 +114,7 @@ $t.buildResult.output"""
 
     def "throws when build is expected to succeed but fails"() {
         given:
-        buildScript """
+        buildFile """
             task helloWorld {
                 doLast {
                     throw new GradleException('Unexpected exception')
@@ -134,7 +134,7 @@ $t.buildResult.output"""
     @InspectsBuildOutput
     def "exposes result with build is expected to succeed but fails "() {
         given:
-        buildScript """
+        buildFile """
             task helloWorld {
                 doLast {
                     throw new GradleException('Unexpected exception')
@@ -164,7 +164,7 @@ $t.buildResult.output"""
 
     def "can expect a build failure without having to call buildAndFail"() {
         given:
-        buildScript """
+        buildFile """
             task helloWorld {
                 doLast {
                     throw new GradleException('Expected exception')

--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerCaptureOutputIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerCaptureOutputIntegrationTest.groovy
@@ -34,7 +34,7 @@ class GradleRunnerCaptureOutputIntegrationTest extends BaseGradleRunnerIntegrati
         given:
         def standardOutput = new StringWriter()
         def standardError = new StringWriter()
-        buildScript helloWorldWithStandardOutputAndError()
+        buildFile helloWorldWithStandardOutputAndError()
 
         when:
         def result = runner('helloWorld', "-d", "-s")

--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerEnvironmentVariablesIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerEnvironmentVariablesIntegrationTest.groovy
@@ -26,7 +26,7 @@ class GradleRunnerEnvironmentVariablesIntegrationTest extends BaseGradleRunnerIn
     @NoDebug //avoid in-process execution so that we can set the env variable
     def "user can provide env vars"() {
         given:
-        buildScript "file('env.txt') << System.getenv('dummyEnvVar')"
+        buildFile "file('env.txt') << System.getenv('dummyEnvVar')"
 
         when:
         runner().withEnvironment(dummyEnvVar: "env var OK").build()

--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerIsolationIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerIsolationIntegrationTest.groovy
@@ -53,6 +53,7 @@ class GradleRunnerIsolationIntegrationTest extends BaseGradleRunnerIntegrationTe
             .build()
 
         when:
+        buildFile.clear()
         buildFile """
             task check {
                 doLast {

--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerIsolationIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerIsolationIntegrationTest.groovy
@@ -36,7 +36,7 @@ class GradleRunnerIsolationIntegrationTest extends BaseGradleRunnerIntegrationTe
         gradleUserHome.file("init.gradle") << 'allprojects { ext.myProp2 = \'initScript\' }'
 
         and:
-        buildScript """
+        buildFile """
             task check {
                 doLast {
                     // Uses testkit dir
@@ -53,7 +53,7 @@ class GradleRunnerIsolationIntegrationTest extends BaseGradleRunnerIntegrationTe
             .build()
 
         when:
-        buildScript """
+        buildFile """
             task check {
                 doLast {
                     // uses specified user home dir

--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerJavaCompilationIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerJavaCompilationIntegrationTest.groovy
@@ -20,7 +20,7 @@ class GradleRunnerJavaCompilationIntegrationTest extends BaseGradleRunnerIntegra
 
     def "can compile Java code through TestKit"() {
         given:
-        buildScript """
+        buildFile """
             plugins {
                 id 'java'
             }

--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerMechanicalFailureIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerMechanicalFailureIntegrationTest.groovy
@@ -33,7 +33,7 @@ class GradleRunnerMechanicalFailureIntegrationTest extends BaseGradleRunnerInteg
 
     def "treats invalid argument as build failure and throws if not expected"() {
         given:
-        buildScript helloWorldTask()
+        buildFile helloWorldTask()
 
         when:
         runner('helloWorld', '--unknown').build()
@@ -44,7 +44,7 @@ class GradleRunnerMechanicalFailureIntegrationTest extends BaseGradleRunnerInteg
 
     def "treats invalid argument as build failure and does not throw if expected"() {
         given:
-        buildScript helloWorldTask()
+        buildFile helloWorldTask()
 
         when:
         runner('helloWorld', '--unknown').buildAndFail()
@@ -105,7 +105,7 @@ class GradleRunnerMechanicalFailureIntegrationTest extends BaseGradleRunnerInteg
     @InspectsExecutedTasks
     def "build fails if project directory does not exist and provides diagnostic information"() {
         given:
-        buildScript helloWorldTask()
+        buildFile helloWorldTask()
         def nonExistentWorkingDir = new File('some/path/that/does/not/exist')
 
         when:

--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerNestedBuildTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerNestedBuildTest.groovy
@@ -23,12 +23,12 @@ class GradleRunnerNestedBuildTest extends BaseGradleRunnerIntegrationTest {
     @Issue("https://github.com/gradle/gradle/issues/2622")
     def "does not break for deeply nested builds"() {
         given:
-        buildScript """          
+        buildFile """
             task nested1(type: GradleBuild)
-            
+
             task nested2(type: GradleBuild) {
                 tasks = ['nested1']
-            }           
+            }
         """
         settingsFile << "rootProject.name='root'"
 

--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerPluginClasspathInjectionIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerPluginClasspathInjectionIntegrationTest.groovy
@@ -43,7 +43,7 @@ class GradleRunnerPluginClasspathInjectionIntegrationTest extends BaseGradleRunn
 
     def "empty classpath is treated as no injected classpath"() {
         when:
-        buildScript plugin.useDeclaration
+        buildFile plugin.useDeclaration
         def result = runner()
             .withPluginClasspath([])
             .buildAndFail()
@@ -54,7 +54,7 @@ class GradleRunnerPluginClasspathInjectionIntegrationTest extends BaseGradleRunn
 
     def "injected classpath is indicated in error message if plugin not found"() {
         when:
-        buildScript plugin.useDeclaration
+        buildFile plugin.useDeclaration
         def expectedClasspath = [file("blah1"), file("blah2")]
         def result = runner()
             .withPluginClasspath(expectedClasspath)
@@ -66,7 +66,7 @@ class GradleRunnerPluginClasspathInjectionIntegrationTest extends BaseGradleRunn
 
     def "can inject plugin classpath and use in build"() {
         given:
-        buildScript plugin.build().useDeclaration
+        buildFile plugin.build().useDeclaration
 
         when:
         def result = runner(':helloWorld1')
@@ -80,7 +80,7 @@ class GradleRunnerPluginClasspathInjectionIntegrationTest extends BaseGradleRunn
 
     def "injected plugin classes are visible in build script applying plugin"() {
         given:
-        buildScript plugin.build().useDeclaration + plugin.echoClassNameTask()
+        buildFile plugin.build().useDeclaration + plugin.echoClassNameTask()
 
         when:
         def result = runner("echo1")
@@ -93,7 +93,7 @@ class GradleRunnerPluginClasspathInjectionIntegrationTest extends BaseGradleRunn
 
     def "injected classes are not visible when plugin is not applied"() {
         given:
-        buildScript plugin.echoClassNameTask()
+        buildFile plugin.echoClassNameTask()
 
         when:
         def result = runner('echo1', "-S")

--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerResultIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerResultIntegrationTest.groovy
@@ -88,7 +88,7 @@ class GradleRunnerResultIntegrationTest extends BaseGradleRunnerIntegrationTest 
             package pkg
             class Message { public static final String MSG = "::msg::" }
         """
-        buildScript """
+        buildFile """
             task echoMsg {
                 doLast {
                     println pkg.Message.MSG

--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerUnsupportedFeatureFailureIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerUnsupportedFeatureFailureIntegrationTest.groovy
@@ -83,7 +83,7 @@ class GradleRunnerUnsupportedFeatureFailureIntegrationTest extends BaseGradleRun
         def minSupportedVersion = TestKitFeature.PLUGIN_CLASSPATH_INJECTION.since.version
 
         given:
-        buildScript plugin.useDeclaration
+        buildFile plugin.useDeclaration
 
         when:
         runner('helloWorld')
@@ -102,7 +102,7 @@ class GradleRunnerUnsupportedFeatureFailureIntegrationTest extends BaseGradleRun
         def maxUnsupportedVersion = getMaxUnsupportedVersion(TestKitFeature.PLUGIN_CLASSPATH_INJECTION)
         def minSupportedVersion = TestKitFeature.PLUGIN_CLASSPATH_INJECTION.since.version
 
-        buildScript plugin.useDeclaration
+        buildFile plugin.useDeclaration
 
         when:
         plugin.build().exposeMetadata {

--- a/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseProjectIntegrationTest.groovy
+++ b/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseProjectIntegrationTest.groovy
@@ -26,7 +26,7 @@ class EclipseProjectIntegrationTest extends AbstractEclipseIntegrationSpec {
     @ToBeFixedForConfigurationCache
     void allowsConfiguringEclipseProject() {
         given:
-        buildScript """
+        buildFile """
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
@@ -82,7 +82,7 @@ eclipse {
     @ToBeFixedForConfigurationCache
     void "allows custom matcher resource filter"() {
         given:
-        buildScript """
+        buildFile """
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
@@ -123,7 +123,7 @@ eclipse {
     @ToBeFixedForConfigurationCache
     void "allows configuring multiple resource filters"() {
         given:
-        buildScript """
+        buildFile """
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
@@ -181,7 +181,7 @@ eclipse {
     @ToBeFixedForConfigurationCache
     void "allows 'include only' type resource filter"() {
         given:
-        buildScript """
+        buildFile """
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
@@ -222,7 +222,7 @@ eclipse {
     @ToBeFixedForConfigurationCache
     void "allows resource filter for files"() {
         given:
-        buildScript """
+        buildFile """
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
@@ -263,7 +263,7 @@ eclipse {
     @ToBeFixedForConfigurationCache
     void "allows resource filter for folders"() {
         given:
-        buildScript """
+        buildFile """
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
@@ -304,7 +304,7 @@ eclipse {
     @ToBeFixedForConfigurationCache
     void "allows non-recursive resource filter"() {
         given:
-        buildScript """
+        buildFile """
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
@@ -364,7 +364,7 @@ eclipse {
 </projectDescription>'''
 
         and:
-        buildScript """
+        buildFile """
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
@@ -466,7 +466,7 @@ eclipse {
         projectFile << projectFileOriginalText
 
         and:
-        buildScript """
+        buildFile """
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
@@ -527,7 +527,7 @@ eclipse {
     @ToBeFixedForConfigurationCache
     void "allows nested matcher"() {
         given:
-        buildScript """
+        buildFile """
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
@@ -605,7 +605,7 @@ eclipse {
 </projectDescription>'''
 
         and:
-        buildScript """
+        buildFile """
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
@@ -642,7 +642,7 @@ org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.3
 '''
 
         and:
-        buildScript """
+        buildFile """
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
@@ -685,7 +685,7 @@ eclipseJdt.doLast() {
     void "setting project name within #hook is disallowed"(){
         given:
 
-        buildScript """
+        buildFile """
 apply plugin: 'java'
 apply plugin: 'eclipse'
 

--- a/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractSourcesAndJavadocJarsIntegrationTest.groovy
+++ b/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractSourcesAndJavadocJarsIntegrationTest.groovy
@@ -312,7 +312,7 @@ dependencies {
         given:
         executer.withEnvironmentVars('GRADLE_REPO_OVERRIDE': "$server.uri/")
 
-        buildScript """
+        buildFile """
             apply plugin: "java"
             apply plugin: "idea"
             apply plugin: "eclipse"
@@ -338,7 +338,7 @@ dependencies {
         given:
         executer.withEnvironmentVars('GRADLE_REPO_OVERRIDE': "$server.uri/")
 
-        buildScript """
+        buildFile """
             apply plugin: "java"
             apply plugin: "idea"
             apply plugin: "eclipse"
@@ -363,7 +363,7 @@ dependencies {
         def repo = givenGroovyExistsInGradleRepo()
         executer.withEnvironmentVars('GRADLE_LIBS_REPO_OVERRIDE': "$repo.uri/")
 
-        buildScript """
+        buildFile """
             apply plugin: "java"
             apply plugin: "idea"
             apply plugin: "eclipse"
@@ -399,7 +399,7 @@ dependencies {
         def repo = givenGroovyExistsInGradleRepo()
         executer.withEnvironmentVars('GRADLE_LIBS_REPO_OVERRIDE': "$repo.uri/")
 
-        buildScript """
+        buildFile """
             apply plugin: "java"
             apply plugin: "idea"
             apply plugin: "eclipse"
@@ -426,7 +426,7 @@ dependencies {
         def repo = givenGroovyExistsInGradleRepo()
         executer.withEnvironmentVars('GRADLE_LIBS_REPO_OVERRIDE': "$repo.uri/")
 
-        buildScript """
+        buildFile """
             apply plugin: "java"
             apply plugin: "idea"
             apply plugin: "eclipse"
@@ -448,7 +448,7 @@ dependencies {
         given:
         executer.withEnvironmentVars('GRADLE_LIBS_REPO_OVERRIDE': "$server.uri/")
 
-        buildScript """
+        buildFile """
             apply plugin: "java"
             apply plugin: "idea"
             apply plugin: "eclipse"
@@ -473,7 +473,7 @@ dependencies {
         given:
         executer.withEnvironmentVars('GRADLE_LIBS_REPO_OVERRIDE': "$server.uri/")
 
-        buildScript """
+        buildFile """
             apply plugin: "java"
             apply plugin: "idea"
             apply plugin: "eclipse"
@@ -501,7 +501,7 @@ dependencies {
             dependencyResolutionManagement { repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS }
         """
 
-        buildScript """
+        buildFile """
             apply plugin: "java"
             apply plugin: "idea"
             apply plugin: "eclipse"

--- a/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseLinkedResourceIntegrationTest.groovy
+++ b/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseLinkedResourceIntegrationTest.groovy
@@ -72,7 +72,7 @@ configure(project(":projectA")){
     def "can use linked resources and generate metadata twice"() {
         given:
         settingsFile.text = 'rootProject.name = "root"'
-        buildScript '''
+        buildFile '''
             plugins {
                 id 'eclipse'
             }

--- a/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
+++ b/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
@@ -307,7 +307,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
 
     def "cannot emit a problem with invalid additional data"() {
         given:
-        buildScript 'class InvalidData implements org.gradle.api.problems.internal.AdditionalData {}'
+        buildFile 'class InvalidData implements org.gradle.api.problems.internal.AdditionalData {}'
         withReportProblemTask """
             problems.forNamespace('org.example.plugin').reporting {
                 it.id('type', 'label')

--- a/platforms/jvm/ear/src/integTest/groovy/org/gradle/plugins/ear/EarPluginIntegrationTest.groovy
+++ b/platforms/jvm/ear/src/integTest/groovy/org/gradle/plugins/ear/EarPluginIntegrationTest.groovy
@@ -320,7 +320,7 @@ ear {
     @Issue("GRADLE-3486")
     def "does not fail when provided with an existing descriptor without a version attribute"() {
         given:
-        buildScript '''
+        buildFile '''
             apply plugin: 'ear'
         '''.stripIndent()
         createDir('src/main/application/META-INF') {
@@ -341,7 +341,7 @@ ear {
 
     def "does not fail when initializeInOrder is null"() {
         given:
-        buildScript '''
+        buildFile '''
             apply plugin: 'ear'
             ear {
                 deploymentDescriptor {
@@ -361,7 +361,7 @@ ear {
     @Issue("GRADLE-3497")
     def "does not fail when provided with an existing descriptor with security roles without description"() {
         given:
-        buildScript '''
+        buildFile '''
             apply plugin: 'ear'
         '''.stripIndent()
         createDir('src/main/application/META-INF') {
@@ -388,7 +388,7 @@ ear {
     @Issue("GRADLE-3497")
     def "does not fail when provided with an existing descriptor with a web module without #missing"() {
         given:
-        buildScript '''
+        buildFile '''
             apply plugin: 'ear'
         '''.stripIndent()
         createDir('src/main/application/META-INF') {
@@ -553,7 +553,7 @@ ear {
     }
 
     def "using nested descriptor file name is not allowed"() {
-        buildScript '''
+        buildFile '''
             apply plugin: 'ear'
 
             ear {

--- a/platforms/jvm/language-groovy/src/integTest/groovy/org/gradle/groovy/compile/CachedGroovyCompileIntegrationTest.groovy
+++ b/platforms/jvm/language-groovy/src/integTest/groovy/org/gradle/groovy/compile/CachedGroovyCompileIntegrationTest.groovy
@@ -86,6 +86,7 @@ class CachedGroovyCompileIntegrationTest extends AbstractCachedCompileIntegratio
 
     def "joint Java and Groovy compilation can be cached"() {
         given:
+        buildFile.clear()
         buildFile """
             plugins {
                 id 'groovy'

--- a/platforms/jvm/language-groovy/src/integTest/groovy/org/gradle/groovy/compile/CachedGroovyCompileIntegrationTest.groovy
+++ b/platforms/jvm/language-groovy/src/integTest/groovy/org/gradle/groovy/compile/CachedGroovyCompileIntegrationTest.groovy
@@ -86,7 +86,7 @@ class CachedGroovyCompileIntegrationTest extends AbstractCachedCompileIntegratio
 
     def "joint Java and Groovy compilation can be cached"() {
         given:
-        buildScript """
+        buildFile """
             plugins {
                 id 'groovy'
             }

--- a/platforms/jvm/language-groovy/src/testFixtures/groovy/org/gradle/groovy/compile/AbstractBasicGroovyCompilerIntegrationSpec.groovy
+++ b/platforms/jvm/language-groovy/src/testFixtures/groovy/org/gradle/groovy/compile/AbstractBasicGroovyCompilerIntegrationSpec.groovy
@@ -455,7 +455,7 @@ abstract class AbstractBasicGroovyCompilerIntegrationSpec extends MultiVersionIn
 
     def "cant compile against gradle base services"() {
         def gradleBaseServicesClass = Action
-        buildScript """
+        buildFile """
             apply plugin: 'groovy'
             ${mavenCentralRepository()}
         """
@@ -476,7 +476,7 @@ abstract class AbstractBasicGroovyCompilerIntegrationSpec extends MultiVersionIn
     @Requires(UnitTestPreconditions.Online)
     def "can compile with Groovy library resolved by classifier"() {
         def gradleBaseServicesClass = Action
-        buildScript """
+        buildFile """
             apply plugin: 'groovy'
             ${mavenCentralRepository()}
             dependencies {

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/BaseIncrementalCompilationAfterFailureIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/BaseIncrementalCompilationAfterFailureIntegrationTest.groovy
@@ -437,7 +437,7 @@ class GroovyIncrementalCompilationAfterFailureIntegrationTest extends BaseIncrem
     @Issue("https://github.com/gradle/gradle/issues/21644")
     def "removes all classes for a recompiled source from output to stash dir for Spock tests when super class is changed"() {
         given:
-        buildScript """
+        buildFile """
             plugins {
                 id 'groovy'
                 id 'java-library'

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/BaseIncrementalCompilationAfterFailureIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/BaseIncrementalCompilationAfterFailureIntegrationTest.groovy
@@ -437,6 +437,7 @@ class GroovyIncrementalCompilationAfterFailureIntegrationTest extends BaseIncrem
     @Issue("https://github.com/gradle/gradle/issues/21644")
     def "removes all classes for a recompiled source from output to stash dir for Spock tests when super class is changed"() {
         given:
+        buildFile.clear()
         buildFile """
             plugins {
                 id 'groovy'

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainIntegrationTest.groovy
@@ -25,7 +25,7 @@ class JavaToolchainIntegrationTest extends AbstractIntegrationSpec implements Ja
 
     def "fails when using an invalid toolchain spec when #description"() {
 
-        buildScript """
+        buildFile """
             apply plugin: JvmToolchainsPlugin
 
             abstract class UnpackLauncher extends DefaultTask {
@@ -61,7 +61,7 @@ class JavaToolchainIntegrationTest extends AbstractIntegrationSpec implements Ja
     def "do not nag user when toolchain spec is valid (#description)"() {
         def jdkMetadata = AvailableJavaHomes.getJvmInstallationMetadata(Jvm.current())
 
-        buildScript """
+        buildFile """
             apply plugin: "java"
 
             javaToolchains.launcherFor {
@@ -86,7 +86,7 @@ class JavaToolchainIntegrationTest extends AbstractIntegrationSpec implements Ja
     def "identify whether #tool toolchain corresponds to the #current JVM"() {
         def jdkMetadata = AvailableJavaHomes.getJvmInstallationMetadata(jvm as Jvm)
 
-        buildScript """
+        buildFile """
             apply plugin: "java"
 
             def tool = javaToolchains.${toolMethod} {
@@ -120,7 +120,7 @@ class JavaToolchainIntegrationTest extends AbstractIntegrationSpec implements Ja
         def jdkMetadata1 = AvailableJavaHomes.getJvmInstallationMetadata(Jvm.current())
         def jdkMetadata2 = AvailableJavaHomes.getJvmInstallationMetadata(AvailableJavaHomes.differentVersion)
 
-        buildScript """
+        buildFile """
             apply plugin: "java"
 
             java {
@@ -146,7 +146,7 @@ class JavaToolchainIntegrationTest extends AbstractIntegrationSpec implements Ja
     def "fails when trying to change captured toolchain spec property after it has been used to resolve a toolchain"() {
         def jdkMetadata1 = AvailableJavaHomes.getJvmInstallationMetadata(Jvm.current())
         def jdkMetadata2 = AvailableJavaHomes.getJvmInstallationMetadata(AvailableJavaHomes.differentVersion)
-        buildScript """
+        buildFile """
             import java.util.concurrent.atomic.AtomicReference
             import org.gradle.jvm.toolchain.JavaToolchainSpec
 
@@ -171,7 +171,7 @@ class JavaToolchainIntegrationTest extends AbstractIntegrationSpec implements Ja
 
     def "nag user when toolchain spec is IBM_SEMERU"() {
         given:
-        buildScript """
+        buildFile """
             apply plugin: "java"
 
             java {

--- a/platforms/jvm/language-jvm/src/integTest/groovy/org/gradle/api/tasks/bundling/JarEncodingIntegrationTest.groovy
+++ b/platforms/jvm/language-jvm/src/integTest/groovy/org/gradle/api/tasks/bundling/JarEncodingIntegrationTest.groovy
@@ -33,7 +33,7 @@ class JarEncodingIntegrationTest extends AbstractIntegrationSpec {
     @Issue(['GRADLE-1506'])
     def "create Jar with metadata encoded using UTF-8 when platform default charset is not UTF-8"() {
         given:
-        buildScript """
+        buildFile """
             task jar(type: Jar) {
                 from file('test')
                 destinationDirectory = file('dest')
@@ -59,7 +59,7 @@ class JarEncodingIntegrationTest extends AbstractIntegrationSpec {
     @Issue('GRADLE-1506')
     def "create Jar with metadata encoded using user supplied charset"() {
         given:
-        buildScript """
+        buildFile """
             task jar(type: Jar) {
                 metadataCharset = 'ISO-8859-15'
                 from file('test')
@@ -84,7 +84,7 @@ class JarEncodingIntegrationTest extends AbstractIntegrationSpec {
     @Issue('GRADLE-3374')
     def "write manifest encoded using UTF-8 when platform default charset is not UTF-8"() {
         given:
-        buildScript """
+        buildFile """
             task jar(type: Jar) {
                 from file('test')
                 destinationDirectory = file('dest')
@@ -109,7 +109,7 @@ class JarEncodingIntegrationTest extends AbstractIntegrationSpec {
     @Issue("GRADLE-3374")
     def "merge manifest read using UTF-8 by default"() {
         given:
-        buildScript """
+        buildFile """
             task jar(type: Jar) {
                 from file('test')
                 destinationDirectory = file('dest')
@@ -135,7 +135,7 @@ class JarEncodingIntegrationTest extends AbstractIntegrationSpec {
     @Issue('GRADLE-3374')
     def "write manifests using a user defined character set"() {
         given:
-        buildScript """
+        buildFile """
             task jar(type: Jar) {
                 from file('test')
                 destinationDirectory = file('dest')
@@ -160,7 +160,7 @@ class JarEncodingIntegrationTest extends AbstractIntegrationSpec {
     @Issue('GRADLE-3374')
     def "merge manifests using user defined character sets"() {
         given:
-        buildScript """
+        buildFile """
             task jar(type: Jar) {
                 from file('test')
                 destinationDirectory = file('dest')
@@ -204,7 +204,7 @@ class JarEncodingIntegrationTest extends AbstractIntegrationSpec {
         def mergedManifestFile = file(mergedManifestFilename)
         mergedManifestFile.withOutputStream { mergedManifest.write(it) }
 
-        buildScript """
+        buildFile """
             $taskTypeDeclaration
             task jar(type: $taskType) {
                 from file('test')
@@ -242,7 +242,7 @@ class JarEncodingIntegrationTest extends AbstractIntegrationSpec {
     def "reports error for unsupported manifest content charsets, write #writeCharset, read #readCharset"() {
         given:
         settingsFile << "rootProject.name = 'root'"
-        buildScript """
+        buildFile """
             task jar(type: Jar) {
                 from file('test')
                 destinationDirectory = file('dest')

--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
@@ -538,7 +538,7 @@ Artifacts
 
     def "accessing reportsDir convention from the java plugin convention is deprecated"() {
         given:
-        buildScript("""
+        buildFile("""
             plugins { id 'java' }
             println(reportsDir)
         """)

--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/integtests/DifferentJnaVersionInPluginIntegrationSpec.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/integtests/DifferentJnaVersionInPluginIntegrationSpec.groovy
@@ -24,7 +24,7 @@ class DifferentJnaVersionInPluginIntegrationSpec extends AbstractIntegrationSpec
     @Requires(UnitTestPreconditions.NotMacOsM1)
     def 'can build a plugin with a different jna version'() {
         given:
-        buildScript """
+        buildFile """
             plugins {
                 id 'java'
             }

--- a/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/compile/CachedScalaCompileIntegrationTest.groovy
+++ b/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/compile/CachedScalaCompileIntegrationTest.groovy
@@ -55,6 +55,7 @@ class CachedScalaCompileIntegrationTest extends AbstractCachedCompileIntegration
 
     def "joint Java and Scala compilation can be cached"() {
         given:
+        buildFile.clear()
         buildFile """
             plugins {
                 id 'scala'

--- a/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/compile/CachedScalaCompileIntegrationTest.groovy
+++ b/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/compile/CachedScalaCompileIntegrationTest.groovy
@@ -55,7 +55,7 @@ class CachedScalaCompileIntegrationTest extends AbstractCachedCompileIntegration
 
     def "joint Java and Scala compilation can be cached"() {
         given:
-        buildScript """
+        buildFile """
             plugins {
                 id 'scala'
             }

--- a/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/compile/UpToDateScalaCompileIntegrationTest.groovy
+++ b/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/compile/UpToDateScalaCompileIntegrationTest.groovy
@@ -35,7 +35,7 @@ class UpToDateScalaCompileIntegrationTest extends AbstractIntegrationSpec implem
     }
 
     def "compile is out of date when changing the #changedVersion version"() {
-        buildScript(scalaProjectBuildScript(defaultZincVersion, defaultScalaVersion))
+        buildFile(scalaProjectBuildScript(defaultZincVersion, defaultScalaVersion))
 
         when:
         run 'compileScala'
@@ -50,7 +50,7 @@ class UpToDateScalaCompileIntegrationTest extends AbstractIntegrationSpec implem
         skipped ':compileScala'
 
         when:
-        buildScript(scalaProjectBuildScript(newZincVersion, newScalaVersion))
+        buildFile(scalaProjectBuildScript(newZincVersion, newScalaVersion))
         run 'compileScala'
 
         then:
@@ -73,7 +73,7 @@ class UpToDateScalaCompileIntegrationTest extends AbstractIntegrationSpec implem
         def jdk8 = AvailableJavaHomes.getJdk(VERSION_1_8)
         def jdk11 = AvailableJavaHomes.getJdk(VERSION_11)
 
-        buildScript(scalaProjectBuildScript(ScalaBasePlugin.DEFAULT_ZINC_VERSION, '2.12.6'))
+        buildFile(scalaProjectBuildScript(ScalaBasePlugin.DEFAULT_ZINC_VERSION, '2.12.6'))
         when:
         executer.withJvm(jdk8)
         run 'compileScala'
@@ -119,7 +119,7 @@ class UpToDateScalaCompileIntegrationTest extends AbstractIntegrationSpec implem
         def jdk8 = AvailableJavaHomes.getJvmInstallationMetadata(AvailableJavaHomes.getJdk(VERSION_1_8))
         def jdk11 = AvailableJavaHomes.getJvmInstallationMetadata(AvailableJavaHomes.getJdk(VERSION_11))
 
-        buildScript """
+        buildFile """
             apply plugin: 'scala'
 
             ${mavenCentralRepository()}
@@ -177,7 +177,7 @@ class UpToDateScalaCompileIntegrationTest extends AbstractIntegrationSpec implem
 
         def jdkMetadata = AvailableJavaHomes.getJvmInstallationMetadata(AvailableJavaHomes.getDifferentJdk { it.languageVersion.majorVersion.toInteger() in 8..17 })
 
-        buildScript """
+        buildFile """
             apply plugin: 'scala'
 
             ${mavenCentralRepository()}

--- a/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/scaladoc/ScalaDocIntegrationTest.groovy
+++ b/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/scaladoc/ScalaDocIntegrationTest.groovy
@@ -53,7 +53,7 @@ class ScalaDocIntegrationTest extends MultiVersionIntegrationSpec implements Dir
 
     def "scaladoc produces output"() {
         classes.baseline()
-        buildScript(classes.buildScript())
+        buildFile(classes.buildScript())
 
         when:
         succeeds scaladoc
@@ -67,7 +67,7 @@ class ScalaDocIntegrationTest extends MultiVersionIntegrationSpec implements Dir
         def newScalaVersion = getOtherScalaVersion()
 
         classes.baseline()
-        buildScript(classes.buildScript())
+        buildFile(classes.buildScript())
 
         when:
         succeeds scaladoc
@@ -82,7 +82,7 @@ class ScalaDocIntegrationTest extends MultiVersionIntegrationSpec implements Dir
 
         when:
         this.classes.scalaVersion = newScalaVersion
-        buildScript(this.classes.buildScript())
+        buildFile(this.classes.buildScript())
         succeeds scaladoc
         then:
         executedAndNotSkipped scaladoc
@@ -90,7 +90,7 @@ class ScalaDocIntegrationTest extends MultiVersionIntegrationSpec implements Dir
 
     def "scaladoc is loaded from cache"() {
         classes.baseline()
-        buildScript(classes.buildScript())
+        buildFile(classes.buildScript())
 
         when:
         withBuildCache().run scaladoc
@@ -108,7 +108,7 @@ class ScalaDocIntegrationTest extends MultiVersionIntegrationSpec implements Dir
 
     def "scaladoc uses maxMemory"() {
         classes.baseline()
-        buildScript(classes.buildScript())
+        buildFile(classes.buildScript())
         buildFile << """
             scaladoc.maxMemory = '234M'
         """
@@ -126,7 +126,7 @@ class ScalaDocIntegrationTest extends MultiVersionIntegrationSpec implements Dir
         settingsFile << """
             include(':utils')
         """
-        buildScript(classes.buildScript())
+        buildFile(classes.buildScript())
 
         def utilsDir = file("utils")
         def utilsClasses = new ScalaCompilationFixture(utilsDir)
@@ -146,7 +146,7 @@ class ScalaDocIntegrationTest extends MultiVersionIntegrationSpec implements Dir
 
     def "can exclude classes from Scaladoc generation"() {
         classes.baseline()
-        buildScript(classes.buildScript())
+        buildFile(classes.buildScript())
 
         when:
         succeeds scaladoc
@@ -176,7 +176,7 @@ class ScalaDocIntegrationTest extends MultiVersionIntegrationSpec implements Dir
         def jdk11 = AvailableJavaHomes.getJvmInstallationMetadata(AvailableJavaHomes.getJdk(VERSION_11))
 
         classes.baseline()
-        buildScript(classes.buildScript())
+        buildFile(classes.buildScript())
 
         buildFile << """
             tasks.withType(ScalaDoc) {

--- a/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/scaladoc/ScalaDocIntegrationTest.groovy
+++ b/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/scaladoc/ScalaDocIntegrationTest.groovy
@@ -82,6 +82,7 @@ class ScalaDocIntegrationTest extends MultiVersionIntegrationSpec implements Dir
 
         when:
         this.classes.scalaVersion = newScalaVersion
+        buildFile.clear()
         buildFile(this.classes.buildScript())
         succeeds scaladoc
         then:

--- a/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/scaladoc/ScalaDocRelocationIntegrationTest.groovy
+++ b/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/scaladoc/ScalaDocRelocationIntegrationTest.groovy
@@ -40,14 +40,14 @@ class ScalaDocRelocationIntegrationTest extends AbstractTaskRelocationIntegratio
             args '-Dscala.classpath.closeZip=true'
         }
         classes.baseline()
-        buildScript(classes.buildScript())
+        buildFile(classes.buildScript())
     }
 
     @Override
     protected void moveFilesAround() {
         Files.move(file("src/main/scala").toPath(), file("src/main/new-scala").toPath())
         classes.sourceDir = 'src/main/new-scala'
-        buildScript(classes.buildScript())
+        buildFile(classes.buildScript())
         // Move scala library dependency around on disk
         executer.requireOwnGradleUserHomeDir()
     }

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractTestReportIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractTestReportIntegrationTest.groovy
@@ -69,7 +69,7 @@ abstract class AbstractTestReportIntegrationTest extends AbstractTestingMultiVer
 
     def "test report task can handle test tasks that did not run tests"() {
         given:
-        buildScript """
+        buildFile """
             $junitSetup
 
             def test = tasks.named('test', Test)
@@ -101,7 +101,7 @@ abstract class AbstractTestReportIntegrationTest extends AbstractTestingMultiVer
 
     def "results or reports are linked to in error output"() {
         given:
-        buildScript """
+        buildFile """
             $junitSetup
             test {
                 reports.all { it.required = true }
@@ -138,7 +138,7 @@ abstract class AbstractTestReportIntegrationTest extends AbstractTestingMultiVer
 
     def "output per test case flag invalidates outputs"() {
         when:
-        buildScript """
+        buildFile """
             $junitSetup
             test.reports.junitXml.outputPerTestCase = false
         """

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/ParallelTestExecutionIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/ParallelTestExecutionIntegrationTest.groovy
@@ -134,7 +134,7 @@ class ParallelTestExecutionIntegrationTest extends AbstractIntegrationSpec {
     def "does not run tests from multiple tasks from the same project in parallel"() {
         withBlockingJUnitTests(2)
         withBlockingJUnitTests(2, "other")
-        buildScript """
+        buildFile """
             plugins {
                 id "java"
                 id "jvm-test-suite"

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/ParallelTestExecutionIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/ParallelTestExecutionIntegrationTest.groovy
@@ -134,6 +134,7 @@ class ParallelTestExecutionIntegrationTest extends AbstractIntegrationSpec {
     def "does not run tests from multiple tasks from the same project in parallel"() {
         withBlockingJUnitTests(2)
         withBlockingJUnitTests(2, "other")
+        buildFile.clear()
         buildFile """
             plugins {
                 id "java"

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/TestReportTaskIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/TestReportTaskIntegrationTest.groovy
@@ -215,7 +215,7 @@ class TestReportTaskIntegrationTest extends AbstractIntegrationSpec {
     // TODO: remove in Gradle 9.0
     def "nag with deprecation warnings when using legacy TestReport APIs"() {
         given:
-        buildScript """
+        buildFile """
             apply plugin: 'java'
             $junitSetup
             tasks.register('otherTests', Test) {
@@ -250,7 +250,7 @@ class TestReportTaskIntegrationTest extends AbstractIntegrationSpec {
     @Issue("https://issues.gradle.org//browse/GRADLE-2915")
     def "test report task can handle tests tasks not having been executed"() {
         when:
-        buildScript """
+        buildFile """
             apply plugin: 'java'
 
             $junitSetup
@@ -292,7 +292,7 @@ class TestReportTaskIntegrationTest extends AbstractIntegrationSpec {
 
     def "#type report files are considered outputs"() {
         given:
-        buildScript """
+        buildFile """
             $junitSetup
         """
 
@@ -329,7 +329,7 @@ class TestReportTaskIntegrationTest extends AbstractIntegrationSpec {
 
     def "merge rerun defaults to false"() {
         when:
-        buildScript """
+        buildFile """
             $junitSetup
         """
         rerunningTest("SomeTest")
@@ -344,7 +344,7 @@ class TestReportTaskIntegrationTest extends AbstractIntegrationSpec {
 
     def "can enable merge rerun in xml report"() {
         when:
-        buildScript """
+        buildFile """
             $junitSetup
             test.reports.junitXml.mergeReruns = true
         """
@@ -363,7 +363,7 @@ class TestReportTaskIntegrationTest extends AbstractIntegrationSpec {
     // TODO: remove in Gradle 9.0
     def "using deprecated testReport elements emits deprecation warnings"() {
         when:
-        buildScript """
+        buildFile """
             apply plugin: 'java'
             $junitSetup
             // Need a second test task to reportOn

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/AbstractJUnitTestClassDetectionIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/AbstractJUnitTestClassDetectionIntegrationTest.groovy
@@ -68,7 +68,7 @@ abstract class AbstractJUnitTestClassDetectionIntegrationTest extends AbstractTe
     @Issue("https://issues.gradle.org/browse/GRADLE-3157")
     def "test class detection works when '-parameters' compiler option is used (JEP 118)"() {
         when:
-        buildScript """
+        buildFile """
             apply plugin: 'java'
             ${mavenCentralRepository()}
             dependencies {

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/AbstractJUnit4TestReportIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/AbstractJUnit4TestReportIntegrationTest.groovy
@@ -29,7 +29,7 @@ abstract class AbstractJUnit4TestReportIntegrationTest extends AbstractTestRepor
         Assume.assumeTrue(VersionNumber.parse(version) >= VersionNumber.parse("4.13"))
 
         when:
-        buildScript """
+        buildFile """
             $junitSetup
             test.reports.junitXml.outputPerTestCase = true
         """

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/jupiter/JUnitJupiterTestReportIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/jupiter/JUnitJupiterTestReportIntegrationTest.groovy
@@ -29,7 +29,7 @@ import static org.hamcrest.CoreMatchers.is
 class JUnitJupiterTestReportIntegrationTest extends AbstractTestReportIntegrationTest implements JUnitJupiterMultiVersionTest {
     def "outputs over lifecycle"() {
         when:
-        buildScript """
+        buildFile """
             $junitSetup
             test.reports.junitXml.outputPerTestCase = true
         """
@@ -95,7 +95,7 @@ class JUnitJupiterTestReportIntegrationTest extends AbstractTestReportIntegratio
 
     def "collects output for failing non-root suite descriptors"() {
         given:
-        buildScript """
+        buildFile """
             $junitSetup
             dependencies {
                 testImplementation(platform('org.junit:junit-bom:$version'))

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/platform/JUnitPlatformIntegrationSpec.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/platform/JUnitPlatformIntegrationSpec.groovy
@@ -31,7 +31,7 @@ class JUnitPlatformIntegrationSpec extends AbstractIntegrationSpec {
     }
 
     def buildScriptWithJupiterDependencies(script, String version = LATEST_JUPITER_VERSION) {
-        buildScript("""
+        buildFile("""
             apply plugin: 'java'
 
             ${mavenCentralRepository()}

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/platform/JUnitPlatformIntegrationSpec.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/platform/JUnitPlatformIntegrationSpec.groovy
@@ -31,6 +31,7 @@ class JUnitPlatformIntegrationSpec extends AbstractIntegrationSpec {
     }
 
     def buildScriptWithJupiterDependencies(script, String version = LATEST_JUPITER_VERSION) {
+        buildFile.clear()
         buildFile("""
             apply plugin: 'java'
 

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/spock/Spock2IntegrationSpec.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/spock/Spock2IntegrationSpec.groovy
@@ -21,7 +21,7 @@ import org.gradle.testing.fixture.GroovyCoverage
 
 class Spock2IntegrationSpec extends AbstractIntegrationSpec {
     def setup() {
-        buildScript("""
+        buildFile("""
             plugins {
                 id("groovy")
             }

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGUpToDateCheckIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGUpToDateCheckIntegrationTest.groovy
@@ -45,7 +45,7 @@ class TestNGUpToDateCheckIntegrationTest extends AbstractIntegrationSpec {
     @Issue('https://github.com/gradle/gradle/issues/4924')
     def 'test task is up-to-date when #property is changed because it should not impact output'() {
         given:
-        buildScript """
+        buildFile """
             apply plugin: "java"
             ${mavenCentralRepository()}
             testing {
@@ -73,7 +73,7 @@ class TestNGUpToDateCheckIntegrationTest extends AbstractIntegrationSpec {
         executedAndNotSkipped ':test'
 
         when:
-        buildScript """
+        buildFile """
             apply plugin: "java"
             ${mavenCentralRepository()}
             testing {
@@ -118,7 +118,7 @@ class TestNGUpToDateCheckIntegrationTest extends AbstractIntegrationSpec {
     @Issue('https://github.com/gradle/gradle/issues/4924')
     def "re-executes test when #property is changed"() {
         given:
-        buildScript """
+        buildFile """
             apply plugin: "java"
             ${mavenCentralRepository()}
             testing {
@@ -146,7 +146,7 @@ class TestNGUpToDateCheckIntegrationTest extends AbstractIntegrationSpec {
         executedAndNotSkipped ':test'
 
         when:
-        buildScript """
+        buildFile """
             apply plugin: "java"
             ${mavenCentralRepository()}
             testing {

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeDependentComponentsReportIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeDependentComponentsReportIntegrationTest.groovy
@@ -29,7 +29,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
     def "displays dependents report for all components of the task's project"() {
         given:
-        buildScript simpleCppBuild()
+        buildFile simpleCppBuild()
 
         when:
         run "dependentComponents"
@@ -42,7 +42,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
     def "displays dependents of targeted '#component' component"() {
         given:
-        buildScript simpleCppBuild()
+        buildFile simpleCppBuild()
 
         when:
         run 'dependentComponents', '--component', component
@@ -59,7 +59,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
     def "fails when targeted component is not found"() {
         given:
-        buildScript simpleCppBuild()
+        buildFile simpleCppBuild()
 
         when:
         fails 'dependentComponents', '--component', 'unknown'
@@ -70,7 +70,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
     def "fails when some of the targeted components are not found"() {
         given:
-        buildScript simpleBuildWithTestSuites()
+        buildFile simpleBuildWithTestSuites()
 
         when:
         fails 'dependentComponents', '--test-suites', '--component', 'unknown', '--component', 'anonymous', '--component', 'whatever', '--component', 'lib', '--component', 'main', '--component', 'libTest'
@@ -81,7 +81,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
     def "displays dependent of multiple targeted components"() {
         given:
-        buildScript simpleCppBuild()
+        buildFile simpleCppBuild()
 
         when:
         run 'dependentComponents', '--component', 'lib', '--component', 'main'
@@ -94,7 +94,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
     def "hide non-buildable dependents by default #nonBuildables"() {
         given:
-        buildScript simpleCppBuild()
+        buildFile simpleCppBuild()
         nonBuildables.each { nonBuildable ->
             buildFile << """
                 model {
@@ -131,7 +131,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
     def "displays non-buildable dependents when using #option"() {
         given:
-        buildScript simpleCppBuild() + '''
+        buildFile simpleCppBuild() + '''
             model {
                 components {
                     lib {
@@ -173,7 +173,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
     def "consider components with no buildable binaries as non-buildables"() {
         given:
-        buildScript simpleCppBuild()
+        buildFile simpleCppBuild()
         buildFile << '''
             model {
                 components {
@@ -197,7 +197,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
     def "displays dependents across projects in a build"() {
         given:
         settingsFile.text = multiProjectSettings()
-        buildScript multiProjectBuild()
+        buildFile multiProjectBuild()
 
         when:
         run 'libraries:dependentComponents', '--component', 'foo'
@@ -222,7 +222,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
     def "can show dependent components in parallel"() {
         given: 'a multiproject build'
         settingsFile.text = multiProjectSettings()
-        buildScript multiProjectBuild()
+        buildFile multiProjectBuild()
 
         when: 'two reports in parallel'
         succeeds('-q', '--parallel', '--max-workers=4', 'libraries:dependentComponents', 'extensions:dependentComponents')
@@ -268,7 +268,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
     def "don't fail with prebuilt libraries"() {
         given:
-        buildScript simpleBuildWithPrebuiltLibrary()
+        buildFile simpleBuildWithPrebuiltLibrary()
 
         expect:
         succeeds 'dependentComponents'
@@ -276,7 +276,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
     def "hide test suites by default"() {
         given:
-        buildScript simpleBuildWithTestSuites()
+        buildFile simpleBuildWithTestSuites()
 
         when:
         run 'dependentComponents'
@@ -290,7 +290,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
     def "displays dependent test suites when using #option"() {
         given:
-        buildScript simpleBuildWithTestSuites()
+        buildFile simpleBuildWithTestSuites()
 
         when:
         run 'dependentComponents', option
@@ -333,7 +333,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
     }
 
     def "direct circular dependencies are handled gracefully"() {
-        buildScript simpleCppBuild()
+        buildFile simpleCppBuild()
         buildFile << '''
             model {
                 components {
@@ -362,7 +362,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
     }
 
     def "indirect circular dependencies are handled gracefully"() {
-        buildScript simpleCppBuild()
+        buildFile simpleCppBuild()
         buildFile << '''
             model {
                 components {
@@ -399,7 +399,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
     def "circular dependencies across projects are handled gracefully"() {
         given:
         settingsFile.text = multiProjectSettings()
-        buildScript multiProjectBuild()
+        buildFile multiProjectBuild()
         buildFile << '''
             project(':api') {
                 model {
@@ -482,7 +482,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
     @ToBeFixedForConfigurationCache(because = ":dependentComponents")
     def "report for empty build displays no component"() {
         given:
-        buildScript emptyNativeBuild()
+        buildFile emptyNativeBuild()
 
         when:
         run 'dependentComponents'
@@ -494,7 +494,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
     @ToBeFixedForConfigurationCache(because = ":dependentComponents")
     def "report for empty build displays no component with task option #option"() {
         given:
-        buildScript emptyNativeBuild()
+        buildFile emptyNativeBuild()
 
         when:
         run 'dependentComponents', option

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/plugins/TestSuiteModelIntegrationSpec.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/plugins/TestSuiteModelIntegrationSpec.groovy
@@ -24,7 +24,7 @@ import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 class TestSuiteModelIntegrationSpec extends AbstractIntegrationSpec {
 
     def "setup"() {
-        buildScript """
+        buildFile """
             apply type: NativeBinariesTestPlugin
 
             interface CustomTestSuite extends TestSuiteSpec {}

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -503,7 +503,7 @@ project('c') {
         given:
         createDirs("a", "b", "c")
         settingsFile << "include 'a', 'b', 'c'"
-        buildScript '''
+        buildFile '''
             subprojects {
                 apply plugin: 'base'
                 task jar(type: Jar)

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenCustomPackagingResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenCustomPackagingResolveIntegrationTest.groovy
@@ -30,7 +30,7 @@ class MavenCustomPackagingResolveIntegrationTest extends AbstractHttpDependencyR
         def local = m2.mavenRepo().module("local", "local", "1.0").hasType("aar").hasPackaging("aar").publish()
 
         when:
-        buildScript """
+        buildFile """
             configurations {
                 local
             }
@@ -59,7 +59,7 @@ class MavenCustomPackagingResolveIntegrationTest extends AbstractHttpDependencyR
         def remote = mavenHttpRepo.module("remote", "remote", "1.0").hasType("aar").hasPackaging("aar").publish()
 
         given:
-        buildScript """
+        buildFile """
             configurations {
                 remote
             }
@@ -99,7 +99,7 @@ class MavenCustomPackagingResolveIntegrationTest extends AbstractHttpDependencyR
         def remote = mavenHttpRepo.module("remote", "remote", "1.0").hasType("notJar").hasPackaging("notJar").publish()
 
         given:
-        buildScript """
+        buildFile """
             plugins {
                 id 'java'
             }
@@ -140,7 +140,7 @@ class MavenCustomPackagingResolveIntegrationTest extends AbstractHttpDependencyR
         def remote = mavenHttpRepo.module("remote", "remote", "1.0").hasType("jar").hasPackaging("hk2-jar").publish()
 
         given:
-        buildScript """
+        buildFile """
             configurations {
                 remote
             }
@@ -190,7 +190,7 @@ class MavenCustomPackagingResolveIntegrationTest extends AbstractHttpDependencyR
             .publish()
 
         given:
-        buildScript """
+        buildFile """
             configurations {
                 conf {
                     attributes {
@@ -237,7 +237,7 @@ class MavenCustomPackagingResolveIntegrationTest extends AbstractHttpDependencyR
         def consumer = mavenHttpRepo.module("consumer", "consumer", "1.0").dependsOn(customPackaging).publish()
 
         given:
-        buildScript """
+        buildFile """
             configurations {
                 remote
             }

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/FunctionalSourceSetIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/FunctionalSourceSetIntegrationTest.groovy
@@ -27,7 +27,7 @@ import static org.gradle.util.internal.TextUtil.normaliseFileSeparators
 class FunctionalSourceSetIntegrationTest extends AbstractIntegrationSpec {
 
     def "can create a top level functional source set with a rule"() {
-        buildScript """
+        buildFile """
         apply plugin: 'language-base'
 
         class Rules extends RuleSource {
@@ -56,7 +56,7 @@ class FunctionalSourceSetIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "can view a functional source set as a ModelElement"() {
-        buildScript """
+        buildFile """
         apply plugin: 'language-base'
 
         class Rules extends RuleSource {
@@ -193,7 +193,7 @@ class FunctionalSourceSetIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "can register a language source set"() {
-        buildScript """
+        buildFile """
         apply plugin: 'language-base'
 
         ${registerJavaLanguage()}

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageSourceSetIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageSourceSetIntegrationTest.groovy
@@ -45,7 +45,7 @@ class LanguageSourceSetIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "can create a top level LSS with a rule"() {
-        buildScript """
+        buildFile """
         ${registerCustomLanguage()}
 
         ${addPrintSourceDirTask()}

--- a/subprojects/core/src/integTest/groovy/org/gradle/NativeServicesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/NativeServicesIntegrationTest.groovy
@@ -103,7 +103,7 @@ class NativeServicesIntegrationTest extends AbstractIntegrationSpec {
     def "native services flag should be passed to the daemon and to the worker"() {
         given:
         executer.withArguments(systemProperties.collect { it.toString() })
-        buildScript("""
+        buildFile("""
             import org.gradle.workers.WorkParameters
             import org.gradle.internal.nativeintegration.services.NativeServices
             import org.gradle.internal.nativeintegration.NativeCapabilities
@@ -148,7 +148,7 @@ class NativeServicesIntegrationTest extends AbstractIntegrationSpec {
     def "native services are not initialized inside a test executor but should be initialized for a build inside the executor"() {
         given:
         def nativeDirOverride = normaliseFileSeparators(new File(tmpDir.testDirectory, 'native-libs-for-test-executor').absolutePath)
-        buildScript("""
+        buildFile("""
             plugins {
                 id("java-gradle-plugin")
                 id("groovy")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/BuildEventsErrorIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/BuildEventsErrorIntegrationTest.groovy
@@ -82,19 +82,19 @@ class BuildEventsErrorIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "produces reasonable error when Gradle.allprojects action fails"() {
-        def initScript = initScript """
-allprojects {
-    throw new RuntimeException("broken")
-}
-"""
+        initScriptFile """
+            allprojects {
+                throw new RuntimeException("broken")
+            }
+        """
         when:
-        executer.usingInitScript(initScript)
+        executer.usingInitScript(initScriptFile)
         fails "a"
 
         then:
         failure.assertHasDescription("broken")
                 .assertHasNoCause()
-                .assertHasFileName("Initialization script '$initScript'")
+                .assertHasFileName("Initialization script '$initScriptFile'")
                 .assertHasLineNumber(3)
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/FinalizerTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/FinalizerTaskIntegrationTest.groovy
@@ -492,7 +492,7 @@ class FinalizerTaskIntegrationTest extends AbstractIntegrationSpec {
 
     void 'finalizer tasks are not run when finalized task does not run due to unrelated task failure and not using --continue'() {
         given:
-        buildScript("""
+        buildFile("""
             task a {
             }
             task b {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/PluginDetectionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/PluginDetectionIntegrationTest.groovy
@@ -214,7 +214,7 @@ class PluginDetectionIntegrationTest extends AbstractIntegrationSpec {
         """
         file("buildSrc/src/main/resources/META-INF/gradle-plugins/c.properties") << "implementation-class=PluginC"
 
-        buildScript """
+        buildFile """
             class ExamplePlugin implements Plugin<Project> {
                 void apply(final Project project) {
                     project.plugins.withId('a') {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
@@ -97,7 +97,7 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
 
     def "handles task with no outputs"() {
         when:
-        buildScript """
+        buildFile """
             task noOutputs {
                 doLast {}
             }
@@ -116,7 +116,7 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
 
     def "handles task with no inputs"() {
         when:
-        buildScript """
+        buildFile """
             task noInputs {
                 outputs.file "foo.txt"
                 doLast {}
@@ -136,7 +136,7 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
 
     def "not sent for task with no actions"() {
         when:
-        buildScript """
+        buildFile """
             task noActions {
             }
         """
@@ -149,7 +149,7 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
     @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "handles invalid implementation classloader"() {
         given:
-        buildScript """
+        buildFile """
             def classLoader = new GroovyClassLoader(this.class.classLoader)
             def clazz = classLoader.parseClass(\"\"\"${customTaskImpl()}\"\"\")
             task customTask(type: clazz){
@@ -203,7 +203,7 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
     @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "handles invalid action classloader"() {
         given:
-        buildScript """
+        buildFile """
             ${customTaskCode('foo', 'bar')}
             def classLoader = new GroovyClassLoader(this.class.classLoader)
             def c = classLoader.parseClass '''
@@ -488,7 +488,7 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
         given:
         withBuildCache()
         file('inputFile').text = 'inputFile'
-        buildScript """
+        buildFile """
             task copy(type:Copy) {
                from 'inputFile'
                into 'destDir'
@@ -516,7 +516,7 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
     @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "handles invalid nested bean classloader"() {
         given:
-        buildScript """
+        buildFile """
             ${customTaskCode('foo', 'bar')}
             def classLoader = new GroovyClassLoader(this.class.classLoader)
             def c = classLoader.parseClass '''

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/execution/ExecuteTaskActionBuildOperationTypeIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/execution/ExecuteTaskActionBuildOperationTypeIntegrationTest.groovy
@@ -25,7 +25,7 @@ class ExecuteTaskActionBuildOperationTypeIntegrationTest extends AbstractIntegra
 
     def "emits operation for each task action execution"() {
         when:
-        buildScript """
+        buildFile """
             task t {
                 doLast {}
                 doLast {}
@@ -46,7 +46,7 @@ class ExecuteTaskActionBuildOperationTypeIntegrationTest extends AbstractIntegra
 
     def "emits operation result for failed task action execution"() {
         when:
-        buildScript """
+        buildFile """
             task t {
                 doLast {
                     throw new RuntimeException("fail")
@@ -61,7 +61,7 @@ class ExecuteTaskActionBuildOperationTypeIntegrationTest extends AbstractIntegra
 
     def "does not emit operation for non-executed task action"() {
         when:
-        buildScript """
+        buildFile """
             task t {
                 doLast {
                     throw new RuntimeException("fail")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/execution/ExecuteTaskBuildOperationTypeIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/execution/ExecuteTaskBuildOperationTypeIntegrationTest.groovy
@@ -27,7 +27,7 @@ class ExecuteTaskBuildOperationTypeIntegrationTest extends AbstractIntegrationSp
 
     def "emits operation for task execution"() {
         when:
-        buildScript """
+        buildFile """
             task t {}
         """
         succeeds "t"
@@ -50,7 +50,7 @@ class ExecuteTaskBuildOperationTypeIntegrationTest extends AbstractIntegrationSp
 
     def "emits operation result for failed task execution"() {
         when:
-        buildScript """
+        buildFile """
             task t {
                 doLast {
                     throw new RuntimeException("!")
@@ -71,7 +71,7 @@ class ExecuteTaskBuildOperationTypeIntegrationTest extends AbstractIntegrationSp
     @UnsupportedWithConfigurationCache
     def "does not emit result for beforeTask failure"() {
         when:
-        buildScript """
+        buildFile """
             task t {
                 doLast {}
             }
@@ -94,7 +94,7 @@ class ExecuteTaskBuildOperationTypeIntegrationTest extends AbstractIntegrationSp
     @UnsupportedWithConfigurationCache
     def "does emit result for afterTask failure"() {
         when:
-        buildScript """
+        buildFile """
             task t {
                 doLast {}
             }
@@ -117,7 +117,7 @@ class ExecuteTaskBuildOperationTypeIntegrationTest extends AbstractIntegrationSp
     @UnsupportedWithConfigurationCache
     def "afterTask failure is included with task failure"() {
         when:
-        buildScript """
+        buildFile """
             task t {
                 doLast {
                     throw new RuntimeException("!")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/execution/ResolveTaskMutationsBuildOperationTypeIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/execution/ResolveTaskMutationsBuildOperationTypeIntegrationTest.groovy
@@ -26,7 +26,7 @@ class ResolveTaskMutationsBuildOperationTypeIntegrationTest extends AbstractInte
 
     def "emits operation for task execution"() {
         when:
-        buildScript """
+        buildFile """
             task t {}
         """
         succeeds "t"
@@ -37,7 +37,7 @@ class ResolveTaskMutationsBuildOperationTypeIntegrationTest extends AbstractInte
 
     def "emits operation for failed task execution"() {
         when:
-        buildScript """
+        buildFile """
             task t {
                 doLast {
                     throw new RuntimeException("BOOM!")
@@ -52,7 +52,7 @@ class ResolveTaskMutationsBuildOperationTypeIntegrationTest extends AbstractInte
 
     def "emits operation when resolving mutations fails"() {
         when:
-        buildScript """
+        buildFile """
             task t {
                 outputs.files({ -> throw new RuntimeException("BOOM!") })
             }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyPermissionsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyPermissionsIntegrationTest.groovy
@@ -412,7 +412,7 @@ class CopyPermissionsIntegrationTest extends AbstractIntegrationSpec implements 
     def "permissions block overrides mode"() {
         given:
         withSourceFiles("r--------")
-        buildScript '''
+        buildFile '''
             task (copy, type:Copy) {
                from 'files'
                into 'dest'
@@ -438,7 +438,7 @@ class CopyPermissionsIntegrationTest extends AbstractIntegrationSpec implements 
     def "permissions block sets sensible defaults"() {
         given:
         withSourceFiles("r--------")
-        buildScript '''
+        buildFile '''
             task (copy, type:Copy) {
                from 'files'
                into 'dest'
@@ -459,7 +459,7 @@ class CopyPermissionsIntegrationTest extends AbstractIntegrationSpec implements 
     def "permissions block can customize permissions (Groovy DSL)"() {
         given:
         withSourceFiles("r--------")
-        buildScript '''
+        buildFile '''
             task (copy, type:Copy) {
                from 'files'
                into 'dest'
@@ -521,7 +521,7 @@ class CopyPermissionsIntegrationTest extends AbstractIntegrationSpec implements 
     def "permissions can be created via factory (#description)"(String description, String setting) {
         given:
         withSourceFiles("r--------")
-        buildScript """
+        buildFile """
             def p = project.services.get(FileSystemOperations).directoryPermissions {
                 user {
                     write = false

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopySpecEncodingIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopySpecEncodingIntegrationSpec.groovy
@@ -26,7 +26,7 @@ class CopySpecEncodingIntegrationSpec extends AbstractIntegrationSpec {
         given:
         file('files').createDir()
         file('files/accents.c').write('éàüî $one', 'ISO-8859-1')
-        buildScript """
+        buildFile """
             task (copy, type: Copy) {
                 from 'files'
                 into 'dest'
@@ -61,7 +61,7 @@ class CopySpecEncodingIntegrationSpec extends AbstractIntegrationSpec {
         given:
         file('files').createDir()
         file('files/accents.c').write('éàüî $one', 'ISO-8859-1')
-        buildScript """
+        buildFile """
             task (copy, type: Copy) {
                 from 'files'
                 into 'dest'
@@ -97,7 +97,7 @@ class CopySpecEncodingIntegrationSpec extends AbstractIntegrationSpec {
         given:
         file('files').createDir()
         file('files/accents.c').write('éàüî $one', 'ISO-8859-1')
-        buildScript """
+        buildFile """
             task copy {
                 def fs = services.get(FileSystemOperations)
                 doLast {
@@ -122,7 +122,7 @@ class CopySpecEncodingIntegrationSpec extends AbstractIntegrationSpec {
         given:
         file('files').createDir()
         file('files/accents.c').write('éàüî $one', 'ISO-8859-1')
-        buildScript """
+        buildFile """
             task copy {
                 def fs = services.get(FileSystemOperations)
                 doLast {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopySpecIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopySpecIntegrationSpec.groovy
@@ -31,7 +31,7 @@ class CopySpecIntegrationSpec extends AbstractIntegrationSpec implements Unreada
 
     def "can use filesMatching with List"() {
         given:
-        buildScript """
+        buildFile """
             task (copy, type: Copy) {
                 from 'src'
                 into 'dest'
@@ -52,7 +52,7 @@ class CopySpecIntegrationSpec extends AbstractIntegrationSpec implements Unreada
 
     def "can use filesNotMatching with List"() {
         given:
-        buildScript """
+        buildFile """
             task (copy, type: Copy) {
                 from 'src'
                 into 'dest'
@@ -75,7 +75,7 @@ class CopySpecIntegrationSpec extends AbstractIntegrationSpec implements Unreada
     @Issue("gradle/gradle#789")
     def "can copy files with supplementary characters or surrogate pairs in file names"() {
         given:
-        buildScript """
+        buildFile """
             task(copy, type: Copy) {
                 from 'src'
                 into 'dest'

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskChildSpecIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskChildSpecIntegrationTest.groovy
@@ -29,7 +29,7 @@ class CopyTaskChildSpecIntegrationTest extends AbstractIntegrationSpec implement
     def "changing child specs of the copy task while executing is disallowed"() {
         given:
         file("some-dir/input.txt") << "Data"
-        buildScript """
+        buildFile """
             task copy(type: Copy) {
                 outputs.cacheIf { true }
                 from ("some-dir")
@@ -54,7 +54,7 @@ class CopyTaskChildSpecIntegrationTest extends AbstractIntegrationSpec implement
     def "can query file and dir mode if set in the parent"() {
         given:
         file("root/root-file.txt") << 'root'
-        buildScript("""
+        buildFile("""
             def baseSpec = copySpec {
                 from("root") {
                     println(filePermissions.getOrNull() == null ? "DEFAULT" : filePermissions.get().toUnixNumeric())

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskIntegrationSpec.groovy
@@ -42,7 +42,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         file("files/sub/dir/b.txt").createFile()
         file("files/c.txt").createFile()
         file("files/sub/empty").createDir()
-        buildScript '''
+        buildFile '''
             task (copy, type:Copy) {
                from 'files'
                into 'dest'
@@ -92,7 +92,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         file("files/sub/a.txt").createFile()
         file("files/sub/dir/b.txt").createFile()
         file("files/c.txt").createFile()
-        buildScript '''
+        buildFile '''
             task (copy, type:Copy) {
                from 'files'
                into 'dest'
@@ -126,7 +126,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         file("files/ignore/sub/ignore.txt").createFile()
         file("files/ignore.txt").createFile()
         file("files/other/ignore.txt").createFile()
-        buildScript '''
+        buildFile '''
             task (copy, type:Copy) {
                from 'files'
                into 'dest'
@@ -183,7 +183,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         file('files/dir/ignore.c').createFile()
         file('files/dir.b/a.a').createFile()
         file('files/dir.b/a.b').createFile()
-        buildScript '''
+        buildFile '''
             task (copy, type:Copy) {
                from 'files'
                into 'dest'
@@ -228,7 +228,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
 
     def "can expand tokens when copying"() {
         file('files/a.txt').text = "\$one,\${two}"
-        buildScript """
+        buildFile """
             task copy(type: Copy) {
                 from 'files'
                 into 'dest'
@@ -260,7 +260,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
 
     def "can expand tokens with escaped backslash when copying"() {
         file('files/a.txt').text = "\$one\\n\${two}"
-        buildScript """
+        buildFile """
             task copy(type: Copy) {
                 from 'files'
                 into 'dest'
@@ -279,7 +279,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
 
     def "can expand tokens but not escape backslash by default when copying"() {
         file('files/a.txt').text = "\$one\\n\${two}"
-        buildScript """
+        buildFile """
             task copy(type: Copy) {
                 from 'files'
                 into 'dest'
@@ -297,7 +297,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
     def "can filter content using a filtering Reader when copying"() {
         file('files/a.txt').text = "one"
         file('files/b.txt').text = "two"
-        buildScript """
+        buildFile """
             task copy(type: Copy) {
                 from 'files'
                 into 'dest'
@@ -337,7 +337,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
     def "can filter content using a Groovy closure when copying"() {
         file('files/a.txt').text = "one"
         file('files/b.txt').text = "two"
-        buildScript """
+        buildFile """
             task copy(type: Copy) {
                 from 'files'
                 into 'dest'
@@ -414,7 +414,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         file('files/two/two.ignore').createFile()
         file('files/two/sub/two.b').createFile()
         file('files/two/sub/ignore/ignore.b').createFile()
-        buildScript '''
+        buildFile '''
             task (copy, type:Copy) {
                into 'dest'
                from('files/one') {
@@ -479,7 +479,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         file('files/two/two.ignore').createFile()
         file('files/two/sub/two.b').createFile()
         file('files/two/sub/ignore.a').createFile()
-        buildScript '''
+        buildFile '''
             task (copy, type:Copy) {
                into 'dest'
                into('common') {
@@ -542,7 +542,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         file('files/one.b').createFile()
         file('files/dir/two.a').createFile()
         file('files/dir/two.b').createFile()
-        buildScript '''
+        buildFile '''
             task copy(type: Copy) {
                 from 'files'
                 into 'dest'
@@ -597,7 +597,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         file('files/one.b').createFile()
         file('files/dir/two.a').createFile()
         file('files/dir/two.b').createFile()
-        buildScript '''
+        buildFile '''
             task copy(type: Copy) {
                 from 'files'
                 into 'dest'
@@ -660,7 +660,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
     @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "rename"() {
         given:
-        buildScript '''
+        buildFile '''
             task (copy, type:Copy) {
                from 'src'
                into 'dest'
@@ -691,7 +691,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
     @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "copy action"() {
         given:
-        buildScript '''
+        buildFile '''
             task copyIt {
                 doLast {
                     copy {
@@ -723,7 +723,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
     @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "copy single files"() {
         given:
-        buildScript '''
+        buildFile '''
             task copyIt {
                 doLast {
                     copy {
@@ -751,7 +751,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
 
     def "copy multiple filter test"() {
         given:
-        buildScript '''
+        buildFile '''
             task (copy, type:Copy) {
                into 'dest\'
                expand(one: 1)
@@ -777,7 +777,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         given:
         file('files/a.txt').createFile()
         file('files/dir/b.txt').createFile()
-        buildScript '''
+        buildFile '''
             task copy(type: Copy) {
                 into 'dest'
                 from 'files'
@@ -836,7 +836,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         given:
         file('files/a.txt').createFile()
         file('files/dir/b.txt').createFile()
-        buildScript '''
+        buildFile '''
             task copy(type: Copy) {
                 into 'dest'
                 from 'files'
@@ -895,7 +895,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         given:
         file('files/a.txt').createFile()
         file('files/dir/b.txt').createFile()
-        buildScript '''
+        buildFile '''
             task copy(type: Copy) {
                 into 'dest'
                 from 'files'
@@ -952,7 +952,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
 
     def "chained transformations"() {
         given:
-        buildScript '''
+        buildFile '''
             task copy(type: Copy) {
                 into 'dest\'
                 rename '(.*).a', '\$1.renamed'
@@ -995,7 +995,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         file('files/a.txt').createFile()
         file('files/dir/b.txt').createFile()
 
-        buildScript '''
+        buildFile '''
             def location = null
 
             task copy(type: Copy) {
@@ -1037,7 +1037,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
     @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "copy from file tree"() {
         given:
-        buildScript '''
+        buildFile '''
         task cpy {
             doLast {
                 copy {
@@ -1067,7 +1067,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
     @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "copy from file collection"() {
         given:
-        buildScript '''
+        buildFile '''
             task copy {
                 doLast {
                     copy {
@@ -1100,7 +1100,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
     def "copy from composite file collection"() {
         given:
         file('a.jar').touch()
-        buildScript '''
+        buildFile '''
             configurations { compile }
             dependencies { compile files('a.jar') }
             task copy {
@@ -1132,7 +1132,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
     @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "copy from task"() {
         given:
-        buildScript '''
+        buildFile '''
             configurations { compile }
             dependencies { compile files('a.jar') }
             task fileProducer {
@@ -1170,7 +1170,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
     @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "copy from task outputs"() {
         given:
-        buildScript '''
+        buildFile '''
             configurations { compile }
             dependencies { compile files('a.jar') }
             task fileProducer {
@@ -1208,7 +1208,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
     @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "copy from task provider"() {
         given:
-        buildScript '''
+        buildFile '''
             configurations { compile }
             dependencies { compile files('a.jar') }
             def fileProducer = tasks.register("fileProducer") {
@@ -1245,7 +1245,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
 
     def "copy with CopySpec"() {
         given:
-        buildScript '''
+        buildFile '''
             def parentSpec = copySpec {
                 from 'src'
                 exclude '**/ignore/**'
@@ -1270,7 +1270,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
 
     def "transform with CopySpec"() {
         given:
-        buildScript '''
+        buildFile '''
             def parentSpec = copySpec {
                 from 'src'
                 include '*/*.a'
@@ -1298,7 +1298,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
 
     def "include exclude with CopySpec"() {
         given:
-        buildScript '''
+        buildFile '''
             def parentSpec = copySpec {
                 from 'src'
                 include '**/one/**'
@@ -1331,7 +1331,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
 
     def "multiple filter with CopySpec"() {
         given:
-        buildScript '''
+        buildFile '''
             def parentSpec = copySpec {
                 from('src/two/two.a')
                 filter { (Integer.parseInt(it) / 2) as String }
@@ -1357,7 +1357,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
 
     def "rename with CopySpec"() {
         given:
-        buildScript '''
+        buildFile '''
             def parentSpec = copySpec {
                from 'src/one'
                exclude '**/ignore/**'
@@ -1389,7 +1389,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         file('files/sub/c.Txt').createFile()
         file('files/EXCLUDE/a.TXT').createFile()
         file('files/sub/Exclude/a.TXT').createFile()
-        buildScript '''
+        buildFile '''
             task copy(type: Copy) {
                 from 'files'
                 into 'dest'
@@ -1427,7 +1427,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         file('files/sub/c.Txt').createFile()
         file('files/EXCLUDE/a.TXT').createFile()
         file('files/sub/Exclude/a.TXT').createFile()
-        buildScript '''
+        buildFile '''
             task copy(type: Copy) {
                 from 'files'
                 into 'dest'
@@ -1466,7 +1466,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         file('files/yet/another/veryEmptyDir').createDir()
         // need to include a file in the copy, otherwise copy task says "no source files"
         file('files/dummy').createFile()
-        buildScript '''
+        buildFile '''
             task copy(type: Copy) {
                 from 'files'
                 into 'dest'
@@ -1502,7 +1502,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         file('files/emptyDir').createDir()
         file('files/yet/another/veryEmptyDir').createDir()
         file('files/one.txt').createFile()
-        buildScript '''
+        buildFile '''
             task copy(type: Copy) {
                 from 'files'
                 into 'dest'
@@ -1537,7 +1537,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         given:
         file('dir1/path/file.txt').createFile() << 'f1'
         file('dir2/path/file.txt').createFile() << 'f2'
-        buildScript '''
+        buildFile '''
             task copy(type: Copy) {
                 from 'dir1'
                 from 'dir2'
@@ -1568,7 +1568,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         given:
         file('dir1/path/file.txt').createFile() << 'f1'
         file('dir2/path/file.txt').createFile() << 'f2'
-        buildScript '''
+        buildFile '''
             task copy(type: Copy) {
                 from 'dir1'
                 from 'dir2'
@@ -1606,7 +1606,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         given:
         file('dir1/path/file.txt').createFile() << 'f1'
         file('dir2/path/file.txt').createFile() << 'f2'
-        buildScript '''
+        buildFile '''
             task copy(type: Copy) {
                 from 'dir1'
                 from 'dir2'
@@ -1644,7 +1644,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         given:
         file('dir1', 'path', 'file.txt').createFile() << 'file1'
         file('dir2', 'path', 'file2.txt').createFile() << 'file2'
-        buildScript '''
+        buildFile '''
             task copy(type: Copy) {
                 from 'dir1'
                 from 'dir2'
@@ -1668,7 +1668,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         given:
         def source1 = file('dir1/path/file.txt') << 'f1'
         def source2 = file('dir2/path/file.txt') << 'f2'
-        buildScript '''
+        buildFile '''
             task copy(type: Copy) {
                 into 'dest'
                 into ('subdir') {
@@ -1692,7 +1692,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         given:
         file('path/abc.txt').createFile() << 'test file with $attr'
         file('path/bcd.txt').createFile()
-        buildScript '''
+        buildFile '''
             task copy(type: Copy) {
                 from 'path'
                 into 'dest'
@@ -1718,7 +1718,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         given:
         file('path/abc.txt').createFile() << 'test file with $attr'
         file('path/bcd.txt').createFile()
-        buildScript '''
+        buildFile '''
             task copy(type: Copy) {
                 from 'path'
                 into 'dest'
@@ -1744,7 +1744,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         given:
         file('path/abc.txt').createFile() << 'content'
         file('path/bcd.txt').createFile()
-        buildScript '''
+        buildFile '''
             task copy(type: Copy) {
                 from 'path'
                 into 'dest'
@@ -1766,7 +1766,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         given:
         file('path/abc.txt').createFile() << 'content'
         file('path/bcd.txt').createFile()
-        buildScript '''
+        buildFile '''
             task copy(type: Copy) {
                 from 'path'
                 into 'dest'
@@ -1788,7 +1788,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         given:
         file('path/abc.txt').createFile() << 'content'
         file('path/bcd.txt').createFile()
-        buildScript '''
+        buildFile '''
             task copy(type: Copy) {
                 from 'path'
                 into 'dest'
@@ -1808,7 +1808,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
 
     def "single line removed"() {
         given:
-        buildScript '''
+        buildFile '''
             task (copy, type:Copy) {
                 from "src/two/two.b"
                 into "dest"
@@ -1828,7 +1828,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
 
     def "all lines removed"() {
         given:
-        buildScript '''
+        buildFile '''
             task (copy, type:Copy) {
                 from "src/two/two.b"
                 into "dest"
@@ -1848,7 +1848,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         given:
         file("a/a.txt").touch()
 
-        buildScript """
+        buildFile """
             task copy(type: Copy) {
                 assert delegate instanceof ${ExtensionAware.name}
                 into "out"
@@ -1877,7 +1877,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         file("b/b.txt") << "foo"
         file("b/dirB").createDir()
 
-        buildScript """
+        buildFile """
             task copyTask(type: Copy) {
                 into "out"
                 from "b", {
@@ -1906,7 +1906,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         file("b/dirB").createDir()
 
 
-        buildScript """
+        buildFile """
             task copyTask(type: Copy) {
                 into "out"
                 from "b", {
@@ -1937,7 +1937,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         when:
         file("res/foo.txt") << "bar"
 
-        buildScript """
+        buildFile """
             interface Services {
                 @Inject FileSystemOperations getFs()
             }
@@ -1974,7 +1974,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         file("a/b.txt") << "\$foo"
 
         when:
-        buildScript """
+        buildFile """
            task c(type: Copy) {
                from("a") {
                    filesMatching("b.txt") {
@@ -1998,7 +1998,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         given:
         file("test/${filePath}/a.txt").touch()
 
-        buildScript """
+        buildFile """
             task copy(type: Copy) {
                 into "out"
                 from "test"
@@ -2021,7 +2021,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
 
     def "changing case-sensitive setting makes task out-of-date"() {
         given:
-        buildScript '''
+        buildFile '''
             task (copy, type:Copy) {
                caseSensitive = providers.systemProperty('case-sensitive').present
                from 'src'
@@ -2055,7 +2055,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
     @Issue("https://issues.gradle.org/browse/GRADLE-1276")
     def "changing expansion makes task out-of-date"() {
         given:
-        buildScript '''
+        buildFile '''
             task (copy, type:Copy) {
                from 'src'
                into 'dest'
@@ -2064,7 +2064,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         '''.stripIndent()
         run 'copy'
 
-        buildScript '''
+        buildFile '''
             task (copy, type:Copy) {
                from 'src'
                into 'dest'
@@ -2082,7 +2082,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
     @Issue("https://issues.gradle.org/browse/GRADLE-1298")
     def "changing filter makes task out-of-date"() {
         given:
-        buildScript '''
+        buildFile '''
             task (copy, type:Copy) {
                from 'src'
                into 'dest'
@@ -2091,7 +2091,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         '''.stripIndent()
         run 'copy'
 
-        buildScript '''
+        buildFile '''
             task (copy, type:Copy) {
                from 'src'
                into 'dest'
@@ -2109,7 +2109,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
     @Issue("https://issues.gradle.org/browse/GRADLE-3549")
     def "changing rename makes task out-of-date"() {
         given:
-        buildScript '''
+        buildFile '''
             task (copy, type:Copy) {
                from 'src'
                into 'dest'
@@ -2118,7 +2118,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         '''.stripIndent()
         run 'copy'
 
-        buildScript '''
+        buildFile '''
             task (copy, type:Copy) {
                from 'src'
                into 'dest'
@@ -2135,7 +2135,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
     @Issue("https://issues.gradle.org/browse/GRADLE-3554")
     def "copy with dependent task executes dependencies"() {
         given:
-        buildScript '''
+        buildFile '''
             apply plugin: "war"
 
             task copy(type: Copy) {
@@ -2153,7 +2153,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
 
     def "changing spec-level property #property makes task out-of-date"() {
         given:
-        buildScript """
+        buildFile """
             task (copy, type:Copy) {
                from ('src') {
                   def newValue = providers.systemProperty('new-value').present
@@ -2200,7 +2200,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
 
     def "null action is forbidden for #method"() {
         given:
-        buildScript """
+        buildFile """
             task copy(type: Copy) {
                 into "out"
                 from 'src'

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskIntegrationSpec.groovy
@@ -2064,6 +2064,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         '''.stripIndent()
         run 'copy'
 
+        buildFile.clear()
         buildFile '''
             task (copy, type:Copy) {
                from 'src'
@@ -2091,6 +2092,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         '''.stripIndent()
         run 'copy'
 
+        buildFile.clear()
         buildFile '''
             task (copy, type:Copy) {
                from 'src'
@@ -2118,6 +2120,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         '''.stripIndent()
         run 'copy'
 
+        buildFile.clear()
         buildFile '''
             task (copy, type:Copy) {
                from 'src'

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DispatchingBuildCacheIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DispatchingBuildCacheIntegrationTest.groovy
@@ -35,7 +35,7 @@ class DispatchingBuildCacheIntegrationTest extends AbstractIntegrationSpec {
         inputFile.text = 'This is the input'
         cacheOriginInputFile.text = 'And this is not'
 
-        buildScript """
+        buildFile """
             apply plugin: 'base'
 
             import org.gradle.api.*

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
@@ -1211,7 +1211,7 @@ task b(dependsOn: a)
     @Issue("https://github.com/gradle/gradle/issues/2180")
     def "fileTrees can be used as output files"() {
         given:
-        buildScript """
+        buildFile """
             task myTask {
                 inputs.file file('input.txt')
                 outputs.files fileTree(dir: 'build', include: 'output.txt')
@@ -1398,7 +1398,7 @@ task b(dependsOn: a)
 
     @Issue("https://github.com/gradle/gradle/issues/7923")
     def "task is not up-to-date when the implementation of a named #actionMethodName action changes"() {
-        buildScript """
+        buildFile """
             tasks.register('myTask') {
                 outputs.dir(layout.buildDirectory.dir('myDir'))
                 ${actionMethodName}('myAction') { println("printing from action") }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/JavaExecJavaVersionIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/JavaExecJavaVersionIntegrationSpec.groovy
@@ -89,7 +89,7 @@ class JavaExecJavaVersionIntegrationSpec extends AbstractIntegrationSpec {
     }
 
     private void setupRunHelloWorldTask() {
-        buildScript '''
+        buildFile '''
             apply plugin: "java"
 
             task runHelloWorld(type: JavaExec) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
@@ -798,7 +798,7 @@ task someTask(type: SomeTask) {
     def "fileTrees with regular file roots cannot be used as output files"() {
         enableProblemsApiCheck()
         expectReindentedValidationMessage()
-        buildScript """
+        buildFile """
             task myTask {
                 inputs.file file('input.txt')
                 outputs.files(files('build/output.txt').asFileTree).withPropertyName('output')

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/outputorigin/BuildCacheOutputOriginIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/outputorigin/BuildCacheOutputOriginIntegrationTest.groovy
@@ -56,7 +56,7 @@ class BuildCacheOutputOriginIntegrationTest extends AbstractIntegrationSpec impl
 
     def "exposes origin build id when reusing cached outputs"() {
         given:
-        buildScript """
+        buildFile """
             apply plugin: "base"
             def write = tasks.create("write", WriteProperties) {
                 destinationFile = file("build/out.properties")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/outputorigin/IncrementalBuildOutputOriginIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/outputorigin/IncrementalBuildOutputOriginIntegrationTest.groovy
@@ -48,7 +48,7 @@ class IncrementalBuildOutputOriginIntegrationTest extends AbstractIntegrationSpe
 
     def "exposes origin build id when reusing outputs"() {
         given:
-        buildScript """
+        buildFile """
             def write = tasks.create("write", WriteProperties) {
                 destinationFile = file("out.properties")
                 properties = [v: 1]
@@ -106,7 +106,7 @@ class IncrementalBuildOutputOriginIntegrationTest extends AbstractIntegrationSpe
 
     def "tracks different tasks"() {
         given:
-        buildScript """
+        buildFile """
             def w1 = tasks.create("w1", WriteProperties) {
                 destinationFile = file("w1.properties")
                 properties = [v: 1]
@@ -195,7 +195,7 @@ class IncrementalBuildOutputOriginIntegrationTest extends AbstractIntegrationSpe
             includeBuild "b"
         """
 
-        buildScript """
+        buildFile """
             tasks.create("w").dependsOn gradle.includedBuild("a").task(":w"), gradle.includedBuild("b").task(":w")
         """
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/outputorigin/ManualUpToDateOutputOriginIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/outputorigin/ManualUpToDateOutputOriginIntegrationTest.groovy
@@ -39,14 +39,14 @@ class ManualUpToDateOutputOriginIntegrationTest extends AbstractIntegrationSpec 
 
     def "considers invocation that manually declared up-to-date to be an origin"() {
         given:
-        buildScript """
+        buildFile """
             class CustomTask extends DefaultTask {
                 @Input
                 String value = "a"
-                
+
                 @OutputFile
                 File file = project.file("out.txt")
-                
+
                 @TaskAction
                 void action() {
                     if (file.file) {
@@ -56,7 +56,7 @@ class ManualUpToDateOutputOriginIntegrationTest extends AbstractIntegrationSpec 
                     }
                 }
             }
-            
+
             def write = tasks.create("write", CustomTask)
         """
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/configuration/ApplyScriptPluginBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/configuration/ApplyScriptPluginBuildOperationIntegrationTest.groovy
@@ -143,7 +143,7 @@ class ApplyScriptPluginBuildOperationIntegrationTest extends AbstractIntegration
     def "captures for arbitrary targets"() {
         given:
         def script = file("script.gradle") << ""
-        buildScript """
+        buildFile """
             apply from: "${normaliseFileSeparators(script.absolutePath)}", to: new Object() {}
         """
 
@@ -170,7 +170,7 @@ class ApplyScriptPluginBuildOperationIntegrationTest extends AbstractIntegration
         httpServer.start()
         def script = file("script.gradle") << ""
         httpServer.allowGetOrHead("/script.gradle", script)
-        buildScript """
+        buildFile """
             apply from: "${httpServer.uri}/script.gradle"
         """
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/RuleTaskBridgingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/RuleTaskBridgingIntegrationTest.groovy
@@ -664,7 +664,7 @@ class RuleTaskBridgingIntegrationTest extends AbstractIntegrationSpec implements
 
     def "only tasks of specified type are created when tasks with type are declared as dependency"() {
         when:
-        buildScript """
+        buildFile """
             ${ruleBasedTasks()}
 
             model {

--- a/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/RuleTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/RuleTaskExecutionIntegrationTest.groovy
@@ -126,7 +126,7 @@ class RuleTaskExecutionIntegrationTest extends AbstractIntegrationSpec implement
 
     def "tasks added via task container and not explicitly required but executed are self closed"() {
         given:
-        buildScript """
+        buildFile """
             ${ruleBasedTasks()}
 
             class Rules extends RuleSource {
@@ -168,7 +168,7 @@ class RuleTaskExecutionIntegrationTest extends AbstractIntegrationSpec implement
         createDirs("a", "b")
         settingsFile << "include 'a', 'b'"
 
-        buildScript """
+        buildFile """
             project(':a') {
                 apply type: ProjectARules
             }
@@ -204,7 +204,7 @@ class RuleTaskExecutionIntegrationTest extends AbstractIntegrationSpec implement
     @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "can use getTasksByName() to get task defined in rules only script plugin after configuration"() {
         when:
-        buildScript """
+        buildFile """
             apply from: "fooTask.gradle"
             task check {
                 doLast {
@@ -225,7 +225,7 @@ class RuleTaskExecutionIntegrationTest extends AbstractIntegrationSpec implement
 
     def "can use getTasksByName() to get task defined in rules only script plugin during configuration"() {
         when:
-        buildScript """
+        buildFile """
             apply from: "fooTask.gradle"
             task check {
               def fooTasks = getTasksByName("foo", false).size()

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/InitScriptIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/InitScriptIntegrationTest.groovy
@@ -32,7 +32,7 @@ import static org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache.Skip
 class InitScriptIntegrationTest extends AbstractIntegrationSpec {
 
     private void createProject() {
-        buildScript """
+        buildFile """
             task hello() {
                 doLast {
                     println "Hello from main project"

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/InternalGradleFailuresIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/InternalGradleFailuresIntegrationTest.groovy
@@ -26,7 +26,7 @@ class InternalGradleFailuresIntegrationTest extends AbstractIntegrationSpec {
         executer.requireOwnGradleUserHomeDir()
         executer.requireDaemon()
 
-        buildScript """
+        buildFile """
             task hello() {
                 doLast {
                     println "Hello Gradle!"

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathIntegrationSpec.groovy
@@ -364,7 +364,7 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implem
             """
         }
 
-        buildScript("""
+        buildFile("""
             buildscript {
                 dependencies {
                     classpath "org.gradle.test:mrjar:1.+"
@@ -430,7 +430,7 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implem
                 """)
             }
         }
-        buildScript("""
+        buildFile("""
             abstract class LambdaTask extends DefaultTask {
                 @Input
                 abstract ListProperty<Runnable> getMyActions()

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathIntegrationSpec.groovy
@@ -504,9 +504,9 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implem
             tasks.register("printMessage") { doLast { println (new org.gradle.test.BuildClass().message()) } }
         """}
 
-        settingsScript("""
+        settingsFile """
             include "reproducible", "current"
-        """)
+        """
 
         file("reproducible/build.gradle").text = subprojectSource(reproducibleJar)
         file("current/build.gradle").text = subprojectSource(currentTimestampJar)

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationContinuousBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationContinuousBuildIntegrationTest.groovy
@@ -28,7 +28,7 @@ class BuildOperationNotificationContinuousBuildIntegrationTest extends AbstractC
     def "obtains notifications about init scripts"() {
         when:
         settingsFile << notifications.registerListener()
-        buildScript """
+        buildFile """
             apply plugin: "java"
         """
         file("src/main/java/Thing.java") << "class Thing {}"

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
@@ -56,7 +56,7 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         def init = executer.gradleUserHomeDir.file("init.d/init.gradle") << """
         """
         addSettingsListener()
-        buildScript """
+        buildFile """
             task t
         """
 
@@ -76,7 +76,7 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
     def "can emit notifications from start of build"() {
         when:
         addSettingsListener()
-        buildScript """
+        buildFile """
             task t
         """
 
@@ -121,7 +121,7 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         file("a/settings.gradle") << ""
         file("settings.gradle") << "includeBuild 'a'"
         addSettingsListener()
-        buildScript """
+        buildFile """
             task t {
                 dependsOn gradle.includedBuild("a").task(":t")
             }
@@ -244,7 +244,7 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
             }
         """
         settingsFile << "rootProject.name = 'parent'"
-        buildScript """
+        buildFile """
             task t(type: GradleBuild) {
                 tasks = ["o"]
             }

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/scopeids/ScopeIdsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/scopeids/ScopeIdsIntegrationTest.groovy
@@ -56,7 +56,7 @@ class ScopeIdsIntegrationTest extends AbstractIntegrationSpec {
         file("b/build.gradle") << "task t {}"
         file("b/buildSrc/build.gradle") << ""
 
-        buildScript """
+        buildFile """
             task t {
                 dependsOn gradle.includedBuild("a").task(":t")
                 dependsOn gradle.includedBuild("b").task(":t")
@@ -76,7 +76,7 @@ class ScopeIdsIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         file("other/settings.gradle").touch()
-        buildScript """
+        buildFile """
             task t(type: GradleBuild) {
                 dir = file("other")
             }
@@ -96,7 +96,7 @@ class ScopeIdsIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         settingsFile << "rootProject.name = 'root'"
-        buildScript """
+        buildFile """
             task t(type: GradleBuild) {
                 startParameter.gradleUserHomeDir = new File("${TextUtil.normaliseFileSeparators(file("other-home").absolutePath)}")
             }
@@ -113,7 +113,7 @@ class ScopeIdsIntegrationTest extends AbstractIntegrationSpec {
     def "gradle-build with same root and user dir inherits all"() {
         when:
         settingsFile << "rootProject.name = 'root'"
-        buildScript """
+        buildFile """
             task t(type: GradleBuild) {}
         """
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/plugin/NonImperativeBuildScriptEvaluationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/plugin/NonImperativeBuildScriptEvaluationIntegrationTest.groovy
@@ -38,7 +38,7 @@ class NonImperativeBuildScriptEvaluationIntegrationTest extends AbstractIntegrat
             }
         """
 
-        buildScript """
+        buildFile """
             apply from: "scriptPlugin1.gradle"
             apply from: "scriptPlugin2.gradle"
         """

--- a/subprojects/core/src/integTest/groovy/org/gradle/plugin/ScriptPluginClassLoadingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/plugin/ScriptPluginClassLoadingIntegrationTest.groovy
@@ -53,7 +53,7 @@ class ScriptPluginClassLoadingIntegrationTest extends AbstractIntegrationSpec {
             task sayMessageFrom3 { doLast { println new pkg.Thing().getMessage() } }
         """
 
-        buildScript "apply from: 'plugin1.gradle'"
+        buildFile "apply from: 'plugin1.gradle'"
 
         then:
         succeeds "sayMessageFrom1", "sayMessageFrom2", "sayMessageFrom3"
@@ -63,7 +63,7 @@ class ScriptPluginClassLoadingIntegrationTest extends AbstractIntegrationSpec {
     @Issue("https://issues.gradle.org/browse/GRADLE-3079")
     def "methods defined in script are available to used script plugins"() {
         given:
-        buildScript """
+        buildFile """
           def addTask(project) {
             project.tasks.create("hello").doLast { println "hello from method" }
           }
@@ -82,7 +82,7 @@ class ScriptPluginClassLoadingIntegrationTest extends AbstractIntegrationSpec {
 
     def "methods defined in script plugin are not inherited by applied script plugin"() {
         given:
-        buildScript """
+        buildFile """
             apply from: "script1.gradle"
         """
 
@@ -109,7 +109,7 @@ class ScriptPluginClassLoadingIntegrationTest extends AbstractIntegrationSpec {
             def someMethod() {}
         """
 
-        buildScript """
+        buildFile """
             someMethod()
         """
 
@@ -127,7 +127,7 @@ class ScriptPluginClassLoadingIntegrationTest extends AbstractIntegrationSpec {
             def someMethod() {}
         """
 
-        buildScript """
+        buildFile """
             someMethod()
         """
 
@@ -147,7 +147,7 @@ class ScriptPluginClassLoadingIntegrationTest extends AbstractIntegrationSpec {
         given:
         settingsFile << "include 'sub'"
 
-        buildScript """
+        buildFile """
             def someMethod() {
                 println "from some method"
             }
@@ -166,7 +166,7 @@ class ScriptPluginClassLoadingIntegrationTest extends AbstractIntegrationSpec {
     @Issue("https://issues.gradle.org/browse/GRADLE-3082")
     def "can use apply block syntax to apply multiple scripts"() {
         given:
-        buildScript """
+        buildFile """
           apply {
             from "script1.gradle"
             from "script2.gradle"
@@ -186,7 +186,7 @@ class ScriptPluginClassLoadingIntegrationTest extends AbstractIntegrationSpec {
 
     def "separate classloaders are used when using multi apply syntax"() {
         given:
-        buildScript """
+        buildFile """
           apply {
             from "script1.gradle"
             from "script2.gradle"
@@ -213,7 +213,7 @@ class ScriptPluginClassLoadingIntegrationTest extends AbstractIntegrationSpec {
 
         settingsFile << "include 'sub'"
 
-        buildScript """
+        buildFile """
             apply from: "script.gradle"
 
             try {
@@ -261,7 +261,7 @@ class ScriptPluginClassLoadingIntegrationTest extends AbstractIntegrationSpec {
         pluginBuilder.addPlugin("project.task('hello')")
         pluginBuilder.publishTo(executer, jar)
 
-        buildScript """
+        buildFile """
             buildscript {
                 dependencies { classpath files("plugin.jar") }
             }
@@ -296,7 +296,7 @@ class ScriptPluginClassLoadingIntegrationTest extends AbstractIntegrationSpec {
         pluginBuilder.addPlugin("project.task('hello')")
         pluginBuilder.publishTo(executer, jar)
 
-        buildScript """
+        buildFile """
             apply from: "script1.gradle"
         """
 
@@ -335,7 +335,7 @@ class ScriptPluginClassLoadingIntegrationTest extends AbstractIntegrationSpec {
         pluginBuilder.addPlugin("project.task('hello')")
         pluginBuilder.publishTo(executer, jar)
 
-        buildScript """
+        buildFile """
             apply from: 'foo.gradle'
         """
 

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/plugins/HelpTasksPluginIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/plugins/HelpTasksPluginIntegrationTest.groovy
@@ -28,7 +28,7 @@ class HelpTasksPluginIntegrationTest extends WellBehavedPluginTest {
 
     def "can fetch tasks during configuration - #task"() {
         when:
-        buildScript """
+        buildFile """
             assert tasks.names.contains("$task")
             tasks.findByName "$task"
         """

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/TaskReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/TaskReportTaskIntegrationTest.groovy
@@ -460,7 +460,7 @@ alpha - ALPHA_in_sub1
 
     def "task report includes tasks defined via model rules running #tasks"() {
         when:
-        buildScript """
+        buildFile """
             model {
                 tasks {
                     create('a') {
@@ -489,7 +489,7 @@ alpha - ALPHA_in_sub1
 
     def "task report includes tasks with dependencies defined via model rules running #tasks"() {
         when:
-        buildScript """
+        buildFile """
             model {
                 tasks {
                     create('a')
@@ -517,7 +517,7 @@ b
 
     def "task report includes task container rule based tasks defined via model rule"() {
         when:
-        buildScript """
+        buildFile """
             tasks.addRule("Pattern: containerRule<ID>") { taskName ->
                 if (taskName.startsWith("containerRule")) {
                     task(taskName) {
@@ -567,7 +567,7 @@ b
     def "renders tasks with dependencies created by model rules running #tasks"() {
         when:
         settingsFile << "rootProject.name = 'test-project'"
-        buildScript """
+        buildFile """
             model {
                 tasks {
                     create('a')

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/BuildSourceBuilderIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/BuildSourceBuilderIntegrationTest.groovy
@@ -40,7 +40,7 @@ class BuildSourceBuilderIntegrationTest extends AbstractIntegrationSpec {
 
     @Issue("https://issues.gradle.org/browse/GRADLE-2032")
     def "can simultaneously run gradle on projects with buildSrc"() {
-        initScript """
+        initScriptFile """
             import ${BuildOperationListenerManager.name}
             import ${BuildOperationListener.name}
             import ${BuildOperationDescriptor.name}

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -37,7 +37,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
             someOtherEmptyDir {}
         }
 
-        buildScript '''
+        buildFile '''
             task sync(type: Sync) {
                 into 'dest'
                 from 'source'
@@ -68,7 +68,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
             }
         }
 
-        buildScript '''
+        buildFile '''
             task sync(type: Sync) {
                 into 'dest'
                 from 'source'
@@ -108,7 +108,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
             }
         }
 
-        buildScript '''
+        buildFile '''
             task sync(type: Sync) {
                 from 'source'
                 into 'dest'
@@ -143,7 +143,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
             file 'preserved.txt'
         }
 
-        buildScript '''
+        buildFile '''
             task sync(type: Sync) {
                 from 'source'
                 into 'dest'
@@ -181,7 +181,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
         defaultSourceFileTree()
         file('dest').create {}
 
-        buildScript '''
+        buildFile '''
             task sync(type: Sync) {
                 from 'source'
                 into 'dest'
@@ -210,7 +210,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
             preserved { file('some-preserved-file.txt') }
         }
 
-        buildScript '''
+        buildFile '''
             task sync(type: Sync) {
                 from 'source'
                 into 'dest'
@@ -228,7 +228,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
         file('dest/preserved').exists()
 
         when:
-        buildScript '''
+        buildFile '''
             task sync(type: Sync) {
                 from 'source'
                 into 'dest'
@@ -256,7 +256,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
             }
         }
 
-        buildScript """
+        buildFile """
             task sync(type: Sync) {
                 from 'source'
                 into 'dest'
@@ -285,7 +285,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
             nonPreservedDir {}
         }
 
-        buildScript '''
+        buildFile '''
             task sync(type: Sync) {
                 from 'source'
                 into 'dest'
@@ -311,7 +311,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
             file 'extra1.txt'
             extraDir { file 'extra2.txt' }
         }
-        buildScript '''
+        buildFile '''
             task syncIt() {
                 project.sync {
                     from 'source'
@@ -346,7 +346,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
             }
 
         }
-        buildScript '''
+        buildFile '''
             task syncIt() {
                 project.sync {
                     from 'source'
@@ -384,7 +384,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
         file('dest').create {
             file 'extra.txt'
         }
-        buildScript '''
+        buildFile '''
             task syncIt {
                 doLast {
                     project.sync {
@@ -419,7 +419,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
         }
         // Intentionally hold open a file
         def ins = new FileInputStream(file("dest/extra.txt"))
-        buildScript '''
+        buildFile '''
             task syncIt {
                 doLast {
                     project.sync {
@@ -556,7 +556,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
             dir1 { file 'extra2.txt' }
             dir2 { file 'extra3.txt' }
         }
-        buildScript '''
+        buildFile '''
         task syncIt {
             doLast {
                 project.sync {
@@ -594,7 +594,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
             dir1 { file 'extra2.txt' }
             dir2 { file 'extra3.txt' }
         }
-        buildScript '''
+        buildFile '''
             task syncIt {
                 doLast {
                     project.sync {
@@ -638,7 +638,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
             dir1 { file 'extra2.txt' }
         }
         file('f.jar').touch()
-        buildScript '''
+        buildFile '''
             configurations { compile }
             dependencies { compile files('f.jar') }
             task syncIt {
@@ -678,7 +678,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
             file 'extra.txt'
         }
 
-        buildScript '''
+        buildFile '''
             task sync(type: Sync) {
                 into 'dest'
                 into ('.') {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -195,10 +195,6 @@ abstract class AbstractIntegrationSpec extends Specification implements Language
         return "junit:junit:4.13"
     }
 
-    void versionCatalogFile(@Language("toml") String script) {
-        versionCatalogFile << script
-    }
-
     TestFile getBuildKotlinFile() {
         testDirectory.file(defaultBuildKotlinFileName)
     }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -70,7 +70,7 @@ import static org.gradle.util.Matchers.normalizedLineSeparators
 @CleanupTestDirectory
 @SuppressWarnings("IntegrationTestFixtures")
 @IntegrationTestTimeout(DEFAULT_TIMEOUT_SECONDS)
-abstract class AbstractIntegrationSpec extends Specification {
+abstract class AbstractIntegrationSpec extends Specification implements LanguageSpecificTestFileFixture {
 
     @Rule
     public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
@@ -195,156 +195,6 @@ abstract class AbstractIntegrationSpec extends Specification {
         return "junit:junit:4.13"
     }
 
-    /**
-     * <b>Appends</b> provided code to the {@link #getBuildFile() default build file}.
-     * <p>
-     * Use {@link #buildScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
-     */
-    void buildFile(@GroovyBuildScriptLanguage String append) {
-        buildFile << append
-    }
-
-    /**
-     * <b>Appends</b> provided code to the given build file.
-     * <p>
-     * Use {@link #buildScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
-     */
-    void buildFile(String buildFile, @GroovyBuildScriptLanguage String append) {
-        file(buildFile) << append
-    }
-
-    /**
-     * <b>Appends</b> provided code to the given build file.
-     * <p>
-     * Use {@link #buildScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
-     */
-    void buildFile(TestFile buildFile, @GroovyBuildScriptLanguage String append) {
-        buildFile << append
-    }
-
-    /**
-     * <b>Appends</b> provided code to the {@link #getSettingsFile() default settings file}.
-     * <p>
-     * Use {@link #settingsScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
-     */
-    void settingsFile(@GroovySettingsScriptLanguage String append) {
-        settingsFile << append
-    }
-
-    /**
-     * <b>Appends</b> provided code to the given settings file.
-     * <p>
-     * Use {@link #settingsScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
-     */
-    void settingsFile(String settingsFile, @GroovySettingsScriptLanguage String append) {
-        file(settingsFile) << append
-    }
-
-    /**
-     * <b>Appends</b> provided code to the given settings file.
-     * <p>
-     * Use {@link #settingsScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
-     */
-    void settingsFile(TestFile settingsFile, @GroovySettingsScriptLanguage String append) {
-        settingsFile << append
-    }
-
-    /**
-     * <b>Appends</b> provided code to the {@link #getInitScriptFile() default init script file}.
-     * <p>
-     * Use {@link #initScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
-     */
-    void initScriptFile(@GroovyInitScriptLanguage String append) {
-        initScriptFile << append
-    }
-
-    /**
-     * <b>Appends</b> provided code to the given init script file.
-     * <p>
-     * Use {@link #initScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
-     */
-    void initScriptFile(String initScriptFile, @GroovyInitScriptLanguage String append) {
-        file(initScriptFile) << append
-    }
-
-    /**
-     * <b>Appends</b> provided code to the given init script file.
-     * <p>
-     * Use {@link #initScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
-     */
-    void initScriptFile(TestFile initScriptFile, @GroovyInitScriptLanguage String append) {
-        initScriptFile << append
-    }
-
-    /**
-     * <b>Appends</b> provided code to the given Java file.
-     */
-    void javaFile(String targetFile, @Language('java') String append) {
-        file(targetFile) << append
-    }
-
-    /**
-     * <b>Appends</b> provided code to the given Java file.
-     */
-    void javaFile(TestFile targetFile, @Language('java') String append) {
-        targetFile << append
-    }
-
-    /**
-     * <b>Appends</b> provided code to the given Groovy file.
-     * <p>
-     * Consider specialized methods for Gradle scripts:
-     * <ul>
-     * <li>{@link #buildFile(java.lang.String, java.lang.String)}
-     * <li>{@link #settingsFile(java.lang.String, java.lang.String)}
-     * <li>{@link #initScriptFile(java.lang.String, java.lang.String)}
-     * </ul>
-     */
-    void groovyFile(String targetFile, @Language('groovy') String append) {
-        file(targetFile) << append
-    }
-
-    /**
-     * <b>Appends</b> provided code to the given Groovy file.
-     * <p>
-     * Consider specialized methods for Gradle scripts:
-     * <ul>
-     * <li>{@link #buildFile(org.gradle.test.fixtures.file.TestFile, java.lang.String)}
-     * <li>{@link #settingsFile(org.gradle.test.fixtures.file.TestFile, java.lang.String)}
-     * <li>{@link #initScriptFile(org.gradle.test.fixtures.file.TestFile, java.lang.String)}
-     * </ul>
-     */
-    void groovyFile(TestFile targetFile, @Language('groovy') String append) {
-        targetFile << append
-    }
-
-    /**
-     * Provides syntax highlighting for the snippet of the build script code.
-     *
-     * @return the same snippet
-     */
-    static String buildScriptSnippet(@GroovyBuildScriptLanguage String snippet) {
-        snippet
-    }
-
-    /**
-     * Provides syntax highlighting for the snippet of the settings script code.
-     *
-     * @return the same snippet
-     */
-    static String settingsScriptSnippet(@GroovySettingsScriptLanguage String snippet) {
-        snippet
-    }
-
-    /**
-     * Provides syntax highlighting for the snippet of the init script code.
-     *
-     * @return the same snippet
-     */
-    static String initScriptSnippet(@GroovyInitScriptLanguage String snippet) {
-        snippet
-    }
-
     void versionCatalogFile(@Language("toml") String script) {
         versionCatalogFile << script
     }
@@ -360,32 +210,6 @@ abstract class AbstractIntegrationSpec extends Specification {
     protected String getDefaultBuildKotlinFileName() {
         'build.gradle.kts'
     }
-
-    /**
-     * Sets (replacing) the contents of the build.gradle file.
-     *
-     * To append, use #buildFile(String).
-     */
-    protected TestFile buildScript(@GroovyBuildScriptLanguage String script) {
-        buildFile.text = script
-        buildFile
-    }
-
-    /**
-     * Sets (replacing) the contents of the settings.gradle file.
-     *
-     * To append, use #settingsFile(String)
-     */
-    protected TestFile settingsScript(@GroovyBuildScriptLanguage String script) {
-        settingsFile.text = script
-        settingsFile
-    }
-
-    protected TestFile initScript(@GroovyBuildScriptLanguage String script) {
-        initScriptFile.text = script
-        initScriptFile
-    }
-
 
     protected TestFile getSettingsFile() {
         testDirectory.file(settingsFileName)

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/LanguageSpecificTestFileFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/LanguageSpecificTestFileFixture.groovy
@@ -159,4 +159,29 @@ trait LanguageSpecificTestFileFixture {
     String initScriptSnippet(@GroovyInitScriptLanguage String snippet) {
         snippet
     }
+
+    /**
+     * Provides syntax highlighting for the snippet of Java code.
+     *
+     * @return the same snippet
+     */
+    String javaSnippet(@Language('java') String snippet) {
+        snippet
+    }
+
+    /**
+     * Provides syntax highlighting for the snippet of Groovy code.
+     * <p>
+     * Consider specialized methods for Gradle scripts:
+     * <ul>
+     * <li>{@link #buildScriptSnippet(java.lang.String)}
+     * <li>{@link #settingsScriptSnippet(java.lang.String)}
+     * <li>{@link #initScriptSnippet(java.lang.String)}
+     * </ul>
+     *
+     * @return the same snippet
+     */
+    String groovySnippet(@Language('groovy') String snippet) {
+        snippet
+    }
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/LanguageSpecificTestFileFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/LanguageSpecificTestFileFixture.groovy
@@ -25,8 +25,6 @@ trait LanguageSpecificTestFileFixture {
 
     /**
      * <b>Appends</b> provided code to the {@link #getBuildFile() default build file}.
-     * <p>
-     * Use {@link #buildScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
      */
     void buildFile(@GroovyBuildScriptLanguage String append) {
         buildFile << append
@@ -34,8 +32,6 @@ trait LanguageSpecificTestFileFixture {
 
     /**
      * <b>Appends</b> provided code to the given build file.
-     * <p>
-     * Use {@link #buildScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
      */
     void buildFile(String buildFile, @GroovyBuildScriptLanguage String append) {
         file(buildFile) << append
@@ -43,8 +39,6 @@ trait LanguageSpecificTestFileFixture {
 
     /**
      * <b>Appends</b> provided code to the given build file.
-     * <p>
-     * Use {@link #buildScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
      */
     void buildFile(TestFile buildFile, @GroovyBuildScriptLanguage String append) {
         buildFile << append
@@ -159,15 +153,5 @@ trait LanguageSpecificTestFileFixture {
      */
     String initScriptSnippet(@GroovyInitScriptLanguage String snippet) {
         snippet
-    }
-
-    /**
-     * Sets (replacing) the contents of the build.gradle file.
-     * <p>
-     * To append, use {@link #buildFile(java.lang.String)}
-     */
-    TestFile buildScript(@GroovyBuildScriptLanguage String script) {
-        buildFile.text = script
-        buildFile
     }
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/LanguageSpecificTestFileFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/LanguageSpecificTestFileFixture.groovy
@@ -52,8 +52,6 @@ trait LanguageSpecificTestFileFixture {
 
     /**
      * <b>Appends</b> provided code to the {@link #getSettingsFile() default settings file}.
-     * <p>
-     * Use {@link #settingsScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
      */
     void settingsFile(@GroovySettingsScriptLanguage String append) {
         settingsFile << append
@@ -61,8 +59,6 @@ trait LanguageSpecificTestFileFixture {
 
     /**
      * <b>Appends</b> provided code to the given settings file.
-     * <p>
-     * Use {@link #settingsScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
      */
     void settingsFile(String settingsFile, @GroovySettingsScriptLanguage String append) {
         file(settingsFile) << append
@@ -70,8 +66,6 @@ trait LanguageSpecificTestFileFixture {
 
     /**
      * <b>Appends</b> provided code to the given settings file.
-     * <p>
-     * Use {@link #settingsScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
      */
     void settingsFile(TestFile settingsFile, @GroovySettingsScriptLanguage String append) {
         settingsFile << append
@@ -79,8 +73,6 @@ trait LanguageSpecificTestFileFixture {
 
     /**
      * <b>Appends</b> provided code to the {@link #getInitScriptFile() default init script file}.
-     * <p>
-     * Use {@link #initScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
      */
     void initScriptFile(@GroovyInitScriptLanguage String append) {
         initScriptFile << append
@@ -88,8 +80,6 @@ trait LanguageSpecificTestFileFixture {
 
     /**
      * <b>Appends</b> provided code to the given init script file.
-     * <p>
-     * Use {@link #initScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
      */
     void initScriptFile(String initScriptFile, @GroovyInitScriptLanguage String append) {
         file(initScriptFile) << append
@@ -97,8 +87,6 @@ trait LanguageSpecificTestFileFixture {
 
     /**
      * <b>Appends</b> provided code to the given init script file.
-     * <p>
-     * Use {@link #initScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
      */
     void initScriptFile(TestFile initScriptFile, @GroovyInitScriptLanguage String append) {
         initScriptFile << append
@@ -182,25 +170,4 @@ trait LanguageSpecificTestFileFixture {
         buildFile.text = script
         buildFile
     }
-
-    /**
-     * Sets (replacing) the contents of the settings.gradle file.
-     * <p>
-     * To append, use {@link #settingsFile(java.lang.String)}
-     */
-    TestFile settingsScript(@GroovyBuildScriptLanguage String script) {
-        settingsFile.text = script
-        settingsFile
-    }
-
-    /**
-     * Sets (replacing) the contents of the settings.gradle file.
-     * <p>
-     * To append, use {@link #initScriptFile(java.lang.String)}
-     */
-    TestFile initScript(@GroovyBuildScriptLanguage String script) {
-        initScriptFile.text = script
-        initScriptFile
-    }
-
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/LanguageSpecificTestFileFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/LanguageSpecificTestFileFixture.groovy
@@ -134,6 +134,13 @@ trait LanguageSpecificTestFileFixture {
     }
 
     /**
+     * <b>Appends</b> provided code to the {@link #getVersionCatalogFile() default version catalog file}.
+     */
+    void versionCatalogFile(@Language("toml") String append) {
+        versionCatalogFile << append
+    }
+
+    /**
      * Provides syntax highlighting for the snippet of the build script code.
      *
      * @return the same snippet

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/LanguageSpecificTestFileFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/LanguageSpecificTestFileFixture.groovy
@@ -20,6 +20,11 @@ import groovy.transform.SelfType
 import org.gradle.test.fixtures.file.TestFile
 import org.intellij.lang.annotations.Language
 
+/**
+ * Utility functions that write to files and provide syntax highlighting for the code snippets.
+ *
+ * @see Language
+ */
 @SelfType(AbstractIntegrationSpec)
 trait LanguageSpecificTestFileFixture {
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/LanguageSpecificTestFileFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/LanguageSpecificTestFileFixture.groovy
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures
+
+import groovy.transform.SelfType
+import org.gradle.test.fixtures.file.TestFile
+import org.intellij.lang.annotations.Language
+
+@SelfType(AbstractIntegrationSpec)
+trait LanguageSpecificTestFileFixture {
+
+    /**
+     * <b>Appends</b> provided code to the {@link #getBuildFile() default build file}.
+     * <p>
+     * Use {@link #buildScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
+     */
+    void buildFile(@GroovyBuildScriptLanguage String append) {
+        buildFile << append
+    }
+
+    /**
+     * <b>Appends</b> provided code to the given build file.
+     * <p>
+     * Use {@link #buildScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
+     */
+    void buildFile(String buildFile, @GroovyBuildScriptLanguage String append) {
+        file(buildFile) << append
+    }
+
+    /**
+     * <b>Appends</b> provided code to the given build file.
+     * <p>
+     * Use {@link #buildScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
+     */
+    void buildFile(TestFile buildFile, @GroovyBuildScriptLanguage String append) {
+        buildFile << append
+    }
+
+    /**
+     * <b>Appends</b> provided code to the {@link #getSettingsFile() default settings file}.
+     * <p>
+     * Use {@link #settingsScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
+     */
+    void settingsFile(@GroovySettingsScriptLanguage String append) {
+        settingsFile << append
+    }
+
+    /**
+     * <b>Appends</b> provided code to the given settings file.
+     * <p>
+     * Use {@link #settingsScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
+     */
+    void settingsFile(String settingsFile, @GroovySettingsScriptLanguage String append) {
+        file(settingsFile) << append
+    }
+
+    /**
+     * <b>Appends</b> provided code to the given settings file.
+     * <p>
+     * Use {@link #settingsScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
+     */
+    void settingsFile(TestFile settingsFile, @GroovySettingsScriptLanguage String append) {
+        settingsFile << append
+    }
+
+    /**
+     * <b>Appends</b> provided code to the {@link #getInitScriptFile() default init script file}.
+     * <p>
+     * Use {@link #initScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
+     */
+    void initScriptFile(@GroovyInitScriptLanguage String append) {
+        initScriptFile << append
+    }
+
+    /**
+     * <b>Appends</b> provided code to the given init script file.
+     * <p>
+     * Use {@link #initScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
+     */
+    void initScriptFile(String initScriptFile, @GroovyInitScriptLanguage String append) {
+        file(initScriptFile) << append
+    }
+
+    /**
+     * <b>Appends</b> provided code to the given init script file.
+     * <p>
+     * Use {@link #initScript(java.lang.String)} to <b>set (replace)</b> the entire file contents instead.
+     */
+    void initScriptFile(TestFile initScriptFile, @GroovyInitScriptLanguage String append) {
+        initScriptFile << append
+    }
+
+    /**
+     * <b>Appends</b> provided code to the given Java file.
+     */
+    void javaFile(String targetFile, @Language('java') String append) {
+        file(targetFile) << append
+    }
+
+    /**
+     * <b>Appends</b> provided code to the given Java file.
+     */
+    void javaFile(TestFile targetBuildFile, @Language('java') String append) {
+        targetBuildFile << append
+    }
+
+    /**
+     * <b>Appends</b> provided code to the given Groovy file.
+     * <p>
+     * Consider specialized methods for Gradle scripts:
+     * <ul>
+     * <li>{@link #buildFile(java.lang.String, java.lang.String)}
+     * <li>{@link #settingsFile(java.lang.String, java.lang.String)}
+     * <li>{@link #initScriptFile(java.lang.String, java.lang.String)}
+     * </ul>
+     */
+    void groovyFile(String targetFile, @Language('groovy') String append) {
+        file(targetFile) << append
+    }
+
+    /**
+     * <b>Appends</b> provided code to the given Groovy file.
+     * <p>
+     * Consider specialized methods for Gradle scripts:
+     * <ul>
+     * <li>{@link #buildFile(org.gradle.test.fixtures.file.TestFile, java.lang.String)}
+     * <li>{@link #settingsFile(org.gradle.test.fixtures.file.TestFile, java.lang.String)}
+     * <li>{@link #initScriptFile(org.gradle.test.fixtures.file.TestFile, java.lang.String)}
+     * </ul>
+     */
+    void groovyFile(TestFile targetFile, @Language('groovy') String append) {
+        targetFile << append
+    }
+
+    /**
+     * Provides syntax highlighting for the snippet of the build script code.
+     *
+     * @return the same snippet
+     */
+    static String buildScriptSnippet(@GroovyBuildScriptLanguage String snippet) {
+        snippet
+    }
+
+    /**
+     * Provides syntax highlighting for the snippet of the settings script code.
+     *
+     * @return the same snippet
+     */
+    static String settingsScriptSnippet(@GroovySettingsScriptLanguage String snippet) {
+        snippet
+    }
+
+    /**
+     * Provides syntax highlighting for the snippet of the init script code.
+     *
+     * @return the same snippet
+     */
+    static String initScriptSnippet(@GroovyInitScriptLanguage String snippet) {
+        snippet
+    }
+
+    /**
+     * Sets (replacing) the contents of the build.gradle file.
+     * <p>
+     * To append, use {@link #buildFile(java.lang.String)}
+     */
+    TestFile buildScript(@GroovyBuildScriptLanguage String script) {
+        buildFile.text = script
+        buildFile
+    }
+
+    /**
+     * Sets (replacing) the contents of the settings.gradle file.
+     * <p>
+     * To append, use {@link #settingsFile(java.lang.String)}
+     */
+    TestFile settingsScript(@GroovyBuildScriptLanguage String script) {
+        settingsFile.text = script
+        settingsFile
+    }
+
+    /**
+     * Sets (replacing) the contents of the settings.gradle file.
+     * <p>
+     * To append, use {@link #initScriptFile(java.lang.String)}
+     */
+    TestFile initScript(@GroovyBuildScriptLanguage String script) {
+        initScriptFile.text = script
+        initScriptFile
+    }
+
+}

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/LanguageSpecificTestFileFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/LanguageSpecificTestFileFixture.groovy
@@ -151,7 +151,7 @@ trait LanguageSpecificTestFileFixture {
      *
      * @return the same snippet
      */
-    static String buildScriptSnippet(@GroovyBuildScriptLanguage String snippet) {
+    String buildScriptSnippet(@GroovyBuildScriptLanguage String snippet) {
         snippet
     }
 
@@ -160,7 +160,7 @@ trait LanguageSpecificTestFileFixture {
      *
      * @return the same snippet
      */
-    static String settingsScriptSnippet(@GroovySettingsScriptLanguage String snippet) {
+    String settingsScriptSnippet(@GroovySettingsScriptLanguage String snippet) {
         snippet
     }
 
@@ -169,7 +169,7 @@ trait LanguageSpecificTestFileFixture {
      *
      * @return the same snippet
      */
-    static String initScriptSnippet(@GroovyInitScriptLanguage String snippet) {
+    String initScriptSnippet(@GroovyInitScriptLanguage String snippet) {
         snippet
     }
 

--- a/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
+++ b/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
@@ -188,6 +188,16 @@ public class TestFile extends File {
         }
     }
 
+    /**
+     * Resets the file content to be empty (creating the file if it does not exist).
+     *
+     * @return the same file
+     * @see #setText(String)
+     */
+    public TestFile clear() {
+        return setText("");
+    }
+
     @Override
     public TestFile[] listFiles() {
         File[] children = super.listFiles();


### PR DESCRIPTION
### Context

We have two flavors of helper functions for writing integration tests:
- `buildFile` -- calling it would *append* content to a given build file
- `buildScript` -- calling it would *replace* content of a given build file

The same flavor variations exist also for settings scripts and init scripts.

In the absolute majority of cases, what is used and what works is the *appending* semantics. However, due to both functions being available and the semantics not making a difference, many tests used one function over the other effectively at random.

An additional problem is that the `buildScript` function name did not imply in any way that it has a behavior different from the `buildFile`.

### Solution

Standardize on the file-appending functions like `buildFile` and completely remove functions like `buildScript`.

For rare cases when the script files do need to be cleared/reset, combine the clearing and appending, making it very explicit.

An example:
```
buildFile.clear()
buildFile """
    plugins { id "java" }
"""
```

### Changes

- Move all snippet-highlighting functions from `AbstractIntegrationSpec` to a dedicated `LanguageSpecificTestFileFixture`
  - Less clutter in the integration spec itself, but make the spec extend the fixture to keep the functions available
- Add `TestFile.clear()` -- a new helper function equivalent to `file.text = ""` or `file.setText("")`
- Replace all usages of `buildScript` and similar with `buildFile` (and `.clear()` where needed)
- Remove `buildScript` and similar functions