### PR TITLE
Support Provider<Configuration> arguments in Configuration extendsFrom method

### DIFF
--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -64,7 +64,7 @@ The `cpp-unit` and `xctest` plugins are not yet compatible.
 
 ### Configuration API enhancements
 
-It is now possible to configure a [Configuration](dsl/org.gradle.api.artifacts.Configuration.html) to extend another configuration by supplying a [Provider<Configuration>](dsl/org.gradle.api.provider.Provider.html) as an argument to [extendsFrom](dsl/org.gradle.api.artifacts.Configuration.html#org.gradle.api.artifacts.Configuration:extendsFrom(org.gradle.api.artifacts.Configuration[])).
+It is now possible to configure a [Configuration](dsl/org.gradle.api.artifacts.Configuration.html) to extend another configuration by supplying a [Provider<Configuration>](dsl/org.gradle.api.provider.Provider.html) as an argument to [extendsFrom](dsl/org.gradle.api.artifacts.Configuration.html#org.gradle.api.artifacts.Configuration:extendsFrom(org.gradle.api.provider.Provider)).
 
 This allows for more flexible configuration hierarchy construction, as the extended configuration can be calculated lazily.
 

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -2,7 +2,7 @@ The Gradle team is excited to announce Gradle @version@.
 
 This release features [1](), [2](), ... [n](), and more.
 
-<!-- 
+<!--
 Include only their name, impactful features should be called out separately below.
  [Some person](https://github.com/some-person)
 
@@ -21,7 +21,7 @@ Switch your build to use Gradle @version@ by updating the [Wrapper](userguide/gr
 
 See the [Gradle 8.x upgrade guide](userguide/upgrading_version_8.html#changes_@baseVersion@) to learn about deprecations, breaking changes, and other considerations when upgrading to Gradle @version@.
 
-For Java, Groovy, Kotlin, and Android compatibility, see the [full compatibility notes](userguide/compatibility.html).   
+For Java, Groovy, Kotlin, and Android compatibility, see the [full compatibility notes](userguide/compatibility.html).
 
 ## New features and usability improvements
 
@@ -61,6 +61,22 @@ vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv -->
 The Swift and C++ plugins are now configuration cache compatible.
 
 The `cpp-unit` and `xctest` plugins are not yet compatible.
+
+### Configuration API enhancements
+
+It is now possible to configure a [Configuration](dsl/org.gradle.api.artifacts.Configuration.html) to extend another configuration by supplying a [Provider<Configuration>](dsl/org.gradle.api.provider.Provider.html) as an argument to [extendsFrom](dsl/org.gradle.api.artifacts.Configuration.html#org.gradle.api.artifacts.Configuration:extendsFrom(org.gradle.api.artifacts.Configuration[])).
+
+This allows for more flexible configuration hierarchy construction, as the extended configuration can be calculated lazily.
+
+```kotlin
+configurations {
+    resolvable("conf1")
+    resolvable("conf2")
+    resolvable("conf3") {
+        extendsFrom(project.provider { if (x == 1) configurations.getByName("conf1") else configurations.getByName("conf2") })
+    }
+}
+```
 
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ADD RELEASE FEATURES ABOVE

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/artifacts/configurations/DefaultConfigurationExtendsFromIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/artifacts/configurations/DefaultConfigurationExtendsFromIntegrationTest.groovy
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.internal.artifacts.configurations
+
+import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.util.GradleVersion
+
+/**
+ * Integration tests for {@code extendsFrom} method in {@link DefaultConfiguration}.
+ */
+class DefaultConfigurationExtendsFromIntegrationTest extends AbstractIntegrationSpec {
+    def "extending a configuration in another project is deprecated"() {
+        given:
+        settingsFile """
+            include ":project1", ":project2"
+        """
+
+        groovyFile(file('project1/build.gradle'), """
+            configurations {
+                resolvable('conf1')
+            }
+        """)
+
+        groovyFile(file('project2/build.gradle'), """
+            configurations {
+                resolvable('conf2') {
+                    extendsFrom project(':project1').configurations.conf1
+                }
+            }
+        """)
+
+        expect:
+        executer.expectDeprecationWarning("Configuration 'conf2' in project ':project2' extends configuration 'conf1' in project ':project1'. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Configurations can only extend from configurations in the same project. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#extending_configurations_in_same_project")
+        succeeds ':project2:resolvableConfigurations', '--all'
+        outputContains("""
+--------------------------------------------------
+Configuration conf2
+--------------------------------------------------
+
+Extended Configurations
+    - conf1
+""")
+    }
+
+    def "extending a configuration in same project is fine"() {
+        given:
+        buildFile """
+            configurations {
+                resolvable('conf1')
+            }
+
+            configurations {
+                resolvable('conf2') {
+                    extendsFrom configurations.conf1
+                }
+            }
+        """
+
+        expect:
+        succeeds 'resolvableConfigurations', '--all'
+        outputContains("""
+--------------------------------------------------
+Configuration conf2
+--------------------------------------------------
+
+Extended Configurations
+    - conf1
+""")
+    }
+}

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/artifacts/configurations/DefaultConfigurationExtendsFromIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/artifacts/configurations/DefaultConfigurationExtendsFromIntegrationTest.groovy
@@ -156,6 +156,30 @@ Extended Configurations
 """)
     }
 
+    def "extending a configuration with a Provider in Kotlin DSL is fine"() {
+        given:
+        buildKotlinFile << """
+            configurations {
+                resolvable("conf1")
+                resolvable("conf2") {
+                    extendsFrom(configurations.named("conf1"))
+                    extendsFrom(project.provider { configurations.getByName("conf1") })
+                }
+            }
+        """
+
+        expect:
+        succeeds 'resolvableConfigurations', '--all'
+        outputContains("""
+--------------------------------------------------
+Configuration conf2
+--------------------------------------------------
+
+Extended Configurations
+    - conf1
+""")
+    }
+
     def "extending a configuration with a lazily-calculated Provider in Kotlin DSL is fine"() {
         given:
         buildKotlinFile << """
@@ -165,7 +189,7 @@ Extended Configurations
                 resolvable("conf1")
                 resolvable("conf2")
                 resolvable("conf3") {
-                    extendsFrom(project.provider { if (x == 1) configurations.getByName("conf1") else configurations.getByName("conf2") })
+                    extendsFrom(project.provider { if (x == 1) configurations.named("conf1").get() else configurations.named("conf2").get() })
                 }
             }
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
@@ -174,7 +174,7 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      * @param configProvider Provider of the super configuration.
      * @return this configuration
      *
-     * @since 8.10
+     * @since 8.11
      */
     @Incubating
     default Configuration setExtendsFrom(Provider<Configuration> configProvider) {
@@ -196,7 +196,7 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      * @param configProvider Provider of the super configuration.
      * @return this configuration
      *
-     * @since 8.10
+     * @since 8.11
      */
     @Incubating
     default Configuration extendsFrom(Provider<Configuration> configProvider) {

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
@@ -167,7 +167,7 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
     Configuration setExtendsFrom(Iterable<Configuration> superConfigs);
 
     /**
-     * Adds the given configurations to the set of configuration which this configuration extends from.
+     * Adds the configuration from the given provider to the set of configuration which this configuration extends from.
      * <p>
      * Configurations are only allowed to extend from other configurations in the same project.
      *

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
@@ -169,7 +169,8 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
     /**
      * Adds the configuration from the given provider to the set of configuration which this configuration extends from.
      * <p>
-     * Configurations are only allowed to extend from other configurations in the same project.
+     * Configurations are only allowed to extend from other configurations in the same project.  Note that this method
+     * will retrieve the configuration from the provider at the time this method is called, not lazily.
      *
      * @param configProvider Provider of the super configuration.
      * @return this configuration
@@ -192,6 +193,8 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
     /**
      * Adds the configuration available via the given provider to the set of configurations which this
      * configuration extends from.
+     * <p>
+     * Note that this method will retrieve the configuration from the provider at the time this method is called, not lazily.
      *
      * @param configProvider Provider of the super configuration.
      * @return this configuration

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
@@ -32,6 +32,7 @@ import org.gradle.internal.deprecation.DeprecationLogger;
 
 import javax.annotation.Nullable;
 import java.io.File;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -170,10 +171,37 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      * <p>
      * Configurations are only allowed to extend from other configurations in the same project.
      *
+     * @param configProvider Provider of the super configuration.
+     * @return this configuration
+     *
+     * @since 8.10
+     */
+    @Incubating
+    default Configuration setExtendsFrom(Provider<Configuration> configProvider) {
+        return setExtendsFrom(Collections.singletonList(configProvider.get()));
+    }
+
+    /**
+     * Adds the given configurations to the set of configurations which this configuration extends from.
+     *
      * @param superConfigs The super configurations.
      * @return this configuration
      */
     Configuration extendsFrom(Configuration... superConfigs);
+
+    /**
+     * Adds the configuration available via the given provider to the set of configurations which this
+     * configuration extends from.
+     *
+     * @param configProvider Provider of the super configuration.
+     * @return this configuration
+     *
+     * @since 8.10
+     */
+    @Incubating
+    default Configuration extendsFrom(Provider<Configuration> configProvider) {
+        return extendsFrom(configProvider.get());
+    }
 
     /**
      * Returns the transitivity of this configuration. A transitive configuration contains the transitive closure of its


### PR DESCRIPTION
**Marked team triage to decide if we want to do something like this, or wait to fully implement lazy behavior.**

Fixes #26732.

This does not add new lazy behavior, which would involve many complications.  This just adds porcelain in the API to make using it (the Kotlin DSL especially) easier.