### PR TITLE
Add `@LeaksFileHandles` onto JavaCleanAssemblePerformanceTest

### DIFF
--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaCleanAssemblePerformanceTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaCleanAssemblePerformanceTest.groovy
@@ -23,11 +23,13 @@ import org.gradle.performance.annotations.Scenario
 import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
 import static org.gradle.performance.annotations.ScenarioType.PER_DAY
 import static org.gradle.performance.results.OperatingSystem.LINUX
+import org.gradle.test.fixtures.file.LeaksFileHandles
 
 @RunFor([
     @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject", "mediumJavaCompositeBuild"]),
     @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["mediumJavaPredefinedCompositeBuild"])
 ])
+@LeaksFileHandles("https://github.com/gradle/gradle-private/issues/4245")
 class JavaCleanAssemblePerformanceTest extends AbstractCrossVersionPerformanceTest {
 
     def "clean assemble"() {


### PR DESCRIPTION
See https://github.com/gradle/gradle-private/issues/4245

Also found this in release MQ build: https://builds.gradle.org/buildConfiguration/Gradle_Release_Check_PerformanceTestTestLinuxbucket17/85016355