### PR TITLE
Expose a project's identity path from DomainObjectContext

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -1038,6 +1038,10 @@ class ProblemReportingCrossProjectModelAccess(
             return delegate.projectPath
         }
 
+        override fun getProjectIdentityPath(): Path? {
+            return delegate.projectIdentityPath
+        }
+
         override fun getIdentityPath(): Path {
             return delegate.identityPath
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DomainObjectContext.java
@@ -43,6 +43,12 @@ public interface DomainObjectContext {
     Path getProjectPath();
 
     /**
+     * If this context represents a project, its identity path.
+     */
+    @Nullable
+    Path getProjectIdentityPath();
+
+    /**
      * If this context represents a project, the project.
      */
     @Nullable

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/RootScriptDomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/RootScriptDomainObjectContext.java
@@ -57,6 +57,12 @@ public class RootScriptDomainObjectContext implements DomainObjectContext, Model
 
     @Nullable
     @Override
+    public Path getProjectIdentityPath() {
+        return null;
+    }
+
+    @Nullable
+    @Override
     public ProjectInternal getProject() {
         return null;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -608,6 +608,12 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
         return owner.getProjectPath();
     }
 
+    @Nullable
+    @Override
+    public Path getProjectIdentityPath() {
+        return getIdentityPath();
+    }
+
     @Override
     public ModelContainer<ProjectInternal> getModel() {
         return getOwner();
@@ -1553,6 +1559,12 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
         @Nullable
         public ProjectInternal getProject() {
             return delegate.getProject();
+        }
+
+        @Nullable
+        @Override
+        public Path getProjectIdentityPath() {
+            return delegate.getProjectIdentityPath();
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -353,6 +353,12 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
 
         @Nullable
         @Override
+        public Path getProjectIdentityPath() {
+            return delegate.getProjectIdentityPath();
+        }
+
+        @Nullable
+        @Override
         public ProjectInternal getProject() {
             return delegate.getProject();
         }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
@@ -152,36 +152,42 @@ class DefaultProjectSpec extends Specification {
         rootProject.path == ":"
         rootProject.buildTreePath == ':'
         rootProject.identityPath == Path.ROOT
+        rootProject.projectIdentityPath == rootProject.identityPath
 
         child1.toString() == "project ':child1'"
         child1.displayName == "project ':child1'"
         child1.path == ":child1"
         child1.buildTreePath == ":child1"
         child1.identityPath == Path.path(":child1")
+        child1.projectIdentityPath == child1.identityPath
 
         child2.toString() == "project ':child1:child2'"
         child2.displayName == "project ':child1:child2'"
         child2.path == ":child1:child2"
         child2.buildTreePath == ":child1:child2"
         child2.identityPath == Path.path(":child1:child2")
+        child2.projectIdentityPath == child2.identityPath
 
         nestedRootProject.toString() == "project ':nested'"
         nestedRootProject.displayName == "project ':nested'"
         nestedRootProject.path == ":"
         nestedRootProject.buildTreePath == ":nested"
         nestedRootProject.identityPath == Path.path(":nested")
+        nestedRootProject.projectIdentityPath == nestedRootProject.identityPath
 
         nestedChild1.toString() == "project ':nested:child1'"
         nestedChild1.displayName == "project ':nested:child1'"
         nestedChild1.path == ":child1"
         nestedChild1.buildTreePath == ":nested:child1"
         nestedChild1.identityPath == Path.path(":nested:child1")
+        nestedChild1.projectIdentityPath == nestedChild1.identityPath
 
         nestedChild2.toString() == "project ':nested:child1:child2'"
         nestedChild2.displayName == "project ':nested:child1:child2'"
         nestedChild2.path == ":child1:child2"
         nestedChild2.buildTreePath == ":nested:child1:child2"
         nestedChild2.identityPath == Path.path(":nested:child1:child2")
+        nestedChild2.projectIdentityPath == nestedChild2.identityPath
     }
 
     def "isolated project view preserves the path and build tree path"() {


### PR DESCRIPTION
This is necessary to uniquely identity a domain object context, if that domain object context is a project.

### Reviewing cheatsheet

Fixes #29893

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
