### PR TITLE
Polish `:configuration-cache`

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeIO.kt
@@ -23,7 +23,6 @@ import org.gradle.internal.cc.impl.cacheentry.EntryDetails
 import org.gradle.internal.cc.impl.cacheentry.ModelKey
 import org.gradle.internal.cc.impl.serialize.Codecs
 import org.gradle.internal.serialize.graph.CloseableWriteContext
-import org.gradle.internal.serialize.graph.DefaultReadContext
 import org.gradle.internal.serialize.graph.MutableReadContext
 import org.gradle.util.Path
 import java.io.InputStream
@@ -61,7 +60,7 @@ interface ConfigurationCacheBuildTreeIO : ConfigurationCacheOperationIO {
     /**
      * @param profile the unique name associated with the output stream for debugging space usage issues
      */
-    fun writerContextFor(stateType: StateType, outputStream: () -> OutputStream, profile: () -> String): Pair<CloseableWriteContext, Codecs>
+    fun writeContextFor(stateType: StateType, outputStream: () -> OutputStream, profile: () -> String): Pair<CloseableWriteContext, Codecs>
 
     fun <R> withReadContextFor(
         stateType: StateType,

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeIO.kt
@@ -22,8 +22,9 @@ import org.gradle.internal.buildtree.BuildTreeWorkGraph
 import org.gradle.internal.cc.impl.cacheentry.EntryDetails
 import org.gradle.internal.cc.impl.cacheentry.ModelKey
 import org.gradle.internal.cc.impl.serialize.Codecs
+import org.gradle.internal.serialize.graph.CloseableWriteContext
 import org.gradle.internal.serialize.graph.DefaultReadContext
-import org.gradle.internal.serialize.graph.DefaultWriteContext
+import org.gradle.internal.serialize.graph.MutableReadContext
 import org.gradle.util.Path
 import java.io.InputStream
 import java.io.OutputStream
@@ -60,11 +61,11 @@ interface ConfigurationCacheBuildTreeIO : ConfigurationCacheOperationIO {
     /**
      * @param profile the unique name associated with the output stream for debugging space usage issues
      */
-    fun writerContextFor(stateType: StateType, outputStream: () -> OutputStream, profile: () -> String): Pair<DefaultWriteContext, Codecs>
+    fun writerContextFor(stateType: StateType, outputStream: () -> OutputStream, profile: () -> String): Pair<CloseableWriteContext, Codecs>
 
     fun <R> withReadContextFor(
         stateType: StateType,
         inputStream: () -> InputStream,
-        readOperation: suspend DefaultReadContext.(Codecs) -> R
+        readOperation: suspend MutableReadContext.(Codecs) -> R
     ): R
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
@@ -66,8 +66,7 @@ import org.gradle.internal.file.FileSystemDefaultExcludesProvider
 import org.gradle.internal.flow.services.BuildFlowScope
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter
 import org.gradle.internal.scopeids.id.BuildInvocationScopeId
-import org.gradle.internal.serialize.graph.DefaultReadContext
-import org.gradle.internal.serialize.graph.DefaultWriteContext
+import org.gradle.internal.serialize.graph.MutableReadContext
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext
 import org.gradle.internal.serialize.graph.logNotImplemented
@@ -156,14 +155,14 @@ class ConfigurationCacheState(
      * Writes the state for the whole build starting from the given root [build] and returns the set
      * of stored included build directories.
      */
-    suspend fun DefaultWriteContext.writeRootBuildState(build: VintageGradleBuild) {
+    suspend fun WriteContext.writeRootBuildState(build: VintageGradleBuild) {
         writeBuildInvocationId()
         writeRootBuild(build).also {
             writeInt(0x1ecac8e)
         }
     }
 
-    suspend fun DefaultReadContext.readRootBuildState(
+    suspend fun MutableReadContext.readRootBuildState(
         graph: BuildTreeWorkGraph,
         graphBuilder: BuildTreeWorkGraphBuilder?,
         loadAfterStore: Boolean
@@ -183,12 +182,12 @@ class ConfigurationCacheState(
     }
 
     private
-    fun DefaultWriteContext.writeBuildInvocationId() {
+    fun WriteContext.writeBuildInvocationId() {
         writeString(host.service<BuildInvocationScopeId>().id.asString())
     }
 
     private
-    fun DefaultReadContext.readBuildInvocationId(): String =
+    fun ReadContext.readBuildInvocationId(): String =
         readString()
 
     private
@@ -252,7 +251,7 @@ class ConfigurationCacheState(
         host.service<BuildState>()
 
     private
-    suspend fun DefaultWriteContext.writeRootBuild(rootBuild: VintageGradleBuild) {
+    suspend fun WriteContext.writeRootBuild(rootBuild: VintageGradleBuild) {
         require(rootBuild.gradle.owner is RootBuildState)
         val gradle = rootBuild.gradle
         withDebugFrame({ "Gradle" }) {
@@ -264,7 +263,7 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultReadContext.readRootBuild(): List<CachedBuildState> {
+    suspend fun MutableReadContext.readRootBuild(): List<CachedBuildState> {
         val settingsFile = read() as File?
         val rootBuild = host.createBuild(settingsFile)
         val gradle = rootBuild.gradle
@@ -273,7 +272,7 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultWriteContext.writeBuildsInTree(rootBuild: VintageGradleBuild, buildEventListeners: List<RegisteredBuildServiceProvider<*, *>>) {
+    suspend fun WriteContext.writeBuildsInTree(rootBuild: VintageGradleBuild, buildEventListeners: List<RegisteredBuildServiceProvider<*, *>>) {
         val requiredBuildServicesPerBuild = buildEventListeners.groupBy { it.buildIdentifier }
         val builds = mutableMapOf<BuildState, BuildToStore>()
         host.visitBuilds { build ->
@@ -294,14 +293,14 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultReadContext.readBuildsInTree(rootBuild: ConfigurationCacheBuild): List<CachedBuildState> {
+    suspend fun MutableReadContext.readBuildsInTree(rootBuild: ConfigurationCacheBuild): List<CachedBuildState> {
         return readList {
             readBuildState(rootBuild)
         }
     }
 
     private
-    suspend fun DefaultWriteContext.writeBuildState(build: BuildToStore, buildTreeState: StoredBuildTreeState, rootBuild: VintageGradleBuild) {
+    suspend fun WriteContext.writeBuildState(build: BuildToStore, buildTreeState: StoredBuildTreeState, rootBuild: VintageGradleBuild) {
         val state = build.build.state
         when {
             !build.hasWork && !build.hasChildren -> {
@@ -331,7 +330,7 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultReadContext.readBuildState(rootBuild: ConfigurationCacheBuild): CachedBuildState {
+    suspend fun MutableReadContext.readBuildState(rootBuild: ConfigurationCacheBuild): CachedBuildState {
         return when (readEnum<BuildType>()) {
             BuildType.BuildWithNoWork -> readBuildWithNoWork(rootBuild)
             BuildType.RootBuild -> readBuildContent(rootBuild)
@@ -341,7 +340,7 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultWriteContext.writeIncludedBuild(state: IncludedBuildState, buildTreeState: StoredBuildTreeState) {
+    suspend fun WriteContext.writeIncludedBuild(state: IncludedBuildState, buildTreeState: StoredBuildTreeState) {
         val gradle = state.mutableModel
         withGradleIsolate(gradle, userTypesCodec) {
             write(gradle.settings.settingsScript.resource.file)
@@ -358,7 +357,7 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultReadContext.readIncludedBuild(rootBuild: ConfigurationCacheBuild): CachedBuildState {
+    suspend fun ReadContext.readIncludedBuild(rootBuild: ConfigurationCacheBuild): CachedBuildState {
         val build = withGradleIsolate(rootBuild.gradle, userTypesCodec) {
             val settingsFile = read() as File?
             val definition = readIncludedBuildDefinition(rootBuild)
@@ -378,7 +377,7 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultWriteContext.writeBuildSrcBuild(state: StandAloneNestedBuild, buildTreeState: StoredBuildTreeState) {
+    suspend fun WriteContext.writeBuildSrcBuild(state: StandAloneNestedBuild, buildTreeState: StoredBuildTreeState) {
         val gradle = state.mutableModel
         withGradleIsolate(gradle, userTypesCodec) {
             write(state.owner.buildIdentifier)
@@ -393,7 +392,7 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultReadContext.readBuildSrcBuild(rootBuild: ConfigurationCacheBuild): CachedBuildState {
+    suspend fun ReadContext.readBuildSrcBuild(rootBuild: ConfigurationCacheBuild): CachedBuildState {
         val build = withGradleIsolate(rootBuild.gradle, userTypesCodec) {
             val ownerIdentifier = readNonNull<BuildIdentifier>()
             rootBuild.getBuildSrcOf(ownerIdentifier)
@@ -412,7 +411,7 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultWriteContext.writeBuildWithNoWork(state: BuildState, rootBuild: VintageGradleBuild) {
+    suspend fun WriteContext.writeBuildWithNoWork(state: BuildState, rootBuild: VintageGradleBuild) {
         withGradleIsolate(rootBuild.gradle, userTypesCodec) {
             writeString(state.identityPath.path)
             if (state.isProjectsCreated) {
@@ -428,7 +427,7 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultReadContext.readBuildWithNoWork(rootBuild: ConfigurationCacheBuild) =
+    suspend fun ReadContext.readBuildWithNoWork(rootBuild: ConfigurationCacheBuild) =
         withGradleIsolate(rootBuild.gradle, userTypesCodec) {
             val identityPath = Path.path(readString())
             val hasProjects = readBoolean()
@@ -442,7 +441,7 @@ class ConfigurationCacheState(
         }
 
     internal
-    suspend fun DefaultWriteContext.writeBuildContent(build: VintageGradleBuild, buildTreeState: StoredBuildTreeState) {
+    suspend fun WriteContext.writeBuildContent(build: VintageGradleBuild, buildTreeState: StoredBuildTreeState) {
         val gradle = build.gradle
         val state = build.state
         if (state.isProjectsCreated) {
@@ -469,7 +468,7 @@ class ConfigurationCacheState(
     }
 
     internal
-    suspend fun DefaultReadContext.readBuildContent(build: ConfigurationCacheBuild): CachedBuildState {
+    suspend fun MutableReadContext.readBuildContent(build: ConfigurationCacheBuild): CachedBuildState {
         val gradle = build.gradle
         if (readBoolean()) {
             readGradleState(build)
@@ -492,14 +491,14 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultWriteContext.writeWorkGraphOf(gradle: GradleInternal, scheduledWork: ScheduledWork) {
+    suspend fun WriteContext.writeWorkGraphOf(gradle: GradleInternal, scheduledWork: ScheduledWork) {
         workNodeCodec(gradle).run {
             writeWork(scheduledWork)
         }
     }
 
     private
-    suspend fun DefaultReadContext.readWorkGraph(gradle: GradleInternal) =
+    suspend fun ReadContext.readWorkGraph(gradle: GradleInternal) =
         workNodeCodec(gradle).run {
             readWork()
         }
@@ -513,7 +512,7 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultReadContext.readFlowScopeOf(gradle: GradleInternal) {
+    suspend fun ReadContext.readFlowScopeOf(gradle: GradleInternal) {
         withIsolate(IsolateOwners.OwnerFlowScope(gradle), userTypesCodec) {
             buildFlowScopeOf(gradle).load(readNonNull())
         }
@@ -528,7 +527,7 @@ class ConfigurationCacheState(
         codecs.workNodeCodecFor(gradle)
 
     private
-    suspend fun DefaultWriteContext.writeRequiredBuildServicesOf(build: BuildState, buildTreeState: StoredBuildTreeState) {
+    suspend fun WriteContext.writeRequiredBuildServicesOf(build: BuildState, buildTreeState: StoredBuildTreeState) {
         withGradleIsolate(build.mutableModel, userTypesCodec) {
             val providers = buildTreeState.requiredBuildServicesPerBuild[build.buildIdentifier] ?: emptyList()
             writeCollection(providers) { listener ->
@@ -538,7 +537,7 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultReadContext.readRequiredBuildServicesOf(gradle: GradleInternal) {
+    suspend fun ReadContext.readRequiredBuildServicesOf(gradle: GradleInternal) {
         val eventListenerRegistry by lazy { gradle.serviceOf<BuildEventListenerRegistryInternal>() }
         withGradleIsolate(gradle, userTypesCodec) {
             readCollection {
@@ -548,12 +547,12 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultWriteContext.writeBuildEventListenerSubscription(listener: Provider<*>) {
+    suspend fun WriteContext.writeBuildEventListenerSubscription(listener: Provider<*>) {
         write(listener)
     }
 
     private
-    suspend fun DefaultReadContext.readBuildEventListenerSubscription(eventListenerRegistry: BuildEventListenerRegistryInternal) {
+    suspend fun ReadContext.readBuildEventListenerSubscription(eventListenerRegistry: BuildEventListenerRegistryInternal) {
         val listener = readNonNull<Provider<*>>()
         eventListenerRegistry.subscribe(listener)
     }
@@ -569,7 +568,7 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultWriteContext.writeBuildTreeScopedState(gradle: GradleInternal) {
+    suspend fun WriteContext.writeBuildTreeScopedState(gradle: GradleInternal) {
         withGradleIsolate(gradle, userTypesCodec) {
             withDebugFrame({ "environment state" }) {
                 writeCachedEnvironmentState(gradle)
@@ -589,7 +588,7 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultReadContext.readBuildTreeScopedState(gradle: GradleInternal) {
+    suspend fun ReadContext.readBuildTreeScopedState(gradle: GradleInternal) {
         withGradleIsolate(gradle, userTypesCodec) {
             readCachedEnvironmentState(gradle)
             readPreviewFlags(gradle)
@@ -603,7 +602,7 @@ class ConfigurationCacheState(
     }
 
     private
-    fun DefaultWriteContext.writeGradleState(gradle: GradleInternal) {
+    fun WriteContext.writeGradleState(gradle: GradleInternal) {
         withGradleIsolate(gradle, userTypesCodec) {
             // per build
             writeStartParameterOf(gradle)
@@ -612,7 +611,7 @@ class ConfigurationCacheState(
     }
 
     private
-    fun DefaultReadContext.readGradleState(
+    fun ReadContext.readGradleState(
         build: ConfigurationCacheBuild
     ) {
         val gradle = build.gradle
@@ -624,13 +623,13 @@ class ConfigurationCacheState(
     }
 
     private
-    fun DefaultWriteContext.writeStartParameterOf(gradle: GradleInternal) {
+    fun WriteContext.writeStartParameterOf(gradle: GradleInternal) {
         val startParameterTaskNames = gradle.startParameter.taskNames
         writeStrings(startParameterTaskNames)
     }
 
     private
-    fun DefaultReadContext.readStartParameterOf(gradle: GradleInternal) {
+    fun ReadContext.readStartParameterOf(gradle: GradleInternal) {
         // Restore startParameter.taskNames to enable `gradle.startParameter.setTaskNames(...)` idiom in included build scripts
         // See org/gradle/caching/configuration/internal/BuildCacheCompositeConfigurationIntegrationTest.groovy:134
         val startParameterTaskNames = readStrings()
@@ -638,7 +637,7 @@ class ConfigurationCacheState(
     }
 
     private
-    fun DefaultWriteContext.writeChildBuilds(gradle: GradleInternal) {
+    fun WriteContext.writeChildBuilds(gradle: GradleInternal) {
         if (gradle.serviceOf<VcsMappingsStore>().asResolver().hasRules()) {
             logNotImplemented(
                 feature = "source dependencies",
@@ -651,7 +650,7 @@ class ConfigurationCacheState(
     }
 
     private
-    fun DefaultReadContext.readChildBuilds() {
+    fun ReadContext.readChildBuilds() {
         if (readBoolean()) {
             logNotImplemented(
                 feature = "source dependencies",
@@ -661,7 +660,7 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultWriteContext.writeBuildDefinition(buildDefinition: BuildDefinition) {
+    suspend fun WriteContext.writeBuildDefinition(buildDefinition: BuildDefinition) {
         buildDefinition.run {
             writeString(name!!)
             write(buildRootDir)
@@ -671,7 +670,7 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultReadContext.readIncludedBuildDefinition(parentBuild: ConfigurationCacheBuild): BuildDefinition {
+    suspend fun ReadContext.readIncludedBuildDefinition(parentBuild: ConfigurationCacheBuild): BuildDefinition {
         val includedBuildName = readString()
         val includedBuildRootDir: File? = read()?.uncheckedCast()
         val fromBuild = readNonNull<PublicBuildPath>()
@@ -688,20 +687,20 @@ class ConfigurationCacheState(
     }
 
     private
-    fun DefaultWriteContext.writeFileSystemDefaultExcludes(gradle: GradleInternal) {
+    fun WriteContext.writeFileSystemDefaultExcludes(gradle: GradleInternal) {
         val fileSystemDefaultExcludesProvider = gradle.serviceOf<FileSystemDefaultExcludesProvider>()
         val currentDefaultExcludes = fileSystemDefaultExcludesProvider.currentDefaultExcludes
         writeStrings(currentDefaultExcludes.toList())
     }
 
     private
-    fun DefaultReadContext.readFileSystemDefaultExcludes(gradle: GradleInternal) {
+    fun ReadContext.readFileSystemDefaultExcludes(gradle: GradleInternal) {
         val defaultExcludes = readStringsSet()
         gradle.serviceOf<FileSystemDefaultExcludesProvider>().updateCurrentDefaultExcludes(defaultExcludes)
     }
 
     private
-    suspend fun DefaultWriteContext.writeBuildCacheConfiguration(gradle: GradleInternal) {
+    suspend fun WriteContext.writeBuildCacheConfiguration(gradle: GradleInternal) {
         gradle.settings.buildCache.let { buildCache ->
             write(buildCache.local)
             write(buildCache.remote)
@@ -710,7 +709,7 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultReadContext.readBuildCacheConfiguration(gradle: GradleInternal) {
+    suspend fun ReadContext.readBuildCacheConfiguration(gradle: GradleInternal) {
         gradle.settings.buildCache.let { buildCache ->
             buildCache.local = readNonNull()
             buildCache.remote = read() as BuildCache?
@@ -720,7 +719,7 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultWriteContext.writeCacheConfigurations(gradle: GradleInternal) {
+    suspend fun WriteContext.writeCacheConfigurations(gradle: GradleInternal) {
         gradle.settings.caches.let { cacheConfigurations ->
             write(cacheConfigurations.releasedWrappers.removeUnusedEntriesOlderThan)
             write(cacheConfigurations.snapshotWrappers.removeUnusedEntriesOlderThan)
@@ -733,7 +732,7 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultReadContext.readCacheConfigurations(gradle: GradleInternal) {
+    suspend fun ReadContext.readCacheConfigurations(gradle: GradleInternal) {
         gradle.settings.caches.let { cacheConfigurations ->
             cacheConfigurations.releasedWrappers.removeUnusedEntriesOlderThan.value(readNonNull<Provider<Long>>())
             cacheConfigurations.snapshotWrappers.removeUnusedEntriesOlderThan.value(readNonNull<Provider<Long>>())
@@ -749,7 +748,7 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultWriteContext.writeBuildOutputCleanupRegistrations(gradle: GradleInternal) {
+    suspend fun WriteContext.writeBuildOutputCleanupRegistrations(gradle: GradleInternal) {
         val buildOutputCleanupRegistry = gradle.serviceOf<BuildOutputCleanupRegistry>()
         withGradleIsolate(gradle, userTypesCodec) {
             writeCollection(buildOutputCleanupRegistry.registeredOutputs)
@@ -757,7 +756,7 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultReadContext.readBuildOutputCleanupRegistrations(gradle: GradleInternal) {
+    suspend fun ReadContext.readBuildOutputCleanupRegistrations(gradle: GradleInternal) {
         val buildOutputCleanupRegistry = gradle.serviceOf<BuildOutputCleanupRegistry>()
         withGradleIsolate(gradle, userTypesCodec) {
             readCollection {
@@ -768,27 +767,27 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultWriteContext.writeCachedEnvironmentState(gradle: GradleInternal) {
+    suspend fun WriteContext.writeCachedEnvironmentState(gradle: GradleInternal) {
         val environmentChangeTracker = gradle.serviceOf<ConfigurationCacheEnvironmentChangeTracker>()
         write(environmentChangeTracker.getCachedState())
     }
 
     private
-    suspend fun DefaultReadContext.readCachedEnvironmentState(gradle: GradleInternal) {
+    suspend fun ReadContext.readCachedEnvironmentState(gradle: GradleInternal) {
         val environmentChangeTracker = gradle.serviceOf<ConfigurationCacheEnvironmentChangeTracker>()
         val storedState = read() as ConfigurationCacheEnvironmentChangeTracker.CachedEnvironmentState
         environmentChangeTracker.loadFrom(storedState)
     }
 
     private
-    suspend fun DefaultWriteContext.writePreviewFlags(gradle: GradleInternal) {
+    suspend fun WriteContext.writePreviewFlags(gradle: GradleInternal) {
         val featureFlags = gradle.serviceOf<FeatureFlags>()
         val enabledFeatures = FeaturePreviews.Feature.values().filter { featureFlags.isEnabledWithApi(it) }
         writeCollection(enabledFeatures)
     }
 
     private
-    suspend fun DefaultReadContext.readPreviewFlags(gradle: GradleInternal) {
+    suspend fun ReadContext.readPreviewFlags(gradle: GradleInternal) {
         val featureFlags = gradle.serviceOf<FeatureFlags>()
         readCollection {
             val enabledFeature = read() as FeaturePreviews.Feature
@@ -797,7 +796,7 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultWriteContext.writeGradleEnterprisePluginManager(gradle: GradleInternal) {
+    suspend fun WriteContext.writeGradleEnterprisePluginManager(gradle: GradleInternal) {
         val manager = gradle.serviceOf<GradleEnterprisePluginManager>()
         val adapter = manager.adapter
         val writtenAdapter = adapter?.takeIf {
@@ -807,7 +806,7 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultReadContext.readGradleEnterprisePluginManager(gradle: GradleInternal) {
+    suspend fun ReadContext.readGradleEnterprisePluginManager(gradle: GradleInternal) {
         val adapter = read() as GradleEnterprisePluginAdapter?
         if (adapter != null) {
             val manager = gradle.serviceOf<GradleEnterprisePluginManager>()

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -504,7 +504,7 @@ class DefaultConfigurationCache internal constructor(
             store.assignSpoolFile(StateType.BuildFingerprint),
             store.assignSpoolFile(StateType.ProjectFingerprint)
         ) { stateFile ->
-            cacheFingerprintWriterContextFor(stateFile.stateType, stateFile.file::outputStream) {
+            cacheFingerprintWriteContextFor(stateFile.stateType, stateFile.file::outputStream) {
                 profileNameFor(stateFile)
             }
         }
@@ -517,12 +517,12 @@ class DefaultConfigurationCache internal constructor(
         }.drop(1)
 
     private
-    fun cacheFingerprintWriterContextFor(
+    fun cacheFingerprintWriteContextFor(
         stateType: StateType,
         outputStream: () -> OutputStream,
         profile: () -> String
     ): CloseableWriteContext {
-        val (context, codecs) = cacheIO.writerContextFor(stateType, outputStream, profile)
+        val (context, codecs) = cacheIO.writeContextFor(stateType, outputStream, profile)
         return context.apply {
             push(IsolateOwners.OwnerHost(host), codecs.fingerprintTypesCodec())
         }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -51,7 +51,7 @@ import org.gradle.internal.extensions.stdlib.toDefaultLowerCase
 import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.model.CalculatedValueContainerFactory
 import org.gradle.internal.operations.BuildOperationRunner
-import org.gradle.internal.serialize.graph.DefaultWriteContext
+import org.gradle.internal.serialize.graph.CloseableWriteContext
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.withIsolate
 import org.gradle.internal.vfs.FileSystemAccess
@@ -355,7 +355,7 @@ class DefaultConfigurationCache internal constructor(
     private
     fun CompositeStoppable.addIfInitialized(closeable: Lazy<*>) {
         if (closeable.isInitialized()) {
-            add(closeable.value)
+            add(closeable.value!!)
         }
     }
 
@@ -521,7 +521,7 @@ class DefaultConfigurationCache internal constructor(
         stateType: StateType,
         outputStream: () -> OutputStream,
         profile: () -> String
-    ): DefaultWriteContext {
+    ): CloseableWriteContext {
         val (context, codecs) = cacheIO.writerContextFor(stateType, outputStream, profile)
         return context.apply {
             push(IsolateOwners.OwnerHost(host), codecs.fingerprintTypesCodec())

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
@@ -216,7 +216,7 @@ class DefaultConfigurationCacheIO internal constructor(
         stateFile: ConfigurationCacheStateFile,
         action: suspend WriteContext.(ConfigurationCacheState) -> T
     ): T {
-        val (context, codecs) = writerContextFor(stateFile.stateType, stateFile::outputStream) {
+        val (context, codecs) = writeContextFor(stateFile.stateType, stateFile::outputStream) {
             host.currentBuild.gradle.owner.displayName.displayName + " state"
         }
         return context.useToRun {
@@ -245,7 +245,7 @@ class DefaultConfigurationCacheIO internal constructor(
     /**
      * @param profile the unique name associated with the output stream for debugging space usage issues
      */
-    override fun writerContextFor(
+    override fun writeContextFor(
         stateType: StateType,
         outputStream: () -> OutputStream,
         profile: () -> String
@@ -285,12 +285,12 @@ class DefaultConfigurationCacheIO internal constructor(
     }
 
     override fun <T> runWriteOperation(encoder: Encoder, writeOperation: suspend WriteContext.(codecs: Codecs) -> T): T {
-        val (context, codecs) = writerContextFor(encoder)
+        val (context, codecs) = writeContextFor(encoder)
         return context.runWriteOperation { writeOperation(codecs) }
     }
 
     private
-    fun writerContextFor(encoder: Encoder): Pair<CloseableWriteContext, Codecs> =
+    fun writeContextFor(encoder: Encoder): Pair<CloseableWriteContext, Codecs> =
         writeContextFor(
             encoder,
             null,
@@ -302,7 +302,7 @@ class DefaultConfigurationCacheIO internal constructor(
         inputStream: () -> InputStream,
         readOperation: suspend MutableReadContext.(Codecs) -> R
     ): R =
-        readerContextFor(KryoBackedDecoder(inputStreamFor(stateType, inputStream)))
+        readContextFor(KryoBackedDecoder(inputStreamFor(stateType, inputStream)))
             .let { (context, codecs) ->
                 context.useToRun {
                     runReadOperation {
@@ -314,12 +314,12 @@ class DefaultConfigurationCacheIO internal constructor(
             }
 
     override fun <T> runReadOperation(decoder: Decoder, readOperation: suspend ReadContext.(codecs: Codecs) -> T): T {
-        val (context, codecs) = readerContextFor(decoder)
+        val (context, codecs) = readContextFor(decoder)
         return context.runReadOperation { readOperation(codecs) }
     }
 
     private
-    fun readerContextFor(
+    fun readContextFor(
         decoder: Decoder,
     ) = readContextFor(decoder, codecs) to codecs
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
@@ -348,8 +348,7 @@ class DefaultConfigurationCacheIO internal constructor(
         beanStateReaderLookup,
         logger,
         problems,
-        DefaultClassDecoder(),
-        javaClass.classLoader
+        DefaultClassDecoder()
     )
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -103,18 +103,31 @@ class ConfigurationCacheFingerprintController internal constructor(
 
     private
     val fileCollectionFingerprinter =
-        fingerprinterRegistry.getFingerprinter(DefaultFileNormalizationSpec.from(InputNormalizer.ABSOLUTE_PATH, DirectorySensitivity.DEFAULT, LineEndingSensitivity.DEFAULT))
+        fingerprinterRegistry.getFingerprinter(
+            DefaultFileNormalizationSpec.from(
+                InputNormalizer.ABSOLUTE_PATH,
+                DirectorySensitivity.DEFAULT,
+                LineEndingSensitivity.DEFAULT
+            )
+        )
 
     private
     abstract class WritingState {
 
-        open fun maybeStart(buildScopedSpoolFile: StateFile, projectScopedSpoolFile: StateFile, writeContextForOutputStream: (StateFile) -> CloseableWriteContext): WritingState =
+        open fun maybeStart(
+            buildScopedSpoolFile: StateFile,
+            projectScopedSpoolFile: StateFile,
+            writeContextForOutputStream: (StateFile) -> CloseableWriteContext
+        ): WritingState =
             illegalStateFor("start")
 
         open fun pause(): WritingState =
             illegalStateFor("pause")
 
-        open fun commit(buildScopedFingerprint: ConfigurationCacheStateFile, projectScopedFingerprint: ConfigurationCacheStateFile): WritingState =
+        open fun commit(
+            buildScopedFingerprint: ConfigurationCacheStateFile,
+            projectScopedFingerprint: ConfigurationCacheStateFile
+        ): WritingState =
             illegalStateFor("commit")
 
         open fun append(fingerprint: ProjectSpecificFingerprint): Unit =
@@ -136,7 +149,11 @@ class ConfigurationCacheFingerprintController internal constructor(
 
     private
     inner class Idle : WritingState() {
-        override fun maybeStart(buildScopedSpoolFile: StateFile, projectScopedSpoolFile: StateFile, writeContextForOutputStream: (StateFile) -> CloseableWriteContext): WritingState {
+        override fun maybeStart(
+            buildScopedSpoolFile: StateFile,
+            projectScopedSpoolFile: StateFile,
+            writeContextForOutputStream: (StateFile) -> CloseableWriteContext
+        ): WritingState {
 
             val fingerprintWriter = ConfigurationCacheFingerprintWriter(
                 CacheFingerprintWriterHost(),
@@ -167,7 +184,11 @@ class ConfigurationCacheFingerprintController internal constructor(
         private val buildScopedSpoolFile: StateFile,
         private val projectScopedSpoolFile: StateFile
     ) : WritingState() {
-        override fun maybeStart(buildScopedSpoolFile: StateFile, projectScopedSpoolFile: StateFile, writeContextForOutputStream: (StateFile) -> CloseableWriteContext): WritingState {
+        override fun maybeStart(
+            buildScopedSpoolFile: StateFile,
+            projectScopedSpoolFile: StateFile,
+            writeContextForOutputStream: (StateFile) -> CloseableWriteContext
+        ): WritingState {
             return this
         }
 
@@ -194,7 +215,11 @@ class ConfigurationCacheFingerprintController internal constructor(
         private val buildScopedSpoolFile: StateFile,
         private val projectScopedSpoolFile: StateFile
     ) : WritingState() {
-        override fun maybeStart(buildScopedSpoolFile: StateFile, projectScopedSpoolFile: StateFile, writeContextForOutputStream: (StateFile) -> CloseableWriteContext): WritingState {
+        override fun maybeStart(
+            buildScopedSpoolFile: StateFile,
+            projectScopedSpoolFile: StateFile,
+            writeContextForOutputStream: (StateFile) -> CloseableWriteContext
+        ): WritingState {
             addListener(fingerprintWriter)
             // Continue with the current spool file, rather than starting a new one
             return Writing(fingerprintWriter, this.buildScopedSpoolFile, this.projectScopedSpoolFile)
@@ -208,7 +233,10 @@ class ConfigurationCacheFingerprintController internal constructor(
             fingerprintWriter.append(fingerprint)
         }
 
-        override fun commit(buildScopedFingerprint: ConfigurationCacheStateFile, projectScopedFingerprint: ConfigurationCacheStateFile): WritingState {
+        override fun commit(
+            buildScopedFingerprint: ConfigurationCacheStateFile,
+            projectScopedFingerprint: ConfigurationCacheStateFile
+        ): WritingState {
             closeStreams()
             buildScopedFingerprint.moveFrom(buildScopedSpoolFile.file)
             projectScopedFingerprint.moveFrom(projectScopedSpoolFile.file)
@@ -250,7 +278,11 @@ class ConfigurationCacheFingerprintController internal constructor(
     // Start fingerprinting if not already started and not already committed
     // This should be strict but currently this method may be called multiple times when a
     // build invocation both runs tasks and queries models
-    fun maybeStartCollectingFingerprint(buildScopedSpoolFile: StateFile, projectScopedSpoolFile: StateFile, writeContextForOutputStream: (StateFile) -> CloseableWriteContext) {
+    fun maybeStartCollectingFingerprint(
+        buildScopedSpoolFile: StateFile,
+        projectScopedSpoolFile: StateFile,
+        writeContextForOutputStream: (StateFile) -> CloseableWriteContext
+    ) {
         writingState = writingState.maybeStart(buildScopedSpoolFile, projectScopedSpoolFile, writeContextForOutputStream)
     }
 
@@ -258,7 +290,10 @@ class ConfigurationCacheFingerprintController internal constructor(
         writingState = writingState.pause()
     }
 
-    fun commitFingerprintTo(buildScopedFingerprint: ConfigurationCacheStateFile, projectScopedFingerprint: ConfigurationCacheStateFile) {
+    fun commitFingerprintTo(
+        buildScopedFingerprint: ConfigurationCacheStateFile,
+        projectScopedFingerprint: ConfigurationCacheStateFile
+    ) {
         writingState = writingState.commit(buildScopedFingerprint, projectScopedFingerprint)
     }
 
@@ -346,10 +381,11 @@ class ConfigurationCacheFingerprintController internal constructor(
         override val ignoredFileSystemCheckInputs: String?
             get() = startParameter.ignoredFileSystemCheckInputs
 
-        override fun hashCodeOf(file: File) =
+        override fun hashCodeOf(file: File): HashCode =
             fileSystemAccess.read(file.absolutePath).hash
 
-        override fun hashCodeOfDirectoryChildrenNames(file: File): HashCode = directoryChildrenNamesHash(file)
+        override fun hashCodeOfDirectoryChildrenNames(file: File): HashCode =
+            directoryChildrenNamesHash(file)
 
         override fun displayNameOf(file: File): String =
             GFileUtils.relativePathOf(file, rootDirectory)
@@ -360,8 +396,18 @@ class ConfigurationCacheFingerprintController internal constructor(
         override fun reportInput(input: PropertyProblem) =
             report.onInput(input)
 
-        override fun reportProblem(exception: Throwable?, documentationSection: DocumentationSection?, message: StructuredMessageBuilder) =
-            problems.onProblem(problemFactory.problem(StructuredMessage.build(message), exception, documentationSection))
+        override fun reportProblem(
+            exception: Throwable?,
+            documentationSection: DocumentationSection?,
+            message: StructuredMessageBuilder
+        ) =
+            problems.onProblem(
+                problemFactory.problem(
+                    StructuredMessage.build(message),
+                    exception,
+                    documentationSection
+                )
+            )
 
         override fun location(consumer: String?) =
             problemFactory.locationForCaller(consumer)
@@ -414,7 +460,8 @@ class ConfigurationCacheFingerprintController internal constructor(
         override fun hashCodeAndTypeOf(file: File): Pair<HashCode, FileType> =
             fileSystemAccess.read(file.absolutePath).let { it.hash to it.type }
 
-        override fun hashCodeOfDirectoryContent(file: File): HashCode = directoryChildrenNamesHash(file)
+        override fun hashCodeOfDirectoryContent(file: File): HashCode =
+            directoryChildrenNamesHash(file)
 
         override fun fingerprintOf(fileCollection: FileCollectionInternal): HashCode =
             fileCollectionFingerprinter.fingerprint(fileCollection).hash

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -27,7 +27,6 @@ import org.gradle.internal.cc.base.services.ConfigurationCacheEnvironmentChangeT
 import org.gradle.internal.cc.impl.CheckedFingerprint
 import org.gradle.internal.cc.impl.ConfigurationCacheStateFile
 import org.gradle.internal.cc.impl.ConfigurationCacheStateStore.StateFile
-import org.gradle.internal.encryption.EncryptionService
 import org.gradle.internal.cc.impl.InputTrackingState
 import org.gradle.internal.cc.impl.initialization.ConfigurationCacheStartParameter
 import org.gradle.internal.cc.impl.problems.ConfigurationCacheProblems
@@ -39,6 +38,7 @@ import org.gradle.internal.configuration.problems.ProblemFactory
 import org.gradle.internal.configuration.problems.PropertyProblem
 import org.gradle.internal.configuration.problems.StructuredMessage
 import org.gradle.internal.configuration.problems.StructuredMessageBuilder
+import org.gradle.internal.encryption.EncryptionService
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.execution.FileCollectionFingerprinterRegistry
 import org.gradle.internal.execution.WorkExecutionTracker
@@ -54,7 +54,7 @@ import org.gradle.internal.hash.HashCode
 import org.gradle.internal.instrumentation.agent.AgentStatus
 import org.gradle.internal.scripts.ProjectScopedScriptResolution
 import org.gradle.internal.scripts.ScriptFileResolverListeners
-import org.gradle.internal.serialize.graph.DefaultWriteContext
+import org.gradle.internal.serialize.graph.CloseableWriteContext
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.service.scopes.Scope
 import org.gradle.internal.service.scopes.ServiceScope
@@ -102,12 +102,13 @@ class ConfigurationCacheFingerprintController internal constructor(
     }
 
     private
-    val fileCollectionFingerprinter = fingerprinterRegistry.getFingerprinter(DefaultFileNormalizationSpec.from(InputNormalizer.ABSOLUTE_PATH, DirectorySensitivity.DEFAULT, LineEndingSensitivity.DEFAULT))
+    val fileCollectionFingerprinter =
+        fingerprinterRegistry.getFingerprinter(DefaultFileNormalizationSpec.from(InputNormalizer.ABSOLUTE_PATH, DirectorySensitivity.DEFAULT, LineEndingSensitivity.DEFAULT))
 
     private
     abstract class WritingState {
 
-        open fun maybeStart(buildScopedSpoolFile: StateFile, projectScopedSpoolFile: StateFile, writeContextForOutputStream: (StateFile) -> DefaultWriteContext): WritingState =
+        open fun maybeStart(buildScopedSpoolFile: StateFile, projectScopedSpoolFile: StateFile, writeContextForOutputStream: (StateFile) -> CloseableWriteContext): WritingState =
             illegalStateFor("start")
 
         open fun pause(): WritingState =
@@ -135,7 +136,7 @@ class ConfigurationCacheFingerprintController internal constructor(
 
     private
     inner class Idle : WritingState() {
-        override fun maybeStart(buildScopedSpoolFile: StateFile, projectScopedSpoolFile: StateFile, writeContextForOutputStream: (StateFile) -> DefaultWriteContext): WritingState {
+        override fun maybeStart(buildScopedSpoolFile: StateFile, projectScopedSpoolFile: StateFile, writeContextForOutputStream: (StateFile) -> CloseableWriteContext): WritingState {
 
             val fingerprintWriter = ConfigurationCacheFingerprintWriter(
                 CacheFingerprintWriterHost(),
@@ -166,7 +167,7 @@ class ConfigurationCacheFingerprintController internal constructor(
         private val buildScopedSpoolFile: StateFile,
         private val projectScopedSpoolFile: StateFile
     ) : WritingState() {
-        override fun maybeStart(buildScopedSpoolFile: StateFile, projectScopedSpoolFile: StateFile, writeContextForOutputStream: (StateFile) -> DefaultWriteContext): WritingState {
+        override fun maybeStart(buildScopedSpoolFile: StateFile, projectScopedSpoolFile: StateFile, writeContextForOutputStream: (StateFile) -> CloseableWriteContext): WritingState {
             return this
         }
 
@@ -193,7 +194,7 @@ class ConfigurationCacheFingerprintController internal constructor(
         private val buildScopedSpoolFile: StateFile,
         private val projectScopedSpoolFile: StateFile
     ) : WritingState() {
-        override fun maybeStart(buildScopedSpoolFile: StateFile, projectScopedSpoolFile: StateFile, writeContextForOutputStream: (StateFile) -> DefaultWriteContext): WritingState {
+        override fun maybeStart(buildScopedSpoolFile: StateFile, projectScopedSpoolFile: StateFile, writeContextForOutputStream: (StateFile) -> CloseableWriteContext): WritingState {
             addListener(fingerprintWriter)
             // Continue with the current spool file, rather than starting a new one
             return Writing(fingerprintWriter, this.buildScopedSpoolFile, this.projectScopedSpoolFile)
@@ -249,7 +250,7 @@ class ConfigurationCacheFingerprintController internal constructor(
     // Start fingerprinting if not already started and not already committed
     // This should be strict but currently this method may be called multiple times when a
     // build invocation both runs tasks and queries models
-    fun maybeStartCollectingFingerprint(buildScopedSpoolFile: StateFile, projectScopedSpoolFile: StateFile, writeContextForOutputStream: (StateFile) -> DefaultWriteContext) {
+    fun maybeStartCollectingFingerprint(buildScopedSpoolFile: StateFile, projectScopedSpoolFile: StateFile, writeContextForOutputStream: (StateFile) -> CloseableWriteContext) {
         writingState = writingState.maybeStart(buildScopedSpoolFile, projectScopedSpoolFile, writeContextForOutputStream)
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -74,7 +74,7 @@ import org.gradle.internal.properties.InputBehavior
 import org.gradle.internal.resource.local.FileResourceListener
 import org.gradle.internal.scripts.ScriptExecutionListener
 import org.gradle.internal.scripts.ScriptFileResolvedListener
-import org.gradle.internal.serialize.graph.DefaultWriteContext
+import org.gradle.internal.serialize.graph.CloseableWriteContext
 import org.gradle.tooling.provider.model.internal.ToolingModelProjectDependencyListener
 import org.gradle.util.Path
 import java.io.File
@@ -86,8 +86,8 @@ import java.util.concurrent.ConcurrentHashMap
 internal
 class ConfigurationCacheFingerprintWriter(
     private val host: Host,
-    buildScopedContext: DefaultWriteContext,
-    projectScopedContext: DefaultWriteContext,
+    buildScopedContext: CloseableWriteContext,
+    projectScopedContext: CloseableWriteContext,
     private val fileCollectionFactory: FileCollectionFactory,
     private val directoryFileTreeFactory: DirectoryFileTreeFactory,
     private val workExecutionTracker: WorkExecutionTracker,
@@ -891,4 +891,4 @@ fun jvmFingerprint() =
         System.getProperty("java.vm.name"),
         System.getProperty("java.vm.vendor"),
         System.getProperty("java.vm.version")
-    ).joinToString (separator = "|")
+    ).joinToString(separator = "|")

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ScopedFingerprintWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ScopedFingerprintWriter.kt
@@ -17,7 +17,7 @@
 package org.gradle.internal.cc.impl.fingerprint
 
 import org.gradle.internal.configuration.problems.PropertyTrace
-import org.gradle.internal.serialize.graph.DefaultWriteContext
+import org.gradle.internal.serialize.graph.CloseableWriteContext
 import org.gradle.internal.serialize.graph.runWriteOperation
 import org.gradle.internal.serialize.graph.withPropertyTrace
 import java.io.Closeable
@@ -25,7 +25,7 @@ import java.io.Closeable
 
 internal
 class ScopedFingerprintWriter<T>(
-    private val writeContext: DefaultWriteContext
+    private val writeContext: CloseableWriteContext
 ) : Closeable {
     override fun close() {
         // we synchronize access to all resources used by callbacks

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/isolation/IsolatedActionSerializer.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/isolation/IsolatedActionSerializer.kt
@@ -140,8 +140,7 @@ class IsolatedActionDeserializer(
         beanStateReaderLookup = beanStateReaderLookup,
         logger = logger,
         problemsListener = ThrowingProblemsListener,
-        classDecoder = EnvironmentDecoder(action.environment),
-        classLoader = javaClass.classLoader
+        classDecoder = EnvironmentDecoder(action.environment)
     )
 }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/isolation/IsolatedActionSerializer.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/isolation/IsolatedActionSerializer.kt
@@ -17,11 +17,11 @@
 package org.gradle.internal.cc.impl.isolation
 
 import org.gradle.api.IsolatedAction
+import org.gradle.internal.cc.base.logger
 import org.gradle.internal.cc.impl.ConfigurationCacheError
 import org.gradle.internal.cc.impl.problems.AbstractProblemsListener
 import org.gradle.internal.cc.impl.services.IsolatedActionCodecsFactory
 import org.gradle.internal.configuration.problems.PropertyProblem
-import org.gradle.internal.cc.base.logger
 import org.gradle.internal.extensions.stdlib.invert
 import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.extensions.stdlib.useToRun
@@ -29,6 +29,7 @@ import org.gradle.internal.serialize.graph.BeanStateReaderLookup
 import org.gradle.internal.serialize.graph.BeanStateWriterLookup
 import org.gradle.internal.serialize.graph.ClassDecoder
 import org.gradle.internal.serialize.graph.ClassEncoder
+import org.gradle.internal.serialize.graph.CloseableWriteContext
 import org.gradle.internal.serialize.graph.DefaultReadContext
 import org.gradle.internal.serialize.graph.DefaultWriteContext
 import org.gradle.internal.serialize.graph.IsolateOwner
@@ -103,7 +104,7 @@ class IsolatedActionSerializer(
     fun writeContextFor(
         outputStream: OutputStream,
         classEncoder: ClassEncoder,
-    ) = DefaultWriteContext(
+    ): CloseableWriteContext = DefaultWriteContext(
         codec = isolatedActionCodecs.isolatedActionCodecs(),
         encoder = KryoBackedEncoder(outputStream),
         beanStateWriterLookup = beanStateWriterLookup,
@@ -139,7 +140,8 @@ class IsolatedActionDeserializer(
         beanStateReaderLookup = beanStateReaderLookup,
         logger = logger,
         problemsListener = ThrowingProblemsListener,
-        classDecoder = EnvironmentDecoder(action.environment)
+        classDecoder = EnvironmentDecoder(action.environment),
+        classLoader = javaClass.classLoader
     )
 }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/isolation/IsolatedActionSerializer.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/isolation/IsolatedActionSerializer.kt
@@ -123,7 +123,7 @@ class IsolatedActionDeserializer(
     private val isolatedActionCodecs: IsolatedActionCodecsFactory
 ) {
     fun <G : Any> deserialize(action: SerializedIsolatedActionGraph<G>): G =
-        readerContextFor(action).useToRun {
+        readContextFor(action).useToRun {
             runReadOperation {
                 withIsolate(owner) {
                     readNonNull()
@@ -132,7 +132,7 @@ class IsolatedActionDeserializer(
         }
 
     private
-    fun readerContextFor(
+    fun readContextFor(
         action: SerializedIsolatedActionGraph<*>
     ) = DefaultReadContext(
         codec = isolatedActionCodecs.isolatedActionCodecs(),

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/DefaultClassDecoder.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/DefaultClassDecoder.kt
@@ -51,7 +51,7 @@ class DefaultClassDecoder : ClassDecoder {
                 scope.exportClassLoader
             }
         } else {
-            this.classLoader
+            javaClass.classLoader
         }
         val newType = Class.forName(name, false, classLoader)
         classes.putInstance(id, newType)

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
@@ -458,9 +458,6 @@ class ConfigurationCacheFingerprintCheckerTest {
         override val isolate: ReadIsolate
             get() = undefined()
 
-        override val classLoader: ClassLoader
-            get() = undefined()
-
         override fun onFinish(action: () -> Unit) =
             undefined()
 

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialization/codecs/AbstractUserTypeCodecTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialization/codecs/AbstractUserTypeCodecTest.kt
@@ -150,8 +150,7 @@ abstract class AbstractUserTypeCodecTest {
             beanStateReaderLookup = beanStateReaderLookupForTesting(),
             logger = mock(),
             problemsListener = mock(),
-            classDecoder = DefaultClassDecoder(),
-            javaClass.classLoader
+            classDecoder = DefaultClassDecoder()
         )
 
     private

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialization/codecs/AbstractUserTypeCodecTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialization/codecs/AbstractUserTypeCodecTest.kt
@@ -18,13 +18,13 @@ package org.gradle.internal.cc.impl.serialization.codecs
 
 import com.nhaarman.mockitokotlin2.mock
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
+import org.gradle.internal.cc.base.serialize.IsolateOwners
 import org.gradle.internal.cc.impl.problems.AbstractProblemsListener
 import org.gradle.internal.cc.impl.serialize.Codecs
 import org.gradle.internal.cc.impl.serialize.DefaultClassDecoder
 import org.gradle.internal.cc.impl.serialize.DefaultClassEncoder
 import org.gradle.internal.configuration.problems.ProblemsListener
 import org.gradle.internal.configuration.problems.PropertyProblem
-import org.gradle.internal.cc.base.serialize.IsolateOwners
 import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.extensions.stdlib.useToRun
 import org.gradle.internal.io.NullOutputStream
@@ -117,7 +117,6 @@ abstract class AbstractUserTypeCodecTest {
     private
     fun readFrom(inputStream: ByteArrayInputStream, codec: Codec<Any?>) =
         readContextFor(inputStream, codec).run {
-            initClassLoader(javaClass.classLoader)
             withIsolateMock(codec) {
                 runReadOperation {
                     read()
@@ -151,7 +150,8 @@ abstract class AbstractUserTypeCodecTest {
             beanStateReaderLookup = beanStateReaderLookupForTesting(),
             logger = mock(),
             problemsListener = mock(),
-            classDecoder = DefaultClassDecoder()
+            classDecoder = DefaultClassDecoder(),
+            javaClass.classLoader
         )
 
     private

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
@@ -18,10 +18,10 @@ package org.gradle.internal.serialize.graph
 
 import org.gradle.api.logging.Logger
 import org.gradle.internal.configuration.problems.PropertyKind
-import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.configuration.problems.PropertyProblem
 import org.gradle.internal.configuration.problems.PropertyTrace
 import org.gradle.internal.configuration.problems.StructuredMessageBuilder
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.Encoder
 
@@ -42,7 +42,7 @@ interface DecodingProvider<T> {
 }
 
 
-interface WriteContext : IsolateContext, MutableIsolateContext, Encoder {
+interface WriteContext : MutableIsolateContext, Encoder {
 
     val tracer: Tracer?
 
@@ -58,6 +58,9 @@ interface WriteContext : IsolateContext, MutableIsolateContext, Encoder {
 
     fun writeClass(type: Class<*>)
 }
+
+
+interface CloseableWriteContext : WriteContext, AutoCloseable
 
 
 interface Tracer {
@@ -94,6 +97,19 @@ interface ReadContext : IsolateContext, MutableIsolateContext, Decoder {
     fun onFinish(action: () -> Unit)
 
     fun <T : Any> getSingletonProperty(propertyType: Class<T>): T
+}
+
+
+interface MutableReadContext : ReadContext {
+    /**
+     * Sets a client specific property value that can be queried via [getSingletonProperty].
+     */
+    fun <T : Any> setSingletonProperty(singletonProperty: T)
+}
+
+
+interface CloseableReadContext : MutableReadContext, AutoCloseable {
+    fun finish()
 }
 
 

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
@@ -77,8 +77,6 @@ interface ReadContext : IsolateContext, MutableIsolateContext, Decoder {
 
     override val isolate: ReadIsolate
 
-    val classLoader: ClassLoader
-
     fun beanStateReaderFor(beanType: Class<*>): BeanStateReader
 
     /**

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
@@ -128,9 +128,7 @@ class DefaultReadContext(
     problemsListener: ProblemsListener,
 
     private
-    val classDecoder: ClassDecoder,
-
-    override val classLoader: ClassLoader
+    val classDecoder: ClassDecoder
 
 ) : AbstractIsolateContext<ReadIsolate>(codec, problemsListener), CloseableReadContext, Decoder by decoder {
 

--- a/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/configurationcache/extensions/CharSequenceExtensions.kt
+++ b/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/configurationcache/extensions/CharSequenceExtensions.kt
@@ -16,20 +16,10 @@
 
 package org.gradle.configurationcache.extensions
 
-import java.util.Locale
-
 
 @Deprecated(
     "This was never intended as a public API.",
-    ReplaceWith("this.let { if (it.isEmpty()) it else it[0].titlecase(java.util.Locale.getDefault()) + it.substring(1) }")
+    ReplaceWith("this.toString().replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }")
 )
 fun CharSequence.capitalized(): String =
-    when {
-        isEmpty() -> ""
-        else -> get(0).let { initial ->
-            when {
-                initial.isLowerCase() -> initial.titlecase(Locale.getDefault()) + substring(1)
-                else -> toString()
-            }
-        }
-    }
+    toString().replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }

--- a/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/internal/extensions/stdlib/CharSequenceExtensions.kt
+++ b/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/internal/extensions/stdlib/CharSequenceExtensions.kt
@@ -16,16 +16,8 @@
 
 package org.gradle.internal.extensions.stdlib
 
-import java.util.Locale
-
 
 fun CharSequence.capitalized(): String =
-    when {
-        isEmpty() -> ""
-        else -> get(0).let { initial ->
-            when {
-                initial.isLowerCase() -> initial.titlecase(Locale.getDefault()) + substring(1)
-                else -> toString()
-            }
-        }
+    toString().replaceFirstChar {
+        if (it.isLowerCase()) it.titlecase() else it.toString()
     }


### PR DESCRIPTION
- Remove direct usages of `DefaultWriteContext` and `DefaultReadContext`
- Rename context factory methods to better match interface names
- Remove unnecessary property
- Polish `CharSequence.capitalized`
- Shorten lines to make them readable under 120 columns
### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
