### PR TITLE
Introduce `MutableStateAccessAwareProject`

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
@@ -944,4 +944,30 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
             projectsConfigured(":", ":a", ":a:tests", ":a:tests:integ-tests")
         }
     }
+
+    def "can use #api(Closure) API added by runtime decoration"() {
+        settingsFile << """
+            include ':a'
+        """
+        file("a/build.gradle") << ""
+        buildFile << """
+            project(':a') {
+                $invocation
+            }
+        """
+
+        when:
+        isolatedProjectsFails 'help'
+
+        then:
+        fixture.assertStateStoredAndDiscarded {
+            projectsConfigured(":", ":a")
+            problem("Build file 'build.gradle': line 3: Project ':' cannot access 'Project.$api' functionality on another project ':a'", 1)
+        }
+
+        where:
+        api                 | invocation
+        "normalization"     | "normalization { runtimeClasspath{} }"
+        "dependencyLocking" | "dependencyLocking { lockAllConfigurations() }"
+    }
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildModelControllerServices.kt
@@ -165,11 +165,18 @@ class DefaultBuildModelControllerServices(
             problemFactory: ProblemFactory,
             listenerManager: ListenerManager,
             dynamicCallProblemReporting: DynamicCallProblemReporting,
-            buildModelParameters: BuildModelParameters
+            buildModelParameters: BuildModelParameters,
+            instantiator: Instantiator
         ): CrossProjectModelAccess {
             val delegate = VintageIsolatedProjectsProvider().createCrossProjectModelAccess(projectRegistry)
             return ProblemReportingCrossProjectModelAccess(
-                delegate, problemsListener, listenerManager.getBroadcaster(CoupledProjectsListener::class.java), problemFactory, dynamicCallProblemReporting, buildModelParameters
+                delegate,
+                problemsListener,
+                listenerManager.getBroadcaster(CoupledProjectsListener::class.java),
+                problemFactory,
+                dynamicCallProblemReporting,
+                buildModelParameters,
+                instantiator
             )
         }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -17,55 +17,36 @@
 package org.gradle.internal.cc.impl
 
 import groovy.lang.Closure
-import groovy.lang.GroovyObjectSupport
 import groovy.lang.GroovyRuntimeException
 import groovy.lang.Script
 import org.gradle.api.Action
 import org.gradle.api.AntBuilder
-import org.gradle.api.NamedDomainObjectContainer
-import org.gradle.api.NamedDomainObjectFactory
 import org.gradle.api.PathValidation
 import org.gradle.api.Project
 import org.gradle.api.ProjectEvaluationListener
-import org.gradle.api.Task
-import org.gradle.api.artifacts.dsl.ArtifactHandler
 import org.gradle.api.artifacts.dsl.DependencyFactory
-import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.artifacts.dsl.DependencyLockingHandler
-import org.gradle.api.artifacts.dsl.RepositoryHandler
-import org.gradle.api.component.SoftwareComponentContainer
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.DeleteSpec
 import org.gradle.api.file.FileTree
-import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.SyncSpec
 import org.gradle.api.internal.DynamicObjectAware
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.ProcessOperations
-import org.gradle.api.internal.artifacts.configurations.RoleBasedConfigurationContainerInternal
 import org.gradle.api.internal.file.FileOperations
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.initialization.ClassLoaderScope
-import org.gradle.api.internal.initialization.ScriptHandlerInternal
-import org.gradle.api.internal.plugins.ExtensionContainerInternal
-import org.gradle.api.internal.plugins.PluginManagerInternal
 import org.gradle.api.internal.project.CrossProjectModelAccess
+import org.gradle.api.internal.project.MutableStateAccessAwareProject
 import org.gradle.api.internal.project.ProjectIdentifier
 import org.gradle.api.internal.project.ProjectInternal
-import org.gradle.api.internal.project.ProjectState
-import org.gradle.api.internal.project.ProjectStateInternal
-import org.gradle.api.internal.tasks.TaskContainerInternal
 import org.gradle.api.internal.tasks.TaskDependencyFactory
 import org.gradle.api.internal.tasks.TaskDependencyUsageTracker
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.LoggingManager
 import org.gradle.api.model.ObjectFactory
-import org.gradle.api.plugins.ObjectConfigurationAction
-import org.gradle.api.plugins.PluginContainer
-import org.gradle.api.project.IsolatedProject
-import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.resources.ResourceHandler
@@ -74,7 +55,6 @@ import org.gradle.configuration.ConfigurationTargetIdentifier
 import org.gradle.configuration.project.ProjectConfigurationActionContainer
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal
 import org.gradle.groovy.scripts.ScriptSource
-import org.gradle.internal.accesscontrol.AllowUsingApiForExternalUse
 import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.cc.impl.CrossProjectModelAccessPattern.ALLPROJECTS
 import org.gradle.internal.cc.impl.CrossProjectModelAccessPattern.CHILD
@@ -85,11 +65,11 @@ import org.gradle.internal.configuration.problems.ProblemsListener
 import org.gradle.internal.configuration.problems.StructuredMessage
 import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.logging.StandardOutputCapture
-import org.gradle.internal.metaobject.BeanDynamicObject
 import org.gradle.internal.metaobject.DynamicInvokeResult
 import org.gradle.internal.metaobject.DynamicObject
 import org.gradle.internal.model.ModelContainer
 import org.gradle.internal.model.RuleBasedPluginListener
+import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.internal.service.scopes.ServiceRegistryFactory
 import org.gradle.model.internal.registry.ModelRegistry
@@ -112,33 +92,34 @@ class ProblemReportingCrossProjectModelAccess(
     private val coupledProjectsListener: CoupledProjectsListener,
     private val problemFactory: ProblemFactory,
     private val dynamicCallProblemReporting: DynamicCallProblemReporting,
-    private val buildModelParameters: BuildModelParameters
+    private val buildModelParameters: BuildModelParameters,
+    private val instantiator: Instantiator
 ) : CrossProjectModelAccess {
     override fun findProject(referrer: ProjectInternal, relativeTo: ProjectInternal, path: String): ProjectInternal? {
         return delegate.findProject(referrer, relativeTo, path)?.let {
-            it.wrap(referrer, CrossProjectModelAccessInstance(DIRECT, it))
+            it.wrap(referrer, CrossProjectModelAccessInstance(DIRECT, it), instantiator)
         }
     }
 
     override fun access(referrer: ProjectInternal, project: ProjectInternal): ProjectInternal {
-        return project.wrap(referrer, CrossProjectModelAccessInstance(DIRECT, project))
+        return project.wrap(referrer, CrossProjectModelAccessInstance(DIRECT, project), instantiator)
     }
 
     override fun getChildProjects(referrer: ProjectInternal, relativeTo: ProjectInternal): MutableMap<String, Project> {
         return delegate.getChildProjects(referrer, relativeTo).mapValuesTo(LinkedHashMap()) {
-            (it.value as ProjectInternal).wrap(referrer, CrossProjectModelAccessInstance(CHILD, relativeTo))
+            (it.value as ProjectInternal).wrap(referrer, CrossProjectModelAccessInstance(CHILD, relativeTo), instantiator)
         }
     }
 
     override fun getSubprojects(referrer: ProjectInternal, relativeTo: ProjectInternal): MutableSet<out ProjectInternal> {
         return delegate.getSubprojects(referrer, relativeTo).mapTo(LinkedHashSet()) {
-            it.wrap(referrer, CrossProjectModelAccessInstance(SUBPROJECT, relativeTo))
+            it.wrap(referrer, CrossProjectModelAccessInstance(SUBPROJECT, relativeTo), instantiator)
         }
     }
 
     override fun getAllprojects(referrer: ProjectInternal, relativeTo: ProjectInternal): MutableSet<out ProjectInternal> {
         return delegate.getAllprojects(referrer, relativeTo).mapTo(LinkedHashSet()) {
-            it.wrap(referrer, CrossProjectModelAccessInstance(ALLPROJECTS, relativeTo))
+            it.wrap(referrer, CrossProjectModelAccessInstance(ALLPROJECTS, relativeTo), instantiator)
         }
     }
 
@@ -165,29 +146,30 @@ class ProblemReportingCrossProjectModelAccess(
     fun ProjectInternal.wrap(
         referrer: ProjectInternal,
         access: CrossProjectModelAccessInstance,
+        instantiator: Instantiator
     ): ProjectInternal {
         return if (this == referrer) {
             this
         } else {
-            ProblemReportingProject(this, referrer, access, problems, coupledProjectsListener, problemFactory, buildModelParameters, dynamicCallProblemReporting)
+            instantiator.newInstance(ProblemReportingProject::class.java, this, referrer, access, problems, coupledProjectsListener, problemFactory, buildModelParameters, dynamicCallProblemReporting)
         }
     }
 
     @Suppress("LargeClass")
-    private
-    class ProblemReportingProject(
-        val delegate: ProjectInternal,
-        val referrer: ProjectInternal,
-        val access: CrossProjectModelAccessInstance,
-        val problems: ProblemsListener,
-        val coupledProjectsListener: CoupledProjectsListener,
-        val problemFactory: ProblemFactory,
-        val buildModelParameters: BuildModelParameters,
-        val dynamicCallProblemReporting: DynamicCallProblemReporting,
-    ) : ProjectInternal, GroovyObjectSupport() {
+    open class ProblemReportingProject(
+        delegate: ProjectInternal,
+        private val referrer: ProjectInternal,
+        private val access: CrossProjectModelAccessInstance,
+        private val problems: ProblemsListener,
+        private val coupledProjectsListener: CoupledProjectsListener,
+        private val problemFactory: ProblemFactory,
+        private val buildModelParameters: BuildModelParameters,
+        private val dynamicCallProblemReporting: DynamicCallProblemReporting,
+    ) : MutableStateAccessAwareProject(delegate) {
 
-        override fun toString(): String {
-            return delegate.toString()
+        override fun onMutableStateAccess(what: String) {
+            reportCrossProjectAccessProblem("Project.$what", "functionality")
+            onProjectsCoupled()
         }
 
         override fun equals(other: Any?): Boolean {
@@ -201,39 +183,22 @@ class ProblemReportingCrossProjectModelAccess(
             return delegate == project.delegate && referrer == project.referrer // do not include `access`
         }
 
-        override fun hashCode(): Int {
-            return delegate.hashCode()
-        }
+        override fun hashCode(): Int = delegate.hashCode()
 
-        override fun getProperty(propertyName: String): Any? {
-            // Attempt to get the property value via this instance. If not present, then attempt to lookup via the delegate
-            val thisBean = BeanDynamicObject(this).withNotImplementsMissing()
-            val result = thisBean.tryGetProperty(propertyName)
-            if (result.isFound) {
-                return result.value
-            }
+        override fun toString(): String = delegate.toString()
 
+        override fun propertyMissing(name: String): Any? {
             onProjectsCoupled()
-
             return withDelegateDynamicCallReportingConfigurationOrder(
-                propertyName,
-                action = { tryGetProperty(propertyName) },
-                resultNotFoundExceptionProvider = { getMissingProperty(propertyName) }
+                name,
+                action = { tryGetProperty(name) },
+                resultNotFoundExceptionProvider = { getMissingProperty(name) }
             )
         }
 
-        @Suppress("SpreadOperator")
-        override fun invokeMethod(name: String, args: Any): Any? {
-            // Attempt to get the property value via this instance. If not present, then attempt to lookup via the delegate
-            val varargs: Array<Any?> = args.uncheckedCast()
-            val thisBean = BeanDynamicObject(this).withNotImplementsMissing()
-            val result = thisBean.tryInvokeMethod(name, *varargs)
-            if (result.isFound) {
-                return result.value
-            }
-
+        override fun methodMissing(name: String, args: Any): Any? {
             onProjectsCoupled()
-
+            val varargs: Array<Any?> = args.uncheckedCast()
             @Suppress("SpreadOperator")
             return withDelegateDynamicCallReportingConfigurationOrder(
                 name,
@@ -242,624 +207,284 @@ class ProblemReportingCrossProjectModelAccess(
             )
         }
 
-        override fun compareTo(other: Project?): Int {
-            return delegate.compareTo(other)
-        }
+        override fun getParent(): ProjectInternal? =
+            super.getParent(referrer)
 
-        override fun getRootDir(): File {
-            return delegate.rootDir
-        }
+        override fun getRootProject(): ProjectInternal =
+            super.getRootProject(referrer)
 
-        @Deprecated("Use layout.buildDirectory instead")
-        override fun getBuildDir(): File {
-            onAccess("buildDir")
-            @Suppress("DEPRECATION")
-            return delegate.buildDir
-        }
+        override fun project(path: String): ProjectInternal =
+            super.project(referrer, path)
 
-        @Deprecated("Use layout.buildDirectory instead")
-        override fun setBuildDir(path: File) {
-            onAccess("buildDir")
-            @Suppress("DEPRECATION")
-            delegate.buildDir = path
-        }
+        override fun project(path: String, configureClosure: Closure<*>): Project =
+            super.project(referrer, path, ConfigureUtil.configureUsing(configureClosure))
 
-        @Deprecated("Use layout.buildDirectory instead")
-        override fun setBuildDir(path: Any) {
-            onAccess("buildDir")
-            @Suppress("DEPRECATION")
-            delegate.setBuildDir(path)
-        }
+        override fun project(path: String, configureAction: Action<in Project>): Project =
+            super.project(referrer, path, configureAction)
 
-        override fun getName(): String {
-            return delegate.name
-        }
+        override fun findProject(path: String): ProjectInternal? =
+            super.findProject(referrer, path)
 
-        override fun getBuildFile(): File {
-            return delegate.buildFile
-        }
-
-        override fun getDisplayName(): String {
-            return delegate.displayName
-        }
-
-        override fun getDescription(): String? {
-            onAccess("description")
-            return delegate.description
-        }
-
-        override fun setDescription(description: String?) {
-            onAccess("description")
-            delegate.description = description
-        }
-
-        override fun getGroup(): Any {
-            onAccess("group")
-            return delegate.group
-        }
-
-        override fun setGroup(group: Any) {
-            onAccess("group")
-            delegate.group = group
-        }
-
-        override fun getVersion(): Any {
-            onAccess("version")
-            return delegate.version
-        }
-
-        override fun setVersion(version: Any) {
-            onAccess("version")
-            delegate.version = version
-        }
-
-        override fun getStatus(): Any {
-            onAccess("status")
-            return delegate.status
-        }
-
-        override fun getInternalStatus(): Property<Any> {
-            onAccess("internalStatus")
-            return delegate.internalStatus
-        }
-
-        override fun setStatus(status: Any) {
-            onAccess("status")
-            delegate.status = status
-        }
-
-        @AllowUsingApiForExternalUse
-        override fun getChildProjects(): MutableMap<String, Project> {
-            return delegate.childProjects
-        }
-
-        override fun getChildProjectsUnchecked(): MutableMap<String, Project> {
-            return delegate.childProjectsUnchecked
-        }
-
-        override fun setProperty(name: String, value: Any?) {
-            onAccess("property")
-            delegate.setProperty(name, value)
-        }
-
-        override fun getProject(): ProjectInternal {
-            return this
-        }
-
-        override fun getIsolated(): IsolatedProject {
-            return delegate.isolated
-        }
-
-        override fun task(name: String): Task {
-            onAccess("task")
-            return delegate.task(name)
-        }
-
-        override fun task(args: MutableMap<String, *>, name: String): Task {
-            onAccess("task")
-            return delegate.task(args, name)
-        }
-
-        override fun task(args: MutableMap<String, *>, name: String, configureClosure: Closure<*>): Task {
-            onAccess("task")
-            return delegate.task(args, name, configureClosure)
-        }
-
-        override fun task(name: String, configureClosure: Closure<*>): Task {
-            onAccess("task")
-            return delegate.task(name, configureClosure)
-        }
-
-        override fun task(name: String, configureAction: Action<in Task>): Task {
-            onAccess("task")
-            return delegate.task(name, configureAction)
-        }
-
-        override fun getPath(): String {
-            return delegate.path
-        }
-
-        override fun getBuildTreePath(): String {
-            return delegate.buildTreePath
-        }
-
-        override fun getDefaultTasks(): MutableList<String> {
-            onAccess("defaultTasks")
-            return delegate.defaultTasks
-        }
-
-        override fun setDefaultTasks(defaultTasks: MutableList<String>) {
-            onAccess("defaultTasks")
-            delegate.defaultTasks = defaultTasks
-        }
-
-        override fun defaultTasks(vararg defaultTasks: String?) {
-            onAccess("defaultTasks")
-            delegate.defaultTasks(*defaultTasks)
-        }
-
-        override fun evaluationDependsOn(path: String): Project {
-            onAccess("evaluationDependsOn")
-            return delegate.evaluationDependsOn(path)
-        }
-
-        override fun evaluationDependsOnChildren() {
-            onAccess("evaluationDependsOnChildren")
-            delegate.evaluationDependsOnChildren()
-        }
-
-        override fun getAllTasks(recursive: Boolean): MutableMap<Project, MutableSet<Task>> {
-            onAccess("allTasks")
-            return delegate.getAllTasks(recursive)
-        }
-
-        override fun getTasksByName(name: String, recursive: Boolean): MutableSet<Task> {
-            onAccess("tasksByName")
-            return delegate.getTasksByName(name, recursive)
-        }
-
-        override fun getProjectDir(): File {
-            return delegate.projectDir
-        }
-
-        override fun file(path: Any): File {
-            onAccess("file")
-            return delegate.file(path)
-        }
-
-        override fun file(path: Any, validation: PathValidation): File {
-            onAccess("file")
-            return delegate.file(path, validation)
-        }
-
-        override fun uri(path: Any): URI {
-            onAccess("uri")
-            return delegate.uri(path)
-        }
-
-        override fun relativePath(path: Any): String {
-            onAccess("relativePath")
-            return delegate.relativePath(path)
-        }
-
-        override fun files(vararg paths: Any?): ConfigurableFileCollection {
-            onAccess("files")
-            return delegate.files(*paths)
-        }
-
-        override fun files(paths: Any, configureClosure: Closure<*>): ConfigurableFileCollection {
-            onAccess("files")
-            return delegate.files(paths, configureClosure)
-        }
-
-        override fun files(paths: Any, configureAction: Action<in ConfigurableFileCollection>): ConfigurableFileCollection {
-            onAccess("files")
-            return delegate.files(paths, configureAction)
-        }
-
-        override fun fileTree(baseDir: Any): ConfigurableFileTree {
-            onAccess("fileTree")
-            return delegate.fileTree(baseDir)
-        }
-
-        override fun fileTree(baseDir: Any, configureClosure: Closure<*>): ConfigurableFileTree {
-            onAccess("fileTree")
-            return delegate.fileTree(baseDir, configureClosure)
-        }
-
-        override fun fileTree(baseDir: Any, configureAction: Action<in ConfigurableFileTree>): ConfigurableFileTree {
-            onAccess("fileTree")
-            return delegate.fileTree(baseDir, configureAction)
-        }
-
-        override fun fileTree(args: MutableMap<String, *>): ConfigurableFileTree {
-            onAccess("fileTree")
-            return delegate.fileTree(args)
-        }
-
-        override fun zipTree(zipPath: Any): FileTree {
-            onAccess("zipTree")
-            return delegate.zipTree(zipPath)
-        }
-
-        override fun tarTree(tarPath: Any): FileTree {
-            onAccess("tarTree")
-            return delegate.tarTree(tarPath)
-        }
-
-        override fun <T : Any> provider(value: Callable<out T?>): Provider<T> {
-            onAccess("provider")
-            return delegate.provider(value)
-        }
-
-        override fun getProviders(): ProviderFactory {
-            onAccess("providers")
-            return delegate.providers
-        }
-
-        override fun getObjects(): ObjectFactory {
-            onAccess("objects")
-            return delegate.objects
-        }
-
-        override fun getLayout(): ProjectLayout {
-            onAccess("layout")
-            return delegate.layout
-        }
-
-        override fun mkdir(path: Any): File {
-            onAccess("mkdir")
-            return delegate.mkdir(path)
-        }
-
-        override fun delete(vararg paths: Any?): Boolean {
-            onAccess("delete")
-            return delegate.delete(*paths)
-        }
-
-        override fun delete(action: Action<in DeleteSpec>): WorkResult {
-            onAccess("delete")
-            return delegate.delete(action)
-        }
-
-        override fun javaexec(closure: Closure<*>): ExecResult {
-            onAccess("javaexec")
-            return delegate.javaexec(closure)
-        }
-
-        override fun javaexec(action: Action<in JavaExecSpec>): ExecResult {
-            onAccess("javaexec")
-            return delegate.javaexec(action)
-        }
-
-        override fun exec(closure: Closure<*>): ExecResult {
-            onAccess("exec")
-            return delegate.exec(closure)
-        }
-
-        override fun exec(action: Action<in ExecSpec>): ExecResult {
-            onAccess("exec")
-            return delegate.exec(action)
-        }
-
-        override fun absoluteProjectPath(path: String): String {
-            return delegate.absoluteProjectPath(path)
-        }
-
-        override fun relativeProjectPath(path: String): String {
-            return delegate.relativeProjectPath(path)
-        }
-
-        override fun getAnt(): AntBuilder {
-            onAccess("ant")
-            return delegate.ant
-        }
-
-        override fun createAntBuilder(): AntBuilder {
-            onAccess("antBuilder")
-            return delegate.createAntBuilder()
-        }
-
-        override fun ant(configureClosure: Closure<*>): AntBuilder {
-            onAccess("ant")
-            return delegate.ant(configureClosure)
-        }
-
-        override fun ant(configureAction: Action<in AntBuilder>): AntBuilder {
-            onAccess("ant")
-            return delegate.ant(configureAction)
-        }
-
-        override fun getConfigurations(): RoleBasedConfigurationContainerInternal {
-            onAccess("configurations")
-            return delegate.configurations
-        }
-
-        override fun configurations(configureClosure: Closure<*>) {
-            onAccess("configurations")
-            delegate.configurations(configureClosure)
-        }
-
-        override fun getArtifacts(): ArtifactHandler {
-            onAccess("artifacts")
-            return delegate.artifacts
-        }
-
-        override fun artifacts(configureClosure: Closure<*>) {
-            onAccess("artifacts")
-            delegate.artifacts(configureClosure)
-        }
-
-        override fun artifacts(configureAction: Action<in ArtifactHandler>) {
-            onAccess("artifacts")
-            delegate.artifacts(configureAction)
-        }
-
-        @Deprecated("The concept of conventions is deprecated. Use extensions instead.")
-        override fun getConvention(): @Suppress("deprecation") org.gradle.api.plugins.Convention {
-            onAccess("convention")
-            @Suppress("deprecation")
-            return delegate.convention
-        }
-
-        override fun depthCompare(otherProject: Project): Int {
-            return delegate.depthCompare(otherProject)
-        }
-
-        override fun getDepth(): Int {
-            return delegate.depth
-        }
-
-        override fun project(path: String, configureClosure: Closure<*>): Project {
-            return project(path, ConfigureUtil.configureUsing(configureClosure))
-        }
-
-        override fun project(path: String, configureAction: Action<in Project>): Project {
-            return delegate.project(referrer, path, configureAction)
-        }
-
-        override fun project(referrer: ProjectInternal, path: String, configureAction: Action<in Project>): ProjectInternal {
-            return delegate.project(referrer, path, configureAction)
-        }
-
-        override fun getSubprojects(): Set<Project> {
-            return delegate.getSubprojects(referrer)
-        }
-
-        override fun getSubprojects(referrer: ProjectInternal): Set<ProjectInternal> {
-            return delegate.getSubprojects(referrer)
-        }
+        override fun getSubprojects(): Set<Project> =
+            super.getSubprojects(referrer)
 
         override fun subprojects(action: Action<in Project>) {
-            delegate.subprojects(referrer, action)
+            super.subprojects(referrer, action)
         }
 
         override fun subprojects(configureClosure: Closure<*>) {
-            delegate.subprojects(referrer, ConfigureUtil.configureUsing(configureClosure))
+            super.subprojects(referrer, ConfigureUtil.configureUsing(configureClosure))
         }
 
-        override fun subprojects(referrer: ProjectInternal, configureAction: Action<in Project>) {
-            delegate.subprojects(referrer, configureAction)
-        }
-
-        override fun getAllprojects(): Set<Project> {
-            return delegate.getAllprojects(referrer)
-        }
-
-        override fun getAllprojects(referrer: ProjectInternal): Set<ProjectInternal> {
-            return delegate.getAllprojects(referrer)
-        }
+        override fun getAllprojects(): Set<Project> =
+            super.getAllprojects(referrer)
 
         override fun allprojects(action: Action<in Project>) {
-            delegate.allprojects(referrer, action)
+            super.allprojects(referrer, action)
         }
 
         override fun allprojects(configureClosure: Closure<*>) {
-            delegate.allprojects(referrer, ConfigureUtil.configureUsing(configureClosure))
+            super.allprojects(referrer, ConfigureUtil.configureUsing(configureClosure))
         }
 
-        override fun allprojects(referrer: ProjectInternal, configureAction: Action<in Project>) {
-            delegate.allprojects(referrer, configureAction)
+        override fun file(path: Any): File {
+            onMutableStateAccess("file")
+            return super.file(path)
         }
 
-        override fun beforeEvaluate(action: Action<in Project>) {
-            onAccess("beforeEvaluate")
-            delegate.beforeEvaluate(action)
+        override fun file(path: Any, validation: PathValidation): File {
+            onMutableStateAccess("file")
+            return super.file(path, validation)
+        }
+
+        override fun uri(path: Any): URI {
+            onMutableStateAccess("uri")
+            return super.uri(path)
+        }
+
+        override fun relativePath(path: Any): String {
+            onMutableStateAccess("relativePath")
+            return super.relativePath(path)
+        }
+
+        override fun files(vararg paths: Any?): ConfigurableFileCollection {
+            onMutableStateAccess("files")
+            return super.files(*paths)
+        }
+
+        override fun files(paths: Any, configureClosure: Closure<*>): ConfigurableFileCollection {
+            onMutableStateAccess("files")
+            return super.files(paths, configureClosure)
+        }
+
+        override fun files(paths: Any, configureAction: Action<in ConfigurableFileCollection>): ConfigurableFileCollection {
+            onMutableStateAccess("files")
+            return super.files(paths, configureAction)
+        }
+
+        override fun fileTree(baseDir: Any): ConfigurableFileTree {
+            onMutableStateAccess("fileTree")
+            return super.fileTree(baseDir)
+        }
+
+        override fun fileTree(baseDir: Any, configureClosure: Closure<*>): ConfigurableFileTree {
+            onMutableStateAccess("fileTree")
+            return super.fileTree(baseDir, configureClosure)
+        }
+
+        override fun fileTree(baseDir: Any, configureAction: Action<in ConfigurableFileTree>): ConfigurableFileTree {
+            onMutableStateAccess("fileTree")
+            return super.fileTree(baseDir, configureAction)
+        }
+
+        override fun fileTree(args: MutableMap<String, *>): ConfigurableFileTree {
+            onMutableStateAccess("fileTree")
+            return super.fileTree(args)
+        }
+
+        override fun zipTree(zipPath: Any): FileTree {
+            onMutableStateAccess("zipTree")
+            return super.zipTree(zipPath)
+        }
+
+        override fun tarTree(tarPath: Any): FileTree {
+            onMutableStateAccess("tarTree")
+            return super.tarTree(tarPath)
+        }
+
+        override fun <T : Any> provider(value: Callable<out T?>): Provider<T> {
+            onMutableStateAccess("provider")
+            return super.provider(value)
+        }
+
+        override fun getProviders(): ProviderFactory {
+            onMutableStateAccess("providers")
+            return super.getProviders()
+        }
+
+        override fun getObjects(): ObjectFactory {
+            onMutableStateAccess("objects")
+            return super.getObjects()
+        }
+
+        override fun mkdir(path: Any): File {
+            onMutableStateAccess("mkdir")
+            return super.mkdir(path)
+        }
+
+        override fun delete(vararg paths: Any?): Boolean {
+            onMutableStateAccess("delete")
+            return super.delete(*paths)
+        }
+
+        override fun delete(action: Action<in DeleteSpec>): WorkResult {
+            onMutableStateAccess("delete")
+            return super.delete(action)
+        }
+
+        override fun javaexec(closure: Closure<*>): ExecResult {
+            onMutableStateAccess("javaexec")
+            return super.javaexec(closure)
+        }
+
+        override fun javaexec(action: Action<in JavaExecSpec>): ExecResult {
+            onMutableStateAccess("javaexec")
+            return super.javaexec(action)
+        }
+
+        override fun exec(closure: Closure<*>): ExecResult {
+            onMutableStateAccess("exec")
+            return super.exec(closure)
+        }
+
+        override fun exec(action: Action<in ExecSpec>): ExecResult {
+            onMutableStateAccess("exec")
+            return super.exec(action)
         }
 
         override fun afterEvaluate(action: Action<in Project>) {
-            onAccess("afterEvaluate")
-            delegate.afterEvaluate(action)
-        }
-
-        override fun beforeEvaluate(closure: Closure<*>) {
-            onAccess("beforeEvaluate")
-            delegate.beforeEvaluate(closure)
+            onMutableStateAccess("afterEvaluate")
+            super.afterEvaluate(action)
         }
 
         override fun afterEvaluate(closure: Closure<*>) {
-            onAccess("afterEvaluate")
-            delegate.afterEvaluate(closure)
+            onMutableStateAccess("afterEvaluate")
+            super.afterEvaluate(closure)
         }
 
-        override fun hasProperty(propertyName: String): Boolean {
-            onAccess("hasProperty")
-            return delegate.hasProperty(propertyName)
+        override fun beforeEvaluate(action: Action<in Project>) {
+            onMutableStateAccess("beforeEvaluate")
+            super.beforeEvaluate(action)
         }
 
-        override fun getProperties(): MutableMap<String, *> {
-            onAccess("properties")
-            return delegate.properties
-        }
-
-        override fun property(propertyName: String): Any? {
-            onAccess("property")
-            return delegate.property(propertyName)
-        }
-
-        override fun findProperty(propertyName: String): Any? {
-            onAccess("findProperty")
-            return delegate.findProperty(propertyName)
-        }
-
-        override fun getLogger(): Logger {
-            onAccess("logger")
-            return delegate.logger
-        }
-
-        override fun getLogging(): LoggingManager {
-            onAccess("logging")
-            return delegate.logging
-        }
-
-        override fun configure(target: Any, configureClosure: Closure<*>): Any {
-            onAccess("configure")
-            return delegate.configure(target, configureClosure)
-        }
-
-        override fun configure(targets: MutableIterable<*>, configureClosure: Closure<*>): MutableIterable<*> {
-            onAccess("configure")
-            return delegate.configure(targets, configureClosure)
-        }
-
-        override fun <T : Any?> configure(targets: MutableIterable<T>, configureAction: Action<in T>): MutableIterable<T> {
-            onAccess("configure")
-            return delegate.configure(targets, configureAction)
-        }
-
-        override fun getRepositories(): RepositoryHandler {
-            onAccess("repositories")
-            return delegate.repositories
-        }
-
-        override fun repositories(configureClosure: Closure<*>) {
-            onAccess("repositories")
-            delegate.repositories(configureClosure)
-        }
-
-        override fun getDependencies(): DependencyHandler {
-            onAccess("dependencies")
-            return delegate.dependencies
-        }
-
-        override fun dependencies(configureClosure: Closure<*>) {
-            onAccess("dependencies")
-            delegate.dependencies(configureClosure)
-        }
-
-        override fun getDependencyFactory(): DependencyFactory {
-            onAccess("dependencyFactory")
-            return delegate.dependencyFactory
-        }
-
-        override fun buildscript(configureClosure: Closure<*>) {
-            onAccess("buildscript")
-            delegate.buildscript(configureClosure)
-        }
-
-        override fun copy(closure: Closure<*>): WorkResult {
-            onAccess("copy")
-            return delegate.copy(closure)
-        }
-
-        override fun copy(action: Action<in CopySpec>): WorkResult {
-            onAccess("copy")
-            return delegate.copy(action)
-        }
-
-        override fun copySpec(closure: Closure<*>): CopySpec {
-            onAccess("copySpec")
-            return delegate.copySpec(closure)
-        }
-
-        override fun copySpec(action: Action<in CopySpec>): CopySpec {
-            onAccess("copySpec")
-            return delegate.copySpec(action)
-        }
-
-        override fun copySpec(): CopySpec {
-            onAccess("copySpec")
-            return delegate.copySpec()
-        }
-
-        override fun sync(action: Action<in SyncSpec>): WorkResult {
-            onAccess("sync")
-            return delegate.sync(action)
-        }
-
-        override fun <T : Any?> container(type: Class<T>): NamedDomainObjectContainer<T> {
-            onAccess("container")
-            return delegate.container(type)
-        }
-
-        override fun <T : Any?> container(type: Class<T>, factory: NamedDomainObjectFactory<T>): NamedDomainObjectContainer<T> {
-            onAccess("container")
-            return delegate.container(type, factory)
-        }
-
-        override fun <T : Any?> container(type: Class<T>, factoryClosure: Closure<*>): NamedDomainObjectContainer<T> {
-            onAccess("container")
-            return delegate.container(type, factoryClosure)
-        }
-
-        override fun getResources(): ResourceHandler {
-            onAccess("resources")
-            return delegate.resources
-        }
-
-        override fun getComponents(): SoftwareComponentContainer {
-            onAccess("components")
-            return delegate.components
-        }
-
-        override fun components(configuration: Action<in SoftwareComponentContainer>) {
-            onAccess("components")
-            delegate.components(configuration)
+        override fun beforeEvaluate(closure: Closure<*>) {
+            onMutableStateAccess("beforeEvaluate")
+            super.beforeEvaluate(closure)
         }
 
         override fun getNormalization(): InputNormalizationHandlerInternal {
-            onAccess("normalization")
-            return delegate.normalization
+            onMutableStateAccess("normalization")
+            return super.getNormalization()
         }
 
         override fun normalization(configuration: Action<in InputNormalizationHandler>) {
-            onAccess("normalization")
-            delegate.normalization(configuration)
+            onMutableStateAccess("normalization")
+            super.normalization(configuration)
         }
 
         override fun dependencyLocking(configuration: Action<in DependencyLockingHandler>) {
-            onAccess("dependencyLocking")
-            delegate.dependencyLocking(configuration)
+            onMutableStateAccess("dependencyLocking")
+            super.dependencyLocking(configuration)
         }
 
         override fun getDependencyLocking(): DependencyLockingHandler {
-            onAccess("dependencyLocking")
-            return delegate.dependencyLocking
+            onMutableStateAccess("dependencyLocking")
+            return super.getDependencyLocking()
         }
 
-        override fun getPlugins(): PluginContainer {
-            onAccess("plugins")
-            return delegate.plugins
+        override fun getResources(): ResourceHandler {
+            onMutableStateAccess("resources")
+            return super.getResources()
         }
 
-        override fun apply(closure: Closure<*>) {
-            onAccess("apply")
-            delegate.apply(closure)
+        override fun sync(action: Action<in SyncSpec>): WorkResult {
+            onMutableStateAccess("sync")
+            return super.sync(action)
         }
 
-        override fun apply(action: Action<in ObjectConfigurationAction>) {
-            onAccess("apply")
-            delegate.apply(action)
+        override fun copySpec(closure: Closure<*>): CopySpec {
+            onMutableStateAccess("copySpec")
+            return super.copySpec(closure)
         }
 
-        override fun apply(options: MutableMap<String, *>) {
-            onAccess("apply")
-            delegate.apply(options)
+        override fun copySpec(action: Action<in CopySpec>): CopySpec {
+            onMutableStateAccess("copySpec")
+            return super.copySpec(action)
         }
 
-        override fun getPluginManager(): PluginManagerInternal {
-            onAccess("pluginManager")
-            return delegate.pluginManager
+        override fun copySpec(): CopySpec {
+            onMutableStateAccess("copySpec")
+            return super.copySpec()
+        }
+
+        override fun copy(closure: Closure<*>): WorkResult {
+            onMutableStateAccess("copy")
+            return super.copy(closure)
+        }
+
+        override fun copy(action: Action<in CopySpec>): WorkResult {
+            onMutableStateAccess("copy")
+            return super.copy(action)
+        }
+
+        override fun getDependencyFactory(): DependencyFactory {
+            onMutableStateAccess("dependencyFactory")
+            return super.getDependencyFactory()
+        }
+
+        override fun configure(`object`: Any, configureClosure: Closure<*>): Any {
+            onMutableStateAccess("configure")
+            return super.configure(`object`, configureClosure)
+        }
+
+        override fun configure(objects: MutableIterable<*>, configureClosure: Closure<*>): MutableIterable<*> {
+            onMutableStateAccess("configure")
+            return super.configure(objects, configureClosure)
+        }
+
+        override fun <T : Any?> configure(objects: MutableIterable<T>, configureAction: Action<in T>): MutableIterable<T> {
+            onMutableStateAccess("configure")
+            return super.configure(objects, configureAction)
+        }
+
+        override fun getLogging(): LoggingManager {
+            onMutableStateAccess("logging")
+            return super.getLogging()
+        }
+
+        override fun getLogger(): Logger {
+            onMutableStateAccess("logger")
+            return super.getLogger()
+        }
+
+        override fun getAnt(): AntBuilder {
+            onMutableStateAccess("ant")
+            return super.getAnt()
+        }
+
+        override fun createAntBuilder(): AntBuilder {
+            onMutableStateAccess("antBuilder")
+            return super.createAntBuilder()
+        }
+
+        override fun ant(configureClosure: Closure<*>): AntBuilder {
+            onMutableStateAccess("ant")
+            return super.ant(configureClosure)
+        }
+
+        override fun ant(configureAction: Action<in AntBuilder>): AntBuilder {
+            onMutableStateAccess("ant")
+            return super.ant(configureAction)
         }
 
         override fun identityPath(name: String): Path {
@@ -906,22 +531,6 @@ class ProblemReportingCrossProjectModelAccess(
             shouldNotBeUsed()
         }
 
-        override fun getParent(): ProjectInternal? {
-            return delegate.getParent(referrer)
-        }
-
-        override fun getParent(referrer: ProjectInternal): ProjectInternal? {
-            return delegate.getParent(referrer)
-        }
-
-        override fun getRootProject(): ProjectInternal {
-            return delegate.getRootProject(referrer)
-        }
-
-        override fun getRootProject(referrer: ProjectInternal): ProjectInternal {
-            return delegate.getRootProject(referrer)
-        }
-
         override fun evaluate(): Project {
             shouldNotBeUsed()
         }
@@ -930,38 +539,13 @@ class ProblemReportingCrossProjectModelAccess(
             shouldNotBeUsed()
         }
 
-        override fun getTasks(): TaskContainerInternal {
-            onAccess("tasks")
-            return delegate.tasks
-        }
-
         override fun getBuildScriptSource(): ScriptSource {
             shouldNotBeUsed()
         }
 
-        override fun project(path: String): ProjectInternal {
-            return delegate.project(referrer, path)
-        }
-
-        override fun project(referrer: ProjectInternal, path: String): ProjectInternal {
-            return delegate.project(referrer, path)
-        }
-
-        override fun findProject(path: String): ProjectInternal? {
-            return delegate.findProject(referrer, path)
-        }
-
-        override fun findProject(referrer: ProjectInternal, path: String): ProjectInternal? {
-            return delegate.findProject(referrer, path)
-        }
-
-        override fun getInheritedScope(): DynamicObject {
-            return delegate.inheritedScope
-        }
-
         override fun getGradle(): GradleInternal {
-            onAccess("gradle")
-            return delegate.gradle
+            onMutableStateAccess("gradle")
+            return super.getGradle()
         }
 
         override fun getProjectEvaluationBroadcaster(): ProjectEvaluationListener {
@@ -996,16 +580,6 @@ class ProblemReportingCrossProjectModelAccess(
             shouldNotBeUsed()
         }
 
-        override fun getState(): ProjectStateInternal {
-            onAccess("state")
-            return delegate.state
-        }
-
-        override fun getExtensions(): ExtensionContainerInternal {
-            onAccess("extensions")
-            return delegate.extensions
-        }
-
         override fun getConfigurationActions(): ProjectConfigurationActionContainer {
             shouldNotBeUsed()
         }
@@ -1034,29 +608,8 @@ class ProblemReportingCrossProjectModelAccess(
             shouldNotBeUsed()
         }
 
-        override fun getProjectPath(): Path {
-            return delegate.projectPath
-        }
-
-        override fun getProjectIdentityPath(): Path? {
-            return delegate.projectIdentityPath
-        }
-
-        override fun getIdentityPath(): Path {
-            return delegate.identityPath
-        }
-
         override fun stepEvaluationListener(listener: ProjectEvaluationListener, action: Action<ProjectEvaluationListener>): ProjectEvaluationListener? {
             shouldNotBeUsed()
-        }
-
-        override fun getOwner(): ProjectState {
-            return delegate.owner
-        }
-
-        override fun getBuildscript(): ScriptHandlerInternal {
-            onAccess("buildscript")
-            return delegate.buildscript
         }
 
         override fun newDetachedResolver(): ProjectInternal.DetachedResolver {
@@ -1065,12 +618,6 @@ class ProblemReportingCrossProjectModelAccess(
 
         fun shouldNotBeUsed(): Nothing {
             throw UnsupportedOperationException("This internal method should not be used.")
-        }
-
-        private
-        fun onAccess(what: String) {
-            reportCrossProjectAccessProblem("Project.$what", "functionality")
-            onProjectsCoupled()
         }
 
         private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -25,7 +25,6 @@ import org.gradle.api.PathValidation
 import org.gradle.api.Project
 import org.gradle.api.ProjectEvaluationListener
 import org.gradle.api.artifacts.dsl.DependencyFactory
-import org.gradle.api.artifacts.dsl.DependencyLockingHandler
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.file.CopySpec
@@ -74,8 +73,6 @@ import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.internal.service.scopes.ServiceRegistryFactory
 import org.gradle.model.internal.registry.ModelRegistry
-import org.gradle.normalization.InputNormalizationHandler
-import org.gradle.normalization.internal.InputNormalizationHandlerInternal
 import org.gradle.process.ExecResult
 import org.gradle.process.ExecSpec
 import org.gradle.process.JavaExecSpec

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -168,8 +168,7 @@ class ProblemReportingCrossProjectModelAccess(
     ) : MutableStateAccessAwareProject(delegate) {
 
         override fun onMutableStateAccess(what: String) {
-            reportCrossProjectAccessProblem("Project.$what", "functionality")
-            onProjectsCoupled()
+            onIsolationViolation(what)
         }
 
         override fun equals(other: Any?): Boolean {
@@ -248,243 +247,248 @@ class ProblemReportingCrossProjectModelAccess(
         }
 
         override fun file(path: Any): File {
-            onMutableStateAccess("file")
+            onIsolationViolation("file")
             return super.file(path)
         }
 
         override fun file(path: Any, validation: PathValidation): File {
-            onMutableStateAccess("file")
+            onIsolationViolation("file")
             return super.file(path, validation)
         }
 
         override fun uri(path: Any): URI {
-            onMutableStateAccess("uri")
+            onIsolationViolation("uri")
             return super.uri(path)
         }
 
         override fun relativePath(path: Any): String {
-            onMutableStateAccess("relativePath")
+            onIsolationViolation("relativePath")
             return super.relativePath(path)
         }
 
         override fun files(vararg paths: Any?): ConfigurableFileCollection {
-            onMutableStateAccess("files")
+            onIsolationViolation("files")
             return super.files(*paths)
         }
 
         override fun files(paths: Any, configureClosure: Closure<*>): ConfigurableFileCollection {
-            onMutableStateAccess("files")
+            onIsolationViolation("files")
             return super.files(paths, configureClosure)
         }
 
         override fun files(paths: Any, configureAction: Action<in ConfigurableFileCollection>): ConfigurableFileCollection {
-            onMutableStateAccess("files")
+            onIsolationViolation("files")
             return super.files(paths, configureAction)
         }
 
         override fun fileTree(baseDir: Any): ConfigurableFileTree {
-            onMutableStateAccess("fileTree")
+            onIsolationViolation("fileTree")
             return super.fileTree(baseDir)
         }
 
         override fun fileTree(baseDir: Any, configureClosure: Closure<*>): ConfigurableFileTree {
-            onMutableStateAccess("fileTree")
+            onIsolationViolation("fileTree")
             return super.fileTree(baseDir, configureClosure)
         }
 
         override fun fileTree(baseDir: Any, configureAction: Action<in ConfigurableFileTree>): ConfigurableFileTree {
-            onMutableStateAccess("fileTree")
+            onIsolationViolation("fileTree")
             return super.fileTree(baseDir, configureAction)
         }
 
         override fun fileTree(args: MutableMap<String, *>): ConfigurableFileTree {
-            onMutableStateAccess("fileTree")
+            onIsolationViolation("fileTree")
             return super.fileTree(args)
         }
 
         override fun zipTree(zipPath: Any): FileTree {
-            onMutableStateAccess("zipTree")
+            onIsolationViolation("zipTree")
             return super.zipTree(zipPath)
         }
 
         override fun tarTree(tarPath: Any): FileTree {
-            onMutableStateAccess("tarTree")
+            onIsolationViolation("tarTree")
             return super.tarTree(tarPath)
         }
 
         override fun <T : Any> provider(value: Callable<out T?>): Provider<T> {
-            onMutableStateAccess("provider")
+            onIsolationViolation("provider")
             return super.provider(value)
         }
 
         override fun getProviders(): ProviderFactory {
-            onMutableStateAccess("providers")
+            onIsolationViolation("providers")
             return super.getProviders()
         }
 
         override fun getObjects(): ObjectFactory {
-            onMutableStateAccess("objects")
+            onIsolationViolation("objects")
             return super.getObjects()
         }
 
         override fun mkdir(path: Any): File {
-            onMutableStateAccess("mkdir")
+            onIsolationViolation("mkdir")
             return super.mkdir(path)
         }
 
         override fun delete(vararg paths: Any?): Boolean {
-            onMutableStateAccess("delete")
+            onIsolationViolation("delete")
             return super.delete(*paths)
         }
 
         override fun delete(action: Action<in DeleteSpec>): WorkResult {
-            onMutableStateAccess("delete")
+            onIsolationViolation("delete")
             return super.delete(action)
         }
 
         override fun javaexec(closure: Closure<*>): ExecResult {
-            onMutableStateAccess("javaexec")
+            onIsolationViolation("javaexec")
             return super.javaexec(closure)
         }
 
         override fun javaexec(action: Action<in JavaExecSpec>): ExecResult {
-            onMutableStateAccess("javaexec")
+            onIsolationViolation("javaexec")
             return super.javaexec(action)
         }
 
         override fun exec(closure: Closure<*>): ExecResult {
-            onMutableStateAccess("exec")
+            onIsolationViolation("exec")
             return super.exec(closure)
         }
 
         override fun exec(action: Action<in ExecSpec>): ExecResult {
-            onMutableStateAccess("exec")
+            onIsolationViolation("exec")
             return super.exec(action)
         }
 
         override fun afterEvaluate(action: Action<in Project>) {
-            onMutableStateAccess("afterEvaluate")
+            onIsolationViolation("afterEvaluate")
             super.afterEvaluate(action)
         }
 
         override fun afterEvaluate(closure: Closure<*>) {
-            onMutableStateAccess("afterEvaluate")
+            onIsolationViolation("afterEvaluate")
             super.afterEvaluate(closure)
         }
 
         override fun beforeEvaluate(action: Action<in Project>) {
-            onMutableStateAccess("beforeEvaluate")
+            onIsolationViolation("beforeEvaluate")
             super.beforeEvaluate(action)
         }
 
         override fun beforeEvaluate(closure: Closure<*>) {
-            onMutableStateAccess("beforeEvaluate")
+            onIsolationViolation("beforeEvaluate")
             super.beforeEvaluate(closure)
         }
 
         override fun getNormalization(): InputNormalizationHandlerInternal {
-            onMutableStateAccess("normalization")
+            onIsolationViolation("normalization")
             return super.getNormalization()
         }
 
         override fun normalization(configuration: Action<in InputNormalizationHandler>) {
-            onMutableStateAccess("normalization")
+            onIsolationViolation("normalization")
             super.normalization(configuration)
         }
 
         override fun dependencyLocking(configuration: Action<in DependencyLockingHandler>) {
-            onMutableStateAccess("dependencyLocking")
+            onIsolationViolation("dependencyLocking")
             super.dependencyLocking(configuration)
         }
 
         override fun getDependencyLocking(): DependencyLockingHandler {
-            onMutableStateAccess("dependencyLocking")
+            onIsolationViolation("dependencyLocking")
             return super.getDependencyLocking()
         }
 
         override fun getResources(): ResourceHandler {
-            onMutableStateAccess("resources")
+            onIsolationViolation("resources")
             return super.getResources()
         }
 
         override fun sync(action: Action<in SyncSpec>): WorkResult {
-            onMutableStateAccess("sync")
+            onIsolationViolation("sync")
             return super.sync(action)
         }
 
         override fun copySpec(closure: Closure<*>): CopySpec {
-            onMutableStateAccess("copySpec")
+            onIsolationViolation("copySpec")
             return super.copySpec(closure)
         }
 
         override fun copySpec(action: Action<in CopySpec>): CopySpec {
-            onMutableStateAccess("copySpec")
+            onIsolationViolation("copySpec")
             return super.copySpec(action)
         }
 
         override fun copySpec(): CopySpec {
-            onMutableStateAccess("copySpec")
+            onIsolationViolation("copySpec")
             return super.copySpec()
         }
 
         override fun copy(closure: Closure<*>): WorkResult {
-            onMutableStateAccess("copy")
+            onIsolationViolation("copy")
             return super.copy(closure)
         }
 
         override fun copy(action: Action<in CopySpec>): WorkResult {
-            onMutableStateAccess("copy")
+            onIsolationViolation("copy")
             return super.copy(action)
         }
 
         override fun getDependencyFactory(): DependencyFactory {
-            onMutableStateAccess("dependencyFactory")
+            onIsolationViolation("dependencyFactory")
             return super.getDependencyFactory()
         }
 
         override fun configure(`object`: Any, configureClosure: Closure<*>): Any {
-            onMutableStateAccess("configure")
+            onIsolationViolation("configure")
             return super.configure(`object`, configureClosure)
         }
 
         override fun configure(objects: MutableIterable<*>, configureClosure: Closure<*>): MutableIterable<*> {
-            onMutableStateAccess("configure")
+            onIsolationViolation("configure")
             return super.configure(objects, configureClosure)
         }
 
         override fun <T : Any?> configure(objects: MutableIterable<T>, configureAction: Action<in T>): MutableIterable<T> {
-            onMutableStateAccess("configure")
+            onIsolationViolation("configure")
             return super.configure(objects, configureAction)
         }
 
         override fun getLogging(): LoggingManager {
-            onMutableStateAccess("logging")
+            onIsolationViolation("logging")
             return super.getLogging()
         }
 
         override fun getLogger(): Logger {
-            onMutableStateAccess("logger")
+            onIsolationViolation("logger")
             return super.getLogger()
         }
 
         override fun getAnt(): AntBuilder {
-            onMutableStateAccess("ant")
+            onIsolationViolation("ant")
             return super.getAnt()
         }
 
         override fun createAntBuilder(): AntBuilder {
-            onMutableStateAccess("antBuilder")
+            onIsolationViolation("antBuilder")
             return super.createAntBuilder()
         }
 
         override fun ant(configureClosure: Closure<*>): AntBuilder {
-            onMutableStateAccess("ant")
+            onIsolationViolation("ant")
             return super.ant(configureClosure)
         }
 
         override fun ant(configureAction: Action<in AntBuilder>): AntBuilder {
-            onMutableStateAccess("ant")
+            onIsolationViolation("ant")
             return super.ant(configureAction)
+        }
+
+        override fun getGradle(): GradleInternal {
+            onIsolationViolation("gradle")
+            return super.getGradle()
         }
 
         override fun identityPath(name: String): Path {
@@ -541,11 +545,6 @@ class ProblemReportingCrossProjectModelAccess(
 
         override fun getBuildScriptSource(): ScriptSource {
             shouldNotBeUsed()
-        }
-
-        override fun getGradle(): GradleInternal {
-            onMutableStateAccess("gradle")
-            return super.getGradle()
         }
 
         override fun getProjectEvaluationBroadcaster(): ProjectEvaluationListener {
@@ -616,8 +615,13 @@ class ProblemReportingCrossProjectModelAccess(
             shouldNotBeUsed()
         }
 
-        fun shouldNotBeUsed(): Nothing {
+        private fun shouldNotBeUsed(): Nothing {
             throw UnsupportedOperationException("This internal method should not be used.")
+        }
+
+        private fun onIsolationViolation(what : String) {
+            reportCrossProjectAccessProblem("Project.$what", "functionality")
+            onProjectsCoupled()
         }
 
         private

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
@@ -91,6 +91,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.function.Function;
 
 /**
  * Wrapper for {@link ProjectInternal}, that declares some API methods as access to a mutable state of the project.
@@ -102,6 +103,16 @@ import java.util.concurrent.Callable;
  * Instances of this class should be created via {@link org.gradle.internal.reflect.Instantiator} to ensure proper runtime decoration.
  */
 public abstract class MutableStateAccessAwareProject implements ProjectInternal, DynamicObjectAware {
+
+    public static <T extends MutableStateAccessAwareProject> ProjectInternal wrap(
+        ProjectInternal target,
+        ProjectInternal referrer,
+        Function<ProjectInternal, T> wrapper
+    ) {
+        return target == referrer
+            ? target
+            : wrapper.apply(target);
+    }
 
     protected final ProjectInternal delegate;
     private final DynamicObject dynamicObject;
@@ -273,11 +284,13 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
 
     @Override
     public Project evaluate() {
+        onMutableStateAccess("evaluate");
         return delegate.evaluate();
     }
 
     @Override
     public ProjectInternal bindAllModelRules() {
+        onMutableStateAccess("bindAllModelRules");
         return delegate.bindAllModelRules();
     }
 
@@ -392,21 +405,25 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
 
     @Override
     public void beforeEvaluate(Action<? super Project> action) {
+        onMutableStateAccess("beforeEvaluate");
         delegate.beforeEvaluate(action);
     }
 
     @Override
     public void beforeEvaluate(Closure closure) {
+        onMutableStateAccess("beforeEvaluate");
         delegate.beforeEvaluate(closure);
     }
 
     @Override
     public void afterEvaluate(Action<? super Project> action) {
+        onMutableStateAccess("afterEvaluate");
         delegate.afterEvaluate(action);
     }
 
     @Override
     public void afterEvaluate(Closure closure) {
+        onMutableStateAccess("afterEvaluate");
         delegate.afterEvaluate(closure);
     }
 
@@ -781,11 +798,13 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
 
     @Override
     public void addRuleBasedPluginListener(RuleBasedPluginListener listener) {
+        onMutableStateAccess("ruleBasedPluginListener");
         delegate.addRuleBasedPluginListener(listener);
     }
 
     @Override
     public void prepareForRuleBasedPlugins() {
+        onMutableStateAccess("ruleBasedPlugins");
         delegate.prepareForRuleBasedPlugins();
     }
 
@@ -796,11 +815,13 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
 
     @Override
     public ServiceRegistry getServices() {
+        onMutableStateAccess("services");
         return delegate.getServices();
     }
 
     @Override
     public ServiceRegistryFactory getServiceRegistryFactory() {
+        onMutableStateAccess("serviceRegistryFactory");
         return delegate.getServiceRegistryFactory();
     }
 
@@ -855,11 +876,13 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
 
     @Override
     public ProjectConfigurationActionContainer getConfigurationActions() {
+        onMutableStateAccess("configurationActions");
         return delegate.getConfigurationActions();
     }
 
     @Override
     public ModelRegistry getModelRegistry() {
+        onMutableStateAccess("modelRegistry");
         return delegate.getModelRegistry();
     }
 
@@ -875,6 +898,7 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
 
     @Override
     public void setScript(Script script) {
+        onMutableStateAccess("script");
         delegate.setScript(script);
     }
 
@@ -885,16 +909,19 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
 
     @Override
     public void addDeferredConfiguration(Runnable configuration) {
+        onMutableStateAccess("deferredConfiguration");
         delegate.addDeferredConfiguration(configuration);
     }
 
     @Override
     public void fireDeferredConfiguration() {
+        onMutableStateAccess("deferredConfiguration");
         delegate.fireDeferredConfiguration();
     }
 
     @Override
     public ModelContainer<?> getModel() {
+        onMutableStateAccess("model");
         return delegate.getModel();
     }
 
@@ -926,26 +953,31 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
 
     @Override
     public ProjectState getOwner() {
+        // TODO: this is a mutable state
         return delegate.getOwner();
     }
 
     @Override
     public InputNormalizationHandlerInternal getNormalization() {
+        onMutableStateAccess("normalization");
         return delegate.getNormalization();
     }
 
     @Override
     public void normalization(Action<? super InputNormalizationHandler> configuration) {
+        onMutableStateAccess("normalization");
         delegate.normalization(configuration);
     }
 
     @Override
     public void dependencyLocking(Action<? super DependencyLockingHandler> configuration) {
+        onMutableStateAccess("dependencyLocking");
         delegate.dependencyLocking(configuration);
     }
 
     @Override
     public DependencyLockingHandler getDependencyLocking() {
+        onMutableStateAccess("dependencyLocking");
         return delegate.getDependencyLocking();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
@@ -125,12 +125,6 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
         return dynamicObject;
     }
 
-    @Nullable
-    @Override
-    public ProjectInternal getParent() {
-        return delegate.getParent();
-    }
-
     @Override
     public String getName() {
         return delegate.getName();
@@ -139,6 +133,11 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     @Override
     public String getDisplayName() {
         return delegate.getDisplayName();
+    }
+
+    @Override
+    public IsolatedProject getIsolated() {
+        return delegate.getIsolated();
     }
 
     @Nullable
@@ -192,13 +191,14 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
 
     @Nullable
     @Override
-    public ProjectInternal getParent(ProjectInternal referrer) {
-        return delegate.getParent(referrer);
+    public ProjectInternal getParent() {
+        return delegate.getParent();
     }
 
+    @Nullable
     @Override
-    public ProjectInternal getRootProject() {
-        return delegate.getRootProject();
+    public ProjectInternal getParent(ProjectInternal referrer) {
+        return delegate.getParent(referrer);
     }
 
     @Override
@@ -237,8 +237,18 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     }
 
     @Override
+    public File getProjectDir() {
+        return delegate.getProjectDir();
+    }
+
+    @Override
     public File getBuildFile() {
         return delegate.getBuildFile();
+    }
+
+    @Override
+    public ProjectInternal getRootProject() {
+        return delegate.getRootProject();
     }
 
     @Override
@@ -263,6 +273,16 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     }
 
     @Override
+    public ProjectInternal getProject() {
+        return this;
+    }
+
+    @Override
+    public void subprojects(ProjectInternal referrer, Action<? super Project> configureAction) {
+        delegate.subprojects(referrer, configureAction);
+    }
+
+    @Override
     public void subprojects(Action<? super Project> action) {
         delegate.subprojects(action);
     }
@@ -283,18 +303,91 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     }
 
     @Override
+    public void allprojects(ProjectInternal referrer, Action<? super Project> configureAction) {
+        delegate.allprojects(referrer, configureAction);
+    }
+
+    @Override
+    public Project project(String path, Closure configureClosure) {
+        return delegate.project(path, configureClosure);
+    }
+
+    @Override
+    public ProjectInternal project(String path) throws UnknownProjectException {
+        return delegate.project(path);
+    }
+
+    @Override
+    public Project project(String path, Action<? super Project> configureAction) {
+        return delegate.project(path, configureAction);
+    }
+
+    @Override
+    public ProjectInternal project(ProjectInternal referrer, String path, Action<? super Project> configureAction) {
+        return delegate.project(referrer, path, configureAction);
+    }
+
+    @Override
+    public ProjectInternal project(ProjectInternal referrer, String path) throws UnknownProjectException {
+        return delegate.project(referrer, path);
+    }
+
+    @Nullable
+    @Override
+    public ProjectInternal findProject(String path) {
+        return delegate.findProject(path);
+    }
+
+    @Override
+    public Set<? extends ProjectInternal> getSubprojects(ProjectInternal referrer) {
+        return delegate.getSubprojects(referrer);
+    }
+
+    @Override
+    @AllowUsingApiForExternalUse
+    public Map<String, Project> getChildProjects() {
+        return delegate.getChildProjects();
+    }
+
+    @Override
+    public Set<Project> getAllprojects() {
+        return delegate.getAllprojects();
+    }
+
+    @Override
+    public Set<? extends ProjectInternal> getAllprojects(ProjectInternal referrer) {
+        return delegate.getAllprojects(referrer);
+    }
+
+    @Override
+    public Set<Project> getSubprojects() {
+        return delegate.getSubprojects();
+    }
+
+    @Override
+    public Map<String, Project> getChildProjectsUnchecked() {
+        return delegate.getChildProjectsUnchecked();
+    }
+
+    @Nullable
+    @Override
+    public ProjectInternal findProject(ProjectInternal referrer, String path) {
+        return delegate.findProject(referrer, path);
+    }
+
+    @Override
     public void beforeEvaluate(Action<? super Project> action) {
         delegate.beforeEvaluate(action);
     }
 
     @Override
-    public void afterEvaluate(Action<? super Project> action) {
-        delegate.afterEvaluate(action);
+    public void beforeEvaluate(Closure closure) {
+        delegate.beforeEvaluate(closure);
     }
 
     @Override
-    public void beforeEvaluate(Closure closure) {
-        delegate.beforeEvaluate(closure);
+    public void afterEvaluate(Action<? super Project> action) {
+        delegate.afterEvaluate(action);
     }
 
     @Override
@@ -329,6 +422,12 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     }
 
     @Override
+    public void setProperty(String name, @Nullable Object value) throws MissingPropertyException {
+        onMutableStateAccess("setProperty");
+        delegate.setProperty(name, value);
+    }
+
+    @Override
     public Logger getLogger() {
         return delegate.getLogger();
     }
@@ -336,21 +435,6 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     @Override
     public ScriptSource getBuildScriptSource() {
         return delegate.getBuildScriptSource();
-    }
-
-    @Override
-    public ProjectInternal project(String path) throws UnknownProjectException {
-        return delegate.project(path);
-    }
-
-    @Override
-    public Project project(String path, Closure configureClosure) {
-        return delegate.project(path, configureClosure);
-    }
-
-    @Override
-    public Project project(String path, Action<? super Project> configureAction) {
-        return delegate.project(path, configureAction);
     }
 
     @Override
@@ -366,8 +450,43 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     }
 
     @Override
-    public File getProjectDir() {
-        return delegate.getProjectDir();
+    public Task task(String name) throws InvalidUserDataException {
+        onMutableStateAccess("task");
+        return delegate.task(name);
+    }
+
+    @Override
+    public Task task(Map<String, ?> args, String name) throws InvalidUserDataException {
+        onMutableStateAccess("task");
+        return delegate.task(args, name);
+    }
+
+    @Override
+    public Task task(Map<String, ?> args, String name, Closure configureClosure) {
+        onMutableStateAccess("task");
+        return delegate.task(args, name, configureClosure);
+    }
+
+    @Override
+    public Task task(String name, Closure configureClosure) {
+        onMutableStateAccess("task");
+        return delegate.task(name, configureClosure);
+    }
+
+    @Override
+    public Task task(String name, Action<? super Task> configureAction) {
+        onMutableStateAccess("task");
+        return delegate.task(name, configureAction);
+    }
+
+    @Override
+    public URI uri(Object path) {
+        return delegate.uri(path);
+    }
+
+    @Override
+    public File mkdir(Object path) {
+        return delegate.mkdir(path);
     }
 
     @Override
@@ -378,16 +497,6 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     @Override
     public File file(Object path, PathValidation validation) throws InvalidUserDataException {
         return delegate.file(path, validation);
-    }
-
-    @Override
-    public URI uri(Object path) {
-        return delegate.uri(path);
-    }
-
-    @Override
-    public String relativePath(Object path) {
-        return delegate.relativePath(path);
     }
 
     @Override
@@ -436,6 +545,16 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     }
 
     @Override
+    public boolean delete(Object... paths) {
+        return delegate.delete(paths);
+    }
+
+    @Override
+    public WorkResult delete(Action<? super DeleteSpec> action) {
+        return delegate.delete(action);
+    }
+
+    @Override
     public <T> Provider<T> provider(Callable<? extends T> value) {
         return delegate.provider(value);
     }
@@ -454,21 +573,6 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     public ProjectLayout getLayout() {
         onMutableStateAccess("layout");
         return delegate.getLayout();
-    }
-
-    @Override
-    public File mkdir(Object path) {
-        return delegate.mkdir(path);
-    }
-
-    @Override
-    public boolean delete(Object... paths) {
-        return delegate.delete(paths);
-    }
-
-    @Override
-    public WorkResult delete(Action<? super DeleteSpec> action) {
-        return delegate.delete(action);
     }
 
     @Override
@@ -492,6 +596,11 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     }
 
     @Override
+    public String relativePath(Object path) {
+        return delegate.relativePath(path);
+    }
+
+    @Override
     public String absoluteProjectPath(String path) {
         return delegate.absoluteProjectPath(path);
     }
@@ -499,6 +608,27 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     @Override
     public String relativeProjectPath(String path) {
         return delegate.relativeProjectPath(path);
+    }
+
+    @Override
+    public String getPath() {
+        return delegate.getPath();
+    }
+
+    @Override
+    public Path identityPath(String name) {
+        return delegate.identityPath(name);
+    }
+
+    @Override
+    public Path projectPath(String name) {
+        return delegate.projectPath(name);
+    }
+
+    @Nonnull
+    @Override
+    public Path getProjectPath() {
+        return delegate.getProjectPath();
     }
 
     @Override
@@ -523,100 +653,6 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     public AntBuilder ant(Action<? super AntBuilder> configureAction) {
         onMutableStateAccess("ant");
         return delegate.ant(configureAction);
-    }
-
-    @Override
-    public ProjectInternal project(ProjectInternal referrer, String path) throws UnknownProjectException {
-        return delegate.project(referrer, path);
-    }
-
-    @Override
-    public ProjectInternal project(ProjectInternal referrer, String path, Action<? super Project> configureAction) {
-        return delegate.project(referrer, path, configureAction);
-    }
-
-    @Nullable
-    @Override
-    public ProjectInternal findProject(String path) {
-        return delegate.findProject(path);
-    }
-
-    @Nullable
-    @Override
-    public ProjectInternal findProject(ProjectInternal referrer, String path) {
-        return delegate.findProject(referrer, path);
-    }
-
-    @Override
-    public Set<? extends ProjectInternal> getSubprojects(ProjectInternal referrer) {
-        return delegate.getSubprojects(referrer);
-    }
-
-    @Override
-    public void subprojects(ProjectInternal referrer, Action<? super Project> configureAction) {
-        delegate.subprojects(referrer, configureAction);
-    }
-
-    @Override
-    @AllowUsingApiForExternalUse
-    public Map<String, Project> getChildProjects() {
-        return delegate.getChildProjects();
-    }
-
-    @Override
-    public void setProperty(String name, @Nullable Object value) throws MissingPropertyException {
-        onMutableStateAccess("setProperty");
-        delegate.setProperty(name, value);
-    }
-
-    @Override
-    public IsolatedProject getIsolated() {
-        return delegate.getIsolated();
-    }
-
-    @Override
-    public Set<Project> getAllprojects() {
-        return delegate.getAllprojects();
-    }
-
-    @Override
-    public Set<Project> getSubprojects() {
-        return delegate.getSubprojects();
-    }
-
-    @Override
-    public Task task(String name) throws InvalidUserDataException {
-        onMutableStateAccess("task");
-        return delegate.task(name);
-    }
-
-    @Override
-    public Task task(Map<String, ?> args, String name) throws InvalidUserDataException {
-        onMutableStateAccess("task");
-        return delegate.task(args, name);
-    }
-
-    @Override
-    public Task task(Map<String, ?> args, String name, Closure configureClosure) {
-        onMutableStateAccess("task");
-        return delegate.task(args, name, configureClosure);
-    }
-
-    @Override
-    public Task task(String name, Closure configureClosure) {
-        onMutableStateAccess("task");
-        return delegate.task(name, configureClosure);
-    }
-
-    @Override
-    public Task task(String name, Action<? super Task> configureAction) {
-        onMutableStateAccess("task");
-        return delegate.task(name, configureAction);
-    }
-
-    @Override
-    public String getPath() {
-        return delegate.getPath();
     }
 
     @Nullable
@@ -658,21 +694,6 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     public void evaluationDependsOnChildren() {
         onMutableStateAccess("evaluationDependsOnChildren");
         delegate.evaluationDependsOnChildren();
-    }
-
-    @Override
-    public Map<String, Project> getChildProjectsUnchecked() {
-        return delegate.getChildProjectsUnchecked();
-    }
-
-    @Override
-    public Set<? extends ProjectInternal> getAllprojects(ProjectInternal referrer) {
-        return delegate.getAllprojects(referrer);
-    }
-
-    @Override
-    public void allprojects(ProjectInternal referrer, Action<? super Project> configureAction) {
-        delegate.allprojects(referrer, configureAction);
     }
 
     @Override
@@ -735,6 +756,11 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     }
 
     @Override
+    public TaskDependencyFactory getTaskDependencyFactory() {
+        return delegate.getTaskDependencyFactory();
+    }
+
+    @Override
     public ProjectEvaluationListener getProjectEvaluationBroadcaster() {
         return delegate.getProjectEvaluationBroadcaster();
     }
@@ -752,11 +778,6 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     @Override
     public FileResolver getFileResolver() {
         return delegate.getFileResolver();
-    }
-
-    @Override
-    public TaskDependencyFactory getTaskDependencyFactory() {
-        return delegate.getTaskDependencyFactory();
     }
 
     @Override
@@ -844,6 +865,11 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     }
 
     @Override
+    public boolean isScript() {
+        return delegate.isScript();
+    }
+
+    @Override
     public void addDeferredConfiguration(Runnable configuration) {
         delegate.addDeferredConfiguration(configuration);
     }
@@ -854,27 +880,6 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     }
 
     @Override
-    public Path identityPath(String name) {
-        return delegate.identityPath(name);
-    }
-
-    @Override
-    public Path projectPath(String name) {
-        return delegate.projectPath(name);
-    }
-
-    @Nonnull
-    @Override
-    public Path getProjectPath() {
-        return delegate.getProjectPath();
-    }
-
-    @Override
-    public ProjectInternal getProject() {
-        return this;
-    }
-
-    @Override
     public ModelContainer<?> getModel() {
         return delegate.getModel();
     }
@@ -882,11 +887,6 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     @Override
     public Path getBuildPath() {
         return delegate.getBuildPath();
-    }
-
-    @Override
-    public boolean isScript() {
-        return delegate.isScript();
     }
 
     @Override
@@ -1058,6 +1058,12 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     }
 
     @Override
+    public PluginManagerInternal getPluginManager() {
+        onMutableStateAccess("pluginManager");
+        return delegate.getPluginManager();
+    }
+
+    @Override
     public void apply(Closure closure) {
         onMutableStateAccess("apply");
         delegate.apply(closure);
@@ -1073,12 +1079,6 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     public void apply(Map<String, ?> options) {
         onMutableStateAccess("apply");
         delegate.apply(options);
-    }
-
-    @Override
-    public PluginManagerInternal getPluginManager() {
-        onMutableStateAccess("pluginManager");
-        return delegate.getPluginManager();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
@@ -94,6 +94,15 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
+/**
+ * Wrapper for {@link ProjectInternal}, that declares some API methods as access to a mutable state of the project.
+ * <p>
+ * This class enables dynamic property and method dispatch on the `this` bean rather than on the {@link #delegate}.
+ * If the dispatch on `this` fails, the control flow is delegated to {@link #propertyMissing(String)} and
+ * {@link #methodMissing(String, Object)} methods.
+ * <p>
+ * Instances of this class should be created via {@link org.gradle.internal.reflect.Instantiator} to ensure proper runtime decoration.
+ * */
 public abstract class MutableStateAccessAwareProject implements ProjectInternal, DynamicObjectAware {
 
     protected final ProjectInternal delegate;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
@@ -1,0 +1,1097 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.project;
+
+import groovy.lang.Closure;
+import groovy.lang.MissingPropertyException;
+import groovy.lang.Script;
+import kotlin.Deprecated;
+import org.gradle.api.Action;
+import org.gradle.api.AntBuilder;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.NamedDomainObjectFactory;
+import org.gradle.api.PathValidation;
+import org.gradle.api.Project;
+import org.gradle.api.ProjectEvaluationListener;
+import org.gradle.api.Task;
+import org.gradle.api.UnknownProjectException;
+import org.gradle.api.artifacts.dsl.ArtifactHandler;
+import org.gradle.api.artifacts.dsl.DependencyFactory;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.artifacts.dsl.DependencyLockingHandler;
+import org.gradle.api.artifacts.dsl.RepositoryHandler;
+import org.gradle.api.component.SoftwareComponentContainer;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ConfigurableFileTree;
+import org.gradle.api.file.CopySpec;
+import org.gradle.api.file.DeleteSpec;
+import org.gradle.api.file.FileTree;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.file.SyncSpec;
+import org.gradle.api.internal.DynamicObjectAware;
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.ProcessOperations;
+import org.gradle.api.internal.artifacts.configurations.RoleBasedConfigurationContainerInternal;
+import org.gradle.api.internal.file.FileOperations;
+import org.gradle.api.internal.file.FileResolver;
+import org.gradle.api.internal.initialization.ClassLoaderScope;
+import org.gradle.api.internal.initialization.ScriptHandlerInternal;
+import org.gradle.api.internal.plugins.ExtensionContainerInternal;
+import org.gradle.api.internal.plugins.PluginManagerInternal;
+import org.gradle.api.internal.tasks.TaskContainerInternal;
+import org.gradle.api.internal.tasks.TaskDependencyFactory;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.LoggingManager;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.ObjectConfigurationAction;
+import org.gradle.api.plugins.PluginContainer;
+import org.gradle.api.project.IsolatedProject;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.resources.ResourceHandler;
+import org.gradle.api.tasks.WorkResult;
+import org.gradle.configuration.ConfigurationTargetIdentifier;
+import org.gradle.configuration.project.ProjectConfigurationActionContainer;
+import org.gradle.groovy.scripts.ScriptSource;
+import org.gradle.internal.accesscontrol.AllowUsingApiForExternalUse;
+import org.gradle.internal.logging.StandardOutputCapture;
+import org.gradle.internal.metaobject.BeanDynamicObject;
+import org.gradle.internal.metaobject.DynamicObject;
+import org.gradle.internal.model.ModelContainer;
+import org.gradle.internal.model.RuleBasedPluginListener;
+import org.gradle.internal.service.ServiceRegistry;
+import org.gradle.internal.service.scopes.ServiceRegistryFactory;
+import org.gradle.model.internal.registry.ModelRegistry;
+import org.gradle.normalization.InputNormalizationHandler;
+import org.gradle.normalization.internal.InputNormalizationHandlerInternal;
+import org.gradle.process.ExecResult;
+import org.gradle.process.ExecSpec;
+import org.gradle.process.JavaExecSpec;
+import org.gradle.util.Path;
+import org.gradle.util.internal.ConfigureUtil;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.File;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+public abstract class MutableStateAccessAwareProject implements ProjectInternal, DynamicObjectAware {
+
+    protected final ProjectInternal delegate;
+    private final DynamicObject dynamicObject;
+
+    protected MutableStateAccessAwareProject(ProjectInternal delegate) {
+        this.delegate = delegate;
+        this.dynamicObject = new BeanDynamicObject(this, Project.class);
+    }
+
+    protected abstract void onMutableStateAccess(String what);
+
+    @Override
+    public abstract boolean equals(Object obj);
+
+    @Override
+    public abstract int hashCode();
+
+    @Nullable
+    @SuppressWarnings("unused") // used by Groovy dynamic dispatch
+    protected abstract Object propertyMissing(String name);
+
+    @Nullable
+    @SuppressWarnings("unused") // used by Groovy dynamic dispatch
+    protected abstract Object methodMissing(String name, Object args);
+
+    @Override
+    public DynamicObject getAsDynamicObject() {
+        return dynamicObject;
+    }
+
+    @Nullable
+    @Override
+    public ProjectInternal getParent() {
+        return delegate.getParent();
+    }
+
+    @Override
+    public String getName() {
+        return delegate.getName();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return delegate.getDisplayName();
+    }
+
+    @Nullable
+    @Override
+    public String getDescription() {
+        onMutableStateAccess("description");
+        return delegate.getDescription();
+    }
+
+    @Override
+    public void setDescription(@Nullable String description) {
+        onMutableStateAccess("description");
+        delegate.setDescription(description);
+    }
+
+    @Override
+    public Object getGroup() {
+        onMutableStateAccess("group");
+        return delegate.getGroup();
+    }
+
+    @Override
+    public void setGroup(Object group) {
+        onMutableStateAccess("group");
+        delegate.setGroup(group);
+    }
+
+    @Override
+    public Object getVersion() {
+        onMutableStateAccess("version");
+        return delegate.getVersion();
+    }
+
+    @Override
+    public void setVersion(Object version) {
+        onMutableStateAccess("version");
+        delegate.setVersion(version);
+    }
+
+    @Override
+    public Object getStatus() {
+        onMutableStateAccess("status");
+        return delegate.getStatus();
+    }
+
+    @Override
+    public void setStatus(Object status) {
+        onMutableStateAccess("status");
+        delegate.setStatus(status);
+    }
+
+    @Nullable
+    @Override
+    public ProjectInternal getParent(ProjectInternal referrer) {
+        return delegate.getParent(referrer);
+    }
+
+    @Override
+    public ProjectInternal getRootProject() {
+        return delegate.getRootProject();
+    }
+
+    @Override
+    public File getRootDir() {
+        return delegate.getRootDir();
+    }
+
+    @Nullable
+    @Override
+    public Path getProjectIdentityPath() {
+        return delegate.getProjectIdentityPath();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    @Deprecated(message = "Use layout.buildDirectory instead")
+    public File getBuildDir() {
+        onMutableStateAccess("buildDir");
+        return delegate.getBuildDir();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    @Deprecated(message = "Use layout.buildDirectory instead")
+    public void setBuildDir(File path) {
+        onMutableStateAccess("buildDir");
+        delegate.setBuildDir(path);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    @Deprecated(message = "Use layout.buildDirectory instead")
+    public void setBuildDir(Object path) {
+        onMutableStateAccess("buildDir");
+        delegate.setBuildDir(path);
+    }
+
+    @Override
+    public File getBuildFile() {
+        return delegate.getBuildFile();
+    }
+
+    @Override
+    public ProjectInternal getRootProject(ProjectInternal referrer) {
+        return delegate.getRootProject(referrer);
+    }
+
+    @Override
+    public Project evaluate() {
+        return delegate.evaluate();
+    }
+
+    @Override
+    public ProjectInternal bindAllModelRules() {
+        return delegate.bindAllModelRules();
+    }
+
+    @Override
+    public TaskContainerInternal getTasks() {
+        onMutableStateAccess("tasks");
+        return delegate.getTasks();
+    }
+
+    @Override
+    public void subprojects(Action<? super Project> action) {
+        delegate.subprojects(action);
+    }
+
+    @Override
+    public void subprojects(Closure configureClosure) {
+        delegate.subprojects(configureClosure);
+    }
+
+    @Override
+    public void allprojects(Action<? super Project> action) {
+        delegate.allprojects(action);
+    }
+
+    @Override
+    public void allprojects(Closure configureClosure) {
+        delegate.allprojects(configureClosure);
+    }
+
+    @Override
+    public void beforeEvaluate(Action<? super Project> action) {
+        delegate.beforeEvaluate(action);
+    }
+
+    @Override
+    public void afterEvaluate(Action<? super Project> action) {
+        delegate.afterEvaluate(action);
+    }
+
+    @Override
+    public void beforeEvaluate(Closure closure) {
+        delegate.beforeEvaluate(closure);
+    }
+
+    @Override
+    public void afterEvaluate(Closure closure) {
+        delegate.afterEvaluate(closure);
+    }
+
+    @Override
+    public boolean hasProperty(String propertyName) {
+        onMutableStateAccess("hasProperty");
+        return delegate.hasProperty(propertyName);
+    }
+
+    @Override
+    public Map<String, ?> getProperties() {
+        onMutableStateAccess("properties");
+        return delegate.getProperties();
+    }
+
+    @Nullable
+    @Override
+    public Object property(String propertyName) throws MissingPropertyException {
+        onMutableStateAccess("property");
+        return delegate.property(propertyName);
+    }
+
+    @Nullable
+    @Override
+    public Object findProperty(String propertyName) {
+        onMutableStateAccess("findProperty");
+        return delegate.findProperty(propertyName);
+    }
+
+    @Override
+    public Logger getLogger() {
+        return delegate.getLogger();
+    }
+
+    @Override
+    public ScriptSource getBuildScriptSource() {
+        return delegate.getBuildScriptSource();
+    }
+
+    @Override
+    public ProjectInternal project(String path) throws UnknownProjectException {
+        return delegate.project(path);
+    }
+
+    @Override
+    public Project project(String path, Closure configureClosure) {
+        return delegate.project(path, configureClosure);
+    }
+
+    @Override
+    public Project project(String path, Action<? super Project> configureAction) {
+        return delegate.project(path, configureAction);
+    }
+
+    @Override
+    public Map<Project, Set<Task>> getAllTasks(boolean recursive) {
+        onMutableStateAccess("allTasks");
+        return delegate.getAllTasks(recursive);
+    }
+
+    @Override
+    public Set<Task> getTasksByName(String name, boolean recursive) {
+        onMutableStateAccess("tasksByName");
+        return delegate.getTasksByName(name, recursive);
+    }
+
+    @Override
+    public File getProjectDir() {
+        return delegate.getProjectDir();
+    }
+
+    @Override
+    public File file(Object path) {
+        return delegate.file(path);
+    }
+
+    @Override
+    public File file(Object path, PathValidation validation) throws InvalidUserDataException {
+        return delegate.file(path, validation);
+    }
+
+    @Override
+    public URI uri(Object path) {
+        return delegate.uri(path);
+    }
+
+    @Override
+    public String relativePath(Object path) {
+        return delegate.relativePath(path);
+    }
+
+    @Override
+    public ConfigurableFileCollection files(Object... paths) {
+        return delegate.files(paths);
+    }
+
+    @Override
+    public ConfigurableFileCollection files(Object paths, Closure configureClosure) {
+        return delegate.files(paths, configureClosure);
+    }
+
+    @Override
+    public ConfigurableFileCollection files(Object paths, Action<? super ConfigurableFileCollection> configureAction) {
+        return delegate.files(paths, configureAction);
+    }
+
+    @Override
+    public ConfigurableFileTree fileTree(Object baseDir) {
+        return delegate.fileTree(baseDir);
+    }
+
+    @Override
+    public ConfigurableFileTree fileTree(Object baseDir, Closure configureClosure) {
+        return delegate.fileTree(baseDir, configureClosure);
+    }
+
+    @Override
+    public ConfigurableFileTree fileTree(Object baseDir, Action<? super ConfigurableFileTree> configureAction) {
+        return delegate.fileTree(baseDir, configureAction);
+    }
+
+    @Override
+    public ConfigurableFileTree fileTree(Map<String, ?> args) {
+        return delegate.fileTree(args);
+    }
+
+    @Override
+    public FileTree zipTree(Object zipPath) {
+        return delegate.zipTree(zipPath);
+    }
+
+    @Override
+    public FileTree tarTree(Object tarPath) {
+        return delegate.tarTree(tarPath);
+    }
+
+    @Override
+    public <T> Provider<T> provider(Callable<? extends T> value) {
+        return delegate.provider(value);
+    }
+
+    @Override
+    public ProviderFactory getProviders() {
+        return delegate.getProviders();
+    }
+
+    @Override
+    public ObjectFactory getObjects() {
+        return delegate.getObjects();
+    }
+
+    @Override
+    public ProjectLayout getLayout() {
+        onMutableStateAccess("layout");
+        return delegate.getLayout();
+    }
+
+    @Override
+    public File mkdir(Object path) {
+        return delegate.mkdir(path);
+    }
+
+    @Override
+    public boolean delete(Object... paths) {
+        return delegate.delete(paths);
+    }
+
+    @Override
+    public WorkResult delete(Action<? super DeleteSpec> action) {
+        return delegate.delete(action);
+    }
+
+    @Override
+    public ExecResult javaexec(Closure closure) {
+        return delegate.javaexec(closure);
+    }
+
+    @Override
+    public ExecResult javaexec(Action<? super JavaExecSpec> action) {
+        return delegate.javaexec(action);
+    }
+
+    @Override
+    public ExecResult exec(Closure closure) {
+        return delegate.exec(closure);
+    }
+
+    @Override
+    public ExecResult exec(Action<? super ExecSpec> action) {
+        return delegate.exec(action);
+    }
+
+    @Override
+    public String absoluteProjectPath(String path) {
+        return delegate.absoluteProjectPath(path);
+    }
+
+    @Override
+    public String relativeProjectPath(String path) {
+        return delegate.relativeProjectPath(path);
+    }
+
+    @Override
+    public AntBuilder getAnt() {
+        onMutableStateAccess("ant");
+        return delegate.getAnt();
+    }
+
+    @Override
+    public AntBuilder createAntBuilder() {
+        onMutableStateAccess("antBuilder");
+        return delegate.createAntBuilder();
+    }
+
+    @Override
+    public AntBuilder ant(Closure configureClosure) {
+        onMutableStateAccess("ant");
+        return delegate.ant(configureClosure);
+    }
+
+    @Override
+    public AntBuilder ant(Action<? super AntBuilder> configureAction) {
+        onMutableStateAccess("ant");
+        return delegate.ant(configureAction);
+    }
+
+    @Override
+    public ProjectInternal project(ProjectInternal referrer, String path) throws UnknownProjectException {
+        return delegate.project(referrer, path);
+    }
+
+    @Override
+    public ProjectInternal project(ProjectInternal referrer, String path, Action<? super Project> configureAction) {
+        return delegate.project(referrer, path, configureAction);
+    }
+
+    @Nullable
+    @Override
+    public ProjectInternal findProject(String path) {
+        return delegate.findProject(path);
+    }
+
+    @Nullable
+    @Override
+    public ProjectInternal findProject(ProjectInternal referrer, String path) {
+        return delegate.findProject(referrer, path);
+    }
+
+    @Override
+    public Set<? extends ProjectInternal> getSubprojects(ProjectInternal referrer) {
+        return delegate.getSubprojects(referrer);
+    }
+
+    @Override
+    public void subprojects(ProjectInternal referrer, Action<? super Project> configureAction) {
+        delegate.subprojects(referrer, configureAction);
+    }
+
+    @Override
+    @AllowUsingApiForExternalUse
+    public Map<String, Project> getChildProjects() {
+        return delegate.getChildProjects();
+    }
+
+    @Override
+    public void setProperty(String name, @Nullable Object value) throws MissingPropertyException {
+        onMutableStateAccess("setProperty");
+        delegate.setProperty(name, value);
+    }
+
+    @Override
+    public IsolatedProject getIsolated() {
+        return delegate.getIsolated();
+    }
+
+    @Override
+    public Set<Project> getAllprojects() {
+        return delegate.getAllprojects();
+    }
+
+    @Override
+    public Set<Project> getSubprojects() {
+        return delegate.getSubprojects();
+    }
+
+    @Override
+    public Task task(String name) throws InvalidUserDataException {
+        onMutableStateAccess("task");
+        return delegate.task(name);
+    }
+
+    @Override
+    public Task task(Map<String, ?> args, String name) throws InvalidUserDataException {
+        onMutableStateAccess("task");
+        return delegate.task(args, name);
+    }
+
+    @Override
+    public Task task(Map<String, ?> args, String name, Closure configureClosure) {
+        onMutableStateAccess("task");
+        return delegate.task(args, name, configureClosure);
+    }
+
+    @Override
+    public Task task(String name, Closure configureClosure) {
+        onMutableStateAccess("task");
+        return delegate.task(name, configureClosure);
+    }
+
+    @Override
+    public Task task(String name, Action<? super Task> configureAction) {
+        onMutableStateAccess("task");
+        return delegate.task(name, configureAction);
+    }
+
+    @Override
+    public String getPath() {
+        return delegate.getPath();
+    }
+
+    @Nullable
+    @Override
+    public ProjectIdentifier getParentIdentifier() {
+        return delegate.getParentIdentifier();
+    }
+
+    @Override
+    public String getBuildTreePath() {
+        return delegate.getBuildTreePath();
+    }
+
+    @Override
+    public List<String> getDefaultTasks() {
+        onMutableStateAccess("defaultTasks");
+        return delegate.getDefaultTasks();
+    }
+
+    @Override
+    public void setDefaultTasks(List<String> defaultTasks) {
+        onMutableStateAccess("defaultTasks");
+        delegate.setDefaultTasks(defaultTasks);
+    }
+
+    @Override
+    public void defaultTasks(String... defaultTasks) {
+        onMutableStateAccess("defaultTasks");
+        delegate.defaultTasks(defaultTasks);
+    }
+
+    @Override
+    public Project evaluationDependsOn(String path) throws UnknownProjectException {
+        onMutableStateAccess("evaluationDependsOn");
+        return delegate.evaluationDependsOn(path);
+    }
+
+    @Override
+    public void evaluationDependsOnChildren() {
+        onMutableStateAccess("evaluationDependsOnChildren");
+        delegate.evaluationDependsOnChildren();
+    }
+
+    @Override
+    public Map<String, Project> getChildProjectsUnchecked() {
+        return delegate.getChildProjectsUnchecked();
+    }
+
+    @Override
+    public Set<? extends ProjectInternal> getAllprojects(ProjectInternal referrer) {
+        return delegate.getAllprojects(referrer);
+    }
+
+    @Override
+    public void allprojects(ProjectInternal referrer, Action<? super Project> configureAction) {
+        delegate.allprojects(referrer, configureAction);
+    }
+
+    @Override
+    public DynamicObject getInheritedScope() {
+        return delegate.getInheritedScope();
+    }
+
+    @Override
+    public GradleInternal getGradle() {
+        return delegate.getGradle();
+    }
+
+    @Override
+    public LoggingManager getLogging() {
+        return delegate.getLogging();
+    }
+
+    @Override
+    public Object configure(Object object, Closure configureClosure) {
+        return delegate.configure(object, configureClosure);
+    }
+
+    @Override
+    public Iterable<?> configure(Iterable<?> objects, Closure configureClosure) {
+        return delegate.configure(objects, configureClosure);
+    }
+
+    @Override
+    public <T> Iterable<T> configure(Iterable<T> objects, Action<? super T> configureAction) {
+        return delegate.configure(objects, configureAction);
+    }
+
+    @Override
+    public RepositoryHandler getRepositories() {
+        onMutableStateAccess("repositories");
+        return delegate.getRepositories();
+    }
+
+    @Override
+    public void repositories(Closure configureClosure) {
+        onMutableStateAccess("repositories");
+        delegate.repositories(configureClosure);
+    }
+
+    @Override
+    public DependencyHandler getDependencies() {
+        onMutableStateAccess("dependencies");
+        return delegate.getDependencies();
+    }
+
+    @Override
+    public void dependencies(Closure configureClosure) {
+        onMutableStateAccess("dependencies");
+        delegate.dependencies(configureClosure);
+    }
+
+    @Override
+    public DependencyFactory getDependencyFactory() {
+        return delegate.getDependencyFactory();
+    }
+
+    @Override
+    public ProjectEvaluationListener getProjectEvaluationBroadcaster() {
+        return delegate.getProjectEvaluationBroadcaster();
+    }
+
+    @Override
+    public void addRuleBasedPluginListener(RuleBasedPluginListener listener) {
+        delegate.addRuleBasedPluginListener(listener);
+    }
+
+    @Override
+    public void prepareForRuleBasedPlugins() {
+        delegate.prepareForRuleBasedPlugins();
+    }
+
+    @Override
+    public FileResolver getFileResolver() {
+        return delegate.getFileResolver();
+    }
+
+    @Override
+    public TaskDependencyFactory getTaskDependencyFactory() {
+        return delegate.getTaskDependencyFactory();
+    }
+
+    @Override
+    public ServiceRegistry getServices() {
+        return delegate.getServices();
+    }
+
+    @Override
+    public ServiceRegistryFactory getServiceRegistryFactory() {
+        return delegate.getServiceRegistryFactory();
+    }
+
+    @Override
+    public StandardOutputCapture getStandardOutputCapture() {
+        return delegate.getStandardOutputCapture();
+    }
+
+    @Override
+    public ProjectStateInternal getState() {
+        onMutableStateAccess("state");
+        return delegate.getState();
+    }
+
+    @Override
+    public <T> NamedDomainObjectContainer<T> container(Class<T> type) {
+        return delegate.container(type);
+    }
+
+    @Override
+    public <T> NamedDomainObjectContainer<T> container(Class<T> type, NamedDomainObjectFactory<T> factory) {
+        return delegate.container(type, factory);
+    }
+
+    @Override
+    public <T> NamedDomainObjectContainer<T> container(Class<T> type, Closure factoryClosure) {
+        return delegate.container(type, factoryClosure);
+    }
+
+    @Override
+    public ExtensionContainerInternal getExtensions() {
+        onMutableStateAccess("extensions");
+        return delegate.getExtensions();
+    }
+
+    @Override
+    public ResourceHandler getResources() {
+        return delegate.getResources();
+    }
+
+    @Override
+    public SoftwareComponentContainer getComponents() {
+        onMutableStateAccess("components");
+        return delegate.getComponents();
+    }
+
+    @Override
+    public void components(Action<? super SoftwareComponentContainer> configuration) {
+        onMutableStateAccess("components");
+        delegate.components(configuration);
+    }
+
+    @Override
+    public ProjectConfigurationActionContainer getConfigurationActions() {
+        return delegate.getConfigurationActions();
+    }
+
+    @Override
+    public ModelRegistry getModelRegistry() {
+        return delegate.getModelRegistry();
+    }
+
+    @Override
+    public ClassLoaderScope getClassLoaderScope() {
+        return delegate.getClassLoaderScope();
+    }
+
+    @Override
+    public ClassLoaderScope getBaseClassLoaderScope() {
+        return delegate.getBaseClassLoaderScope();
+    }
+
+    @Override
+    public void setScript(Script script) {
+        delegate.setScript(script);
+    }
+
+    @Override
+    public void addDeferredConfiguration(Runnable configuration) {
+        delegate.addDeferredConfiguration(configuration);
+    }
+
+    @Override
+    public void fireDeferredConfiguration() {
+        delegate.fireDeferredConfiguration();
+    }
+
+    @Override
+    public Path identityPath(String name) {
+        return delegate.identityPath(name);
+    }
+
+    @Override
+    public Path projectPath(String name) {
+        return delegate.projectPath(name);
+    }
+
+    @Nonnull
+    @Override
+    public Path getProjectPath() {
+        return delegate.getProjectPath();
+    }
+
+    @Override
+    public ProjectInternal getProject() {
+        return this;
+    }
+
+    @Override
+    public ModelContainer<?> getModel() {
+        return delegate.getModel();
+    }
+
+    @Override
+    public Path getBuildPath() {
+        return delegate.getBuildPath();
+    }
+
+    @Override
+    public boolean isScript() {
+        return delegate.isScript();
+    }
+
+    @Override
+    public boolean isRootScript() {
+        return delegate.isRootScript();
+    }
+
+    @Override
+    public boolean isPluginContext() {
+        return delegate.isPluginContext();
+    }
+
+    @Override
+    public Path getIdentityPath() {
+        return delegate.getIdentityPath();
+    }
+
+    @Nullable
+    @Override
+    public ProjectEvaluationListener stepEvaluationListener(ProjectEvaluationListener listener, Action<ProjectEvaluationListener> action) {
+        return delegate.stepEvaluationListener(listener, action);
+    }
+
+    @Override
+    public ProjectState getOwner() {
+        return delegate.getOwner();
+    }
+
+    @Override
+    public InputNormalizationHandlerInternal getNormalization() {
+        return delegate.getNormalization();
+    }
+
+    @Override
+    public void normalization(Action<? super InputNormalizationHandler> configuration) {
+        delegate.normalization(configuration);
+    }
+
+    public void normalization(Closure closure) {
+        normalization(ConfigureUtil.configureUsing(closure));
+    }
+
+    public void dependencyLocking(Closure configuration) {
+        dependencyLocking(ConfigureUtil.configureUsing(configuration));
+    }
+
+    @Override
+    public void dependencyLocking(Action<? super DependencyLockingHandler> configuration) {
+        delegate.dependencyLocking(configuration);
+    }
+
+    @Override
+    public DependencyLockingHandler getDependencyLocking() {
+        return delegate.getDependencyLocking();
+    }
+
+    @Override
+    public ScriptHandlerInternal getBuildscript() {
+        onMutableStateAccess("buildscript");
+        return delegate.getBuildscript();
+    }
+
+    @Override
+    public void buildscript(Closure configureClosure) {
+        onMutableStateAccess("buildscript");
+        delegate.buildscript(configureClosure);
+    }
+
+    @Override
+    public WorkResult copy(Closure closure) {
+        return delegate.copy(closure);
+    }
+
+    @Override
+    public WorkResult copy(Action<? super CopySpec> action) {
+        return delegate.copy(action);
+    }
+
+    @Override
+    public CopySpec copySpec(Closure closure) {
+        return delegate.copySpec(closure);
+    }
+
+    @Override
+    public CopySpec copySpec(Action<? super CopySpec> action) {
+        return delegate.copySpec(action);
+    }
+
+    @Override
+    public CopySpec copySpec() {
+        return delegate.copySpec();
+    }
+
+    @Override
+    public WorkResult sync(Action<? super SyncSpec> action) {
+        return delegate.sync(action);
+    }
+
+    @Override
+    public DetachedResolver newDetachedResolver() {
+        return delegate.newDetachedResolver();
+    }
+
+    @Override
+    public Property<Object> getInternalStatus() {
+        onMutableStateAccess("internalStatus");
+        return delegate.getInternalStatus();
+    }
+
+    @Override
+    public RoleBasedConfigurationContainerInternal getConfigurations() {
+        onMutableStateAccess("configurations");
+        return delegate.getConfigurations();
+    }
+
+    @Override
+    public void configurations(Closure configureClosure) {
+        onMutableStateAccess("configurations");
+        delegate.configurations(configureClosure);
+    }
+
+    @Override
+    public ArtifactHandler getArtifacts() {
+        onMutableStateAccess("artifacts");
+        return delegate.getArtifacts();
+    }
+
+    @Override
+    public void artifacts(Closure configureClosure) {
+        onMutableStateAccess("artifacts");
+        delegate.artifacts(configureClosure);
+    }
+
+    @Override
+    public void artifacts(Action<? super ArtifactHandler> configureAction) {
+        onMutableStateAccess("artifacts");
+        delegate.artifacts(configureAction);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    @Deprecated(message = "The concept of conventions is deprecated. Use extensions instead.")
+    public org.gradle.api.plugins.Convention getConvention() {
+        onMutableStateAccess("convention");
+        return delegate.getConvention();
+    }
+
+    @Override
+    public int depthCompare(Project otherProject) {
+        return delegate.depthCompare(otherProject);
+    }
+
+    @Override
+    public int getDepth() {
+        return delegate.getDepth();
+    }
+
+    @Override
+    public int compareTo(@Nonnull Project o) {
+        return delegate.compareTo(o);
+    }
+
+    @Override
+    public FileOperations getFileOperations() {
+        return delegate.getFileOperations();
+    }
+
+    @Override
+    public ProcessOperations getProcessOperations() {
+        return delegate.getProcessOperations();
+    }
+
+    @Override
+    public PluginContainer getPlugins() {
+        onMutableStateAccess("plugins");
+        return delegate.getPlugins();
+    }
+
+    @Override
+    public void apply(Closure closure) {
+        onMutableStateAccess("apply");
+        delegate.apply(closure);
+    }
+
+    @Override
+    public void apply(Action<? super ObjectConfigurationAction> action) {
+        onMutableStateAccess("apply");
+        delegate.apply(action);
+    }
+
+    @Override
+    public void apply(Map<String, ?> options) {
+        onMutableStateAccess("apply");
+        delegate.apply(options);
+    }
+
+    @Override
+    public PluginManagerInternal getPluginManager() {
+        onMutableStateAccess("pluginManager");
+        return delegate.getPluginManager();
+    }
+
+    @Override
+    public ConfigurationTargetIdentifier getConfigurationTargetIdentifier() {
+        return delegate.getConfigurationTargetIdentifier();
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.project;
 import groovy.lang.Closure;
 import groovy.lang.MissingPropertyException;
 import groovy.lang.Script;
-import kotlin.Deprecated;
 import org.gradle.api.Action;
 import org.gradle.api.AntBuilder;
 import org.gradle.api.InvalidUserDataException;
@@ -85,7 +84,6 @@ import org.gradle.process.ExecSpec;
 import org.gradle.process.JavaExecSpec;
 import org.gradle.util.Path;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.net.URI;
@@ -102,7 +100,7 @@ import java.util.concurrent.Callable;
  * {@link #methodMissing(String, Object)} methods.
  * <p>
  * Instances of this class should be created via {@link org.gradle.internal.reflect.Instantiator} to ensure proper runtime decoration.
- * */
+ */
 public abstract class MutableStateAccessAwareProject implements ProjectInternal, DynamicObjectAware {
 
     protected final ProjectInternal delegate;
@@ -221,25 +219,33 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
         return delegate.getProjectIdentityPath();
     }
 
+    /**
+     * @deprecated Use layout.buildDirectory instead
+     */
     @Override
-    @SuppressWarnings("deprecation")
-    @Deprecated(message = "Use layout.buildDirectory instead")
+    @Deprecated
     public File getBuildDir() {
         onMutableStateAccess("buildDir");
         return delegate.getBuildDir();
     }
 
+    /**
+     * @deprecated Use layout.buildDirectory instead
+     */
     @Override
+    @Deprecated
     @SuppressWarnings("deprecation")
-    @Deprecated(message = "Use layout.buildDirectory instead")
     public void setBuildDir(File path) {
         onMutableStateAccess("buildDir");
         delegate.setBuildDir(path);
     }
 
+    /**
+     * @deprecated Use layout.buildDirectory instead
+     */
     @Override
+    @Deprecated
     @SuppressWarnings("deprecation")
-    @Deprecated(message = "Use layout.buildDirectory instead")
     public void setBuildDir(Object path) {
         onMutableStateAccess("buildDir");
         delegate.setBuildDir(path);
@@ -634,7 +640,6 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
         return delegate.projectPath(name);
     }
 
-    @Nonnull
     @Override
     public Path getProjectPath() {
         return delegate.getProjectPath();
@@ -1027,9 +1032,12 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
         delegate.artifacts(configureAction);
     }
 
+    /**
+     * @deprecated the concept of conventions is deprecated. Use extensions instead
+     */
     @Override
+    @Deprecated
     @SuppressWarnings("deprecation")
-    @Deprecated(message = "The concept of conventions is deprecated. Use extensions instead.")
     public org.gradle.api.plugins.Convention getConvention() {
         onMutableStateAccess("convention");
         return delegate.getConvention();
@@ -1046,7 +1054,7 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     }
 
     @Override
-    public int compareTo(@Nonnull Project o) {
+    public int compareTo(Project o) {
         return delegate.compareTo(o);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
@@ -84,7 +84,6 @@ import org.gradle.process.ExecResult;
 import org.gradle.process.ExecSpec;
 import org.gradle.process.JavaExecSpec;
 import org.gradle.util.Path;
-import org.gradle.util.internal.ConfigureUtil;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -924,14 +923,6 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     @Override
     public void normalization(Action<? super InputNormalizationHandler> configuration) {
         delegate.normalization(configuration);
-    }
-
-    public void normalization(Closure closure) {
-        normalization(ConfigureUtil.configureUsing(closure));
-    }
-
-    public void dependencyLocking(Closure configuration) {
-        dependencyLocking(ConfigureUtil.configureUsing(configuration));
     }
 
     @Override


### PR DESCRIPTION
Part of https://github.com/gradle/gradle/issues/29187

Currently, instances of `ProblemReportingProject` are being creating [by hands](https://github.com/gradle/gradle/blob/master/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt#L172), what is not allowing to them to be decorated in runtime. 

However, `ProblemReportingProject` contains APIs:
[normalization(Action)](https://github.com/gradle/gradle/blob/bbfbe8a9d6a8cc8afcaaac6ce071837aed484752/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt#L825)
[dependencyLocking(Action)](https://github.com/gradle/gradle/blob/bbfbe8a9d6a8cc8afcaaac6ce071837aed484752/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt#L830)
and missing `Closure`-accepting counterparts of it. These counterparts are required to working correctly in Groovy DSL, and are being added by runtime decoration.

Having said that - `ProblemReportingProject` instances must be created via `Instantiator` to get proper runtime decoration. Runtime decoration is adding `implements DynamicObjectAware` signature to decorated class, what is [changes](https://github.com/gradle/gradle/blob/232cdd18634e4ce10326a3bf9fcbad65648c9362/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/metaobject/BeanDynamicObject.java#L137) Groovy dynamic dispatch for `getProperty`/`invokeMethod`, that we were relating on.

This PR introduces `abstract class MutableStateAccessAwareProject implements ProjectInternal` that declares basic set of `mutable state access` methods of `Project` and making `ProblemReportingProject` to extend it.

This abstract class also `implements DynamicObjectAware`, to have control over dynamic dispatch after runtime decoration. Now, the class is using Groovy's [propertyMissing](https://docs.groovy-lang.org/latest/html/documentation/core-metaprogramming.html#_propertymissing) concept, when `propertyMissing(String)` method is getting invoked if no property was found on a bean. Same for `invokeMethod`. In our current getProperty/invokeMethod [control flow](https://github.com/gradle/gradle/blob/bbfbe8a9d6a8cc8afcaaac6ce071837aed484752/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt#L210) `check property in current bean -> report if not found -> check in delegate`, this new approach allow to skip manual current bean check in favor of natural lookup.







