### PR TITLE
Introduce `LifecycleAwareProject`

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildModelControllerServices.kt
@@ -168,7 +168,7 @@ class DefaultBuildModelControllerServices(
             buildModelParameters: BuildModelParameters,
             instantiator: Instantiator
         ): CrossProjectModelAccess {
-            val delegate = VintageIsolatedProjectsProvider().createCrossProjectModelAccess(projectRegistry)
+            val delegate = VintageIsolatedProjectsProvider().createCrossProjectModelAccess(projectRegistry, instantiator)
             return ProblemReportingCrossProjectModelAccess(
                 delegate,
                 problemsListener,
@@ -201,9 +201,10 @@ class DefaultBuildModelControllerServices(
     class VintageIsolatedProjectsProvider : ServiceRegistrationProvider {
         @Provides
         fun createCrossProjectModelAccess(
-            projectRegistry: ProjectRegistry<ProjectInternal>
+            projectRegistry: ProjectRegistry<ProjectInternal>,
+            instantiator: Instantiator
         ): CrossProjectModelAccess {
-            return DefaultCrossProjectModelAccess(projectRegistry)
+            return DefaultCrossProjectModelAccess(projectRegistry, instantiator)
         }
 
         @Provides

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -240,6 +240,9 @@ class ProblemReportingCrossProjectModelAccess(
             super.allprojects(referrer, ConfigureUtil.configureUsing(configureClosure))
         }
 
+        override fun getOwner(): ProjectState =
+            delegate.owner
+
         override fun file(path: Any): File {
             onIsolationViolation("file")
             return super.file(path)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -200,13 +200,6 @@ class ProblemReportingCrossProjectModelAccess(
             )
         }
 
-        override fun hasPropertyMissing(name: String): Boolean {
-            return hasProperty(name)
-        }
-
-        override fun getOwner(): ProjectState =
-            delegate.owner
-
         override fun file(path: Any): File {
             onIsolationViolation("file")
             return super.file(path)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -200,6 +200,10 @@ class ProblemReportingCrossProjectModelAccess(
             )
         }
 
+        override fun hasPropertyMissing(name: String): Boolean {
+            return hasProperty(name)
+        }
+
         override fun getParent(): ProjectInternal? =
             super.getParent(referrer)
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -152,14 +152,14 @@ class ProblemReportingCrossProjectModelAccess(
     @Suppress("LargeClass")
     open class ProblemReportingProject(
         delegate: ProjectInternal,
-        private val referrer: ProjectInternal,
+        referrer: ProjectInternal,
         private val access: CrossProjectModelAccessInstance,
         private val problems: ProblemsListener,
         private val coupledProjectsListener: CoupledProjectsListener,
         private val problemFactory: ProblemFactory,
         private val buildModelParameters: BuildModelParameters,
         private val dynamicCallProblemReporting: DynamicCallProblemReporting,
-    ) : MutableStateAccessAwareProject(delegate) {
+    ) : MutableStateAccessAwareProject(delegate, referrer) {
 
         override fun onMutableStateAccess(what: String) {
             onIsolationViolation(what)
@@ -202,46 +202,6 @@ class ProblemReportingCrossProjectModelAccess(
 
         override fun hasPropertyMissing(name: String): Boolean {
             return hasProperty(name)
-        }
-
-        override fun getParent(): ProjectInternal? =
-            super.getParent(referrer)
-
-        override fun getRootProject(): ProjectInternal =
-            super.getRootProject(referrer)
-
-        override fun project(path: String): ProjectInternal =
-            super.project(referrer, path)
-
-        override fun project(path: String, configureClosure: Closure<*>): Project =
-            super.project(referrer, path, ConfigureUtil.configureUsing(configureClosure))
-
-        override fun project(path: String, configureAction: Action<in Project>): Project =
-            super.project(referrer, path, configureAction)
-
-        override fun findProject(path: String): ProjectInternal? =
-            super.findProject(referrer, path)
-
-        override fun getSubprojects(): Set<Project> =
-            super.getSubprojects(referrer)
-
-        override fun subprojects(action: Action<in Project>) {
-            super.subprojects(referrer, action)
-        }
-
-        override fun subprojects(configureClosure: Closure<*>) {
-            super.subprojects(referrer, ConfigureUtil.configureUsing(configureClosure))
-        }
-
-        override fun getAllprojects(): Set<Project> =
-            super.getAllprojects(referrer)
-
-        override fun allprojects(action: Action<in Project>) {
-            super.allprojects(referrer, action)
-        }
-
-        override fun allprojects(configureClosure: Closure<*>) {
-            super.allprojects(referrer, ConfigureUtil.configureUsing(configureClosure))
         }
 
         override fun getOwner(): ProjectState =

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/typesafe/TypeSafeProjectAccessorsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/typesafe/TypeSafeProjectAccessorsIntegrationTest.groovy
@@ -36,9 +36,9 @@ class TypeSafeProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAcc
         """
 
         buildFile << """
-            assert project(":one").is(projects.one.dependencyProject)
-            assert project(":one:other").is(projects.one.other.dependencyProject)
-            assert project(":two:other").is(projects.two.other.dependencyProject)
+            assert project(":one") == projects.one.dependencyProject
+            assert project(":one:other") == projects.one.other.dependencyProject
+            assert project(":two:other") == projects.two.other.dependencyProject
         """
 
         when:
@@ -99,9 +99,9 @@ class TypeSafeProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAcc
         """
 
         buildFile << """
-            assert project(":one").is(ts.one.dependencyProject)
-            assert project(":one:other").is(ts.one.other.dependencyProject)
-            assert project(":two:other").is(ts.two.other.dependencyProject)
+            assert project(":one") == ts.one.dependencyProject
+            assert project(":one:other") == ts.one.other.dependencyProject
+            assert project(":two:other") == ts.two.other.dependencyProject
         """
 
         when:
@@ -114,7 +114,7 @@ class TypeSafeProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAcc
     def "can refer to the root project via its name"() {
         given:
         buildFile << """
-            assert project(":").is(projects.typesafeProjectAccessors.dependencyProject)
+            assert project(":") == projects.typesafeProjectAccessors.dependencyProject
         """
 
         when:
@@ -153,8 +153,8 @@ class TypeSafeProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAcc
     def "buildSrc project accessors are independent from the main build accessors"() {
         given:
         file("buildSrc/build.gradle") << """
-            assert project(":one").is(projects.one.dependencyProject)
-            assert project(":two").is(projects.two.dependencyProject)
+            assert project(":one") == projects.one.dependencyProject
+            assert project(":two") == projects.two.dependencyProject
         """
         createDirs("buildSrc/one", "buildSrc/two")
         file("buildSrc/settings.gradle") << """
@@ -169,8 +169,8 @@ class TypeSafeProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAcc
         """
 
         buildFile << """
-            assert project(":one").is(projects.one.dependencyProject)
-            assert project(":two").is(projects.two.dependencyProject)
+            assert project(":one") == projects.one.dependencyProject
+            assert project(":two") == projects.two.dependencyProject
         """
 
         when:
@@ -190,7 +190,7 @@ class TypeSafeProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAcc
             include 'one'
         """
         file("project/build.gradle") << """
-            assert project(":one").is(projects.one.dependencyProject)
+            assert project(":one") == projects.one.dependencyProject
         """
         FeaturePreviewsFixture.enableTypeSafeProjectAccessors(file("project/settings.gradle"))
 
@@ -221,7 +221,7 @@ class TypeSafeProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAcc
         """
 
         buildFile << """
-            assert project(":one").is(projects.one.dependencyProject)
+            assert project(":one") == projects.one.dependencyProject
         """
 
         //run once

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/LifecycleAwareProjectIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/LifecycleAwareProjectIntegrationTest.groovy
@@ -21,15 +21,15 @@ import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
 
 @Requires(IntegTestPreconditions.NotIsolatedProjects)
-class LifecycleAwareProjectTest extends AbstractIntegrationSpec {
+class LifecycleAwareProjectIntegrationTest extends AbstractIntegrationSpec {
 
     def 'Different equal instances of LifecycleAwareProject bear the same state'() {
         given:
-        settingsFile << """
+        settingsFile """
             rootProject.name = 'root'
             include(":a")
         """
-        buildFile << """
+        buildFile"""
             allprojects {
                 ext.foo = "bar"
             }
@@ -47,12 +47,12 @@ class LifecycleAwareProjectTest extends AbstractIntegrationSpec {
 
     def 'LifecycleAwareProject delegates hasProperty correctly'() {
         given:
-        settingsFile << """
+        settingsFile """
             rootProject.name = 'root'
             include(":a")
         """
         file("a/build.gradle") << ""
-        buildFile << """
+        buildFile"""
             project(':a') {
                 println("a contains foo: \${it.hasProperty('foo')}")
             }
@@ -63,5 +63,28 @@ class LifecycleAwareProjectTest extends AbstractIntegrationSpec {
 
         then:
         outputContains "a contains foo: true"
+    }
+
+    def 'LifecycleAwareProject delegates setProperty correctly'() {
+        given:
+        settingsFile """
+            rootProject.name = 'root'
+            include(":a")
+        """
+        file("a/build.gradle") << ""
+        buildFile"""
+            project(':a') {
+                foo='bar1'
+            }
+            project(':a') {
+                println("a foo=\$foo")
+            }
+        """
+
+        when:
+        run "help", "-Pfoo=bar"
+
+        then:
+        outputContains "a foo=bar1"
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/LifecycleAwareProjectTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/LifecycleAwareProjectTest.groovy
@@ -20,9 +20,9 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
 
+@Requires(IntegTestPreconditions.NotIsolatedProjects)
 class LifecycleAwareProjectTest extends AbstractIntegrationSpec {
 
-    @Requires(IntegTestPreconditions.NotIsolatedProjects)
     def 'Different equal instances of LifecycleAwareProject bear the same state'() {
         given:
         settingsFile << """
@@ -43,5 +43,25 @@ class LifecycleAwareProjectTest extends AbstractIntegrationSpec {
 
         then:
         outputContains "root foo=bar\na foo=bar"
+    }
+
+    def 'LifecycleAwareProject delegates hasProperty correctly'() {
+        given:
+        settingsFile << """
+            rootProject.name = 'root'
+            include(":a")
+        """
+        file("a/build.gradle") << ""
+        buildFile << """
+            project(':a') {
+                println("a contains foo: \${it.hasProperty('foo')}")
+            }
+        """
+
+        when:
+        run "help", "-Pfoo=bar"
+
+        then:
+        outputContains "a contains foo: true"
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/LifecycleAwareProjectTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/LifecycleAwareProjectTest.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.project
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.IntegTestPreconditions
+
+class LifecycleAwareProjectTest extends AbstractIntegrationSpec {
+
+    @Requires(IntegTestPreconditions.NotIsolatedProjects)
+    def 'Different equal instances of LifecycleAwareProject bear the same state'() {
+        given:
+        settingsFile << """
+            rootProject.name = 'root'
+            include(":a")
+        """
+        buildFile << """
+            allprojects {
+                ext.foo = "bar"
+            }
+            allprojects {
+                println("\$name foo=\$foo")
+            }
+        """
+
+        when:
+        run "help", "-q"
+
+        then:
+        outputContains "root foo=bar\na foo=bar"
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultCrossProjectModelAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultCrossProjectModelAccess.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.tasks.TaskDependencyUsageTracker;
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
 import org.gradle.internal.metaobject.DynamicObject;
+import org.gradle.internal.reflect.Instantiator;
 
 import java.util.Map;
 import java.util.Set;
@@ -29,9 +30,11 @@ import java.util.stream.Collectors;
 
 public class DefaultCrossProjectModelAccess implements CrossProjectModelAccess {
     private final ProjectRegistry<ProjectInternal> projectRegistry;
+    private final Instantiator instantiator;
 
-    public DefaultCrossProjectModelAccess(ProjectRegistry<ProjectInternal> projectRegistry) {
+    public DefaultCrossProjectModelAccess(ProjectRegistry<ProjectInternal> projectRegistry, Instantiator instantiator) {
         this.projectRegistry = projectRegistry;
+        this.instantiator = instantiator;
     }
 
     @Override
@@ -41,7 +44,10 @@ public class DefaultCrossProjectModelAccess implements CrossProjectModelAccess {
 
     @Override
     public ProjectInternal findProject(ProjectInternal referrer, ProjectInternal relativeTo, String path) {
-        return projectRegistry.getProject(relativeTo.absoluteProjectPath(path));
+        ProjectInternal project = projectRegistry.getProject(relativeTo.absoluteProjectPath(path));
+        return project != null
+            ? LifecycleAwareProject.from(project, instantiator)
+            : null;
     }
 
     @Override
@@ -49,19 +55,23 @@ public class DefaultCrossProjectModelAccess implements CrossProjectModelAccess {
         return relativeTo.getChildProjectsUnchecked().entrySet().stream().collect(
             Collectors.toMap(
                 Map.Entry::getKey,
-                entry -> access(referrer, (ProjectInternal) entry.getValue())
+                entry -> LifecycleAwareProject.from((ProjectInternal) entry.getValue(), instantiator)
             )
         );
     }
 
     @Override
     public Set<? extends ProjectInternal> getSubprojects(ProjectInternal referrer, ProjectInternal relativeTo) {
-        return new TreeSet<>(projectRegistry.getSubProjects(relativeTo.getPath()));
+        return projectRegistry.getSubProjects(relativeTo.getPath()).stream()
+            .map(project -> LifecycleAwareProject.from(project, instantiator))
+            .collect(Collectors.toCollection(TreeSet::new));
     }
 
     @Override
     public Set<? extends ProjectInternal> getAllprojects(ProjectInternal referrer, ProjectInternal relativeTo) {
-        return new TreeSet<>(projectRegistry.getAllProjects(relativeTo.getPath()));
+        return projectRegistry.getAllProjects(relativeTo.getPath()).stream()
+            .map(project -> LifecycleAwareProject.from(project, instantiator))
+            .collect(Collectors.toCollection(TreeSet::new));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultCrossProjectModelAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultCrossProjectModelAccess.java
@@ -46,7 +46,7 @@ public class DefaultCrossProjectModelAccess implements CrossProjectModelAccess {
     public ProjectInternal findProject(ProjectInternal referrer, ProjectInternal relativeTo, String path) {
         ProjectInternal project = projectRegistry.getProject(relativeTo.absoluteProjectPath(path));
         return project != null
-            ? LifecycleAwareProject.from(project, instantiator)
+            ? LifecycleAwareProject.from(project, referrer, instantiator)
             : null;
     }
 
@@ -55,7 +55,7 @@ public class DefaultCrossProjectModelAccess implements CrossProjectModelAccess {
         return relativeTo.getChildProjectsUnchecked().entrySet().stream().collect(
             Collectors.toMap(
                 Map.Entry::getKey,
-                entry -> LifecycleAwareProject.from((ProjectInternal) entry.getValue(), instantiator)
+                entry -> LifecycleAwareProject.from((ProjectInternal) entry.getValue(), referrer, instantiator)
             )
         );
     }
@@ -63,14 +63,14 @@ public class DefaultCrossProjectModelAccess implements CrossProjectModelAccess {
     @Override
     public Set<? extends ProjectInternal> getSubprojects(ProjectInternal referrer, ProjectInternal relativeTo) {
         return projectRegistry.getSubProjects(relativeTo.getPath()).stream()
-            .map(project -> LifecycleAwareProject.from(project, instantiator))
+            .map(project -> LifecycleAwareProject.from(project, referrer, instantiator))
             .collect(Collectors.toCollection(TreeSet::new));
     }
 
     @Override
     public Set<? extends ProjectInternal> getAllprojects(ProjectInternal referrer, ProjectInternal relativeTo) {
         return projectRegistry.getAllProjects(relativeTo.getPath()).stream()
-            .map(project -> LifecycleAwareProject.from(project, instantiator))
+            .map(project -> LifecycleAwareProject.from(project, referrer, instantiator))
             .collect(Collectors.toCollection(TreeSet::new));
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -696,7 +696,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Override
     public void allprojects(ProjectInternal referrer, Action<? super Project> action) {
-        getProjectConfigurator().allprojects(getCrossProjectModelAccess().getAllprojects(referrer, this), action);
+        getProjectConfigurator().allprojects(getAllprojects(referrer), action);
     }
 
     @Override
@@ -721,7 +721,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Override
     public void subprojects(ProjectInternal referrer, Action<? super Project> configureAction) {
-        getProjectConfigurator().subprojects(getCrossProjectModelAccess().getSubprojects(referrer, this), configureAction);
+        getProjectConfigurator().subprojects(getSubprojects(referrer), configureAction);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/HasPropertyMissingDynamicObject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/HasPropertyMissingDynamicObject.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.project;
+
+import org.gradle.internal.metaobject.BeanDynamicObject;
+
+import javax.annotation.Nullable;
+import java.util.function.Function;
+
+class HasPropertyMissingDynamicObject extends BeanDynamicObject {
+    private final Function<String, Boolean> hasPropertyMissing;
+
+    public HasPropertyMissingDynamicObject(Object bean, @Nullable Class<?> publicType, Function<String, Boolean> hasPropertyMissing) {
+        super(bean, publicType);
+        this.hasPropertyMissing = hasPropertyMissing;
+    }
+
+    @Override
+    public boolean hasProperty(String name) {
+        if (super.hasProperty(name)) {
+            return true;
+        } else {
+            return hasPropertyMissing.apply(name);
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/LifecycleAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/LifecycleAwareProject.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.project;
+
+import org.gradle.internal.Cast;
+import org.gradle.internal.metaobject.DynamicInvokeResult;
+import org.gradle.internal.metaobject.DynamicObject;
+import org.gradle.internal.metaobject.DynamicObjectUtil;
+import org.gradle.internal.reflect.Instantiator;
+
+import javax.annotation.Nullable;
+
+
+public class LifecycleAwareProject extends MutableStateAccessAwareProject {
+
+    public static ProjectInternal from(ProjectInternal project, Instantiator instantiator) {
+        if (project instanceof LifecycleAwareProject) {
+            return project;
+        } else {
+            return instantiator.newInstance(LifecycleAwareProject.class, project);
+        }
+    }
+
+    public LifecycleAwareProject(ProjectInternal delegate) {
+        super(delegate);
+    }
+
+    @Override
+    protected void onMutableStateAccess(String what) {
+        // no-op yet
+    }
+
+    @Override
+    protected Object propertyMissing(String name) {
+        onMutableStateAccess("getProperty");
+        DynamicObject dynamicDelegate = DynamicObjectUtil.asDynamicObject(delegate);
+        DynamicInvokeResult delegateResult = dynamicDelegate.tryGetProperty(name);
+
+        if (delegateResult.isFound()) {
+            return delegateResult.getValue();
+        }
+
+        throw dynamicDelegate.getMissingProperty(name);
+    }
+
+    @Nullable
+    @Override
+    protected Object methodMissing(String name, Object args) {
+        onMutableStateAccess("invokeMethod");
+        Object[] varargs = Cast.uncheckedNonnullCast(args);
+        DynamicObject dynamicDelegate = DynamicObjectUtil.asDynamicObject(delegate);
+        DynamicInvokeResult delegateResult = dynamicDelegate.tryInvokeMethod(name, varargs);
+
+        if (delegateResult.isFound()) {
+            return delegateResult.getValue();
+        }
+
+        throw dynamicDelegate.methodMissingException(name, varargs);
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null) {
+            return false;
+        }
+        if (other instanceof LifecycleAwareProject) {
+            LifecycleAwareProject lifecycleAwareProject = (LifecycleAwareProject) other;
+            return delegate.equals(lifecycleAwareProject.delegate);
+        } else {
+            return delegate.equals(other);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/LifecycleAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/LifecycleAwareProject.java
@@ -73,6 +73,12 @@ public class LifecycleAwareProject extends MutableStateAccessAwareProject {
     }
 
     @Override
+    protected boolean hasPropertyMissing(String name) {
+        onMutableStateAccess("hasProperty");
+        return delegate.hasProperty(name);
+    }
+
+    @Override
     public String toString() {
         return delegate.toString();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/LifecycleAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/LifecycleAwareProject.java
@@ -27,16 +27,16 @@ import javax.annotation.Nullable;
 
 public class LifecycleAwareProject extends MutableStateAccessAwareProject {
 
-    public static ProjectInternal from(ProjectInternal project, Instantiator instantiator) {
-        if (project instanceof LifecycleAwareProject) {
-            return project;
-        } else {
-            return instantiator.newInstance(LifecycleAwareProject.class, project);
-        }
+    public static ProjectInternal from(ProjectInternal target, ProjectInternal referrer, Instantiator instantiator) {
+        return MutableStateAccessAwareProject.wrap(
+            target,
+            referrer,
+            project -> instantiator.newInstance(LifecycleAwareProject.class, target, referrer)
+        );
     }
 
-    public LifecycleAwareProject(ProjectInternal delegate) {
-        super(delegate);
+    public LifecycleAwareProject(ProjectInternal delegate, ProjectInternal referrer) {
+        super(delegate, referrer);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/LifecycleAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/LifecycleAwareProject.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
 
 /**
  * Wrapper for {@link ProjectInternal} that has been accessed across projects, even in vintage mode.
- * */
+ */
 public class LifecycleAwareProject extends MutableStateAccessAwareProject {
 
     public static ProjectInternal from(ProjectInternal target, ProjectInternal referrer, Instantiator instantiator) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/LifecycleAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/LifecycleAwareProject.java
@@ -24,7 +24,9 @@ import org.gradle.internal.reflect.Instantiator;
 
 import javax.annotation.Nullable;
 
-
+/**
+ * Wrapper for {@link ProjectInternal} that has been accessed across projects, even in vintage mode.
+ * */
 public class LifecycleAwareProject extends MutableStateAccessAwareProject {
 
     public static ProjectInternal from(ProjectInternal target, ProjectInternal referrer, Instantiator instantiator) {
@@ -41,7 +43,7 @@ public class LifecycleAwareProject extends MutableStateAccessAwareProject {
 
     @Override
     protected void onMutableStateAccess(String what) {
-        // no-op yet
+        // no-op for now
     }
 
     @Override
@@ -73,12 +75,6 @@ public class LifecycleAwareProject extends MutableStateAccessAwareProject {
     }
 
     @Override
-    protected boolean hasPropertyMissing(String name) {
-        onMutableStateAccess("hasProperty");
-        return delegate.hasProperty(name);
-    }
-
-    @Override
     public String toString() {
         return delegate.toString();
     }
@@ -93,7 +89,7 @@ public class LifecycleAwareProject extends MutableStateAccessAwareProject {
         }
         if (other instanceof LifecycleAwareProject) {
             LifecycleAwareProject lifecycleAwareProject = (LifecycleAwareProject) other;
-            return delegate.equals(lifecycleAwareProject.delegate);
+            return delegate.equals(lifecycleAwareProject.delegate) && referrer.equals(lifecycleAwareProject.referrer);
         } else {
             return delegate.equals(other);
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
@@ -70,7 +70,6 @@ import org.gradle.configuration.project.ProjectConfigurationActionContainer;
 import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.internal.accesscontrol.AllowUsingApiForExternalUse;
 import org.gradle.internal.logging.StandardOutputCapture;
-import org.gradle.internal.metaobject.BeanDynamicObject;
 import org.gradle.internal.metaobject.DynamicObject;
 import org.gradle.internal.model.ModelContainer;
 import org.gradle.internal.model.RuleBasedPluginListener;
@@ -119,7 +118,7 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
 
     protected MutableStateAccessAwareProject(ProjectInternal delegate) {
         this.delegate = delegate;
-        this.dynamicObject = new BeanDynamicObject(this, Project.class);
+        this.dynamicObject = new HasPropertyMissingDynamicObject(this, Project.class, this::hasPropertyMissing);
     }
 
     protected abstract void onMutableStateAccess(String what);
@@ -137,6 +136,8 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     @Nullable
     @SuppressWarnings("unused") // used by Groovy dynamic dispatch
     protected abstract Object methodMissing(String name, Object args);
+
+    protected abstract boolean hasPropertyMissing(String name);
 
     @Override
     public DynamicObject getAsDynamicObject() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
@@ -98,8 +98,8 @@ import java.util.function.Function;
  * Wrapper for {@link ProjectInternal}, that declares some API methods as access to a mutable state of the project.
  * <p>
  * This class enables dynamic property and method dispatch on the `this` bean rather than on the {@link #delegate}.
- * If the dispatch on `this` fails, the control flow is delegated to {@link #propertyMissing(String)} and
- * {@link #methodMissing(String, Object)} methods.
+ * If the dispatch on `this` fails, the control flow is delegated to {@link #propertyMissing(String)},
+ * {@link #methodMissing(String, Object)} and {@link #hasPropertyMissing(String)} methods.
  * <p>
  * Instances of this class should be created via {@link org.gradle.internal.reflect.Instantiator} to ensure proper runtime decoration.
  */

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
@@ -141,6 +141,13 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     @SuppressWarnings("unused") // used by Groovy dynamic dispatch
     protected abstract Object methodMissing(String name, Object args);
 
+    // used by Groovy dynamic dispatch
+    protected void propertyMissing(String name, Object args) {
+        onMutableStateAccess("setProperty");
+        delegate.setProperty(name, args);
+    }
+
+    // used by Groovy dynamic dispatch
     protected boolean hasPropertyMissing(String name) {
         onMutableStateAccess("hasProperty");
         return delegate.hasProperty(name);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
@@ -98,7 +98,7 @@ import java.util.function.Function;
  * Wrapper for {@link ProjectInternal}, that declares some API methods as access to a mutable state of the project.
  * <p>
  * This class enables dynamic property and method dispatch on the `this` bean rather than on the {@link #delegate}.
- * If the dispatch on `this` fails, the control flow is delegated to {@link #propertyMissing(String)},
+ * If the dispatch on `this` fails, the control flow is delegated to {@link #propertyMissing(String)}, {@link #propertyMissing(String, Object)},
  * {@link #methodMissing(String, Object)} and {@link #hasPropertyMissing(String)} methods.
  * <p>
  * Instances of this class should be created via {@link org.gradle.internal.reflect.Instantiator} to ensure proper runtime decoration.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
@@ -141,7 +141,10 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     @SuppressWarnings("unused") // used by Groovy dynamic dispatch
     protected abstract Object methodMissing(String name, Object args);
 
-    protected abstract boolean hasPropertyMissing(String name);
+    protected boolean hasPropertyMissing(String name) {
+        onMutableStateAccess("hasProperty");
+        return delegate.hasProperty(name);
+    }
 
     @Override
     public DynamicObject getAsDynamicObject() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -148,7 +148,7 @@ class DefaultProjectTest extends Specification {
     Instantiator instantiatorMock = Stub(Instantiator) {
         newInstance(LifecycleAwareProject, _) >> { args ->
             def params = args[1]
-            new LifecycleAwareProject(params[0])
+            new LifecycleAwareProject(params[0], params[1])
         }
     }
     SoftwareComponentContainer softwareComponentsMock = Stub(SoftwareComponentContainer)
@@ -947,6 +947,26 @@ def scriptMethod(Closure closure) {
         project.container(String) instanceof FactoryNamedDomainObjectContainer
         project.container(String, Stub(NamedDomainObjectFactory)) instanceof FactoryNamedDomainObjectContainer
         project.container(String, {}) instanceof FactoryNamedDomainObjectContainer
+    }
+
+    def selfAccessWithoutLifecycleAwareWrapping() {
+        expect:
+        project.project(":child1").parent instanceof DefaultProject
+        project.project(":child1").rootProject instanceof DefaultProject
+        child1.allprojects { project ->
+            if (project.name == "child1") {
+                assert project instanceof DefaultProject
+            } else {
+                assert project instanceof LifecycleAwareProject
+            }
+        }
+        child1.getAllprojects().forEach { project ->
+            if (project.name == "child1") {
+                assert project instanceof DefaultProject
+            } else {
+                assert project instanceof LifecycleAwareProject
+            }
+        }
     }
 
     static boolean assertLifecycleAwareProjectOf(Project crosslyAccessed, Project of) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -526,7 +526,7 @@ class DefaultProjectTest extends Specification {
 
     def getProject() {
         expect:
-        assertLifecycleAwareProjectOf(project.project(Project.PATH_SEPARATOR), project)
+        project.project(Project.PATH_SEPARATOR).is(project)
         assertLifecycleAwareProjectOf(project.project(Project.PATH_SEPARATOR + "child1"), child1)
         assertLifecycleAwareProjectOf(project.project("child1"), child1)
         assertLifecycleAwareProjectOf(child1.project("childchild"), childchild)
@@ -565,7 +565,7 @@ class DefaultProjectTest extends Specification {
 
     def findProject() {
         expect:
-        assertLifecycleAwareProjectOf(project.findProject(Project.PATH_SEPARATOR), project)
+        project.findProject(Project.PATH_SEPARATOR).is(project)
         assertLifecycleAwareProjectOf(project.findProject(Project.PATH_SEPARATOR + "child1"), child1)
         assertLifecycleAwareProjectOf(project.findProject("child1"), child1)
         assertLifecycleAwareProjectOf(child1.findProject('childchild'), childchild)


### PR DESCRIPTION
Part of https://github.com/gradle/gradle/issues/29187

This PR introduces an another inheritor of `MutableStateAccessAwareProject` - `LifecycleAwareProject`. This project become a wrapper of `DefaultProject` after any cross project access. During cross project access target project may be configured eagerly and we want to make sure appropriate lifecycle callback be invoked before.

Note, that similar wrapping is happening during crossproject access in IP mode, so in IP mode final structure is `ProblemReportingProject(LifecycleAwareProject(DefaultProject))`.

Since `LifecycleAwareProject` is using in a vintage mode, it highlighted more state-bearing nuances in Groovy, that wasn't considered in `ProblemReportingProject` in [this](https://github.com/gradle/gradle/pull/29911) PR:

As soon as these wrappers aren't persistent, they can't bear any state, because it will be dropped. But with Groovy it's not so easy to achieve it - in Groovy properties can be added to `this` bean without delegation, and we handle it with `missing` callbacks. 

However, for `hasProperty` there is no support as a for `getProperty/setProperty/invokeMethod`. Conceptually, it means
```
val a = DefaultProject()
a.setProperty("foo", "bar")
val b = LifecycleAwareProject(a)
b.hasProperty("foo") // false
```

This PR solves the issue with special `DynamicObject` implementation, that delegates `hasProperty` invocations in the same manner `this has property? -> no! mutable state accessed -> return delegate has property`.