### PR TITLE
Make AllCrossVersionTestsReadyForRelease depend on AllCrossVersionTestsReadyForNightly

### DIFF
--- a/.teamcity/src/main/kotlin/projects/CheckProject.kt
+++ b/.teamcity/src/main/kotlin/projects/CheckProject.kt
@@ -3,6 +3,7 @@ package projects
 import common.cleanupRule
 import common.hiddenArtifactDestination
 import common.isSecurityFork
+import configurations.BaseGradleBuildType
 import configurations.GitHubMergeQueueCheckPass
 import configurations.PerformanceTestsPass
 import configurations.StagePasses
@@ -57,17 +58,19 @@ class CheckProject(
 
     var prevStage: Stage? = null
     val previousPerformanceTestPasses: MutableList<PerformanceTestsPass> = mutableListOf()
+    val previousCrossVersionTests: MutableList<BaseGradleBuildType> = mutableListOf()
     model.stages.forEach { stage ->
         if (isSecurityFork() && stage.stageName > StageName.READY_FOR_RELEASE) {
             return@forEach
         }
-        val stageProject = StageProject(model, functionalTestBucketProvider, performanceTestBucketProvider, stage, previousPerformanceTestPasses)
+        val stageProject = StageProject(model, functionalTestBucketProvider, performanceTestBucketProvider, stage, previousPerformanceTestPasses, previousCrossVersionTests)
         val stagePasses = StagePasses(model, stage, prevStage, stageProject)
         buildType(stagePasses)
         subProject(stageProject)
 
         prevStage = stage
         previousPerformanceTestPasses.addAll(stageProject.performanceTests)
+        previousCrossVersionTests.addAll(stageProject.crossVersionTests)
     }
 
     buildType(GitHubMergeQueueCheckPass(model))

--- a/.teamcity/src/main/kotlin/projects/StageProject.kt
+++ b/.teamcity/src/main/kotlin/projects/StageProject.kt
@@ -32,7 +32,8 @@ class StageProject(
     functionalTestBucketProvider: FunctionalTestBucketProvider,
     performanceTestBucketProvider: PerformanceTestBucketProvider,
     stage: Stage,
-    previousPerformanceTestPasses: List<PerformanceTestsPass>
+    previousPerformanceTestPasses: List<PerformanceTestsPass>,
+    previousCrossVersionTests: List<BaseGradleBuildType>
 ) : Project({
     this.id("${model.projectId}_Stage_${stage.stageName.id}")
     this.uuid = "${DslContext.uuidPrefix}_${model.projectId}_Stage_${stage.stageName.uuid}"
@@ -44,6 +45,8 @@ class StageProject(
     val performanceTests: List<PerformanceTestsPass>
 
     val functionalTests: List<BaseGradleBuildType>
+
+    val crossVersionTests: List<BaseGradleBuildType>
 
     val docsTestTriggers: List<BaseGradleBuildType>
 
@@ -81,7 +84,7 @@ class StageProject(
         }
 
         functionalTests = topLevelFunctionalTests + functionalTestsPass
-        val crossVersionTests = topLevelFunctionalTests.filter { it.testCoverage.isCrossVersionTest } + functionalTestsPass.filter { it.testCoverage.isCrossVersionTest }
+        crossVersionTests = topLevelFunctionalTests.filter { it.testCoverage.isCrossVersionTest } + functionalTestsPass.filter { it.testCoverage.isCrossVersionTest }
         if (stage.stageName !in listOf(StageName.QUICK_FEEDBACK_LINUX_ONLY, StageName.QUICK_FEEDBACK)) {
             if (topLevelFunctionalTests.size + functionalTestProjects.size > 1) {
                 buildType(PartialTrigger("All Functional Tests for ${stage.stageName.stageName}", "Stage_${stage.stageName.id}_FuncTests", model, functionalTests))
@@ -91,7 +94,7 @@ class StageProject(
                 buildType(PartialTrigger("All Smoke Tests for ${stage.stageName.stageName}", "Stage_${stage.stageName.id}_SmokeTests", model, smokeTests))
             }
             if (crossVersionTests.size > 1) {
-                buildType(PartialTrigger("All Cross-Version Tests for ${stage.stageName.stageName}", "Stage_${stage.stageName.id}_CrossVersionTests", model, crossVersionTests))
+                buildType(PartialTrigger("All Cross-Version Tests for ${stage.stageName.stageName}", "Stage_${stage.stageName.id}_CrossVersionTests", model, crossVersionTests + previousCrossVersionTests))
             }
 
             // in gradleBuildSmokeTest, most of the tests are for using the configuration cache on gradle/gradle


### PR DESCRIPTION
Previously, `ACT= AllCrossVersionTestsReadyForNightly` which is not really "all cross version tests", and `ACTR=AllCrossVersionTestsReadyForRelease` is not really "all", either.

This PR makes `AllCrossVersionTestsReadyForRelease` depends on `AllCrossVersionTestsReadyForNightly`, so we can rename `ACT=AllCrossVersionTestsReadyForRelease` on gradle-bot's side. 