### PR TITLE
Update ErrorProne to 2.29.0

### DIFF
--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.code-quality.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.code-quality.gradle.kts
@@ -38,6 +38,7 @@ open class ErrorProneSourceSetExtension(
 val errorproneExtension = project.extensions.create<ErrorProneProjectExtension>("errorprone", project.objects.listProperty<String>())
 errorproneExtension.disabledChecks.addAll(
     // DISCUSS
+    "EnumOrdinal", // This violation is ubiquitous, though most are benign.
     "EqualsGetClass", // Let's agree if we want to adopt Error Prone's idea of valid equals()
     "JdkObsolete", // Most of the checks are good, but we do not want to replace all LinkedLists without a good reason
 
@@ -58,7 +59,7 @@ project.plugins.withType<JavaBasePlugin> {
 
         project.dependencies.addProvider(
             annotationProcessorConfigurationName,
-            extension.enabled.filter { it }.map { "com.google.errorprone:error_prone_core:2.24.1" }
+            extension.enabled.filter { it }.map { "com.google.errorprone:error_prone_core:2.29.0" }
         )
 
         project.tasks.named<JavaCompile>(this.compileJavaTaskName) {

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -1534,8 +1534,8 @@
             <pgp value="F9514E84AE3708288374BBBE097586CFEA37F9A6"/>
          </artifact>
       </component>
-      <component group="org.pcollections" name="pcollections" version="3.1.4">
-         <artifact name="pcollections-3.1.4.jar">
+      <component group="org.pcollections" name="pcollections" version="4.0.1">
+         <artifact name="pcollections-4.0.1.jar">
             <pgp value="E0D98C5FD55A8AF232290E58DEE12B9896F97E34"/>
          </artifact>
       </component>

--- a/platforms/core-configuration/model-core/build.gradle.kts
+++ b/platforms/core-configuration/model-core/build.gradle.kts
@@ -5,12 +5,6 @@ plugins {
 
 description = "Implementation of configuration model types and annotation metadata handling (Providers, software model, conventions)"
 
-errorprone {
-    disabledChecks.addAll(
-        "UnusedVariable", // This cannot really be turned off, because of the false positive in errorprone (https://github.com/google/error-prone/issues/4409)
-    )
-}
-
 dependencies {
     api(projects.serialization)
     api(projects.serviceLookup)

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
@@ -53,6 +53,7 @@ public interface ValueSupplier {
     /**
      * Carries information about the producer of a value.
      */
+    @SuppressWarnings("ClassInitializationDeadlock")
     interface ValueProducer extends TaskDependencyContainer {
         NoProducer NO_PRODUCER = new NoProducer();
         UnknownProducer UNKNOWN_PRODUCER = new UnknownProducer();
@@ -673,6 +674,7 @@ public interface ValueSupplier {
      *
      * @see ProviderInternal for a discussion of these states.
      */
+    @SuppressWarnings("ClassInitializationDeadlock")
     abstract class ExecutionTimeValue<T> {
         private static final MissingExecutionTimeValue MISSING = new MissingExecutionTimeValue();
 

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/classloader/TransformReplacer.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/classloader/TransformReplacer.java
@@ -156,9 +156,8 @@ public class TransformReplacer implements Closeable {
     }
 
     private static class Loader implements Closeable {
-          // used in subclasses
         @Nullable
-        public byte[] loadTransformedClass(@SuppressWarnings("UnusedVariable") String className) throws IOException {
+        public byte[] loadTransformedClass(String className) throws IOException {
             return null;
         }
 

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/os/OperatingSystem.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/os/OperatingSystem.java
@@ -28,6 +28,8 @@ import java.util.regex.Pattern;
 
 import static org.gradle.internal.FileUtils.withExtension;
 
+
+@SuppressWarnings("ClassInitializationDeadlock")
 public abstract class OperatingSystem {
     public static final Windows WINDOWS = new Windows();
     public static final MacOs MAC_OS = new MacOs();

--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/serialization/Transient.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/serialization/Transient.java
@@ -113,5 +113,6 @@ public abstract class Transient<T> implements java.io.Serializable {
         }
     }
 
+    @SuppressWarnings("ClassInitializationDeadlock")
     private static final Transient<Object> DISCARDED = new Discarded<>();
 }

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/sink/GroupingProgressLogEventGenerator.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/sink/GroupingProgressLogEventGenerator.java
@@ -180,8 +180,7 @@ public class GroupingProgressLogEventGenerator implements OutputEventListener {
         void flushOutput() {
         }
 
-         // Used in subclasses
-        void maybeFlushOutput(@SuppressWarnings("UnusedVariable") long timestamp) {
+        void maybeFlushOutput(long timestamp) {
         }
     }
 

--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/console/FallbackConsoleDetector.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/console/FallbackConsoleDetector.java
@@ -23,6 +23,7 @@ public class FallbackConsoleDetector implements ConsoleDetector {
     }
 
     @Override
+    @SuppressWarnings("SystemConsoleNull")
     public boolean isConsoleInput() {
         return System.console() != null;
     }

--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/console/WindowsConsoleDetector.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/console/WindowsConsoleDetector.java
@@ -36,6 +36,7 @@ public class WindowsConsoleDetector implements ConsoleDetector {
     }
 
     @Override
+    @SuppressWarnings("SystemConsoleNull")
     public boolean isConsoleInput() {
         return System.console() != null;
     }

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultBuildLauncher.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultBuildLauncher.java
@@ -93,8 +93,7 @@ public class DefaultBuildLauncher extends AbstractLongRunningOperation<DefaultBu
 
             @Override
             public Void run(ConsumerConnection connection) {
-                Void sink = connection.run(Void.class, operationParameters);
-                return sink;
+                return connection.run(Void.class, operationParameters);
             }
         }, new ResultHandlerAdapter(handler));
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/GroovyCallInterceptorsProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/GroovyCallInterceptorsProvider.java
@@ -33,6 +33,7 @@ import java.util.stream.Stream;
 @NonNullApi
 public interface GroovyCallInterceptorsProvider {
 
+    @SuppressWarnings("ClassInitializationDeadlock")
     GroovyCallInterceptorsProvider DEFAULT = new ClassSourceGroovyCallInterceptorsProvider(Instrumented.class.getName());
 
     List<FilterableCallInterceptor> getCallInterceptors();

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/JvmBytecodeInterceptorFactoryProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/JvmBytecodeInterceptorFactoryProvider.java
@@ -36,6 +36,7 @@ import java.util.stream.Stream;
 @NonNullApi
 public interface JvmBytecodeInterceptorFactoryProvider {
 
+    @SuppressWarnings("ClassInitializationDeadlock")
     JvmBytecodeInterceptorFactoryProvider DEFAULT = new ClassLoaderSourceJvmBytecodeInterceptorFactoryProvider(JvmBytecodeInterceptorFactoryProvider.class.getClassLoader());
 
     List<JvmBytecodeCallInterceptor.Factory> getInterceptorFactories();

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/PluginRequests.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/PluginRequests.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 public interface PluginRequests extends Iterable<PluginRequestInternal> {
 
+    @SuppressWarnings("ClassInitializationDeadlock")
     PluginRequests EMPTY = new EmptyPluginRequests();
 
     boolean isEmpty();

--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -71,7 +71,7 @@ dependencies {
         api(libs.commonsLang3)          { version { strictly("3.14.0") }}
         api(libs.commonsMath)           { version { strictly("3.6.1") }}
         api(libs.eclipseSisuPlexus)     { version { strictly("0.3.5"); because("transitive dependency of Maven modules to process POM metadata") }}
-        api(libs.errorProneAnnotations) { version { strictly("2.26.1") }}
+        api(libs.errorProneAnnotations) { version { strictly("2.29.0") }}
         api(libs.fastutil)              { version { strictly("8.5.2") }}
         api(libs.gradleProfiler)        { version { strictly("0.21.0-alpha-4") }}
         api(libs.develocityTestAnnotation) { version { strictly("2.0.1") }}


### PR DESCRIPTION
This update contains fixes to false positives in `UnusedVariable` diagnostic.

[`ClassInitializationDeadlock`](https://errorprone.info/bugpattern/ClassInitializationDeadlock) and [`SystemConsoleNull`](https://errorprone.info/bugpattern/SystemConsoleNull) should be addressed separately as they likely need deeper investigation.

We're using `Enum.ordinal` in too many places, but we might want to eventually reconsider this practice, as it is recommended by the [`EnumOrdinal`](https://errorprone.info/bugpattern/EnumOrdinal) diagnostics. This is also out of scope of the version bump.
