### PR TITLE
Reintroduce implicit registration of extensions for software types

### DIFF
--- a/platforms/core-configuration/declarative-dsl-provider/build.gradle.kts
+++ b/platforms/core-configuration/declarative-dsl-provider/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation(projects.baseServices)
     implementation(projects.resources)
     implementation(projects.serviceLookup)
+    implementation(projects.modelCore)
 
     implementation(libs.guava)
     implementation(libs.kotlinReflect)

--- a/platforms/core-configuration/declarative-dsl-provider/src/testFixtures/groovy/org/gradle/internal/declarativedsl/settings/SoftwareTypeFixture.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/testFixtures/groovy/org/gradle/internal/declarativedsl/settings/SoftwareTypeFixture.groovy
@@ -324,7 +324,6 @@ trait SoftwareTypeFixture {
                 public void apply(Project target) {
                     System.out.println("Applying " + getClass().getSimpleName());
                     ${implementationTypeClassName} extension = getTestSoftwareTypeExtension();
-                    target.getExtensions().add("${softwareType}", extension);
 
                     ${conventions}
                     target.getTasks().register("print${implementationTypeClassName}Configuration", DefaultTask.class, task -> {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/plugins/ExtensionContainerInternal.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/plugins/ExtensionContainerInternal.java
@@ -17,6 +17,8 @@
 package org.gradle.api.internal.plugins;
 
 import org.gradle.api.plugins.ExtensionContainer;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.reflect.TypeOf;
 
 import java.util.Map;
 
@@ -26,4 +28,44 @@ public interface ExtensionContainerInternal extends ExtensionContainer {
      * @return A map of extensions, keyed by name.
      */
     Map<String, Object> getAsMap();
+
+    /**
+     * Adds a new extension to this container whose object will be calculated later, once something
+     * calls a "get" method to retrieve the object from the container.
+     *
+     * Adding an extension of name 'foo' will:
+     * <ul>
+     * <li> add 'foo' dynamic property
+     * <li> add 'foo' dynamic method that accepts a closure that is a configuration script block
+     * </ul>
+     *
+     * The extension will be exposed as {@code publicType}.
+     *
+     * @param publicType The extension public type
+     * @param name The name for the extension
+     * @param extensionProvider A {@link Provider} of any object implementing {@code publicType}
+     * @throws IllegalArgumentException When an extension with the given name already exists.
+     * @since 8.10
+     */
+    <T> void addLater(Class<T> publicType, String name, Provider<? extends T> extensionProvider);
+
+    /**
+     * Adds a new extension to this container whose object will be calculated later, once something
+     * calls a "get" method to retrieve the object from the container.
+     *
+     * Adding an extension of name 'foo' will:
+     * <ul>
+     * <li> add 'foo' dynamic property
+     * <li> add 'foo' dynamic method that accepts a closure that is a configuration script block
+     * </ul>
+     *
+     * The extension will be exposed as {@code publicType}.
+     *
+     * @param publicType The extension public type
+     * @param name The name for the extension
+     * @param extensionProvider A {@link Provider} of any object implementing {@code publicType}
+     * @throws IllegalArgumentException When an extension with the given name already exists.
+     * @since 8.10
+     */
+    <T> void addLater(TypeOf<T> publicType, String name, Provider<? extends T> extensionProvider);
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/extensibility/DefaultConvention.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/extensibility/DefaultConvention.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.internal.plugins.ExtensionContainerInternal;
 import org.gradle.api.plugins.ExtensionsSchema;
 import org.gradle.api.plugins.ExtraPropertiesExtension;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.reflect.TypeOf;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Describables;
@@ -131,6 +132,16 @@ public class DefaultConvention implements org.gradle.api.plugins.Convention, Ext
     @Override
     public <T> void add(TypeOf<T> publicType, String name, T extension) {
         extensionsStorage.add(publicType, name, extension);
+    }
+
+    @Override
+    public <T> void addLater(Class<T> publicType, String name, Provider<? extends T> extensionProvider) {
+        addLater(typeOf(publicType), name, extensionProvider);
+    }
+
+    @Override
+    public <T> void addLater(TypeOf<T> publicType, String name, Provider<? extends T> extensionProvider) {
+        extensionsStorage.addLater(publicType, name, extensionProvider);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/AddSoftwareTypesAsExtensionsPluginTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/AddSoftwareTypesAsExtensionsPluginTarget.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.plugins;
+
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.NonNullApi;
+import org.gradle.api.Plugin;
+import org.gradle.api.internal.plugins.software.SoftwareType;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.tasks.properties.InspectionScheme;
+import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.configuration.ConfigurationTargetIdentifier;
+import org.gradle.internal.Cast;
+import org.gradle.internal.exceptions.DefaultMultiCauseException;
+import org.gradle.internal.properties.PropertyValue;
+import org.gradle.internal.properties.PropertyVisitor;
+import org.gradle.internal.reflect.DefaultTypeValidationContext;
+import org.gradle.internal.reflect.validation.TypeValidationProblemRenderer;
+import org.gradle.model.internal.type.ModelType;
+import org.gradle.plugin.software.internal.SoftwareTypeRegistry;
+import org.gradle.plugin.use.PluginId;
+import org.gradle.plugin.use.internal.DefaultPluginId;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+/**
+ * A {@link PluginTarget} that inspects the plugin for {@link SoftwareType} properties and adds them as extensions on the target prior to
+ * applying the plugin via the delegate.
+ */
+@NonNullApi
+public class AddSoftwareTypesAsExtensionsPluginTarget implements PluginTarget {
+    private final ExtensionAddingVisitor extensionAddingVisitor;
+    private final PluginTarget delegate;
+    private final InspectionScheme inspectionScheme;
+
+    private final SoftwareTypeRegistry softwareTypeRegistry;
+
+    public AddSoftwareTypesAsExtensionsPluginTarget(ProjectInternal target, PluginTarget delegate, InspectionScheme inspectionScheme, SoftwareTypeRegistry softwareTypeRegistry) {
+        this.extensionAddingVisitor = new ExtensionAddingVisitor(target);
+        this.delegate = delegate;
+        this.inspectionScheme = inspectionScheme;
+        this.softwareTypeRegistry = softwareTypeRegistry;
+    }
+
+    @Override
+    public ConfigurationTargetIdentifier getConfigurationTargetIdentifier() {
+        return delegate.getConfigurationTargetIdentifier();
+    }
+
+    @Override
+    public void applyImperative(@Nullable String pluginId, Plugin<?> plugin) {
+        if (softwareTypeRegistry.implementationFor(Cast.uncheckedCast(plugin.getClass())).isPresent()) {
+            DefaultTypeValidationContext typeValidationContext = DefaultTypeValidationContext.withRootType(plugin.getClass(), false);
+            inspectionScheme.getPropertyWalker().visitProperties(
+                plugin,
+                typeValidationContext,
+                extensionAddingVisitor
+            );
+
+            if (!typeValidationContext.getProblems().isEmpty()) {
+                throw new DefaultMultiCauseException(
+                    String.format(typeValidationContext.getProblems().size() == 1
+                            ? "A problem was found with the %s plugin."
+                            : "Some problems were found with the %s plugin.",
+                        getPluginObjectDisplayName(plugin)),
+                    typeValidationContext.getProblems().stream()
+                        .map(TypeValidationProblemRenderer::renderMinimalInformationAbout)
+                        .sorted()
+                        .map(InvalidUserDataException::new)
+                        .collect(toImmutableList())
+                );
+            }
+        }
+
+        delegate.applyImperative(pluginId, plugin);
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+
+    private static String getPluginObjectDisplayName(Object parameterObject) {
+        return ModelType.of(new DslObject(parameterObject).getDeclaredType()).getDisplayName();
+    }
+
+    private static Supplier<Optional<PluginId>> getOptionalSupplier(@Nullable String pluginId) {
+        return () -> Optional.ofNullable(pluginId).map(DefaultPluginId::of);
+    }
+
+    @Override
+    public void applyRules(@Nullable String pluginId, Class<?> clazz) {
+        delegate.applyRules(pluginId, clazz);
+    }
+
+    @Override
+    public void applyImperativeRulesHybrid(@Nullable String pluginId, Plugin<?> plugin, Class<?> declaringClass) {
+        delegate.applyImperativeRulesHybrid(pluginId, plugin, declaringClass);
+    }
+
+    @NonNullApi
+    public static class ExtensionAddingVisitor implements PropertyVisitor {
+        private final ProjectInternal target;
+
+        public ExtensionAddingVisitor(ProjectInternal target) {
+            this.target = target;
+        }
+
+        @Override
+        public void visitSoftwareTypeProperty(String propertyName, PropertyValue value, Class<?> declaredPropertyType, SoftwareType softwareType) {
+            ExtensionContainerInternal extensions = (ExtensionContainerInternal) ((ExtensionAware) target).getExtensions();
+            extensions.addLater(
+                publicTypeFrom(softwareType.modelPublicType(), declaredPropertyType),
+                softwareType.name(),
+                target.getProviders().provider(Cast.uncheckedNonnullCast(value))
+            );
+        }
+
+        private static Class<?> publicTypeFrom(Class<?> fromAnnotation, Class<?> declaredPropertyType) {
+            return fromAnnotation == Void.class ? declaredPropertyType : fromAnnotation;
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -39,6 +39,7 @@ import org.gradle.api.internal.initialization.BuildLogicBuilder;
 import org.gradle.api.internal.initialization.DefaultScriptHandlerFactory;
 import org.gradle.api.internal.initialization.ScriptHandlerFactory;
 import org.gradle.api.internal.initialization.ScriptHandlerInternal;
+import org.gradle.api.internal.plugins.AddSoftwareTypesAsExtensionsPluginTarget;
 import org.gradle.api.internal.plugins.DefaultPluginManager;
 import org.gradle.api.internal.plugins.ImperativeOnlyPluginTarget;
 import org.gradle.api.internal.plugins.PluginInstantiator;
@@ -107,6 +108,7 @@ import org.gradle.normalization.internal.InputNormalizationHandlerInternal;
 import org.gradle.normalization.internal.RuntimeClasspathNormalizationInternal;
 import org.gradle.plugin.software.internal.ModelDefaultsApplicator;
 import org.gradle.plugin.software.internal.PluginScheme;
+import org.gradle.plugin.software.internal.SoftwareTypeRegistry;
 import org.gradle.process.internal.ExecFactory;
 import org.gradle.tooling.provider.model.internal.DefaultToolingModelBuilderRegistry;
 import org.gradle.util.Path;
@@ -233,7 +235,8 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
         DomainObjectCollectionFactory domainObjectCollectionFactory,
         PluginScheme pluginScheme,
         InternalProblems problems,
-        ModelDefaultsApplicator modelDefaultsApplicator
+        ModelDefaultsApplicator modelDefaultsApplicator,
+        SoftwareTypeRegistry softwareTypeRegistry
     ) {
 
         PluginTarget ruleBasedTarget = new RuleBasedPluginTarget(
@@ -242,7 +245,13 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
             modelRuleExtractor,
             modelRuleSourceDetector
         );
-        PluginTarget pluginTarget = new ModelDefaultsApplyingPluginTarget<>(project, ruleBasedTarget, modelDefaultsApplicator);
+        PluginTarget addExtensionsTarget = new AddSoftwareTypesAsExtensionsPluginTarget(
+            project,
+            ruleBasedTarget,
+            pluginScheme.getInspectionScheme(),
+            softwareTypeRegistry
+        );
+        PluginTarget pluginTarget = new ModelDefaultsApplyingPluginTarget<>(project, addExtensionsTarget, modelDefaultsApplicator);
         return instantiator.newInstance(
             DefaultPluginManager.class,
             pluginRegistry,

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/AddSoftwareTypesAsExtensionsPluginTargetTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/AddSoftwareTypesAsExtensionsPluginTargetTest.groovy
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.plugins
+
+import org.gradle.api.Plugin
+import org.gradle.api.internal.plugins.software.SoftwareType
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.internal.tasks.properties.InspectionScheme
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.internal.properties.PropertyValue
+import org.gradle.internal.properties.bean.PropertyWalker
+import org.gradle.plugin.software.internal.SoftwareTypeRegistry
+import spock.lang.Specification
+
+class AddSoftwareTypesAsExtensionsPluginTargetTest extends Specification {
+    def target = Mock(ProjectInternal)
+    def delegate = Mock(PluginTarget)
+    def inspectionScheme = Mock(InspectionScheme)
+    def softwareTypeRegistry = Mock(SoftwareTypeRegistry)
+    def pluginTarget = new AddSoftwareTypesAsExtensionsPluginTarget(target, delegate, inspectionScheme, softwareTypeRegistry)
+
+    def "adds software types as extensions when software type plugin is applied"() {
+        def plugin = Mock(Plugin)
+        def propertyWalker = Mock(PropertyWalker)
+        def propertyValue = Mock(PropertyValue)
+        def softwareType = Mock(SoftwareType)
+        def extensions = Mock(ExtensionContainerInternal)
+        def providers = Mock(ProviderFactory)
+        def provider = Mock(Provider)
+        def foo = new Foo()
+
+        when:
+        pluginTarget.applyImperative(null, plugin)
+
+        then:
+        1 * softwareTypeRegistry.implementationFor(_) >> Optional.of(true)
+        1 * inspectionScheme.getPropertyWalker() >> propertyWalker
+        1 * propertyWalker.visitProperties(plugin, _, _) >> { args -> args[2].visitSoftwareTypeProperty("foo", propertyValue, Foo.class, softwareType) }
+        1 * target.getExtensions() >> extensions
+        1 * target.getProviders() >> providers
+        1 * softwareType.modelPublicType() >> Foo.class
+        1 * softwareType.name() >> "foo"
+        1 * providers.provider(propertyValue) >> provider
+        1 * extensions.addLater(Foo.class, "foo", provider)
+
+        and:
+        1 * delegate.applyImperative(null, plugin)
+    }
+
+    def "does not add software types for plugins that are not registered"() {
+        def plugin = Mock(Plugin)
+
+        when:
+        pluginTarget.applyImperative(null, plugin)
+
+        then:
+        1 * softwareTypeRegistry.implementationFor(_) >> Optional.empty()
+
+        and:
+        1 * delegate.applyImperative(null, plugin)
+    }
+
+    def "passes rule targets to delegate only"() {
+        when:
+        pluginTarget.applyRules(null, Rule.class)
+
+        then:
+        1 * delegate.applyRules(null, Rule.class)
+        0 * _
+    }
+
+    private static class Foo {}
+    private static class Rule {}
+}

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/ProjectReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/ProjectReportTaskIntegrationTest.groovy
@@ -169,9 +169,7 @@ No sub-projects
                 public abstract LibraryExtension getLibrary();
 
                 @Override
-                public void apply(Project project) {
-                    project.getExtensions().add("library", getLibrary());
-                }
+                public void apply(Project project) {}
             }
         """
         file("build-logic/src/main/java/com/example/restricted/ApplicationPlugin.java") << """
@@ -186,9 +184,7 @@ No sub-projects
                 public abstract ApplicationExtension getApplication();
 
                 @Override
-                public void apply(Project project) {
-                    project.getExtensions().add("application", getApplication());
-                }
+                public void apply(Project project) {}
             }
         """
         file("build-logic/src/main/java/com/example/restricted/UtilityPlugin.java") << """
@@ -203,9 +199,7 @@ No sub-projects
                 public abstract UtilityExtension getUtility();
 
                 @Override
-                public void apply(Project project) {
-                    project.getExtensions().add("utility", getUtility());
-                }
+                public void apply(Project project) {}
             }
         """
         file("build-logic/src/main/java/com/example/restricted/SoftwareTypeRegistrationPlugin.java") << """


### PR DESCRIPTION
In #29648, we stopped automatically registering an extension for the software type when its plugin is applied.  This was because we had cases where we wanted to allow the plugin to create the model object rather than injecting it via an abstract getter.  However, this requires plugin authors to manually register the extension.

This adds some internal methods to ExtensionContainerInternal that allow us to register the extension with a Provider object early (i.e. immediately prior to the plugin being applied), even if the extension object is not actually available until later (i.e. during plugin application).

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
