### PR TITLE
Reduce lock contention in ImmutableAttributesFactory

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ComponentVariantNodeIdentifier.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ComponentVariantNodeIdentifier.java
@@ -27,10 +27,12 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 public class ComponentVariantNodeIdentifier implements NodeIdentifier {
     private final ComponentIdentifier componentId;
     private final String variantName;
+    private final int hashCode;
 
     public ComponentVariantNodeIdentifier(ComponentIdentifier componentId, String variantName) {
         this.componentId = componentId;
         this.variantName = variantName;
+        this.hashCode = 31 * componentId.hashCode() + variantName.hashCode();
     }
 
     @Override
@@ -57,6 +59,6 @@ public class ComponentVariantNodeIdentifier implements NodeIdentifier {
 
     @Override
     public int hashCode() {
-        return componentId.hashCode() ^ variantName.hashCode();
+        return hashCode;
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -609,16 +609,16 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
     @Override
     public void markAsObserved(InternalState requestedState) {
-        markThisObserved(requestedState);
-        markParentsObserved(requestedState);
-    }
-
-    private void markThisObserved(InternalState requestedState) {
         synchronized (observationLock) {
             if (observedState.compareTo(requestedState) < 0) {
                 observedState = requestedState;
+            } else {
+                // If the target state is the same as or greater than the current state,
+                // we and our parents are already at this state or later and we can skip.
+                return;
             }
         }
+        markParentsObserved(requestedState);
     }
 
     @VisibleForTesting

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalVariantMetadataBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalVariantMetadataBuilder.java
@@ -305,7 +305,7 @@ public class DefaultLocalVariantMetadataBuilder implements LocalVariantMetadataB
 
         @Override
         public int hashCode() {
-            return parent.hashCode() ^ name.hashCode();
+            return 31 * parent.hashCode() + name.hashCode();
         }
 
         @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinder.java
@@ -238,7 +238,7 @@ public class ConsumerProvidedVariantFinder {
             public CacheKey(List<ImmutableAttributes> variantAttributes, ImmutableAttributes requested) {
                 this.variantAttributes = variantAttributes;
                 this.requested = requested;
-                this.hashCode = variantAttributes.hashCode() ^ requested.hashCode();
+                this.hashCode = 31 * variantAttributes.hashCode() + requested.hashCode();
             }
 
             @Override
@@ -283,7 +283,7 @@ public class ConsumerProvidedVariantFinder {
             public CacheKey(ImmutableAttributes candidate, ImmutableAttributes requested) {
                 this.candidate = candidate;
                 this.requested = requested;
-                this.hashCode = candidate.hashCode() ^ requested.hashCode();
+                this.hashCode = 31 * candidate.hashCode() + requested.hashCode();
             }
 
             @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentConfigurationIdentifier.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentConfigurationIdentifier.java
@@ -44,6 +44,6 @@ public class ComponentConfigurationIdentifier implements VariantResolveMetadata.
 
     @Override
     public int hashCode() {
-        return component.hashCode() ^ configurationName.hashCode();
+        return 31 * component.hashCode() + configurationName.hashCode();
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultVariantArtifactResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultVariantArtifactResolver.java
@@ -181,11 +181,7 @@ public class DefaultVariantArtifactResolver implements VariantArtifactResolver {
         public VariantWithOverloadAttributes(VariantResolveMetadata.Identifier variantIdentifier, ImmutableAttributes targetVariant) {
             this.variantIdentifier = variantIdentifier;
             this.targetVariant = targetVariant;
-            this.hashCode = computeHashCode();
-        }
-
-        private int computeHashCode() {
-            return variantIdentifier.hashCode() ^ targetVariant.hashCode();
+            this.hashCode = 31 * variantIdentifier.hashCode() + targetVariant.hashCode();
         }
 
         @Override


### PR DESCRIPTION
Previously, anyone trying to concat attributes would need to lock on a build-session-scoped service. This seemed apparent in profiling results.

We attempt to avoid this by intead using a ConcurrentHashMap to lock on the node being concatenated to

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
