### PR TITLE
Memory Improvements based on findings in >6k project build

### DIFF
--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/util/Path.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/util/Path.java
@@ -20,6 +20,7 @@ import com.google.common.base.Strings;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.util.internal.GUtil;
 
 import javax.annotation.Nullable;
@@ -36,6 +37,7 @@ import static org.apache.commons.lang.StringUtils.join;
 public class Path implements Comparable<Path> {
     public static final Path ROOT = new Path(new String[0], true);
 
+    private static final StringInterner STRING_INTERNER = new StringInterner();
     private static final Comparator<String> STRING_COMPARATOR = GUtil.caseInsensitive();
     public static final String SEPARATOR = ":";
 
@@ -61,7 +63,11 @@ public class Path implements Comparable<Path> {
     }
 
     private static Path parsePath(String path) {
-        String[] segments = StringUtils.split(path, SEPARATOR);
+        String[] temp = StringUtils.split(path, SEPARATOR);
+        String[] segments = new String[temp.length];
+        for (int i = 0; i < temp.length; i++) {
+            segments[i] = STRING_INTERNER.intern(temp[i]);
+        }
         boolean absolute = path.startsWith(SEPARATOR);
         return new Path(segments, absolute);
     }
@@ -114,7 +120,7 @@ public class Path implements Comparable<Path> {
         if (absolute) {
             path.append(SEPARATOR);
         }
-        return path.append(join(segments, SEPARATOR)).toString();
+        return STRING_INTERNER.intern(path.append(join(segments, SEPARATOR)).toString());
     }
 
     /**

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/InjectUtil.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/InjectUtil.java
@@ -37,7 +37,9 @@ final class InjectUtil {
      */
     static Constructor<?> selectConstructor(final Class<?> type) {
         Constructor<?> result = CACHED_CONSTRUCTORS.get(type);
-        if (result != null) return result;
+        if (result != null) {
+            return result;
+        }
         if (isInnerClass(type)) {
             // The DI system doesn't support injecting non-static inner classes.
             throw new ServiceValidationException(

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -442,7 +442,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
     @Override
     public Configuration setDescription(@Nullable String description) {
-        this.description = description;
+        this.description = STRING_INTERNER.intern(description);
         return this;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -87,6 +87,7 @@ import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.FreezableAttributeContainer;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.AbstractFileCollection;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -157,6 +158,8 @@ import static org.gradle.util.internal.ConfigureUtil.configure;
  */
 @SuppressWarnings("rawtypes")
 public abstract class DefaultConfiguration extends AbstractFileCollection implements ConfigurationInternal, MutationValidator, ResettableConfiguration {
+    private final static StringInterner STRING_INTERNER = new StringInterner();
+
     private final ConfigurationResolver resolver;
     private final DependencyLockingProvider dependencyLockingProvider;
     private final DefaultDependencySet dependencies;
@@ -273,14 +276,15 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         boolean lockUsage
     ) {
         super(taskDependencyFactory);
+        String internedName = STRING_INTERNER.intern(name);
         this.userCodeApplicationContext = userCodeApplicationContext;
         this.projectStateRegistry = projectStateRegistry;
         this.workerThreadRegistry = workerThreadRegistry;
         this.domainObjectCollectionFactory = domainObjectCollectionFactory;
         this.calculatedValueContainerFactory = calculatedValueContainerFactory;
-        this.identityPath = domainObjectContext.identityPath(name);
-        this.projectPath = domainObjectContext.projectPath(name);
-        this.name = name;
+        this.identityPath = domainObjectContext.identityPath(internedName);
+        this.projectPath = domainObjectContext.projectPath(internedName);
+        this.name = internedName;
         this.configurationsProvider = configurationsProvider;
         this.resolver = resolver;
         this.dependencyLockingProvider = dependencyLockingProvider;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
@@ -28,6 +28,7 @@ import org.gradle.api.internal.artifacts.DefaultPublishArtifactSet;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.FreezableAttributeContainer;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
@@ -41,6 +42,7 @@ import java.util.List;
 import java.util.Optional;
 
 public class DefaultVariant implements ConfigurationVariantInternal {
+    private final static StringInterner STRING_INTERNER = new StringInterner();
     private final Describable parentDisplayName;
     private final String name;
     private final FreezableAttributeContainer attributes;
@@ -58,7 +60,7 @@ public class DefaultVariant implements ConfigurationVariantInternal {
                           DomainObjectCollectionFactory domainObjectCollectionFactory,
                           TaskDependencyFactory taskDependencyFactory) {
         this.parentDisplayName = parentDisplayName;
-        this.name = name;
+        this.name = STRING_INTERNER.intern(name);
         this.attributes = new FreezableAttributeContainer(cache.mutable(parentAttributes), parentDisplayName);
         this.artifactNotationParser = artifactNotationParser;
         artifacts = new DefaultPublishArtifactSet(getDisplayName(), domainObjectCollectionFactory.newDomainObjectSet(PublishArtifact.class), fileCollectionFactory, taskDependencyFactory);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
@@ -87,7 +87,7 @@ public class MavenResolver extends ExternalResourceResolver {
             injector,
             checksumService);
         this.mavenMetaDataLoader = mavenMetadataLoader;
-        this.root = URI_CACHE.computeIfAbsent(rootUri, u -> rootUri);
+        this.root = URI_CACHE.computeIfAbsent(rootUri, r -> r);
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
@@ -47,10 +47,14 @@ import org.gradle.internal.resource.local.LocallyAvailableResourceFinder;
 
 import javax.annotation.Nullable;
 import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class MavenResolver extends ExternalResourceResolver {
+    private final static Map<URI, URI> URI_CACHE = Collections.synchronizedMap(new WeakHashMap<>());
     private final URI root;
     private final MavenMetadataLoader mavenMetaDataLoader;
 
@@ -83,7 +87,7 @@ public class MavenResolver extends ExternalResourceResolver {
             injector,
             checksumService);
         this.mavenMetaDataLoader = mavenMetadataLoader;
-        this.root = rootUri;
+        this.root = URI_CACHE.computeIfAbsent(rootUri, u -> rootUri);
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapabilities.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapabilities.java
@@ -22,6 +22,9 @@ import org.gradle.api.internal.capabilities.ImmutableCapability;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
 
 /**
  * A deeply immutable implementation of {@link CapabilitiesMetadata}.
@@ -34,12 +37,17 @@ import java.util.Collection;
  * subclassing should not break the immutability contract.
  */
 public class ImmutableCapabilities {
+    private static final Map<ImmutableCapability, ImmutableCapability> IMMUTABLE_CAPABILITY_CACHE = Collections.synchronizedMap(new WeakHashMap<>());
     public static final ImmutableCapabilities EMPTY = new ImmutableCapabilities(ImmutableSet.of());
 
     private final ImmutableSet<ImmutableCapability> capabilities;
 
     public ImmutableCapabilities(ImmutableSet<ImmutableCapability> capabilities) {
-        this.capabilities = capabilities;
+        ImmutableSet.Builder<ImmutableCapability> builder = ImmutableSet.builderWithExpectedSize(capabilities.size());
+        for (ImmutableCapability c : capabilities) {
+            builder.add(IMMUTABLE_CAPABILITY_CACHE.computeIfAbsent(c, x -> x));
+        }
+        this.capabilities = builder.build();
     }
 
     public static ImmutableCapabilities of(@Nullable Capability capability) {


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
This set of changes reduce the number of duplicate Strings/Objects created during the configuration phase of Gradle. From testing with a 6k+ project build, I was able to see close to 0.5gb heap usage drop, mostly within the `java` package, but also in the `org.gradle` package.

I performed all these tests utilizing this branch of `affected-paths` (https://github.com/big-guy/affected-paths/tree/heap-dump), which dumps the heap memory after the Gradle Tooling API has run and generated models, but before returning the models via IPC back to the calling process.

Runtime given on these tests are based on the affected-paths JVM app, and not on what Gradle has reported, so they include the time spent generating the heap dumps.

---

The following were my findings on a commit basis:
- Currently (as of commit 94faa3d523951f395123f459d4f513bd417a654f)
  - Heap memory retained after configuration: 12.4gb 
  - Strongly reachable memory retained: 12.3gb
  - Runtime: 3m49s

- Caching the `DefaultVariant` name (d04d268ac9e66ce8d5fc545131577f79ec7825bb)
  - Heap memory retained after configuration: 12.1gb 
  - Strongly reachable memory retained: 12.1gb
  - Runtime: 3m39s
  - Purpose of change:
    - There were many strings (upwards of 11k+ duplicates per unique string) that were being generated and stored, which increased heap usage. Example string that was generated and stored:
```
android-lint-vital-variant-dependencies-partial-results-Aorg.gradle.category=verification-Aorg.gradle.verificationtype=android-lint-vital-variant-dependencies-partial-results
```

- Caching URIs used for `MavenResolver` (82e890703f4b4d66444481ae123ba5b72ceb7330)
  - Heap memory retained after configuration: 12.1gb 
  - Strongly reachable memory retained: 12.1gb
  - Runtime: 3m58s
  - Purpose of change:
    - Many of the URIs shared the same path. This change just cached the URI objects for re-use.

- Caching `Constructor` objects (2ed515dd5dbf0b86b1f948fe7df4568696d9f3fb)
  - Heap memory retained after configuration: 12gb 
  - Strongly reachable memory retained: 12gb
  - Runtime: 3m54s
  - Purpose of change:
    - In the `InjectUtil` class, the `Constructor` object being returned in the `selectConstructor()` function was being recreated, not to mention that reflection was used on each call. The constructors are now cached, keyed off the `Class` object passed in.

- Reduce duplicate configuration names (b75b53f6df9f657c002c798ca424600049d678aa)
  - Heap memory retained after configuration: 12gb 
  - Strongly reachable memory retained: 12gb
  - Runtime: 4m2s
  - Purpose of change:
    - Many configuration objects contained the exact same name, though all these strings were generated, thus taking up more heap memory.

- De-duplicate `ImmutableCapability` objects and Configuraton description (1881adf6d5b5bb21ad1297d92d49776058675e78)
  - Heap memory retained after configuration: 11.9gb 
  - Strongly reachable memory retained: 11.9gb
  - Runtime: 3m48s
  - Purpose of change:
    - Many `ImmutableCapability` objects were duplicated across a number of variants per project. On top of that, the `description` variable in `DefaultConfiguration` was storing generated strings for many other different variatns.

Total heap memory savings: ~0.5gb

Comparison between 94faa3d523951f395123f459d4f513bd417a654f and 4f54b99f62ecb893a86ffd53ade5ff9d49023c8f:
<img width="765" alt="image" src="https://github.com/user-attachments/assets/63f46d93-19aa-401f-8edc-23e409647b49">

<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
