### PR TITLE
Deduplicate strings stored in the configuration cache

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEncryptionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEncryptionIntegrationTest.groovy
@@ -119,26 +119,30 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
         findRequiredKeystoreFile(false) == null
 
         when:
-        runWithEncryption(kind, ["useSensitive"], ["-Psensitive_property_name=sensitive_property_value"], [
-            (ENV_PROJECT_PROPERTIES_PREFIX + 'sensitive_property_name2'): 'sensitive_property_value2',
-            "SENSITIVE_ENV_VAR_NAME": 'sensitive_env_var_value'
-        ])
+        runWithEncryption(
+            kind,
+            ["useSensitive"],
+            ["-Psensitive_property_name=sensitive_property_value",
+             "-Dorg.gradle.configuration-cache.internal.deduplicate-strings=false"],
+            [(ENV_PROJECT_PROPERTIES_PREFIX + 'sensitive_property_name2'): 'sensitive_property_value2',
+             "SENSITIVE_ENV_VAR_NAME": 'sensitive_env_var_value']
+        )
 
         then:
         configurationCache.assertStateStored()
         enabled == kind.encrypted
         def cacheDir = new File(this.testDirectory, ".gradle/configuration-cache")
-        isFoundInDirectory(cacheDir, encodedBytesOf("sensitive_property_name")) == !enabled
-        isFoundInDirectory(cacheDir, encodedBytesOf("sensitive_property_value")) == !enabled
-        isFoundInDirectory(cacheDir, encodedBytesOf("sensitive_property_name2")) == !enabled
-        isFoundInDirectory(cacheDir, encodedBytesOf("sensitive_property_value2")) == !enabled
-        isFoundInDirectory(cacheDir, encodedBytesOf("sensitive_value1")) == !enabled
-        isFoundInDirectory(cacheDir, encodedBytesOf("sensitive_value2")) == !enabled
-        isFoundInDirectory(cacheDir, encodedBytesOf("sensitive_env_var_value")) == !enabled
-        isFoundInDirectory(cacheDir, encodedBytesOf("sensitive_value3")) == !enabled
-        isFoundInDirectory(cacheDir, encodedBytesOf("sensitive_convention")) == !enabled
-        isFoundInDirectory(cacheDir, "sensitive".getBytes(StandardCharsets.US_ASCII)) == !enabled
-        isFoundInDirectory(cacheDir, "SENSITIVE".getBytes(StandardCharsets.US_ASCII)) == !enabled
+        isFoundInDirectory(cacheDir, "sensitive_property_name".getBytes()) == !enabled
+        isFoundInDirectory(cacheDir, "sensitive_property_value".getBytes()) == !enabled
+        isFoundInDirectory(cacheDir, "sensitive_property_name2".getBytes()) == !enabled
+        isFoundInDirectory(cacheDir, "sensitive_property_value2".getBytes()) == !enabled
+        isFoundInDirectory(cacheDir, "sensitive_value1".getBytes()) == !enabled
+        isFoundInDirectory(cacheDir, "sensitive_value2".getBytes()) == !enabled
+        isFoundInDirectory(cacheDir, "sensitive_env_var_value".getBytes()) == !enabled
+        isFoundInDirectory(cacheDir, "sensitive_value3".getBytes()) == !enabled
+        isFoundInDirectory(cacheDir, "sensitive_convention".getBytes()) == !enabled
+        isFoundInDirectory(cacheDir, "sensitive".getBytes()) == !enabled
+        isFoundInDirectory(cacheDir, "SENSITIVE".getBytes()) == !enabled
 
         (findRequiredKeystoreFile(false) != null) == keystoreExpected
 
@@ -147,21 +151,6 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
         EncryptionKind.NONE     | false   | false
         EncryptionKind.KEYSTORE | true    | true
         EncryptionKind.ENV_VAR  | true    | false
-    }
-
-    /**
-     * Returns the bytes as encoded by {@link org.gradle.internal.serialize.kryo.StringDeduplicatingKryoBackedEncoder},
-     * which uses the last byte as a marker.
-     *
-     * @see com.esotericsoftware.kryo.io.Output#writeString(java.lang.String)
-     */
-    @SuppressWarnings('GrDeprecatedAPIUsage')
-    private static byte[] encodedBytesOf(String string) {
-        def charCount = string.length()
-        def bytes = new byte[charCount];
-        string.getBytes(0, charCount, bytes, 0)
-        bytes[charCount - 1] = (byte) (bytes[charCount - 1] | 128);
-        return bytes
     }
 
     private boolean isFoundInDirectory(File startDir, byte[] toFind) {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheStringDeduplicationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheStringDeduplicationIntegrationTest.groovy
@@ -24,10 +24,9 @@ class ConfigurationCacheStringDeduplicationIntegrationTest extends AbstractConfi
     def "strings are deduplicated across projects"() {
         given:
         createDirs 'foo', 'bar'
-        settingsFile '''
+        settingsFile """
             include 'foo', 'bar'
-        '''
-        buildFile """
+
             abstract class StringDedupCheckerService implements ${BuildService.name}<${BuildServiceParameters.name}.None>{
 
                 private String string = null
@@ -51,7 +50,7 @@ class ConfigurationCacheStringDeduplicationIntegrationTest extends AbstractConfi
             }
 
             def service = gradle.sharedServices.registerIfAbsent('stringChecker', StringDedupCheckerService) {}
-            allprojects {
+            gradle.lifecycle.beforeProject {
                 tasks.register('check', StringTask) {
                     string = ['it', 'will', 'be', 'deduplicated'].join(' ')
                 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheStringDeduplicationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheStringDeduplicationIntegrationTest.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl
+
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+
+class ConfigurationCacheStringDeduplicationIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+
+    def "strings are deduplicated across projects"() {
+        given:
+        createDirs 'foo', 'bar'
+        settingsFile '''
+            include 'foo', 'bar'
+        '''
+        buildFile """
+            abstract class StringDedupCheckerService implements ${BuildService.name}<${BuildServiceParameters.name}.None>{
+
+                private String string = null
+
+                synchronized def check(String s) {
+                    if (string === null) {
+                        string = s
+                    } else {
+                        assert string === s
+                        println 'Strings have been deduplicated'
+                    }
+                }
+            }
+
+            abstract class StringTask extends DefaultTask {
+                @Input abstract Property<String> getString()
+                @ServiceReference('stringChecker') abstract Property<StringDedupCheckerService> getService()
+                @TaskAction def check() {
+                    service.get().check(string.get())
+                }
+            }
+
+            def service = gradle.sharedServices.registerIfAbsent('stringChecker', StringDedupCheckerService) {}
+            allprojects {
+                tasks.register('check', StringTask) {
+                    string = ['it', 'will', 'be', 'deduplicated'].join(' ')
+                }
+            }
+        """
+
+        when:
+        configurationCacheRun 'check'
+
+        then:
+        output.count('Strings have been deduplicated') == 2
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheKey.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheKey.kt
@@ -78,6 +78,7 @@ class ConfigurationCacheKey(
         putBuildScan()
         putBoolean(encryptionConfiguration.isEncrypting)
         putHash(encryptionConfiguration.encryptionKeyHashCode)
+        putBoolean(startParameter.isDeduplicatingStrings)
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
@@ -38,6 +38,7 @@ import org.gradle.internal.hash.HashCode
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.Encoder
+import org.gradle.internal.serialize.PositionAwareEncoder
 import org.gradle.internal.serialize.graph.BeanStateReaderLookup
 import org.gradle.internal.serialize.graph.BeanStateWriterLookup
 import org.gradle.internal.serialize.graph.CloseableReadContext
@@ -57,6 +58,8 @@ import org.gradle.internal.serialize.graph.runReadOperation
 import org.gradle.internal.serialize.graph.runWriteOperation
 import org.gradle.internal.serialize.graph.writeCollection
 import org.gradle.internal.serialize.graph.writeFile
+import org.gradle.internal.serialize.kryo.KryoBackedDecoder
+import org.gradle.internal.serialize.kryo.KryoBackedEncoder
 import org.gradle.internal.serialize.kryo.StringDeduplicatingKryoBackedDecoder
 import org.gradle.internal.serialize.kryo.StringDeduplicatingKryoBackedEncoder
 import org.gradle.internal.service.scopes.Scope
@@ -250,12 +253,26 @@ class DefaultConfigurationCacheIO internal constructor(
         outputStream: () -> OutputStream,
         profile: () -> String
     ): Pair<CloseableWriteContext, Codecs> =
-        StringDeduplicatingKryoBackedEncoder(outputStreamFor(stateType, outputStream)).let { encoder ->
+        encoderFor(stateType, outputStream).let { encoder ->
             writeContextFor(
                 encoder,
                 loggingTracerFor(profile, encoder),
                 codecs
             ) to codecs
+        }
+
+    private
+    fun encoderFor(stateType: StateType, outputStream: () -> OutputStream): PositionAwareEncoder =
+        outputStreamFor(stateType, outputStream).let { stream ->
+            if (startParameter.isDeduplicatingStrings) StringDeduplicatingKryoBackedEncoder(stream)
+            else KryoBackedEncoder(stream)
+        }
+
+    private
+    fun decoderFor(stateType: StateType, inputStream: () -> InputStream): Decoder =
+        inputStreamFor(stateType, inputStream).let { stream ->
+            if (startParameter.isDeduplicatingStrings) StringDeduplicatingKryoBackedDecoder(stream)
+            else KryoBackedDecoder(stream)
         }
 
     private
@@ -272,7 +289,7 @@ class DefaultConfigurationCacheIO internal constructor(
         else inner()
 
     private
-    fun loggingTracerFor(profile: () -> String, encoder: StringDeduplicatingKryoBackedEncoder) =
+    fun loggingTracerFor(profile: () -> String, encoder: PositionAwareEncoder) =
         loggingTracerLogLevel()?.let { level ->
             LoggingTracer(profile(), encoder::getWritePosition, logger, level)
         }
@@ -302,7 +319,7 @@ class DefaultConfigurationCacheIO internal constructor(
         inputStream: () -> InputStream,
         readOperation: suspend MutableReadContext.(Codecs) -> R
     ): R =
-        readContextFor(StringDeduplicatingKryoBackedDecoder(inputStreamFor(stateType, inputStream)))
+        readContextFor(decoderFor(stateType, inputStream))
             .let { (context, codecs) ->
                 context.useToRun {
                     runReadOperation {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheStartParameter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheStartParameter.kt
@@ -64,6 +64,14 @@ class ConfigurationCacheStartParameter(
      */
     val alwaysLogReportLinkAsWarning: Boolean = options.getInternalFlag("org.gradle.configuration-cache.internal.report-link-as-warning", false)
 
+    /**
+     * Whether strings stored to the configuration cache should be deduplicated
+     * in order to save space on disk and to use less memory on a cache hit.
+     *
+     * The default is `true`.
+     */
+    val isDeduplicatingStrings: Boolean = options.getInternalFlag("org.gradle.configuration-cache.internal.deduplicate-strings", true)
+
     val gradleProperties: Map<String, Any?>
         get() = startParameter.projectProperties
             .filterKeys { !Workarounds.isIgnoredStartParameterProperty(it) }

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
@@ -91,10 +91,6 @@ class DefaultWriteContext(
         }
     }
 
-    // TODO: consider interning strings
-    override fun writeString(string: CharSequence) =
-        encoder.writeString(string)
-
     override fun newIsolate(owner: IsolateOwner): WriteIsolate =
         DefaultWriteIsolate(owner)
 }

--- a/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/PositionAwareEncoder.java
+++ b/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/PositionAwareEncoder.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.serialize;
+
+/**
+ * An {@link Encoder} that can return its current {@link #getWritePosition() write position}.
+ */
+public interface PositionAwareEncoder extends Encoder {
+    long getWritePosition();
+}

--- a/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/kryo/KryoBackedEncoder.java
+++ b/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/kryo/KryoBackedEncoder.java
@@ -20,13 +20,14 @@ import com.esotericsoftware.kryo.io.Output;
 import org.gradle.internal.serialize.AbstractEncoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.FlushableEncoder;
+import org.gradle.internal.serialize.PositionAwareEncoder;
 
 import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
 
-public class KryoBackedEncoder extends AbstractEncoder implements FlushableEncoder, Closeable {
+public class KryoBackedEncoder extends AbstractEncoder implements PositionAwareEncoder, FlushableEncoder, Closeable {
     private final Output output;
     private KryoBackedEncoder nested;
 
@@ -133,6 +134,7 @@ public class KryoBackedEncoder extends AbstractEncoder implements FlushableEncod
     /**
      * Returns the total number of bytes written by this encoder, some of which may still be buffered.
      */
+    @Override
     public long getWritePosition() {
         return output.total();
     }

--- a/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/kryo/StringDeduplicatingKryoBackedDecoder.java
+++ b/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/kryo/StringDeduplicatingKryoBackedDecoder.java
@@ -32,9 +32,19 @@ import java.io.InputStream;
  */
 public class StringDeduplicatingKryoBackedDecoder extends AbstractDecoder implements Decoder, Closeable {
     public static final int INITIAL_CAPACITY = 32;
+    private static final String[] INITIAL_CAPACITY_MARKER = new String[0];
     private final Input input;
     private final InputStream inputStream;
-    private String[] strings;
+    private String[] strings = INITIAL_CAPACITY_MARKER;
+    /**
+     * Actual stored string indices start from 2 so `0` and `1` can be used as special codes:
+     * <ul>
+     *     <li>0 for null</li>
+     *     <li>1 for a new string</li>
+     * </ul>
+     * And be efficiently encoded as var ints (writeVarInt/readVarInt) to save even more space.
+     **/
+    private int nextString = 2;
     private long extraSkipped;
 
     public StringDeduplicatingKryoBackedDecoder(InputStream inputStream) {
@@ -175,29 +185,37 @@ public class StringDeduplicatingKryoBackedDecoder extends AbstractDecoder implem
     @Override
     public String readNullableString() throws EOFException {
         try {
-            int idx = readInt();
-            if (idx == -1) {
-                return null;
+            int index = readStringIndex();
+            switch (index) {
+                case 0:
+                    return null;
+                case 1:
+                    return readNewString();
+                default:
+                    return strings[index];
             }
-            if (strings == null) {
-                strings = new String[INITIAL_CAPACITY];
-            }
-            String string = null;
-            if (idx >= strings.length) {
-                String[] grow = new String[strings.length * 3 / 2];
-                System.arraycopy(strings, 0, grow, 0, strings.length);
-                strings = grow;
-            } else {
-                string = strings[idx];
-            }
-            if (string == null) {
-                string = input.readString();
-                strings[idx] = string;
-            }
-            return string;
         } catch (KryoException e) {
             throw maybeEndOfStream(e);
         }
+    }
+
+    private int readStringIndex() {
+        return input.readVarInt(true);
+    }
+
+    private String readNewString() {
+        if (nextString >= strings.length) {
+            strings = growStringArray(strings);
+        }
+        String string = input.readString();
+        strings[nextString++] = string;
+        return string;
+    }
+
+    private static String[] growStringArray(String[] strings) {
+        String[] grow = new String[strings == INITIAL_CAPACITY_MARKER ? INITIAL_CAPACITY : strings.length * 3 / 2];
+        System.arraycopy(strings, 0, grow, 0, strings.length);
+        return grow;
     }
 
     /**

--- a/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/kryo/StringDeduplicatingKryoBackedDecoder.java
+++ b/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/kryo/StringDeduplicatingKryoBackedDecoder.java
@@ -26,13 +26,16 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 
+import static org.gradle.internal.serialize.kryo.StringDeduplicatingKryoBackedEncoder.NEW_STRING;
+import static org.gradle.internal.serialize.kryo.StringDeduplicatingKryoBackedEncoder.NULL_STRING;
+
 /**
  * Note that this decoder uses buffering, so will attempt to read beyond the end of the encoded data. This means you should use this type only when this decoder will be used to decode the entire
  * stream.
  */
 public class StringDeduplicatingKryoBackedDecoder extends AbstractDecoder implements Decoder, Closeable {
-    public static final int INITIAL_CAPACITY = 32;
-    private static final String[] INITIAL_CAPACITY_MARKER = new String[0];
+    private static final int INITIAL_CAPACITY = 32;
+    private static final String[] INITIAL_CAPACITY_MARKER = {};
     private final Input input;
     private final InputStream inputStream;
     private String[] strings = INITIAL_CAPACITY_MARKER;
@@ -43,6 +46,9 @@ public class StringDeduplicatingKryoBackedDecoder extends AbstractDecoder implem
      *     <li>1 for a new string</li>
      * </ul>
      * And be efficiently encoded as var ints (writeVarInt/readVarInt) to save even more space.
+     *
+     * @see StringDeduplicatingKryoBackedEncoder#NULL_STRING
+     * @see StringDeduplicatingKryoBackedEncoder#NEW_STRING
      **/
     private int nextString = 2;
     private long extraSkipped;
@@ -187,9 +193,9 @@ public class StringDeduplicatingKryoBackedDecoder extends AbstractDecoder implem
         try {
             int index = readStringIndex();
             switch (index) {
-                case 0:
+                case NULL_STRING:
                     return null;
-                case 1:
+                case NEW_STRING:
                     return readNewString();
                 default:
                     return strings[index];

--- a/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/kryo/StringDeduplicatingKryoBackedEncoder.java
+++ b/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/kryo/StringDeduplicatingKryoBackedEncoder.java
@@ -20,6 +20,7 @@ import com.esotericsoftware.kryo.io.Output;
 import com.google.common.collect.Maps;
 import org.gradle.internal.serialize.AbstractEncoder;
 import org.gradle.internal.serialize.FlushableEncoder;
+import org.gradle.internal.serialize.PositionAwareEncoder;
 
 import javax.annotation.Nullable;
 import java.io.Closeable;
@@ -27,7 +28,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Map;
 
-public class StringDeduplicatingKryoBackedEncoder extends AbstractEncoder implements FlushableEncoder, Closeable {
+public class StringDeduplicatingKryoBackedEncoder extends AbstractEncoder implements PositionAwareEncoder, FlushableEncoder, Closeable {
 
     static final int NULL_STRING = 0;
     static final int NEW_STRING = 1;
@@ -146,6 +147,7 @@ public class StringDeduplicatingKryoBackedEncoder extends AbstractEncoder implem
     /**
      * Returns the total number of bytes written by this encoder, some of which may still be buffered.
      */
+    @Override
     public long getWritePosition() {
         return output.total();
     }

--- a/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/kryo/StringDeduplicatingKryoBackedEncoder.java
+++ b/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/kryo/StringDeduplicatingKryoBackedEncoder.java
@@ -28,6 +28,10 @@ import java.io.OutputStream;
 import java.util.Map;
 
 public class StringDeduplicatingKryoBackedEncoder extends AbstractEncoder implements FlushableEncoder, Closeable {
+
+    static final int NULL_STRING = 0;
+    static final int NEW_STRING = 1;
+
     private Map<String, Integer> strings;
 
     private final Output output;
@@ -93,7 +97,7 @@ public class StringDeduplicatingKryoBackedEncoder extends AbstractEncoder implem
     @Override
     public void writeNullableString(@Nullable CharSequence value) {
         if (value == null) {
-            writeStringIndex(0);
+            writeStringIndex(NULL_STRING);
             return;
         }
         writeNonnullString(value);
@@ -131,7 +135,7 @@ public class StringDeduplicatingKryoBackedEncoder extends AbstractEncoder implem
          */
         Integer newIndex = strings.size() + 2;
         strings.put(key, newIndex);
-        writeStringIndex(1);
+        writeStringIndex(NEW_STRING);
         output.writeString(key);
     }
 

--- a/testing/architecture-test/src/changes/archunit-store/internal-api-nullability.txt
+++ b/testing/architecture-test/src/changes/archunit-store/internal-api-nullability.txt
@@ -2720,6 +2720,7 @@ Class <org.gradle.internal.serialize.OutputStreamBackedEncoder> is not annotated
 Class <org.gradle.internal.serialize.PlaceholderAssertionError> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (PlaceholderAssertionError.java:0)
 Class <org.gradle.internal.serialize.PlaceholderException> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (PlaceholderException.java:0)
 Class <org.gradle.internal.serialize.PlaceholderExceptionSupport> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (PlaceholderExceptionSupport.java:0)
+Class <org.gradle.internal.serialize.PositionAwareEncoder> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (PositionAwareEncoder.java:0)
 Class <org.gradle.internal.serialize.Serializer> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (Serializer.java:0)
 Class <org.gradle.internal.serialize.SerializerRegistry> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (SerializerRegistry.java:0)
 Class <org.gradle.internal.serialize.Serializers$1> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (Serializers.java:0)


### PR DESCRIPTION
With this change, the configuration cache entry for `assembleDebug` on `perf-android-large-2` is 74% smaller (356M against 1.3G) and it runs ~30% faster on a cache hit:

<img width="931" alt="Screenshot 2024-07-18 at 10 46 21" src="https://github.com/user-attachments/assets/b975b2be-129c-4415-b16e-73579e5a2f1d">

<img width="1358" alt="Screenshot 2024-07-18 at 10 51 42" src="https://github.com/user-attachments/assets/683cc514-4a17-4239-95cc-22b7052b6633">

Gradle performance tests also [show improvement](https://builds.gradle.org/repository/download/Gradle_Master_Check_PerformanceTest7_Trigger/85288034:id/performance-test-results.zip!/report/index.html).

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
