### PR TITLE
Fix broken Problems API sample

### DIFF
--- a/platforms/documentation/docs/src/samples/ide/problems-api-usage/groovy/reporters/script-plugin/src/main/groovy/reporters.script.plugin.gradle
+++ b/platforms/documentation/docs/src/samples/ide/problems-api-usage/groovy/reporters/script-plugin/src/main/groovy/reporters.script.plugin.gradle
@@ -1,9 +1,11 @@
-import org.gradle.api.internal.GradleInternal
 import org.gradle.api.problems.Problems
 import org.gradle.api.problems.Severity
 
-def gradleInternal = gradle as GradleInternal
-def problems = gradleInternal.services.get(Problems)
+interface Injected {
+    @Inject Problems getProblems()
+}
+
+def problems = project.objects.newInstance(Injected).getProblems()
 
 problems.forNamespace('buildscript').reporting {
     it.id('adhoc-script-deprecation', 'Deprecated script plugin')

--- a/platforms/documentation/docs/src/samples/ide/problems-api-usage/groovy/sample-ide/build.gradle
+++ b/platforms/documentation/docs/src/samples/ide/problems-api-usage/groovy/sample-ide/build.gradle
@@ -15,7 +15,7 @@ application {
 
 dependencies {
     implementation('reporters:model-builder-plugin')
-    implementation('org.gradle:gradle-tooling-api:8.6-milestone-1')
+    implementation('org.gradle:gradle-tooling-api:8.9')
 }
 
 tasks.run.configure {

--- a/platforms/documentation/docs/src/samples/ide/problems-api-usage/kotlin/reporters/script-plugin/src/main/kotlin/reporters/script.plugin.gradle.kts
+++ b/platforms/documentation/docs/src/samples/ide/problems-api-usage/kotlin/reporters/script-plugin/src/main/kotlin/reporters/script.plugin.gradle.kts
@@ -1,9 +1,11 @@
 package reporters
-import org.gradle.api.internal.GradleInternal
 import org.gradle.kotlin.dsl.registering
 
-val gradleInternal = gradle as GradleInternal
-val problems = gradleInternal.services.get(Problems::class.java)
+interface Injected {
+    @get:Inject val problems: Problems
+}
+
+val problems = project.objects.newInstance<Injected>().problems
 
 problems.forNamespace("buildscript").reporting {
     id("adhoc-script-deprecation", "Deprecated script plugin")

--- a/platforms/documentation/docs/src/samples/ide/problems-api-usage/tests/runSample.sample.conf
+++ b/platforms/documentation/docs/src/samples/ide/problems-api-usage/tests/runSample.sample.conf
@@ -1,0 +1,4 @@
+commands: [{
+    executable: gradle
+    args: ":sample-ide:importBuild"
+}]

--- a/platforms/documentation/docs/src/samples/ide/problems-api-usage/tests/runSample.sample.conf
+++ b/platforms/documentation/docs/src/samples/ide/problems-api-usage/tests/runSample.sample.conf
@@ -1,4 +1,0 @@
-commands: [{
-    executable: gradle
-    args: ":sample-ide:importBuild"
-}]


### PR DESCRIPTION
The sample contains a Tooling API client that executes a Gradle build producing problems reported via the Problems API. The sample test coverage only executed sanity check which only validates the build scripts and omits the TAPI client compilation and execution. Because of that, we broke the sample when we refactored the Problems API. 

This pull request fixes the broken sample. In addition, the PR removes the internal API usage in the sample.

Fixes https://github.com/gradle/gradle/issues/29890