### PR TITLE
Expose ProjectIdentity on DomainObjectContext

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheHost.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheHost.kt
@@ -22,6 +22,7 @@ import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.SettingsInternal
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.initialization.ScriptHandlerFactory
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.execution.plan.ScheduledWork
@@ -193,7 +194,7 @@ class DefaultConfigurationCacheHost internal constructor(
                 gradle,
                 classLoaderScope,
                 baseClassLoaderScope,
-                service<ScriptHandlerFactory>().create(settingsSource, classLoaderScope),
+                service<ScriptHandlerFactory>().create(settingsSource, classLoaderScope, StandaloneDomainObjectContext.forScript(settingsSource)),
                 settingsDir(),
                 settingsSource,
                 gradle.startParameter

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -40,7 +40,6 @@ import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.project.CrossProjectModelAccess
 import org.gradle.api.internal.project.MutableStateAccessAwareProject
 import org.gradle.api.internal.project.ProjectIdentifier
-import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.tasks.TaskDependencyFactory
 import org.gradle.api.internal.tasks.TaskDependencyUsageTracker

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -40,6 +40,7 @@ import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.project.CrossProjectModelAccess
 import org.gradle.api.internal.project.MutableStateAccessAwareProject
 import org.gradle.api.internal.project.ProjectIdentifier
+import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.tasks.TaskDependencyFactory
 import org.gradle.api.internal.tasks.TaskDependencyUsageTracker

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/settings/PluginsInterpretationSequenceStep.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/settings/PluginsInterpretationSequenceStep.kt
@@ -18,6 +18,7 @@ package org.gradle.internal.declarativedsl.settings
 
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.initialization.ScriptHandlerFactory
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext
 import org.gradle.api.internal.plugins.PluginManagerInternal
 import org.gradle.declarative.dsl.evaluation.AnalysisStatementFilter
 import org.gradle.declarative.dsl.evaluation.InterpretationSequenceStep.StepIdentifier
@@ -67,7 +68,7 @@ class PluginsInterpretationSequenceStep(
             DefaultPluginRequest(DefaultPluginId.unvalidated(it.id), it.apply, PluginRequestInternal.Origin.OTHER, scriptSource.displayName, null, it.version, null, null, null)
         }
         with(getTargetServices()) {
-            val scriptHandler = get(ScriptHandlerFactory::class.java).create(scriptSource, targetScope)
+            val scriptHandler = get(ScriptHandlerFactory::class.java).create(scriptSource, targetScope, StandaloneDomainObjectContext.forScript(scriptSource))
             val pluginManager = get(PluginManagerInternal::class.java)
             val pluginApplicator = get(PluginRequestApplicator::class.java)
             pluginApplicator.applyPlugins(PluginRequests.of(pluginRequests), scriptHandler, pluginManager, targetScope)

--- a/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/transform/IsolateTransformParametersCodec.kt
+++ b/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/transform/IsolateTransformParametersCodec.kt
@@ -21,7 +21,7 @@ import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.artifacts.transform.DefaultTransform
 import org.gradle.api.internal.artifacts.transform.TransformParameterScheme
 import org.gradle.api.internal.file.FileCollectionFactory
-import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext
 import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.ReadContext
@@ -54,7 +54,7 @@ class IsolateTransformParametersCodec(
             parameterObject,
             implementationClass,
             cacheable,
-            RootScriptDomainObjectContext.INSTANCE,
+            StandaloneDomainObjectContext.ANONYMOUS,
             parameterScheme.inspectionScheme.propertyWalker,
             isolatableFactory,
             buildOperationRunner,

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
@@ -33,7 +33,7 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactoryInter
 import org.gradle.api.internal.artifacts.dsl.dependencies.UnknownProjectFinder
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileResolver
-import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext
 import org.gradle.api.internal.initialization.ScriptClassPathResolver
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectStateRegistry
@@ -443,7 +443,7 @@ abstract class GeneratePrecompiledScriptPluginAccessors @Inject internal constru
             fileCollectionFactory,
             gradle.serviceOf<DependencyMetaDataProvider>(),
             UnknownProjectFinder("Project dependencies are not allowed at GeneratePrecompiledScriptPluginAccessors resolution"),
-            RootScriptDomainObjectContext.PLUGINS
+            StandaloneDomainObjectContext.PLUGINS
         )
 
         val dependencies = dependencyResolutionServices.dependencyHandler

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
@@ -24,6 +24,7 @@ import org.gradle.api.internal.SettingsInternal
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.initialization.ScriptHandlerFactory
 import org.gradle.api.internal.initialization.ScriptHandlerInternal
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.tasks.SourceSet
@@ -360,7 +361,7 @@ fun compilationClassPathForScriptPluginOf(
 
     val scriptSource = textResourceScriptSource(resourceDescription, scriptFile, project.serviceOf())
     val scriptScope = baseScope.createChild("model-${scriptFile.toURI()}", null)
-    val scriptHandler = scriptHandlerFactory.create(scriptSource, scriptScope)
+    val scriptHandler = scriptHandlerFactory.create(scriptSource, scriptScope, StandaloneDomainObjectContext.forScript(scriptSource))
 
     kotlinScriptFactoryOf(project).evaluate(
         target = target,

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/util/Path.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/util/Path.java
@@ -68,7 +68,7 @@ public class Path implements Comparable<Path> {
 
     private final String[] segments;
     private final boolean absolute;
-    private String fullPath;
+    private volatile String fullPath;
 
     private Path(String[] segments, boolean absolute) {
         this.segments = segments;
@@ -104,7 +104,11 @@ public class Path implements Comparable<Path> {
 
     public String getPath() {
         if (fullPath == null) {
-            fullPath = createFullPath();
+            synchronized (this) {
+                if (fullPath == null) {
+                    fullPath = createFullPath();
+                }
+            }
         }
         return fullPath;
     }

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/util/Path.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/util/Path.java
@@ -104,11 +104,7 @@ public class Path implements Comparable<Path> {
 
     public String getPath() {
         if (fullPath == null) {
-            synchronized (this) {
-                if (fullPath == null) {
-                    fullPath = createFullPath();
-                }
-            }
+            fullPath = createFullPath();
         }
         return fullPath;
     }

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/internal/PluginUseServices.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/internal/PluginUseServices.java
@@ -26,7 +26,7 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.artifacts.dsl.dependencies.UnknownProjectFinder;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
-import org.gradle.api.internal.initialization.RootScriptDomainObjectContext;
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext;
 import org.gradle.api.internal.initialization.ScriptClassPathResolver;
 import org.gradle.api.internal.plugins.PluginInspector;
 import org.gradle.api.internal.plugins.software.SoftwareType;
@@ -211,7 +211,7 @@ public class PluginUseServices extends AbstractGradleModuleServices {
             return new Factory<DependencyResolutionServices>() {
                 @Override
                 public DependencyResolutionServices create() {
-                    return dependencyManagementServices.create(fileResolver, fileCollectionFactory, dependencyMetaDataProvider, makeUnknownProjectFinder(), RootScriptDomainObjectContext.PLUGINS);
+                    return dependencyManagementServices.create(fileResolver, fileCollectionFactory, dependencyMetaDataProvider, makeUnknownProjectFinder(), StandaloneDomainObjectContext.PLUGINS);
                 }
             };
         }

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/DefaultIdeArtifactRegistry.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/DefaultIdeArtifactRegistry.java
@@ -20,15 +20,15 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.file.FileOperations;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
-import org.gradle.internal.build.BuildState;
 import org.gradle.util.internal.CollectionUtils;
 
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -37,18 +37,19 @@ public class DefaultIdeArtifactRegistry implements IdeArtifactRegistry {
     private final IdeArtifactStore store;
     private final ProjectStateRegistry projectRegistry;
     private final FileOperations fileOperations;
-    private final ProjectComponentIdentifier currentProject;
+    private final ProjectComponentIdentifier currentProjectId;
 
-    public DefaultIdeArtifactRegistry(IdeArtifactStore store, ProjectStateRegistry projectRegistry, FileOperations fileOperations, DomainObjectContext domainObjectContext, BuildState currentBuild) {
+    @Inject
+    public DefaultIdeArtifactRegistry(IdeArtifactStore store, ProjectStateRegistry projectRegistry, FileOperations fileOperations, ProjectInternal currentProject) {
         this.store = store;
         this.projectRegistry = projectRegistry;
         this.fileOperations = fileOperations;
-        currentProject = currentBuild.getProjects().getProject(domainObjectContext.getProjectPath()).getComponentIdentifier();
+        this.currentProjectId = currentProject.getOwner().getComponentIdentifier();
     }
 
     @Override
     public void registerIdeProject(IdeProjectMetadata ideProjectMetadata) {
-        store.put(currentProject, ideProjectMetadata);
+        store.put(currentProjectId, ideProjectMetadata);
     }
 
     @Nullable

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ExtendingConfigurationsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ExtendingConfigurationsIntegrationTest.groovy
@@ -218,6 +218,32 @@ Extended Configurations
 """)
     }
 
+    def "extending a configuration from the buildscript is deprecated"() {
+        settingsFile """
+            rootProject.name = 'foo'
+        """
+        buildFile """
+            configurations {
+                resolvable('conf1') {
+                    extendsFrom(buildscript.configurations.classpath)
+                }
+            }
+        """
+
+        expect:
+        executer.expectDeprecationWarning("Configuration 'conf1' in root project 'foo' extends configuration 'classpath' in buildscript of root project 'foo'. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Configurations can only extend from configurations in the same project. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#extending_configurations_in_same_project")
+        succeeds ':resolvableConfigurations', '--configuration', 'conf1'
+        outputContains("""
+--------------------------------------------------
+Configuration conf1
+--------------------------------------------------
+
+Extended Configurations
+    - classpath
+""")
+
+    }
+
     def "extending a configuration in same project is fine"() {
         given:
         buildFile """

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -23,7 +23,6 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.deprecation.DeprecatableConfiguration;
-import org.gradle.operations.dependencies.configurations.ConfigurationIdentity;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -110,14 +109,6 @@ public interface ConfigurationInternal extends ResolveContext, DeprecatableConfi
      * @param role the role specifying the usage the conf should possess
      */
      void setAllowedUsageFromRole(ConfigurationRole role);
-
-     /**
-      * Returns the identity of this configuration, which can be used to get the configuration's name, project path, and build path
-      * for comparison purposes.
-      *
-      * @return identity of this configuration
-      */
-     ConfigurationIdentity getIdentity();
 
     /**
      * Test if the given configuration can either be declared against or extends another

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -93,6 +93,7 @@ import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.api.internal.initialization.ResettableConfiguration;
+import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
@@ -827,11 +828,11 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
             @Override
             public BuildOperationDescriptor.Builder description() {
                 String displayName = "Resolve dependencies of " + identityPath;
-                Path projectPath = domainObjectContext.getProjectPath();
+                ProjectIdentity projectId = domainObjectContext.getProjectIdentity();
                 String projectPathString = null;
                 if (!domainObjectContext.isScript()) {
-                    if (projectPath != null) {
-                        projectPathString = projectPath.getPath();
+                    if (projectId != null) {
+                        projectPathString = projectId.getProjectPath().getPath();
                     }
                 }
                 return BuildOperationDescriptor.displayName(displayName)
@@ -1529,7 +1530,8 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     @Override
     public ConfigurationIdentity getIdentity() {
         String name = getName();
-        String projectPath = domainObjectContext.getProjectPath() == null ? null : domainObjectContext.getProjectPath().toString();
+        ProjectIdentity projectId = domainObjectContext.getProjectIdentity();
+        String projectPath = projectId == null ? null : projectId.getProjectPath().getPath();
         String buildPath = domainObjectContext.getBuildPath().toString();
         return new DefaultConfigurationIdentity(buildPath, projectPath, name);
     }
@@ -2005,13 +2007,13 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
         @Override
         public List<String> forVersionConflict(Set<Conflict> conflicts) {
-            Path projectPath = domainObjectContext.getProjectPath();
-            if (projectPath == null) {
+            ProjectIdentity projectId = domainObjectContext.getProjectIdentity();
+            if (projectId == null) {
                 // projectPath is null for settings execution
                 return Collections.emptyList();
             }
 
-            String taskPath = projectPath.append(Path.path("dependencyInsight")).getPath();
+            String taskPath = projectId.getBuildTreePath().append(Path.path("dependencyInsight")).getPath();
 
             ModuleVersionIdentifier identifier = conflicts.iterator().next().getVersions().get(0);
             String dependencyNotation = identifier.getGroup() + ":" + identifier.getName();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -399,12 +399,22 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         validateMutation(MutationType.HIERARCHY);
         for (Configuration extended : extendsFrom) {
             ConfigurationInternal other = Objects.requireNonNull(Cast.uncheckedCast(extended));
-            if (!Objects.equals(this.getIdentity().getProjectPath(), other.getIdentity().getProjectPath())) {
-                DeprecationLogger.deprecateBehaviour("Configuration '" + this.getName() + "' in project '" + this.getIdentity().getProjectPath() + "' extends configuration '" + other.getName() + "' in project '" + other.getIdentity().getProjectPath() + "'.")
+            if (!domainObjectContext.equals(other.getDomainObjectContext())) {
+
+                String message = String.format(
+                    "Configuration '%s' in %s extends configuration '%s' in %s.",
+                    this.getName(),
+                    this.domainObjectContext.getDisplayName(),
+                    other.getName(),
+                    other.getDomainObjectContext().getDisplayName()
+                );
+
+                DeprecationLogger.deprecateBehaviour(message)
                     .withAdvice("Configurations can only extend from configurations in the same project.")
                     .willBeRemovedInGradle9()
                     .withUpgradeGuideSection(8, "extending_configurations_in_same_project")
                     .nagUser();
+
             }
             if (other.getHierarchy().contains(this)) {
                 throw new InvalidUserDataException(String.format(
@@ -1527,7 +1537,6 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         }
     }
 
-    @Override
     public ConfigurationIdentity getIdentity() {
         String name = getName();
         ProjectIdentity projectId = domainObjectContext.getProjectIdentity();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultLocalComponentRegistry.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultLocalComponentRegistry.java
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ProjectComponentIdentifierInternal;
 import org.gradle.api.internal.artifacts.configurations.ProjectComponentObservationListener;
+import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveState;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.util.Path;
@@ -72,8 +73,9 @@ public class DefaultLocalComponentRegistry implements LocalComponentRegistry {
 
     @Nullable
     private static Path getProjectIdentityPath(DomainObjectContext domainObjectContext) {
-        if (domainObjectContext.getProject() != null) {
-            return domainObjectContext.getProject().getIdentityPath();
+        ProjectIdentity id = domainObjectContext.getProjectIdentity();
+        if (id != null) {
+            return id.getBuildTreePath();
         }
 
         return null;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultLocalComponentRegistry.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultLocalComponentRegistry.java
@@ -46,7 +46,7 @@ public class DefaultLocalComponentRegistry implements LocalComponentRegistry {
         ListenerManager listenerManager,
         BuildTreeLocalComponentProvider componentProvider
     ) {
-        this.currentProjectPath = getProjectIdentityPath(domainObjectContext);
+        this.currentProjectPath = getProjectBuildTreePath(domainObjectContext);
         this.currentBuildPath = domainObjectContext.getBuildPath();
         this.projectComponentObservationListener = listenerManager.getBroadcaster(ProjectComponentObservationListener.class);
         this.componentProvider = componentProvider;
@@ -72,7 +72,7 @@ public class DefaultLocalComponentRegistry implements LocalComponentRegistry {
     }
 
     @Nullable
-    private static Path getProjectIdentityPath(DomainObjectContext domainObjectContext) {
+    private static Path getProjectBuildTreePath(DomainObjectContext domainObjectContext) {
         ProjectIdentity id = domainObjectContext.getProjectIdentity();
         if (id != null) {
             return id.getBuildTreePath();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformStepNode.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformStepNode.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.transform;
 import org.gradle.api.Describable;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
+import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.NodeExecutionContext;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
@@ -98,8 +99,9 @@ public abstract class TransformStepNode extends CreationOrderedNode implements S
     }
 
     private PlannedTransformStepIdentity createIdentity() {
-        String consumerBuildPath = transformStep.getOwningProject().getBuildPath().toString();
-        String consumerProjectPath = transformStep.getOwningProject().getProjectPath().toString();
+        ProjectIdentity projectId = transformStep.getOwningProject().getProjectIdentity();
+        String consumerBuildPath = projectId.getBuildIdentifier().getBuildPath();
+        String consumerProjectPath = projectId.getProjectPath().getPath();
         ComponentIdentifier componentId = ComponentToOperationConverter.convertComponentIdentifier(targetComponentVariant.getComponentId());
         Map<String, String> sourceAttributes = AttributesToMapConverter.convertToMap(this.sourceAttributes);
         Map<String, String> targetAttributes = AttributesToMapConverter.convertToMap(targetComponentVariant.getAttributes());

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalComponentGraphResolveStateFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalComponentGraphResolveStateFactory.java
@@ -177,8 +177,6 @@ public class LocalComponentGraphResolveStateFactory {
 
     /**
      * A {@link VariantMetadataFactory} which uses a {@link ConfigurationsProvider} as its data source.
-     *
-     * TODO: This class should acquire a project lock before accessing the configurations provider.
      */
     private static class ConfigurationsProviderMetadataFactory implements VariantMetadataFactory {
 
@@ -211,7 +209,7 @@ public class LocalComponentGraphResolveStateFactory {
 
                 configurationsProvider.visitAll(configuration -> {
                     if (configuration.isCanBeConsumed()) {
-                    visitor.accept(createVariantMetadata(configuration));
+                        visitor.accept(createVariantMetadata(configuration));
                     }
                 });
             });

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
@@ -159,7 +159,7 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
                 allLockState = lockFileReaderWriter.readUniqueLockFile();
                 uniqueLockStateLoaded = true;
             } catch (IllegalStateException e) {
-                throw new InvalidLockFileException("project '" + context.getProjectPath().getPath() + "'", e, LockFileReaderWriter.FORMATTING_DOC_LINK);
+                throw new InvalidLockFileException(context.getDisplayName(), e, LockFileReaderWriter.FORMATTING_DOC_LINK);
             }
         }
     }
@@ -210,11 +210,7 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
     public void buildFinished() {
         if (uniqueLockStateLoaded && lockFileReaderWriter.canWrite()) {
             lockFileReaderWriter.writeUniqueLockfile(allLockState);
-            if (context.isScript()) {
-                LOGGER.lifecycle("Persisted dependency lock state for buildscript of project '{}'", context.getProjectPath());
-            } else {
-                LOGGER.lifecycle("Persisted dependency lock state for project '{}'", context.getProjectPath());
-            }
+            LOGGER.lifecycle("Persisted dependency lock state for {}", context.getDisplayName());
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
@@ -47,7 +47,7 @@ import java.util.stream.Stream;
 public class LockFileReaderWriter {
 
     private static final Logger LOGGER = Logging.getLogger(LockFileReaderWriter.class);
-    private static final String LIMITATIONS_DOC_LINK = " " + new DocumentationRegistry().getDocumentationRecommendationFor("information on limitations", "dependency_locking", "locking_limitations");
+    private static final String LIMITATIONS_DOC_LINK = new DocumentationRegistry().getDocumentationRecommendationFor("information on limitations", "dependency_locking", "locking_limitations");
     static final String FORMATTING_DOC_LINK = "Verify the lockfile content. " + new DocumentationRegistry().getDocumentationRecommendationFor("information on lock file format", "dependency_locking", "lock_state_location_and_format");
 
     static final String UNIQUE_LOCKFILE_NAME = "gradle.lockfile";
@@ -112,8 +112,7 @@ public class LockFileReaderWriter {
 
     private void checkValidRoot() {
         if (lockFilesRoot == null) {
-            throw new IllegalStateException("Dependency locking cannot be used for project '" + context.getProjectPath() + "'." +
-                LIMITATIONS_DOC_LINK);
+            throw new IllegalStateException("Dependency locking cannot be used for " + context.getDisplayName() + ". " + LIMITATIONS_DOC_LINK);
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/management/DefaultDependencyResolutionManagement.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/management/DefaultDependencyResolutionManagement.java
@@ -41,7 +41,7 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.artifacts.dsl.dependencies.UnknownProjectFinder;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
-import org.gradle.api.internal.initialization.RootScriptDomainObjectContext;
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -84,7 +84,7 @@ public class DefaultDependencyResolutionManagement implements DependencyResoluti
         this.context = context;
         this.repositoryMode = objects.property(RepositoriesMode.class).convention(RepositoriesMode.PREFER_PROJECT);
         this.rulesMode = objects.property(RulesMode.class).convention(RulesMode.PREFER_PROJECT);
-        this.dependencyResolutionServices = Lazy.locking().of(() -> dependencyManagementServices.create(fileResolver, fileCollectionFactory, dependencyMetaDataProvider, makeUnknownProjectFinder(), RootScriptDomainObjectContext.INSTANCE));
+        this.dependencyResolutionServices = Lazy.locking().of(() -> dependencyManagementServices.create(fileResolver, fileCollectionFactory, dependencyMetaDataProvider, makeUnknownProjectFinder(), StandaloneDomainObjectContext.ANONYMOUS));
         this.librariesExtensionName = objects.property(String.class).convention("libs");
         this.projectsExtensionName = objects.property(String.class).convention("projects");
         this.versionCatalogs = objects.newInstance(DefaultVersionCatalogBuilderContainer.class, collectionCallbackActionDecorator, objects, context, dependencyResolutionServices);

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -29,7 +29,7 @@ import org.gradle.api.internal.attributes.AttributeDesugaring
 import org.gradle.api.internal.attributes.EmptySchema
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext
 import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.api.specs.Spec
 import org.gradle.internal.code.UserCodeApplicationContext
@@ -91,7 +91,7 @@ class DefaultConfigurationContainerSpec extends Specification {
         instantiator,
         domainObjectCollectionCallbackActionDecorator,
         metaDataProvider,
-        RootScriptDomainObjectContext.INSTANCE,
+        domainObjectContext,
         EmptySchema.INSTANCE,
         rootComponentMetadataBuilderFactory,
         configurationFactory,
@@ -105,7 +105,7 @@ class DefaultConfigurationContainerSpec extends Specification {
     def "adds and gets"() {
         1 * domainObjectContext.identityPath("compile") >> Path.path(":build:compile")
         1 * domainObjectContext.projectPath("compile") >> Path.path(":compile")
-        1 * domainObjectContext.model >> RootScriptDomainObjectContext.INSTANCE
+        1 * domainObjectContext.model >> StandaloneDomainObjectContext.ANONYMOUS
 
         when:
         def compile = configurationContainer.create("compile")
@@ -136,7 +136,7 @@ class DefaultConfigurationContainerSpec extends Specification {
     def "configures and finds"() {
         1 * domainObjectContext.identityPath("compile") >> Path.path(":build:compile")
         1 * domainObjectContext.projectPath("compile") >> Path.path(":compile")
-        1 * domainObjectContext.model >> RootScriptDomainObjectContext.INSTANCE
+        1 * domainObjectContext.model >> StandaloneDomainObjectContext.ANONYMOUS
 
         when:
         def compile = configurationContainer.create("compile") {
@@ -152,7 +152,7 @@ class DefaultConfigurationContainerSpec extends Specification {
     def "creates detached"() {
         given:
         1 * domainObjectContext.projectPath("detachedConfiguration1") >> Path.path(":detachedConfiguration1")
-        1 * domainObjectContext.model >> RootScriptDomainObjectContext.INSTANCE
+        1 * domainObjectContext.model >> StandaloneDomainObjectContext.ANONYMOUS
 
         def dependency1 = new DefaultExternalModuleDependency("group", "name", "version")
         def dependency2 = new DefaultExternalModuleDependency("group", "name2", "version")

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
@@ -26,7 +26,6 @@ import org.gradle.api.artifacts.DependencyScopeConfiguration
 import org.gradle.api.artifacts.ResolvableConfiguration
 import org.gradle.api.artifacts.UnknownConfigurationException
 import org.gradle.api.internal.CollectionCallbackActionDecorator
-import org.gradle.api.internal.DomainObjectContext
 import org.gradle.api.internal.artifacts.ConfigurationResolver
 import org.gradle.api.internal.artifacts.ResolveExceptionMapper
 import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParserFactory
@@ -36,7 +35,7 @@ import org.gradle.api.internal.attributes.AttributeDesugaring
 import org.gradle.api.internal.attributes.EmptySchema
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext
 import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.internal.artifacts.configurations.NoContextRoleBasedConfigurationCreationRequest
 import org.gradle.internal.code.UserCodeApplicationContext
@@ -64,7 +63,6 @@ class DefaultConfigurationContainerTest extends Specification {
     private CalculatedValueContainerFactory calculatedValueContainerFactory = Mock()
     private Instantiator instantiator = TestUtil.instantiatorFactory().decorateLenient()
     private ImmutableAttributesFactory immutableAttributesFactory = AttributeTestUtil.attributesFactory()
-    private DomainObjectContext domainObjectContext = new RootScriptDomainObjectContext()
     private DefaultRootComponentMetadataBuilder metadataBuilder = Mock(DefaultRootComponentMetadataBuilder) {
         getValidator() >> Mock(MutationValidator)
     }
@@ -76,7 +74,7 @@ class DefaultConfigurationContainerTest extends Specification {
         resolver,
         listenerManager,
         lockingProvider,
-        domainObjectContext,
+        StandaloneDomainObjectContext.ANONYMOUS,
         TestFiles.fileCollectionFactory(),
         buildOperationRunner,
         new PublishArtifactNotationParserFactory(
@@ -99,7 +97,7 @@ class DefaultConfigurationContainerTest extends Specification {
         instantiator,
         callbackActionDecorator,
         metaDataProvider,
-        RootScriptDomainObjectContext.INSTANCE,
+        StandaloneDomainObjectContext.ANONYMOUS,
         EmptySchema.INSTANCE,
         rootComponentMetadataBuilderFactory,
         configurationFactory,

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilderTest.groovy
@@ -26,7 +26,7 @@ import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies
 import org.gradle.api.internal.attributes.AttributeDesugaring
 import org.gradle.api.internal.attributes.EmptySchema
 import org.gradle.api.internal.attributes.ImmutableAttributes
-import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveStateFactory
 import org.gradle.internal.component.local.model.LocalVariantGraphResolveMetadata
 import org.gradle.internal.component.model.ComponentIdGenerator
@@ -57,7 +57,7 @@ class DefaultRootComponentMetadataBuilderTest extends Specification {
         )
     )
 
-    def builder = builderFactory.create(RootScriptDomainObjectContext.INSTANCE, configurationsProvider, metaDataProvider, EmptySchema.INSTANCE)
+    def builder = builderFactory.create(StandaloneDomainObjectContext.ANONYMOUS, configurationsProvider, metaDataProvider, EmptySchema.INSTANCE)
 
     def "caches root component resolve state and metadata"() {
         configurationsProvider.findByName('conf') >> resolvable()

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalVariantGraphResolveMetadataBuilderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalVariantGraphResolveMetadataBuilderTest.groovy
@@ -27,7 +27,7 @@ import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
 import org.gradle.api.internal.artifacts.configurations.DetachedConfigurationsProvider
 import org.gradle.api.internal.attributes.AttributeContainerInternal
-import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext
 import org.gradle.internal.component.model.Exclude
 import org.gradle.internal.component.model.ExcludeMetadata
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata
@@ -163,6 +163,6 @@ class DefaultLocalVariantGraphResolveMetadataBuilderTest extends Specification {
     }
 
     def create() {
-        return converter.create(configuration, configurationsProvider, componentId, cache, RootScriptDomainObjectContext.INSTANCE, TestUtil.calculatedValueContainerFactory())
+        return converter.create(configuration, configurationsProvider, componentId, cache, StandaloneDomainObjectContext.ANONYMOUS, TestUtil.calculatedValueContainerFactory())
     }
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
@@ -29,7 +29,7 @@ import org.gradle.api.internal.DomainObjectContext
 import org.gradle.api.internal.DynamicObjectAware
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileLookup
-import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext
 import org.gradle.api.internal.tasks.properties.InspectionScheme
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.internal.execution.InputFingerprinter
@@ -63,7 +63,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
         getPropertyWalker() >> propertyWalker
     }
     def domainObjectContext = Mock(DomainObjectContext) {
-        getModel() >> RootScriptDomainObjectContext.INSTANCE
+        getModel() >> StandaloneDomainObjectContext.ANONYMOUS
     }
 
     def isolatableFactory = new TestIsolatableFactory()

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/LocalComponentGraphResolveStateFactoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/LocalComponentGraphResolveStateFactoryTest.groovy
@@ -36,7 +36,7 @@ import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies
 import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact
 import org.gradle.api.internal.attributes.AttributeDesugaring
 import org.gradle.api.internal.attributes.EmptySchema
-import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.model.ComponentIdGenerator
 import org.gradle.internal.component.model.DefaultIvyArtifactName
@@ -69,7 +69,7 @@ class LocalComponentGraphResolveStateFactoryTest extends AbstractProjectBuilderS
 
     def setup() {
         state = stateFactory.stateFor(
-            RootScriptDomainObjectContext.INSTANCE,
+            StandaloneDomainObjectContext.ANONYMOUS,
             componentIdentifier,
             id,
             project.configurations as ConfigurationsProvider,

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DomainObjectContext.java
@@ -15,6 +15,8 @@
  */
 package org.gradle.api.internal;
 
+import org.gradle.api.Describable;
+import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.model.ModelContainer;
 import org.gradle.util.Path;
@@ -24,7 +26,7 @@ import javax.annotation.Nullable;
 /**
  * Represents a node in the tree of builds/projects.
  */
-public interface DomainObjectContext {
+public interface DomainObjectContext extends Describable {
 
     /**
      * Creates a path from the root of the build tree to the current context + name.
@@ -37,19 +39,16 @@ public interface DomainObjectContext {
     Path projectPath(String name);
 
     /**
-     * If this context represents a project, its path.
+     * If this context represents a project, its identity.
      */
     @Nullable
-    Path getProjectPath();
-
-    /**
-     * If this context represents a project, its identity path.
-     */
-    @Nullable
-    Path getProjectIdentityPath();
+    ProjectIdentity getProjectIdentity();
 
     /**
      * If this context represents a project, the project.
+     *
+     * NOTE: This method should be avoided if at all possible. Instead, rely on
+     * {@link #getProjectIdentity()}, or if not possible, prefer {@code getProject().getOwner()}.
      */
     @Nullable
     ProjectInternal getProject();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandlerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandlerFactory.java
@@ -49,11 +49,6 @@ public class DefaultScriptHandlerFactory implements ScriptHandlerFactory {
     }
 
     @Override
-    public ScriptHandlerInternal create(ScriptSource scriptSource, ClassLoaderScope classLoaderScope) {
-        return create(scriptSource, classLoaderScope, RootScriptDomainObjectContext.INSTANCE);
-    }
-
-    @Override
     public ScriptHandlerInternal create(ScriptSource scriptSource, ClassLoaderScope classLoaderScope, DomainObjectContext context) {
         DependencyResolutionServices services = dependencyManagementServices.create(fileResolver, fileCollectionFactory, dependencyMetaDataProvider, projectFinder, context);
         return services.getObjectFactory().newInstance(

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ScriptHandlerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ScriptHandlerFactory.java
@@ -20,7 +20,9 @@ import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.groovy.scripts.ScriptSource;
 
 public interface ScriptHandlerFactory {
-    ScriptHandlerInternal create(ScriptSource scriptSource, ClassLoaderScope classLoaderScope);
 
+    /**
+     * Create a script handler tied to the given domain object context
+     */
     ScriptHandlerInternal create(ScriptSource scriptSource, ClassLoaderScope classLoaderScope, DomainObjectContext context);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/StandaloneDomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/StandaloneDomainObjectContext.java
@@ -28,6 +28,9 @@ import javax.annotation.Nullable;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+/**
+ * Domain object context implementation intended for identifying contexts that wrap no mutable state.
+ */
 public abstract class StandaloneDomainObjectContext implements DomainObjectContext, ModelContainer<Object> {
     private static final Object MODEL = new Object();
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/StandaloneDomainObjectContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/StandaloneDomainObjectContext.java
@@ -17,7 +17,9 @@
 package org.gradle.api.internal.initialization;
 
 import org.gradle.api.internal.DomainObjectContext;
+import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.internal.model.CalculatedModelValue;
 import org.gradle.internal.model.ModelContainer;
 import org.gradle.util.Path;
@@ -26,18 +28,52 @@ import javax.annotation.Nullable;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public class RootScriptDomainObjectContext implements DomainObjectContext, ModelContainer<Object> {
+public abstract class StandaloneDomainObjectContext implements DomainObjectContext, ModelContainer<Object> {
     private static final Object MODEL = new Object();
-    public static final RootScriptDomainObjectContext INSTANCE = new RootScriptDomainObjectContext();
 
-    public static final RootScriptDomainObjectContext PLUGINS = new RootScriptDomainObjectContext() {
+    /**
+     * A domain object context not tied to any mutable state.
+     *
+     * NOTE: In almost all cases, other than testing, there is a better domain object context to use.
+     */
+    public static final StandaloneDomainObjectContext ANONYMOUS = new StandaloneDomainObjectContext() {
+        @Override
+        public String getDisplayName() {
+            return "unknown";
+        }
+    };
+
+    /**
+     * Domain object context for resolving plugins outside a project's buildscript.
+     */
+    public static final StandaloneDomainObjectContext PLUGINS = new StandaloneDomainObjectContext() {
         @Override
         public boolean isPluginContext() {
             return true;
         }
+
+        @Override
+        public String getDisplayName() {
+            return "plugin resolution";
+        }
     };
 
-    private RootScriptDomainObjectContext() {
+    /**
+     * A domain object context for resolution within some script.
+     *
+     * TODO: We should probably have more specialized types for each script, to ensure locks
+     * on mutable state are properly acquired, build ID is properly reported, etc.
+     */
+    public static StandaloneDomainObjectContext forScript(ScriptSource source) {
+        return new StandaloneDomainObjectContext() {
+            @Override
+            public String getDisplayName() {
+                return source.getShortDisplayName().getDisplayName();
+            }
+        };
+    }
+
+    private StandaloneDomainObjectContext() {
     }
 
     @Override
@@ -50,14 +86,9 @@ public class RootScriptDomainObjectContext implements DomainObjectContext, Model
         return Path.path(name);
     }
 
-    @Override
-    public Path getProjectPath() {
-        return null;
-    }
-
     @Nullable
     @Override
-    public Path getProjectIdentityPath() {
+    public ProjectIdentity getProjectIdentity() {
         return null;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultObjectConfigurationAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultObjectConfigurationAction.java
@@ -21,6 +21,7 @@ import org.gradle.api.initialization.dsl.ScriptHandler;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.initialization.ScriptHandlerFactory;
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext;
 import org.gradle.api.internal.resources.InsecureProtocolException;
 import org.gradle.api.plugins.ObjectConfigurationAction;
 import org.gradle.api.plugins.PluginAware;
@@ -144,7 +145,7 @@ public class DefaultObjectConfigurationAction implements ObjectConfigurationActi
         }
         ScriptSource scriptSource = new TextResourceScriptSource(resource);
         ClassLoaderScope classLoaderScopeChild = classLoaderScope.createChild("script-" + scriptUri, null);
-        ScriptHandler scriptHandler = scriptHandlerFactory.create(scriptSource, classLoaderScopeChild);
+        ScriptHandler scriptHandler = scriptHandlerFactory.create(scriptSource, classLoaderScopeChild, StandaloneDomainObjectContext.forScript(scriptSource));
         ScriptPlugin configurer = configurerFactory.create(scriptSource, scriptHandler, classLoaderScopeChild, classLoaderScope, false);
         for (Object target : targets) {
             configurer.apply(target);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -608,15 +608,14 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     }
 
     @Override
-    @Nonnull
     public Path getProjectPath() {
         return owner.getProjectPath();
     }
 
-    @Nullable
+    @Nonnull
     @Override
-    public Path getProjectIdentityPath() {
-        return getIdentityPath();
+    public ProjectIdentity getProjectIdentity() {
+        return owner.getIdentity();
     }
 
     @Override
@@ -1556,20 +1555,14 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
         @Override
         @Nullable
-        public Path getProjectPath() {
-            return delegate.getProjectPath();
-        }
-
-        @Override
-        @Nullable
         public ProjectInternal getProject() {
             return delegate.getProject();
         }
 
         @Nullable
         @Override
-        public Path getProjectIdentityPath() {
-            return delegate.getProjectIdentityPath();
+        public ProjectIdentity getProjectIdentity() {
+            return delegate.getProjectIdentity();
         }
 
         @Override
@@ -1600,6 +1593,11 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
         @Override
         public boolean isDetachedState() {
             return true;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "detached context of " + delegate.getDisplayName();
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
@@ -85,6 +85,7 @@ import org.gradle.process.JavaExecSpec;
 import org.gradle.util.Path;
 import org.gradle.util.internal.ConfigureUtil;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.net.URI;
@@ -239,10 +240,10 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
         return delegate.getRootDir();
     }
 
-    @Nullable
     @Override
-    public Path getProjectIdentityPath() {
-        return delegate.getProjectIdentityPath();
+    @Nonnull
+    public ProjectIdentity getProjectIdentity() {
+        return delegate.getProjectIdentity();
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
@@ -183,11 +183,13 @@ public interface ProjectInternal extends Project, ProjectIdentifier, HasScriptSe
 
     void fireDeferredConfiguration();
 
+    @Override
+    @Nonnull
+    ProjectIdentity getProjectIdentity();
+
     /**
      * Returns a unique path for this project within its containing build.
      */
-    @Override
-    @Nonnull
     Path getProjectPath();
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/configuration/DefaultInitScriptProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/DefaultInitScriptProcessor.java
@@ -19,6 +19,7 @@ import org.gradle.api.initialization.dsl.ScriptHandler;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.initialization.ScriptHandlerFactory;
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext;
 import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.internal.id.IdGenerator;
 import org.gradle.internal.id.LongIdGenerator;
@@ -45,7 +46,7 @@ public class DefaultInitScriptProcessor implements InitScriptProcessor {
         URI uri = initScript.getResource().getLocation().getURI();
         String id = uri == null ? idGenerator.generateId().toString() : uri.toString();
         ClassLoaderScope scriptScope = baseScope.createChild("init-" + id, null);
-        ScriptHandler scriptHandler = scriptHandlerFactory.create(initScript, scriptScope);
+        ScriptHandler scriptHandler = scriptHandlerFactory.create(initScript, scriptScope, StandaloneDomainObjectContext.forScript(initScript));
         ScriptPlugin configurer = configurerFactory.create(initScript, scriptHandler, scriptScope, baseScope, true);
         configurer.apply(gradle);
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/SettingsFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/SettingsFactory.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.initialization.ScriptHandlerFactory;
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext;
 import org.gradle.api.internal.properties.GradleProperties;
 import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.internal.extensibility.ExtensibleDynamicObject;
@@ -62,7 +63,7 @@ public class SettingsFactory {
             gradle,
             classLoaderScope,
             baseClassLoaderScope,
-            scriptHandlerFactory.create(settingsScript, classLoaderScope),
+            scriptHandlerFactory.create(settingsScript, classLoaderScope, StandaloneDomainObjectContext.forScript(settingsScript)),
             settingsDir,
             settingsScript,
             startParameter

--- a/subprojects/core/src/main/java/org/gradle/internal/model/CalculatedValueContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/model/CalculatedValueContainer.java
@@ -17,7 +17,7 @@
 package org.gradle.internal.model;
 
 import org.gradle.api.Project;
-import org.gradle.api.internal.initialization.RootScriptDomainObjectContext;
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext;
 import org.gradle.api.internal.tasks.NodeExecutionContext;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.internal.tasks.WorkNodeAction;
@@ -146,7 +146,8 @@ public class CalculatedValueContainer<T, S extends ValueCalculator<? extends T>>
         if (calculationState != null && calculationState.supplier.usesMutableProjectState()) {
             return calculationState.supplier.getOwningProject().getOwner();
         } else {
-            return RootScriptDomainObjectContext.INSTANCE.getModel();
+            // TODO: The supplier should be able to give us a better answer than this.
+            return StandaloneDomainObjectContext.ANONYMOUS.getModel();
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -52,6 +52,7 @@ import org.gradle.api.internal.project.CrossProjectConfigurator;
 import org.gradle.api.internal.project.CrossProjectModelAccess;
 import org.gradle.api.internal.project.DefaultAntBuilderFactory;
 import org.gradle.api.internal.project.DeferredProjectConfiguration;
+import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectRegistry;
 import org.gradle.api.internal.project.ProjectState;
@@ -347,15 +348,10 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
             return delegate.projectPath(name);
         }
 
-        @Override
-        public Path getProjectPath() {
-            return delegate.getProjectPath();
-        }
-
         @Nullable
         @Override
-        public Path getProjectIdentityPath() {
-            return delegate.getProjectIdentityPath();
+        public ProjectIdentity getProjectIdentity() {
+            return delegate.getProjectIdentity();
         }
 
         @Nullable
@@ -387,6 +383,11 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
         @Override
         public boolean isPluginContext() {
             return false;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "buildscript of " + delegate.getDisplayName();
         }
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultObjectConfigurationActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultObjectConfigurationActionTest.groovy
@@ -52,7 +52,7 @@ class DefaultObjectConfigurationActionTest extends Specification {
         given:
         1 * resolver.resolveUri('script') >> file
         1 * parentCompileScope.createChild("script-$file", null) >> scriptCompileScope
-        1 * scriptHandlerFactory.create(_, scriptCompileScope) >> scriptHandler
+        1 * scriptHandlerFactory.create(_, scriptCompileScope, _) >> scriptHandler
         1 * scriptPluginFactory.create(_, scriptHandler, scriptCompileScope, parentCompileScope, false) >> configurer
 
         when:
@@ -67,7 +67,7 @@ class DefaultObjectConfigurationActionTest extends Specification {
         Object target1 = new Object()
         Object target2 = new Object()
         1 * resolver.resolveUri('script') >> file
-        1 * scriptHandlerFactory.create(_, scriptCompileScope) >> scriptHandler
+        1 * scriptHandlerFactory.create(_, scriptCompileScope, _) >> scriptHandler
         1 * scriptPluginFactory.create(_, scriptHandler, scriptCompileScope, parentCompileScope, false) >> configurer
         1 * configurer.apply(target1)
         1 * configurer.apply(target2)
@@ -85,7 +85,7 @@ class DefaultObjectConfigurationActionTest extends Specification {
         Object target1 = new Object()
         Object target2 = new Object()
         1 * resolver.resolveUri('script') >> file
-        1 * scriptHandlerFactory.create(_, scriptCompileScope) >> scriptHandler
+        1 * scriptHandlerFactory.create(_, scriptCompileScope, _) >> scriptHandler
         1 * scriptPluginFactory.create(_, scriptHandler, scriptCompileScope, parentCompileScope, false) >> configurer
         1 * configurer.apply(target1)
         1 * configurer.apply(target2)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
@@ -153,42 +153,42 @@ class DefaultProjectSpec extends Specification {
         rootProject.path == ":"
         rootProject.buildTreePath == ':'
         rootProject.identityPath == Path.ROOT
-        rootProject.projectIdentityPath == rootProject.identityPath
+        rootProject.projectIdentity == rootProject.owner.identity
 
         child1.toString() == "project ':child1'"
         child1.displayName == "project ':child1'"
         child1.path == ":child1"
         child1.buildTreePath == ":child1"
         child1.identityPath == Path.path(":child1")
-        child1.projectIdentityPath == child1.identityPath
+        child1.projectIdentity == child1.owner.identity
 
         child2.toString() == "project ':child1:child2'"
         child2.displayName == "project ':child1:child2'"
         child2.path == ":child1:child2"
         child2.buildTreePath == ":child1:child2"
         child2.identityPath == Path.path(":child1:child2")
-        child2.projectIdentityPath == child2.identityPath
+        child2.projectIdentity == child2.owner.identity
 
         nestedRootProject.toString() == "project ':nested'"
         nestedRootProject.displayName == "project ':nested'"
         nestedRootProject.path == ":"
         nestedRootProject.buildTreePath == ":nested"
         nestedRootProject.identityPath == Path.path(":nested")
-        nestedRootProject.projectIdentityPath == nestedRootProject.identityPath
+        nestedRootProject.projectIdentity == nestedRootProject.owner.identity
 
         nestedChild1.toString() == "project ':nested:child1'"
         nestedChild1.displayName == "project ':nested:child1'"
         nestedChild1.path == ":child1"
         nestedChild1.buildTreePath == ":nested:child1"
         nestedChild1.identityPath == Path.path(":nested:child1")
-        nestedChild1.projectIdentityPath == nestedChild1.identityPath
+        nestedChild1.projectIdentity == nestedChild1.owner.identity
 
         nestedChild2.toString() == "project ':nested:child1:child2'"
         nestedChild2.displayName == "project ':nested:child1:child2'"
         nestedChild2.path == ":child1:child2"
         nestedChild2.buildTreePath == ":nested:child1:child2"
         nestedChild2.identityPath == Path.path(":nested:child1:child2")
-        nestedChild2.projectIdentityPath == nestedChild2.identityPath
+        nestedChild2.projectIdentity == nestedChild2.owner.identity
     }
 
     def "isolated project view preserves the path and build tree path"() {

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultInitScriptProcessorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultInitScriptProcessorTest.groovy
@@ -47,7 +47,7 @@ class DefaultInitScriptProcessorTest extends Specification {
         1 * gradleMock.getClassLoaderScope() >> gradleScope
         1 * gradleScope.createChild("init-$uri", null) >> siblingScope
 
-        1 * scriptHandlerFactory.create(initScriptMock, siblingScope) >> scriptHandler
+        1 * scriptHandlerFactory.create(initScriptMock, siblingScope, _) >> scriptHandler
         1 * scriptPluginFactory.create(initScriptMock, scriptHandler, siblingScope, gradleScope, true) >> scriptPlugin
         1 * scriptPlugin.apply(gradleMock)
 

--- a/subprojects/core/src/test/groovy/org/gradle/util/internal/NameValidatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/internal/NameValidatorTest.groovy
@@ -28,7 +28,7 @@ import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultRootC
 import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeContainer
 import org.gradle.api.internal.attributes.EmptySchema
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
+import org.gradle.api.internal.initialization.StandaloneDomainObjectContext
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.taskfactory.TaskFactory
 import org.gradle.api.internal.project.taskfactory.TaskIdentityFactory
@@ -55,7 +55,7 @@ class NameValidatorTest extends Specification {
     @Shared
     def domainObjectContainersWithValidation = [
         ["artifact types", new DefaultArtifactTypeContainer(TestUtil.instantiatorFactory().decorateLenient(), AttributeTestUtil.attributesFactory(), CollectionCallbackActionDecorator.NOOP)],
-        ["configurations", new DefaultConfigurationContainer(TestUtil.instantiatorFactory().decorateLenient(), CollectionCallbackActionDecorator.NOOP, Mock(DependencyMetaDataProvider), RootScriptDomainObjectContext.INSTANCE, EmptySchema.INSTANCE, rootComponentMetaDataBuilderFactory, Mock(DefaultConfigurationFactory), Mock(ResolutionStrategyFactory))],
+        ["configurations", new DefaultConfigurationContainer(TestUtil.instantiatorFactory().decorateLenient(), CollectionCallbackActionDecorator.NOOP, Mock(DependencyMetaDataProvider), StandaloneDomainObjectContext.ANONYMOUS, EmptySchema.INSTANCE, rootComponentMetaDataBuilderFactory, Mock(DefaultConfigurationFactory), Mock(ResolutionStrategyFactory))],
         ["flavors", new DefaultFlavorContainer(TestUtil.instantiatorFactory().decorateLenient(), CollectionCallbackActionDecorator.NOOP)],
         ["source sets", new DefaultSourceSetContainer(TestFiles.resolver(), TestFiles.taskDependencyFactory(), null, TestUtil.instantiatorFactory().decorateLenient(), TestUtil.objectFactory(), CollectionCallbackActionDecorator.NOOP)]
     ]


### PR DESCRIPTION
Replace the existing getProjectPath and getProjectIdentityPath methods on DomainObjectContext with a single getProjectIdentity method Rename RootScriptDomainObjectContext to StandaloneDomainObjectContext, to reflect the fact that the class is used for many other purposes than the root script Implement Describable for DomainObjectContext, allowing more contextualized error messages without needing to deconstruct the type of context

Also, ensure lazy calcualtion of Path fullPath String is thread-safe, as this may be called from multiple threads

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
