### PR TITLE
Remove `test-disable-load-after-store` flag

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeStructureIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeStructureIntegrationTest.groovy
@@ -51,9 +51,6 @@ class ConfigurationCacheBuildTreeStructureIntegrationTest extends AbstractConfig
 
     def "restores only projects that have work scheduled"(List<String> tasks) {
         def fixture = new BuildOperationsFixture(executer, temporaryFolder)
-        executer.beforeExecute {
-            withArgument("-Dorg.gradle.configuration-cache.internal.load-after-store=true")
-        }
         createDirs("a", "b", "c", "custom")
         settingsFile << """
             rootProject.name = 'thing'
@@ -254,10 +251,6 @@ class ConfigurationCacheBuildTreeStructureIntegrationTest extends AbstractConfig
 
     def "restores only builds and projects of included build that have work scheduled"(String task) {
         def fixture = new BuildOperationsFixture(executer, temporaryFolder)
-        executer.beforeExecute {
-            withArgument("-Dorg.gradle.configuration-cache.internal.load-after-store=true")
-        }
-
         createDir("include") {
             dir("inner-include") {
                 file("settings.gradle") << """

--- a/subprojects/build-events/src/integTest/groovy/org/gradle/build/event/BuildEventsIntegrationTest.groovy
+++ b/subprojects/build-events/src/integTest/groovy/org/gradle/build/event/BuildEventsIntegrationTest.groovy
@@ -187,7 +187,6 @@ class BuildEventsIntegrationTest extends AbstractIntegrationSpec {
         """
         executer.beforeExecute {
             withArgument("--configuration-cache")
-            withArgument("-Dorg.gradle.configuration-cache.internal.load-after-store=true")
         }
 
         when:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
@@ -829,7 +829,6 @@ service: closed with value 12
         """
         executer.beforeExecute {
             withArgument("--configuration-cache")
-            withArgument("-Dorg.gradle.configuration-cache.internal.load-after-store=true")
         }
 
         when:

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ConfigurationCacheGradleExecuter.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ConfigurationCacheGradleExecuter.groovy
@@ -29,12 +29,7 @@ class ConfigurationCacheGradleExecuter extends DaemonGradleExecuter {
         "--${ConfigurationCacheOption.LONG_OPTION}",
         "-D${ConfigurationCacheQuietOption.PROPERTY_NAME}=true",
         "-D${ConfigurationCacheMaxProblemsOption.PROPERTY_NAME}=0",
-        "-Dorg.gradle.configuration-cache.internal.load-after-store=${testWithLoadAfterStore()}"
     ].collect { it.toString() }
-
-    static boolean testWithLoadAfterStore() {
-        return !Boolean.getBoolean("org.gradle.configuration-cache.internal.test-disable-load-after-store")
-    }
 
     ConfigurationCacheGradleExecuter(
         GradleDistribution distribution,

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/IsolatedProjectsGradleExecuter.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/IsolatedProjectsGradleExecuter.groovy
@@ -25,12 +25,7 @@ class IsolatedProjectsGradleExecuter extends DaemonGradleExecuter {
     static final List<String> ISOLATED_PROJECTS_ARGS = [
         "-D${StartParameterBuildOptions.IsolatedProjectsOption.PROPERTY_NAME}=true",
         "-D${StartParameterBuildOptions.ConfigurationCacheMaxProblemsOption.PROPERTY_NAME}=0",
-        "-Dorg.gradle.configuration-cache.internal.load-after-store=${testWithLoadAfterStore()}"
     ].collect { it.toString() }
-
-    static boolean testWithLoadAfterStore() {
-        return !Boolean.getBoolean("org.gradle.configuration-cache.internal.test-disable-load-after-store")
-    }
 
     IsolatedProjectsGradleExecuter(
         GradleDistribution distribution,


### PR DESCRIPTION
All tests run with `load-after-store` enabled now.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
