### PR TITLE
Revert "Resolve a number of bugs resulting in corrupt dependency graphs"

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIntegrationTest.groovy
@@ -16,23 +16,24 @@
 
 package org.gradle.integtests.resolve.capabilities
 
+
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 
-@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
 class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDependencyResolveTest {
 
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     def "reasonable error message when a user rule throws an exception (#rule)"() {
         given:
         repository {
-            id('org:testA:1.0') {
+            'org:testA:1.0' {
                 variant('runtime') {
                     capability('org', 'testA', '1.0')
                     capability('cap')
                 }
             }
-            id('org:testB:1.0') {
+            'org:testB:1.0' {
                 variant('runtime') {
                     capability('org', 'testB', '1.0')
                     capability('cap')
@@ -59,10 +60,10 @@ class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDepend
 
         when:
         repositoryInteractions {
-            id('org:testA:1.0') {
+            'org:testA:1.0' {
                 expectGetMetadata()
             }
-            id('org:testB:1.0') {
+            'org:testB:1.0' {
                 expectGetMetadata()
             }
         }
@@ -79,16 +80,17 @@ class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDepend
 
     }
 
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     def "can express preference for capabilities declared in published modules (#rule)"() {
         given:
         repository {
-            id('org:testA:1.0') {
+            'org:testA:1.0' {
                 variant('runtime') {
                     capability('org', 'testA', '1.0')
                     capability('cap')
                 }
             }
-            id('org:testB:1.0') {
+            'org:testB:1.0' {
                 variant('runtime') {
                     capability('org', 'testB', '1.0')
                     capability('cap')
@@ -115,10 +117,10 @@ class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDepend
 
         when:
         repositoryInteractions {
-            id('org:testA:1.0') {
+            'org:testA:1.0' {
                 expectGetMetadata()
             }
-            id('org:testB:1.0') {
+            'org:testB:1.0' {
                 expectResolve()
             }
         }
@@ -142,10 +144,11 @@ class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDepend
         ]
     }
 
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     def "can express preference for a certain variant with capabilities declared in published modules"() {
         given:
         repository {
-            id('org:testB:1.0') {
+            'org:testB:1.0' {
                 variant('runtime') {
                     capability('org', 'testB', '1.0')
                 }
@@ -179,7 +182,7 @@ class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDepend
 
         when:
         repositoryInteractions {
-            id('org:testB:1.0') {
+            'org:testB:1.0' {
                 expectResolve()
             }
         }
@@ -195,10 +198,11 @@ class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDepend
         }
     }
 
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     def "expressing a preference for a variant with capabilities declared in a published modules does not evict unrelated variants"() {
         given:
         repository {
-            id('org:testB:1.0') {
+            'org:testB:1.0' {
                 variant('runtime') {
                     capability('org', 'testB', '1.0')
                 }
@@ -240,7 +244,7 @@ class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDepend
 
         when:
         repositoryInteractions {
-            id('org:testB:1.0') {
+            'org:testB:1.0' {
                 expectResolve()
             }
         }
@@ -256,5 +260,4 @@ class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDepend
             }
         }
     }
-
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesRulesIntegrationTest.groovy
@@ -513,10 +513,10 @@ dependencies {
         resolve.expectGraph {
             root(":", ":test:") {
                 edge('jakarta:xml', 'jakarta:xml:1.0') {
-                    byConflictResolution("Explicit selection of jakarta:xml:1.0 variant ${this.runtimeVariant}")
+                    byConflictResolution()
                     selectedByRule()
                     module('jakarta:activation:1.0') {
-                        byConflictResolution("Explicit selection of jakarta:activation:1.0 variant ${this.runtimeVariant}")
+                        byConflictResolution()
                     }
                 }
                 module('hadoop:yarn:1.0') {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCapabilitiesResolution.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCapabilitiesResolution.java
@@ -120,11 +120,6 @@ public class DefaultCapabilitiesResolution implements CapabilitiesResolutionInte
                 String reason = resolutionDetails.reason;
                 if (reason != null) {
                     cand.byReason(Describables.of("On capability", version.getCapabilityId(), reason));
-                } else {
-                    cand.byReason(() -> String.format("Explicit selection of %s variant %s",
-                        resolutionDetails.selected.getId().getDisplayName(),
-                        resolutionDetails.selected.getVariantName()
-                    ));
                 }
             } else {
                 cand.evict();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphResolver.java
@@ -154,20 +154,9 @@ public class DependencyGraphResolver {
     }
 
     private static List<CapabilitiesConflictHandler.Resolver> createCapabilityConflictResolvers(CapabilitiesResolutionInternal capabilitiesResolutionRules) {
-
-        // The order of these resolvers is significant. They run in the declared order.
         return ImmutableList.of(
-            // Candidates that are no longer selected are filtered out before these resolvers are executed.
-            // If there is only one candidate at the beginning of conflict resolution, select that candidate.
-            new LastCandidateCapabilityResolver(),
-
-            // Otherwise, let the user resolvers reject candidates.
             new UserConfiguredCapabilityResolver(capabilitiesResolutionRules),
-
-            // If there is one candidate left after the user resolvers are executed, select that candidate.
             new LastCandidateCapabilityResolver(),
-
-            // Otherwise, reject all remaining candidates.
             new RejectRemainingCandidates()
         );
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -31,7 +31,6 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflict
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons;
-import org.gradle.api.internal.capabilities.CapabilityInternal;
 import org.gradle.internal.Pair;
 import org.gradle.internal.component.external.model.DefaultImmutableCapability;
 import org.gradle.internal.component.model.ComponentGraphResolveMetadata;
@@ -454,7 +453,7 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
         }
     }
 
-    CapabilityInternal getImplicitCapability() {
+    Capability getImplicitCapability() {
         return implicitCapability;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DefaultPendingDependenciesVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DefaultPendingDependenciesVisitor.java
@@ -31,7 +31,7 @@ class DefaultPendingDependenciesVisitor implements PendingDependenciesVisitor {
     }
 
     @Override
-    public PendingState maybeAddAsPendingDependency(NodeState sourceNode, DependencyState dependencyState) {
+    public PendingState maybeAddAsPendingDependency(NodeState node, DependencyState dependencyState) {
         ModuleIdentifier key = dependencyState.getModuleIdentifier();
         boolean isConstraint = dependencyState.getDependency().isConstraint();
         if (!isConstraint) {
@@ -52,7 +52,7 @@ class DefaultPendingDependenciesVisitor implements PendingDependenciesVisitor {
         }
 
         // No hard dependency, queue up pending dependency in case we see a hard dependency later.
-        module.registerConstraintProvider(sourceNode);
+        module.registerConstraintProvider(node);
         return PendingState.PENDING;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyState.java
@@ -42,21 +42,9 @@ import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.FORCED;
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.REQUESTED;
 
-/**
- * A declared dependency, potentially transformed based on a substitution.
- */
 class DependencyState {
-
-    /**
-     * The original requested component, before substitution.
-     */
     private final ComponentSelector requested;
-
-    /**
-     * The declared dependency this state is based off of, after substitution.
-     */
     private final DependencyMetadata dependency;
-
     private final List<ComponentSelectionDescriptorInternal> ruleDescriptors;
     private final ComponentSelectorConverter componentSelectorConverter;
     private final int hashCode;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/IncompatibleDependencyAttributesMessageBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/IncompatibleDependencyAttributesMessageBuilder.java
@@ -36,7 +36,7 @@ class IncompatibleDependencyAttributesMessageBuilder {
         fmt.append("' are requested");
         fmt.startChildren();
         Set<EdgeState> incomingEdges = module.getIncomingEdges();
-        incomingEdges.addAll(module.getUnattachedEdges());
+        incomingEdges.addAll(module.getUnattachedDependencies());
         for (EdgeState incomingEdge : incomingEdges) {
             SelectorState selector = incomingEdge.getSelector();
             for (String path : pathTo(incomingEdge, false)) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -64,7 +64,7 @@ public class ModuleResolveState implements CandidateModule {
     private final ComponentMetaDataResolver metaDataResolver;
     private final ComponentIdGenerator idGenerator;
     private final ModuleIdentifier id;
-    private final List<EdgeState> unattachedEdges = new LinkedList<>();
+    private final List<EdgeState> unattachedDependencies = new LinkedList<>();
     private final Map<ModuleVersionIdentifier, ComponentState> versions = new LinkedHashMap<>();
     private final ModuleSelectors<SelectorState> selectors;
     private final ConflictResolution conflictResolution;
@@ -199,7 +199,7 @@ public class ModuleResolveState implements CandidateModule {
     }
 
     /**
-     * Changes the selected target component for this module due to version conflict resolution.
+     * Changes the selected target component for this module.
      */
     private void changeSelection(ComponentState newSelection) {
         assert this.selected != null;
@@ -239,8 +239,7 @@ public class ModuleResolveState implements CandidateModule {
     }
 
     /**
-     * Overrides the component selection for this module, when this module has been replaced
-     * by another due to capability conflict resolution.
+     * Overrides the component selection for this module, when this module has been replaced by another.
      */
     @Override
     public void replaceWith(ComponentState selected) {
@@ -256,10 +255,6 @@ public class ModuleResolveState implements CandidateModule {
         }
         this.selected = selected;
         this.replaced = computeReplaced(selected);
-
-        if (replaced) {
-            selected.getModule().getPendingDependencies().retarget(pendingDependencies);
-        }
 
         doRestart(selected);
     }
@@ -277,29 +272,29 @@ public class ModuleResolveState implements CandidateModule {
         for (SelectorState selector : selectors) {
             selector.overrideSelection(selected);
         }
-        if (!unattachedEdges.isEmpty()) {
-            restartUnattachedEdges();
+        if (!unattachedDependencies.isEmpty()) {
+            restartUnattachedDependencies();
         }
     }
 
-    private void restartUnattachedEdges() {
-        if (unattachedEdges.size() == 1) {
-            EdgeState singleEdge = unattachedEdges.get(0);
-            singleEdge.restart();
+    private void restartUnattachedDependencies() {
+        if (unattachedDependencies.size() == 1) {
+            EdgeState singleDependency = unattachedDependencies.get(0);
+            singleDependency.restart();
         } else {
-            for (EdgeState edge : new ArrayList<>(unattachedEdges)) {
-                edge.restart();
+            for (EdgeState dependency : new ArrayList<>(unattachedDependencies)) {
+                dependency.restart();
             }
         }
     }
 
-    public void addUnattachedEdge(EdgeState edge) {
-        unattachedEdges.add(edge);
+    public void addUnattachedDependency(EdgeState edge) {
+        unattachedDependencies.add(edge);
         edge.markUnattached();
     }
 
-    public void removeUnattachedEdge(EdgeState edge) {
-        if (unattachedEdges.remove(edge)) {
+    public void removeUnattachedDependency(EdgeState edge) {
+        if (unattachedDependencies.remove(edge)) {
             edge.markAttached();
         }
     }
@@ -320,7 +315,7 @@ public class ModuleResolveState implements CandidateModule {
         }
     }
 
-    void removeSelector(SelectorState selector) {
+    void removeSelector(SelectorState selector, ResolutionConflictTracker conflictTracker) {
         selectors.remove(selector);
         boolean alreadyReused = selector.markForReuse();
         mergedConstraintAttributes = ImmutableAttributes.EMPTY;
@@ -328,7 +323,7 @@ public class ModuleResolveState implements CandidateModule {
             mergedConstraintAttributes = appendAttributes(mergedConstraintAttributes, selectorState);
         }
         if (!alreadyReused && selectors.size() != 0 && selected != null) {
-            maybeUpdateSelection();
+            maybeUpdateSelection(conflictTracker);
         }
     }
 
@@ -336,8 +331,8 @@ public class ModuleResolveState implements CandidateModule {
         return selectors;
     }
 
-    List<EdgeState> getUnattachedEdges() {
-        return unattachedEdges;
+    List<EdgeState> getUnattachedDependencies() {
+        return unattachedDependencies;
     }
 
     ImmutableAttributes mergedConstraintsAttributes(AttributeContainer append) throws AttributeMergingException {
@@ -405,9 +400,6 @@ public class ModuleResolveState implements CandidateModule {
     }
 
     PendingDependencies getPendingDependencies() {
-        if (replaced) {
-            return selected.getModule().getPendingDependencies();
-        }
         return pendingDependencies;
     }
 
@@ -419,7 +411,7 @@ public class ModuleResolveState implements CandidateModule {
         pendingDependencies.unregisterConstraintProvider(nodeState);
     }
 
-    public void maybeUpdateSelection() {
+    public void maybeUpdateSelection(ResolutionConflictTracker conflictTracker) {
         if (replaced) {
             // Never update selection for a replaced module
             return;
@@ -431,14 +423,14 @@ public class ModuleResolveState implements CandidateModule {
         ComponentState newSelected = selectorStateResolver.selectBest(getId(), selectors);
         newSelected.setSelectors(selectors);
         if (selected == null) {
-            select(newSelected);
+            // In some cases we should ignore this because the selection happens to be a known conflict
+            if (!conflictTracker.hasKnownConflict(newSelected.getId())) {
+                select(newSelected);
+            }
         } else if (newSelected != selected) {
             if (++selectionChangedCounter > MAX_SELECTION_CHANGE) {
                 // Let's ignore modules that are changing selection way too much, by keeping the highest version
                 if (maybeSkipSelectionChange(newSelected)) {
-                    // TODO: selectBest updates state, but we ignore that. We should do something with newSelected here
-                    // or reset the selectors to before the selectBest call. Alternatively, we should fail here and ask
-                    // the user to add a version constraint.
                     return;
                 }
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -38,13 +38,12 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.Dependen
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphVariant;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.CapabilitiesConflictHandler;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.strict.StrictVersionConstraints;
-import org.gradle.api.internal.capabilities.CapabilityInternal;
 import org.gradle.api.internal.capabilities.ImmutableCapability;
 import org.gradle.api.internal.capabilities.ShadowedCapability;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.component.external.model.VirtualComponentIdentifier;
-import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 import org.gradle.internal.component.local.model.LocalVariantGraphResolveMetadata;
+import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 import org.gradle.internal.component.model.ComponentGraphResolveState;
 import org.gradle.internal.component.model.ComponentGraphSpecificResolveState;
 import org.gradle.internal.component.model.DelegatingDependencyMetadata;
@@ -224,11 +223,18 @@ public class NodeState implements DependencyGraphNode {
      * @param discoveredEdges A collector for visited edges.
      */
     public void visitOutgoingDependencies(Collection<EdgeState> discoveredEdges) {
+        // If this configuration's version is in conflict, do not traverse.
         // If none of the incoming edges are transitive, remove previous state and do not traverse.
         // If not traversed before, simply add all selected outgoing edges (either hard or pending edges)
         // If traversed before:
         //      If net exclusions for this node have not changed, ignore
         //      If net exclusions for this node have changed, remove previous state and traverse outgoing edges again.
+
+        if (!component.isSelected()) {
+            LOGGER.debug("version for {} is not selected. ignoring.", this);
+            cleanupConstraints();
+            return;
+        }
 
         // Check if there are any transitive incoming edges at all. Don't traverse if not.
         if (transitiveEdgeCount == 0 && !isRoot() && canIgnoreExternalVariant()) {
@@ -255,7 +261,6 @@ public class NodeState implements DependencyGraphNode {
             }
         }
 
-        // The exclusions changed or we are in a virtual platform needing refresh.
         // Clear previous traversal state, if any
         if (previousTraversalExclusions != null) {
             removeOutgoingEdges();
@@ -289,16 +294,16 @@ public class NodeState implements DependencyGraphNode {
      * * Rescheduling any deferred selection impacted by a constraint coming from this node
      * * Making sure we no longer are registered as pending interest on nodes pointed by constraints
      */
-    void cleanupConstraints() {
+    private void cleanupConstraints() {
         // This part covers constraint that were taken into account between a selection being deferred and this node being scheduled for traversal
         if (upcomingNoLongerPendingConstraints != null) {
             for (ModuleIdentifier identifier : upcomingNoLongerPendingConstraints) {
                 ModuleResolveState module = resolveState.getModule(identifier);
-                for (EdgeState unattachedEdge : module.getUnattachedEdges()) {
-                    if (!unattachedEdge.getSelector().isResolved()) {
+                for (EdgeState unattachedDependency : module.getUnattachedDependencies()) {
+                    if (!unattachedDependency.getSelector().isResolved()) {
                         // Unresolved - we have a selector that was deferred but the constraint has been removed in between
-                        NodeState from = unattachedEdge.getFrom();
-                        from.prepareToRecomputeEdge(unattachedEdge);
+                        NodeState from = unattachedDependency.getFrom();
+                        from.prepareToRecomputeEdge(unattachedDependency);
                     }
                 }
             }
@@ -518,9 +523,6 @@ public class NodeState implements DependencyGraphNode {
         return dependencyStateCache.computeIfAbsent(md, this::createDependencyState);
     }
 
-    /**
-     * Creates an edge and add it to this node as an outgoing edge.
-     */
     private void createAndLinkEdgeState(DependencyState dependencyState, Collection<EdgeState> discoveredEdges, ExcludeSpec resolutionFilter, boolean deferSelection) {
         EdgeState dependencyEdge = edgesCache.computeIfAbsent(dependencyState, ds -> new EdgeState(this, ds, resolutionFilter, resolveState));
         dependencyEdge.computeSelector(); // the selector changes, if the 'versionProvidedByAncestors' state changes
@@ -1014,9 +1016,9 @@ public class NodeState implements DependencyGraphNode {
         boolean alreadyRemoving = removingOutgoingEdges;
         removingOutgoingEdges = true;
         if (!outgoingEdges.isEmpty() && !alreadyRemoving) {
-            for (EdgeState outgoingEdge : outgoingEdges) {
-                outgoingEdge.markUnused();
-                ComponentState targetComponent = outgoingEdge.getTargetComponent();
+            for (EdgeState outgoingDependency : outgoingEdges) {
+                outgoingDependency.markUnused();
+                ComponentState targetComponent = outgoingDependency.getTargetComponent();
                 if (targetComponent == component) {
                     // if the same component depends on itself: do not attempt to cleanup the same thing several times
                     continue;
@@ -1025,7 +1027,7 @@ public class NodeState implements DependencyGraphNode {
                     // don't requeue something which is already changing selection
                     continue;
                 }
-                outgoingEdge.cleanUpOnSourceChange(this);
+                outgoingDependency.cleanUpOnSourceChange(this);
             }
             outgoingEdges.clear();
         }
@@ -1033,7 +1035,7 @@ public class NodeState implements DependencyGraphNode {
             for (EdgeState outgoingDependency : virtualEdges) {
                 outgoingDependency.markUnused();
                 outgoingDependency.removeFromTargetConfigurations();
-                outgoingDependency.getSelector().release();
+                outgoingDependency.getSelector().release(resolveState.getConflictTracker());
             }
         }
         virtualEdges = null;
@@ -1137,7 +1139,7 @@ public class NodeState implements DependencyGraphNode {
                 // Only remove edges that come from a different node than the source of the dependency going back to pending
                 // The edges from the "From" will be removed first
                 if (from.removeOutgoingEdge(incomingEdge)) {
-                    incomingEdge.getSelector().release();
+                    incomingEdge.getSelector().release(resolveState.getConflictTracker());
                 }
             }
             pendingDependencies.registerConstraintProvider(from);
@@ -1156,7 +1158,7 @@ public class NodeState implements DependencyGraphNode {
         return false;
     }
 
-    void forEachCapability(CapabilitiesConflictHandler capabilitiesConflictHandler, Action<? super CapabilityInternal> action) {
+    void forEachCapability(CapabilitiesConflictHandler capabilitiesConflictHandler, Action<? super Capability> action) {
         ImmutableSet<ImmutableCapability> capabilities = metadata.getCapabilities().asSet();
         // If there's more than one node selected for the same component, we need to add
         // the implicit capability to the list, in order to make sure we can discover conflicts
@@ -1165,21 +1167,15 @@ public class NodeState implements DependencyGraphNode {
         // capability in order to detect the conflict between the two.
         // Note that the fact that the implicit capability is not included in other cases
         // is not a bug but a performance optimization.
-        boolean defaultCapabilityHasConflict = capabilitiesConflictHandler.hasSeenNonDefaultCapabilityExplicitly(component.getImplicitCapability());
-        if (capabilities.isEmpty() && (component.hasMoreThanOneSelectedNodeUsingVariantAwareResolution() || defaultCapabilityHasConflict)) {
+        if (capabilities.isEmpty() && (component.hasMoreThanOneSelectedNodeUsingVariantAwareResolution() || capabilitiesConflictHandler.hasSeenCapability(component.getImplicitCapability()))) {
             action.execute(component.getImplicitCapability());
         } else {
             // The isEmpty check is not required, might look innocent, but Guava's performance bad for an empty immutable list
             // because it still creates an inner class for an iterator, which delegates to an Array iterator, which does... nothing.
             // so just adding this check has a significant impact because most components do not declare any capability
             if (!capabilities.isEmpty()) {
-                for (CapabilityInternal capability : capabilities) {
-                    // Only process non-default capabilities
-                    // Or, for the default capability if we have seen that capability on a node for which it is not the default
-                    // Or, the component has multiple selected variants, in which case two nodes in that component may conflict with each other
-                    if (!capability.equals(component.getImplicitCapability()) || defaultCapabilityHasConflict || component.hasMoreThanOneSelectedNodeUsingVariantAwareResolution()) {
-                        action.execute(capability);
-                    }
+                for (Capability capability : capabilities) {
+                    action.execute(capability);
                 }
             }
         }
@@ -1230,7 +1226,7 @@ public class NodeState implements DependencyGraphNode {
             // We can ignore if we are already removing edges anyway
             outgoingEdges.remove(edgeState);
             edgeState.markUnused();
-            edgeState.getSelector().release();
+            edgeState.getSelector().release(resolveState.getConflictTracker());
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PendingDependencies.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PendingDependencies.java
@@ -20,11 +20,6 @@ import org.gradle.api.artifacts.ModuleIdentifier;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-/**
- * Tracks hard (non-constraint) dependencies targeting a given module. A module should end up in a graph if it has
- * hard dependencies. Also tracks all constraints that have been observed for a module. These constraints should be
- * activated when the hard edge count becomes positive.
- */
 public class PendingDependencies {
     private final ModuleIdentifier moduleIdentifier;
     private final Set<NodeState> constraintProvidingNodes;
@@ -63,9 +58,6 @@ public class PendingDependencies {
         reportActivePending = true;
     }
 
-    /**
-     * Return true iff all nodes in this module have no non-constraint edges
-     */
     public boolean isPending() {
         return hardEdges == 0;
     }
@@ -87,7 +79,4 @@ public class PendingDependencies {
         return reportActivePending;
     }
 
-    public void retarget(PendingDependencies pendingDependencies) {
-        hardEdges += pendingDependencies.hardEdges;
-    }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PendingDependenciesVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PendingDependenciesVisitor.java
@@ -36,21 +36,6 @@ public interface PendingDependenciesVisitor {
         }
     }
 
-    /**
-     * If this dependency declaration is not a constraint, indicate whether an edge should be created.
-     *
-     * If this dependency declaration is a constraint:
-     * <ul>
-     *      <li>
-     *          If the target module is <strong>already present</strong> in the graph: indicate that an edge should be created
-     *      </li>
-     *      <li>
-     *          If the target module is <strong>not present</strong> in the graph: track the source node as a constraint provider for the target module
-     *      </li>
-     * </ul>
-     *
-     * @return The pending state of the <strong>target module</strong>
-     */
     PendingState maybeAddAsPendingDependency(NodeState node, DependencyState dependencyState);
 
     boolean markNotPending(ModuleIdentifier id);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RejectedModuleMessageBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RejectedModuleMessageBuilder.java
@@ -44,7 +44,7 @@ class RejectedModuleMessageBuilder {
 
         Set<EdgeState> allEdges = new LinkedHashSet<>();
         allEdges.addAll(module.getIncomingEdges());
-        allEdges.addAll(module.getUnattachedEdges());
+        allEdges.addAll(module.getUnattachedDependencies());
         renderEdges(sb, allEdges);
         return sb.toString();
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolutionConflictTracker.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolutionConflictTracker.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
+
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.CapabilitiesConflictHandler;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.ModuleConflictHandler;
+
+class ResolutionConflictTracker {
+
+    private final ModuleConflictHandler moduleConflictHandler;
+    private final CapabilitiesConflictHandler capabilitiesConflictHandler;
+
+    ResolutionConflictTracker(ModuleConflictHandler moduleConflictHandler, CapabilitiesConflictHandler capabilitiesConflictHandler) {
+        this.moduleConflictHandler = moduleConflictHandler;
+        this.capabilitiesConflictHandler = capabilitiesConflictHandler;
+    }
+
+    public boolean hasKnownConflict(ModuleVersionIdentifier id) {
+        return moduleConflictHandler.hasKnownConflictFor(id) || capabilitiesConflictHandler.hasKnownConflictFor(id);
+    }
+
+    public ModuleConflictHandler getModuleConflictHandler() {
+        return moduleConflictHandler;
+    }
+
+    public CapabilitiesConflictHandler getCapabilitiesConflictHandler() {
+        return capabilitiesConflictHandler;
+    }
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/CapabilitiesConflictHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/CapabilitiesConflictHandler.java
@@ -19,21 +19,20 @@ import org.gradle.api.Describable;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.NodeState;
-import org.gradle.api.internal.capabilities.CapabilityInternal;
 
 import java.util.Collection;
 
 public interface CapabilitiesConflictHandler extends ConflictHandler<CapabilitiesConflictHandler.Candidate, ConflictResolutionResult> {
 
     /**
-     * Has the given capability been seen as a non-default capability on a node?
-     * This is needed to determine if default capabilities need to enter conflict detection.
+     * Was the given capability already seen which might require a conflict check later?
+     * This is needed to determine if also implicit capabilities need to enter conflict detection.
      */
-    boolean hasSeenNonDefaultCapabilityExplicitly(CapabilityInternal capability);
+    boolean hasSeenCapability(Capability capability);
 
     interface Candidate {
         NodeState getNode();
-        CapabilityInternal getCapability();
+        Capability getCapability();
         Collection<NodeState> getImplicitCapabilityProviders();
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/ConflictHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/ConflictHandler.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts;
 
 import org.gradle.api.Action;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
 
 public interface ConflictHandler<CANDIDATE, RESULT> {
 
@@ -31,9 +32,15 @@ public interface ConflictHandler<CANDIDATE, RESULT> {
     boolean hasConflicts();
 
     /**
-     * Resolves next conflict and trigger provided action after the resolution.
-     *
-     * Must be called only if {@link #hasConflicts()} returns true.
+     * Resolves next conflict and trigger provided action after the resolution
      */
     void resolveNextConflict(Action<RESULT> resolutionAction);
+
+    /**
+     * Indicates if the identifier is a known participant in a conflict
+     *
+     * @param id the identifier to check
+     * @return {@code true} if the identifier is part of a conflict, {@code false} otherwise
+     */
+    boolean hasKnownConflictFor(ModuleVersionIdentifier id);
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictHandler.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflic
 
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.dsl.ModuleReplacementsData;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ConflictResolverDetails;
@@ -103,5 +104,10 @@ public class DefaultConflictHandler implements ModuleConflictHandler {
                 selected.addCause(moduleReplacement);
             }
         }
+    }
+
+    @Override
+    public boolean hasKnownConflictFor(ModuleVersionIdentifier id) {
+        return conflicts.hasMatchingConflict(state -> state.getId().equals(id));
     }
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandlerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandlerTest.groovy
@@ -25,7 +25,6 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.NodeState
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.ResolveState
 import org.gradle.api.internal.capabilities.CapabilityInternal
-import org.gradle.internal.component.external.model.DefaultImmutableCapability
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.ImmutableCapabilities
 import org.gradle.internal.component.model.VariantGraphResolveMetadata
@@ -104,7 +103,10 @@ class DefaultCapabilitiesConflictHandlerTest extends Specification {
     }
 
     CapabilityInternal capability(String group="org", String name="cap") {
-        new DefaultImmutableCapability(group, name, null)
+        Mock(CapabilityInternal) {
+            getGroup() >> group
+            getName() >> name
+        }
     }
 
     NodeState node(ComponentState cs) {

--- a/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractModuleDependencyResolveTest.groovy
+++ b/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractModuleDependencyResolveTest.groovy
@@ -144,10 +144,6 @@ abstract class AbstractModuleDependencyResolveTest extends AbstractHttpDependenc
         useIvy() ? ivyRepository : mavenRepository
     }
 
-    String getRuntimeVariant() {
-        usesJavaLibraryVariants() ? "runtime" : "default"
-    }
-
     boolean isDeclareRepositoriesInSettings() {
         false
     }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -855,6 +855,14 @@ $END_MARKER
         /**
          * Marks that this node was selected due to conflict resolution.
          */
+        NodeBuilder byConflictResolution() {
+            reasons << 'conflict resolution'
+            this
+        }
+
+        /**
+         * Marks that this node was selected due to conflict resolution.
+         */
         NodeBuilder byConflictResolution(String message) {
             reasons << "${ComponentSelectionCause.CONFLICT_RESOLUTION.defaultReason}: $message".toString()
             this

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenFileModule.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenFileModule.groovy
@@ -39,12 +39,6 @@ class MavenFileModule extends AbstractMavenModule {
     }
 
     @Override
-    MavenFileModule dependsOn(String group, String artifactId, String version, String type = null, String scope = null, String classifier = null, Collection<Map> exclusions = null) {
-        super.dependsOn(group, artifactId, version, type, scope, classifier, exclusions)
-        return this
-    }
-
-    @Override
     MavenFileModule artifact(Map<String, ?> options) {
         super.artifact(options)
         return this


### PR DESCRIPTION
Reverts gradle/gradle#29853 as it currently causes [failures](https://ge.gradle.org/scans?search.buildOutcome=failure&search.names=gitCommitId&search.tags=CI&search.timeZoneId=America%2FSao_Paulo&search.values=73b6993d6aaf08a0b1ebcae8991ae5143391e953) when trying to [upgrade the Gradle wrapper to the latest nightly](https://github.com/gradle/gradle/pull/29980).