### PR TITLE
Reduce configuration cache boxing overhead

### DIFF
--- a/platforms/core-configuration/core-serialization-codecs/build.gradle.kts
+++ b/platforms/core-configuration/core-serialization-codecs/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
     implementation(projects.stdlibKotlinExtensions)
 
     implementation(libs.asm)
+    implementation(libs.fastutil)
     implementation(libs.groovy)
     implementation(libs.guava)
 }

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/WorkNodeCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/WorkNodeCodec.kt
@@ -17,6 +17,7 @@
 package org.gradle.internal.serialize.codecs.core
 
 import com.google.common.collect.ImmutableSet
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.artifacts.transform.DefaultTransformUpstreamDependenciesResolver
 import org.gradle.api.internal.tasks.NodeExecutionContext
@@ -34,13 +35,21 @@ import org.gradle.internal.cc.base.serialize.withGradleIsolate
 import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext
+import org.gradle.internal.serialize.graph.buildCollection
 import org.gradle.internal.serialize.graph.decodePreservingIdentity
 import org.gradle.internal.serialize.graph.encodePreservingIdentityOf
 import org.gradle.internal.serialize.graph.ownerService
-import org.gradle.internal.serialize.graph.readCollection
 import org.gradle.internal.serialize.graph.readCollectionInto
 import org.gradle.internal.serialize.graph.readNonNull
 import org.gradle.internal.serialize.graph.writeCollection
+
+
+private
+typealias NodeForId = (Int) -> Node
+
+
+private
+typealias IdForNode = (Node) -> Int
 
 
 class WorkNodeCodec(
@@ -66,7 +75,7 @@ class WorkNodeCodec(
         val nodes = work.scheduledNodes
         val nodeCount = nodes.size
         writeSmallInt(nodeCount)
-        val scheduledNodeIds = HashMap<Node, Int>(nodeCount)
+        val scheduledNodeIds = Object2IntOpenHashMap<Node>(nodeCount)
         // Not all entry nodes are always scheduled.
         // In particular, it happens when the entry node is a task of the included plugin build that runs as part of building the plugin.
         // Such tasks do not rerun when configuration cache is re-used, even if specified on the command line.
@@ -88,9 +97,10 @@ class WorkNodeCodec(
         writeCollection(scheduledEntryNodeIds) {
             writeSmallInt(it)
         }
+        val idForNode: IdForNode = scheduledNodeIds::getInt
         nodes.forEach { node ->
-            writeSuccessorReferencesOf(node, scheduledNodeIds)
-            writeNodeGroup(node.group, scheduledNodeIds)
+            writeSuccessorReferencesOf(node, idForNode)
+            writeNodeGroup(node.group, idForNode)
         }
     }
 
@@ -98,26 +108,28 @@ class WorkNodeCodec(
     suspend fun ReadContext.doRead(): ScheduledWork {
         val nodeCount = readSmallInt()
         val nodes = ArrayList<Node>(nodeCount)
-        val nodesById = HashMap<Int, Node>(nodeCount)
+        val nodesById = ArrayList<Node>(nodeCount)
         repeat(nodeCount) {
             val node = readNode()
-            nodesById[nodesById.size] = node
+            nodesById.add(node)
             if (node is LocalTaskNode) {
                 node.prepareNode.require()
-                nodesById[nodesById.size] = node.prepareNode
+                nodesById.add(node.prepareNode)
             }
             nodes.add(node)
         }
         // Note that using the ImmutableSet retains the original ordering of entry nodes.
-        val entryNodes = ImmutableSet.builder<Node>()
-        readCollection {
-            entryNodes.add(nodesById.getValue(readSmallInt()))
-        }
+        val entryNodes =
+            buildCollection({ ImmutableSet.builderWithExpectedSize<Node>(it) }) {
+                add(nodesById[readSmallInt()])
+            }.build()
+
+        val nodeForId: NodeForId = nodesById::get
         nodes.forEach { node ->
-            readSuccessorReferencesOf(node, nodesById)
-            node.group = readNodeGroup(nodesById)
+            readSuccessorReferencesOf(node, nodeForId)
+            node.group = readNodeGroup(nodeForId)
         }
-        return ScheduledWork(nodes, entryNodes.build())
+        return ScheduledWork(nodes, entryNodes)
     }
 
     private
@@ -129,7 +141,7 @@ class WorkNodeCodec(
     }
 
     private
-    fun WriteContext.writeNodeGroup(group: NodeGroup, nodesById: Map<Node, Int>) {
+    fun WriteContext.writeNodeGroup(group: NodeGroup, idForNode: IdForNode) {
         encodePreservingIdentityOf(group) {
             when (group) {
                 is OrdinalGroup -> {
@@ -139,16 +151,16 @@ class WorkNodeCodec(
 
                 is FinalizerGroup -> {
                     writeSmallInt(1)
-                    writeSmallInt(nodesById.getValue(group.node))
-                    writeNodeGroup(group.delegate, nodesById)
+                    writeSmallInt(idForNode(group.node))
+                    writeNodeGroup(group.delegate, idForNode)
                 }
 
                 is CompositeNodeGroup -> {
                     writeSmallInt(2)
                     writeBoolean(group.isReachableFromEntryPoint)
-                    writeNodeGroup(group.ordinalGroup, nodesById)
+                    writeNodeGroup(group.ordinalGroup, idForNode)
                     writeCollection(group.finalizerGroups) {
-                        writeNodeGroup(it, nodesById)
+                        writeNodeGroup(it, idForNode)
                     }
                 }
 
@@ -162,7 +174,7 @@ class WorkNodeCodec(
     }
 
     private
-    fun ReadContext.readNodeGroup(nodesById: Map<Int, Node>): NodeGroup {
+    fun ReadContext.readNodeGroup(nodeForId: NodeForId): NodeGroup {
         return decodePreservingIdentity { id ->
             when (readSmallInt()) {
                 0 -> {
@@ -171,15 +183,15 @@ class WorkNodeCodec(
                 }
 
                 1 -> {
-                    val finalizerNode = nodesById.getValue(readSmallInt()) as TaskNode
-                    val delegate = readNodeGroup(nodesById)
+                    val finalizerNode = nodeForId(readSmallInt()) as TaskNode
+                    val delegate = readNodeGroup(nodeForId)
                     FinalizerGroup(finalizerNode, delegate)
                 }
 
                 2 -> {
                     val reachableFromCommandLine = readBoolean()
-                    val ordinalGroup = readNodeGroup(nodesById)
-                    val groups = readCollectionInto(::HashSet) { readNodeGroup(nodesById) as FinalizerGroup }
+                    val ordinalGroup = readNodeGroup(nodeForId)
+                    val groups = readCollectionInto(::HashSet) { readNodeGroup(nodeForId) as FinalizerGroup }
                     CompositeNodeGroup(reachableFromCommandLine, ordinalGroup, groups)
                 }
 
@@ -192,7 +204,7 @@ class WorkNodeCodec(
     }
 
     private
-    fun WriteContext.writeSuccessorReferencesOf(node: Node, scheduledNodeIds: Map<Node, Int>) {
+    fun WriteContext.writeSuccessorReferencesOf(node: Node, scheduledNodeIds: IdForNode) {
         var successors = node.dependencySuccessors
         if (node is ActionNode) {
             val setupNode = node.action?.preExecutionNode
@@ -218,26 +230,26 @@ class WorkNodeCodec(
     }
 
     private
-    fun ReadContext.readSuccessorReferencesOf(node: Node, nodesById: Map<Int, Node>) {
-        readSuccessorReferences(nodesById) {
+    fun ReadContext.readSuccessorReferencesOf(node: Node, nodeForId: NodeForId) {
+        readSuccessorReferences(nodeForId) {
             node.addDependencySuccessor(it)
         }
         when (node) {
             is TaskNode -> {
-                readSuccessorReferences(nodesById) {
+                readSuccessorReferences(nodeForId) {
                     node.addShouldSuccessor(it)
                 }
-                readSuccessorReferences(nodesById) {
+                readSuccessorReferences(nodeForId) {
                     require(it is TaskNode) {
                         "Expecting a TaskNode as a must successor of `$node`, got `$it`."
                     }
                     node.addMustSuccessor(it)
                 }
-                readSuccessorReferences(nodesById) {
+                readSuccessorReferences(nodeForId) {
                     node.addFinalizingSuccessor(it)
                 }
                 val lifecycleSuccessors = mutableSetOf<Node>()
-                readSuccessorReferences(nodesById) {
+                readSuccessorReferences(nodeForId) {
                     lifecycleSuccessors.add(it)
                 }
                 node.lifecycleSuccessors = lifecycleSuccessors
@@ -248,11 +260,11 @@ class WorkNodeCodec(
     private
     fun WriteContext.writeSuccessorReferences(
         successors: Collection<Node>,
-        scheduledNodeIds: Map<Node, Int>
+        scheduledNodeIds: IdForNode
     ) {
         for (successor in successors) {
             if (successor.isRequired) {
-                val successorId = scheduledNodeIds.getValue(successor)
+                val successorId = scheduledNodeIds(successor)
                 writeSmallInt(successorId)
             }
         }
@@ -260,11 +272,11 @@ class WorkNodeCodec(
     }
 
     private
-    fun ReadContext.readSuccessorReferences(nodesById: Map<Int, Node>, onSuccessor: (Node) -> Unit) {
+    fun ReadContext.readSuccessorReferences(nodeForId: NodeForId, onSuccessor: (Node) -> Unit) {
         while (true) {
             val successorId = readSmallInt()
             if (successorId == -1) break
-            val successor = nodesById.getValue(successorId)
+            val successor = nodeForId(successorId)
             onSuccessor(successor)
         }
     }

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Combinators.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Combinators.kt
@@ -266,11 +266,19 @@ inline fun Decoder.readCollection(readElement: () -> Unit) {
 inline fun <T, C : MutableCollection<T>> Decoder.readCollectionInto(
     containerForSize: (Int) -> C,
     readElement: () -> T
+): C = buildCollection(containerForSize) {
+    add(readElement())
+}
+
+
+inline fun <T, C> Decoder.buildCollection(
+    containerForSize: (Int) -> C,
+    readElement: C.() -> T
 ): C {
     val size = readSmallInt()
     val container = containerForSize(size)
     for (i in 0 until size) {
-        container.add(readElement())
+        container.readElement()
     }
     return container
 }

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Identities.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Identities.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.serialize.graph
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap
 import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet
 import java.util.IdentityHashMap
 
@@ -25,7 +26,7 @@ class WriteIdentities {
     private
     val instanceIds = IdentityHashMap<Any, Int>()
 
-    fun getId(instance: Any) = instanceIds[instance]
+    fun getId(instance: Any): Int? = instanceIds[instance]
 
     fun putInstance(instance: Any): Int {
         val id = instanceIds.size
@@ -38,9 +39,9 @@ class WriteIdentities {
 class ReadIdentities {
 
     private
-    val instanceIds = HashMap<Int, Any>()
+    val instanceIds = Int2ObjectOpenHashMap<Any>()
 
-    fun getInstance(id: Int) = instanceIds[id]
+    fun getInstance(id: Int): Any? = instanceIds[id]
 
     fun putInstance(id: Int, instance: Any) {
         instanceIds[id] = instance

--- a/platforms/core-runtime/serialization/build.gradle.kts
+++ b/platforms/core-runtime/serialization/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
 
     implementation(projects.io)
 
+    implementation(libs.fastutil)
     implementation(libs.kryo)
     implementation(libs.slf4jApi)
 


### PR DESCRIPTION
This PR reduces memory allocations on `perf-android-large-2` `assembleDebug` cache hit by **5.7%**.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
