### PR TITLE
Reduce boxing overhead in `CachingDirectedGraphWalker`

### DIFF
--- a/platforms/core-runtime/base-services/build.gradle.kts
+++ b/platforms/core-runtime/base-services/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     implementation(libs.asm)
     implementation(libs.commonsIo)
     implementation(libs.commonsLang)
+    implementation(libs.fastutil)
     implementation(libs.slf4jApi)
 
     integTestImplementation(projects.logging)

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/graph/CachingDirectedGraphWalker.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/graph/CachingDirectedGraphWalker.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.graph;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.gradle.util.internal.GUtil;
 
 import java.util.ArrayDeque;
@@ -95,7 +97,7 @@ public class CachingDirectedGraphWalker<N, T> {
     private Set<T> doSearch() {
         int componentCount = 0;
         Map<N, NodeDetails<N, T>> seenNodes = new HashMap<N, NodeDetails<N, T>>();
-        Map<Integer, NodeDetails<N, T>> components = new HashMap<Integer, NodeDetails<N, T>>();
+        Int2ObjectMap<NodeDetails<N, T>> components = new Int2ObjectOpenHashMap<NodeDetails<N, T>>();
         Deque<N> queue = new ArrayDeque<N>(startNodes);
 
         while (!queue.isEmpty()) {


### PR DESCRIPTION
By replacing a `Map<Integer, ...>` with a `Int2ObjectMap<...>`.

It seems to slightly improve things on `gradle/gradle` using `codeQuality` as the benchmark:

<img width="936" alt="Screenshot 2024-07-22 at 15 49 57" src="https://github.com/user-attachments/assets/10dd0622-41ad-4f51-b170-9ad9191e9fd6">


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
