### PR TITLE
Fix performance issue with projectsObserved callback

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/RelevantProjectsRegistry.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/RelevantProjectsRegistry.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.cc.impl
 
+import com.google.common.collect.Sets.newConcurrentHashSet
 import org.gradle.api.internal.artifacts.configurations.ProjectComponentObservationListener
 import org.gradle.api.internal.project.ProjectState
 import org.gradle.api.internal.project.ProjectStateRegistry
@@ -33,7 +34,7 @@ class RelevantProjectsRegistry(
 ) : ProjectComponentObservationListener {
 
     private
-    val targetProjects = mutableSetOf<ProjectState>()
+    val targetProjects = newConcurrentHashSet<ProjectState>()
 
     fun relevantProjects(nodes: List<Node>): Set<ProjectState> {
         val result = mutableSetOf<ProjectState>()

--- a/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/event/ListenerManager.java
+++ b/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/event/ListenerManager.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.event;
 
+import org.gradle.internal.service.scopes.NonThreadSafeListener;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -25,8 +26,10 @@ import org.gradle.internal.service.scopes.ServiceScope;
  *
  * <p>While the methods work with any Object, in general only interfaces should be used as listener types.
  *
- * <p>Implementations are thread-safe: A listener is notified by at most 1 thread at a time, and so do not need to be thread-safe. All listeners
- * of a given type receive events in the same order. Listeners can be added and removed at any time.
+ * <p>Implementations are thread-safe except for the types that include the {@link NonThreadSafeListener} annotation:
+ * For any other listener, a listener is notified by at most 1 thread at a time, and so do not need to be thread-safe.
+ * All listeners of a given type receive events in the same order. Listeners can be added and removed at any time.
+ * Non thread safe listeners have no such guarantees.
  */
 @ServiceScope(Scope.Global.class)
 public interface ListenerManager {

--- a/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/service/scopes/NonThreadSafeListener.java
+++ b/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/service/scopes/NonThreadSafeListener.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service.scopes;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Attached to a listener interface to indicate that its events are not thread safe.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface NonThreadSafeListener {
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ProjectComponentObservationListener.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ProjectComponentObservationListener.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.configurations;
 
 import org.gradle.internal.service.scopes.EventScope;
+import org.gradle.internal.service.scopes.NonThreadSafeListener;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.StatefulListener;
 import org.gradle.util.Path;
@@ -27,6 +28,7 @@ import javax.annotation.Nullable;
  * A listener that is notified when one project observes the local component metadata of another.
  */
 @StatefulListener
+@NonThreadSafeListener
 @EventScope(Scope.Build.class)
 public interface ProjectComponentObservationListener {
     /**


### PR DESCRIPTION
<!--- The issue this PR addresses -->
https://github.com/gradle/gradle/issues/29026
<!-- Fixes #? -->

I have verified the issue is gone after these changes, attaching a YourKit profile with the fix. 
[projectsObservedFix.zip](https://github.com/user-attachments/files/16331488/projectsObservedFix.zip)

For comparison original issue has the problematic profile too.


### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
