### PR TITLE
Add gradleception test coverage for `:docs:embeddedCrossVersionTest`

### DIFF
--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildDocumentationConfigurationCacheSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildDocumentationConfigurationCacheSmokeTest.groovy
@@ -89,4 +89,15 @@ class GradleBuildDocumentationConfigurationCacheSmokeTest extends AbstractGradle
         result.task(":docs:docs").outcome == TaskOutcome.SUCCESS
         result.task("':docs:docsTest'").outcome == TaskOutcome.SUCCESS
     }
+
+    def "can resolve classpath for :docs:embeddedCrossVersionTest with configuration cache enabled"() {
+        given:
+        def tasks = [":docs:embeddedCrossVersionTest", "--dry-run"]
+
+        when:
+        configurationCacheRun(tasks)
+
+        then:
+        result.assertConfigurationCacheStateStored()
+    }
 }


### PR DESCRIPTION
To prevent the reintroduction of the issue caused by #29853

```
Could not resolve all dependencies for configuration ':docs:crossVersionTestRuntimeClasspath'.
> Expected to find a selector with a failure but none was found
```

See [the build scan](https://ge.gradle.org/s/deg5djqood4xo/failure?expanded-stacktrace=WyIwLTEtMiJd#1) for details.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
