### PR TITLE
Gradle doesn't recognise inherited OpenTest4J FileInfo in test assertion exception

### DIFF
--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r810/TestFailureProgressEventCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r810/TestFailureProgressEventCrossVersionTest.groovy
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r810
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.TestFailureSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.BuildException
+import org.gradle.tooling.FileComparisonTestAssertionFailure
+import spock.lang.Issue
+
+@ToolingApiVersion(">=8.3")
+@TargetGradleVersion(">=8.10")
+class TestFailureProgressEventCrossVersionTest extends TestFailureSpecification {
+
+    def setup() {
+        enableTestJvmDebugging = false
+        enableStdoutProxying = true
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/29994")
+    def "Custom assertion file info are emitted as test failure events using JUnit 4"() {
+        given:
+        setupJUnit4()
+        file('src/test/java/org/gradle/JUnitTest.java') << '''
+            package org.gradle;
+
+            import org.junit.Test;
+            import org.opentest4j.AssertionFailedError;
+            import org.opentest4j.FileInfo;
+
+            public class JUnitTest {
+                @Test
+                public void test() {
+                    CustomFileInfo expected = new CustomFileInfo("/path/from", new byte[]{ 0x0 });
+                    throw new AssertionFailedError(
+                        "Asymmetric expected and actual objects",
+                        expected,
+                        "actual content"
+                    );
+                }
+
+                private static class CustomFileInfo extends FileInfo {
+                    CustomFileInfo(String path, byte[] contents) {
+                        super(path, contents);
+                    }
+                }
+            }
+        '''
+        def collector = new TestFailureEventCollector()
+
+        when:
+        runTestTaskWithFailureCollection(collector)
+
+        then:
+        thrown(BuildException)
+        collector.failures.size() == 1
+        collector.failures[0] instanceof FileComparisonTestAssertionFailure
+
+        def failure = collector.failures[0] as FileComparisonTestAssertionFailure
+        failure.expected == '/path/from'
+        failure.expectedContent == new byte[]{0x0}
+        failure.actual == 'actual content'
+    }
+
+
+    @Issue("https://github.com/gradle/gradle/issues/29994")
+    def "Custom assertion file info are emitted as test failure events using JUnit 5"() {
+        given:
+        setupJUnit5()
+        file('src/test/java/org/gradle/JUnitTest.java') << '''
+            package org.gradle;
+
+            import org.junit.jupiter.api.Test;
+            import org.opentest4j.AssertionFailedError;
+            import org.opentest4j.FileInfo;
+
+            public class JUnitTest {
+                @Test
+                public void test() {
+                    CustomFileInfo expected = new CustomFileInfo("/path/from", new byte[]{ 0x0 });
+                    throw new AssertionFailedError(
+                        "Asymmetric expected and actual objects",
+                        expected,
+                        "actual content"
+                    );
+                }
+
+                private static class CustomFileInfo extends FileInfo {
+                    CustomFileInfo(String path, byte[] contents) {
+                        super(path, contents);
+                    }
+                }
+            }
+        '''
+        def collector = new TestFailureEventCollector()
+
+        when:
+        runTestTaskWithFailureCollection(collector)
+
+        then:
+        thrown(BuildException)
+        collector.failures.size() == 1
+        collector.failures[0] instanceof FileComparisonTestAssertionFailure
+
+        def failure = collector.failures[0] as FileComparisonTestAssertionFailure
+        failure.expected == '/path/from'
+        failure.expectedContent == new byte[]{0x0}
+        failure.actual == 'actual content'
+    }
+}

--- a/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/failure/mappers/OpenTestAssertionFailedMapper.java
+++ b/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/failure/mappers/OpenTestAssertionFailedMapper.java
@@ -76,8 +76,18 @@ public class OpenTestAssertionFailedMapper extends TestFailureMapper {
         return TestFailure.fromTestAssertionFailure(throwable, expectedString, actualString);
     }
 
-    private static boolean isFileInfo(@Nullable  Object value) {
-        return value != null && "org.opentest4j.FileInfo".equals(value.getClass().getName());
+    private static boolean isFileInfo(@Nullable Object value) {
+        return value != null && isAssignableFrom("org.opentest4j.FileInfo", value.getClass());
+    }
+
+    private static boolean isAssignableFrom(String className, @Nullable Class<?> aClass) {
+        if (aClass == null) {
+            return false;
+        }
+        if (className.equals(aClass.getName())) {
+            return true;
+        }
+        return isAssignableFrom(className, aClass.getSuperclass());
     }
 
     /**

--- a/platforms/jvm/testing-jvm-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/failure/mappers/OpenTestAssertionFailedMapperTest.groovy
+++ b/platforms/jvm/testing-jvm-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/failure/mappers/OpenTestAssertionFailedMapperTest.groovy
@@ -25,6 +25,9 @@ import java.nio.charset.StandardCharsets
 
 class OpenTestAssertionFailedMapperTest extends Specification {
 
+    private static final FileInfo ACTUAL_CUSTOM_FILE_INFO = new CustomFileInfo("actual_custom_file", "actual_custom_content")
+    private static final FileInfo EXPECTED_CUSTOM_FILE_INFO = new CustomFileInfo("expected_custom_file", "expected_custom_content")
+
     private static final FileInfo ACTUAL_FILE_INFO = new FileInfo("actual_file", "actual_content".getBytes(StandardCharsets.UTF_8))
     private static final FileInfo EXPECTED_FILE_INFO = new FileInfo("expected_file", "expected_content".getBytes(StandardCharsets.UTF_8))
 
@@ -33,6 +36,12 @@ class OpenTestAssertionFailedMapperTest extends Specification {
 
     private static final ValueWrapper ACTUAL_INT_VALUE_WRAPPER = ValueWrapper.create(1)
     private static final ValueWrapper EXPECTED_INT_VALUE_WRAPPER = ValueWrapper.create(2)
+
+    private static class CustomFileInfo extends FileInfo {
+        CustomFileInfo(String path, String contents) {
+            super(path, contents.getBytes(StandardCharsets.UTF_8))
+        }
+    }
 
     def "can map null expected values"() {
         given:
@@ -57,6 +66,7 @@ class OpenTestAssertionFailedMapperTest extends Specification {
             [
                 [null, null, null],
                 ["actual", "actual", null],
+                [ACTUAL_CUSTOM_FILE_INFO, ACTUAL_CUSTOM_FILE_INFO.path, ACTUAL_CUSTOM_FILE_INFO.contents],
                 [ACTUAL_FILE_INFO, ACTUAL_FILE_INFO.path, ACTUAL_FILE_INFO.contents],
                 [ACTUAL_STRING_VALUE_WRAPPER, ACTUAL_STRING_VALUE_WRAPPER.value, null],
                 [ACTUAL_INT_VALUE_WRAPPER, ACTUAL_INT_VALUE_WRAPPER.value.toString(), null]
@@ -64,6 +74,7 @@ class OpenTestAssertionFailedMapperTest extends Specification {
             [
                 [null, null, null],
                 ["expected", "expected", null],
+                [EXPECTED_CUSTOM_FILE_INFO, EXPECTED_CUSTOM_FILE_INFO.path, EXPECTED_CUSTOM_FILE_INFO.contents],
                 [EXPECTED_FILE_INFO, EXPECTED_FILE_INFO.path, EXPECTED_FILE_INFO.contents],
                 [EXPECTED_STRING_VALUE_WRAPPER, EXPECTED_STRING_VALUE_WRAPPER.value, null],
                 [EXPECTED_INT_VALUE_WRAPPER, EXPECTED_INT_VALUE_WRAPPER.value.toString(), null]


### PR DESCRIPTION
### Issues
https://github.com/gradle/gradle/issues/29994

### Fixes
* Check all subclasses in the reflective `instanceof` check with `FileInfo`

### Context
The IntelliJ IDEA use Gradle tooling API to provide a better IDE experience in the test tool window. It receives typed test failure results from the Gradle progress listener.
Some test assertions have information about the files that were compared. The IDE can show arrows to fix up text in the "expected" file by the text from "actual" and vice versa.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `tooling-api/src/crossVersionTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `testing-jvm-infrastructure/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew testing-jvm-infrastructure:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things

Fixes https://github.com/gradle/gradle/issues/29994
