### PR TITLE
Deprecate build listeners when CC is off

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradle.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradle.kt
@@ -132,10 +132,12 @@ class CrossProjectConfigurationReportingGradle private constructor(
     override fun getLifecycle(): GradleLifecycle =
         delegate.lifecycle
 
+    @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
     override fun addListener(listener: Any) {
         delegate.addListener(maybeWrapListener(listener))
     }
 
+    @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
     override fun removeListener(listener: Any) {
         delegate.removeListener(maybeWrapListener(listener))
     }
@@ -280,10 +282,12 @@ class CrossProjectConfigurationReportingGradle private constructor(
         // already reported as configuration cache problem, no need to override
         delegate.buildFinished(action)
 
+    @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
     override fun addBuildListener(buildListener: BuildListener) =
         // already reported as configuration cache problem, no need to override
         delegate.addBuildListener(buildListener)
 
+    @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
     override fun useLogger(logger: Any) =
         delegate.useLogger(logger)
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DeprecatedFeaturesListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DeprecatedFeaturesListener.kt
@@ -23,8 +23,10 @@ import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.tasks.execution.TaskExecutionAccessListener
 import org.gradle.execution.ExecutionAccessListener
 import org.gradle.internal.buildoption.FeatureFlags
+import org.gradle.internal.buildoption.InternalOptions
 import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.deprecation.DeprecationLogger
+import org.gradle.internal.extensions.core.getInternalFlag
 import org.gradle.internal.service.scopes.ListenerService
 import org.gradle.internal.service.scopes.Scope
 import org.gradle.internal.service.scopes.ServiceScope
@@ -40,13 +42,18 @@ import org.gradle.internal.service.scopes.ServiceScope
 internal
 class DeprecatedFeaturesListener(
     private val featureFlags: FeatureFlags,
-    private val buildModelParameters: BuildModelParameters
+    private val buildModelParameters: BuildModelParameters,
+    private val internalOptions: InternalOptions
 ) : BuildScopeListenerRegistrationListener, TaskExecutionAccessListener, ExecutionAccessListener {
 
     override fun onBuildScopeListenerRegistration(listener: Any, invocationDescription: String, invocationSource: Any) {
-        if (!isConfigurationCache()) {
+        if (!isConfigurationCache() && isBuildScopeListenerDeprecationEnabled()) {
             nagUserAbout("Listener registration using $invocationDescription()", 7, "task_execution_events")
         }
+    }
+
+    private fun isBuildScopeListenerDeprecationEnabled(): Boolean {
+        return internalOptions.getInternalFlag("org.gradle.configuration-cache.internal.deprecation.buildScopeListener", true)
     }
 
     override fun onProjectAccess(invocationDescription: String, task: TaskInternal, runningTask: TaskInternal?) {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DeprecatedFeaturesListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DeprecatedFeaturesListener.kt
@@ -44,7 +44,7 @@ class DeprecatedFeaturesListener(
 ) : BuildScopeListenerRegistrationListener, TaskExecutionAccessListener, ExecutionAccessListener {
 
     override fun onBuildScopeListenerRegistration(listener: Any, invocationDescription: String, invocationSource: Any) {
-        if (shouldNag()) {
+        if (!isConfigurationCache()) {
             nagUserAbout("Listener registration using $invocationDescription()", 7, "task_execution_events")
         }
     }
@@ -88,7 +88,10 @@ class DeprecatedFeaturesListener(
     private
     fun shouldNag(): Boolean =
         // TODO:configuration-cache - this listener shouldn't be registered when cc is enabled
-        !buildModelParameters.isConfigurationCache && featureFlags.isEnabled(STABLE_CONFIGURATION_CACHE)
+        !isConfigurationCache() && featureFlags.isEnabled(STABLE_CONFIGURATION_CACHE)
+
+    private
+    fun isConfigurationCache() = buildModelParameters.isConfigurationCache
 
     /**
      * Only nag about tasks that are actually executing, but not tasks that are configured by the executing tasks.

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -276,6 +276,8 @@ class GradleKotlinDslIntegrationTest : AbstractKotlinIntegrationTest() {
                     "Consult the upgrading guide for further information: " +
                     "https://docs.gradle.org/current/userguide/upgrading_version_7.html#for_use_at_configuration_time_deprecation"
             )
+        } else {
+            executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.addBuildListener() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         }
 
         assertThat(
@@ -348,6 +350,7 @@ class GradleKotlinDslIntegrationTest : AbstractKotlinIntegrationTest() {
             """
         )
 
+        executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.buildFinished() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         assert(
             build("build").output.contains("*Build*")
         )

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
@@ -59,6 +59,8 @@ class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
         expectKotlinDslPluginDeprecation()
         if (GradleContextualExecuter.isConfigCache()) {
             expectForUseAtConfigurationTimeDeprecation()
+        } else {
+            expectBuildScopeListenerDeprecation()
         }
 
         build("help").apply {
@@ -166,6 +168,8 @@ class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
         expectKotlinDslPluginDeprecation()
         if (GradleContextualExecuter.isConfigCache()) {
             expectForUseAtConfigurationTimeDeprecation()
+        } else {
+            expectBuildScopeListenerDeprecation()
         }
 
         build("help").apply {
@@ -208,6 +212,9 @@ class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
                 "Consult the upgrading guide for further information: " +
                 "https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_access_to_conventions"
         )
+        if (!GradleContextualExecuter.isConfigCache()) {
+            expectBuildScopeListenerDeprecation()
+        }
 
         build("help").apply {
             assertThat(
@@ -220,6 +227,11 @@ class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
                 containsString("some!")
             )
         }
+    }
+
+    private
+    fun expectBuildScopeListenerDeprecation() {
+        executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.addBuildListener() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
     }
 
     private

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
@@ -212,7 +212,7 @@ class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
                 "Consult the upgrading guide for further information: " +
                 "https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_access_to_conventions"
         )
-        if (!GradleContextualExecuter.isConfigCache()) {
+        if (GradleContextualExecuter.isNotConfigCache()) {
             expectBuildScopeListenerDeprecation()
         }
 

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginGradlePluginCrossVersionSmokeTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginGradlePluginCrossVersionSmokeTest.kt
@@ -158,7 +158,7 @@ class KotlinDslPluginGradlePluginCrossVersionSmokeTest(
                     "https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_access_to_conventions"
             )
         }
-        if (kotlinVersion < VersionNumber.parse("1.9.0") && !GradleContextualExecuter.isConfigCache()) {
+        if (kotlinVersion < VersionNumber.parse("1.9.0") && GradleContextualExecuter.isNotConfigCache()) {
             executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.addBuildListener() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         }
         if (kotlinVersion < VersionNumber.parse("1.8.0") && GradleContextualExecuter.isConfigCache()) {

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginGradlePluginCrossVersionSmokeTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginGradlePluginCrossVersionSmokeTest.kt
@@ -158,6 +158,9 @@ class KotlinDslPluginGradlePluginCrossVersionSmokeTest(
                     "https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_access_to_conventions"
             )
         }
+        if (kotlinVersion < VersionNumber.parse("1.9.0") && !GradleContextualExecuter.isConfigCache()) {
+            executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.addBuildListener() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
+        }
         if (kotlinVersion < VersionNumber.parse("1.8.0") && GradleContextualExecuter.isConfigCache()) {
             executer.expectDocumentedDeprecationWarning(
                 "The Provider.forUseAtConfigurationTime method has been deprecated. " +

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginTemplatesTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginTemplatesTest.kt
@@ -140,6 +140,7 @@ class PrecompiledScriptPluginTemplatesTest : AbstractPrecompiledScriptPluginTest
             )
         )
 
+        @Suppress("deprecation")
         verify(gradle).useLogger("my-logger")
     }
 

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/GradleDelegate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/GradleDelegate.kt
@@ -127,24 +127,34 @@ abstract class GradleDelegate : Gradle {
     override fun projectsEvaluated(action: Action<in Gradle>) =
         delegate.projectsEvaluated(action)
 
-    @Suppress("DEPRECATION")
+    @Deprecated("Deprecated in Java")
     override fun buildFinished(closure: Closure<Any>) =
+        @Suppress("DEPRECATION")
         delegate.buildFinished(closure)
 
-    @Suppress("DEPRECATION")
+    @Deprecated("Deprecated in Java")
     override fun buildFinished(action: Action<in BuildResult>) =
+        @Suppress("DEPRECATION")
         delegate.buildFinished(action)
 
+    @Deprecated("Deprecated in Java")
     override fun addBuildListener(buildListener: BuildListener) =
+        @Suppress("DEPRECATION")
         delegate.addBuildListener(buildListener)
 
+    @Deprecated("Deprecated in Java")
     override fun addListener(listener: Any) =
+        @Suppress("DEPRECATION")
         delegate.addListener(listener)
 
+    @Deprecated("Deprecated in Java")
     override fun removeListener(listener: Any) =
+        @Suppress("DEPRECATION")
         delegate.removeListener(listener)
 
+    @Deprecated("Deprecated in Java")
     override fun useLogger(logger: Any) =
+        @Suppress("DEPRECATION")
         delegate.useLogger(logger)
 
     override fun getGradle(): Gradle =

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/ModelRuleCachingIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/ModelRuleCachingIntegrationTest.groovy
@@ -43,12 +43,14 @@ class ModelRuleCachingIntegrationTest extends PersistentBuildProcessIntegrationT
         '''
 
         when:
+        executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.buildFinished() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         run()
 
         then:
         newRulesExtracted
 
         when:
+        executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.buildFinished() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         run()
 
         then:

--- a/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelBuildOperationsIntegrationTest.groovy
+++ b/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelBuildOperationsIntegrationTest.groovy
@@ -143,7 +143,7 @@ This means workTask and slowTask would be expected to run concurrently in this c
         """
 
         then:
-        workTaskDoesNotCompleteFirst()
+        workTaskDoesNotCompleteFirst(true)
     }
 
     @UnsupportedWithConfigurationCache
@@ -163,12 +163,15 @@ This means workTask and slowTask would be expected to run concurrently in this c
         """
 
         then:
-        workTaskDoesNotCompleteFirst()
+        workTaskDoesNotCompleteFirst(true)
     }
 
-    private void workTaskDoesNotCompleteFirst() {
+    private void workTaskDoesNotCompleteFirst(boolean expectDeprecation = false) {
         blockingHttpServer.expectConcurrent("workTask", "slowTask")
         args("--max-workers=4")
+        if (expectDeprecation) {
+            executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.addListener() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
+        }
         succeeds(":workTask", ":slowTask")
         assert !endTime(":workTask").isBefore(endTime(":slowTask"))
     }

--- a/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelBuildOperationsIntegrationTest.groovy
+++ b/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelBuildOperationsIntegrationTest.groovy
@@ -141,9 +141,10 @@ This means workTask and slowTask would be expected to run concurrently in this c
                 }
             }
         """
+        executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.addListener() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
 
         then:
-        workTaskDoesNotCompleteFirst(true)
+        workTaskDoesNotCompleteFirst()
     }
 
     @UnsupportedWithConfigurationCache
@@ -161,17 +162,15 @@ This means workTask and slowTask would be expected to run concurrently in this c
                 }
             }
         """
+        executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.addListener() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
 
         then:
-        workTaskDoesNotCompleteFirst(true)
+        workTaskDoesNotCompleteFirst()
     }
 
-    private void workTaskDoesNotCompleteFirst(boolean expectDeprecation = false) {
+    private void workTaskDoesNotCompleteFirst() {
         blockingHttpServer.expectConcurrent("workTask", "slowTask")
         args("--max-workers=4")
-        if (expectDeprecation) {
-            executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.addListener() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
-        }
         succeeds(":workTask", ":slowTask")
         assert !endTime(":workTask").isBefore(endTime(":slowTask"))
     }

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/health/gc/GarbageCollectionMonitoringIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/health/gc/GarbageCollectionMonitoringIntegrationTest.groovy
@@ -130,6 +130,7 @@ ${COMMON_HINT}""")
             }
         """
         executer.usingInitScript(initScript)
+        executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.buildFinished() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
 
         when:
         succeeds "startLeakAfterBuild"

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/BuildOutcomeReportingBuildActionRunner.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/BuildOutcomeReportingBuildActionRunner.java
@@ -26,6 +26,7 @@ import org.gradle.internal.buildevents.BuildStartedTime;
 import org.gradle.internal.buildevents.TaskExecutionStatisticsReporter;
 import org.gradle.internal.buildtree.BuildActionRunner;
 import org.gradle.internal.buildtree.BuildTreeLifecycleController;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
@@ -52,6 +53,7 @@ public class BuildOutcomeReportingBuildActionRunner implements BuildActionRunner
         this.buildLoggerFactory = buildLoggerFactory;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public Result run(BuildAction action, BuildTreeLifecycleController buildController) {
         StartParameter startParameter = action.getStartParameter();
@@ -60,7 +62,7 @@ public class BuildOutcomeReportingBuildActionRunner implements BuildActionRunner
 
         BuildLogger buildLogger = buildLoggerFactory.create(Logging.getLogger(BuildLogger.class), startParameter, buildStartedTime, buildRequestMetaData);
         // Register as a 'logger' to support this being replaced by build logic.
-        buildController.beforeBuild(gradle -> gradle.useLogger(buildLogger));
+        buildController.beforeBuild(gradle -> DeprecationLogger.whileDisabled(() -> gradle.useLogger(buildLogger)));
 
         Result result = delegate.run(action, buildController);
 

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/BuildOutcomeReportingBuildActionRunner.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/BuildOutcomeReportingBuildActionRunner.java
@@ -26,7 +26,6 @@ import org.gradle.internal.buildevents.BuildStartedTime;
 import org.gradle.internal.buildevents.TaskExecutionStatisticsReporter;
 import org.gradle.internal.buildtree.BuildActionRunner;
 import org.gradle.internal.buildtree.BuildTreeLifecycleController;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
@@ -62,7 +61,7 @@ public class BuildOutcomeReportingBuildActionRunner implements BuildActionRunner
 
         BuildLogger buildLogger = buildLoggerFactory.create(Logging.getLogger(BuildLogger.class), startParameter, buildStartedTime, buildRequestMetaData);
         // Register as a 'logger' to support this being replaced by build logic.
-        buildController.beforeBuild(gradle -> DeprecationLogger.whileDisabled(() -> gradle.useLogger(buildLogger)));
+        buildController.beforeBuild(gradle -> gradle.useLogger(buildLogger));
 
         Result result = delegate.run(action, buildController);
 

--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/LoggingIntegrationTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/LoggingIntegrationTest.groovy
@@ -202,6 +202,9 @@ class LoggingIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         executer.noExtraLogging().inDirectory(loggingDir).withArguments(allArgs)
+        if (level != "quiet") {
+            executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.useLogger() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
+        }
         run "log"
         then:
         logLevel.checkOuts(result)

--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractLoggingHooksFunctionalTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractLoggingHooksFunctionalTest.groovy
@@ -37,6 +37,11 @@ abstract class AbstractLoggingHooksFunctionalTest extends AbstractConsoleGrouped
         """
     }
 
+    def disableBuildListenerDeprecation() {
+        // deprecation warnings mess up console logging tests
+        executer.withArgument("-Dorg.gradle.configuration-cache.internal.deprecation.buildScopeListener=false")
+    }
+
     @ToBeFixedForConfigurationCache(because = "Gradle.buildFinished")
     def "listener added to script receives output synchronously and only while script is running"() {
         buildFile << """
@@ -70,6 +75,7 @@ abstract class AbstractLoggingHooksFunctionalTest extends AbstractConsoleGrouped
         """
 
         expect:
+        disableBuildListenerDeprecation()
         succeeds("log")
     }
 
@@ -121,6 +127,7 @@ abstract class AbstractLoggingHooksFunctionalTest extends AbstractConsoleGrouped
         """
 
         expect:
+        disableBuildListenerDeprecation()
         succeeds("log", "other")
     }
 
@@ -150,6 +157,7 @@ abstract class AbstractLoggingHooksFunctionalTest extends AbstractConsoleGrouped
 
         when:
         executer.withArguments("--debug")
+        disableBuildListenerDeprecation()
         run("log")
         def captured = file("output.txt").text
 
@@ -164,6 +172,7 @@ abstract class AbstractLoggingHooksFunctionalTest extends AbstractConsoleGrouped
 
         when:
         executer.withArguments("--info")
+        disableBuildListenerDeprecation()
         run("log")
         def lines = file("output.txt").text.readLines()
 
@@ -181,6 +190,7 @@ abstract class AbstractLoggingHooksFunctionalTest extends AbstractConsoleGrouped
         !lines.contains('debug')
 
         when:
+        disableBuildListenerDeprecation()
         run("log")
         lines = file("output.txt").text.readLines()
 
@@ -200,6 +210,7 @@ abstract class AbstractLoggingHooksFunctionalTest extends AbstractConsoleGrouped
 
         when:
         executer.withArguments("--warn")
+        disableBuildListenerDeprecation()
         run("log")
         lines = file("output.txt").text.readLines()
 

--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/plain/PlainConsoleBuildResultReportingFunctionalTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/plain/PlainConsoleBuildResultReportingFunctionalTest.groovy
@@ -21,4 +21,9 @@ import org.gradle.internal.logging.console.taskgrouping.AbstractConsoleBuildResu
 
 class PlainConsoleBuildResultReportingFunctionalTest extends AbstractConsoleBuildResultFunctionalTest {
     ConsoleOutput consoleType = ConsoleOutput.Plain
+
+    @Override
+    def setup() {
+        executer.withArgument("-Dorg.gradle.configuration-cache.internal.deprecation.buildScopeListener=false")
+    }
 }

--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/verbose/AutoConsoleBuildResultReportingFunctionalTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/verbose/AutoConsoleBuildResultReportingFunctionalTest.groovy
@@ -22,4 +22,9 @@ import org.gradle.internal.logging.console.taskgrouping.AbstractConsoleBuildResu
 
 class AutoConsoleBuildResultReportingFunctionalTest extends AbstractConsoleBuildResultFunctionalTest {
     ConsoleOutput consoleType = ConsoleOutput.Auto
+
+    @Override
+    def setup() {
+        executer.withArgument("-Dorg.gradle.configuration-cache.internal.deprecation.buildScopeListener=false")
+    }
 }

--- a/platforms/documentation/docs/build.gradle
+++ b/platforms/documentation/docs/build.gradle
@@ -812,6 +812,8 @@ tasks.named("docsTest") { task ->
     } else {
         filter {
             excludeTestsMatching "*WithCC*.sample"
+            // these sanityCheck tests fail without CC due to deprecation warnings as they use gradle.taskGraph.beforeTask and afterTask
+            excludeTestsMatching "*.snippet-buildlifecycle-task-execution-events_*_sanityCheck.sample"
         }
     }
 }

--- a/platforms/documentation/docs/src/snippets/buildlifecycle/taskExecutionEvents/tests-groovy/taskExecutionEvents.groovy.sample.conf
+++ b/platforms/documentation/docs/src/snippets/buildlifecycle/taskExecutionEvents/tests-groovy/taskExecutionEvents.groovy.sample.conf
@@ -3,7 +3,8 @@
 # end::cli[]
 executable: gradle
 args: broken
-flags: --quiet
+# Do not fail for deprecation warnings: TaskExecutionGraph.beforeTask|afterTask
+flags: "--quiet --warning-mode=none"
 expect-failure: true
 expected-output-file: taskExecutionEvents.groovy.out
 allow-additional-output: true

--- a/platforms/documentation/docs/src/snippets/buildlifecycle/taskExecutionEvents/tests-kotlin/taskExecutionEvents.kotlin.sample.conf
+++ b/platforms/documentation/docs/src/snippets/buildlifecycle/taskExecutionEvents/tests-kotlin/taskExecutionEvents.kotlin.sample.conf
@@ -3,7 +3,8 @@
 # end::cli[]
 executable: gradle
 args: broken
-flags: --quiet
+# Do not fail for deprecation warnings: TaskExecutionGraph.beforeTask|afterTask
+flags: "--quiet --warning-mode=none"
 expect-failure: true
 expected-output-file: taskExecutionEvents.kotlin.out
 allow-additional-output: true

--- a/platforms/documentation/docs/src/snippets/initScripts/customLogger/tests-groovy/customLogger.groovy.sample.conf
+++ b/platforms/documentation/docs/src/snippets/initScripts/customLogger/tests-groovy/customLogger.groovy.sample.conf
@@ -1,3 +1,5 @@
 executable: gradle
 args: "build --init-script=customLogger.init.gradle"
 expected-output-file: customLogger.out
+# Do not fail for deprecation warnings: Gradle.useLogger
+flags: "--warning-mode=none"

--- a/platforms/documentation/docs/src/snippets/initScripts/customLogger/tests-kotlin/customLogger.kotlin.sample.conf
+++ b/platforms/documentation/docs/src/snippets/initScripts/customLogger/tests-kotlin/customLogger.kotlin.sample.conf
@@ -1,3 +1,5 @@
 executable: gradle
 args: "build --init-script=customLogger.init.gradle.kts"
 expected-output-file: customLogger.out
+# Do not fail for deprecation warnings: Gradle.useLogger
+flags: "--warning-mode=none"

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/legacy/BuildScanEndOfBuildNotifierIntegrationTest.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/legacy/BuildScanEndOfBuildNotifierIntegrationTest.groovy
@@ -119,6 +119,7 @@ notified
             task t
         """
 
+        executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.buildFinished() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         runAndFail("t")
 
         then:

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r32/BuildFinishedCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r32/BuildFinishedCrossVersionSpec.groovy
@@ -25,7 +25,6 @@ import org.gradle.util.GradleVersion
 class BuildFinishedCrossVersionSpec extends ToolingApiSpecification {
 
     def "model builders are executed before buildFinished hook"() {
-        println("releasedGradleVersion: " + targetVersion)
         when:
         if (targetVersion >= GradleVersion.version("8.10")) {
             expectDocumentedDeprecationWarning("Listener registration using Gradle.buildFinished() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r32/BuildFinishedCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r32/BuildFinishedCrossVersionSpec.groovy
@@ -19,12 +19,17 @@ package org.gradle.integtests.tooling.r32
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.tooling.model.GradleProject
+import org.gradle.util.GradleVersion
 
 @TargetGradleVersion(">=3.2")
 class BuildFinishedCrossVersionSpec extends ToolingApiSpecification {
 
     def "model builders are executed before buildFinished hook"() {
+        println("releasedGradleVersion: " + targetVersion)
         when:
+        if (targetVersion >= GradleVersion.version("8.10")) {
+            expectDocumentedDeprecationWarning("Listener registration using Gradle.buildFinished() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
+        }
         def project = loadToolingModel(GradleProject)
 
         then:

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
@@ -492,7 +492,7 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
                     "Consult the upgrading guide for further information: " +
                     "https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_access_to_conventions")
         }
-        if (kotlinVersionNumber < VersionNumber.parse("1.9.0") && !GradleContextualExecuter.isConfigCache()) {
+        if (kotlinVersionNumber < VersionNumber.parse("1.9.0") && GradleContextualExecuter.isNotConfigCache()) {
             executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.addBuildListener() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         }
         withInstallations(jdkMetadata).run(":compileKotlin", ":test")

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
@@ -492,6 +492,9 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
                     "Consult the upgrading guide for further information: " +
                     "https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_access_to_conventions")
         }
+        if (kotlinVersionNumber < VersionNumber.parse("1.9.0") && !GradleContextualExecuter.isConfigCache()) {
+            executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.addBuildListener() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
+        }
         withInstallations(jdkMetadata).run(":compileKotlin", ":test")
         def eventsOnCompile = toolchainEvents(":compileKotlin")
         def eventsOnTest = toolchainEvents(":test")

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
@@ -527,7 +527,7 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
                     "Consult the upgrading guide for further information: " +
                     "https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_access_to_conventions")
         }
-        if (kotlinVersionNumber < VersionNumber.parse("1.9.0") && !GradleContextualExecuter.isConfigCache()) {
+        if (kotlinVersionNumber < VersionNumber.parse("1.9.0") && GradleContextualExecuter.isNotConfigCache()) {
             executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.addBuildListener() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         }
         withInstallations(jdkMetadata).run(":compileKotlin", ":test")

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
@@ -527,6 +527,9 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
                     "Consult the upgrading guide for further information: " +
                     "https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_access_to_conventions")
         }
+        if (kotlinVersionNumber < VersionNumber.parse("1.9.0") && !GradleContextualExecuter.isConfigCache()) {
+            executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.addBuildListener() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
+        }
         withInstallations(jdkMetadata).run(":compileKotlin", ":test")
         eventsOnCompile = toolchainEvents(":compileKotlin")
         eventsOnTest = toolchainEvents(":test")

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractTestOutputListenerIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractTestOutputListenerIntegrationTest.groovy
@@ -125,6 +125,7 @@ abstract class AbstractTestOutputListenerIntegrationTest extends AbstractTesting
         """.stripIndent()
 
         when:
+        executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.addListener() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         succeeds('test')
 
         then:

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/TestEventsIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/TestEventsIntegrationTest.groovy
@@ -23,11 +23,8 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 class TestEventsIntegrationTest extends AbstractIntegrationSpec {
-    @UnsupportedWithConfigurationCache(because = "tests listener behaviour")
+    @UnsupportedWithConfigurationCache(because = "expects deprecation that is only issued without CC")
     def "nags when #type is registered via gradle.addListener() and feature preview is enabled"() {
-        settingsFile """
-            enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
-        """
         buildFile """
             def testListener = new TestListener() {
                 void beforeSuite(TestDescriptor suite) {}

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
@@ -1560,6 +1560,7 @@ ${verifFile.getText('us-ascii')}""", 'us-ascii')
 
         when:
         serveValidKey()
+        executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.buildFinished() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         fails ":help"
 
         then:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureWriteIntegTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureWriteIntegTest.groovy
@@ -487,6 +487,8 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         when:
         serveValidKey()
         writeVerificationMetadata()
+
+        executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.buildFinished() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         succeeds ":help"
 
         then:

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildEventsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildEventsIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.integtests.composite
 import org.gradle.execution.MultipleBuildFailures
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.build.BuildTestFile
+import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.internal.exceptions.LocationAwareException
 
 class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrationTest {
@@ -87,6 +88,10 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
         includedBuilds << buildC
     }
 
+    protected GradleExecuter expectedDeprecatedListenerRegistration(deprecatedInvocation) {
+        executer.expectDocumentedDeprecationWarning("Listener registration using ${deprecatedInvocation}() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
+    }
+
     @ToBeFixedForConfigurationCache(because = "build listener")
     def "fires build listener events on included builds"() {
         given:
@@ -94,15 +99,20 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
         dependency buildB, 'org.test:buildC:1.0'
 
         when:
+        expectedDeprecatedListenerRegistration("Gradle.buildFinished")
+        expectedDeprecatedListenerRegistration("Gradle.addBuildListener")
         execute()
 
         then:
         verifyBuildEvents()
     }
 
+
     @ToBeFixedForConfigurationCache(because = "build listener")
     def "fires build listener events for unused included builds"() {
         when:
+        expectedDeprecatedListenerRegistration("Gradle.buildFinished")
+        expectedDeprecatedListenerRegistration("Gradle.addBuildListener")
         execute()
 
         then:
@@ -126,6 +136,8 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
         dependency(pluginBuild, 'org.test:b2:1.0')
 
         when:
+        expectedDeprecatedListenerRegistration("Gradle.buildFinished")
+        expectedDeprecatedListenerRegistration("Gradle.addBuildListener")
         execute()
 
         then:
@@ -152,6 +164,8 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
 """
 
         when:
+        expectedDeprecatedListenerRegistration("Gradle.buildFinished")
+        expectedDeprecatedListenerRegistration("Gradle.addBuildListener")
         execute()
 
         then:
@@ -185,6 +199,10 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
         """
 
         when:
+        2.times {
+            expectedDeprecatedListenerRegistration("Gradle.buildFinished")
+        }
+        expectedDeprecatedListenerRegistration("Gradle.addBuildListener")
         execute()
 
         then:
@@ -231,6 +249,10 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
         """
 
         when:
+        2.times {
+            expectedDeprecatedListenerRegistration("Gradle.buildFinished")
+        }
+        expectedDeprecatedListenerRegistration("Gradle.addBuildListener")
         executeAndExpectFailure("help")
 
         then:
@@ -276,6 +298,10 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
         """
 
         when:
+        4.times {
+            expectedDeprecatedListenerRegistration("Gradle.buildFinished")
+        }
+        expectedDeprecatedListenerRegistration("Gradle.addBuildListener")
         executeAndExpectFailure("help")
 
         then:
@@ -328,6 +354,10 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
         """
 
         when:
+        4.times {
+            expectedDeprecatedListenerRegistration("Gradle.buildFinished")
+        }
+        expectedDeprecatedListenerRegistration("Gradle.addBuildListener")
         executeAndExpectFailure("help")
 
         then:
@@ -384,6 +414,10 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
         """
 
         when:
+        4.times {
+            expectedDeprecatedListenerRegistration("Gradle.buildFinished")
+        }
+        expectedDeprecatedListenerRegistration("Gradle.addBuildListener")
         executeAndExpectFailure("broken")
 
         then:

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
@@ -43,7 +43,6 @@ import org.gradle.internal.buildtree.DefaultBuildTreeWorkExecutor;
 import org.gradle.internal.composite.IncludedBuildInternal;
 import org.gradle.internal.composite.IncludedRootBuild;
 import org.gradle.internal.concurrent.CompositeStoppable;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.service.CloseableServiceRegistry;
@@ -123,14 +122,12 @@ class DefaultRootBuildState extends AbstractCompositeParticipantBuildState imple
             try {
                 GradleInternal gradle = getBuildController().getGradle();
                 DefaultDeploymentRegistry deploymentRegistry = gradle.getServices().get(DefaultDeploymentRegistry.class);
-                DeprecationLogger.whileDisabled(() ->
-                    gradle.addBuildListener(new InternalBuildAdapter() {
-                        @Override
-                        public void buildFinished(BuildResult result) {
-                            deploymentRegistry.buildFinished(result);
-                        }
-                    })
-                );
+                gradle.addBuildListener(new InternalBuildAdapter() {
+                    @Override
+                    public void buildFinished(BuildResult result) {
+                        deploymentRegistry.buildFinished(result);
+                    }
+                });
                 return action.apply(buildTreeLifecycleController);
             } finally {
                 buildLifecycleListener.beforeComplete();

--- a/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
@@ -306,7 +306,9 @@ public interface Gradle extends PluginAware, ExtensionAware {
      * The listener is notified of events which occur during the execution of the build.
      *
      * @param buildListener The listener to add.
+     * @deprecated This method is not supported when configuration caching is enabled.
      */
+    @Deprecated
     void addBuildListener(BuildListener buildListener);
 
     /**
@@ -330,14 +332,18 @@ public interface Gradle extends PluginAware, ExtensionAware {
      * </ul>
      *
      * @param listener The listener to add. Does nothing if this listener has already been added.
+     * @deprecated This method is not supported when configuration caching is enabled.
      */
+    @Deprecated
     void addListener(Object listener);
 
     /**
      * Removes the given listener from this build.
      *
      * @param listener The listener to remove. Does nothing if this listener has not been added.
+     * @deprecated This method is not supported when configuration caching is enabled.
      */
+    @Deprecated
     void removeListener(Object listener);
 
     /**
@@ -352,7 +358,9 @@ public interface Gradle extends PluginAware, ExtensionAware {
      * provides with your own implementation, for certain types of events.
      *
      * @param logger The logger to use.
+     * @deprecated This method is not supported when configuration caching is enabled.
      */
+    @Deprecated
     void useLogger(Object logger);
 
     /**

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/BuildEventsErrorIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/BuildEventsErrorIntegrationTest.groovy
@@ -24,6 +24,10 @@ import static org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache.Skip
 
 class BuildEventsErrorIntegrationTest extends AbstractIntegrationSpec {
 
+    def expectBuildScopeListenerDeprecation(String invocation) {
+        executer.expectDocumentedDeprecationWarning("Listener registration using $invocation() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
+    }
+
     def "produces reasonable error message when taskGraph.whenReady closure fails"() {
         buildFile << """
     gradle.taskGraph.whenReady {
@@ -107,6 +111,9 @@ gradle.${method} {
 gradle.rootProject { task a }
 """
         when:
+        if (deprecation) {
+            expectBuildScopeListenerDeprecation("Gradle.${method}")
+        }
         fails "a"
 
         then:
@@ -116,11 +123,11 @@ gradle.rootProject { task a }
                 .assertHasLineNumber(3)
 
         where:
-        method              | _
-        "settingsEvaluated" | _
-        "projectsLoaded"    | _
-        "projectsEvaluated" | _
-        "buildFinished"     | _
+        method              | deprecation
+        "settingsEvaluated" | false
+        "projectsLoaded"    | false
+        "projectsEvaluated" | false
+        "buildFinished"     | true
     }
 
     @UnsupportedWithConfigurationCache(iterationMatchers = ".*Gradle.buildFinished.*")
@@ -133,6 +140,9 @@ gradle.${method}(action)
 gradle.rootProject { task a }
 """
         when:
+        if (deprecation) {
+            expectBuildScopeListenerDeprecation("Gradle.${method}")
+        }
         fails "a"
 
         then:
@@ -142,11 +152,11 @@ gradle.rootProject { task a }
                 .assertHasLineNumber(3)
 
         where:
-        method              | _
-        "settingsEvaluated" | _
-        "projectsLoaded"    | _
-        "projectsEvaluated" | _
-        "buildFinished"     | _
+        method              | deprecation
+        "settingsEvaluated" | false
+        "projectsLoaded"    | false
+        "projectsEvaluated" | false
+        "buildFinished"     | true
     }
 
     @UnsupportedWithConfigurationCache
@@ -163,6 +173,7 @@ gradle.addListener(listener)
 gradle.rootProject { task a }
 """
         when:
+        expectBuildScopeListenerDeprecation("Gradle.addListener")
         fails "a"
 
         then:
@@ -191,6 +202,7 @@ gradle.rootProject { task a }
 """
 
         when:
+        expectBuildScopeListenerDeprecation("Gradle.buildFinished")
         fails("broken")
 
         then:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/GradlePluginIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/GradlePluginIntegrationTest.groovy
@@ -26,6 +26,7 @@ class GradlePluginIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         initFile = temporaryFolder.createFile("initscripts/init.gradle")
         executer.usingInitScript(initFile);
+        executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.buildFinished() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
     }
 
     @ToBeFixedForConfigurationCache(because = "Gradle.buildFinished")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/InitScriptExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/InitScriptExecutionIntegrationTest.groovy
@@ -267,6 +267,7 @@ initscript {
         settingsFile << "rootProject.name = 'root'"
 
         when:
+        executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.addListener() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         succeeds()
 
         then:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/PluginDetectionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/PluginDetectionIntegrationTest.groovy
@@ -105,6 +105,7 @@ class PluginDetectionIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.buildFinished() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         run("verify")
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/state/UpToDateIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/state/UpToDateIntegTest.groovy
@@ -245,18 +245,21 @@ public abstract class CreateEmptyDirectory extends DefaultTask {
         inputFile.text = "input"
 
         when:
+        executer.expectDocumentedDeprecationWarning("Listener registration using TaskExecutionGraph.beforeTask() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         run "customTask"
         then:
         executedAndNotSkipped(":customTask")
 
         when:
         Files.move(inputFile.toPath(), inputDir2.file(inputFileName).toPath())
+        executer.expectDocumentedDeprecationWarning("Listener registration using TaskExecutionGraph.beforeTask() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         run "customTask"
         then:
         skipped(":customTask")
 
         when:
         inputDir2.file(inputFileName).text = "changed"
+        executer.expectDocumentedDeprecationWarning("Listener registration using TaskExecutionGraph.beforeTask() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         run "customTask"
         then:
         executedAndNotSkipped(":customTask")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/execution/ExecuteTaskBuildOperationTypeIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/execution/ExecuteTaskBuildOperationTypeIntegrationTest.groovy
@@ -80,6 +80,8 @@ class ExecuteTaskBuildOperationTypeIntegrationTest extends AbstractIntegrationSp
                 throw new RuntimeException("!")
             }
         """
+
+        executer.expectDocumentedDeprecationWarning("Listener registration using TaskExecutionGraph.beforeTask() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         fails "t"
 
         then:
@@ -103,6 +105,7 @@ class ExecuteTaskBuildOperationTypeIntegrationTest extends AbstractIntegrationSp
                 throw new RuntimeException("!")
             }
         """
+        executer.expectDocumentedDeprecationWarning("Listener registration using TaskExecutionGraph.afterTask() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         fails "t"
 
         then:
@@ -128,6 +131,7 @@ class ExecuteTaskBuildOperationTypeIntegrationTest extends AbstractIntegrationSp
                 throw new RuntimeException("2")
             }
         """
+        executer.expectDocumentedDeprecationWarning("Listener registration using TaskExecutionGraph.afterTask() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         fails "t"
 
         then:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskEventsErrorIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskEventsErrorIntegrationTest.groovy
@@ -31,6 +31,7 @@ class TaskEventsErrorIntegrationTest extends AbstractIntegrationSpec {
     task test
 """
         then:
+        executer.expectDocumentedDeprecationWarning("Listener registration using TaskExecutionGraph.beforeTask() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         fails('test')
         failure.assertHasDescription("Execution failed for task ':test'.")
                 .assertHasCause("beforeTask failure")
@@ -47,6 +48,7 @@ class TaskEventsErrorIntegrationTest extends AbstractIntegrationSpec {
     task test
 """
         then:
+        executer.expectDocumentedDeprecationWarning("Listener registration using TaskExecutionGraph.afterTask() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         fails('test')
         failure.assertHasDescription("Execution failed for task ':test'.")
                 .assertHasCause("afterTask failure")
@@ -71,6 +73,8 @@ class TaskEventsErrorIntegrationTest extends AbstractIntegrationSpec {
     }
 """
         then:
+        executer.expectDocumentedDeprecationWarning("Listener registration using TaskExecutionGraph.afterTask() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
+        executer.expectDocumentedDeprecationWarning("Listener registration using TaskExecutionGraph.beforeTask() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         fails('test')
         result.groupedOutput.task(":test").output == """beforeTask action
 task action
@@ -90,6 +94,7 @@ afterTask action"""
     }
 """
         then:
+        executer.expectDocumentedDeprecationWarning("Listener registration using TaskExecutionGraph.afterTask() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         fails('test')
         failure.assertHasDescription("Execution failed for task ':test'.")
                 .assertHasCause("afterTask failure")

--- a/subprojects/core/src/integTest/groovy/org/gradle/configuration/ExecuteUserLifecycleListenerBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/configuration/ExecuteUserLifecycleListenerBuildOperationIntegrationTest.groovy
@@ -133,6 +133,10 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
         applyInlinePlugin(settingsFile, 'Settings', addGradleListeners('settings plugin'))
 
         when:
+        3.times {
+            executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.addListener() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
+            executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.addBuildListener() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
+        }
         run()
 
         then:
@@ -219,6 +223,10 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
         applyScript(buildFile, scriptFile)
 
         when:
+        6.times {
+            executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.addListener() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
+            executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.addBuildListener() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
+        }
         run()
 
         then:
@@ -593,6 +601,7 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
         initFile << addGradleListeners('init')
 
         when:
+        executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.addListener() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         run()
 
         then:
@@ -710,6 +719,7 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
         """
 
         when:
+        executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.addListener() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         run()
 
         then:

--- a/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/RuleTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/RuleTaskExecutionIntegrationTest.groovy
@@ -117,6 +117,7 @@ class RuleTaskExecutionIntegrationTest extends AbstractIntegrationSpec implement
         '''
 
         then:
+        executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.buildFinished() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         succeeds "t1"
 
         and:

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcEventsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcEventsIntegrationTest.groovy
@@ -45,6 +45,9 @@ class BuildSrcEventsIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
+        2.times {
+            executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.buildFinished() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
+        }
         run()
 
         then:
@@ -68,6 +71,9 @@ class BuildSrcEventsIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
+        2.times {
+            executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.buildFinished() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
+        }
         fails()
 
         then:
@@ -92,6 +98,9 @@ class BuildSrcEventsIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
+        2.times {
+            executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.buildFinished() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
+        }
         fails()
 
         then:

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
@@ -196,6 +196,7 @@ class LoggingBuildOperationProgressIntegTest extends AbstractIntegrationSpec {
         """
 
         when:
+        executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.buildFinished() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         succeeds("all")
 
         then:
@@ -377,6 +378,7 @@ class LoggingBuildOperationProgressIntegTest extends AbstractIntegrationSpec {
         """
 
         then:
+        executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.buildFinished() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
         succeeds "t"
 
         List<BuildOperationRecord.Progress> output = []

--- a/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSrcUpdateFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSrcUpdateFactory.java
@@ -18,6 +18,7 @@ package org.gradle.initialization.buildsrc;
 
 import org.gradle.internal.buildtree.BuildTreeLifecycleController;
 import org.gradle.internal.classpath.ClassPath;
+import org.gradle.internal.deprecation.DeprecationLogger;
 
 import javax.annotation.Nonnull;
 
@@ -29,9 +30,10 @@ public class BuildSrcUpdateFactory {
     }
 
     @Nonnull
+    @SuppressWarnings("deprecation")
     public ClassPath create(BuildTreeLifecycleController buildController) {
         BuildSrcBuildListenerFactory.Listener listener = listenerFactory.create();
-        buildController.beforeBuild(gradle -> gradle.addListener(listener));
+        buildController.beforeBuild(gradle -> DeprecationLogger.whileDisabled(() -> gradle.addListener(listener)));
 
         buildController.scheduleAndRunTasks(listener);
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSrcUpdateFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSrcUpdateFactory.java
@@ -18,7 +18,6 @@ package org.gradle.initialization.buildsrc;
 
 import org.gradle.internal.buildtree.BuildTreeLifecycleController;
 import org.gradle.internal.classpath.ClassPath;
-import org.gradle.internal.deprecation.DeprecationLogger;
 
 import javax.annotation.Nonnull;
 
@@ -33,7 +32,7 @@ public class BuildSrcUpdateFactory {
     @SuppressWarnings("deprecation")
     public ClassPath create(BuildTreeLifecycleController buildController) {
         BuildSrcBuildListenerFactory.Listener listener = listenerFactory.create();
-        buildController.beforeBuild(gradle -> DeprecationLogger.whileDisabled(() -> gradle.addListener(listener)));
+        buildController.beforeBuild(gradle -> gradle.addListener(listener));
 
         buildController.scheduleAndRunTasks(listener);
 

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/ProblemReportingBuildActionRunner.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/ProblemReportingBuildActionRunner.java
@@ -21,6 +21,7 @@ import org.gradle.api.invocation.Gradle;
 import org.gradle.initialization.exception.ExceptionAnalyser;
 import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.internal.InternalBuildAdapter;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.problems.buildtree.ProblemReporter;
 import org.gradle.problems.buildtree.ProblemReporter.ProblemConsumer;
@@ -66,11 +67,12 @@ public class ProblemReportingBuildActionRunner implements BuildActionRunner {
         return failures;
     }
 
+    @SuppressWarnings("deprecation")
     private RootProjectBuildDirCollectingListener getRootProjectBuildDirCollectingListener(BuildTreeLifecycleController buildController) {
         RootProjectBuildDirCollectingListener listener = new RootProjectBuildDirCollectingListener(
             defaultRootBuildDirOf()
         );
-        buildController.beforeBuild(gradle -> gradle.addBuildListener(listener));
+        buildController.beforeBuild(gradle -> DeprecationLogger.whileDisabled(() -> gradle.addBuildListener(listener)));
         return listener;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/ProblemReportingBuildActionRunner.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/ProblemReportingBuildActionRunner.java
@@ -21,7 +21,6 @@ import org.gradle.api.invocation.Gradle;
 import org.gradle.initialization.exception.ExceptionAnalyser;
 import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.internal.InternalBuildAdapter;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.problems.buildtree.ProblemReporter;
 import org.gradle.problems.buildtree.ProblemReporter.ProblemConsumer;
@@ -72,7 +71,7 @@ public class ProblemReportingBuildActionRunner implements BuildActionRunner {
         RootProjectBuildDirCollectingListener listener = new RootProjectBuildDirCollectingListener(
             defaultRootBuildDirOf()
         );
-        buildController.beforeBuild(gradle -> DeprecationLogger.whileDisabled(() -> gradle.addBuildListener(listener)));
+        buildController.beforeBuild(gradle -> gradle.addBuildListener(listener));
         return listener;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/enterprise/core/GradleEnterprisePluginManager.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/enterprise/core/GradleEnterprisePluginManager.java
@@ -21,7 +21,6 @@ import org.gradle.StartParameter;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.internal.InternalBuildAdapter;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.slf4j.Logger;
@@ -88,16 +87,14 @@ public class GradleEnterprisePluginManager {
             StartParameter startParameter = gradle.getStartParameter();
             boolean requested = !startParameter.isNoBuildScan() && startParameter.isBuildScan();
             if (requested) {
-                DeprecationLogger.whileDisabled(() ->
-                    gradle.addListener(new InternalBuildAdapter() {
-                        @Override
-                        public void settingsEvaluated(@Nonnull Settings settings) {
-                            if (!isPresent() && !unsupported) {
-                                LOGGER.warn(NO_SCAN_PLUGIN_MSG);
-                            }
+                gradle.addListener(new InternalBuildAdapter() {
+                    @Override
+                    public void settingsEvaluated(@Nonnull Settings settings) {
+                        if (!isPresent() && !unsupported) {
+                            LOGGER.warn(NO_SCAN_PLUGIN_MSG);
                         }
-                    })
-                );
+                    }
+                });
             }
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/enterprise/core/GradleEnterprisePluginManager.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/enterprise/core/GradleEnterprisePluginManager.java
@@ -21,6 +21,7 @@ import org.gradle.StartParameter;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.internal.InternalBuildAdapter;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.slf4j.Logger;
@@ -81,19 +82,22 @@ public class GradleEnterprisePluginManager {
      * This should never happen due to the auto apply behavior.
      * It's only here as a kind of safeguard or fallback.
      */
+    @SuppressWarnings("deprecation")
     public void registerMissingPluginWarning(GradleInternal gradle) {
         if (gradle.isRootBuild()) {
             StartParameter startParameter = gradle.getStartParameter();
             boolean requested = !startParameter.isNoBuildScan() && startParameter.isBuildScan();
             if (requested) {
-                gradle.addListener(new InternalBuildAdapter() {
-                    @Override
-                    public void settingsEvaluated(@Nonnull Settings settings) {
-                        if (!isPresent() && !unsupported) {
-                            LOGGER.warn(NO_SCAN_PLUGIN_MSG);
+                DeprecationLogger.whileDisabled(() ->
+                    gradle.addListener(new InternalBuildAdapter() {
+                        @Override
+                        public void settingsEvaluated(@Nonnull Settings settings) {
+                            if (!isPresent() && !unsupported) {
+                                LOGGER.warn(NO_SCAN_PLUGIN_MSG);
+                            }
                         }
-                    }
-                });
+                    })
+                );
             }
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -410,11 +410,13 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
         buildListenerBroadcast.add("buildFinished", action);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void addListener(Object listener) {
         addListener("Gradle.addListener", listener);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void removeListener(Object listener) {
         // do same decoration as in addListener to remove correctly
@@ -489,6 +491,7 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
             || listener instanceof DependencyResolutionListener;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void useLogger(Object logger) {
         notifyListenerRegistration("Gradle.useLogger", logger);
@@ -500,6 +503,7 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
         return projectEvaluationListenerBroadcast.getSource();
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void addBuildListener(BuildListener buildListener) {
         addListener("Gradle.addBuildListener", buildListener);

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
@@ -79,6 +79,7 @@ class TaskExecutionIntegrationTest extends AbstractIntegrationSpec implements Ta
         """
         expect:
         2.times {
+            executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.buildFinished() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
             succeeds "a"
             result.assertTasksExecuted(":b", ":a")
         }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -111,7 +111,7 @@ abstract class AbstractSmokeTest extends Specification {
         ]
 
         // https://plugins.gradle.org/plugin/org.ajoberstar.grgit
-        static grgit = "4.1.1"
+        static grgit = "5.2.2"
 
         // https://plugins.gradle.org/plugin/com.github.ben-manes.versions
         static gradleVersions = "0.51.0"

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NebulaPluginsSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NebulaPluginsSmokeTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.smoketests
 
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.reflect.validation.ValidationMessageChecker
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
@@ -277,7 +278,10 @@ class NebulaPluginDeprecations extends BaseDeprecations {
     }
 
     void expectNebulaDependencyLockPluginDeprecations() {
-        expectDeprecation("Gradle.buildFinished", "https://github.com/nebula-plugins/gradle-dependency-lock-plugin/issues/271")
-        expectDeprecation("TaskExecutionGraph.addTaskExecutionListener", "https://github.com/nebula-plugins/gradle-dependency-lock-plugin/issues/247")
+        if (GradleContextualExecuter.isNotConfigCache()) {
+            // with CC, these are reported as config cache problems only
+            expectDeprecation("Gradle.buildFinished", "https://github.com/nebula-plugins/gradle-dependency-lock-plugin/issues/271")
+            expectDeprecation("TaskExecutionGraph.addTaskExecutionListener", "https://github.com/nebula-plugins/gradle-dependency-lock-plugin/issues/247")
+        }
     }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NebulaPluginsSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NebulaPluginsSmokeTest.groovy
@@ -22,6 +22,8 @@ import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 import spock.lang.Issue
 
+import static org.gradle.api.internal.DocumentationRegistry.BASE_URL
+
 class NebulaPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implements ValidationMessageChecker {
 
     @Issue('https://plugins.gradle.org/plugin/com.netflix.nebula.dependency-recommender')
@@ -71,8 +73,9 @@ class NebulaPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implement
         """
 
         then:
-        runner('groovydoc', '-s')
-            .build()
+        runner('groovydoc', '-s').deprecations(NebulaPluginDeprecations) {
+            expectNebulaPluginDeprecations()
+        }.build()
     }
 
     @Issue('https://plugins.gradle.org/plugin/nebula.lint')
@@ -128,7 +131,9 @@ testImplementation('junit:junit:4.7')""")
         """.stripIndent()
 
         then:
-        runner('buildEnvironment', 'generateLock').build()
+        runner('buildEnvironment', 'generateLock').deprecations(NebulaPluginDeprecations) {
+            expectNebulaDependencyLockPluginDeprecations()
+        }.build()
 
         where:
         nebulaDepLockVersion << TestedVersions.nebulaDependencyLock.versions
@@ -190,9 +195,17 @@ testImplementation('junit:junit:4.7')""")
 }'''
 
         then:
-        runner('dependencies').build()
-        runner('generateLock').build()
-        runner('resolve').build()
+        runner('dependencies').deprecations(NebulaPluginDeprecations) {
+            expectNebulaDependencyLockPluginDeprecations()
+        }.build()
+
+        runner('generateLock').deprecations(NebulaPluginDeprecations) {
+            expectNebulaDependencyLockPluginDeprecations()
+        }.build()
+
+        runner('resolve').deprecations(NebulaPluginDeprecations) {
+            expectNebulaDependencyLockPluginDeprecations()
+        }.build()
 
         where:
         version << TestedVersions.nebulaDependencyLock
@@ -245,5 +258,26 @@ testImplementation('junit:junit:4.7')""")
             'com.netflix.nebula.dependency-lock': TestedVersions.nebulaDependencyLock,
             'com.netflix.nebula.resolution-rules': Versions.of(TestedVersions.nebulaResolutionRules)
         ]
+    }
+}
+
+class NebulaPluginDeprecations extends BaseDeprecations {
+
+    NebulaPluginDeprecations(SmokeTestGradleRunner runner) {
+        super(runner)
+    }
+
+    void expectDeprecation(String deprecatedInvocation, String followUp) {
+        runner.expectDeprecationWarning("Listener registration using ${deprecatedInvocation}() has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: ${BASE_URL}/userguide/upgrading_version_7.html#task_execution_events", followUp)
+    }
+
+    void expectNebulaPluginDeprecations() {
+        // nebula plugin applies dependency lock
+        expectNebulaDependencyLockPluginDeprecations()
+    }
+
+    void expectNebulaDependencyLockPluginDeprecations() {
+        expectDeprecation("Gradle.buildFinished", "https://github.com/nebula-plugins/gradle-dependency-lock-plugin/issues/271")
+        expectDeprecation("TaskExecutionGraph.addTaskExecutionListener", "https://github.com/nebula-plugins/gradle-dependency-lock-plugin/issues/247")
     }
 }


### PR DESCRIPTION
...regardless of the STABLE_CONFIGURATION_CACHE flag.

Issue: #22930

This changeset does the following:
- makes issuing of deprecation for build scope listeners not be dependent on STABLE_CONFIGURATION_CACHE
- introduces an internal option that allows disabling the issuing of deprecations for build scope listeners, to be leveraged by some tests
- changes tests that enabled STABLE_CONFIGURATION_CACHE so the build scope listener deprecations would be issued so they no longer did that, as that is no longer needed
- add expectation for deprecation warning for tests that use:
    -  `Gradle.buildFinished`
    - `Gradle.addListener`
    - `Gradle.addBuildListener`
    - `Gradle.useLogger`
    - `TaskExecutionGraph.beforeTask`
    - `TaskExecutionGraph.afterTask`
    - `TaskExecutionGraph.addTaskExecutionListener`
 - leverages the internal property introduced in a few console logging tests, as those get mixed with the expected output, and test cases don't have enough context to decide whether a deprecation should be expected or not.    
 - disables errors for deprecation warnings for some tests that hit the deprecated API
 - updates the `grgit` plugin to avoid a deprecation warning
 - add expected deprecations for Nebula smoke tests
