### PR TITLE
Mark `RichConsolePerformanceTest` as `@LeaksFileHandles`

### DIFF
--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/RichConsolePerformanceTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/RichConsolePerformanceTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.performance.regression.corefeature
 import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
+import org.gradle.test.fixtures.file.LeaksFileHandles
 
 import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
 import static org.gradle.performance.annotations.ScenarioType.PER_DAY
@@ -35,6 +36,7 @@ class RichConsolePerformanceTest extends AbstractCrossVersionPerformanceTest {
         @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["largeJavaMultiProject", "bigNative"], iterationMatcher = "^clean assemble.*"),
         @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["withVerboseJUnit"], iterationMatcher = "^cleanTest.*")
     ])
+    @LeaksFileHandles
     def "#tasks with rich console"() {
         given:
         runner.tasksToRun = tasks.split(' ')


### PR DESCRIPTION
See https://github.com/gradle/gradle-private/issues/4245

We've found some occurrences with `RichConsolePerformanceTest`: https://builds.gradle.org/buildConfiguration/Gradle_Release_Check_PerformanceTestSlowLinuxbucket6/85085203