### PR TITLE
Rebaseline perf tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ develocity.internal.testdistribution.writeTraceFile=true
 gradle.internal.testdistribution.queryResponseTimeout=PT20S
 develocity.internal.testdistribution.queryResponseTimeout=PT20S
 # Default performance baseline
-defaultPerformanceBaselines=8.10-commit-c3e5113f547
+defaultPerformanceBaselines=8.10-commit-8b0eccc59c9
 
 # Skip dependency analysis for tests
 systemProp.dependency.analysis.test.analysis=false


### PR DESCRIPTION
Observed ~3% regression in https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_PerformanceTestTestLinux_Trigger/85696829, which seems like an accumulated regression.