### PR TITLE
Restore original `Proxy` classloader whenever possible

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProxyIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProxyIntegrationTest.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl
+
+class ConfigurationCacheProxyIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+
+    def "can store Proxy created in script classloader"() {
+        given:
+        buildFile """
+            import java.lang.reflect.*
+            import java.util.function.Supplier
+
+            interface Proxied {
+                Integer getValue()
+            }
+
+            abstract class PrintTask extends DefaultTask {
+                @Input abstract Property<Proxied> getAnswer()
+                @TaskAction void print() {
+                    println("The answer is " + answer.get().value)
+                }
+            }
+
+            tasks.register("print", PrintTask) {
+                answer.set(
+                    Proxy.newProxyInstance(
+                        Proxied.classLoader,
+                        // Supplier goes as the first interface to ensure Gradle is not trying
+                        // to infer the classloader from the list of interfaces
+                        new Class[] {Supplier.class, Proxied.class},
+                        new InvocationHandler() {
+                            @Override Object invoke(Object proxy, Method method, Object[] args) {
+                                return 42
+                            }
+                        }
+                    ) as Proxied
+                )
+            }
+        """
+
+        when:
+        configurationCacheRun 'print'
+
+        then:
+        outputContains 'The answer is 42'
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/DefaultClassEncoder.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/DefaultClassEncoder.kt
@@ -67,17 +67,23 @@ class DefaultClassEncoder(
         if (id != null) {
             writeSmallInt(id)
         } else {
-            val scope = scopeLookup.scopeFor(type.classLoader)
             val newId = classes.putInstance(type)
             writeSmallInt(newId)
             writeString(type.name)
-            if (scope == null) {
-                writeBoolean(false)
-            } else {
-                writeBoolean(true)
-                writeScope(scope.first)
-                writeBoolean(scope.second.local)
-            }
+            encodeClassLoader(type.classLoader)
+        }
+    }
+
+    override fun WriteContext.encodeClassLoader(classLoader: ClassLoader?): Boolean {
+        val scope = classLoader?.let { scopeLookup.scopeFor(it) }
+        if (scope == null) {
+            writeBoolean(false)
+            return false
+        } else {
+            writeBoolean(true)
+            writeScope(scope.first)
+            writeBoolean(scope.second.local)
+            return true
         }
     }
 

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
@@ -57,6 +57,11 @@ interface WriteContext : MutableIsolateContext, Encoder {
     suspend fun write(value: Any?)
 
     fun writeClass(type: Class<*>)
+
+    /**
+     * @see ClassEncoder.encodeClassLoader
+     */
+    fun writeClassLoader(classLoader: ClassLoader?): Boolean = false
 }
 
 
@@ -88,6 +93,11 @@ interface ReadContext : IsolateContext, MutableIsolateContext, Decoder {
     suspend fun read(): Any?
 
     fun readClass(): Class<*>
+
+    /**
+     * @see ClassDecoder.decodeClassLoader
+     */
+    fun readClassLoader(): ClassLoader? = null
 
     /**
      * Defers the given [action] until all objects have been read.

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
@@ -91,6 +91,10 @@ class DefaultWriteContext(
         }
     }
 
+    override fun writeClassLoader(classLoader: ClassLoader?): Boolean = classEncoder.run {
+        encodeClassLoader(classLoader)
+    }
+
     override fun newIsolate(owner: IsolateOwner): WriteIsolate =
         DefaultWriteIsolate(owner)
 }
@@ -102,11 +106,25 @@ value class ClassLoaderRole(val local: Boolean)
 
 interface ClassEncoder {
     fun WriteContext.encodeClass(type: Class<*>)
+
+    /**
+     * Tries to encode the given [classLoader].
+     *
+     * @return `true` when the given [ClassLoader] is not `null` and could be encoded, `false` otherwise.
+     */
+    fun WriteContext.encodeClassLoader(classLoader: ClassLoader?): Boolean = false
 }
 
 
 interface ClassDecoder {
     fun ReadContext.decodeClass(): Class<*>
+
+    /**
+     * Decodes a [ClassLoader] previously encoded via [ClassEncoder.encodeClassLoader].
+     *
+     * @return the previously encoded [ClassLoader] or `null` when [ClassEncoder.encodeClassLoader] returns `false`
+     */
+    fun ReadContext.decodeClassLoader(): ClassLoader? = null
 }
 
 
@@ -159,6 +177,10 @@ class DefaultReadContext(
 
     override fun readClass(): Class<*> = classDecoder.run {
         decodeClass()
+    }
+
+    override fun readClassLoader(): ClassLoader? = classDecoder.run {
+        decodeClassLoader()
     }
 
     override val isolate: ReadIsolate


### PR DESCRIPTION
When a `Proxy` created in a Gradle-specific classloader is stored to the configuration cache.

This can happen when a plugin tries to access classes from different builds via proxies.

Fixes #30023

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
