### PR TITLE
Fix autolinks in Logging documentation

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/logging.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/logging.adoc
@@ -93,7 +93,7 @@ It's advisable to discuss this with your organization's security team.
 
 Some CI providers attempt to redact sensitive credentials from logs, but this process is not foolproof and typically only redacts exact matches of pre-configured secrets.
 
-If you suspect that a Gradle Plugin may inadvertently expose sensitive information, please contact [security@gradle.com](mailto:security@gradle.com) for assistance with disclosure.
+If you suspect that a Gradle Plugin may inadvertently expose sensitive information, please contact security@gradle.com for assistance with disclosure.
 
 [[sec:sending_your_own_log_messages]]
 == Writing your own log messages

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/logging.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/logging.adoc
@@ -158,7 +158,7 @@ include::sample[dir="snippets/tutorial/logging/kotlin",files="build.gradle.kts[t
 include::sample[dir="snippets/tutorial/logging/groovy",files="build.gradle[tags=task-capture-stdout]"]
 ====
 
-Gradle also integrates with the [Java Util Logging](https://docs.oracle.com/javase/8/docs/api/java/util/logging/package-summary.html), Jakarta Commons Logging and [Log4j](https://logging.apache.org/log4j/2.x/) logging toolkits.
+Gradle also integrates with the https://docs.oracle.com/javase/8/docs/api/java/util/logging/package-summary.html[Java Util Logging], Jakarta Commons Logging and https://logging.apache.org/log4j/2.x/[Log4j] logging toolkits.
 Any log messages your build classes write using these logging toolkits will be redirected to Gradle's logging system.
 
 [[sec:changing_what_gradle_logs]]


### PR DESCRIPTION
### Context
Fixes the display of some links in the documentation.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
