### PR TITLE
Honor installation paths set by -P on the cmdline for daemon toolchains

### DIFF
--- a/platforms/core-runtime/build-configuration/src/testFixtures/groovy/org/gradle/internal/buildconfiguration/fixture/DaemonJvmPropertiesFixture.groovy
+++ b/platforms/core-runtime/build-configuration/src/testFixtures/groovy/org/gradle/internal/buildconfiguration/fixture/DaemonJvmPropertiesFixture.groovy
@@ -53,7 +53,7 @@ trait DaemonJvmPropertiesFixture {
 
     void writeJvmCriteria(Jvm jvm) {
         def otherMetadata = AvailableJavaHomes.getJvmInstallationMetadata(jvm)
-        writeJvmCriteria(jvm.javaVersion, otherMetadata.vendor.knownVendor.name())
+        writeJvmCriteria(jvm.javaVersion, otherMetadata.vendor.rawVendor)
     }
 
     void writeJvmCriteria(JavaVersion version, String vendor = null, String implementation = null) {

--- a/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/configuration/AllProperties.java
+++ b/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/configuration/AllProperties.java
@@ -29,6 +29,11 @@ public interface AllProperties {
     Map<String, String> getRequestedSystemProperties();
 
     /**
+     * Returns the project properties defined as command-line options.
+     */
+    Map<String, String> getRequestedProjectProperties();
+
+    /**
      * Returns all properties that should be considered to calculate build option values.
      */
     Map<String, String> getProperties();

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/converter/BuildLayoutConverter.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/converter/BuildLayoutConverter.java
@@ -55,8 +55,8 @@ public class BuildLayoutConverter {
             layoutParameters.setCurrentDir(workingDir);
         }
         defaults.accept(layoutParameters);
-        Map<String, String> requestedSystemProperties = systemProperties.getRequestedSystemProperties();
-        new BuildLayoutParametersBuildOptions().propertiesConverter().convert(requestedSystemProperties, layoutParameters);
+        Map<String, String> requestedProperties = systemProperties.getRequestedProperties();
+        new BuildLayoutParametersBuildOptions().propertiesConverter().convert(requestedProperties, layoutParameters);
         buildLayoutConverter.convert(commandLine, layoutParameters);
         return new Result(layoutParameters);
     }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/converter/InitialPropertiesConverter.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/converter/InitialPropertiesConverter.java
@@ -19,6 +19,7 @@ package org.gradle.launcher.cli.converter;
 import org.gradle.cli.CommandLineConverter;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
+import org.gradle.cli.ProjectPropertiesCommandLineConverter;
 import org.gradle.cli.SystemPropertiesCommandLineConverter;
 import org.gradle.launcher.configuration.InitialProperties;
 
@@ -28,18 +29,34 @@ import java.util.Map;
 
 public class InitialPropertiesConverter {
     private final CommandLineConverter<Map<String, String>> systemPropertiesCommandLineConverter = new SystemPropertiesCommandLineConverter();
+    private final CommandLineConverter<Map<String, String>> projectPropertiesCommandLineConverter = new ProjectPropertiesCommandLineConverter();
 
     public void configure(CommandLineParser parser) {
         systemPropertiesCommandLineConverter.configure(parser);
+        projectPropertiesCommandLineConverter.configure(parser);
     }
 
     public InitialProperties convert(ParsedCommandLine commandLine) {
         Map<String, String> requestedSystemProperties = systemPropertiesCommandLineConverter.convert(commandLine, new HashMap<>());
+        Map<String, String> requestedProjectProperties = projectPropertiesCommandLineConverter.convert(commandLine, new HashMap<>());
+
+        Map<String, String> allRequestedProperties = new HashMap<>(requestedSystemProperties);
+        allRequestedProperties.putAll(requestedProjectProperties);
 
         return new InitialProperties() {
             @Override
             public Map<String, String> getRequestedSystemProperties() {
                 return Collections.unmodifiableMap(requestedSystemProperties);
+            }
+
+            @Override
+            public Map<String, String> getRequestedProjectProperties() {
+                return Collections.unmodifiableMap(requestedProjectProperties);
+            }
+
+            @Override
+            public Map<String, String> getRequestedProperties() {
+                return Collections.unmodifiableMap(allRequestedProperties);
             }
         };
     }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
@@ -67,7 +67,7 @@ public class LayoutToPropertiesConverter {
         configureFromBuildDir(layout, properties);
         configureFromHomeDir(layout.getGradleUserHomeDir(), properties);
         configureFromSystemPropertiesOfThisJvm(Cast.uncheckedNonnullCast(properties));
-        properties.putAll(initialProperties.getRequestedSystemProperties());
+        properties.putAll(initialProperties.getRequestedProperties());
 
         Map<String, String> daemonJvmProperties = new HashMap<>();
         configureFromDaemonJVMProperties(layout, daemonJvmProperties);
@@ -151,6 +151,11 @@ public class LayoutToPropertiesConverter {
         }
 
         @Override
+        public Map<String, String> getRequestedProjectProperties() {
+            return initialProperties.getRequestedProjectProperties();
+        }
+
+        @Override
         public Map<String, String> getProperties() {
             return Collections.unmodifiableMap(properties);
         }
@@ -164,7 +169,7 @@ public class LayoutToPropertiesConverter {
         public Result merge(Map<String, String> systemProperties) {
             Map<String, String> properties = new HashMap<>(this.properties);
             properties.putAll(systemProperties);
-            properties.putAll(initialProperties.getRequestedSystemProperties());
+            properties.putAll(initialProperties.getRequestedProperties());
             return new Result(properties, daemonJvmProperties, initialProperties);
         }
     }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/converter/StartParameterConverter.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/converter/StartParameterConverter.java
@@ -21,7 +21,6 @@ import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.cli.CommandLineArgumentException;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
-import org.gradle.cli.ProjectPropertiesCommandLineConverter;
 import org.gradle.concurrent.ParallelismConfiguration;
 import org.gradle.initialization.ParallelismBuildOptions;
 import org.gradle.initialization.StartParameterBuildOptions;
@@ -33,14 +32,12 @@ public class StartParameterConverter {
     private final BuildOptionBackedConverter<WelcomeMessageConfiguration> welcomeMessageConfigurationCommandLineConverter = new BuildOptionBackedConverter<>(new WelcomeMessageBuildOptions());
     private final BuildOptionBackedConverter<LoggingConfiguration> loggingConfigurationCommandLineConverter = new BuildOptionBackedConverter<>(new LoggingConfigurationBuildOptions());
     private final BuildOptionBackedConverter<ParallelismConfiguration> parallelConfigurationCommandLineConverter = new BuildOptionBackedConverter<>(new ParallelismBuildOptions());
-    private final ProjectPropertiesCommandLineConverter projectPropertiesCommandLineConverter = new ProjectPropertiesCommandLineConverter();
     private final BuildOptionBackedConverter<StartParameterInternal> buildOptionsConverter = new BuildOptionBackedConverter<>(new StartParameterBuildOptions());
 
     public void configure(CommandLineParser parser) {
         welcomeMessageConfigurationCommandLineConverter.configure(parser);
         loggingConfigurationCommandLineConverter.configure(parser);
         parallelConfigurationCommandLineConverter.configure(parser);
-        projectPropertiesCommandLineConverter.configure(parser);
         parser.allowMixedSubcommandsAndOptions();
         buildOptionsConverter.configure(parser);
     }
@@ -53,8 +50,7 @@ public class StartParameterConverter {
         parallelConfigurationCommandLineConverter.convert(parsedCommandLine, properties.getProperties(), startParameter);
 
         startParameter.getSystemPropertiesArgs().putAll(properties.getRequestedSystemProperties());
-
-        projectPropertiesCommandLineConverter.convert(parsedCommandLine, startParameter.getProjectProperties());
+        startParameter.getProjectProperties().putAll(properties.getRequestedProjectProperties());
 
         if (!parsedCommandLine.getExtraArguments().isEmpty()) {
             startParameter.setTaskNames(parsedCommandLine.getExtraArguments());

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/configuration/InitialProperties.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/configuration/InitialProperties.java
@@ -19,12 +19,23 @@ package org.gradle.launcher.configuration;
 import java.util.Map;
 
 /**
- * An immutable view of the properties that are available prior to calculating the build layout. That is, the properties that are
- * defined on the command-line and in the system properties of the current JVM.
+ * An immutable view of the properties that are available prior to calculating the build layout.
+ * That is, the properties that are defined on the command-line.
  */
 public interface InitialProperties {
+
     /**
      * Returns the system properties defined as command-line options.
      */
     Map<String, String> getRequestedSystemProperties();
+
+    /**
+     * Returns the project properties defined as command-line options.
+     */
+    Map<String, String> getRequestedProjectProperties();
+
+    /**
+     * Returns the all properties defined as command-line options.
+     */
+    Map<String, String> getRequestedProperties();
 }

--- a/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/cli/converter/InitialPropertiesConverterTest.groovy
+++ b/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/cli/converter/InitialPropertiesConverterTest.groovy
@@ -20,16 +20,24 @@ import org.gradle.cli.CommandLineParser
 import spock.lang.Specification
 
 class InitialPropertiesConverterTest extends Specification {
-    def "collects -D command-line options"() {
+    def "collects command-line options"() {
         def converter = new InitialPropertiesConverter()
         def parser = new CommandLineParser()
         converter.configure(parser)
-        def commandLine = parser.parse("-Done=12", "-Dtwo")
+        def commandLine = parser.parse("-Done=12", "-Dtwo", "-Pthree=3")
         def result = converter.convert(commandLine)
 
         expect:
+        result.requestedProperties.size() == 3
+        result.requestedProperties.get("one") == "12"
+        result.requestedProperties.get("two") == ""
+        result.requestedProperties.get("three") == "3"
+
         result.requestedSystemProperties.size() == 2
         result.requestedSystemProperties.get("one") == "12"
         result.requestedSystemProperties.get("two") == ""
+
+        result.requestedProjectProperties.size() == 1
+        result.requestedProjectProperties.get("three") == "3"
     }
 }


### PR DESCRIPTION
The tests were ignoring the value we set since we were setting it with -P and they were ignored.

We also use the raw vendor when writing installation metadata so we don't write UNKNOWN when the test is run with a non-known vendor.

Fixes https://github.com/gradle/gradle-private/issues/4274

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
