### PR TITLE
Avoid flakiness in SupportedBuildJvmVersionIntegrationTest

### DIFF
--- a/platforms/core-runtime/build-configuration/src/testFixtures/groovy/org/gradle/internal/buildconfiguration/fixture/DaemonJvmPropertiesFixture.groovy
+++ b/platforms/core-runtime/build-configuration/src/testFixtures/groovy/org/gradle/internal/buildconfiguration/fixture/DaemonJvmPropertiesFixture.groovy
@@ -53,7 +53,7 @@ trait DaemonJvmPropertiesFixture {
 
     void writeJvmCriteria(Jvm jvm) {
         def otherMetadata = AvailableJavaHomes.getJvmInstallationMetadata(jvm)
-        writeJvmCriteria(jvm.javaVersion, otherMetadata.vendor.knownVendor.name())
+        writeJvmCriteria(jvm.javaVersion, otherMetadata.vendor.rawVendor)
     }
 
     void writeJvmCriteria(JavaVersion version, String vendor = null, String implementation = null) {

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/SupportedBuildJvmVersionIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/SupportedBuildJvmVersionIntegrationTest.groovy
@@ -34,6 +34,7 @@ class SupportedBuildJvmVersionIntegrationTest extends AbstractIntegrationSpec im
 
     def setup() {
         executer.disableDaemonJavaVersionDeprecationFiltering()
+        executer.requireIsolatedDaemons() // Because we check which JVM the daemon uses, and we don't want to pick a compatible JVM from another test but with different java home.
     }
 
     @Requires(


### PR DESCRIPTION
Make sure to write the raw vendor in case we don't recognise the vendor. Previously if we found a JVM with an unknown vendor, we would write UNKNOWN as the vendor, and then fail when checking if that JVM was compatible.

Also require isolated daemons for SupportedBuildJvmVersionIntegrationTest since before it was possible that the test picked up a compatible daemon from another test but with a different java home. We need are checking that the java home configured via installation paths is the same as the java home used by the daemon. It is a bit weird that the launcher will pick a running daemon started with a jvm that is not in its list of discovered JVMs, but as long as that happens, we need isolated daemons

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
