### PR TITLE
Don't use default Xmx settings for sourceZipContents test

### DIFF
--- a/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
+++ b/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
@@ -59,6 +59,9 @@ class SrcDistributionIntegrationSpec extends DistributionIntegrationSpec {
         executer.with {
             inDirectory(contentsDir)
             usingExecutable('gradlew')
+            // we add implicit Xmx1024m in AbstractGradleExecuter.getImplicitBuildJvmArgs()
+            // that's too small for this build
+            useOnlyRequestedJvmOpts()
             withArgument("--no-configuration-cache") // TODO:configuration-cache remove me
             withTasks(':distributions-full:binDistributionZip')
             withArgument("-D${PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY}=${gradlePluginRepositoryMirrorUrl()}")


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-private/issues/4275

In the past, every Gradle invocation started via infrastructure was injected a default `-Xmx1024m` via `GRADLE_OPTS`.

This is not enough for `sourceZipContents`, which builds Gradle from source. We'll remove these implciti JVM args because Gradle has its own JVM settings in `gradle.properties`.
