### PR TITLE
Clarify the confusing difference between `.gradle` and `gradle`

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/gradle_directories.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/gradle_directories.adoc
@@ -71,9 +71,11 @@ Consult the <<directory_layout.adoc#dir:gradle_user_home,Gradle Directories refe
 
 The project root directory contains all source files from your project.
 
-It also contains files and directories Gradle generates, such as `.gradle` and `build`.
+It also contains files and directories Gradle generates, such as `.gradle` and `build`, as well as the Gradle configuration directory: `gradle`.
 
-While `gradle` is usually checked into source control, the `build` directory contains the output of your builds as well as transient files Gradle uses to support features like incremental builds.
+TIP: `gradle` and `.gradle` directories are different.
+
+While `gradle` is usually checked into source control, `build` and `.gradle` directories contain the output of your builds, caches, and other transient files Gradle uses to support features like incremental builds.
 
 The anatomy of a typical project root directory looks as follows:
 


### PR DESCRIPTION
Fixes: a follow-up for the discussion in #30058. Difference between `.gradle` and `gradle` clarified:

![image](https://github.com/user-attachments/assets/eeea2c72-9329-4c6d-b09b-67c8256aa8bd)

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
