### PR TITLE
Improve boolean property upgrade accepted binary compatibility changes

### DIFF
--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/upgrades/UpgradedProperty.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/upgrades/UpgradedProperty.java
@@ -136,6 +136,13 @@ public class UpgradedProperty {
             return new AccessorKey(containingType, replacedAccessor.getName(), replacedAccessor.getDescriptor());
         }
 
+        public static AccessorKey ofMethodWithSameSignatureButNewName(String newName, JApiMethod jApiMethod) {
+            String descriptor = jApiMethod.getNewMethod().get().getSignature();
+            String containingType = jApiMethod.getjApiClass().getFullyQualifiedName();
+            return new AccessorKey(containingType, newName, descriptor);
+        }
+
+
         public static AccessorKey ofNewMethod(JApiMethod jApiMethod) {
             String name = jApiMethod.getName();
             String descriptor = jApiMethod.getNewMethod().get().getSignature();

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/UpgradedPropertiesChangesTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/UpgradedPropertiesChangesTest.kt
@@ -149,10 +149,10 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                         import org.gradle.api.provider.Property;
 
                         public abstract class Task {
-                            /**
-                             * @since 2.0
-                             */
                             public abstract Property<Boolean> getFailOnError();
+                            public Property<Boolean> getIsFailOnError() {
+                                return getFailOnError();
+                            }
                         }
                     """
                 )
@@ -181,6 +181,9 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
             assertHasNoError()
             assertHasAccepted(
                 "Method com.example.Task.getFailOnError(): Is not annotated with @Incubating. Reason for accepting this: Upgraded property" to listOf("Method added to public class", "Abstract method has been added to this class"),
+                "Method com.example.Task.getFailOnError(): Is not annotated with @since 2.0. Reason for accepting this: Upgraded property" to listOf("Method added to public class", "Abstract method has been added to this class"),
+                "Method com.example.Task.getIsFailOnError(): Is not annotated with @Incubating. Reason for accepting this: Upgraded property" to listOf("Method added to public class"),
+                "Method com.example.Task.getIsFailOnError(): Is not annotated with @since 2.0. Reason for accepting this: Upgraded property" to listOf("Method added to public class"),
                 "Method com.example.Task.isFailOnError(): Is not binary compatible. Reason for accepting this: Upgraded property" to listOf("Method has been removed"),
                 "Method com.example.Task.setFailOnError(boolean): Is not binary compatible. Reason for accepting this: Upgraded property" to listOf("Method has been removed")
             )
@@ -188,7 +191,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
     }
 
     @Test
-    fun `should report an error if newly added method does not have @since`() {
+    fun `should report an error if newly added method with different name does not have @since`() {
         checkNotBinaryCompatible(
             v1 = {
                 withFile(
@@ -197,8 +200,8 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                         package com.example;
 
                         public abstract class Task {
-                            public boolean isFailOnError() {
-                                return false;
+                            public String getOldDescription() {
+                                return "";
                             }
                         }
                     """
@@ -212,7 +215,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                         import org.gradle.api.provider.Property;
 
                         public abstract class Task {
-                            public abstract Property<Boolean> getFailOnError();
+                            public abstract Property<String> getNewDescription();
                         }
                     """
                 )
@@ -221,23 +224,23 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                     """
                         [{
                             "containingType": "com.example.Task",
-                            "methodName": "getFailOnError",
+                            "methodName": "getNewDescription",
                             "methodDescriptor": "()Lorg/gradle/api/provider/Property;",
-                            "propertyName": "failOnError",
+                            "propertyName": "newDescription",
                             "replacedAccessors": [{
                                 "binaryCompatibility": "ACCESSORS_REMOVED",
-                                "descriptor": "()Z",
-                                "name": "isFailOnError"
+                                "descriptor": "()Ljava/lang/String;",
+                                "name": "getOldDescription"
                             }]
                         }]
                         """
                 )
             }
         ) {
-            assertHasErrors("Method com.example.Task.getFailOnError(): Is not annotated with @since 2.0.")
+            assertHasErrors("Method com.example.Task.getNewDescription(): Is not annotated with @since 2.0.")
             assertHasAccepted(
-                "Method com.example.Task.getFailOnError(): Is not annotated with @Incubating. Reason for accepting this: Upgraded property" to listOf("Method added to public class", "Abstract method has been added to this class"),
-                "Method com.example.Task.isFailOnError(): Is not binary compatible. Reason for accepting this: Upgraded property" to listOf("Method has been removed"),
+                "Method com.example.Task.getNewDescription(): Is not annotated with @Incubating. Reason for accepting this: Upgraded property" to listOf("Method added to public class", "Abstract method has been added to this class"),
+                "Method com.example.Task.getOldDescription(): Is not binary compatible. Reason for accepting this: Upgraded property" to listOf("Method has been removed"),
             )
         }
     }


### PR DESCRIPTION
This simplifies upgrading boolean properties, so we don't need to add `@since` and `@Incubating` anymore.