### PR TITLE
Fix failing ReadOnlyDependencyCacheWithinContainerTest

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rocache/ReadOnlyDependencyCacheWithinContainerTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rocache/ReadOnlyDependencyCacheWithinContainerTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.resolve.rocache
 
+import com.gradle.develocity.testing.annotations.LocalOnly
 import org.gradle.containers.GradleInContainer
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
@@ -29,6 +30,7 @@ import org.gradle.test.preconditions.UnitTestPreconditions
     value = [UnitTestPreconditions.HasDocker, IntegTestPreconditions.NotEmbeddedExecutor],
     reason = "needs real Gradle distribution to run in container"
 )
+@LocalOnly
 class ReadOnlyDependencyCacheWithinContainerTest extends AbstractReadOnlyCacheDependencyResolutionTest {
 
     BlockingHttpServer synchronizer

--- a/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/containers/GradleInContainer.groovy
+++ b/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/containers/GradleInContainer.groovy
@@ -32,7 +32,7 @@ import org.testcontainers.utility.MountableFile
 @CompileStatic
 @NotThreadSafe
 class GradleInContainer {
-    static final String BASE_IMAGE = "openjdk:11-jre-slim"
+    static final String BASE_IMAGE = "adoptopenjdk/openjdk11:jdk-11.0.24_8-slim"
 
     private final GradleContainer container
     private final GradleContainerExecuter executer


### PR DESCRIPTION
See https://ge.gradle.org/scans/tests?search.relativeStartTime=P28D&search.timeZoneId=Asia%2FShanghai&tests.container=org.gradle.integtests.resolve.rocache.ReadOnlyDependencyCacheWithinContainerTest&tests.test=can%20use%20a%20read-only%20cache%20within%20a%20container&tests.unstableOnly=false

It fails with

```
Toolchain installation '/usr/local/openjdk-11' does not provide the required capabilities: [JAVA_COMPILER]
```

Because we are using `jre` docker image. Also, it was skipped a lot when it's running with Test Distribution, so `@LocalOnly` was added.