### PR TITLE
Deprecate mutating configurations in buildscript block

### DIFF
--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratedManagedStateTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratedManagedStateTest.groovy
@@ -189,7 +189,7 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
         def bean = create(InterfaceDomainSetPropertyBean)
 
         expect:
-        bean.prop.toString() == "[]"
+        bean.prop.toString() == "NamedBean collection"
         bean.prop.empty
         bean.prop.add(Stub(NamedBean))
         bean.prop.size() == 1

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/Documentation.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/Documentation.java
@@ -35,7 +35,7 @@ public abstract class Documentation implements DocLink {
         return new UserGuide(id, null);
     }
 
-    static Documentation upgradeGuide(int majorVersion, String upgradeGuideSection) {
+    public static Documentation upgradeGuide(int majorVersion, String upgradeGuideSection) {
         return new UpgradeGuide(majorVersion, upgradeGuideSection);
     }
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -99,6 +99,56 @@ We decided to upgrade the minimum version of the Java runtime for a number of re
 - Some of the most popular plugins already require JVM 17 or later.
 - Download metrics for Gradle distributions show that JVM 17 is widely used.
 
+[[creating_new_buildscript_configurations]]
+==== Deprecated creating new buildscript configurations
+
+Starting in Gradle 9.0, creating new configurations in a script's link:{javadocPath}/org/gradle/api/Script.html#buildscript-groovy.lang.Closure-[buildscript] block will result in an error.
+This applies to project, settings, init, and standalone scripts.
+
+The buildscript configurations block is only intended to be used to declare dependencies for the buildscript classpath.
+
+Consider the following script that creates a new buildscript configuration in a Settings script and resolves it:
+
+=====
+[.multi-language-sample]
+======
+.settings.gradle.kts
+[source,kotlin]
+----
+buildscript {
+    configurations {
+        create("myConfig")
+    }
+    dependencies {
+        "myConfig"("org:foo:1.0")
+    }
+}
+
+val files = buildscript.configurations["myConfig"].files
+----
+======
+=====
+
+This pattern is sometimes used to resolve dependencies in Settings, where there is no other way to obtain a Configuration.
+Resolving dependencies in this context is not recommended, however using a detached configuration will still work for the time being.
+
+Consider the following replacement to the above example, which uses a detached configuration instead:
+
+=====
+[.multi-language-sample]
+======
+.settings.gradle.kts
+[source,kotlin]
+----
+val myConfig = buildscript.configurations.detachedConfiguration(
+    buildscript.dependencies.create("org:foo:1.0")
+)
+
+val files = myConfig.files
+----
+======
+=====
+
 [[consuming_non_consumable_variants_from_ivy_component]]
 ==== Deprecated consuming non-consumable configurations from Ivy
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -99,20 +99,16 @@ We decided to upgrade the minimum version of the Java runtime for a number of re
 - Some of the most popular plugins already require JVM 17 or later.
 - Download metrics for Gradle distributions show that JVM 17 is widely used.
 
-[[creating_new_buildscript_configurations]]
-==== Deprecated creating new buildscript configurations
+[[mutating_buildscript_configurations]]
+==== Deprecated mutating buildscript configurations
 
-Starting in Gradle 9.0, creating new configurations in a script's link:{javadocPath}/org/gradle/api/Script.html#buildscript-groovy.lang.Closure-[buildscript] block will result in an error.
+Starting in Gradle 9.0, mutating configurations in a script's link:{javadocPath}/org/gradle/api/Script.html#buildscript-groovy.lang.Closure-[buildscript] block will result in an error.
 This applies to project, settings, init, and standalone scripts.
 
-The buildscript configurations block is only intended to be used to declare dependencies for the buildscript classpath.
+The buildscript configurations block is only intended to control buildscript classpath resolution.
 
 Consider the following script that creates a new buildscript configuration in a Settings script and resolves it:
 
-=====
-[.multi-language-sample]
-======
-.settings.gradle.kts
 [source,kotlin]
 ----
 buildscript {
@@ -126,18 +122,13 @@ buildscript {
 
 val files = buildscript.configurations["myConfig"].files
 ----
-======
-=====
 
 This pattern is sometimes used to resolve dependencies in Settings, where there is no other way to obtain a Configuration.
-Resolving dependencies in this context is not recommended, however using a detached configuration will still work for the time being.
+Resolving dependencies in this context is not recommended.
+Using a detached configuration is a possible yet discouraged alternative.
 
-Consider the following replacement to the above example, which uses a detached configuration instead:
+The above example can be modified to use a detached configuration:
 
-=====
-[.multi-language-sample]
-======
-.settings.gradle.kts
 [source,kotlin]
 ----
 val myConfig = buildscript.configurations.detachedConfiguration(
@@ -146,8 +137,6 @@ val myConfig = buildscript.configurations.detachedConfiguration(
 
 val files = myConfig.files
 ----
-======
-=====
 
 [[consuming_non_consumable_variants_from_ivy_component]]
 ==== Deprecated consuming non-consumable configurations from Ivy

--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/java/dependencies/JavaConfigurationSetupIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/java/dependencies/JavaConfigurationSetupIntegrationTest.groovy
@@ -149,6 +149,7 @@ class JavaConfigurationSetupIntegrationTest extends AbstractIntegrationSpec {
 
     def "the #configuration configuration is setup correctly for resolution in the #plugin plugin"() {
         given:
+        settingsFile << "rootProject.name = 'test'"
         buildFile << """
             plugins { id '$plugin' }
             task resolve {
@@ -174,7 +175,7 @@ class JavaConfigurationSetupIntegrationTest extends AbstractIntegrationSpec {
         !deprecated(alternatives)   || output.contains("The $configuration configuration has been deprecated for resolution. This will fail with an error in Gradle 8.0. Please resolve the ${alternatives} configuration instead.")
         !valid(alternatives)        || output.contains("> Task :resolve\n\n")
         !forbidden(alternatives)    || errorOutput.contains("Resolving dependency configuration '$configuration' is not allowed as it is defined as 'canBeResolved=false'.\nInstead, a resolvable ('canBeResolved=true') dependency configuration that extends '$configuration' should be resolved.")
-        !doesNotExist(alternatives) || errorOutput.contains("Could not get unknown property '$configuration' for configuration container of type org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer.")
+        !doesNotExist(alternatives) || errorOutput.contains("Could not get unknown property '$configuration' for configuration container for root project 'test' of type org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer.")
 
         where:
         plugin         | configuration                  | alternatives

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/plugins/TestSuiteModelIntegrationSpec.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/plugins/TestSuiteModelIntegrationSpec.groovy
@@ -268,11 +268,11 @@ class TestSuiteModelIntegrationSpec extends AbstractIntegrationSpec {
                     binaries {
                         first {
                             sources()
-                            tasks(nodeValue: "[]")
+                            tasks(nodeValue: "Task collection")
                         }
                         second {
                             sources()
-                            tasks(nodeValue: "[]")
+                            tasks(nodeValue: "Task collection")
                         }
 
                     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/BuildscriptResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/BuildscriptResolutionIntegrationTest.groovy
@@ -1,0 +1,832 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.dsl.GradleDsl
+
+/**
+ * Tests edge cases of buildscript configuration resolution.
+ *
+ * <p>Tests should cover cases of initscript, settings, standalone, and project buildscript configurations.</p>
+ */
+class BuildscriptResolutionIntegrationTest extends AbstractIntegrationSpec {
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'root'
+        """
+    }
+
+    // This is not desired behavior. A project dependency should refer to the actual
+    // project, not its buildscript component. This is a bug.
+    def "project buildscript configuration can select itself"() {
+        buildFile << """
+            buildscript {
+                configurations {
+                    conf {
+                        outgoing {
+                            artifact file('foo.txt')
+                        }
+                        attributes {
+                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "foo"))
+                        }
+                    }
+                }
+
+                dependencies {
+                    conf project(":")
+                }
+            }
+
+            task resolve {
+                def files = buildscript.configurations.conf.incoming.files
+                doLast {
+                    assert files.files*.name == ["foo.txt"]
+                }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("While resolving configuration 'conf', it was also selected as a variant. Configurations should not act as both a resolution root and a variant simultaneously. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false or use the 'resolvable(String)' configuration factory method to create them. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration")
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        succeeds("resolve")
+    }
+
+    // This is not desired behavior. A project dependency should refer to the actual
+    // project, not its buildscript component. This is a bug.
+    def "project buildscript classpath configuration can select itself"() {
+        file("foo.txt") << "foo"
+        buildFile << """
+            buildscript {
+                configurations {
+                    classpath {
+                        outgoing {
+                            artifact file('foo.txt')
+                        }
+                    }
+                }
+
+                dependencies {
+                    classpath project(":")
+                }
+            }
+
+            assert buildscript.configurations.classpath.incoming.files*.name == ["foo.txt"]
+        """
+
+        expect:
+        2.times {
+            // Once when resolving the classpath normally, once when re-resolving
+            executer.expectDocumentedDeprecationWarning("The classpath configuration has been deprecated for consumption. This will fail with an error in Gradle 9.0. For more information, please refer to https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.")
+            executer.expectDocumentedDeprecationWarning("While resolving configuration 'classpath', it was also selected as a variant. Configurations should not act as both a resolution root and a variant simultaneously. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false or use the 'resolvable(String)' configuration factory method to create them. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration")
+        }
+        succeeds("help")
+    }
+
+    def "project buildscript configuration can select another project"() {
+        buildFile << """
+            buildscript {
+                configurations {
+                    conf {
+                        attributes {
+                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "foo"))
+                        }
+                    }
+                }
+
+                dependencies {
+                    conf project(":other")
+                }
+            }
+
+            task resolve {
+                def files = buildscript.configurations.conf.incoming.files
+                doLast {
+                    assert files.files*.name == ["bar.txt"]
+                }
+            }
+        """
+        settingsFile << """
+            include "other"
+        """
+        file("other/build.gradle") << """
+            configurations {
+                consumable("conf") {
+                    outgoing {
+                        artifact file('bar.txt')
+                    }
+                    attributes {
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "foo"))
+                    }
+                }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        succeeds(":resolve")
+    }
+
+    def "project buildscript classpath configuration can select another project"() {
+        settingsFile << """
+            include "first"
+            include "other"
+        """
+        file("first/build.gradle") << """
+            buildscript {
+                dependencies {
+                    classpath project(":other")
+                }
+            }
+        """
+        file("other/bar.txt") << "bar"
+        file("other/build.gradle") << """
+            configurations {
+                other {
+                    outgoing {
+                        artifact file('bar.txt')
+                    }
+                    attributes {
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "library"))
+                    }
+                }
+            }
+        """
+
+        expect:
+        succeeds("help")
+    }
+
+    def "project buildscript configuration cannot select another project when the selected artifact is built by a task"() {
+        settingsFile << """
+            include "first"
+            include "other"
+        """
+        file("first/build.gradle") << """
+            buildscript {
+                configurations {
+                    conf {
+                        attributes {
+                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "foo"))
+                        }
+                    }
+                }
+
+                dependencies {
+                    conf project(":other")
+                }
+            }
+
+            task resolve {
+                def files = buildscript.configurations.conf.incoming.files
+                doLast {
+                    assert files.files*.name == ["bar.txt"]
+                }
+            }
+        """
+        file("other/build.gradle") << """
+            task myTask { }
+            configurations {
+                other {
+                    outgoing {
+                        artifact(file('bar.txt')) {
+                            builtBy tasks.myTask
+                        }
+                    }
+                    attributes {
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "foo"))
+                    }
+                }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of project ':first' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        succeeds(":first:resolve")
+    }
+
+    def "project buildscript classpath configuration cannot select another project when the selected artifact is built by a task"() {
+        settingsFile << """
+            include "first"
+            include "other"
+        """
+        file("first/build.gradle") << """
+            buildscript {
+                dependencies {
+                    classpath project(":other")
+                }
+            }
+        """
+        file("bar.txt") << "bar"
+        file("other/build.gradle") << """
+            task myTask { }
+            configurations {
+                other {
+                    outgoing {
+                        artifact(file('bar.txt')) {
+                            builtBy tasks.myTask
+                        }
+                    }
+                    attributes {
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "library"))
+                    }
+                }
+            }
+        """
+
+        expect:
+        fails("help")
+        failure.assertHasCause("Script classpath dependencies must reside in a separate build from the script itself.")
+    }
+
+    // This is not desired behavior. A project dependency should refer to the actual
+    // project, not its buildscript component. This is a bug.
+    def "project buildscript configuration can select other buildscript configurations"() {
+        buildFile << """
+            buildscript {
+                configurations {
+                    conf {
+                        canBeConsumed = false
+                        attributes {
+                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "other"))
+                        }
+                    }
+                    other {
+                        outgoing {
+                            artifact file('bar.txt')
+                        }
+                        attributes {
+                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "other"))
+                        }
+                    }
+                }
+
+                dependencies {
+                    conf project(":")
+                }
+            }
+
+            task resolve {
+                def files = buildscript.configurations.conf.incoming.files
+                doLast {
+                    assert files*.name == ["bar.txt"]
+                }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        succeeds("resolve")
+    }
+
+    // This is not desired behavior. A project dependency should refer to the actual
+    // project, not its buildscript component. This is a bug.
+    def "project buildscript classpath configuration can select other buildscript configurations"() {
+        file("bar.txt") << "bar"
+        buildFile << """
+            buildscript {
+                configurations {
+                    classpath {
+                        // To ensure it doesn't select itself over `other`
+                        canBeConsumed = false
+                    }
+                    other {
+                        outgoing {
+                            artifact file('bar.txt')
+                        }
+                        attributes {
+                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "library"))
+                        }
+                    }
+                }
+
+                dependencies {
+                    classpath project(":")
+                }
+            }
+
+            task resolve {
+                def files = buildscript.configurations.classpath.incoming.files
+                doLast {
+                    assert files*.name == ["bar.txt"]
+                }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Calling setCanBeConsumed(false) on configuration ':classpath' has been deprecated. This will fail with an error in Gradle 9.0. This configuration's role was set upon creation and its usage should not be changed. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        succeeds("resolve")
+    }
+
+    // This is not desired behavior. A project dependency should refer to the actual
+    // project, not its buildscript component. This is a bug.
+    def "project buildscript resolvable configuration and consumable configuration from same project live in same resolved component"() {
+        file("foo.txt") << "foo"
+        buildFile << """
+            buildscript {
+                configurations {
+                    conf {
+                        canBeConsumed = false
+                        attributes {
+                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "foo"))
+                        }
+                    }
+                    other {
+                        outgoing {
+                            artifact file("foo.txt")
+                        }
+                        attributes {
+                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "foo"))
+                        }
+                    }
+                }
+
+                dependencies {
+                    conf project(":")
+                }
+            }
+
+            task resolve {
+                def rootComponent = buildscript.configurations.conf.incoming.resolutionResult.rootComponent
+                doLast {
+                    def root = rootComponent.get()
+                    assert root.id.projectName == 'root'
+                    assert root.variants.size() == 2
+                    def conf = root.variants.find { it.displayName == 'conf' }
+                    def other = root.variants.find { it.displayName == 'other' }
+                    assert conf != null
+                    assert other != null
+                }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        succeeds("resolve")
+    }
+
+    // This is not necessarily desired behavior, or important behavior at all -- who cares about the identity of the buildscript classpath resolution?
+    // The buildscript is _not_ the project. It should not claim to be the project.
+    // Ideally, this configuration would have an unspecified identity, similar to init, settings, and standalone scripts.
+    def "project buildscript classpath configuration is identified by the root project's identity"() {
+        buildFile << """
+            version = "1.0"
+            group = "foo"
+
+            task resolve {
+                def rootComponent = buildscript.configurations.classpath.incoming.resolutionResult.rootComponent
+                doLast {
+                    def root = rootComponent.get()
+                    assert root.moduleVersion.group == "foo"
+                    assert root.moduleVersion.name == "root"
+                    assert root.moduleVersion.version == "1.0"
+                    assert root.id instanceof ProjectComponentIdentifier
+                    assert root.id.projectName == "root"
+                    assert root.id.build.buildPath == ":"
+                    assert root.id.projectPath == ":"
+                    assert root.id.buildTreePath == ":"
+                    assert root.id.projectName == "root"
+                }
+            }
+        """
+
+        expect:
+        succeeds("resolve")
+    }
+
+    def "settings buildscript classpath configuration has unspecified identity"() {
+        settingsFile << """
+            def rootComponent = buildscript.configurations.classpath.incoming.resolutionResult.rootComponent
+            def root = rootComponent.get()
+            assert root.moduleVersion.group == "unspecified"
+            assert root.moduleVersion.name == "unspecified"
+            assert root.moduleVersion.version == "unspecified"
+            assert root.id instanceof ModuleComponentIdentifier
+            assert root.id.module == "unspecified"
+            assert root.id.group == "unspecified"
+            assert root.id.version == "unspecified"
+        """
+
+        expect:
+        succeeds("help")
+    }
+
+    def "init buildscript classpath configuration has unspecified identity"() {
+        initScriptFile << """
+            def rootComponent = buildscript.configurations.classpath.incoming.resolutionResult.rootComponent
+            def root = rootComponent.get()
+            assert root.moduleVersion.group == "unspecified"
+            assert root.moduleVersion.name == "unspecified"
+            assert root.moduleVersion.version == "unspecified"
+            assert root.id instanceof ModuleComponentIdentifier
+            assert root.id.module == "unspecified"
+            assert root.id.group == "unspecified"
+            assert root.id.version == "unspecified"
+        """
+
+        when:
+        executer.usingInitScript(initScriptFile)
+
+        then:
+        succeeds("help")
+    }
+
+    def "standalone buildscript classpath configuration has unspecified identity"() {
+        file("foo.gradle") << """
+            def rootComponent = buildscript.configurations.classpath.incoming.resolutionResult.rootComponent
+            def root = rootComponent.get()
+            assert root.moduleVersion.group == "unspecified"
+            assert root.moduleVersion.name == "unspecified"
+            assert root.moduleVersion.version == "unspecified"
+            assert root.id instanceof ModuleComponentIdentifier
+            assert root.id.module == "unspecified"
+            assert root.id.group == "unspecified"
+            assert root.id.version == "unspecified"
+        """
+
+        buildFile << """
+            apply from: "foo.gradle"
+        """
+
+        expect:
+        succeeds("help")
+    }
+
+    def "Adding configuration to project buildscript is deprecated"() {
+        buildFile << """
+            buildscript {
+                configurations {
+                    newconf
+                }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        succeeds("help")
+    }
+
+    def "Adding configuration to settings buildscript is deprecated"() {
+        settingsFile << """
+            buildscript {
+                configurations {
+                    newconf
+                }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for settings file 'settings.gradle' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        succeeds("help")
+    }
+
+    def "Adding configuration to init buildscript is deprecated"() {
+        initScriptFile << """
+            buildscript {
+                configurations {
+                    newconf
+                }
+            }
+        """
+
+        when:
+        executer.usingInitScript(initScriptFile)
+
+        then:
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for initialization script 'init.gradle' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        succeeds("help")
+    }
+
+    def "Adding configuration to standalone buildscript is deprecated"() {
+        file("foo.gradle") << """
+            buildscript {
+                configurations {
+                    newconf
+                }
+            }
+        """
+
+        buildFile << """
+            apply from: "foo.gradle"
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for script 'foo.gradle' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        succeeds("help")
+    }
+
+    def "project buildscripts support detached configurations for resolving external dependencies"() {
+        mavenRepo.module("org", "foo").publish()
+        buildFile << """
+            buildscript {
+                ${mavenTestRepository()}
+            }
+            task resolve {
+                def files = buildscript.configurations.detachedConfiguration(
+                    buildscript.dependencies.create("org:foo:1.0")
+                ).incoming.files
+                doLast {
+                    assert files.files*.name == ["foo-1.0.jar"]
+                }
+            }
+        """
+
+        expect:
+        succeeds("resolve")
+    }
+
+    def "settings buildscripts support detached configurations for resolving external dependencies"() {
+        mavenRepo.module("org", "foo").publish()
+        settingsFile << """
+            buildscript {
+                ${mavenTestRepository()}
+            }
+            def files = buildscript.configurations.detachedConfiguration(
+                buildscript.dependencies.create("org:foo:1.0")
+            ).incoming.files
+            assert files.files*.name == ["foo-1.0.jar"]
+        """
+
+        expect:
+        succeeds("help")
+    }
+
+    def "init buildscripts support detached configurations for resolving external dependencies"() {
+        mavenRepo.module("org", "foo").publish()
+        initScriptFile << """
+            buildscript {
+                ${mavenTestRepository()}
+            }
+            def files = buildscript.configurations.detachedConfiguration(
+                buildscript.dependencies.create("org:foo:1.0")
+            ).incoming.files
+            assert files.files*.name == ["foo-1.0.jar"]
+        """
+
+        when:
+        executer.usingInitScript(initScriptFile)
+
+        then:
+        succeeds("help")
+    }
+
+    def "standalone buildscripts support detached configurations for resolving external dependencies"() {
+        mavenRepo.module("org", "foo").publish()
+        file("foo.gradle") << """
+            buildscript {
+                ${mavenTestRepository()}
+            }
+            def files = buildscript.configurations.detachedConfiguration(
+                buildscript.dependencies.create("org:foo:1.0")
+            ).incoming.files
+            assert files.files*.name == ["foo-1.0.jar"]
+        """
+
+        buildFile << """
+            apply from: "foo.gradle"
+        """
+
+        expect:
+        succeeds("help")
+    }
+
+    // This is not necessarily desired behavior, or important behavior at all.
+    // The detached configuration is _not_ the project. It should not claim to be the project.
+    // Ideally, this configuration would have an unspecified identity, similar to init, settings, and standalone scripts.
+    def "project buildscripts detached configurations are identified as detached from root project's identity"() {
+        mavenRepo.module("org", "foo").publish()
+        buildFile << """
+            buildscript {
+                ${mavenTestRepository()}
+            }
+
+            version = "1.0"
+            group = "foo"
+
+            task resolve {
+                def rootComponent = buildscript.configurations.detachedConfiguration(
+                    buildscript.dependencies.create("org:foo:1.0")
+                ).incoming.resolutionResult.rootComponent
+                doLast {
+                    def root = rootComponent.get()
+                    assert root.moduleVersion.group == "foo"
+                    assert root.moduleVersion.name == "root-detachedConfiguration1"
+                    assert root.moduleVersion.version == "1.0"
+                    assert root.id instanceof ModuleComponentIdentifier
+                    assert root.id.group == "foo"
+                    assert root.id.module == "root-detachedConfiguration1"
+                    assert root.id.version == "1.0"
+                }
+            }
+        """
+
+        expect:
+        succeeds("resolve")
+    }
+
+    def "settings buildscripts detached configurations have unspecified identity"() {
+        mavenRepo.module("org", "foo").publish()
+        settingsFile << """
+            buildscript {
+                ${mavenTestRepository()}
+            }
+            def rootComponent = buildscript.configurations.detachedConfiguration(
+                buildscript.dependencies.create("org:foo:1.0")
+            ).incoming.resolutionResult.rootComponent
+            def root = rootComponent.get()
+            assert root.moduleVersion.group == "unspecified"
+            assert root.moduleVersion.name == "unspecified-detachedConfiguration1"
+            assert root.moduleVersion.version == "unspecified"
+            assert root.id instanceof ModuleComponentIdentifier
+            assert root.id.module == "unspecified-detachedConfiguration1"
+            assert root.id.group == "unspecified"
+            assert root.id.version == "unspecified"
+        """
+
+        expect:
+        succeeds("help")
+    }
+
+    def "init buildscripts detached configurations have unspecified identity"() {
+        mavenRepo.module("org", "foo").publish()
+        initScriptFile << """
+            buildscript {
+                ${mavenTestRepository()}
+            }
+            def rootComponent = buildscript.configurations.detachedConfiguration(
+                buildscript.dependencies.create("org:foo:1.0")
+            ).incoming.resolutionResult.rootComponent
+            def root = rootComponent.get()
+            assert root.moduleVersion.group == "unspecified"
+            assert root.moduleVersion.name == "unspecified-detachedConfiguration1"
+            assert root.moduleVersion.version == "unspecified"
+            assert root.id instanceof ModuleComponentIdentifier
+            assert root.id.module == "unspecified-detachedConfiguration1"
+            assert root.id.group == "unspecified"
+            assert root.id.version == "unspecified"
+        """
+
+        when:
+        executer.usingInitScript(initScriptFile)
+
+        then:
+        succeeds("help")
+    }
+
+    def "standalone buildscripts detached configurations have unspecified identity"() {
+        mavenRepo.module("org", "foo").publish()
+        file("foo.gradle") << """
+            buildscript {
+                ${mavenTestRepository()}
+            }
+            def rootComponent = buildscript.configurations.detachedConfiguration(
+                buildscript.dependencies.create("org:foo:1.0")
+            ).incoming.resolutionResult.rootComponent
+            def root = rootComponent.get()
+            assert root.moduleVersion.group == "unspecified"
+            assert root.moduleVersion.name == "unspecified-detachedConfiguration1"
+            assert root.moduleVersion.version == "unspecified"
+            assert root.id instanceof ModuleComponentIdentifier
+            assert root.id.module == "unspecified-detachedConfiguration1"
+            assert root.id.group == "unspecified"
+            assert root.id.version == "unspecified"
+        """
+
+        buildFile << """
+            apply from: "foo.gradle"
+        """
+
+        expect:
+        succeeds("help")
+    }
+
+    def "project buildscripts support detached configurations for resolving local dependencies"() {
+        buildFile << """
+            task resolve {
+                def conf = buildscript.configurations.detachedConfiguration(
+                    buildscript.dependencies.create(project(":other"))
+                )
+                conf.attributes {
+                    attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "foo"))
+                }
+                def files = conf.incoming.files
+                doLast {
+                    assert files.files*.name == ["foo.txt"]
+                }
+            }
+        """
+        settingsFile << """
+            include "other"
+        """
+        file("other/build.gradle") << """
+            configurations {
+                consumable("foo") {
+                    outgoing {
+                        artifact file("foo.txt")
+                    }
+                    attributes {
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "foo"))
+                    }
+                }
+            }
+        """
+
+        expect:
+        succeeds(":resolve")
+    }
+
+    def "standalone buildscripts support detached configurations for resolving local dependencies"() {
+        mavenRepo.module("org", "foo").publish()
+        file("foo.gradle") << """
+            buildscript {
+                ${mavenTestRepository()}
+            }
+            def files = buildscript.configurations.detachedConfiguration(
+                buildscript.dependencies.create(project(":other"))
+            ).incoming.files
+            assert files.files*.name == ["foo.txt"]
+        """
+        settingsFile << """
+            include "other"
+        """
+        file("other/build.gradle") << """
+            configurations {
+                consumable("foo") {
+                    outgoing {
+                        artifact file("foo.txt")
+                    }
+                    attributes {
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "foo"))
+                    }
+                }
+            }
+        """
+
+        buildFile << """
+            apply from: "foo.gradle"
+        """
+
+        expect:
+        succeeds("help")
+    }
+
+    def "creating a settings buildscript configuration is deprecated in Kotlin"() {
+        mavenRepo.module("org", "foo").publish()
+        settingsFile.delete()
+        settingsKotlinFile << """
+            buildscript {
+                ${mavenTestRepository(GradleDsl.KOTLIN)}
+                configurations {
+                    create("myConfig")
+                }
+                dependencies {
+                    "myConfig"("org:foo:1.0")
+                }
+            }
+
+            val files = buildscript.configurations["myConfig"].files
+            assert(files.map { it.name } == listOf("foo-1.0.jar"))
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for settings file 'settings.gradle.kts' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        succeeds("help")
+    }
+
+    def "creating a detached settings buildscript configuration works in Kotlin"() {
+        mavenRepo.module("org", "foo").publish()
+        settingsFile.delete()
+        settingsKotlinFile << """
+            buildscript {
+                ${mavenTestRepository(GradleDsl.KOTLIN)}
+            }
+
+            val myConfig = buildscript.configurations.detachedConfiguration(
+                buildscript.dependencies.create("org:foo:1.0")
+            )
+
+            val files = myConfig.files
+            assert(files.map { it.name } == listOf("foo-1.0.jar"))
+        """
+
+        expect:
+        succeeds("help")
+    }
+}

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/BuildscriptResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/BuildscriptResolutionIntegrationTest.groovy
@@ -62,7 +62,7 @@ class BuildscriptResolutionIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         executer.expectDocumentedDeprecationWarning("While resolving configuration 'conf', it was also selected as a variant. Configurations should not act as both a resolution root and a variant simultaneously. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false or use the 'resolvable(String)' configuration factory method to create them. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration")
-        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' using create(String, Closure) has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutating_buildscript_configurations")
         succeeds("resolve")
     }
 
@@ -137,7 +137,7 @@ class BuildscriptResolutionIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' using create(String, Closure) has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutating_buildscript_configurations")
         succeeds(":resolve")
     }
 
@@ -215,7 +215,7 @@ class BuildscriptResolutionIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of project ':first' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of project ':first' using create(String, Closure) has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutating_buildscript_configurations")
         succeeds(":first:resolve")
     }
 
@@ -289,8 +289,8 @@ class BuildscriptResolutionIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
-        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' using create(String, Closure) has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutating_buildscript_configurations")
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' using create(String, Closure) has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutating_buildscript_configurations")
         succeeds("resolve")
     }
 
@@ -330,7 +330,7 @@ class BuildscriptResolutionIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         executer.expectDocumentedDeprecationWarning("Calling setCanBeConsumed(false) on configuration ':classpath' has been deprecated. This will fail with an error in Gradle 9.0. This configuration's role was set upon creation and its usage should not be changed. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
-        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' using create(String, Closure) has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutating_buildscript_configurations")
         succeeds("resolve")
     }
 
@@ -377,8 +377,8 @@ class BuildscriptResolutionIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
-        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' using create(String, Closure) has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutating_buildscript_configurations")
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' using create(String, Closure) has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutating_buildscript_configurations")
         succeeds("resolve")
     }
 
@@ -479,7 +479,7 @@ class BuildscriptResolutionIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' using create(String) has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutating_buildscript_configurations")
         succeeds("help")
     }
 
@@ -493,7 +493,7 @@ class BuildscriptResolutionIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("Mutating configuration container for settings file 'settings.gradle' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for settings file 'settings.gradle' using create(String) has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutating_buildscript_configurations")
         succeeds("help")
     }
 
@@ -510,7 +510,7 @@ class BuildscriptResolutionIntegrationTest extends AbstractIntegrationSpec {
         executer.usingInitScript(initScriptFile)
 
         then:
-        executer.expectDocumentedDeprecationWarning("Mutating configuration container for initialization script 'init.gradle' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for initialization script 'init.gradle' using create(String) has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutating_buildscript_configurations")
         succeeds("help")
     }
 
@@ -528,7 +528,70 @@ class BuildscriptResolutionIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("Mutating configuration container for script 'foo.gradle' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for script 'foo.gradle' using create(String) has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutating_buildscript_configurations")
+        succeeds("help")
+    }
+
+    def "removing the classpath configuration from project buildscript is deprecated"() {
+        buildFile << """
+            buildscript {
+                configurations {
+                    remove(classpath)
+                }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' using remove(Object) has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutating_buildscript_configurations")
+        succeeds("help")
+    }
+
+    def "removing the classpath configuration from settings buildscript is deprecated"() {
+        settingsFile << """
+            buildscript {
+                configurations {
+                    remove(classpath)
+                }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for settings file 'settings.gradle' using remove(Object) has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutating_buildscript_configurations")
+        succeeds("help")
+    }
+
+    def "removing the classpath configuration from init buildscript is deprecated"() {
+        initScriptFile << """
+            buildscript {
+                configurations {
+                    remove(classpath)
+                }
+            }
+        """
+
+        when:
+        executer.usingInitScript(initScriptFile)
+
+        then:
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for initialization script 'init.gradle' using remove(Object) has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutating_buildscript_configurations")
+        succeeds("help")
+    }
+
+    def "removing the classpath configuration from standalone buildscript is deprecated"() {
+        file("foo.gradle") << """
+            buildscript {
+                configurations {
+                    remove(classpath)
+                }
+            }
+        """
+
+        buildFile << """
+            apply from: "foo.gradle"
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for script 'foo.gradle' using remove(Object) has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutating_buildscript_configurations")
         succeeds("help")
     }
 
@@ -806,7 +869,7 @@ class BuildscriptResolutionIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("Mutating configuration container for settings file 'settings.gradle.kts' has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#creating_new_buildscript_configurations")
+        executer.expectDocumentedDeprecationWarning("Mutating configuration container for settings file 'settings.gradle.kts' using create(String) has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutating_buildscript_configurations")
         succeeds("help")
     }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ScriptDependencyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ScriptDependencyResolveIntegrationTest.groovy
@@ -167,13 +167,13 @@ rootProject.name = 'testproject'
         buildFile << """
             buildscript {
                 configurations {
-                    foo {
+                    classpath {
                         attributes {
                             attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, "bar"))
                         }
                     }
                 }
-                assert configurations.foo.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).name == "bar"
+                assert configurations.classpath.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).name == "bar"
             }
 
             assert configurations.empty
@@ -187,13 +187,13 @@ rootProject.name = 'testproject'
         buildKotlinFile << """
             buildscript {
                 configurations {
-                    create("foo") {
+                    named("classpath") {
                         attributes {
                             attribute(Category.CATEGORY_ATTRIBUTE, objects.named<Category>("bar"))
                         }
                     }
                 }
-                assert(configurations.named("foo").get().attributes.getAttribute(Category.CATEGORY_ATTRIBUTE)?.name == "bar")
+                assert(configurations.named("classpath").get().attributes.getAttribute(Category.CATEGORY_ATTRIBUTE)?.name == "bar")
             }
 
             assert(configurations.isEmpty())

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultArtifactRepositoryContainer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultArtifactRepositoryContainer.java
@@ -97,7 +97,7 @@ public class DefaultArtifactRepositoryContainer extends DefaultNamedDomainObject
             repository.setName(uniquifyName(repositoryName));
         }
 
-        assertCanAdd(repository.getName());
+        assertElementNotPresent(repository.getName());
         insertion.execute(repository);
         return repository;
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -329,7 +329,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         this.roleAtCreation = roleAtCreation;
     }
 
-    private static Action<Void> validateMutationType(final MutationValidator mutationValidator, final MutationType type) {
+    private static Action<String> validateMutationType(final MutationValidator mutationValidator, final MutationType type) {
         return arg -> mutationValidator.validateMutation(type);
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -37,6 +37,7 @@ import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponen
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.internal.Actions;
 import org.gradle.internal.Cast;
+import org.gradle.internal.Describables;
 import org.gradle.internal.artifacts.configurations.AbstractRoleBasedConfigurationCreationRequest;
 import org.gradle.internal.artifacts.configurations.NoContextRoleBasedConfigurationCreationRequest;
 import org.gradle.internal.deprecation.DeprecationLogger;
@@ -61,9 +62,10 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
     @SuppressWarnings("deprecation")
     private static final Set<ConfigurationRole> VALID_MAYBE_CREATE_ROLES = new HashSet<>(Arrays.asList(ConfigurationRoles.CONSUMABLE, ConfigurationRoles.RESOLVABLE, ConfigurationRoles.DEPENDENCY_SCOPE, ConfigurationRoles.RESOLVABLE_DEPENDENCY_SCOPE));
 
+    private final DependencyMetaDataProvider rootComponentIdentity;
+    private final DomainObjectContext owner;
     private final DefaultConfigurationFactory defaultConfigurationFactory;
     private final ResolutionStrategyFactory resolutionStrategyFactory;
-    private final DependencyMetaDataProvider rootComponentIdentity;
 
     private final AtomicInteger detachedConfigurationDefaultNameCounter = new AtomicInteger(1);
     private final RootComponentMetadataBuilder rootComponentMetadataBuilder;
@@ -81,9 +83,10 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
     ) {
         super(Configuration.class, instantiator, Named.Namer.INSTANCE, callbackDecorator);
 
+        this.rootComponentIdentity = rootComponentIdentity;
+        this.owner = owner;
         this.defaultConfigurationFactory = defaultConfigurationFactory;
         this.resolutionStrategyFactory = resolutionStrategyFactory;
-        this.rootComponentIdentity = rootComponentIdentity;
 
         this.rootComponentMetadataBuilder = rootComponentMetadataBuilderFactory.create(owner, this, rootComponentIdentity, schema);
         this.getEventRegister().registerLazyAddAction(x -> rootComponentMetadataBuilder.getValidator().validateMutation(MutationValidator.MutationType.HIERARCHY));
@@ -171,99 +174,99 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
 
     @Override
     public NamedDomainObjectProvider<ResolvableConfiguration> resolvable(String name) {
-        assertMutable("resolvable(String)");
+        assertCanMutate("resolvable(String)");
         return registerResolvableConfiguration(name, Actions.doNothing());
     }
 
     @Override
     public NamedDomainObjectProvider<ResolvableConfiguration> resolvable(String name, Action<? super ResolvableConfiguration> action) {
-        assertMutable("resolvableUnlocked(String, Action)");
+        assertCanMutate("resolvableUnlocked(String, Action)");
         return registerResolvableConfiguration(name, action);
     }
 
     @Override
     public Configuration resolvableUnlocked(String name) {
-        assertMutable("resolvableUnlocked(String)");
+        assertCanMutate("resolvableUnlocked(String)");
         return createUnlockedConfiguration(name, ConfigurationRoles.RESOLVABLE, Actions.doNothing());
     }
 
     @Override
     public Configuration resolvableUnlocked(String name, Action<? super Configuration> action) {
-        assertMutable("resolvableUnlocked(String, Action)");
+        assertCanMutate("resolvableUnlocked(String, Action)");
         return createUnlockedConfiguration(name, ConfigurationRoles.RESOLVABLE, action);
     }
 
     @Override
     public NamedDomainObjectProvider<ConsumableConfiguration> consumable(String name) {
-        assertMutable("consumable(String)");
+        assertCanMutate("consumable(String)");
         return registerConsumableConfiguration(name, Actions.doNothing());
     }
 
     @Override
     public NamedDomainObjectProvider<ConsumableConfiguration> consumable(String name, Action<? super ConsumableConfiguration> action) {
-        assertMutable("consumable(String, Action)");
+        assertCanMutate("consumable(String, Action)");
         return registerConsumableConfiguration(name, action);
     }
 
     @Override
     public Configuration consumableUnlocked(String name) {
-        assertMutable("consumableUnlocked(String)");
+        assertCanMutate("consumableUnlocked(String)");
         return createUnlockedConfiguration(name, ConfigurationRoles.CONSUMABLE, Actions.doNothing());
     }
 
     @Override
     public Configuration consumableUnlocked(String name, Action<? super Configuration> action) {
-        assertMutable("consumableUnlocked(String, Action)");
+        assertCanMutate("consumableUnlocked(String, Action)");
         return createUnlockedConfiguration(name, ConfigurationRoles.CONSUMABLE, action);
     }
 
     @Override
     public NamedDomainObjectProvider<DependencyScopeConfiguration> dependencyScope(String name) {
-        assertMutable("dependencyScope(String)");
+        assertCanMutate("dependencyScope(String)");
         return registerDependencyScopeConfiguration(name, Actions.doNothing());
     }
 
     @Override
     public NamedDomainObjectProvider<DependencyScopeConfiguration> dependencyScope(String name, Action<? super DependencyScopeConfiguration> action) {
-        assertMutable("dependencyScope(String, Action)");
+        assertCanMutate("dependencyScope(String, Action)");
         return registerDependencyScopeConfiguration(name, action);
     }
 
     @Override
     public Configuration dependencyScopeUnlocked(String name) {
-        assertMutable("dependencyScopeUnlocked(String)");
+        assertCanMutate("dependencyScopeUnlocked(String)");
         return createUnlockedConfiguration(name, ConfigurationRoles.DEPENDENCY_SCOPE, Actions.doNothing());
     }
 
     @Override
     public Configuration dependencyScopeUnlocked(String name, Action<? super Configuration> action) {
-        assertMutable("dependencyScopeUnlocked(String, Action)");
+        assertCanMutate("dependencyScopeUnlocked(String, Action)");
         return createUnlockedConfiguration(name, ConfigurationRoles.DEPENDENCY_SCOPE, action);
     }
 
     @Override
     @Deprecated
     public Configuration resolvableDependencyScopeUnlocked(String name) {
-        assertMutable("resolvableDependencyScopeUnlocked(String)");
+        assertCanMutate("resolvableDependencyScopeUnlocked(String)");
         return createUnlockedConfiguration(name, ConfigurationRoles.RESOLVABLE_DEPENDENCY_SCOPE, Actions.doNothing());
     }
 
     @Override
     @Deprecated
     public Configuration resolvableDependencyScopeUnlocked(String name, Action<? super Configuration> action) {
-        assertMutable("resolvableDependencyScopeUnlocked(String, Action)");
+        assertCanMutate("resolvableDependencyScopeUnlocked(String, Action)");
         return createUnlockedConfiguration(name, ConfigurationRoles.RESOLVABLE_DEPENDENCY_SCOPE, action);
     }
 
     @Override
     public Configuration migratingUnlocked(String name, ConfigurationRole role) {
-        assertMutable("migratingUnlocked(String, ConfigurationRole)");
+        assertCanMutate("migratingUnlocked(String, ConfigurationRole)");
         return migratingUnlocked(name, role, Actions.doNothing());
     }
 
     @Override
     public Configuration migratingUnlocked(String name, ConfigurationRole role, Action<? super Configuration> action) {
-        assertMutable("migratingUnlocked(String, ConfigurationRole, Action)");
+        assertCanMutate("migratingUnlocked(String, ConfigurationRole, Action)");
 
         if (ConfigurationRolesForMigration.ALL.contains(role)) {
             return createUnlockedConfiguration(name, role, action);
@@ -399,5 +402,10 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
         protected I createDomainObject() {
             return factory.apply(getName());
         }
+    }
+
+    @Override
+    public String getDisplayName() {
+        return Describables.of("configuration container for", owner).getDisplayName();
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -37,7 +37,6 @@ import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponen
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.internal.Actions;
 import org.gradle.internal.Cast;
-import org.gradle.internal.Describables;
 import org.gradle.internal.artifacts.configurations.AbstractRoleBasedConfigurationCreationRequest;
 import org.gradle.internal.artifacts.configurations.NoContextRoleBasedConfigurationCreationRequest;
 import org.gradle.internal.deprecation.DeprecationLogger;
@@ -360,7 +359,7 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
 
         // TODO: Deprecate changing roles of unlocked non-legacy configurations.
 
-        assertCanAdd(name);
+        assertElementNotPresent(name);
         validateNameIsAllowed(name);
         Configuration configuration = defaultConfigurationFactory.create(name, this, resolutionStrategyFactory, rootComponentMetadataBuilder, role);
         add(configuration);
@@ -369,7 +368,7 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
     }
 
     private <T extends Configuration> NamedDomainObjectProvider<T> registerConfiguration(String name, Action<? super T> configureAction, Class<T> publicType, Function<String, T> factory) {
-        assertCanAdd(name);
+        assertElementNotPresent(name);
         validateNameIsAllowed(name);
 
         NamedDomainObjectProvider<T> configuration = Cast.uncheckedCast(
@@ -406,6 +405,6 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
 
     @Override
     public String getDisplayName() {
-        return Describables.of("configuration container for", owner).getDisplayName();
+        return "configuration container for " + owner.getDisplayName();
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/service/scopes/DetachedDependencyMetadataProvider.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/service/scopes/DetachedDependencyMetadataProvider.java
@@ -77,7 +77,7 @@ public class DetachedDependencyMetadataProvider implements DependencyMetaDataPro
 
         @Override
         public String getName() {
-            return module.getVersion() + "-" + suffix;
+            return module.getName() + "-" + suffix;
         }
 
         @Override

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentModelReportIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentModelReportIntegrationTest.groovy
@@ -72,7 +72,7 @@ class ComponentModelReportIntegrationTest extends AbstractIntegrationSpec {
                                          ⤷ ComponentModelBasePlugin.PluginRules#applyFallbackSourceConventions(LanguageSourceSet, ProjectIdentifier)
                             + tasks
                                   | Type:   	org.gradle.platform.base.BinaryTasksCollection
-                                  | Value:  	[]
+                                  | Value:  	Task collection
                                   | Creator: 	myComponent(UnmanagedComponent) { ... } @ build.gradle line 89, column 9 > create(myBinary)
                     + sources
                           | Type:   	org.gradle.model.ModelMap<org.gradle.language.base.LanguageSourceSet>
@@ -145,7 +145,7 @@ class ComponentModelReportIntegrationTest extends AbstractIntegrationSpec {
                                           | Creator: 	myComponent(ManagedComponent) { ... } @ build.gradle line 89, column 9 > create(myBinary) > create(myBinarySource)
                             + tasks
                                   | Type:   	org.gradle.platform.base.BinaryTasksCollection
-                                  | Value:  	[]
+                                  | Value:  	Task collection
                                   | Creator: 	myComponent(ManagedComponent) { ... } @ build.gradle line 89, column 9 > create(myBinary)
                     + data
                           | Type:   	java.lang.String

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/FunctionalSourceSetIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/FunctionalSourceSetIntegrationTest.groovy
@@ -236,7 +236,7 @@ class FunctionalSourceSetIntegrationTest extends AbstractIntegrationSpec {
         then:
         def modelNode = ModelReportOutput.from(output).modelNode
         modelNode.functionalSources.myJavaSourceSet.@type[0] == 'SomeJavaSourceSet'
-        modelNode.sources.@nodeValue[0]  == '[]'
+        modelNode.sources.@nodeValue[0]  == 'LanguageSourceSet collection'
 
         and:
         normaliseFileSeparators(output).contains("source dirs: [${normaliseFileSeparators(testDirectory.path)}/src/main/myJavaSourceSet]")

--- a/platforms/software/reporting/src/main/java/org/gradle/api/reporting/internal/DefaultReportContainer.java
+++ b/platforms/software/reporting/src/main/java/org/gradle/api/reporting/internal/DefaultReportContainer.java
@@ -21,9 +21,9 @@ import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.NamedDomainObjectSet;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultNamedDomainObjectSet;
+import org.gradle.api.internal.lambdas.SerializableLambdas;
 import org.gradle.api.reporting.Report;
 import org.gradle.api.reporting.ReportContainer;
-import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Internal;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.util.internal.ConfigureUtil;
@@ -37,18 +37,11 @@ public class DefaultReportContainer<T extends Report> extends DefaultNamedDomain
 
     public DefaultReportContainer(Class<? extends T> type, Instantiator instantiator, CollectionCallbackActionDecorator callbackActionDecorator) {
         super(type, instantiator, Report.NAMER, callbackActionDecorator);
+        beforeCollectionChanges(SerializableLambdas.action(arg -> {
+            throw new ImmutableViolationException();
+        }));
 
-        enabled = matching(new Spec<T>() {
-            @Override
-            public boolean isSatisfiedBy(T element) {
-                return element.getRequired().get();
-            }
-        });
-    }
-
-    @Override
-    protected void assertMutableCollectionContents() {
-        throw new ImmutableViolationException();
+        enabled = matching(SerializableLambdas.spec(element -> element.getRequired().get()));
     }
 
     @Override

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ObjectExtensionInstantiationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ObjectExtensionInstantiationIntegrationTest.groovy
@@ -364,7 +364,7 @@ class ObjectExtensionInstantiationIntegrationTest extends AbstractIntegrationSpe
             }
 
             extensions.create("thing", Thing)
-            assert thing.value.toString() == "[]"
+            assert thing.value.toString() == "Bean collection"
             assert thing.value.empty
             thing.value.add(new Bean(name: "a"))
             thing.value.add(new Bean(name: "b"))

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractNamedDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractNamedDomainObjectContainer.java
@@ -52,7 +52,7 @@ public abstract class AbstractNamedDomainObjectContainer<T> extends DefaultNamed
 
     @Override
     public T create(String name) {
-        assertMutable("create(String)");
+        assertCanMutate("create(String)");
         return create(name, Actions.doNothing());
     }
 
@@ -67,13 +67,13 @@ public abstract class AbstractNamedDomainObjectContainer<T> extends DefaultNamed
 
     @Override
     public T create(String name, Closure configureClosure) {
-        assertMutable("create(String, Closure)");
+        assertCanMutate("create(String, Closure)");
         return create(name, ConfigureUtil.configureUsing(configureClosure));
     }
 
     @Override
     public T create(String name, Action<? super T> configureAction) throws InvalidUserDataException {
-        assertMutable("create(String, Action)");
+        assertCanMutate("create(String, Action)");
         assertCanAdd(name);
         T object = doCreate(name);
         add(object);
@@ -104,13 +104,13 @@ public abstract class AbstractNamedDomainObjectContainer<T> extends DefaultNamed
 
     @Override
     public NamedDomainObjectProvider<T> register(String name) throws InvalidUserDataException {
-        assertMutable("register(String)");
+        assertCanMutate("register(String)");
         return createDomainObjectProvider(name, null);
     }
 
     @Override
     public NamedDomainObjectProvider<T> register(String name, Action<? super T> configurationAction) throws InvalidUserDataException {
-        assertMutable("register(String, Action)");
+        assertCanMutate("register(String, Action)");
         return createDomainObjectProvider(name, configurationAction);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractPolymorphicDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractPolymorphicDomainObjectContainer.java
@@ -46,7 +46,7 @@ public abstract class AbstractPolymorphicDomainObjectContainer<T>
 
     @Override
     public <U extends T> U create(String name, Class<U> type) {
-        assertMutable("create(String, Class)");
+        assertCanMutate("create(String, Class)");
         return create(name, type, null);
     }
 
@@ -61,7 +61,7 @@ public abstract class AbstractPolymorphicDomainObjectContainer<T>
 
     @Override
     public <U extends T> U create(String name, Class<U> type, Action<? super U> configuration) {
-        assertMutable("create(String, Class, Action)");
+        assertCanMutate("create(String, Class, Action)");
         assertCanAdd(name);
         U object = doCreate(name, type);
         add(object);
@@ -73,13 +73,13 @@ public abstract class AbstractPolymorphicDomainObjectContainer<T>
 
     @Override
     public <U extends T> NamedDomainObjectProvider<U> register(String name, Class<U> type) throws InvalidUserDataException {
-        assertMutable("register(String, Class)");
+        assertCanMutate("register(String, Class)");
         return createDomainObjectProvider(name, type, null);
     }
 
     @Override
     public <U extends T> NamedDomainObjectProvider<U> register(String name, Class<U> type, Action<? super U> configurationAction) throws InvalidUserDataException {
-        assertMutable("register(String, Class, Action)");
+        assertCanMutate("register(String, Class, Action)");
         return createDomainObjectProvider(name, type, configurationAction);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractPolymorphicDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractPolymorphicDomainObjectContainer.java
@@ -62,7 +62,7 @@ public abstract class AbstractPolymorphicDomainObjectContainer<T>
     @Override
     public <U extends T> U create(String name, Class<U> type, Action<? super U> configuration) {
         assertCanMutate("create(String, Class, Action)");
-        assertCanAdd(name);
+        assertElementNotPresent(name);
         U object = doCreate(name, type);
         add(object);
         if (configuration != null) {
@@ -84,7 +84,7 @@ public abstract class AbstractPolymorphicDomainObjectContainer<T>
     }
 
     protected <U extends T> NamedDomainObjectProvider<U> createDomainObjectProvider(String name, Class<U> type, @Nullable Action<? super U> configurationAction) {
-        assertCanAdd(name);
+        assertElementNotPresent(name);
         NamedDomainObjectProvider<U> provider = Cast.uncheckedCast(
             getInstantiator().newInstance(NamedDomainObjectCreatingProvider.class, AbstractPolymorphicDomainObjectContainer.this, name, type, configurationAction)
         );

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractValidatingNamedDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractValidatingNamedDomainObjectContainer.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal;
 
+import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Namer;
@@ -39,6 +40,18 @@ public abstract class AbstractValidatingNamedDomainObjectContainer<T> extends Ab
     protected AbstractValidatingNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, CollectionCallbackActionDecorator callbackActionDecorator) {
         super(type, instantiator, callbackActionDecorator);
         nameDescription = type.getSimpleName() + " name";
+    }
+
+    @Override
+    public T create(String name) {
+        NameValidator.validate(name, nameDescription, "");
+        return super.create(name);
+    }
+
+    @Override
+    public T create(String name, Closure configureClosure) {
+        NameValidator.validate(name, nameDescription, "");
+        return super.create(name, configureClosure);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/CompositeDomainObjectSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/CompositeDomainObjectSet.java
@@ -326,7 +326,7 @@ public class CompositeDomainObjectSet<T> extends DelegatingDomainObjectSet<T> {
         }
 
         @Override
-        public MutationGuard getMutationGuard() {
+        public MutationGuard getLazyBehaviorGuard() {
             return MutationGuards.identity();
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
@@ -190,7 +190,7 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
     @Override
     public void configureEach(Action<? super T> action) {
         assertEagerContext("configureEach(Action)");
-        Action<? super T> wrappedAction = withMutationDisabled(decorate(action));
+        Action<? super T> wrappedAction = wrapLazyAction(decorate(action));
         Action<? super T> registerLazyAddActionDecorated = eventRegister.registerLazyAddAction(wrappedAction);
 
         // copy in case any actions mutate the store
@@ -211,8 +211,8 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
         }
     }
 
-    protected <I extends T> Action<? super I> withMutationDisabled(Action<? super I> action) {
-        return store.getMutationGuard().withMutationDisabled(action);
+    protected <I extends T> Action<? super I> wrapLazyAction(Action<? super I> action) {
+        return store.getLazyBehaviorGuard().wrapLazyAction(action);
     }
 
     @Override
@@ -458,9 +458,7 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
      * This method should be called by methods that must not be called in lazy actions.
      */
     protected final void assertEagerContext(String methodName) {
-        // MutationGuard is poorly named. In practice, it tracks and asserts whether
-        // we are executing within a lazy context.
-        store.getMutationGuard().assertMutationAllowed(methodName, this);
+        store.getLazyBehaviorGuard().assertEagerContext(methodName, this);
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectSet.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal;
 
 import groovy.lang.Closure;
-import org.gradle.api.Action;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.internal.collections.CollectionEventRegister;
 import org.gradle.api.internal.collections.CollectionFilter;
@@ -24,37 +23,14 @@ import org.gradle.api.internal.collections.ElementSource;
 import org.gradle.api.internal.collections.IterationOrderRetainingSetElementSource;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
-import org.gradle.internal.ImmutableActionSet;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class DefaultDomainObjectSet<T> extends DefaultDomainObjectCollection<T> implements DomainObjectSet<T> {
-    // TODO: Combine these with MutationGuard
-    private ImmutableActionSet<Void> beforeContainerChange = ImmutableActionSet.empty();
 
     public DefaultDomainObjectSet(Class<? extends T> type, CollectionCallbackActionDecorator decorator) {
         super(type, new IterationOrderRetainingSetElementSource<T>(), decorator);
-    }
-
-    /**
-     * Adds an action which is executed before this collection is mutated with the addition or removal of elements.
-     * Any exception thrown by the action will veto the mutation.
-     *
-     * TODO: Combine this with the MutationGuard or rework CompositeDomainObject to behave with MutationGuard/MutationValidator.
-     * The mutation validators used in DefaultConfiguration only expect to be used with add/remove methods and fail when we
-     * correctly try to also prevent all/withType/etc mutation methods.
-     *
-     * assertMutableCollectionContents is only used by add/remove methods, but we should remove this special handling and fix
-     * DefaultConfiguration and CompositeDomainObjects.
-     */
-    public void beforeCollectionChanges(Action<Void> action) {
-        beforeContainerChange = beforeContainerChange.add(action);
-    }
-
-    @Override
-    protected void assertMutableCollectionContents() {
-        beforeContainerChange.execute(null);
     }
 
     public DefaultDomainObjectSet(Class<? extends T> type, ElementSource<T> store, CollectionCallbackActionDecorator decorator) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultMutationGuard.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultMutationGuard.java
@@ -26,32 +26,32 @@ public class DefaultMutationGuard implements MutationGuard {
     private final ThreadLocal<Boolean> mutationGuardState = ThreadLocal.withInitial(SerializableLambdas.supplier(() -> true));
 
     @Override
-    public <T> Action<? super T> withMutationDisabled(Action<? super T> action) {
+    public <T> Action<? super T> wrapLazyAction(Action<? super T> action) {
         return newActionWithMutation(action, false);
     }
 
     @Override
-    public <T> Action<? super T> withMutationEnabled(Action<? super T> action) {
+    public <T> Action<? super T> wrapEagerAction(Action<? super T> action) {
         return newActionWithMutation(action, true);
     }
 
     @Override
-    public boolean isMutationAllowed() {
+    public boolean isLazyContext() {
         boolean mutationAllowed = mutationGuardState.get();
         removeThreadLocalStateIfMutationAllowed(mutationAllowed);
-        return mutationAllowed;
+        return !mutationAllowed;
     }
 
     @Override
-    public void assertMutationAllowed(String methodName, Object target) {
-        if (!isMutationAllowed()) {
+    public void assertEagerContext(String methodName, Object target) {
+        if (isLazyContext()) {
             throw createIllegalStateException(new DslObject(target).getPublicType().getConcreteClass(), methodName, target);
         }
     }
 
     @Override
-    public <T> void assertMutationAllowed(String methodName, T target, Class<T> targetType) {
-        if (!isMutationAllowed()) {
+    public <T> void assertEagerContext(String methodName, T target, Class<T> targetType) {
+        if (isLazyContext()) {
             throw createIllegalStateException(targetType, methodName, target);
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -899,7 +899,7 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
         @Override
         public void configure(Action<? super I> action) {
             assertEagerContext("NamedDomainObjectProvider.configure(Action)");
-            withMutationDisabled(action).execute(get());
+            wrapLazyAction(action).execute(get());
         }
 
         @Override
@@ -949,7 +949,7 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
                 return;
             }
 
-            Action<? super I> wrappedAction = withMutationDisabled(action);
+            Action<? super I> wrappedAction = wrapLazyAction(action);
             Action<? super I> decoratedAction = getEventRegister().getDecorator().decorate(wrappedAction);
 
             if (object != null) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -218,19 +218,19 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
     }
 
     /**
-     * Asserts that an item with the given name can be added to this collection.
+     * Asserts that an item with the given name is not present in this collection.
      */
-    protected void assertCanAdd(String name) {
+    protected void assertElementNotPresent(String name) {
         if (hasWithName(name)) {
             throw new InvalidUserDataException(String.format("Cannot add a %s with name '%s' as a %s with that name already exists.", getTypeDisplayName(), name, getTypeDisplayName()));
         }
     }
 
     /**
-     * Asserts that the given item can be added to this collection.
+     * Asserts that this collection does not contain an item with the same name as the given item.
      */
-    protected void assertCanAdd(T t) {
-        assertCanAdd(getNamer().determineName(t));
+    protected void assertElementNotPresent(T t) {
+        assertElementNotPresent(getNamer().determineName(t));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectList.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectList.java
@@ -48,7 +48,7 @@ public class DefaultNamedDomainObjectList<T> extends DefaultNamedDomainObjectCol
 
     @Override
     public void add(int index, T element) {
-        assertMutable("add(int, T)");
+        assertCanMutate("add(int, T)");
         assertCanAdd(element);
         getStore().add(index, element);
         didAdd(element);
@@ -57,7 +57,7 @@ public class DefaultNamedDomainObjectList<T> extends DefaultNamedDomainObjectCol
 
     @Override
     public boolean addAll(int index, Collection<? extends T> c) {
-        assertMutable("addAll(int, Collection)");
+        assertCanMutate("addAll(int, Collection)");
         boolean changed = false;
         int current = index;
         for (T t : c) {
@@ -84,7 +84,7 @@ public class DefaultNamedDomainObjectList<T> extends DefaultNamedDomainObjectCol
 
     @Override
     public T set(int index, T element) {
-        assertMutable("set(int, T)");
+        assertCanMutate("set(int, T)");
         assertCanAdd(element);
         T oldElement = getStore().set(index, element);
         if (oldElement != null) {
@@ -98,7 +98,7 @@ public class DefaultNamedDomainObjectList<T> extends DefaultNamedDomainObjectCol
 
     @Override
     public T remove(int index) {
-        assertMutable("remove(int)");
+        assertCanMutate("remove(int)");
         T element = getStore().remove(index);
         if (element != null) {
             didRemove(element);
@@ -205,7 +205,7 @@ public class DefaultNamedDomainObjectList<T> extends DefaultNamedDomainObjectCol
 
         @Override
         public void add(T t) {
-            assertMutable("listIterator().add(T)");
+            assertCanMutate("listIterator().add(T)");
             assertCanAdd(t);
             iterator.add(t);
             didAdd(t);
@@ -214,7 +214,7 @@ public class DefaultNamedDomainObjectList<T> extends DefaultNamedDomainObjectCol
 
         @Override
         public void remove() {
-            assertMutable("listIterator().remove()");
+            assertCanMutate("listIterator().remove()");
             iterator.remove();
             didRemove(lastElement);
             getEventRegister().fireObjectRemoved(lastElement);
@@ -223,7 +223,7 @@ public class DefaultNamedDomainObjectList<T> extends DefaultNamedDomainObjectCol
 
         @Override
         public void set(T t) {
-            assertMutable("listIterator().set(T)");
+            assertCanMutate("listIterator().set(T)");
             assertCanAdd(t);
             iterator.set(t);
             didRemove(lastElement);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectList.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectList.java
@@ -49,7 +49,7 @@ public class DefaultNamedDomainObjectList<T> extends DefaultNamedDomainObjectCol
     @Override
     public void add(int index, T element) {
         assertCanMutate("add(int, T)");
-        assertCanAdd(element);
+        assertElementNotPresent(element);
         getStore().add(index, element);
         didAdd(element);
         getEventRegister().fireObjectAdded(element);
@@ -85,7 +85,7 @@ public class DefaultNamedDomainObjectList<T> extends DefaultNamedDomainObjectCol
     @Override
     public T set(int index, T element) {
         assertCanMutate("set(int, T)");
-        assertCanAdd(element);
+        assertElementNotPresent(element);
         T oldElement = getStore().set(index, element);
         if (oldElement != null) {
             didRemove(oldElement);
@@ -206,7 +206,7 @@ public class DefaultNamedDomainObjectList<T> extends DefaultNamedDomainObjectCol
         @Override
         public void add(T t) {
             assertCanMutate("listIterator().add(T)");
-            assertCanAdd(t);
+            assertElementNotPresent(t);
             iterator.add(t);
             didAdd(t);
             getEventRegister().fireObjectAdded(t);
@@ -224,7 +224,7 @@ public class DefaultNamedDomainObjectList<T> extends DefaultNamedDomainObjectCol
         @Override
         public void set(T t) {
             assertCanMutate("listIterator().set(T)");
-            assertCanAdd(t);
+            assertElementNotPresent(t);
             iterator.set(t);
             didRemove(lastElement);
             getEventRegister().fireObjectRemoved(lastElement);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectSet.java
@@ -103,7 +103,7 @@ public class DefaultNamedDomainObjectSet<T> extends DefaultNamedDomainObjectColl
     }
 
     @Override
-    protected <I extends T> Action<? super I> withMutationDisabled(Action<? super I> action) {
-        return parentMutationGuard.withMutationDisabled(super.withMutationDisabled(action));
+    protected <I extends T> Action<? super I> wrapLazyAction(Action<? super I> action) {
+        return parentMutationGuard.wrapLazyAction(super.wrapLazyAction(action));
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DelegatingDomainObjectSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DelegatingDomainObjectSet.java
@@ -180,12 +180,17 @@ public class DelegatingDomainObjectSet<T> implements DomainObjectSet<T>, DomainO
     }
 
     @Override
-    public MutationGuard getMutationGuard() {
-        return ((DomainObjectCollectionInternal<?>) delegate).getMutationGuard();
+    public int estimatedSize() {
+        return ((DomainObjectCollectionInternal<?>) delegate).estimatedSize();
     }
 
     @Override
-    public int estimatedSize() {
-        return ((DomainObjectCollectionInternal<?>) delegate).estimatedSize();
+    public void beforeCollectionChanges(Action<String> action) {
+        ((DomainObjectCollectionInternal<?>) delegate).beforeCollectionChanges(action);
+    }
+
+    @Override
+    public String getDisplayName() {
+        return ((DomainObjectCollectionInternal<?>) delegate).getDisplayName();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DomainObjectCollectionInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DomainObjectCollectionInternal.java
@@ -15,24 +15,23 @@
  */
 package org.gradle.api.internal;
 
+import org.gradle.api.Action;
+import org.gradle.api.Describable;
 import org.gradle.api.DomainObjectCollection;
 import org.gradle.api.internal.collections.ElementSource;
-import org.gradle.api.tasks.Internal;
 
 /**
  * Internal counterpart to {@link DomainObjectCollection}.
  */
-public interface DomainObjectCollectionInternal<T> extends DomainObjectCollection<T> {
-
-    /**
-     * Get the guard that controls the mutation of this collection.
-     */
-    @Internal
-    MutationGuard getMutationGuard();
+public interface DomainObjectCollectionInternal<T> extends DomainObjectCollection<T>, Describable {
 
     /**
      * @see ElementSource#estimatedSize()
      */
     int estimatedSize();
 
+    /**
+     * Provide an action to be executed before any changes are made to the collection.
+     */
+    void beforeCollectionChanges(Action<String> action);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/FactoryNamedDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/FactoryNamedDomainObjectContainer.java
@@ -90,8 +90,8 @@ public class FactoryNamedDomainObjectContainer<T> extends AbstractNamedDomainObj
     }
 
     @Override
-    protected <I extends T> Action<? super I> withMutationDisabled(Action<? super I> action) {
-        return crossProjectConfiguratorMutationGuard.withMutationDisabled(super.withMutationDisabled(action));
+    protected <I extends T> Action<? super I> wrapLazyAction(Action<? super I> action) {
+        return crossProjectConfiguratorMutationGuard.wrapLazyAction(super.wrapLazyAction(action));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/FactoryNamedDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/FactoryNamedDomainObjectContainer.java
@@ -30,6 +30,9 @@ public class FactoryNamedDomainObjectContainer<T> extends AbstractNamedDomainObj
     private final NamedDomainObjectFactory<T> factory;
     private final MutationGuard crossProjectConfiguratorMutationGuard;
 
+    // Many of these constructors are called by the nebula plugins
+    // https://github.com/nebula-plugins/nebula-project-plugin/blob/f0f587f7b7014b6202875dc499dae05b0fc32344/src/main/groovy/nebula/plugin/responsible/gradle/NamedContainerProperOrder.groovy#L12-L31
+
     /**
      * <p>Creates a container that instantiates using the given factory.<p>
      *
@@ -97,6 +100,12 @@ public class FactoryNamedDomainObjectContainer<T> extends AbstractNamedDomainObj
     @Override
     protected T doCreate(String name) {
         return factory.create(name);
+    }
+
+    // For backwards compatibility with nebula plugins
+    // https://github.com/nebula-plugins/nebula-project-plugin/blob/f0f587f7b7014b6202875dc499dae05b0fc32344/src/main/groovy/nebula/plugin/responsible/gradle/NamedContainerProperOrder.groovy#L35
+    protected void assertCanAdd(String name) {
+        assertElementNotPresent(name);
     }
 
     private static class ClosureObjectFactory<T> implements NamedDomainObjectFactory<T> {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/MutationGuard.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/MutationGuard.java
@@ -19,41 +19,49 @@ package org.gradle.api.internal;
 import org.gradle.api.Action;
 
 /**
- * A guard object for the mutability of an object.
- * All mutable methods of an object protected by this guard needs to be guarded
- * by calling {@code #assertMutationAllowed(String)}.
+ * Tracks whether the current thread is executing a lazy operation.
+ * <p>
+ * This class is poorly named, and should be renamed to something like "LazyGuard",
+ * as the intention of this class is to track whether the current thread is executing
+ * a lazy action, so that we can fail other operations in those cases.
  */
 public interface MutationGuard {
     /**
-     * Wraps the specified action with mutation disabling code.
+     * Wraps the specified action that is executed lazily. When this action
+     * is executed, the executing thread is marked as executing a lazy operation.
      *
-     * @param action the action to disable mutation during execution.
-     * @param <T> the action parameter type
+     * @param action the action to wrap.
+     *
      * @return an action
      */
-    <T> Action<? super T> withMutationDisabled(Action<? super T> action);
+    <T> Action<? super T> wrapLazyAction(Action<? super T> action);
 
     /**
-     * Wraps the specified action with mutation enabling code.
+     * Wraps the specified action that is executed eagerly. When this action
+     * is executed, the executing thread is marked as executing an eager operation.
      *
-     * @param action the action to enable mutation during execution.
-     * @param <T> the action parameter type
+     * @param action the action to wrap.
+     *
      * @return an action
      */
-    <T> Action<? super T> withMutationEnabled(Action<? super T> action);
+    <T> Action<? super T> wrapEagerAction(Action<? super T> action);
 
     /**
-     * Returns {@code true} if the mutation is enabled, and {@code false} otherwise.
+     * Returns {@code true} iff the current thread is executing a lazy operation.
      */
-    boolean isMutationAllowed();
+    boolean isLazyContext();
 
     /**
-     * Throws exception when mutation is not allowed.
+     * Throws exception if the current thread is executing a lazy action.
      *
      * @param methodName the method name the assertion is testing
      * @param target the target object been asserted on
      */
-    void assertMutationAllowed(String methodName, Object target);
+    void assertEagerContext(String methodName, Object target);
 
-    <T> void assertMutationAllowed(String methodName, T target, Class<T> targetType);
+    /**
+     * Same as {@link #assertEagerContext(String, Object)}, but the public type
+     * of the target may be specified for improved error messages.
+     */
+    <T> void assertEagerContext(String methodName, T target, Class<T> targetType);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/MutationGuards.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/MutationGuards.java
@@ -21,27 +21,27 @@ import org.gradle.api.Action;
 public class MutationGuards {
     private static final MutationGuard IDENTITY_MUTATION_GUARD = new MutationGuard() {
         @Override
-        public <T> Action<? super T> withMutationDisabled(Action<? super T> action) {
+        public <T> Action<? super T> wrapLazyAction(Action<? super T> action) {
             return action;
         }
 
         @Override
-        public <T> Action<? super T> withMutationEnabled(Action<? super T> action) {
+        public <T> Action<? super T> wrapEagerAction(Action<? super T> action) {
             return action;
         }
 
         @Override
-        public boolean isMutationAllowed() {
-            return true;
+        public boolean isLazyContext() {
+            return false;
         }
 
         @Override
-        public void assertMutationAllowed(String methodName, Object target) {
+        public void assertEagerContext(String methodName, Object target) {
             // do nothing
         }
 
         @Override
-        public <T> void assertMutationAllowed(String methodName, T target, Class<T> targetType) {
+        public <T> void assertEagerContext(String methodName, T target, Class<T> targetType) {
             // do nothing
         }
     };

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/RoleBasedConfigurationContainerInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/RoleBasedConfigurationContainerInternal.java
@@ -20,6 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.internal.DomainObjectCollectionInternal;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -34,7 +35,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
  * <strong>New configurations should leverage the role-based factory methods on {@link ConfigurationContainer}.</strong>
  */
 @ServiceScope(Scope.Project.class)
-public interface RoleBasedConfigurationContainerInternal extends ConfigurationContainer {
+public interface RoleBasedConfigurationContainerInternal extends ConfigurationContainer, DomainObjectCollectionInternal<Configuration> {
 
     /**
      * Creates a consumable configuration which can change roles.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/AbstractIterationOrderRetainingElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/AbstractIterationOrderRetainingElementSource.java
@@ -52,7 +52,7 @@ abstract public class AbstractIterationOrderRetainingElementSource<T> implements
     // or provided.  We construct a correct iteration order from this set.
     private final List<Element<T>> inserted = new ArrayList<>();
 
-    private final MutationGuard mutationGuard = new DefaultMutationGuard();
+    private final MutationGuard lazyGuard = new DefaultMutationGuard();
 
     private Action<T> pendingAddedAction;
     private EventSubscriptionVerifier<T> subscriptionVerifier = type -> false;
@@ -229,8 +229,8 @@ abstract public class AbstractIterationOrderRetainingElementSource<T> implements
     }
 
     @Override
-    public MutationGuard getMutationGuard() {
-        return mutationGuard;
+    public MutationGuard getLazyBehaviorGuard() {
+        return lazyGuard;
     }
 
     protected class RealizedElementCollectionIterator implements Iterator<T> {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/ElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/ElementSource.java
@@ -106,8 +106,8 @@ public interface ElementSource<T> extends Iterable<T> {
     void onPendingAdded(Action<T> action);
 
     /**
-     * Controls the mutability of this element source.
+     * Tracks whether lazy actions are currently being executed against this element source.
      */
-    MutationGuard getMutationGuard();
+    MutationGuard getLazyBehaviorGuard();
 
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/FilteredElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/FilteredElementSource.java
@@ -93,8 +93,8 @@ public class FilteredElementSource<T, S extends T> implements ElementSource<S> {
     }
 
     @Override
-    public MutationGuard getMutationGuard() {
-        return collection.getMutationGuard();
+    public MutationGuard getLazyBehaviorGuard() {
+        return collection.getLazyBehaviorGuard();
     }
 
     private static class FilteringIterator<T, S extends T> implements Iterator<S> {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/SortedSetElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/SortedSetElementSource.java
@@ -45,7 +45,7 @@ public class SortedSetElementSource<T> implements ElementSource<T> {
     private Set<Collectors.TypedCollector<T>> pending = Collections.emptySet();
     private Action<T> addRealizedAction;
     private EventSubscriptionVerifier<T> subscriptionVerifier = type -> false;
-    private final MutationGuard mutationGuard = new DefaultMutationGuard();
+    private final MutationGuard lazyGuard = new DefaultMutationGuard();
 
     public SortedSetElementSource(Comparator<T> comparator) {
         this.values = new TreeSet<T>(comparator);
@@ -261,7 +261,7 @@ public class SortedSetElementSource<T> implements ElementSource<T> {
     }
 
     @Override
-    public MutationGuard getMutationGuard() {
-        return mutationGuard;
+    public MutationGuard getLazyBehaviorGuard() {
+        return lazyGuard;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultBuildLogicBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultBuildLogicBuilder.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.initialization;
 
+import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
@@ -68,7 +69,9 @@ public class DefaultBuildLogicBuilder implements BuildLogicBuilder {
         List<TaskIdentifier.TaskBasedTaskIdentifier> tasksToBuild = new ArrayList<>();
         for (Task task : getDependenciesForInternalUse(classpath)) {
             BuildState targetBuild = owningBuildOf(task);
-            assert targetBuild != currentBuild;
+            if (targetBuild == currentBuild) {
+                throw new InvalidUserDataException("Script classpath dependencies must reside in a separate build from the script itself.");
+            }
             tasksToBuild.add(TaskIdentifier.of(targetBuild.getBuildIdentifier(), (TaskInternal) task));
         }
         return tasksToBuild;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
@@ -35,6 +35,7 @@ import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.internal.Factory;
 import org.gradle.internal.classloader.ClasspathUtil;
 import org.gradle.internal.classpath.ClassPath;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.resource.ResourceLocation;
 import org.gradle.util.internal.ConfigureUtil;
 
@@ -158,6 +159,12 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
         }
         if (classpathConfiguration == null) {
             classpathConfiguration = configContainer.migratingUnlocked(CLASSPATH_CONFIGURATION, ConfigurationRolesForMigration.LEGACY_TO_RESOLVABLE_DEPENDENCY_SCOPE);
+            configContainer.beforeCollectionChanges(methodName ->
+                DeprecationLogger.deprecateAction("Mutating " + configContainer.getDisplayName())
+                .willBecomeAnErrorInGradle9()
+                .withUpgradeGuideSection(8, "creating_new_buildscript_configurations")
+                .nagUser()
+            );
             buildLogicBuilder.prepareClassPath(classpathConfiguration, resolutionContext);
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
@@ -160,9 +160,9 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
         if (classpathConfiguration == null) {
             classpathConfiguration = configContainer.migratingUnlocked(CLASSPATH_CONFIGURATION, ConfigurationRolesForMigration.LEGACY_TO_RESOLVABLE_DEPENDENCY_SCOPE);
             configContainer.beforeCollectionChanges(methodName ->
-                DeprecationLogger.deprecateAction("Mutating " + configContainer.getDisplayName())
+                DeprecationLogger.deprecateAction("Mutating " + configContainer.getDisplayName() + " using " + methodName)
                 .willBecomeAnErrorInGradle9()
-                .withUpgradeGuideSection(8, "creating_new_buildscript_configurations")
+                .withUpgradeGuideSection(8, "mutating_buildscript_configurations")
                 .nagUser()
             );
             buildLogicBuilder.prepareClassPath(classpathConfiguration, resolutionContext);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/BuildOperationCrossProjectConfigurator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/BuildOperationCrossProjectConfigurator.java
@@ -31,7 +31,7 @@ import java.util.Collections;
 public class BuildOperationCrossProjectConfigurator implements CrossProjectConfigurator {
 
     private final BuildOperationRunner buildOperationRunner;
-    private final MutationGuard mutationGuard = new DefaultMutationGuard();
+    private final MutationGuard lazyGuard = new DefaultMutationGuard();
 
     public BuildOperationCrossProjectConfigurator(BuildOperationRunner buildOperationRunner) {
         this.buildOperationRunner = buildOperationRunner;
@@ -65,14 +65,14 @@ public class BuildOperationCrossProjectConfigurator implements CrossProjectConfi
         project.getOwner().applyToMutableState(p -> buildOperationRunner.run(new CrossConfigureProjectBuildOperation(project) {
             @Override
             public void run(BuildOperationContext context) {
-                Actions.with(project, mutationGuard.withMutationEnabled(configureAction));
+                Actions.with(project, lazyGuard.wrapEagerAction(configureAction));
             }
         }));
     }
 
     @Override
-    public MutationGuard getMutationGuard() {
-        return mutationGuard;
+    public MutationGuard getLazyBehaviorGuard() {
+        return lazyGuard;
     }
 
     private final static BuildOperationDescriptor.Builder ALLPROJECTS_DETAILS = computeConfigurationBlockBuildOperationDetails("allprojects");

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/CrossProjectConfigurator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/CrossProjectConfigurator.java
@@ -30,6 +30,10 @@ public interface CrossProjectConfigurator {
 
     void rootProject(ProjectInternal project, Action<? super Project> buildOperationExecutor);
 
-    MutationGuard getMutationGuard();
+    /**
+     * Tracks whether the current thread is executing a lazy operation on a domain
+     * object within this project.
+     */
+    MutationGuard getLazyBehaviorGuard();
 
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -1043,26 +1043,26 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Override
     public void beforeEvaluate(Action<? super Project> action) {
-        assertMutatingMethodAllowed("beforeEvaluate(Action)");
+        assertEagerContext("beforeEvaluate(Action)");
         evaluationListener.add("beforeEvaluate", getListenerBuildOperationDecorator().decorate("Project.beforeEvaluate", action));
     }
 
     @Override
     public void afterEvaluate(Action<? super Project> action) {
-        assertMutatingMethodAllowed("afterEvaluate(Action)");
+        assertEagerContext("afterEvaluate(Action)");
         failAfterProjectIsEvaluated("afterEvaluate(Action)");
         evaluationListener.add("afterEvaluate", getListenerBuildOperationDecorator().decorate("Project.afterEvaluate", action));
     }
 
     @Override
     public void beforeEvaluate(Closure closure) {
-        assertMutatingMethodAllowed("beforeEvaluate(Closure)");
+        assertEagerContext("beforeEvaluate(Closure)");
         evaluationListener.add(new ClosureBackedMethodInvocationDispatch("beforeEvaluate", getListenerBuildOperationDecorator().decorate("Project.beforeEvaluate", Cast.<Closure<?>>uncheckedNonnullCast(closure))));
     }
 
     @Override
     public void afterEvaluate(Closure closure) {
-        assertMutatingMethodAllowed("afterEvaluate(Closure)");
+        assertEagerContext("afterEvaluate(Closure)");
         failAfterProjectIsEvaluated("afterEvaluate(Closure)");
         evaluationListener.add(new ClosureBackedMethodInvocationDispatch("afterEvaluate", getListenerBuildOperationDecorator().decorate("Project.afterEvaluate", Cast.<Closure<?>>uncheckedNonnullCast(closure))));
     }
@@ -1471,8 +1471,12 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
             : nextBatch.getSource();
     }
 
-    private void assertMutatingMethodAllowed(String methodName) {
-        getProjectConfigurator().getMutationGuard().assertMutationAllowed(methodName, this, Project.class);
+    /**
+     * Assert that the current thread is not running a lazy action on a domain object within this project.
+     *  This method should be called by methods that must not be called in lazy actions.
+     */
+    private void assertEagerContext(String methodName) {
+        getProjectConfigurator().getLazyBehaviorGuard().assertEagerContext(methodName, this, Project.class);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskCollection.java
@@ -151,8 +151,8 @@ public class DefaultTaskCollection<T extends Task> extends DefaultNamedDomainObj
     }
 
     @Override
-    protected <I extends T> Action<? super I> withMutationDisabled(Action<? super I> action) {
-        return parentMutationGuard.withMutationDisabled(super.withMutationDisabled(action));
+    protected <I extends T> Action<? super I> wrapLazyAction(Action<? super I> action) {
+        return parentMutationGuard.wrapLazyAction(super.wrapLazyAction(action));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -108,7 +108,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         CollectionCallbackActionDecorator callbackDecorator,
         ProjectRegistry<ProjectInternal> projectRegistry
     ) {
-        super(Task.class, instantiator, project, crossProjectConfigurator.getMutationGuard(), callbackDecorator);
+        super(Task.class, instantiator, project, crossProjectConfigurator.getLazyBehaviorGuard(), callbackDecorator);
         this.taskIdentityFactory = taskIdentityFactory;
         this.taskFactory = taskFactory;
         taskInstantiator = new TaskInstantiator(taskIdentityFactory, taskFactory, project);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -120,7 +120,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
     @Override
     public Task create(Map<String, ?> options) {
-        assertMutable("create(Map<String, ?>)");
+        assertCanMutate("create(Map)");
         return doCreate(options, Actions.doNothing());
     }
 
@@ -244,7 +244,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
                         onCreate = Cast.uncheckedCast(taskProvider.getOnCreateActions().mergeFrom(getEventRegister().getAddActions()));
                     }
 
-                    add(task, onCreate);
+                    doAdd(task, onCreate);
                     return; // Exit early as we are reusing the create actions from the provider
                 } else {
                     throw new IllegalStateException("Unnecessarily replacing a task that does not exist is not supported.  Use create() or register() directly instead.  You attempted to replace a task named '" + name + "', but there is no existing task with that name.");
@@ -272,19 +272,19 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
     @Override
     public Task create(Map<String, ?> options, Closure configureClosure) throws InvalidUserDataException {
-        assertMutable("create(Map<String, ?>, Closure)");
+        assertCanMutate("create(Map, Closure)");
         return doCreate(options, ConfigureUtil.configureUsing(configureClosure));
     }
 
     @Override
     public <T extends Task> T create(String name, Class<T> type) {
-        assertMutable("create(String, Class)");
+        assertCanMutate("create(String, Class)");
         return doCreate(name, type, NO_ARGS, Actions.doNothing());
     }
 
     @Override
     public <T extends Task> T create(final String name, final Class<T> type, final Object... constructorArgs) throws InvalidUserDataException {
-        assertMutable("create(String, Class, Object...)");
+        assertCanMutate("create(String, Class, Object...)");
         return doCreate(name, type, constructorArgs, Actions.doNothing());
     }
 
@@ -334,13 +334,13 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
     @Override
     public Task create(String name) {
-        assertMutable("create(String)");
+        assertCanMutate("create(String)");
         return doCreate(name, DefaultTask.class, NO_ARGS, Actions.doNothing());
     }
 
     @Override
     public Task create(String name, Action<? super Task> configureAction) throws InvalidUserDataException {
-        assertMutable("create(String, Action)");
+        assertCanMutate("create(String, Action)");
         return doCreate(name, DefaultTask.class, NO_ARGS, configureAction);
     }
 
@@ -355,19 +355,19 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
     @Override
     public Task replace(String name) {
-        assertMutable("replace(String)");
+        assertCanMutate("replace(String)");
         return replace(name, DefaultTask.class);
     }
 
     @Override
     public Task create(String name, Closure configureClosure) {
-        assertMutable("create(String, Closure)");
+        assertCanMutate("create(String, Closure)");
         return doCreate(name, DefaultTask.class, NO_ARGS, ConfigureUtil.configureUsing(configureClosure));
     }
 
     @Override
     public <T extends Task> T create(String name, Class<T> type, Action<? super T> configuration) throws InvalidUserDataException {
-        assertMutable("create(String, Class, Action)");
+        assertCanMutate("create(String, Class, Action)");
         T task = create(name, type);
         configuration.execute(task);
         return task;
@@ -375,31 +375,31 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
     @Override
     public TaskProvider<Task> register(String name, Action<? super Task> configurationAction) throws InvalidUserDataException {
-        assertMutable("register(String, Action)");
+        assertCanMutate("register(String, Action)");
         return Cast.uncheckedCast(register(name, DefaultTask.class, configurationAction));
     }
 
     @Override
     public <T extends Task> TaskProvider<T> register(String name, Class<T> type, Action<? super T> configurationAction) throws InvalidUserDataException {
-        assertMutable("register(String, Class, Action)");
+        assertCanMutate("register(String, Class, Action)");
         return registerTask(name, type, configurationAction, NO_ARGS);
     }
 
     @Override
     public <T extends Task> TaskProvider<T> register(String name, Class<T> type) throws InvalidUserDataException {
-        assertMutable("register(String, Class)");
+        assertCanMutate("register(String, Class)");
         return register(name, type, NO_ARGS);
     }
 
     @Override
     public TaskProvider<Task> register(String name) throws InvalidUserDataException {
-        assertMutable("register(String)");
+        assertCanMutate("register(String)");
         return Cast.uncheckedCast(register(name, DefaultTask.class));
     }
 
     @Override
     public <T extends Task> TaskProvider<T> register(String name, Class<T> type, Object... constructorArgs) {
-        assertMutable("register(String, Class, Object...)");
+        assertCanMutate("register(String, Class, Object...)");
         return registerTask(name, type, null, constructorArgs);
     }
 
@@ -438,7 +438,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
     @Override
     public <T extends Task> T replace(final String name, final Class<T> type) {
-        assertMutable("replace(String, Class)");
+        assertCanMutate("replace(String, Class)");
         final TaskIdentity<T> identity = taskIdentityFactory.create(name, type, project);
         return buildOperationRunner.call(new CallableBuildOperation<T>() {
             @Override
@@ -462,7 +462,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
     @Override
     public <T extends Task> T createWithoutConstructor(String name, Class<T> type, long uniqueId) {
-        assertMutable("createWithoutConstructor(String, Class, Object...)");
+        assertCanMutate("createWithoutConstructor(String, Class, Object...)");
         return doCreate(taskIdentityFactory.recreate(name, type, project, uniqueId), null, Actions.doNothing());
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -423,7 +423,7 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
         CollectionCallbackActionDecorator collectionCallbackActionDecorator,
         CrossProjectConfigurator projectConfigurator
     ) {
-        return new DefaultDomainObjectCollectionFactory(instantiatorFactory, projectScopeServiceRegistry, collectionCallbackActionDecorator, projectConfigurator.getMutationGuard());
+        return new DefaultDomainObjectCollectionFactory(instantiatorFactory, projectScopeServiceRegistry, collectionCallbackActionDecorator, projectConfigurator.getLazyBehaviorGuard());
     }
 
     @Provides

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -340,7 +340,7 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
     }
 
     private void assertProjectMutatingMethodAllowed(String methodName) {
-        crossProjectConfigurator.getMutationGuard().assertMutationAllowed(methodName, this, Gradle.class);
+        crossProjectConfigurator.getLazyBehaviorGuard().assertEagerContext(methodName, this, Gradle.class);
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractDomainObjectCollectionSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractDomainObjectCollectionSpec.groovy
@@ -1667,7 +1667,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         if (isDirectElementAdditionAllowed()) {
             methods += [
                 "add(T)": { container.add(b) },
-                "addAll(Collection<T>)": { container.addAll([b]) }
+                "addAll(Collection)": { container.addAll([b]) }
             ]
         }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectCollectionTest.groovy
@@ -426,6 +426,137 @@ class DefaultDomainObjectCollectionTest extends AbstractDomainObjectCollectionSp
         !container.remove("a")
     }
 
+    def callsVetoActionBeforeObjectIsAdded() {
+        def action = Mock(Action)
+        container.beforeCollectionChanges(action)
+
+        when:
+        container.add("a")
+
+        then:
+        1 * action.execute("add(T)")
+        0 * _
+    }
+
+    def objectIsNotAddedWhenVetoActionThrowsAnException() {
+        def action = Mock(Action)
+        def failure = new RuntimeException()
+        container.beforeCollectionChanges(action)
+
+        when:
+        container.add("a")
+
+        then:
+        def e = thrown(RuntimeException)
+        e == failure
+
+        and:
+        1 * action.execute("add(T)") >> { throw failure }
+
+        and:
+        !toList(container).contains("a")
+    }
+
+    def callsVetoActionOnceBeforeCollectionIsAdded() {
+        def action = Mock(Action)
+        container.beforeCollectionChanges(action)
+
+        when:
+        container.addAll(["a", "b"])
+
+        then:
+        1 * action.execute("addAll(Collection)")
+        0 * _
+    }
+
+    def callsVetoActionBeforeObjectIsRemoved() {
+        def action = Mock(Action)
+        container.beforeCollectionChanges(action)
+
+        when:
+        container.remove("a")
+
+        then:
+        1 * action.execute("remove(Object)")
+        0 * _
+    }
+
+    def callsVetoActionBeforeObjectIsRemovedUsingIterator() {
+        def action = Mock(Action)
+
+        container.add("a")
+        container.beforeCollectionChanges(action)
+
+        def iterator = container.iterator()
+        iterator.next()
+
+        when:
+        iterator.remove()
+
+        then:
+        1 * action.execute("iterator().remove()")
+        0 * _
+    }
+
+    def objectIsNotRemovedWhenVetoActionThrowsAnException() {
+        def action = Mock(Action)
+        def failure = new RuntimeException()
+
+        container.add("a")
+        container.beforeCollectionChanges(action)
+
+        when:
+        container.remove("a")
+
+        then:
+        def e = thrown(RuntimeException)
+        e == failure
+
+        and:
+        1 * action.execute("remove(Object)") >> { throw failure }
+
+        and:
+        toList(container).contains("a")
+    }
+
+    def callsVetoActionBeforeCollectionIsCleared() {
+        def action = Mock(Action)
+        container.beforeCollectionChanges(action)
+
+        when:
+        container.clear()
+
+        then:
+        1 * action.execute("clear()")
+        0 * _
+    }
+
+    def callsVetoActionOnceBeforeCollectionIsRemoved() {
+        def action = Mock(Action)
+        container.beforeCollectionChanges(action)
+
+        when:
+        container.removeAll(["a", "b"])
+
+        then:
+        1 * action.execute("removeAll(Collection)")
+        0 * _
+    }
+
+    def callsVetoActionOnceBeforeCollectionIsIntersected() {
+        def action = Mock(Action)
+        container.add("a")
+        container.add("b")
+        container.beforeCollectionChanges(action)
+
+        when:
+        container.retainAll(toList())
+
+        then:
+        1 * action.execute("retainAll(Collection)")
+        0 * _
+    }
+
     def "withType works with addLater"() {
         given:
         def value = Mock(Subtype)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectCollectionTest.groovy
@@ -426,7 +426,7 @@ class DefaultDomainObjectCollectionTest extends AbstractDomainObjectCollectionSp
         !container.remove("a")
     }
 
-    def callsVetoActionBeforeObjectIsAdded() {
+    def "calls beforeCollectionChanges before object is added"() {
         def action = Mock(Action)
         container.beforeCollectionChanges(action)
 
@@ -438,7 +438,7 @@ class DefaultDomainObjectCollectionTest extends AbstractDomainObjectCollectionSp
         0 * _
     }
 
-    def objectIsNotAddedWhenVetoActionThrowsAnException() {
+    def "object is not added when beforeCollectionChanges throws an exception"() {
         def action = Mock(Action)
         def failure = new RuntimeException()
         container.beforeCollectionChanges(action)
@@ -457,7 +457,7 @@ class DefaultDomainObjectCollectionTest extends AbstractDomainObjectCollectionSp
         !toList(container).contains("a")
     }
 
-    def callsVetoActionOnceBeforeCollectionIsAdded() {
+    def "calls beforeCollectionChanges once before collection is added"() {
         def action = Mock(Action)
         container.beforeCollectionChanges(action)
 
@@ -469,7 +469,7 @@ class DefaultDomainObjectCollectionTest extends AbstractDomainObjectCollectionSp
         0 * _
     }
 
-    def callsVetoActionBeforeObjectIsRemoved() {
+    def "calls beforeCollectionChanges before object is removed"() {
         def action = Mock(Action)
         container.beforeCollectionChanges(action)
 
@@ -481,7 +481,7 @@ class DefaultDomainObjectCollectionTest extends AbstractDomainObjectCollectionSp
         0 * _
     }
 
-    def callsVetoActionBeforeObjectIsRemovedUsingIterator() {
+    def "calls beforeCollectionChanges before object is removed using iterator"() {
         def action = Mock(Action)
 
         container.add("a")
@@ -498,7 +498,7 @@ class DefaultDomainObjectCollectionTest extends AbstractDomainObjectCollectionSp
         0 * _
     }
 
-    def objectIsNotRemovedWhenVetoActionThrowsAnException() {
+    def "object is not removed when beforeCollectionChanges throws an exception"() {
         def action = Mock(Action)
         def failure = new RuntimeException()
 
@@ -519,7 +519,7 @@ class DefaultDomainObjectCollectionTest extends AbstractDomainObjectCollectionSp
         toList(container).contains("a")
     }
 
-    def callsVetoActionBeforeCollectionIsCleared() {
+    def "calls beforeCollectionChanges before collection is cleared"() {
         def action = Mock(Action)
         container.beforeCollectionChanges(action)
 
@@ -531,7 +531,7 @@ class DefaultDomainObjectCollectionTest extends AbstractDomainObjectCollectionSp
         0 * _
     }
 
-    def callsVetoActionOnceBeforeCollectionIsRemoved() {
+    def "calls beforeCollectionChanges before collection is removed"() {
         def action = Mock(Action)
         container.beforeCollectionChanges(action)
 
@@ -543,7 +543,7 @@ class DefaultDomainObjectCollectionTest extends AbstractDomainObjectCollectionSp
         0 * _
     }
 
-    def callsVetoActionOnceBeforeCollectionIsIntersected() {
+    def "calls beforeCollectionChanges before collection is intersected"() {
         def action = Mock(Action)
         container.add("a")
         container.add("b")

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectSetTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectSetTest.groovy
@@ -16,10 +16,7 @@
 package org.gradle.api.internal
 
 import groovy.test.NotYetImplemented
-import org.gradle.api.Action
 import org.gradle.util.TestUtil
-
-import static org.gradle.util.internal.WrapUtil.toList
 
 class DefaultDomainObjectSetTest extends AbstractDomainObjectCollectionSpec<CharSequence> {
     DefaultDomainObjectSet<CharSequence> set = new DefaultDomainObjectSet<CharSequence>(CharSequence, callbackActionDecorator)
@@ -62,137 +59,6 @@ class DefaultDomainObjectSetTest extends AbstractDomainObjectCollectionSpec<Char
         set.size() == 4
         set.findAll { it != "c" } == ["a", "b", "d"] as LinkedHashSet
         set.iterator().collect { it } == ["a", "b", "c", "d"]
-    }
-
-    def callsVetoActionBeforeObjectIsAdded() {
-        def action = Mock(Action)
-        container.beforeCollectionChanges(action)
-
-        when:
-        container.add("a")
-
-        then:
-        1 * action.execute(null)
-        0 * _
-    }
-
-    def objectIsNotAddedWhenVetoActionThrowsAnException() {
-        def action = Mock(Action)
-        def failure = new RuntimeException()
-        container.beforeCollectionChanges(action)
-
-        when:
-        container.add("a")
-
-        then:
-        def e = thrown(RuntimeException)
-        e == failure
-
-        and:
-        1 * action.execute(null) >> { throw failure }
-
-        and:
-        !toList(container).contains("a")
-    }
-
-    def callsVetoActionOnceBeforeCollectionIsAdded() {
-        def action = Mock(Action)
-        container.beforeCollectionChanges(action)
-
-        when:
-        container.addAll(["a", "b"])
-
-        then:
-        1 * action.execute(null)
-        0 * _
-    }
-
-    def callsVetoActionBeforeObjectIsRemoved() {
-        def action = Mock(Action)
-        container.beforeCollectionChanges(action)
-
-        when:
-        container.remove("a")
-
-        then:
-        1 * action.execute(null)
-        0 * _
-    }
-
-    def callsVetoActionBeforeObjectIsRemovedUsingIterator() {
-        def action = Mock(Action)
-
-        container.add("a")
-        container.beforeCollectionChanges(action)
-
-        def iterator = container.iterator()
-        iterator.next()
-
-        when:
-        iterator.remove()
-
-        then:
-        1 * action.execute(null)
-        0 * _
-    }
-
-    def objectIsNotRemovedWhenVetoActionThrowsAnException() {
-        def action = Mock(Action)
-        def failure = new RuntimeException()
-
-        container.add("a")
-        container.beforeCollectionChanges(action)
-
-        when:
-        container.remove("a")
-
-        then:
-        def e = thrown(RuntimeException)
-        e == failure
-
-        and:
-        1 * action.execute(null) >> { throw failure }
-
-        and:
-        toList(container).contains("a")
-    }
-
-    def callsVetoActionBeforeCollectionIsCleared() {
-        def action = Mock(Action)
-        container.beforeCollectionChanges(action)
-
-        when:
-        container.clear()
-
-        then:
-        1 * action.execute(null)
-        0 * _
-    }
-
-    def callsVetoActionOnceBeforeCollectionIsRemoved() {
-        def action = Mock(Action)
-        container.beforeCollectionChanges(action)
-
-        when:
-        container.removeAll(["a", "b"])
-
-        then:
-        1 * action.execute(null)
-        0 * _
-    }
-
-    def callsVetoActionOnceBeforeCollectionIsIntersected() {
-        def action = Mock(Action)
-        container.add("a")
-        container.add("b")
-        container.beforeCollectionChanges(action)
-
-        when:
-        container.retainAll(toList())
-
-        then:
-        1 * action.execute(null)
-        0 * _
     }
 
     def "withType works with addLater"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultNamedDomainObjectListTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultNamedDomainObjectListTest.groovy
@@ -28,7 +28,7 @@ class DefaultNamedDomainObjectListTest extends AbstractNamedDomainObjectCollecti
     }
     final DefaultNamedDomainObjectList<CharSequence> list = new DefaultNamedDomainObjectList<CharSequence>(CharSequence, TestUtil.instantiatorFactory().decorateLenient(), toStringNamer, callbackActionDecorator)
 
-    DefaultNamedDomainObjectList<String> container = list
+    DefaultNamedDomainObjectList<CharSequence> container = list
     StringBuffer a = new StringBuffer("a")
     StringBuffer b = new StringBuffer("b")
     StringBuffer c = new StringBuffer("c")

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/TestContainer.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/TestContainer.java
@@ -23,6 +23,7 @@ public class TestContainer extends AbstractNamedDomainObjectContainer<TestObject
         super(TestObject.class, instantiator, new DynamicPropertyNamer(), CollectionCallbackActionDecorator.NOOP);
     }
 
+    @Override
     protected TestObject doCreate(String name) {
         Instantiator instantiator = getInstantiator();
         TestObject testObject = new TestObject(instantiator);

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultScriptHandlerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultScriptHandlerTest.groovy
@@ -63,6 +63,7 @@ class DefaultScriptHandlerTest extends Specification {
         1 * depMgmtServices.dependencyHandler >> dependencyHandler
         1 * buildLogicBuilder.prepareDependencyHandler(dependencyHandler) >> resolutionContext
         1 * configurationContainer.migratingUnlocked('classpath', ConfigurationRolesForMigration.LEGACY_TO_RESOLVABLE_DEPENDENCY_SCOPE) >> configuration
+        1 * configurationContainer.beforeCollectionChanges(_)
         1 * buildLogicBuilder.prepareClassPath(configuration, resolutionContext)
         0 * configurationContainer._
         0 * depMgmtServices._
@@ -78,6 +79,7 @@ class DefaultScriptHandlerTest extends Specification {
         1 * depMgmtServices.dependencyHandler >> dependencyHandler
         1 * buildLogicBuilder.prepareDependencyHandler(dependencyHandler) >> resolutionContext
         1 * configurationContainer.migratingUnlocked('classpath', ConfigurationRolesForMigration.LEGACY_TO_RESOLVABLE_DEPENDENCY_SCOPE) >> configuration
+        1 * configurationContainer.beforeCollectionChanges(_)
         1 * buildLogicBuilder.prepareClassPath(configuration, resolutionContext)
         0 * configurationContainer._
         0 * depMgmtServices._

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
@@ -254,7 +254,7 @@ class DefaultProjectSpec extends Specification {
         serviceRegistry.add(DynamicLookupRoutine, new DefaultDynamicLookupRoutine())
         serviceRegistry.add(SoftwareComponentContainer, Mock(SoftwareComponentContainer))
         serviceRegistry.add(CrossProjectConfigurator, Mock(CrossProjectConfigurator) {
-            getMutationGuard() >> Mock(MutationGuard)
+            getLazyBehaviorGuard() >> Mock(MutationGuard)
         })
         serviceRegistry.add(ListenerBuildOperationDecorator, Mock(ListenerBuildOperationDecorator))
         serviceRegistry.add(ArtifactHandler, Mock(ArtifactHandler))

--- a/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
@@ -70,7 +70,7 @@ class DefaultGradleSpec extends Specification {
     BuildOperationRunner buildOperationRunner = new TestBuildOperationRunner()
     ListenerBuildOperationDecorator listenerBuildOperationDecorator = new TestListenerBuildOperationDecorator()
     CrossProjectConfigurator crossProjectConfigurator = Mock(CrossProjectConfigurator) {
-        getMutationGuard() >> Mock(MutationGuard)
+        getLazyBehaviorGuard() >> Mock(MutationGuard)
     }
     GradleLifecycleActionExecutor gradleLifecycleActionExecutor = Mock(GradleLifecycleActionExecutor)
 


### PR DESCRIPTION
The intention of the buildscript block is to contain the 'classpath' configuration and allow dependencies to be declared on the configuration

This commit deprecates using the block for other questionable purposes, by deprecating creation of new configuration in the block.
    
This closes some odd corner cases where a buildscript configuration can resolve other buildscript configurations, a behavior that we never intended to support. There are some questionable use-cases for using the buildscript block to perform adhoc resolutions, for example in settings scripts where there is no other way to obtain a configuration. For this reason, creating detached configurations are still permitted in buildscript blocks.
    
We add a bunch of tests in BuildscriptResolutionIntegrationTest.groovy, which tests corner cases for buildscript configuration resolution.


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
