### PR TITLE
Deprecate AbstractOptions

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -121,6 +121,43 @@ Since Configurations are mutable, extending configurations across project bounda
 
 Extending configurations in different projects is deprecated and will result in an error in Gradle 9.0.
 
+==== Deprecated `AbstractOptions`
+
+The `AbstractOptions` class has been deprecated and will be removed in Gradle 9.0.
+All classes extending `AbstractOptions` will no longer extend it.
+
+As a result, the `AbstractOptions#define(Map)` method will no longer be present.
+This method exposes a non-type-safe API and unnecessarily relies on reflection.
+It can be replaced by directly setting the properties specified in the map.
+
+Additionally, `CompileOptions#fork(Map)`, `CompileOptions#debug(Map)`, and `GroovyCompileOptions#fork(Map)`, which depend on `define`, are also deprecated for removal in Gradle 9.0.
+
+Consider the following example of the deprecated behavior and its replacement:
+=====
+[.multi-language-sample]
+======
+.build.gradle
+[source,groovy]
+----
+tasks.withType(JavaCompile) {
+    // Deprecated behavior
+    options.define(encoding: 'UTF-8')
+    options.fork(memoryMaximumSize: '1G')
+    options.debug(debugLevel: 'lines')
+
+    // Can be replaced by
+    options.encoding = 'UTF-8'
+
+    options.fork = true
+    options.forkOptions.memoryMaximumSize = '1G'
+
+    options.debug = true
+    options.debugOptions.debugLevel = 'lines'
+}
+----
+======
+=====
+
 ==== Deprecated `Dependency#contentEquals(Dependency)`
 
 The link:{javadocPath}/org/gradle/api/artifacts/Dependency.html#contentEquals(org.gradle.api.artifacts.Dependency)[Dependency#contentEquals(Dependency)] method has been deprecated and will be removed in Gradle 9.0.

--- a/platforms/jvm/language-groovy/build.gradle.kts
+++ b/platforms/jvm/language-groovy/build.gradle.kts
@@ -14,6 +14,7 @@ errorprone {
 
 dependencies {
     api(projects.serviceProvider)
+    api(projects.baseServices)
     api(projects.buildOption)
     api(projects.coreApi)
     api(projects.core)
@@ -36,7 +37,6 @@ dependencies {
     implementation(projects.concurrent)
     implementation(projects.serviceLookup)
     implementation(projects.stdlibJavaExtensions)
-    implementation(projects.baseServices)
     implementation(projects.fileCollections)
     implementation(projects.logging)
     implementation(projects.loggingApi)

--- a/platforms/jvm/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompileOptions.java
+++ b/platforms/jvm/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompileOptions.java
@@ -26,6 +26,7 @@ import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 
 import javax.annotation.Nullable;
@@ -38,6 +39,7 @@ import java.util.Map;
 /**
  * Compilation options to be passed to the Groovy compiler.
  */
+@SuppressWarnings("deprecation")
 public abstract class GroovyCompileOptions extends AbstractOptions {
     private static final long serialVersionUID = 0;
 
@@ -374,10 +376,22 @@ public abstract class GroovyCompileOptions extends AbstractOptions {
     /**
      * Convenience method to set {@link GroovyForkOptions} with named parameter syntax.
      * Calling this method will set {@code fork} to {@code true}.
+     *
+     * @deprecated This method will be removed in Gradle 9.0
      */
+    @Deprecated
     public GroovyCompileOptions fork(Map<String, Object> forkArgs) {
+
+        DeprecationLogger.deprecateMethod(GroovyCompileOptions.class, "fork(Map)")
+            .withAdvice("Set properties directly on the 'forkOptions' property instead.")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(8, "deprecated_abstract_options")
+            .nagUser();
+
         fork = true;
-        forkOptions.define(forkArgs);
+
+        // Disable deprecation to avoid double-warning
+        DeprecationLogger.whileDisabled(() -> forkOptions.define(forkArgs));
         return this;
     }
 }

--- a/platforms/jvm/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompileOptions.java
+++ b/platforms/jvm/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompileOptions.java
@@ -16,6 +16,7 @@
 package org.gradle.api.tasks.compile;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.Action;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Console;
@@ -274,6 +275,15 @@ public abstract class GroovyCompileOptions extends AbstractOptions {
      */
     public void setForkOptions(GroovyForkOptions forkOptions) {
         this.forkOptions = forkOptions;
+    }
+
+    /**
+     * Execute the given action against {@link #getForkOptions()}.
+     *
+     * @since 8.11
+     */
+    public void forkOptions(Action<? super GroovyForkOptions> action) {
+        action.execute(forkOptions);
     }
 
     /**

--- a/platforms/jvm/language-groovy/src/test/groovy/org/gradle/api/tasks/compile/GroovyCompileOptionsTest.groovy
+++ b/platforms/jvm/language-groovy/src/test/groovy/org/gradle/api/tasks/compile/GroovyCompileOptionsTest.groovy
@@ -24,6 +24,8 @@ import org.gradle.util.TestUtil
 import org.junit.Before
 import org.junit.Test
 
+import java.util.concurrent.atomic.AtomicReference
+
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertNotNull
@@ -74,5 +76,12 @@ class GroovyCompileOptionsTest {
         assertFalse(compileOptions.verbose)
         assertFalse(compileOptions.fork)
         assertTrue(compileOptions.parameters)
+    }
+
+    @Test
+    void "forkOptions closure"() {
+        AtomicReference<ForkOptions> forkOptions = new AtomicReference<ForkOptions>()
+        compileOptions.forkOptions(forkOptions::set)
+        assertEquals(compileOptions.forkOptions, forkOptions.get())
     }
 }

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -44,7 +44,9 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         def executable = TextUtil.normaliseFileSeparators(Jvm.current().javacExecutable.toString())
 
         buildFile << """
-            apply plugin: "java"
+            plugins {
+                id("java-library")
+            }
             tasks.withType(JavaCompile) {
                 options.fork = true
                 options.forkOptions.executable = new File(".").getCanonicalFile().toPath().relativize(new File("${executable}").toPath()).toString()
@@ -101,7 +103,9 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
     def "uses default platform settings when applying java plugin"() {
         buildFile << """
-            apply plugin: "java"
+            plugins {
+                id("java-library")
+            }
         """
 
         file("src/main/java/Foo.java") << "public class Foo {}"
@@ -322,7 +326,9 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
     def "test runtime classpath includes implementation dependencies"() {
         given:
         buildFile << """
-            apply plugin: 'java'
+            plugins {
+                id("java-library")
+            }
 
             ${mavenCentralRepository()}
 
@@ -358,7 +364,9 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
     def "test runtime classpath includes test implementation dependencies"() {
         given:
         buildFile << """
-            apply plugin: 'java'
+            plugins {
+                id("java-library")
+            }
 
             ${mavenCentralRepository()}
 
@@ -394,7 +402,9 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
     def "test compile classpath includes implementation dependencies"() {
         given:
         buildFile << """
-            apply plugin: 'java'
+            plugins {
+                id("java-library")
+            }
 
             ${mavenCentralRepository()}
 
@@ -436,7 +446,9 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         createDirs("a", "b")
         settingsFile << "include 'a', 'b'"
         buildFile << """
-            apply plugin: 'java'
+            plugins {
+                id("java-library")
+            }
 
             repositories {
                 maven { url '$mavenRepo.uri' }
@@ -470,7 +482,9 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         given:
         settingsFile << "include 'a', 'b'"
         file('a/build.gradle') << """
-            apply plugin: 'java'
+            plugins {
+                id("java-library")
+            }
 
             dependencies {
                 implementation project(':b')
@@ -488,7 +502,9 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
             }
         """
         file('b/build.gradle') << '''
-            apply plugin: 'java'
+            plugins {
+                id("java-library")
+            }
         '''
         file('b/src/main/java/Foo.java') << 'class Foo {}'
         file('b/src/main/resources/foo.txt') << 'some resource'
@@ -510,7 +526,9 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
     def "compile classpath snapshotting ignores non-relevant elements"() {
         def buildFileWithDependencies = { String... dependencies ->
             buildFile.text = """
-                apply plugin: 'java'
+                plugins {
+                    id("java-library")
+                }
 
                 ${mavenCentralRepository()}
 
@@ -586,7 +604,9 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
     // Java 9 compiler throws error already: 'zip END header not found'
     def "compile classpath snapshotting should warn when jar on classpath is malformed"() {
         buildFile << '''
-            apply plugin: 'java'
+            plugins {
+                id("java-library")
+            }
 
             dependencies {
                implementation files('foo.jar')
@@ -608,7 +628,9 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
     @Requires(UnitTestPreconditions.Jdk8OrEarlier)
     def "compile classpath snapshotting on Java 8 and earlier should warn when jar on classpath has non-utf8 characters in filenames"() {
         buildFile << '''
-            apply plugin: 'java'
+            plugins {
+                id("java-library")
+            }
 
             dependencies {
                implementation files('broken-utf8.jar')
@@ -631,7 +653,9 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
     @Issue("gradle/gradle#1358")
     def "compile classpath snapshotting should warn when jar on classpath contains malformed class file"() {
         buildFile << '''
-            apply plugin: 'java'
+            plugins {
+                id("java-library")
+            }
 
             task fooJar(type:Jar) {
                 archiveFileName = 'foo.jar'
@@ -661,7 +685,9 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
     @Issue("gradle/gradle#1358")
     def "compile classpath snapshotting should warn when class on classpath is malformed"() {
         buildFile << '''
-            apply plugin: 'java'
+            plugins {
+                id("java-library")
+            }
 
             dependencies {
                implementation files('classes')
@@ -684,12 +710,16 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
     def "compile classpath snapshotting should support unicode class names"() {
         settingsFile << 'include "b"'
         file("b/build.gradle") << '''
-            apply plugin: 'java'
+            plugins {
+                id("java-library")
+            }
         '''
         file("b/src/main/java/λ.java") << 'public class λ {}'
 
         buildFile << '''
-            apply plugin: 'java'
+            plugins {
+                id("java-library")
+            }
 
             dependencies {
                implementation project(':b')
@@ -887,7 +917,9 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
     def "fails when sourcepath is set on compilerArgs"() {
         buildFile << '''
-            apply plugin: 'java'
+            plugins {
+                id("java-library")
+            }
 
             compileJava {
                 options.compilerArgs = ['-sourcepath', files('src/main/java').asPath]
@@ -904,7 +936,9 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
     def "fails when processorpath is set on compilerArgs"() {
         buildFile << '''
-            apply plugin: 'java'
+            plugins {
+                id("java-library")
+            }
 
             compileJava {
                 options.compilerArgs = ['-processorpath', files('src/main/java').asPath]
@@ -921,7 +955,9 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
     def "fails when a -J (compiler JVM) flag is set on compilerArgs"() {
         buildFile << '''
-            apply plugin: 'java'
+            plugins {
+                id("java-library")
+            }
 
             compileJava {
                 options.compilerArgs = ['-J-Xdiag']
@@ -944,7 +980,9 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         def jdk8 = AvailableJavaHomes.getJdk8()
         def jdk8bootClasspath = TextUtil.escapeString(jdk8.jre.absolutePath) + "/lib/rt.jar"
         buildFile << """
-            apply plugin: 'java'
+            plugins {
+                id("java-library")
+            }
 
             compileJava {
                 if (providers.gradleProperty("java7").isPresent()) {
@@ -1004,7 +1042,9 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
     def "deletes empty packages dirs"() {
         given:
         buildFile << """
-            apply plugin: 'java'
+            plugins {
+                id("java-library")
+            }
         """
         def a = file('src/main/java/com/foo/internal/A.java') << """
             package com.foo.internal;
@@ -1028,7 +1068,9 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
     def "can configure custom header output"() {
         given:
         buildFile << """
-            apply plugin: 'java'
+            plugins {
+                id("java-library")
+            }
             compileJava.options.headerOutputDirectory = file("build/headers/java/main")
         """
         file('src/main/java/Foo.java') << """
@@ -1046,7 +1088,9 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
     def "can connect generated headers to input of another task"() {
         given:
         buildFile << """
-            apply plugin: 'java'
+            plugins {
+                id("java-library")
+            }
 
             task copy(type: Copy) {
                 from tasks.compileJava.options.headerOutputDirectory
@@ -1069,7 +1113,9 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
     def "deletes stale header files"() {
         given:
         buildFile << """
-            apply plugin: 'java'
+            plugins {
+                id("java-library")
+            }
         """
         def header = file('src/main/java/my/org/Foo.java') << """
             package my.org;
@@ -1097,7 +1143,9 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
     def "does not use case insensitive default excludes"() {
         given:
         buildFile << """
-            apply plugin: 'java'
+            plugins {
+                id("java-library")
+            }
         """
         file("src/main/java/com/example/Main.java") << """
             package com.example;
@@ -1198,7 +1246,9 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
     def "should compile sources from source with -sourcepath option for modules"() {
         given:
         buildFile << """
-            apply plugin: 'java'
+            plugins {
+                id("java-library")
+            }
 
             tasks.register("compileCustomJava", JavaCompile) {
                 destinationDirectory.set(new File(buildDir, "classes/java-custom-path/main"))
@@ -1223,5 +1273,36 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         file("build/classes/java-custom-path/main/module-info.class").exists()
         // We compile only classes defined in `source`
         !file("build/classes/java-custom-path/main/com/example/SourcePathTest.class").exists()
+    }
+
+    def "Map-accepting methods are deprecated"() {
+        buildFile << """
+            plugins {
+                id("java-library")
+            }
+
+            tasks.compileJava {
+                options.define(encoding: 'UTF-8')
+                options.fork(memoryMaximumSize: '1G')
+                options.debug(debugLevel: 'lines')
+                options.forkOptions.define([:])
+                options.debugOptions.define([:])
+
+                // Ensure replacement compiles successfully
+                options.encoding = 'UTF-8'
+                options.fork = true
+                options.forkOptions.memoryMaximumSize = '1G'
+                options.debug = true
+                options.debugOptions.debugLevel = 'lines'
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("The AbstractOptions.define(Map) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_abstract_options")
+        executer.expectDocumentedDeprecationWarning("The CompileOptions.fork(Map) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Set properties directly on the 'forkOptions' property instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_abstract_options")
+        executer.expectDocumentedDeprecationWarning("The CompileOptions.debug(Map) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Set properties directly on the 'debugOptions' property instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_abstract_options")
+        executer.expectDocumentedDeprecationWarning("The AbstractOptions.define(Map) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_abstract_options")
+        executer.expectDocumentedDeprecationWarning("The AbstractOptions.define(Map) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_abstract_options")
+        succeeds("compileJava")
     }
 }

--- a/platforms/jvm/language-java/src/test/groovy/org/gradle/api/tasks/compile/CompileOptionsTest.groovy
+++ b/platforms/jvm/language-java/src/test/groovy/org/gradle/api/tasks/compile/CompileOptionsTest.groovy
@@ -19,6 +19,8 @@ package org.gradle.api.tasks.compile
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
+import java.util.concurrent.atomic.AtomicReference
+
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNull
 import static org.junit.Assert.assertTrue
@@ -94,5 +96,21 @@ class CompileOptionsTest extends Specification {
 
         expect:
         compileOptions.allCompilerArgs.contains('Foo23')
+    }
+
+    void "forkOptions closure"() {
+        AtomicReference<ForkOptions> forkOptions = new AtomicReference<ForkOptions>()
+        compileOptions.forkOptions(forkOptions::set)
+
+        expect:
+        compileOptions.forkOptions == forkOptions.get()
+    }
+
+    void "debugOptions closure"() {
+        AtomicReference<DebugOptions> debugOptions = new AtomicReference<DebugOptions>()
+        compileOptions.debugOptions(debugOptions::set)
+
+        expect:
+        compileOptions.debugOptions == debugOptions.get()
     }
 }

--- a/platforms/jvm/language-jvm/src/main/java/org/gradle/api/tasks/compile/AbstractOptions.java
+++ b/platforms/jvm/language-jvm/src/main/java/org/gradle/api/tasks/compile/AbstractOptions.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.tasks.compile;
 
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.reflect.JavaPropertyReflectionUtil;
 
 import javax.annotation.Nullable;
@@ -24,11 +25,26 @@ import java.util.Map;
 
 /**
  * Base class for compilation-related options.
+ *
+ * @deprecated This class will be removed in Gradle 9.0. All classes that extend this class will no longer extend it.
  */
+@Deprecated
 public abstract class AbstractOptions implements Serializable {
     private static final long serialVersionUID = 0;
 
+    /**
+     * Reflectively sets the properties of this object from the given map.
+     *
+     * @deprecated This method will be removed in Gradle 9.0
+     */
+    @Deprecated
     public void define(@Nullable Map<String, Object> args) {
+
+        DeprecationLogger.deprecateMethod(AbstractOptions.class, "define(Map)")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(8, "deprecated_abstract_options")
+            .nagUser();
+
         if (args == null) {
             return;
         }

--- a/platforms/jvm/language-jvm/src/main/java/org/gradle/api/tasks/compile/BaseForkOptions.java
+++ b/platforms/jvm/language-jvm/src/main/java/org/gradle/api/tasks/compile/BaseForkOptions.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
  * Fork options for compilation. Only take effect if {@code fork}
  * is {@code true}.
  */
+@SuppressWarnings("deprecation")
 public class BaseForkOptions extends AbstractOptions {
     private static final long serialVersionUID = 0;
 

--- a/platforms/jvm/language-jvm/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/platforms/jvm/language-jvm/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -59,6 +59,7 @@ import static org.gradle.internal.instrumentation.api.annotations.ReplacesEagerP
 /**
  * Main options for Java compilation.
  */
+@SuppressWarnings("deprecation")
 public abstract class CompileOptions extends AbstractOptions {
     private static final long serialVersionUID = 0;
 
@@ -380,20 +381,42 @@ public abstract class CompileOptions extends AbstractOptions {
     /**
      * Convenience method to set {@link ForkOptions} with named parameter syntax.
      * Calling this method will set {@code fork} to {@code true}.
+     *
+     * @deprecated This method will be removed in Gradle 9.0
      */
+    @Deprecated
     public CompileOptions fork(Map<String, Object> forkArgs) {
+
+        DeprecationLogger.deprecateMethod(CompileOptions.class, "fork(Map)")
+            .withAdvice("Set properties directly on the 'forkOptions' property instead.")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(8, "deprecated_abstract_options")
+            .nagUser();
+
         fork = true;
-        forkOptions.define(forkArgs);
+        DeprecationLogger.whileDisabled(() -> forkOptions.define(forkArgs));
         return this;
     }
 
     /**
      * Convenience method to set {@link DebugOptions} with named parameter syntax.
      * Calling this method will set {@code debug} to {@code true}.
+     *
+     * @deprecated This method will be removed in Gradle 9.0
      */
+    @Deprecated
     public CompileOptions debug(Map<String, Object> debugArgs) {
+
+        DeprecationLogger.deprecateMethod(CompileOptions.class, "debug(Map)")
+            .withAdvice("Set properties directly on the 'debugOptions' property instead.")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(8, "deprecated_abstract_options")
+            .nagUser();
+
         debug = true;
-        debugOptions.define(debugArgs);
+
+        // Disable deprecation to avoid double-warning
+        DeprecationLogger.whileDisabled(() -> debugOptions.define(debugArgs));
         return this;
     }
 

--- a/platforms/jvm/language-jvm/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/platforms/jvm/language-jvm/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -17,6 +17,7 @@
 package org.gradle.api.tasks.compile;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
@@ -251,6 +252,15 @@ public abstract class CompileOptions extends AbstractOptions {
     }
 
     /**
+     * Execute the given action against {@link #getDebugOptions()}.
+     *
+     * @since 8.11
+     */
+    public void debugOptions(Action<? super DebugOptions> action) {
+        action.execute(debugOptions);
+    }
+
+    /**
      * Tells whether to run the compiler in its own process. Note that this does
      * not necessarily mean that a new process will be created for each compile task.
      * Defaults to {@code false}.
@@ -283,6 +293,15 @@ public abstract class CompileOptions extends AbstractOptions {
      */
     public void setForkOptions(ForkOptions forkOptions) {
         this.forkOptions = forkOptions;
+    }
+
+    /**
+     * Execute the given action against {@link #getForkOptions()}.
+     *
+     * @since 8.11
+     */
+    public void forkOptions(Action<? super ForkOptions> action) {
+        action.execute(forkOptions);
     }
 
     /**

--- a/platforms/jvm/language-jvm/src/main/java/org/gradle/api/tasks/compile/DebugOptions.java
+++ b/platforms/jvm/language-jvm/src/main/java/org/gradle/api/tasks/compile/DebugOptions.java
@@ -26,6 +26,7 @@ import javax.annotation.Nullable;
  * Debug options for Java compilation. Only take effect if {@link CompileOptions#debug}
  * is set to {@code true}.
  */
+@SuppressWarnings("deprecation")
 public class DebugOptions extends AbstractOptions {
     private static final long serialVersionUID = 0;
 

--- a/platforms/jvm/plugins-groovy/src/integTest/groovy/org/gradle/groovy/GroovyBasePluginIntegrationTest.groovy
+++ b/platforms/jvm/plugins-groovy/src/integTest/groovy/org/gradle/groovy/GroovyBasePluginIntegrationTest.groovy
@@ -21,31 +21,33 @@ import spock.lang.Issue
 class GroovyBasePluginIntegrationTest extends AbstractIntegrationSpec {
     def "defaults Groovy class path to inferred Groovy dependency"() {
         file("build.gradle") << """
-apply plugin: "groovy-base"
+            plugins {
+                id("groovy-base")
+            }
 
-sourceSets {
-    custom
-}
+            sourceSets {
+                custom
+            }
 
-${mavenCentralRepository()}
+            ${mavenCentralRepository()}
 
-dependencies {
-    customImplementation "$dependency"
-}
+            dependencies {
+                customImplementation "$dependency"
+            }
 
-task groovydoc(type: Groovydoc) {
-    classpath = sourceSets.custom.runtimeClasspath
-}
+            task groovydoc(type: Groovydoc) {
+                classpath = sourceSets.custom.runtimeClasspath
+            }
 
-task verify {
-    def compileCustomGroovyClasspath = compileCustomGroovy.groovyClasspath
-    def groovydocGroovyClasspath = groovydoc.groovyClasspath
-    doLast {
-        assert compileCustomGroovyClasspath.files.any { it.name == "$jarFile" }
-        assert groovydocGroovyClasspath.files.any { it.name == "$jarFile" }
-    }
-}
-"""
+            task verify {
+                def compileCustomGroovyClasspath = compileCustomGroovy.groovyClasspath
+                def groovydocGroovyClasspath = groovydoc.groovyClasspath
+                doLast {
+                    assert compileCustomGroovyClasspath.files.any { it.name == "$jarFile" }
+                    assert groovydocGroovyClasspath.files.any { it.name == "$jarFile" }
+                }
+            }
+        """
 
         expect:
         succeeds("verify")
@@ -59,34 +61,36 @@ task verify {
 
     def "only resolves source class path feeding into inferred Groovy class path if/when the latter is actually used (but not during autowiring)"() {
         file("build.gradle") << """
-apply plugin: "groovy-base"
+            plugins {
+                id("groovy-base")
+            }
 
-sourceSets {
-    custom
-}
+            sourceSets {
+                custom
+            }
 
-${mavenCentralRepository()}
+            ${mavenCentralRepository()}
 
-dependencies {
-    customImplementation "org.codehaus.groovy:groovy-all:2.4.10"
-}
+            dependencies {
+                customImplementation "org.codehaus.groovy:groovy-all:2.4.10"
+            }
 
-task groovydoc(type: Groovydoc) {
-    classpath = sourceSets.custom.runtimeClasspath
-}
+            task groovydoc(type: Groovydoc) {
+                classpath = sourceSets.custom.runtimeClasspath
+            }
 
-task verify {
-    def customCompileClasspathState = provider {
-        configurations.customCompileClasspath.state.toString()
-    }
-    def customRuntimeClasspathState = provider {
-        configurations.customRuntimeClasspath.state.toString()
-    }
-    doLast {
-        assert customCompileClasspathState.get() == "UNRESOLVED"
-        assert customRuntimeClasspathState.get() == "UNRESOLVED"
-    }
-}
+            task verify {
+                def customCompileClasspathState = provider {
+                    configurations.customCompileClasspath.state.toString()
+                }
+                def customRuntimeClasspathState = provider {
+                    configurations.customRuntimeClasspath.state.toString()
+                }
+                doLast {
+                    assert customCompileClasspathState.get() == "UNRESOLVED"
+                    assert customRuntimeClasspathState.get() == "UNRESOLVED"
+                }
+            }
         """
 
         expect:
@@ -96,7 +100,9 @@ task verify {
     def "not specifying a groovy runtime produces decent error message"() {
         given:
         buildFile << """
-            apply plugin: "groovy-base"
+            plugins {
+                id("groovy-base")
+            }
 
             sourceSets {
                 main {}
@@ -125,7 +131,9 @@ task verify {
     def "can override sourceSet language destinationDirectory to override compile task destinationDirectory"() {
         given:
         buildFile << '''
-            apply plugin: 'groovy-base'
+            plugins {
+                id("groovy-base")
+            }
 
             sourceSets {
                 main {
@@ -147,5 +155,39 @@ task verify {
 
         expect:
         succeeds 'assertDirectoriesAreEquals'
+    }
+
+    def "Map-accepting methods are deprecated"() {
+        buildFile << """
+            plugins {
+                id("groovy-base")
+            }
+
+            sourceSets {
+                main
+            }
+
+            tasks.compileGroovy {
+                options.define([:])
+                options.fork([:])
+                options.debug([:])
+                options.forkOptions.define([:])
+                options.debugOptions.define([:])
+                groovyOptions.define([:])
+                groovyOptions.fork([:])
+                groovyOptions.forkOptions.define([:])
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("The AbstractOptions.define(Map) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_abstract_options")
+        executer.expectDocumentedDeprecationWarning("The CompileOptions.fork(Map) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Set properties directly on the 'forkOptions' property instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_abstract_options")
+        executer.expectDocumentedDeprecationWarning("The CompileOptions.debug(Map) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Set properties directly on the 'debugOptions' property instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_abstract_options")
+        executer.expectDocumentedDeprecationWarning("The AbstractOptions.define(Map) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_abstract_options")
+        executer.expectDocumentedDeprecationWarning("The AbstractOptions.define(Map) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_abstract_options")
+        executer.expectDocumentedDeprecationWarning("The AbstractOptions.define(Map) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_abstract_options")
+        executer.expectDocumentedDeprecationWarning("The GroovyCompileOptions.fork(Map) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Set properties directly on the 'forkOptions' property instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_abstract_options")
+        executer.expectDocumentedDeprecationWarning("The AbstractOptions.define(Map) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_abstract_options")
+        succeeds("compileGroovy")
     }
 }

--- a/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/ScalaPluginIntegrationTest.groovy
+++ b/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/ScalaPluginIntegrationTest.groovy
@@ -32,8 +32,10 @@ class ScalaPluginIntegrationTest extends MultiVersionIntegrationSpec {
 
     @Issue("https://issues.gradle.org/browse/GRADLE-3094")
     def "can apply scala plugin"() {
-        file("build.gradle") << """
-            apply plugin: "scala"
+        buildFile << """
+            plugins {
+                id("scala")
+            }
 
             task someTask
         """
@@ -202,7 +204,9 @@ class ScalaPluginIntegrationTest extends MultiVersionIntegrationSpec {
             rootProject.name = "scala"
         """
         buildFile << """
-            apply plugin: 'scala'
+            plugins {
+                id("scala")
+            }
 
             ${mavenCentralRepository()}
             dependencies {
@@ -229,7 +233,9 @@ class ScalaPluginIntegrationTest extends MultiVersionIntegrationSpec {
             rootProject.name = "scala"
         """
         buildFile << """
-            apply plugin: 'scala'
+            plugins {
+                id("scala")
+            }
 
             ${mavenCentralRepository()}
 
@@ -249,8 +255,10 @@ class ScalaPluginIntegrationTest extends MultiVersionIntegrationSpec {
     @Issue("gradle/gradle#19300")
     def 'show that log4j-core, if present, is 2_17_1 at the minimum'() {
         given:
-        file('build.gradle') << """
-            apply plugin: 'scala'
+        buildFile << """
+            plugins {
+                id("scala")
+            }
 
             ${mavenCentralRepository()}
         """
@@ -268,7 +276,7 @@ class ScalaPluginIntegrationTest extends MultiVersionIntegrationSpec {
     def "Scala compiler daemon respects keepalive option"() {
         buildFile << """
             plugins {
-                id 'scala'
+                id("scala")
             }
 
             ${mavenCentralRepository()}
@@ -295,5 +303,40 @@ class ScalaPluginIntegrationTest extends MultiVersionIntegrationSpec {
         then:
         succeeds(':compileScala', '--info')
         postBuildOutputDoesNotContain('Stopped 1 worker daemon')
+    }
+
+    def "Map-accepting methods are deprecated"() {
+        buildFile << """
+            plugins {
+                id("scala")
+            }
+
+            ${mavenCentralRepository()}
+
+            tasks.compileScala {
+                options.define([:])
+                options.fork([:])
+                options.debug([:])
+                options.forkOptions.define([:])
+                options.debugOptions.define([:])
+                scalaCompileOptions.define([:])
+                scalaCompileOptions.forkOptions.define([:])
+            }
+
+            tasks.scaladoc {
+                scalaDocOptions.define([:])
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("The AbstractOptions.define(Map) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_abstract_options")
+        executer.expectDocumentedDeprecationWarning("The CompileOptions.fork(Map) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Set properties directly on the 'forkOptions' property instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_abstract_options")
+        executer.expectDocumentedDeprecationWarning("The CompileOptions.debug(Map) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Set properties directly on the 'debugOptions' property instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_abstract_options")
+        executer.expectDocumentedDeprecationWarning("The AbstractOptions.define(Map) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_abstract_options")
+        executer.expectDocumentedDeprecationWarning("The AbstractOptions.define(Map) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_abstract_options")
+        executer.expectDocumentedDeprecationWarning("The AbstractOptions.define(Map) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_abstract_options")
+        executer.expectDocumentedDeprecationWarning("The AbstractOptions.define(Map) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_abstract_options")
+        executer.expectDocumentedDeprecationWarning("The AbstractOptions.define(Map) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_abstract_options")
+        succeeds("compileScala", "scaladoc")
     }
 }

--- a/platforms/jvm/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDocOptions.java
+++ b/platforms/jvm/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDocOptions.java
@@ -17,7 +17,6 @@ package org.gradle.api.tasks.scala;
 
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
-import org.gradle.api.tasks.compile.AbstractOptions;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 
 import javax.annotation.Nullable;
@@ -26,7 +25,8 @@ import java.util.List;
 /**
  * Options for the ScalaDoc tool.
  */
-public abstract class ScalaDocOptions extends AbstractOptions {
+@SuppressWarnings("deprecation")
+public abstract class ScalaDocOptions extends org.gradle.api.tasks.compile.AbstractOptions {
     private boolean deprecation = true;
     private boolean unchecked = true;
     private String windowTitle;

--- a/platforms/jvm/scala/src/main/java/org/gradle/language/scala/tasks/BaseScalaCompileOptions.java
+++ b/platforms/jvm/scala/src/main/java/org/gradle/language/scala/tasks/BaseScalaCompileOptions.java
@@ -23,7 +23,6 @@ import org.gradle.api.tasks.Console;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
-import org.gradle.api.tasks.compile.AbstractOptions;
 import org.gradle.api.tasks.scala.IncrementalCompileOptions;
 import org.gradle.api.tasks.scala.ScalaForkOptions;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
@@ -36,7 +35,8 @@ import java.util.List;
 /**
  * Options for Scala platform compilation.
  */
-public abstract class BaseScalaCompileOptions extends AbstractOptions {
+@SuppressWarnings("deprecation")
+public abstract class BaseScalaCompileOptions extends org.gradle.api.tasks.compile.AbstractOptions {
 
     private static final long serialVersionUID = 0;
 

--- a/subprojects/core/build.gradle.kts
+++ b/subprojects/core/build.gradle.kts
@@ -314,7 +314,11 @@ tasks.test {
 }
 
 tasks.compileTestGroovy {
-    groovyOptions.fork("memoryInitialSize" to "128M", "memoryMaximumSize" to "1G")
+    groovyOptions.isFork = true
+    groovyOptions.forkOptions.run {
+        memoryInitialSize = "128M"
+        memoryMaximumSize = "1G"
+    }
 }
 
 tasks.isolatedProjectsIntegTest {

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -1,3 +1,28 @@
 {
-    "acceptedApiChanges": []
+    "acceptedApiChanges": [
+        {
+            "type": "org.gradle.api.tasks.compile.CompileOptions",
+            "member": "Method org.gradle.api.tasks.compile.CompileOptions.debugOptions(org.gradle.api.Action)",
+            "acceptation": "No need to incubate",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.api.tasks.compile.CompileOptions",
+            "member": "Method org.gradle.api.tasks.compile.CompileOptions.forkOptions(org.gradle.api.Action)",
+            "acceptation": "No need to incubate",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.api.tasks.compile.GroovyCompileOptions",
+            "member": "Method org.gradle.api.tasks.compile.GroovyCompileOptions.forkOptions(org.gradle.api.Action)",
+            "acceptation": "No need to incubate",
+            "changes": [
+                "Method added to public class"
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
This type exposes a non-type-safe API and relies on reflection. It stands as a blocker to the provider API migration as this method cannot be migrated.

Fixes #26550

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
