### PR TITLE
Deprecate Dependency.contentEquals

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/ClientModuleDelegate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/ClientModuleDelegate.kt
@@ -17,17 +17,16 @@
 package org.gradle.kotlin.dsl.support.delegates
 
 import groovy.lang.Closure
-
 import org.gradle.api.Action
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.DependencyArtifact
 import org.gradle.api.artifacts.ExcludeRule
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ModuleDependency
-import org.gradle.api.artifacts.ModuleVersionSelector
 import org.gradle.api.artifacts.ModuleDependencyCapabilitiesHandler
 import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.artifacts.ModuleVersionIdentifier
+import org.gradle.api.artifacts.ModuleVersionSelector
 import org.gradle.api.artifacts.MutableVersionConstraint
 import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.attributes.AttributeContainer
@@ -102,6 +101,7 @@ abstract class ClientModuleDelegate : org.gradle.api.artifacts.ClientModule {
     override fun setTransitive(transitive: Boolean): ModuleDependency =
         delegate.setTransitive(transitive)
 
+    @Deprecated("Deprecated in Java", ReplaceWith("Object.equals(Object)"))
     override fun contentEquals(dependency: Dependency): Boolean =
         delegate.contentEquals(dependency)
 

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/ClientModuleDelegate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/ClientModuleDelegate.kt
@@ -101,7 +101,7 @@ abstract class ClientModuleDelegate : org.gradle.api.artifacts.ClientModule {
     override fun setTransitive(transitive: Boolean): ModuleDependency =
         delegate.setTransitive(transitive)
 
-    @Deprecated("Deprecated in Java", ReplaceWith("Object.equals(Object)"))
+    @Deprecated("Deprecated in Java", ReplaceWith("this.equals(dependency)"))
     override fun contentEquals(dependency: Dependency): Boolean =
         delegate.contentEquals(dependency)
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -107,6 +107,15 @@ Since Configurations are mutable, extending configurations across project bounda
 
 Extending configurations in different projects is deprecated and will result in an error in Gradle 9.0.
 
+==== Deprecated `Dependency#contentEquals(Dependency)`
+
+The link:{javadocPath}/org/gradle/api/artifacts/Dependency.html#contentEquals(org.gradle.api.artifacts.Dependency)[Dependency#contentEquals(Dependency)] method has been deprecated and will be removed in Gradle 9.0.
+
+The method was originally intended to compare dependencies based on their actual target component, regardless of whether they were of different dependency type.
+The existing method does not behave as specified by its javadoc, and we do not plan to introduce a replacement that does.
+
+Potential migrations include using `Object.equals(Object)` directly, or comparing the fields of dependencies manually.
+
 [[changes_8.9]]
 == Upgrading from 8.8 and earlier
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultClientModule.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultClientModule.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.dependencies;
 
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.internal.deprecation.DeprecationLogger;
 
 import javax.annotation.Nullable;
 import java.util.LinkedHashSet;
@@ -70,7 +71,8 @@ public class DefaultClientModule extends AbstractExternalModuleDependency implem
         if (!(o instanceof Dependency)) {
             return false;
         }
-        return contentEquals((Dependency) o);
+
+        return DeprecationLogger.whileDisabled(() -> contentEquals((Dependency) o));
     }
 
     @Override
@@ -79,7 +81,15 @@ public class DefaultClientModule extends AbstractExternalModuleDependency implem
     }
 
     @Override
+    @Deprecated
     public boolean contentEquals(Dependency dependency) {
+
+        DeprecationLogger.deprecateMethod(Dependency.class, "contentEquals(Dependency)")
+            .withAdvice("Use Object.equals(Object) instead")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(8, "deprecated_content_equals")
+            .nagUser();
+
         if (this == dependency) {
             return true;
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultExternalModuleDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultExternalModuleDependency.java
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.MutableVersionConstraint;
+import org.gradle.internal.deprecation.DeprecationLogger;
 
 import javax.annotation.Nullable;
 
@@ -45,7 +46,15 @@ public class DefaultExternalModuleDependency extends AbstractExternalModuleDepen
     }
 
     @Override
+    @Deprecated
     public boolean contentEquals(Dependency dependency) {
+
+        DeprecationLogger.deprecateMethod(Dependency.class, "contentEquals(Dependency)")
+            .withAdvice("Use Object.equals(Object) instead")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(8, "deprecated_content_equals")
+            .nagUser();
+
         if (this == dependency) {
             return true;
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -191,7 +191,15 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
     }
 
     @Override
+    @Deprecated
     public boolean contentEquals(Dependency dependency) {
+
+        DeprecationLogger.deprecateMethod(Dependency.class, "contentEquals(Dependency)")
+            .withAdvice("Use Object.equals(Object) instead")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(8, "deprecated_content_equals")
+            .nagUser();
+
         if (this == dependency) {
             return true;
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DelegatingProjectDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DelegatingProjectDependency.java
@@ -180,6 +180,7 @@ public class DelegatingProjectDependency implements ProjectDependencyInternal {
     }
 
     @Override
+    @Deprecated
     public boolean contentEquals(Dependency dependency) {
         return delegate.contentEquals(dependency);
     }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Dependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Dependency.java
@@ -54,7 +54,10 @@ public interface Dependency {
      * key. Therefore dependencies might be equal and yet have different properties.
      *
      * @param dependency The dependency to compare this dependency with
+     *
+     * @deprecated Use {@link Object#equals(Object)} instead.
      */
+    @Deprecated
     boolean contentEquals(Dependency dependency);
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultFileCollectionDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultFileCollectionDependency.java
@@ -42,7 +42,15 @@ public class DefaultFileCollectionDependency extends AbstractDependency implemen
     }
 
     @Override
+    @Deprecated
     public boolean contentEquals(Dependency dependency) {
+
+        DeprecationLogger.deprecateMethod(Dependency.class, "contentEquals(Dependency)")
+            .withAdvice("Use Object.equals(Object) instead")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(8, "deprecated_content_equals")
+            .nagUser();
+
         if (!(dependency instanceof DefaultFileCollectionDependency)) {
             return false;
         }


### PR DESCRIPTION
This method does not behave as the javadoc specifies, and we do not plan to fix it. We do not want to support this method, as doing so is very difficult to do correctly and use cases for using this method are questionable

Fixes: #30094

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
