### PR TITLE
Do not inherit all environment variables from client process

### DIFF
--- a/platforms/core-runtime/daemon-protocol/src/main/java/org/gradle/launcher/exec/DefaultBuildActionParameters.java
+++ b/platforms/core-runtime/daemon-protocol/src/main/java/org/gradle/launcher/exec/DefaultBuildActionParameters.java
@@ -16,7 +16,9 @@
 package org.gradle.launcher.exec;
 
 import org.gradle.api.logging.LogLevel;
+import org.gradle.internal.Cast;
 import org.gradle.internal.classpath.ClassPath;
+import org.gradle.internal.jvm.Jvm;
 import org.gradle.util.internal.GUtil;
 
 import java.io.File;
@@ -39,9 +41,11 @@ public class DefaultBuildActionParameters implements BuildActionParameters, Seri
         this.useDaemon = useDaemon;
         assert systemProperties != null;
         assert envVariables != null;
+
         this.systemProperties = new HashMap<String, String>();
         GUtil.addToMap(this.systemProperties, systemProperties);
-        this.envVariables = new HashMap<String, String>(envVariables);
+
+        this.envVariables = new HashMap<String, String>(Cast.uncheckedCast(Jvm.getInheritableEnvironmentVariables(envVariables)));
         this.injectedPluginClasspath = injectedPluginClasspath;
     }
 

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/BuildEnvironmentIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/BuildEnvironmentIntegrationTest.groovy
@@ -246,4 +246,12 @@ task check {
         expect:
         succeeds 'help'
     }
+
+    def "does not see JAVA_MAIN_CLASS environment variable on macOS"() {
+        buildFile """
+            assert providers.environmentVariablesPrefixedBy("JAVA_MAIN_CLASS").get().size() == 0
+        """
+        expect:
+        succeeds("help")
+    }
 }


### PR DESCRIPTION
When starting a new worker process, we filter certain environment variables:
- JAVA_MAIN_CLASS_$pid
- APP_NAME_$pid
- TERM_SESSION_ID
- ITERM_SESSION_ID

These are environment variables that are not considered "inheritable".

JAVA_MAIN_CLASS_$pid in particular is set by the JVM automatically on macOS for versions below 18.

Some plugins/libraries used by configuration indiscriminately capture all environment variables with System.getenv(). This was noticed with Quarkus and causes all environment variables to be part of the CC key.

These environment variables reduce CC cache hits.

This change filters out non-inheritable environment variables for the Gradle daemon in the same way as other workers started by Gradle.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
