### PR TITLE
Fix native plugins to be configuration cache compatible

### DIFF
--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/work/DefaultSynchronizer.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/work/DefaultSynchronizer.java
@@ -19,6 +19,8 @@ package org.gradle.internal.work;
 import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
 
+import javax.annotation.Nullable;
+
 class DefaultSynchronizer implements Synchronizer {
     private final WorkerLeaseService workerLeaseService;
     private Thread owner;
@@ -47,6 +49,7 @@ class DefaultSynchronizer implements Synchronizer {
         }
     }
 
+    @Nullable
     private Thread takeOwnership() {
         final Thread currentThread = Thread.currentThread();
         if (!workerLeaseService.isWorkerThread()) {

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/ProcessCrashHandlingIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/ProcessCrashHandlingIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.launcher.daemon
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.integtests.fixtures.daemon.DaemonClientFixture
 import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
 import org.gradle.launcher.daemon.client.DaemonDisappearedException
@@ -92,7 +92,6 @@ class ProcessCrashHandlingIntegrationTest extends DaemonIntegrationSpec {
      * of the daemon is different than the session id of the client.
      */
     @Requires([UnitTestPreconditions.NotWindows])
-    @ToBeFixedForConfigurationCache(because = "fixture uses the software model")
     def "session id of daemon is different from daemon client"() {
         given:
         withGetSidProject()

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -53,7 +53,14 @@ Example:
 ADD RELEASE FEATURES BELOW
 vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv -->
 
+<a name="native-plugin-improvements"></a>
+### Swift and C++ plugin improvements
 
+#### Configuration cache compatibility
+
+The Swift and C++ plugins are now configuration cache compatible.
+
+The `cpp-unit` and `xctest` plugins are not yet compatible.
 
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ADD RELEASE FEATURES ABOVE

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/configuration_cache.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/configuration_cache.adoc
@@ -322,11 +322,11 @@ link:{gradle-issues}13462[[.green]#✓#]:: <<antlr_plugin.adoc#antlr_plugin,ANTL
 
 a|
 [horizontal]
-link:{gradle-issues}13484[[.red]#✖#]:: <<cpp_application_plugin.adoc#cpp_application_plugin,C++ Application>>
-link:{gradle-issues}13485[[.red]#✖#]:: <<cpp_library_plugin.adoc#cpp_library_plugin,C++ Library>>
+link:{gradle-issues}13484[[.green]#✓#]:: <<cpp_application_plugin.adoc#cpp_application_plugin,C++ Application>>
+link:{gradle-issues}13485[[.green]#✓#]:: <<cpp_library_plugin.adoc#cpp_library_plugin,C++ Library>>
 link:{gradle-issues}13514[[.red]#✖#]:: <<cpp_unit_test_plugin.adoc#cpp_unit_test_plugin,C++ Unit Test>>
-link:{gradle-issues}13515[[.red]#✖#]:: <<swift_application_plugin.adoc#swift_application_plugin,Swift Application>>
-link:{gradle-issues}13487[[.red]#✖#]:: <<swift_library_plugin.adoc#swift_library_plugin,Swift Library>>
+link:{gradle-issues}13515[[.green]#✓#]:: <<swift_application_plugin.adoc#swift_application_plugin,Swift Application>>
+link:{gradle-issues}13487[[.green]#✓#]:: <<swift_library_plugin.adoc#swift_library_plugin,Swift Library>>
 link:{gradle-issues}13488[[.red]#✖#]:: <<xctest_plugin.adoc#xctest_plugin,XCTest>>
 
 a|

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLanguageIncrementalBuildIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLanguageIncrementalBuildIntegrationTest.groovy
@@ -91,7 +91,6 @@ abstract class AbstractNativeLanguageIncrementalBuildIntegrationTest extends Abs
         }
     }
 
-    @ToBeFixedForConfigurationCache
     def "does not re-execute build with no change"() {
         given:
         run "installMainExecutable"
@@ -104,7 +103,6 @@ abstract class AbstractNativeLanguageIncrementalBuildIntegrationTest extends Abs
     }
 
     @Requires(UnitTestPreconditions.CanInstallExecutable)
-    @ToBeFixedForConfigurationCache
     def "rebuilds executable with source file change"() {
         given:
         run "installMainExecutable"
@@ -131,7 +129,6 @@ abstract class AbstractNativeLanguageIncrementalBuildIntegrationTest extends Abs
         install.exec().out == app.alternateOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles but does not relink executable with source comment change"() {
         given:
         run "installMainExecutable"
@@ -158,7 +155,6 @@ abstract class AbstractNativeLanguageIncrementalBuildIntegrationTest extends Abs
     }
 
     @Requires(UnitTestPreconditions.CanInstallExecutable)
-    @ToBeFixedForConfigurationCache
     def "recompiles library and relinks executable after library source file change"() {
         given:
         run "installMainExecutable"
@@ -185,7 +181,6 @@ abstract class AbstractNativeLanguageIncrementalBuildIntegrationTest extends Abs
         install.exec().out == app.alternateLibraryOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles binary when header file changes"() {
         given:
         run "installMainExecutable"
@@ -211,7 +206,6 @@ abstract class AbstractNativeLanguageIncrementalBuildIntegrationTest extends Abs
         }
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles binary when system header file changes"() {
         given:
         def systemHeader = file("src/main/system/${headerFile.name}")
@@ -265,7 +259,6 @@ abstract class AbstractNativeLanguageIncrementalBuildIntegrationTest extends Abs
         skipped mainCompileTask
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles binary when header file changes in a way that does not affect the object files"() {
         given:
         run "installMainExecutable"
@@ -292,7 +285,6 @@ abstract class AbstractNativeLanguageIncrementalBuildIntegrationTest extends Abs
     }
 
     @Requires(UnitTestPreconditions.CanInstallExecutable)
-    @ToBeFixedForConfigurationCache
     def "rebuilds binary with compiler option change"() {
         given:
         run "installMainExecutable"
@@ -365,7 +357,6 @@ abstract class AbstractNativeLanguageIncrementalBuildIntegrationTest extends Abs
         executedAndNotSkipped ":helloSharedLibrary", ":mainExecutable"
     }
 
-    @ToBeFixedForConfigurationCache
     def "relinks binary when set of input libraries changes"() {
         given:
         run "mainExecutable", "helloStaticLibrary"
@@ -430,7 +421,6 @@ abstract class AbstractNativeLanguageIncrementalBuildIntegrationTest extends Abs
         }
     }
 
-    @ToBeFixedForConfigurationCache
     def "cleans up stale object files when executable source file renamed"() {
         given:
         run "installMainExecutable"
@@ -459,7 +449,6 @@ abstract class AbstractNativeLanguageIncrementalBuildIntegrationTest extends Abs
         newObjFile.file
     }
 
-    @ToBeFixedForConfigurationCache
     def "cleans up stale object files when library source file renamed"() {
         when:
         run "helloStaticLibrary"
@@ -500,7 +489,6 @@ abstract class AbstractNativeLanguageIncrementalBuildIntegrationTest extends Abs
     }
 
     @RequiresInstalledToolChain(GCC_COMPATIBLE)
-    @ToBeFixedForConfigurationCache
     def "recompiles binary when imported header file changes"() {
         sourceFile.text = sourceFile.text.replaceFirst('#include "hello.h"', "#import \"hello.h\"")
         if (buildingCorCppWithGcc()) {
@@ -576,7 +564,6 @@ abstract class AbstractNativeLanguageIncrementalBuildIntegrationTest extends Abs
     }
 
     @Issue("GRADLE-3248")
-    @ToBeFixedForConfigurationCache
     def "incremental compilation isn't considered up-to-date when compilation fails"() {
         expect:
         succeeds mainCompileTask

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLanguageIncrementalBuildIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLanguageIncrementalBuildIntegrationTest.groovy
@@ -320,7 +320,6 @@ abstract class AbstractNativeLanguageIncrementalBuildIntegrationTest extends Abs
 
     @Requires(UnitTestPreconditions.CanInstallExecutable)
     @RequiresInstalledToolChain(SUPPORTS_32_AND_64)
-    @ToBeFixedForConfigurationCache
     def "rebuilds binary with target platform change"() {
         Assume.assumeTrue(languageBuildsOnMultiplePlatforms())
         given:
@@ -378,7 +377,6 @@ abstract class AbstractNativeLanguageIncrementalBuildIntegrationTest extends Abs
         executable.assertHasChangedSince(snapshot)
     }
 
-    @ToBeFixedForConfigurationCache
     def "relinks binary but does not recompile when linker option changed"() {
         given:
         run "mainExecutable"

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLanguageIncrementalCompileIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLanguageIncrementalCompileIntegrationTest.groovy
@@ -69,7 +69,6 @@ abstract class AbstractNativeLanguageIncrementalCompileIntegrationTest extends A
         outputs = new CompilationOutputsFixture(objectFileDir)
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles changed source file only"() {
         given:
         outputs.snapshot { run "mainExecutable" }
@@ -88,7 +87,6 @@ abstract class AbstractNativeLanguageIncrementalCompileIntegrationTest extends A
         outputs.recompiledFile sourceFile
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles all source files that include changed header file"() {
         given:
         outputs.snapshot { run "mainExecutable" }
@@ -107,7 +105,6 @@ abstract class AbstractNativeLanguageIncrementalCompileIntegrationTest extends A
         outputs.recompiledFiles allSources
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles only source file that includes changed header file"() {
         given:
         sourceFile << """
@@ -130,7 +127,6 @@ abstract class AbstractNativeLanguageIncrementalCompileIntegrationTest extends A
         outputs.recompiledFile sourceFile
     }
 
-    @ToBeFixedForConfigurationCache
     def "does not recompile when fallback mechanism is used and empty directory added to include directory"() {
         given:
         file("src/main/headers/empty/directory").mkdirs()
@@ -148,7 +144,6 @@ abstract class AbstractNativeLanguageIncrementalCompileIntegrationTest extends A
         skipped compileTask
     }
 
-    @ToBeFixedForConfigurationCache
     def "does not recompile when included header has the same name as a directory"() {
         given:
         buildFile << """
@@ -187,7 +182,6 @@ model {
         skipped compileTask
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles when included header has the same name as a directory and the directory becomes a file"() {
         given:
         buildFile << """
@@ -230,7 +224,6 @@ model {
 
     }
 
-    @ToBeFixedForConfigurationCache
     def "source is always recompiled if it includes header via complex macro"() {
         given:
         def notIncluded = file("src/main/headers/notIncluded.h")
@@ -283,7 +276,6 @@ model {
         skipped compileTask
     }
 
-    @ToBeFixedForConfigurationCache
     def "source is recompiled when headers form a cycle and one is changed"() {
         given:
         def headerFile1 = file("src/main/headers/bar.h")
@@ -327,7 +319,6 @@ model {
         skipped compileTask
     }
 
-    @ToBeFixedForConfigurationCache
     def "source is not recompiled when preprocessor removed header is changed"() {
         given:
         def notIncluded = file("src/main/headers/notIncluded.h")
@@ -371,7 +362,6 @@ model {
         executedAndNotSkipped compileTask
     }
 
-    @ToBeFixedForConfigurationCache
     def "source is compiled when preprocessor removed header does not exist"() {
         given:
         sourceFile << """
@@ -404,7 +394,6 @@ model {
         skipped compileTask
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles source file when transitively included header file is changed"() {
         given:
         def transitiveHeaderFile = file("src/main/headers/transitive.h") << """
@@ -434,7 +423,6 @@ model {
         outputs.recompiledFile sourceFile
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles source file when an included header file is renamed"() {
         given:
         outputs.snapshot { run "mainExecutable" }
@@ -452,7 +440,6 @@ model {
         failure.assertHasDescription("Execution failed for task '${compileTask}'.")
     }
 
-    @ToBeFixedForConfigurationCache
     def "does not recompile any sources when unused header file is changed"() {
         given:
         outputs.snapshot { run "mainExecutable" }
@@ -472,7 +459,6 @@ model {
         outputs.noneRecompiled()
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles when include path is changed so that replacement header file occurs before previous header"() {
         given:
         outputs.snapshot { run "mainExecutable" }
@@ -506,7 +492,6 @@ model {
         outputs.recompiledFiles allSources
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles when replacement header file is added before previous header to existing include path"() {
         given:
         buildFile << """
@@ -540,7 +525,6 @@ model {
         outputs.recompiledFiles allSources
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles when replacement header file with different content is added to source directory"() {
         given:
         outputs.snapshot { run "mainExecutable" }
@@ -559,7 +543,6 @@ model {
         outputs.recompiledFiles allSources + [commonHeaderFile]
     }
 
-    @ToBeFixedForConfigurationCache
     def "does not recompile when replacement header file with same content is added to source directory"() {
         given:
         outputs.snapshot { run "mainExecutable" }
@@ -578,7 +561,6 @@ model {
         outputs.recompiledFiles sharedHeaderFile, commonHeaderFile
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles all source files and removes stale outputs when compiler arg changes"() {
         given:
         def extraSource = file("src/main/${app.sourceType}/extra.${app.sourceExtension}")
@@ -616,7 +598,6 @@ model {
         objectFileFor(extraSource).assertDoesNotExist()
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles all source files when generated object files are removed"() {
         given:
         outputs.snapshot { run "mainExecutable" }
@@ -633,7 +614,6 @@ model {
         outputs.recompiledFiles allSources
     }
 
-    @ToBeFixedForConfigurationCache
     def "removes output file when source file is renamed"() {
         given:
         outputs.snapshot { run "mainExecutable" }
@@ -651,7 +631,6 @@ model {
         objectFileFor(sourceFile).assertDoesNotExist()
     }
 
-    @ToBeFixedForConfigurationCache
     def "removes output file when source file is removed"() {
         given:
         def extraSource = file("src/main/${app.sourceType}/extra.${app.sourceExtension}")
@@ -676,7 +655,6 @@ model {
         outputs.noneRecompiled()
     }
 
-    @ToBeFixedForConfigurationCache
     def "removes output files when all source files are removed"() {
         given:
         run "mainExecutable"
@@ -721,7 +699,6 @@ model {
         }
     }
 
-    @ToBeFixedForConfigurationCache
     def "incremental compile is not effected by other compile tasks"() {
         given:
         buildFile << """

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLanguageIncrementalCompileIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLanguageIncrementalCompileIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.language
 
 import groovy.io.FileType
 import org.gradle.integtests.fixtures.CompilationOutputsFixture
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.IncrementalHelloWorldApp
 import org.gradle.test.fixtures.file.TestFile

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLanguageIncrementalCompileWithDiscoveredInputsIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLanguageIncrementalCompileWithDiscoveredInputsIntegrationTest.groovy
@@ -24,7 +24,6 @@ abstract class AbstractNativeLanguageIncrementalCompileWithDiscoveredInputsInteg
         ":dependMainExecutableMain${sourceType}"
     }
 
-    @ToBeFixedForConfigurationCache
     def "does not recompile when include path has #testCase"() {
         given:
         outputs.snapshot { run "mainExecutable" }

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLanguageIncrementalCompileWithDiscoveredInputsIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLanguageIncrementalCompileWithDiscoveredInputsIntegrationTest.groovy
@@ -16,8 +16,6 @@
 
 package org.gradle.language
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
-
 abstract class AbstractNativeLanguageIncrementalCompileWithDiscoveredInputsIntegrationTest extends AbstractNativeLanguageIncrementalCompileIntegrationTest {
 
     String getDependTask() {

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLanguageIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLanguageIntegrationTest.groovy
@@ -16,8 +16,6 @@
 
 package org.gradle.language
 
-
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.HelloWorldApp
 import org.gradle.test.precondition.Requires

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLanguageIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLanguageIntegrationTest.groovy
@@ -32,7 +32,6 @@ abstract class AbstractNativeLanguageIntegrationTest extends AbstractInstalledTo
         buildFile << helloWorldApp.extraConfiguration
     }
 
-    @ToBeFixedForConfigurationCache
     def "compile and link executable"() {
         given:
         buildFile << """
@@ -55,7 +54,6 @@ abstract class AbstractNativeLanguageIntegrationTest extends AbstractInstalledTo
         mainExecutable.exec().out == helloWorldApp.englishOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "build executable with custom compiler arg"() {
         given:
         buildFile << """
@@ -82,7 +80,6 @@ abstract class AbstractNativeLanguageIntegrationTest extends AbstractInstalledTo
         mainExecutable.exec().out == helloWorldApp.frenchOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "build executable with macro defined"() {
         given:
         buildFile << """
@@ -110,7 +107,6 @@ abstract class AbstractNativeLanguageIntegrationTest extends AbstractInstalledTo
     }
 
     @Requires(UnitTestPreconditions.CanInstallExecutable)
-    @ToBeFixedForConfigurationCache
     def "install and run executable with dependencies"() {
         given:
         buildFile << """
@@ -144,7 +140,6 @@ abstract class AbstractNativeLanguageIntegrationTest extends AbstractInstalledTo
     }
 
     @Requires(UnitTestPreconditions.CanInstallExecutable)
-    @ToBeFixedForConfigurationCache
     def "install and run executable with dependencies and customized installation"() {
         given:
         buildFile << """
@@ -178,7 +173,6 @@ abstract class AbstractNativeLanguageIntegrationTest extends AbstractInstalledTo
     }
 
     @Requires(UnitTestPreconditions.CanInstallExecutable)
-    @ToBeFixedForConfigurationCache
     def "build shared library and link into executable"() {
         given:
         buildFile << """
@@ -212,7 +206,6 @@ abstract class AbstractNativeLanguageIntegrationTest extends AbstractInstalledTo
     }
 
     @Requires(UnitTestPreconditions.CanInstallExecutable)
-    @ToBeFixedForConfigurationCache
     def "build static library and link into executable"() {
         given:
         buildFile << """
@@ -249,7 +242,6 @@ abstract class AbstractNativeLanguageIntegrationTest extends AbstractInstalledTo
         install.exec().out == helloWorldApp.frenchOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "link order is stable across project directories for the same sources"() {
         def firstCopy = file("firstDir")
         def secondCopy = file("secondDir")

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLibraryDependenciesIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLibraryDependenciesIntegrationTest.groovy
@@ -16,10 +16,7 @@
 
 package org.gradle.language
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
-
 abstract class AbstractNativeLibraryDependenciesIntegrationTest extends AbstractNativeProductionComponentDependenciesIntegrationTest {
-    @ToBeFixedForConfigurationCache(bottomSpecs = ['CppLibraryDependenciesIntegrationTest'])
     def "can define api dependencies on component"() {
         given:
         createDirs("lib")

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeSoftwareModelParallelIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeSoftwareModelParallelIntegrationTest.groovy
@@ -27,7 +27,6 @@ import org.gradle.test.preconditions.UnitTestPreconditions
 abstract class AbstractNativeSoftwareModelParallelIntegrationTest extends AbstractNativeParallelIntegrationTest {
     abstract HelloWorldApp getApp()
 
-    @ToBeFixedForConfigurationCache
     def "can execute link executable tasks in parallel"() {
         given:
         withComponentForApp()
@@ -40,7 +39,6 @@ abstract class AbstractNativeSoftwareModelParallelIntegrationTest extends Abstra
         assertTaskIsParallel("linkMainExecutable")
     }
 
-    @ToBeFixedForConfigurationCache
     def "can execute link shared library tasks in parallel"() {
         given:
         withComponentsForAppAndSharedLib()
@@ -53,7 +51,6 @@ abstract class AbstractNativeSoftwareModelParallelIntegrationTest extends Abstra
         assertTaskIsParallel("linkMainLibSharedLibrary")
     }
 
-    @ToBeFixedForConfigurationCache
     def "can execute create static library tasks in parallel"() {
         given:
         withComponentsForAppAndStaticLib()
@@ -66,7 +63,6 @@ abstract class AbstractNativeSoftwareModelParallelIntegrationTest extends Abstra
         assertTaskIsParallel("createMainLibStaticLibrary")
     }
 
-    @ToBeFixedForConfigurationCache
     def "can execute compile tasks in parallel"() {
         given:
         withComponentForApp()

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/DuplicateBaseNamesIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/DuplicateBaseNamesIntegrationTest.groovy
@@ -152,7 +152,6 @@ model {
 
     @RequiresInstalledToolChain(GCC_COMPATIBLE)
     @Requires(UnitTestPreconditions.NotWindows)
-    @ToBeFixedForConfigurationCache
     def "can have objectiveC and objectiveCpp source files with same name in different directories"() {
         setup:
         testApp.writeSources(file("src/main"))

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/DuplicateBaseNamesIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/DuplicateBaseNamesIntegrationTest.groovy
@@ -38,7 +38,6 @@ import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.VISUALCPP
 class DuplicateBaseNamesIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
 
     @RequiresInstalledToolChain(SUPPORTS_32)
-    @ToBeFixedForConfigurationCache
     def "can have sourcefiles with same base name but different directories"() {
         given:
         def testApp = initTestApp(testAppType)
@@ -94,7 +93,6 @@ model {
      * is implemented
      * */
     @RequiresInstalledToolChain(SUPPORTS_32)
-    @ToBeFixedForConfigurationCache
     def "can have sourcefiles with same base name in same directory"() {
         setup:
         def testApp = new DuplicateMixedSameBaseNamesTestApp(AbstractInstalledToolChainIntegrationSpec.toolChain)

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/assembler/AssemblyLanguageIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/assembler/AssemblyLanguageIntegrationTest.groovy
@@ -17,7 +17,7 @@
 
 package org.gradle.language.assembler
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.language.AbstractNativeLanguageIntegrationTest
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
@@ -60,7 +60,6 @@ pushl
         failure.assertThatCause(containsText("Assembler failed while compiling broken.s"))
     }
 
-    @ToBeFixedForConfigurationCache
     def "can manually define Assembler source sets"() {
         given:
         helloWorldApp.mainSource.writeToDir(file("src/main"))

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/assembler/AssemblyLanguageParallelIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/assembler/AssemblyLanguageParallelIntegrationTest.groovy
@@ -16,11 +16,10 @@
 
 package org.gradle.language.assembler
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.language.AbstractNativeSoftwareModelParallelIntegrationTest
 import org.gradle.nativeplatform.fixtures.app.AssemblerWithCHelloWorldApp
 import org.gradle.nativeplatform.fixtures.app.HelloWorldApp
-
 
 class AssemblyLanguageParallelIntegrationTest extends AbstractNativeSoftwareModelParallelIntegrationTest {
 
@@ -29,7 +28,6 @@ class AssemblyLanguageParallelIntegrationTest extends AbstractNativeSoftwareMode
         return new AssemblerWithCHelloWorldApp(toolChain)
     }
 
-    @ToBeFixedForConfigurationCache
     def "can execute assembler tasks in parallel"() {
         given:
         withComponentForApp()

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/c/CLanguageIncrementalCompileIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/c/CLanguageIncrementalCompileIntegrationTest.groovy
@@ -28,7 +28,6 @@ class CLanguageIncrementalCompileIntegrationTest extends AbstractNativeLanguageI
     }
 
     @Issue("GRADLE-3109")
-    @ToBeFixedForConfigurationCache
     def "recompiles source file that includes header file on first line"() {
         given:
         sourceFile << """#include "${otherHeaderFile.name}"

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/c/CLanguageIncrementalCompileIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/c/CLanguageIncrementalCompileIntegrationTest.groovy
@@ -15,7 +15,6 @@
  */
 package org.gradle.language.c
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.language.AbstractNativeLanguageIncrementalCompileWithDiscoveredInputsIntegrationTest
 import org.gradle.nativeplatform.fixtures.app.CHelloWorldApp
 import org.gradle.nativeplatform.fixtures.app.IncrementalHelloWorldApp

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/c/CLanguageIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/c/CLanguageIntegrationTest.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.language.c
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.language.AbstractNativeLanguageIntegrationTest
 import org.gradle.nativeplatform.fixtures.app.CCompilerDetectingTestApp
 import org.gradle.nativeplatform.fixtures.app.CHelloWorldApp
@@ -28,7 +28,6 @@ class CLanguageIntegrationTest extends AbstractNativeLanguageIntegrationTest {
 
     HelloWorldApp helloWorldApp = new CHelloWorldApp()
 
-    @ToBeFixedForConfigurationCache
     def "sources are compiled with C compiler"() {
         def app = new CCompilerDetectingTestApp()
 
@@ -49,7 +48,6 @@ class CLanguageIntegrationTest extends AbstractNativeLanguageIntegrationTest {
         executable("build/exe/main/main").exec().out == app.expectedOutput(toolChain)
     }
 
-    @ToBeFixedForConfigurationCache
     def "can manually define C source sets"() {
         given:
         helloWorldApp.library.headerFiles.each { it.writeToDir(file("src/shared")) }
@@ -97,7 +95,6 @@ class CLanguageIntegrationTest extends AbstractNativeLanguageIntegrationTest {
         mainExecutable.exec().out == helloWorldApp.englishOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "uses headers co-located with sources"() {
         given:
         // Write headers so they sit with sources
@@ -126,7 +123,6 @@ model {
     }
 
     @Issue("GRADLE-2943")
-    @ToBeFixedForConfigurationCache
     def "can define macro #output"() {
         given:
         buildFile << """
@@ -160,7 +156,6 @@ model {
         '"with \\\\"quote\\\\" and space"' | 'with "quote" and space'
     }
 
-    @ToBeFixedForConfigurationCache
     def "compiler and linker args can contain quotes and spaces"() {
         given:
         buildFile << '''
@@ -194,7 +189,6 @@ model {
         succeeds "mainExecutable"
     }
 
-    @ToBeFixedForConfigurationCache
     def "build fails when compilation fails"() {
         given:
         buildFile << """
@@ -218,7 +212,6 @@ model {
         failure.assertThatCause(containsText("C compiler failed while compiling broken.c"))
     }
 
-    @ToBeFixedForConfigurationCache
     def "build fails when multiple compilations fail"() {
         given:
         def brokenFileCount = 5

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/c/MixedLanguageIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/c/MixedLanguageIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.language.c
 
 import org.gradle.integtests.fixtures.SourceFile
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.language.AbstractNativeLanguageIntegrationTest
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
@@ -32,7 +31,6 @@ class MixedLanguageIntegrationTest extends AbstractNativeLanguageIntegrationTest
         return new MixedLanguageHelloWorldApp(toolChain)
     }
 
-    @ToBeFixedForConfigurationCache
     def "can have all source files co-located in a common directory"() {
         given:
         buildFile << """
@@ -81,7 +79,6 @@ model {
         mainExecutable.exec().out == helloWorldApp.englishOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "build and execute program with non-conventional source layout"() {
         given:
         buildFile << """

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/AbstractCppIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/AbstractCppIntegrationTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.util.Matchers
 
 abstract class AbstractCppIntegrationTest extends AbstractCppComponentIntegrationTest {
-    @ToBeFixedForConfigurationCache
     def "skip assemble tasks when no source"() {
         given:
         makeSingleProject()
@@ -32,7 +31,6 @@ abstract class AbstractCppIntegrationTest extends AbstractCppComponentIntegratio
         result.assertTasksSkipped(tasksToAssembleDevelopmentBinary, ":assemble")
     }
 
-    @ToBeFixedForConfigurationCache
     def "build fails when compilation fails"() {
         given:
         makeSingleProject()

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/AbstractCppIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/AbstractCppIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.language.cpp
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.util.Matchers
 
 abstract class AbstractCppIntegrationTest extends AbstractCppComponentIntegrationTest {

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
@@ -60,7 +60,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         return new CppApp()
     }
 
-    @ToBeFixedForConfigurationCache
     def "skip compile, link and install tasks when no source"() {
         given:
         buildFile << """
@@ -74,7 +73,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         result.assertTasksSkipped(tasks.debug.allToInstall, ':assemble')
     }
 
-    @ToBeFixedForConfigurationCache
     def "build fails when compilation fails"() {
         given:
         buildFile << """
@@ -95,7 +93,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         failure.assertThatCause(containsText("C++ compiler failed while compiling broken.cpp"))
     }
 
-    @ToBeFixedForConfigurationCache
     def "sources are compiled and linked with C++ tools"() {
         settingsFile << "rootProject.name = 'app'"
         def app = new CppCompilerDetectingTestApp()
@@ -116,7 +113,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation("build/install/main/debug").exec().out == app.expectedOutput(toolChain)
     }
 
-    @ToBeFixedForConfigurationCache
     def "can build debug and release variants of executable"() {
         settingsFile << "rootProject.name = 'app'"
         def app = new CppAppWithOptionalFeature()
@@ -148,7 +144,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation("build/install/main/debug").exec().out == app.withFeatureDisabled().expectedOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "can use executable file as task dependency"() {
         settingsFile << "rootProject.name = 'app'"
         def app = new CppApp()
@@ -171,7 +166,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         executable("build/exe/main/debug/app").assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "can use objects as task dependency"() {
         settingsFile << "rootProject.name = 'app'"
         def app = new CppApp()
@@ -195,7 +189,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         objectFiles(app.main)*.assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "can use installDirectory as task dependency"() {
         settingsFile << "rootProject.name = 'app'"
         def app = new CppApp()
@@ -218,7 +211,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation("build/install/main/debug").exec().out == app.expectedOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "ignores non-C++ source files in source directory"() {
         settingsFile << "rootProject.name = 'app'"
         def app = new CppApp()
@@ -244,7 +236,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation("build/install/main/debug").exec().out == app.expectedOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "build logic can change source layout convention"() {
         settingsFile << "rootProject.name = 'app'"
         def app = new CppApp()
@@ -273,7 +264,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation("build/install/main/debug").exec().out == app.expectedOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "build logic can add individual source files"() {
         settingsFile << "rootProject.name = 'app'"
         def app = new CppApp()
@@ -306,7 +296,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation("build/install/main/debug").exec().out == app.expectedOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "build logic can change buildDir"() {
         settingsFile << "rootProject.name = 'app'"
         def app = new CppApp()
@@ -330,7 +319,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation("output/install/main/debug").exec().out == app.expectedOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "build logic can define the base name"() {
         def app = new CppApp()
 
@@ -352,7 +340,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation("build/install/main/debug").exec().out == app.expectedOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "build logic can change task output locations"() {
         settingsFile << "rootProject.name = 'app'"
         def app = new CppApp()
@@ -379,7 +366,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation("build/some-app").exec().out == app.expectedOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "can compile and link against a library"() {
         createDirs("app", "hello")
         settingsFile << "include 'app', 'hello'"
@@ -411,7 +397,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation.assertIncludesLibraries("hello")
     }
 
-    @ToBeFixedForConfigurationCache
     def "can compile and link against a library when specifying multiple target machines"() {
         createDirs("app", "hello")
         settingsFile << "include 'app', 'hello'"
@@ -518,7 +503,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         failure.assertHasErrorOutput("Incompatible because this component declares attribute 'org.gradle.native.architecture' with value 'foo', attribute 'org.gradle.usage' with value 'native-link' and the consumer needed attribute 'org.gradle.native.architecture' with value '${currentArchitecture}', attribute 'org.gradle.usage' with value 'native-runtime'")
     }
 
-    @ToBeFixedForConfigurationCache
     def "can directly depend on generated sources on includePath"() {
         settingsFile << "rootProject.name = 'app'"
 
@@ -559,7 +543,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         succeeds "compileDebug"
     }
 
-    @ToBeFixedForConfigurationCache
     def "can compile and link against a library with explicit target machine defined"() {
         createDirs("app", "hello")
         settingsFile << "include 'app', 'hello'"
@@ -639,7 +622,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
           - Doesn't say anything about org.gradle.native.optimized (required 'false')"""
     }
 
-    @ToBeFixedForConfigurationCache
     def "can compile and link against a static library"() {
         createDirs("app", "hello")
         settingsFile << "include 'app', 'hello'"
@@ -673,7 +655,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation.assertIncludesLibraries()
     }
 
-    @ToBeFixedForConfigurationCache
     def "can compile and link against a library with both linkages defined"() {
         createDirs("app", "hello")
         settingsFile << "include 'app', 'hello'"
@@ -707,7 +688,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation.assertIncludesLibraries("hello")
     }
 
-    @ToBeFixedForConfigurationCache
     def "can compile and link against a library with debug and release variants"() {
         createDirs("app", "hello")
         settingsFile << "include 'app', 'hello'"
@@ -755,7 +735,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation("app/build/install/main/debug").exec().out == app.withFeatureDisabled().expectedOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "can compile and link against library with api and implementation dependencies"() {
         createDirs("app", "deck", "card", "shuffle")
         settingsFile << "include 'app', 'deck', 'card', 'shuffle'"
@@ -801,7 +780,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation.exec().out == app.expectedOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "can compile and link against a static library with api and implementation dependencies"() {
         createDirs("app", "deck", "card", "shuffle")
         settingsFile << "include 'app', 'deck', 'card', 'shuffle'"
@@ -850,7 +828,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation.exec().out == app.expectedOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "honors changes to library buildDir"() {
         createDirs("app", "lib1", "lib2")
         settingsFile << "include 'app', 'lib1', 'lib2'"
@@ -893,7 +870,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         sharedLibrary("app/build/install/main/debug/lib/lib2").file.assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "honors changes to library output locations"() {
         createDirs("app", "lib1", "lib2")
         settingsFile << "include 'app', 'lib1', 'lib2'"
@@ -942,7 +918,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         file("app/build/install/main/debug/lib/lib1_debug.dll").assertIsFile()
     }
 
-    @ToBeFixedForConfigurationCache
     def "honors changes to library public header location"() {
         createDirs("app", "lib1", "lib2")
         settingsFile << "include 'app', 'lib1', 'lib2'"
@@ -992,7 +967,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         sharedLibrary("app/build/install/main/debug/lib/lib2").file.assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "multiple components can share the same source directory"() {
         createDirs("app", "greeter", "logger")
         settingsFile << "include 'app', 'greeter', 'logger'"
@@ -1043,7 +1017,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         sharedLibrary("app/build/install/main/debug/lib/logger").file.assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "can compile and link against libraries in included builds"() {
         createDirs("app", "lib1", "lib2")
         settingsFile << """
@@ -1091,7 +1064,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.GCC_COMPATIBLE)
-    @ToBeFixedForConfigurationCache
     def "system headers are not evaluated when compiler warnings are enabled"() {
         settingsFile << "rootProject.name = 'app'"
         def app = new CppCompilerDetectingTestApp()
@@ -1120,7 +1092,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
     }
 
     @Issue("https://github.com/gradle/gradle-native/issues/950")
-    @ToBeFixedForConfigurationCache
     def "can handle candidate header directory which happens to match an existing file"() {
         def app = new CppApp()
 

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.language.cpp
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.CppApp

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppBinariesRelocationIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppBinariesRelocationIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.language.cpp
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 
 class CppBinariesRelocationIntegrationTest extends AbstractInstalledToolChainIntegrationSpec implements CppTaskNames {
@@ -73,7 +73,6 @@ class CppBinariesRelocationIntegrationTest extends AbstractInstalledToolChainInt
         """
     }
 
-    @ToBeFixedForConfigurationCache
     def "can execute application with dependencies when relocated"() {
         def installDir = file("build/install/main/debug")
         def relocatedInstallDir = file("relocated-install")

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppBothLibraryLinkageIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppBothLibraryLinkageIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.language.cpp
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.app.CppLib
 import org.gradle.nativeplatform.fixtures.app.SourceElement
 
@@ -54,7 +54,6 @@ class CppBothLibraryLinkageIntegrationTest extends AbstractCppIntegrationTest {
         return new CppLib()
     }
 
-    @ToBeFixedForConfigurationCache
     def "creates shared library binary by default when both linkage specified"() {
         def library = new CppLib()
         makeSingleProject()
@@ -71,7 +70,6 @@ class CppBothLibraryLinkageIntegrationTest extends AbstractCppIntegrationTest {
         sharedLibrary('build/lib/main/debug/shared/foo').assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "can assemble static library followed by shared library"() {
         def library = new CppLib()
         makeSingleProject()

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppCachingIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppCachingIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.language.cpp
 
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibraries
@@ -51,7 +50,6 @@ class CppCachingIntegrationTest extends AbstractInstalledToolChainIntegrationSpe
         app.main.writeToProject(project)
     }
 
-    @ToBeFixedForConfigurationCache
     def 'compilation can be cached (#buildType)'() {
         setupProject()
 
@@ -81,7 +79,6 @@ class CppCachingIntegrationTest extends AbstractInstalledToolChainIntegrationSpe
         buildType << [debug, release]
     }
 
-    @ToBeFixedForConfigurationCache
     def "compilation task is relocatable for release"() {
 
         def originalLocation = file('original-location')

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppCustomHeaderDependencyIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppCustomHeaderDependencyIntegrationTest.groovy
@@ -16,12 +16,11 @@
 
 package org.gradle.language.cpp
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.CppApp
 
 class CppCustomHeaderDependencyIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
-    @ToBeFixedForConfigurationCache
     def "can consume a directory as a header dependency"() {
         def app = new CppApp()
         settingsFile << """

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppDependenciesIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppDependenciesIntegrationTest.groovy
@@ -29,7 +29,6 @@ class CppDependenciesIntegrationTest extends AbstractInstalledToolChainIntegrati
     @Rule
     GitFileRepository repo = new GitFileRepository(testDirectory)
 
-    @ToBeFixedForConfigurationCache
     def "can combine C++ builds in a composite"() {
         given:
         createDirs("app", "hello", "log")

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppGeneratedPublicHeadersIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppGeneratedPublicHeadersIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.language.cpp
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibraries
 import org.gradle.test.fixtures.file.TestFile
@@ -33,7 +33,6 @@ class CppGeneratedPublicHeadersIntegrationTest extends AbstractInstalledToolChai
         writeApp()
     }
 
-    @ToBeFixedForConfigurationCache
     @Issue("https://github.com/gradle/gradle-native/issues/994")
     def "can depends on library with generated headers"() {
         given:
@@ -60,7 +59,6 @@ class CppGeneratedPublicHeadersIntegrationTest extends AbstractInstalledToolChai
         result.assertTasksExecuted(":hello:generatePublicHeaders", ":app:compileDebugCpp")
     }
 
-    @ToBeFixedForConfigurationCache
     @Issue("https://github.com/gradle/gradle-native/issues/994")
     def "can transitively depends on library with generated headers"() {
         given:

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalBuildIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalBuildIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.language.cpp
 
 import org.gradle.integtests.fixtures.CompilationOutputsFixture
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.AvailableToolChains
@@ -145,7 +144,6 @@ class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInteg
         """
     }
 
-    @ToBeFixedForConfigurationCache
     def "rebuilds executable with single source file change"() {
         given:
         run installApp
@@ -180,7 +178,6 @@ class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInteg
         allSkipped()
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles library and relinks executable after single library source file change"() {
         given:
         run installApp
@@ -220,7 +217,6 @@ class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInteg
         allSkipped()
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles binary and does not relink when public header file changes in a way that does not affect the object files"() {
         given:
         run installApp
@@ -257,7 +253,6 @@ class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInteg
         allSkipped()
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles binary when implementation header file changes"() {
         given:
         run installApp
@@ -294,7 +289,6 @@ class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInteg
         allSkipped()
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles only those source files affected by a header file change"() {
         given:
         def greetingHeader = file("app/src/main/headers/greeting.hpp")
@@ -346,7 +340,6 @@ class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInteg
         appObjects.noneRecompiled()
     }
 
-    @ToBeFixedForConfigurationCache
     def "considers only those headers that are reachable from source files as inputs"() {
         given:
         def unused = file("app/src/main/headers/ignore1.h") << "broken!"
@@ -393,7 +386,6 @@ class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInteg
         libObjects.recompiledFiles(librarySourceFile, libraryOtherSourceFile)
     }
 
-    @ToBeFixedForConfigurationCache
     def "header file referenced using relative path is considered an input"() {
         given:
         def unused = file("app/src/main/headers/ignore1.h") << "broken!"
@@ -453,7 +445,6 @@ class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInteg
         allSkipped()
     }
 
-    @ToBeFixedForConfigurationCache
     def "header file referenced using macro #macro is considered an input"() {
         when:
         def unused = file("app/src/main/headers/ignore1.h") << "broken!"
@@ -556,7 +547,6 @@ class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInteg
         ]
     }
 
-    @ToBeFixedForConfigurationCache
     def "header file referenced using external macro #macro is considered an input"() {
         when:
         def unused = file("app/src/main/headers/ignore1.h") << "broken!"
@@ -634,7 +624,6 @@ class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInteg
         ]
     }
 
-    @ToBeFixedForConfigurationCache
     def "considers all header files as input to source file with complex macro include #include"() {
         when:
         appSourceFile.text = """
@@ -774,7 +763,6 @@ class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInteg
         '''
     }
 
-    @ToBeFixedForConfigurationCache
     def "does not consider all header files as inputs if complex macro include is found in dependency and special flag is active"() {
         when:
 
@@ -851,7 +839,6 @@ class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInteg
         return executer
     }
 
-    @ToBeFixedForConfigurationCache
     def "can have a cycle between header files"() {
         def header1 = file("app/src/main/headers/hello.h")
         def header2 = file("app/src/main/headers/other.h")
@@ -913,7 +900,6 @@ class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInteg
         allSkipped()
     }
 
-    @ToBeFixedForConfigurationCache
     def "can reference a missing header file"() {
         def header = file("app/src/main/headers/hello.h")
 
@@ -969,7 +955,6 @@ class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInteg
         allSkipped()
     }
 
-    @ToBeFixedForConfigurationCache
     def "source file can reference multiple header files using the same macro"() {
         def header1 = file("app/src/main/headers/hello1.h")
         def header2 = file("app/src/main/headers/hello2.h")
@@ -1094,7 +1079,6 @@ class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInteg
         allSkipped()
     }
 
-    @ToBeFixedForConfigurationCache
     def "changes to the included header graph are reflected in the inputs"() {
         def header = file("app/src/main/headers/hello.h")
         def header1 = file("app/src/main/headers/hello1.h")
@@ -1160,7 +1144,6 @@ class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInteg
         allSkipped()
     }
 
-    @ToBeFixedForConfigurationCache
     def "shared header can reference project specific header"() {
         when:
         appSourceFile.replace("log(msg)", "log_info(msg)")
@@ -1231,7 +1214,6 @@ class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInteg
         libObjects.noneRecompiled()
     }
 
-    @ToBeFixedForConfigurationCache
     def "shared header can reference source file specific header using macro include"() {
         when:
         libraryHeaderFile << """
@@ -1314,7 +1296,6 @@ class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInteg
         libObjects.noneRecompiled()
     }
 
-    @ToBeFixedForConfigurationCache
     def "project specific header can shadow shared header"() {
         when:
         appSourceFile.insertBefore('#include <lib.h>', '#include "common.h"')
@@ -1438,7 +1419,6 @@ class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInteg
         libObjects.noneRecompiled()
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles when include path changes resolve different headers"() {
         when:
         appSourceFile.insertBefore('#include <lib.h>', '#include <common.h>')
@@ -1526,7 +1506,6 @@ class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInteg
         libObjects.noneRecompiled()
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles when system headers change"() {
         when:
         appSourceFile.insertBefore('#include <lib.h>', '#include <common.h>')

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalBuildStaleOutputsIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalBuildStaleOutputsIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.language.cpp
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.SourceFile
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.IncrementalCppStaleCompileOutputApp
@@ -28,7 +27,6 @@ import org.gradle.nativeplatform.fixtures.app.SourceElement
 
 class CppIncrementalBuildStaleOutputsIntegrationTest extends AbstractInstalledToolChainIntegrationSpec implements CppTaskNames {
 
-    @ToBeFixedForConfigurationCache
     def "removes stale object files for executable"() {
         settingsFile << "rootProject.name = 'app'"
         def app = new IncrementalCppStaleCompileOutputApp()
@@ -55,7 +53,6 @@ class CppIncrementalBuildStaleOutputsIntegrationTest extends AbstractInstalledTo
         installation("build/install/main/debug").exec().out == app.expectedOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "removes stale object files for library"() {
         def lib = new IncrementalCppStaleCompileOutputLib()
         settingsFile << "rootProject.name = 'hello'"
@@ -81,7 +78,6 @@ class CppIncrementalBuildStaleOutputsIntegrationTest extends AbstractInstalledTo
         sharedLibrary("build/lib/main/debug/hello").assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "removes stale installed executable and library file when all source files for executable are removed"() {
         createDirs("app", "greeter")
         settingsFile << "include 'app', 'greeter'"
@@ -134,7 +130,6 @@ class CppIncrementalBuildStaleOutputsIntegrationTest extends AbstractInstalledTo
         file("greeter/build/obj/main/debug").assertHasDescendants(expectIntermediateDescendants(app.library.alternate))
     }
 
-    @ToBeFixedForConfigurationCache
     def "removes stale executable file when all source files are removed"() {
         settingsFile << "rootProject.name = 'app'"
         def app = new IncrementalCppStaleLinkOutputApp()
@@ -169,7 +164,6 @@ class CppIncrementalBuildStaleOutputsIntegrationTest extends AbstractInstalledTo
         installation("build/install/main/debug").assertNotInstalled()
     }
 
-    @ToBeFixedForConfigurationCache
     def "removes stale library file when all source files are removed"() {
         def lib = new IncrementalCppStaleLinkOutputLib()
         settingsFile << "rootProject.name = 'hello'"

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalCompileIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalCompileIntegrationTest.groovy
@@ -16,14 +16,13 @@
 
 package org.gradle.language.cpp
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.CppApp
 import org.gradle.nativeplatform.fixtures.app.CppLib
 
 class CppIncrementalCompileIntegrationTest extends AbstractInstalledToolChainIntegrationSpec implements CppTaskNames {
 
-    @ToBeFixedForConfigurationCache
     def "skips compile and link tasks for executable when source doesn't change"() {
         def app = new CppApp()
         settingsFile << "rootProject.name = 'app'"
@@ -56,7 +55,6 @@ class CppIncrementalCompileIntegrationTest extends AbstractInstalledToolChainInt
         installation("build/install/main/release").exec().out == app.expectedOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "skips compile and link tasks for library when source doesn't change"() {
         def lib = new CppLib()
         settingsFile << "rootProject.name = 'hello'"

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLanguageIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLanguageIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.language.cpp
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.language.AbstractNativeLanguageIntegrationTest
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
@@ -31,7 +31,6 @@ class CppLanguageIntegrationTest extends AbstractNativeLanguageIntegrationTest {
 
     HelloWorldApp helloWorldApp = new CppHelloWorldApp()
 
-    @ToBeFixedForConfigurationCache
     def "build fails when compilation fails"() {
         given:
         buildFile << """
@@ -56,7 +55,6 @@ model {
         failure.assertThatCause(containsText("C++ compiler failed while compiling broken.cpp"))
     }
 
-    @ToBeFixedForConfigurationCache
     def "finds C and C++ standard library headers"() {
         // https://github.com/gradle/gradle-native/issues/282
         Assume.assumeFalse(toolChain.id == "gcccygwin")
@@ -83,7 +81,6 @@ model {
         output.contains("Found all include files for ':compileMainSharedLibraryMainCpp'")
     }
 
-    @ToBeFixedForConfigurationCache
     def "sources are compiled with C++ compiler"() {
         def app = new CppCompilerDetectingTestApp()
 
@@ -104,7 +101,6 @@ model {
         executable("build/exe/main/main").exec().out == app.expectedOutput(toolChain)
     }
 
-    @ToBeFixedForConfigurationCache
     def "can manually define C++ source sets"() {
         given:
         helloWorldApp.library.headerFiles.each { it.writeToDir(file("src/shared")) }
@@ -153,7 +149,6 @@ model {
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.GCC_COMPATIBLE)
-    @ToBeFixedForConfigurationCache
     def "system headers are not evaluated when compiler warnings are enabled"() {
         def app = new CppCompilerDetectingTestApp()
 

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLanguageParallelIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLanguageParallelIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.language.cpp
 
 import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.language.AbstractNativeSoftwareModelParallelIntegrationTest
 import org.gradle.nativeplatform.fixtures.NativeInstallationFixture
 import org.gradle.nativeplatform.fixtures.app.CppHelloWorldApp
@@ -26,12 +25,10 @@ import org.gradle.nativeplatform.fixtures.app.HelloWorldApp
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 
-
 class CppLanguageParallelIntegrationTest extends AbstractNativeSoftwareModelParallelIntegrationTest {
     HelloWorldApp app = new CppHelloWorldApp()
 
     @Requires(UnitTestPreconditions.CanInstallExecutable)
-    @ToBeFixedForConfigurationCache
     def "can produce multiple executables that use a library from a single project in parallel"() {
         given:
         def apps = [

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.language.cpp
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibraries

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryIntegrationTest.groovy
@@ -57,7 +57,6 @@ class CppLibraryIntegrationTest extends AbstractCppIntegrationTest implements Cp
         return new CppLib()
     }
 
-    @ToBeFixedForConfigurationCache
     def "skip compile and link tasks when no source"() {
         given:
         buildFile << """
@@ -71,7 +70,6 @@ class CppLibraryIntegrationTest extends AbstractCppIntegrationTest implements Cp
         result.assertTasksSkipped(tasks.debug.allToLink, ":assemble")
     }
 
-    @ToBeFixedForConfigurationCache
     def "build fails when compilation fails"() {
         given:
         buildFile << """
@@ -92,7 +90,6 @@ class CppLibraryIntegrationTest extends AbstractCppIntegrationTest implements Cp
         failure.assertThatCause(containsText("C++ compiler failed while compiling broken.cpp"))
     }
 
-    @ToBeFixedForConfigurationCache
     def "finds C and C++ standard library headers"() {
         given:
         buildFile << """
@@ -113,7 +110,6 @@ class CppLibraryIntegrationTest extends AbstractCppIntegrationTest implements Cp
         output.contains("Found all include files for ':compileDebugCpp'")
     }
 
-    @ToBeFixedForConfigurationCache
     def "sources are compiled with C++ compiler"() {
         given:
         settingsFile << "rootProject.name = 'hello'"
@@ -131,7 +127,6 @@ class CppLibraryIntegrationTest extends AbstractCppIntegrationTest implements Cp
         sharedLibrary("build/lib/main/debug/hello").assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "can build debug and release variants of library"() {
         given:
         settingsFile << "rootProject.name = 'hello'"
@@ -162,7 +157,6 @@ class CppLibraryIntegrationTest extends AbstractCppIntegrationTest implements Cp
         !output.contains('compiling with feature enabled')
     }
 
-    @ToBeFixedForConfigurationCache
     def "can use link file as task dependency"() {
         given:
         settingsFile << "rootProject.name = 'hello'"
@@ -184,7 +178,6 @@ class CppLibraryIntegrationTest extends AbstractCppIntegrationTest implements Cp
         sharedLibrary("build/lib/main/debug/hello").assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "can use runtime file as task dependency"() {
         given:
         settingsFile << "rootProject.name = 'hello'"
@@ -206,7 +199,6 @@ class CppLibraryIntegrationTest extends AbstractCppIntegrationTest implements Cp
         sharedLibrary("build/lib/main/debug/hello").assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "can use objects as task dependency"() {
         given:
         settingsFile << "rootProject.name = 'hello'"
@@ -229,7 +221,6 @@ class CppLibraryIntegrationTest extends AbstractCppIntegrationTest implements Cp
         sharedLibrary("build/lib/main/debug/hello").assertDoesNotExist()
     }
 
-    @ToBeFixedForConfigurationCache
     def "build logic can change source layout convention"() {
         def lib = new CppLib()
         settingsFile << "rootProject.name = 'hello'"
@@ -259,7 +250,6 @@ class CppLibraryIntegrationTest extends AbstractCppIntegrationTest implements Cp
         sharedLibrary("build/lib/main/debug/hello").assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "build logic can add individual source files"() {
         def lib = new CppLib()
         settingsFile << "rootProject.name = 'hello'"
@@ -288,7 +278,6 @@ class CppLibraryIntegrationTest extends AbstractCppIntegrationTest implements Cp
         sharedLibrary("build/lib/main/debug/hello").assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "honors changes to buildDir"() {
         given:
         settingsFile << "rootProject.name = 'hello'"
@@ -310,7 +299,6 @@ class CppLibraryIntegrationTest extends AbstractCppIntegrationTest implements Cp
         sharedLibrary("output/lib/main/debug/hello").assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "honors changes to task output locations"() {
         given:
         settingsFile << "rootProject.name = 'hello'"
@@ -341,7 +329,6 @@ class CppLibraryIntegrationTest extends AbstractCppIntegrationTest implements Cp
         }
     }
 
-    @ToBeFixedForConfigurationCache
     def "library can define public and implementation headers"() {
         given:
         settingsFile << "rootProject.name = 'hello'"
@@ -362,7 +349,6 @@ class CppLibraryIntegrationTest extends AbstractCppIntegrationTest implements Cp
         sharedLibrary("build/lib/main/debug/hello").assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "can compile and link against implementation and api libraries"() {
         createDirs("lib1", "lib2", "lib3")
         settingsFile << "include 'lib1', 'lib2', 'lib3'"
@@ -408,7 +394,6 @@ class CppLibraryIntegrationTest extends AbstractCppIntegrationTest implements Cp
         sharedLibrary("lib3/build/lib/main/release/lib3").strippedRuntimeFile.assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "can compile and link against static implementation and api libraries"() {
         createDirs("lib1", "lib2", "lib3")
         settingsFile << "include 'lib1', 'lib2', 'lib3'"
@@ -454,7 +439,6 @@ class CppLibraryIntegrationTest extends AbstractCppIntegrationTest implements Cp
         sharedLibrary("lib1/build/lib/main/release/lib1").strippedRuntimeFile.assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "private headers are not visible to consumer"() {
         def lib = new CppLib()
 
@@ -495,7 +479,6 @@ project(':greeter') {
         succeeds(":consumer:compileDebugCpp")
     }
 
-    @ToBeFixedForConfigurationCache
     def "implementation dependencies are not visible to consumer"() {
         def app = new CppAppWithLibraries()
 
@@ -533,7 +516,6 @@ project(':greeter') {
         succeeds(":consumer:compileDebugCpp")
     }
 
-    @ToBeFixedForConfigurationCache
     def "can change default base name and successfully link against library"() {
         createDirs("lib1", "lib2")
         settingsFile << "include 'lib1', 'lib2'"
@@ -568,7 +550,6 @@ project(':greeter') {
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.GCC_COMPATIBLE)
-    @ToBeFixedForConfigurationCache
     def "system headers are not evaluated when compiler warnings are enabled"() {
         given:
         settingsFile << "rootProject.name = 'hello'"

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryPublishingIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryPublishingIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.language.cpp
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.language.VariantContext
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
@@ -815,7 +815,6 @@ dependencies { implementation 'some.group:greeter:1.2' }
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32_AND_64)
-    @ToBeFixedForConfigurationCache
     def "can publish a library and its dependencies to a Maven repository when multiple target architectures are specified"() {
         def app = new CppAppWithLibrariesWithApiDependencies()
         def targetMachines = [machine(currentOsFamilyName, X86), machine(currentOsFamilyName, X86_64)]
@@ -886,7 +885,6 @@ dependencies { implementation 'some.group:greeter:1.2' }
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32_AND_64)
-    @ToBeFixedForConfigurationCache
     def "fails when a dependency is published without a matching target architecture"() {
         def app = new CppAppWithLibrariesWithApiDependencies()
 

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryPublishingIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryPublishingIntegrationTest.groovy
@@ -39,7 +39,6 @@ import static org.gradle.nativeplatform.OperatingSystemFamily.WINDOWS
 
 class CppLibraryPublishingIntegrationTest extends AbstractCppPublishingIntegrationTest implements CppTaskNames {
 
-    @ToBeFixedForConfigurationCache
     def "can publish the binaries and headers of a library to a Maven repository"() {
         def lib = new CppLib()
         assert !lib.publicHeaders.files.empty
@@ -149,7 +148,6 @@ class CppLibraryPublishingIntegrationTest extends AbstractCppPublishingIntegrati
         releaseRuntime.files[0].url == withSharedLibrarySuffix("test_release-1.2")
     }
 
-    @ToBeFixedForConfigurationCache
     def "can publish a library and its dependencies to a Maven repository"() {
         def app = new CppAppWithLibrariesWithApiDependencies()
 
@@ -270,7 +268,6 @@ class CppLibraryPublishingIntegrationTest extends AbstractCppPublishingIntegrati
         installation(consumer.file("build/install/main/debug")).exec().out == app.expectedOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "can publish a library with external dependencies to a Maven repository"() {
         def app = new CppAppWithLibrariesWithApiDependencies()
 
@@ -385,7 +382,6 @@ class CppLibraryPublishingIntegrationTest extends AbstractCppPublishingIntegrati
         installation(consumer.file("build/install/main/debug")).exec().out == app.expectedOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "uses base name of library to calculate coordinates"() {
         def app = new CppAppWithLibrariesWithApiDependencies()
 
@@ -499,7 +495,6 @@ class CppLibraryPublishingIntegrationTest extends AbstractCppPublishingIntegrati
         installation(consumer.file("build/install/main/debug")).exec().out == app.expectedOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "can adjust main publication coordinates"() {
         def lib = new CppLib()
 
@@ -532,7 +527,6 @@ class CppLibraryPublishingIntegrationTest extends AbstractCppPublishingIntegrati
         main.assertArtifactsPublished("test-adjusted-1.2-cpp-api-headers.zip", "test-adjusted-1.2.pom", "test-adjusted-1.2.module")
     }
 
-    @ToBeFixedForConfigurationCache
     def "private headers are not visible to consumer"() {
         def lib = new CppLib()
         def repoDir = file("repo")
@@ -583,7 +577,6 @@ library.publicHeaders.from 'src/main/public', 'src/main/headers'
         succeeds("compileDebugCpp")
     }
 
-    @ToBeFixedForConfigurationCache
     def "implementation dependencies are not visible to consumer"() {
         def app = new CppAppWithLibraries()
         def repoDir = file("repo")
@@ -638,7 +631,6 @@ dependencies { implementation 'some.group:greeter:1.2' }
         succeeds("compileDebugCpp")
     }
 
-    @ToBeFixedForConfigurationCache
     def "correct variant of published library is selected when resolving"() {
         def app = new CppAppWithLibraryAndOptionalFeature()
 
@@ -702,7 +694,6 @@ dependencies { implementation 'some.group:greeter:1.2' }
     }
 
     @Issue("https://github.com/gradle/gradle/issues/6766")
-    @ToBeFixedForConfigurationCache
     void "configuration exclusions are published in generated POM and Gradle metadata"() {
         def app = new CppAppWithLibrariesWithApiDependencies()
 
@@ -754,7 +745,6 @@ dependencies { implementation 'some.group:greeter:1.2' }
         }
     }
 
-    @ToBeFixedForConfigurationCache
     def "can publish a library and its dependencies to a Maven repository when multiple target operating systems are specified"() {
         def app = new CppAppWithLibrariesWithApiDependencies()
         def targetMachines = [machine(WINDOWS, currentArchitecture), machine(LINUX, currentArchitecture), machine(MACOS, currentArchitecture)]

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryWithBothLinkagePublishingIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryWithBothLinkagePublishingIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.language.cpp
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibraryAndOptionalFeature
 import org.gradle.nativeplatform.fixtures.app.CppLib
@@ -25,7 +25,6 @@ import org.gradle.test.fixtures.maven.MavenFileRepository
 
 class CppLibraryWithBothLinkagePublishingIntegrationTest extends AbstractInstalledToolChainIntegrationSpec implements CppTaskNames {
 
-    @ToBeFixedForConfigurationCache
     def "can publish the binaries and headers of a library to a Maven repository"() {
         def lib = new CppLib()
         assert !lib.publicHeaders.files.empty
@@ -155,7 +154,6 @@ class CppLibraryWithBothLinkagePublishingIntegrationTest extends AbstractInstall
         releaseStaticMetadata.variant('releaseStaticRuntime')
     }
 
-    @ToBeFixedForConfigurationCache
     def "correct variant of published library is selected when resolving"() {
         def app = new CppAppWithLibraryAndOptionalFeature()
 

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryWithStaticLinkagePublishingIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryWithStaticLinkagePublishingIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.language.cpp
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibraryAndOptionalFeature
 import org.gradle.nativeplatform.fixtures.app.CppLib
@@ -25,7 +25,6 @@ import org.gradle.test.fixtures.maven.MavenFileRepository
 
 class CppLibraryWithStaticLinkagePublishingIntegrationTest extends AbstractInstalledToolChainIntegrationSpec implements CppTaskNames {
 
-    @ToBeFixedForConfigurationCache
     def "can publish the binaries and headers of a library to a Maven repository"() {
         def lib = new CppLib()
         assert !lib.publicHeaders.files.empty
@@ -129,7 +128,6 @@ class CppLibraryWithStaticLinkagePublishingIntegrationTest extends AbstractInsta
         releaseRuntime.files.empty
     }
 
-    @ToBeFixedForConfigurationCache
     def "correct variant of published library is selected when resolving"() {
         def app = new CppAppWithLibraryAndOptionalFeature()
 

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppMissingToolchainIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppMissingToolchainIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.language.cpp
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AvailableToolChains
 import org.gradle.nativeplatform.fixtures.HostPlatform
@@ -27,7 +26,6 @@ import org.gradle.nativeplatform.fixtures.app.CppCompilerDetectingTestApp
 import org.junit.Assume
 
 class CppMissingToolchainIntegrationTest extends AbstractIntegrationSpec implements HostPlatform {
-    @ToBeFixedForConfigurationCache
     def "user receives reasonable error message when no tool chains are available"() {
         given:
         buildFile << """
@@ -83,7 +81,6 @@ class CppMissingToolchainIntegrationTest extends AbstractIntegrationSpec impleme
         }
     }
 
-    @ToBeFixedForConfigurationCache
     def "can build with Clang when gcc is available but g++ is not available"() {
         def gcc = AvailableToolChains.getToolChain(ToolChainRequirement.GCC)
         Assume.assumeTrue(gcc != null)

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppSharedLibraryLinkageIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppSharedLibraryLinkageIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.language.cpp
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.app.CppLib
 import org.gradle.nativeplatform.fixtures.app.SourceElement
 
@@ -49,7 +49,6 @@ class CppSharedLibraryLinkageIntegrationTest extends AbstractCppIntegrationTest 
         return new CppLib()
     }
 
-    @ToBeFixedForConfigurationCache
     def "can create shared library binary when only shared linkage is specified"() {
         def library = new CppLib()
         buildFile << """

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppStaticLibraryLinkageIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppStaticLibraryLinkageIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.language.cpp
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.app.CppLib
 import org.gradle.nativeplatform.fixtures.app.SourceElement
 
@@ -49,7 +49,6 @@ class CppStaticLibraryLinkageIntegrationTest extends AbstractCppIntegrationTest 
         return new CppLib()
     }
 
-    @ToBeFixedForConfigurationCache
     def "can create static library binary when only static linkage is specified"() {
         def library = new CppLib()
         buildFile << """
@@ -72,7 +71,6 @@ class CppStaticLibraryLinkageIntegrationTest extends AbstractCppIntegrationTest 
         staticLibrary('build/lib/main/debug/foo').assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "can create debug and release variants of library"() {
         def library = new CppLib()
         buildFile << """
@@ -102,7 +100,6 @@ class CppStaticLibraryLinkageIntegrationTest extends AbstractCppIntegrationTest 
         staticLibrary('build/lib/main/debug/foo').assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "can use link file as task dependency"() {
         given:
         settingsFile << "rootProject.name = 'hello'"
@@ -128,7 +125,6 @@ class CppStaticLibraryLinkageIntegrationTest extends AbstractCppIntegrationTest 
         staticLibrary("build/lib/main/debug/hello").assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "can use objects as task dependency"() {
         given:
         settingsFile << "rootProject.name = 'hello'"

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppStaticLibraryPublishingIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppStaticLibraryPublishingIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.language.cpp
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.language.VariantContext
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
@@ -98,7 +98,6 @@ class CppStaticLibraryPublishingIntegrationTest extends AbstractCppPublishingInt
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32_AND_64)
-    @ToBeFixedForConfigurationCache
     def "can publish a library and its dependencies to a Maven repository when multiple target architectures are specified"() {
         def app = new CppAppWithLibrariesWithApiDependencies()
         def targetMachines = [machine(currentOsFamilyName, X86), machine(currentOsFamilyName, X86_64)]

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppStaticLibraryPublishingIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppStaticLibraryPublishingIntegrationTest.groovy
@@ -30,7 +30,6 @@ import static org.gradle.nativeplatform.OperatingSystemFamily.MACOS
 import static org.gradle.nativeplatform.OperatingSystemFamily.WINDOWS
 
 class CppStaticLibraryPublishingIntegrationTest extends AbstractCppPublishingIntegrationTest {
-    @ToBeFixedForConfigurationCache
     def "can publish a library and its dependencies to a Maven repository when multiple target operating systems are specified"() {
         def app = new CppAppWithLibrariesWithApiDependencies()
         def targetMachines = [machine(WINDOWS, currentArchitecture), machine(LINUX, currentArchitecture), machine(MACOS, currentArchitecture)]

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppToolChainChangesIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppToolChainChangesIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.language.cpp
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.nativeplatform.fixtures.AvailableToolChains
 import org.gradle.nativeplatform.fixtures.AvailableToolChains.InstalledToolChain
 import org.gradle.nativeplatform.fixtures.app.CppHelloWorldApp
@@ -58,7 +57,6 @@ class CppToolChainChangesIntegrationTest extends AbstractIntegrationSpec {
         }
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles binary when toolchain changes from #toolChainBefore to #toolChainAfter"() {
         buildFile.text = buildScriptForToolChains(toolChainBefore, toolChainAfter)
         def useAlternateToolChain = false

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/nativeplatform/NativeLanguageSamplesIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/nativeplatform/NativeLanguageSamplesIntegrationTest.groovy
@@ -51,7 +51,6 @@ class NativeLanguageSamplesIntegrationTest extends AbstractInstalledToolChainInt
     }
 
     @RequiresInstalledToolChain(SUPPORTS_32_AND_64)
-    @ToBeFixedForConfigurationCache
     def "assembler"() {
         given:
         sample assembler
@@ -66,7 +65,6 @@ class NativeLanguageSamplesIntegrationTest extends AbstractInstalledToolChainInt
         installation(assembler.dir.file("build/install/main")).exec().out == "5 + 7 = 12\n"
     }
 
-    @ToBeFixedForConfigurationCache
     def "c"() {
         given:
         sample c
@@ -82,7 +80,6 @@ class NativeLanguageSamplesIntegrationTest extends AbstractInstalledToolChainInt
         installation(c.dir.file("build/install/main")).exec().out == "Hello world!"
     }
 
-    @ToBeFixedForConfigurationCache
     def "cpp"() {
         given:
         sample cpp
@@ -100,7 +97,6 @@ class NativeLanguageSamplesIntegrationTest extends AbstractInstalledToolChainInt
 
     @RequiresInstalledToolChain(GCC_COMPATIBLE)
     @Requires(UnitTestPreconditions.NotWindows)
-    @ToBeFixedForConfigurationCache
     def "objectiveC"() {
         given:
         sample objectiveC
@@ -117,7 +113,6 @@ class NativeLanguageSamplesIntegrationTest extends AbstractInstalledToolChainInt
 
     @RequiresInstalledToolChain(GCC_COMPATIBLE)
     @Requires(UnitTestPreconditions.NotWindows)
-    @ToBeFixedForConfigurationCache
     def "objectiveCpp"() {
         given:
         sample objectiveCpp
@@ -160,7 +155,6 @@ class NativeLanguageSamplesIntegrationTest extends AbstractInstalledToolChainInt
         file(windowsResources.dir.file("build/libs/helloRes/shared/helloRes.dll")).assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "custom layout"() {
         given:
         sample customLayout
@@ -176,7 +170,6 @@ class NativeLanguageSamplesIntegrationTest extends AbstractInstalledToolChainInt
         installation(customLayout.dir.file("build/install/main")).exec().out == "Hello world!"
     }
 
-    @ToBeFixedForConfigurationCache
     def "idl"() {
         given:
         sample idl

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/objectivec/ObjectiveCLanguageIncrementalCompileIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/objectivec/ObjectiveCLanguageIncrementalCompileIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.language.objectivec
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.language.AbstractNativeLanguageIncrementalCompileIntegrationTest
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.app.IncrementalHelloWorldApp
@@ -34,7 +34,6 @@ class ObjectiveCLanguageIncrementalCompileIntegrationTest extends AbstractNative
         return new ObjectiveCHelloWorldApp()
     }
 
-    @ToBeFixedForConfigurationCache
     def "does not recompile when include path has #testCase"() {
         given:
         outputs.snapshot { run "mainExecutable" }
@@ -76,7 +75,6 @@ class ObjectiveCLanguageIncrementalCompileIntegrationTest extends AbstractNative
         "replacement header dir after" | '"src/main/headers", "src/replacement-headers"'
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles only source file that imported changed header file"() {
         given:
         sourceFile << """
@@ -99,7 +97,6 @@ class ObjectiveCLanguageIncrementalCompileIntegrationTest extends AbstractNative
         outputs.recompiledFile sourceFile
     }
 
-    @ToBeFixedForConfigurationCache
     def "source is always recompiled if it imported header via complex macro"() {
         given:
         def notIncluded = file("src/main/headers/notIncluded.h")
@@ -140,7 +137,6 @@ class ObjectiveCLanguageIncrementalCompileIntegrationTest extends AbstractNative
         outputs.recompiledFile sourceFile
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles source file when transitively imported header file is changed"() {
         given:
         def transitiveHeaderFile = file("src/main/headers/transitive.h") << """

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/rc/WindowsResourcesUnsupportedIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/rc/WindowsResourcesUnsupportedIntegrationTest.groovy
@@ -29,7 +29,6 @@ class WindowsResourcesUnsupportedIntegrationTest extends AbstractInstalledToolCh
     HelloWorldApp helloWorldApp = new CppHelloWorldApp()
 
     @Requires(UnitTestPreconditions.NotWindows)
-    @ToBeFixedForConfigurationCache
     def "resource files are ignored on unsupported platforms"() {
         given:
         buildFile << """

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/rc/WindowsResourcesUnsupportedIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/rc/WindowsResourcesUnsupportedIntegrationTest.groovy
@@ -15,7 +15,6 @@
  */
 package org.gradle.language.rc
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftApplicationCppInteroperabilityIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftApplicationCppInteroperabilityIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.language.swift
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.app.CppGreeterFunction
 import org.gradle.nativeplatform.fixtures.app.CppGreeterFunctionUsesLogger
 import org.gradle.nativeplatform.fixtures.app.CppGreeterFunctionUsesLoggerApi
@@ -31,7 +31,6 @@ import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 
 @DoesNotSupportNonAsciiPaths(reason = "Swift sometimes fails when executed from non-ASCII directory")
 class SwiftApplicationCppInteroperabilityIntegrationTest extends AbstractSwiftMixedLanguageIntegrationTest {
-    @ToBeFixedForConfigurationCache
     def "can compile and link against a #linkage.toLowerCase() c++ library"() {
         createDirs("app", "cppGreeter")
         settingsFile << "include 'app', 'cppGreeter'"
@@ -73,7 +72,6 @@ class SwiftApplicationCppInteroperabilityIntegrationTest extends AbstractSwiftMi
         linkage << [SHARED, STATIC]
     }
 
-    @ToBeFixedForConfigurationCache
     def "can compile and link against a c++ library with both static and shared linkages"() {
         createDirs("app", "cppGreeter")
         settingsFile << "include 'app', 'cppGreeter'"
@@ -105,7 +103,6 @@ class SwiftApplicationCppInteroperabilityIntegrationTest extends AbstractSwiftMi
         installation("app/build/install/main/debug").exec().out == app.expectedOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "can compile and link against a library with a dependency on a #linkage.toLowerCase() c++ library"() {
         createDirs("app", "greeter", "cppGreeter")
         settingsFile << "include 'app', 'greeter', 'cppGreeter'"
@@ -163,7 +160,6 @@ class SwiftApplicationCppInteroperabilityIntegrationTest extends AbstractSwiftMi
         linkage << [SHARED, STATIC]
     }
 
-    @ToBeFixedForConfigurationCache
     def "can compile and link against a #linkage.toLowerCase() c++ library with a dependency on another c++ library"() {
         createDirs("app", "greeter", "cppGreeter", "logger")
         settingsFile << "include 'app', 'greeter', 'cppGreeter', ':logger'"
@@ -215,7 +211,6 @@ class SwiftApplicationCppInteroperabilityIntegrationTest extends AbstractSwiftMi
         linkage << [SHARED, STATIC]
     }
 
-    @ToBeFixedForConfigurationCache
     def "can compile and link against a c++ library with an api dependency on another c++ library"() {
         createDirs("app", "greeter", "cppGreeter", "logger")
         settingsFile << "include 'app', 'greeter', 'cppGreeter', ':logger'"
@@ -256,7 +251,6 @@ class SwiftApplicationCppInteroperabilityIntegrationTest extends AbstractSwiftMi
         installation("app/build/install/main/debug").exec().out == app.expectedOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "declaring a dependency on a c++ library without public headers does not fail"() {
         createDirs("app", "cppGreeter")
         settingsFile << "include 'app', 'cppGreeter'"

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalCppInteroperabilityIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalCppInteroperabilityIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.language.swift
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.app.IncrementalSwiftModifyCppDepApp
 import org.gradle.nativeplatform.fixtures.app.IncrementalSwiftModifyCppDepHeadersApp
 import org.gradle.nativeplatform.fixtures.app.IncrementalSwiftModifyCppDepModuleMapApp
@@ -25,7 +25,6 @@ import org.gradle.test.preconditions.UnitTestPreconditions
 
 @Requires(UnitTestPreconditions.NotMacOs)
 class SwiftIncrementalCppInteroperabilityIntegrationTest extends AbstractSwiftMixedLanguageIntegrationTest {
-    @ToBeFixedForConfigurationCache
     def "relinks but does not recompile when c++ sources change"() {
         def app = new IncrementalSwiftModifyCppDepApp()
         createDirs("app", "cppGreeter")
@@ -75,7 +74,6 @@ class SwiftIncrementalCppInteroperabilityIntegrationTest extends AbstractSwiftMi
         result.assertTasksSkipped(":cppGreeter:compileDebugCpp", ":cppGreeter:linkDebug", ":app:compileDebugSwift", ":app:linkDebug", ":app:installDebug", ":app:assemble")
     }
 
-    @ToBeFixedForConfigurationCache
     def "recompiles when c++ headers change"() {
         def app = new IncrementalSwiftModifyCppDepHeadersApp()
         createDirs("app", "cppGreeter")
@@ -125,7 +123,6 @@ class SwiftIncrementalCppInteroperabilityIntegrationTest extends AbstractSwiftMi
         result.assertTasksSkipped(":cppGreeter:compileDebugCpp", ":cppGreeter:linkDebug", ":app:compileDebugSwift", ":app:linkDebug", ":app:installDebug", ":app:assemble")
     }
 
-    @ToBeFixedForConfigurationCache
     def "regenerates module map and recompiles swift app when headers change"() {
         def app = new IncrementalSwiftModifyCppDepModuleMapApp()
         createDirs("app", "cppGreeter")

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftLibraryCppInteroperabilityIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftLibraryCppInteroperabilityIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.language.swift
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.NativeBinaryFixture
 import org.gradle.nativeplatform.fixtures.app.CppGreeterFunction
 import org.gradle.nativeplatform.fixtures.app.CppGreeterFunctionUsesLogger
@@ -75,7 +75,6 @@ class SwiftLibraryCppInteroperabilityIntegrationTest extends AbstractSwiftMixedL
         linkage << [SHARED, STATIC]
     }
 
-    @ToBeFixedForConfigurationCache
     def "can compile and link against a c++ library with a dependency on a #linkage.toLowerCase() c++ library"() {
         createDirs("hello", "cppGreeter", "logger")
         settingsFile << "include 'hello', 'cppGreeter', 'logger'"

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftLibraryCppInteroperabilityIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftLibraryCppInteroperabilityIntegrationTest.groovy
@@ -27,7 +27,6 @@ import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 @DoesNotSupportNonAsciiPaths(reason = "Swift sometimes fails when executed from non-ASCII directory")
 class SwiftLibraryCppInteroperabilityIntegrationTest extends AbstractSwiftMixedLanguageIntegrationTest {
 
-    @ToBeFixedForConfigurationCache
     def "can compile and link against a #linkage.toLowerCase() c++ library"() {
         createDirs("hello", "cppGreeter")
         settingsFile << "include 'hello', 'cppGreeter'"

--- a/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeDependenciesIntegrationTest.groovy
+++ b/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeDependenciesIntegrationTest.groovy
@@ -27,6 +27,9 @@ abstract class AbstractNativeDependenciesIntegrationTest extends AbstractInstall
         """
     }
 
+    @ToBeFixedForConfigurationCache(bottomSpecs = [
+        'XCTestDependenciesIntegrationTest'
+    ])
     def "can define implementation dependencies on component"() {
         given:
         createDirs("lib")
@@ -47,6 +50,9 @@ abstract class AbstractNativeDependenciesIntegrationTest extends AbstractInstall
         result.assertTasksExecuted(libDebugTasks, assembleDevBinaryTasks, assembleDevBinaryTask)
     }
 
+    @ToBeFixedForConfigurationCache(bottomSpecs = [
+        'XCTestDependenciesIntegrationTest'
+    ])
     def "can define implementation dependencies on each binary"() {
         given:
         createDirs("lib")

--- a/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeDependenciesIntegrationTest.groovy
+++ b/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeDependenciesIntegrationTest.groovy
@@ -27,12 +27,6 @@ abstract class AbstractNativeDependenciesIntegrationTest extends AbstractInstall
         """
     }
 
-    @ToBeFixedForConfigurationCache(bottomSpecs = [
-        'CppUnitTestDependenciesIntegrationTest',
-        'CppApplicationDependenciesIntegrationTest',
-        'CppLibraryDependenciesIntegrationTest',
-        'XCTestDependenciesIntegrationTest'
-    ])
     def "can define implementation dependencies on component"() {
         given:
         createDirs("lib")
@@ -53,12 +47,6 @@ abstract class AbstractNativeDependenciesIntegrationTest extends AbstractInstall
         result.assertTasksExecuted(libDebugTasks, assembleDevBinaryTasks, assembleDevBinaryTask)
     }
 
-    @ToBeFixedForConfigurationCache(bottomSpecs = [
-        'CppLibraryDependenciesIntegrationTest',
-        'CppApplicationDependenciesIntegrationTest',
-        'CppUnitTestDependenciesIntegrationTest',
-        'XCTestDependenciesIntegrationTest'
-    ])
     def "can define implementation dependencies on each binary"() {
         given:
         createDirs("lib")

--- a/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeProductionComponentDependenciesIntegrationTest.groovy
+++ b/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeProductionComponentDependenciesIntegrationTest.groovy
@@ -16,8 +16,6 @@
 
 package org.gradle.language
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
-
 abstract class AbstractNativeProductionComponentDependenciesIntegrationTest extends AbstractNativeDependenciesIntegrationTest {
     def "can define different implementation dependencies on each binary"() {
         given:

--- a/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeProductionComponentDependenciesIntegrationTest.groovy
+++ b/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeProductionComponentDependenciesIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.language
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 
 abstract class AbstractNativeProductionComponentDependenciesIntegrationTest extends AbstractNativeDependenciesIntegrationTest {
-    @ToBeFixedForConfigurationCache(bottomSpecs = ['CppLibraryDependenciesIntegrationTest', 'CppApplicationDependenciesIntegrationTest'])
     def "can define different implementation dependencies on each binary"() {
         given:
         createDirs("lib")
@@ -48,10 +47,6 @@ abstract class AbstractNativeProductionComponentDependenciesIntegrationTest exte
         result.assertTasksExecuted(assembleReleaseTasks, ':assembleRelease')
     }
 
-    @ToBeFixedForConfigurationCache(bottomSpecs = [
-        'CppLibraryDependenciesIntegrationTest',
-        'CppApplicationDependenciesIntegrationTest',
-    ])
     def "can define an included build implementation dependency on a binary"() {
         settingsFile << 'includeBuild "lib"'
         makeComponentWithIncludedBuildLibrary()

--- a/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
+++ b/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
@@ -160,9 +160,11 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
         buildFile << configureTargetMachines("machines.${currentHostOperatingSystemFamilyDsl}", "machines.${currentHostOperatingSystemFamilyDsl}")
         buildFile << """
             task verifyTargetMachineCount {
+                def targetMachines = ${componentUnderTestDsl}.targetMachines
+                def expectedMachine = machines.${currentHostOperatingSystemFamilyDsl}
                 doLast {
-                    assert ${componentUnderTestDsl}.targetMachines.get().size() == 1
-                    assert ${componentUnderTestDsl}.targetMachines.get() == [machines.${currentHostOperatingSystemFamilyDsl}] as Set
+                    assert targetMachines.get().size() == 1
+                    assert targetMachines.get() == [expectedMachine] as Set
                 }
             }
         """

--- a/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
+++ b/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.language.cpp
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.language.AbstractNativeLanguageComponentIntegrationTest
 import org.gradle.nativeplatform.MachineArchitecture
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
@@ -24,7 +24,6 @@ import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.util.internal.GUtil
 
 abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguageComponentIntegrationTest {
-    @ToBeFixedForConfigurationCache
     def "can build on current operating system family and architecture when explicitly specified"() {
         given:
         makeSingleProject()
@@ -94,7 +93,6 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
         failure.assertHasCause("A target machine needs to be specified for the ${GUtil.toWords(componentUnderTestDsl, (char) ' ')}.")
     }
 
-    @ToBeFixedForConfigurationCache
     def "can build for current machine when multiple target machines are specified"() {
         given:
         makeSingleProject()
@@ -109,7 +107,6 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32_AND_64)
-    @ToBeFixedForConfigurationCache
     def "can build for multiple target machines"() {
         given:
         makeSingleProject()
@@ -126,7 +123,6 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
                 getTaskNameToAssembleDevelopmentBinaryWithArchitecture(MachineArchitecture.X86_64))
     }
 
-    @ToBeFixedForConfigurationCache
     def "fails when no target architecture can be built"() {
         given:
         makeSingleProject()
@@ -141,7 +137,6 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
         failure.assertHasCause("No tool chain is available to build C++")
     }
 
-    @ToBeFixedForConfigurationCache
     def "can build current architecture when other, non-buildable architectures are specified"() {
         given:
         makeSingleProject()
@@ -156,7 +151,6 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
         result.assertTasksExecutedAndNotSkipped(getTasksToAssembleDevelopmentBinary(currentArchitecture), ":$taskNameToAssembleDevelopmentBinary")
     }
 
-    @ToBeFixedForConfigurationCache
     def "ignores duplicate target machines"() {
         given:
         makeSingleProject()
@@ -177,7 +171,6 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
         succeeds "verifyTargetMachineCount"
     }
 
-    @ToBeFixedForConfigurationCache
     def "can specify unbuildable architecture as a component target machine"() {
         given:
         makeSingleProject()

--- a/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
+++ b/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.language.cpp
 
-
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.language.AbstractNativeLanguageComponentIntegrationTest
 import org.gradle.nativeplatform.MachineArchitecture
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
@@ -24,6 +24,12 @@ import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.util.internal.GUtil
 
 abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguageComponentIntegrationTest {
+    @ToBeFixedForConfigurationCache(bottomSpecs = [
+        'CppUnitTestComponentWithBothLibraryLinkageIntegrationTest',
+        'CppUnitTestComponentWithSharedLibraryLinkageIntegrationTest',
+        'CppUnitTestComponentWithStaticLibraryLinkageIntegrationTest',
+        'CppUnitTestComponentWithoutComponentIntegrationTest'
+    ])
     def "can build on current operating system family and architecture when explicitly specified"() {
         given:
         makeSingleProject()
@@ -93,6 +99,12 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
         failure.assertHasCause("A target machine needs to be specified for the ${GUtil.toWords(componentUnderTestDsl, (char) ' ')}.")
     }
 
+    @ToBeFixedForConfigurationCache(bottomSpecs = [
+        'CppUnitTestComponentWithBothLibraryLinkageIntegrationTest',
+        'CppUnitTestComponentWithSharedLibraryLinkageIntegrationTest',
+        'CppUnitTestComponentWithStaticLibraryLinkageIntegrationTest',
+        'CppUnitTestComponentWithoutComponentIntegrationTest'
+    ])
     def "can build for current machine when multiple target machines are specified"() {
         given:
         makeSingleProject()
@@ -107,6 +119,12 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32_AND_64)
+    @ToBeFixedForConfigurationCache(bottomSpecs = [
+        'CppUnitTestComponentWithBothLibraryLinkageIntegrationTest',
+        'CppUnitTestComponentWithSharedLibraryLinkageIntegrationTest',
+        'CppUnitTestComponentWithStaticLibraryLinkageIntegrationTest',
+        'CppUnitTestComponentWithoutComponentIntegrationTest'
+    ])
     def "can build for multiple target machines"() {
         given:
         makeSingleProject()
@@ -123,6 +141,12 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
                 getTaskNameToAssembleDevelopmentBinaryWithArchitecture(MachineArchitecture.X86_64))
     }
 
+    @ToBeFixedForConfigurationCache(bottomSpecs = [
+        'CppUnitTestComponentWithBothLibraryLinkageIntegrationTest',
+        'CppUnitTestComponentWithSharedLibraryLinkageIntegrationTest',
+        'CppUnitTestComponentWithStaticLibraryLinkageIntegrationTest',
+        'CppUnitTestComponentWithoutComponentIntegrationTest'
+    ])
     def "fails when no target architecture can be built"() {
         given:
         makeSingleProject()
@@ -137,6 +161,12 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
         failure.assertHasCause("No tool chain is available to build C++")
     }
 
+    @ToBeFixedForConfigurationCache(bottomSpecs = [
+        'CppUnitTestComponentWithBothLibraryLinkageIntegrationTest',
+        'CppUnitTestComponentWithSharedLibraryLinkageIntegrationTest',
+        'CppUnitTestComponentWithStaticLibraryLinkageIntegrationTest',
+        'CppUnitTestComponentWithoutComponentIntegrationTest'
+    ])
     def "can build current architecture when other, non-buildable architectures are specified"() {
         given:
         makeSingleProject()
@@ -173,6 +203,12 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
         succeeds "verifyTargetMachineCount"
     }
 
+    @ToBeFixedForConfigurationCache(bottomSpecs = [
+        'CppUnitTestComponentWithBothLibraryLinkageIntegrationTest',
+        'CppUnitTestComponentWithSharedLibraryLinkageIntegrationTest',
+        'CppUnitTestComponentWithStaticLibraryLinkageIntegrationTest',
+        'CppUnitTestComponentWithoutComponentIntegrationTest'
+    ])
     def "can specify unbuildable architecture as a component target machine"() {
         given:
         makeSingleProject()

--- a/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/swift/AbstractSwiftComponentIntegrationTest.groovy
+++ b/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/swift/AbstractSwiftComponentIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.language.swift
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.language.AbstractNativeLanguageComponentIntegrationTest
 import org.gradle.nativeplatform.OperatingSystemFamily
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
@@ -28,12 +28,6 @@ import org.hamcrest.CoreMatchers
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
 abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLanguageComponentIntegrationTest {
 
-    @ToBeFixedForConfigurationCache(bottomSpecs = [
-        'SwiftXCTestComponentWithoutComponentIntegrationTest',
-        'SwiftXCTestComponentWithBothLibraryLinkageIntegrationTest',
-        'SwiftXCTestComponentWithSharedLibraryLinkageIntegrationTest',
-        'SwiftXCTestComponentWithStaticLibraryLinkageIntegrationTest',
-        'SwiftXCTestComponentWithApplicationIntegrationTest'])
     def "sources are built with Swift tools"() {
         given:
         makeSingleProject()
@@ -46,7 +40,6 @@ abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLangu
         assertComponentUnderTestWasBuilt()
     }
 
-    @ToBeFixedForConfigurationCache
     def "binaries have the right Swift version"() {
         given:
         makeSingleProject()
@@ -89,12 +82,6 @@ abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLangu
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_4)
-    @ToBeFixedForConfigurationCache(bottomSpecs = [
-        'SwiftXCTestComponentWithoutComponentIntegrationTest',
-        'SwiftXCTestComponentWithBothLibraryLinkageIntegrationTest',
-        'SwiftXCTestComponentWithSharedLibraryLinkageIntegrationTest',
-        'SwiftXCTestComponentWithStaticLibraryLinkageIntegrationTest',
-        'SwiftXCTestComponentWithApplicationIntegrationTest'])
     def "can build Swift 3 source code on Swift 4 compiler"() {
         given:
         makeSingleProject()
@@ -123,7 +110,6 @@ abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLangu
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_5)
-    @ToBeFixedForConfigurationCache
     def "can build Swift 4 source code on Swift 5 compiler"() {
         given:
         makeSingleProject()
@@ -152,7 +138,6 @@ abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLangu
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_3)
-    @ToBeFixedForConfigurationCache
     def "throws exception with meaningful message when building Swift 4 source code on Swift 3 compiler"() {
         given:
         makeSingleProject()
@@ -182,7 +167,6 @@ abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLangu
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_3)
-    @ToBeFixedForConfigurationCache
     def "throws exception with meaningful message when building Swift 5 source code on Swift 3 compiler"() {
         given:
         makeSingleProject()
@@ -212,7 +196,6 @@ abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLangu
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_4)
-    @ToBeFixedForConfigurationCache
     def "throws exception with meaningful message when building Swift 5 source code on Swift 4 compiler"() {
         given:
         makeSingleProject()
@@ -242,7 +225,6 @@ abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLangu
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_5)
-    @ToBeFixedForConfigurationCache
     def "throws exception with meaningful message when building Swift 3 source code on Swift 5 compiler"() {
         given:
         makeSingleProject()
@@ -272,7 +254,6 @@ abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLangu
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_3)
-    @ToBeFixedForConfigurationCache
     def "can compile Swift 3 component on Swift 3 compiler"() {
         given:
         makeSingleProject()
@@ -297,12 +278,6 @@ abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLangu
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_4)
-    @ToBeFixedForConfigurationCache(bottomSpecs = [
-        'SwiftXCTestComponentWithoutComponentIntegrationTest',
-        'SwiftXCTestComponentWithBothLibraryLinkageIntegrationTest',
-        'SwiftXCTestComponentWithSharedLibraryLinkageIntegrationTest',
-        'SwiftXCTestComponentWithStaticLibraryLinkageIntegrationTest',
-        'SwiftXCTestComponentWithApplicationIntegrationTest'])
     def "can compile Swift 4 component on Swift 4 compiler"() {
         given:
         makeSingleProject()
@@ -327,7 +302,6 @@ abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLangu
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_5)
-    @ToBeFixedForConfigurationCache
     def "can compile Swift 5 component on Swift 5 compiler"() {
         given:
         makeSingleProject()

--- a/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/swift/AbstractSwiftComponentIntegrationTest.groovy
+++ b/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/swift/AbstractSwiftComponentIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.language.swift
 
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.language.AbstractNativeLanguageComponentIntegrationTest
 import org.gradle.nativeplatform.OperatingSystemFamily
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
@@ -27,6 +28,13 @@ import org.hamcrest.CoreMatchers
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
 abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLanguageComponentIntegrationTest {
 
+    @ToBeFixedForConfigurationCache(bottomSpecs = [
+        'SwiftXCTestComponentWithBothLibraryLinkageIntegrationTest',
+        'SwiftXCTestComponentWithSharedLibraryLinkageIntegrationTest',
+        'SwiftXCTestComponentWithStaticLibraryLinkageIntegrationTest',
+        'SwiftXCTestComponentWithoutComponentIntegrationTest',
+        'SwiftXCTestComponentWithApplicationIntegrationTest'
+    ])
     def "sources are built with Swift tools"() {
         given:
         makeSingleProject()
@@ -93,6 +101,13 @@ abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLangu
         result.assertTasksExecuted(tasksToAssembleDevelopmentBinaryOfComponentUnderTest, ":$taskNameToAssembleDevelopmentBinary")
     }
 
+    @ToBeFixedForConfigurationCache(bottomSpecs = [
+        'SwiftXCTestComponentWithBothLibraryLinkageIntegrationTest',
+        'SwiftXCTestComponentWithSharedLibraryLinkageIntegrationTest',
+        'SwiftXCTestComponentWithStaticLibraryLinkageIntegrationTest',
+        'SwiftXCTestComponentWithoutComponentIntegrationTest',
+        'SwiftXCTestComponentWithApplicationIntegrationTest'
+    ])
     @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_5)
     def "can build Swift 4 source code on Swift 5 compiler"() {
         given:
@@ -181,6 +196,13 @@ abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLangu
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_5)
+    @ToBeFixedForConfigurationCache(bottomSpecs = [
+        'SwiftXCTestComponentWithBothLibraryLinkageIntegrationTest',
+        'SwiftXCTestComponentWithStaticLibraryLinkageIntegrationTest',
+        'SwiftXCTestComponentWithSharedLibraryLinkageIntegrationTest',
+        'SwiftXCTestComponentWithApplicationIntegrationTest',
+        'SwiftXCTestComponentWithoutComponentIntegrationTest'
+    ])
     def "throws exception with meaningful message when building Swift 3 source code on Swift 5 compiler"() {
         given:
         makeSingleProject()
@@ -235,6 +257,13 @@ abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLangu
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_5)
+    @ToBeFixedForConfigurationCache(bottomSpecs = [
+        'SwiftXCTestComponentWithBothLibraryLinkageIntegrationTest',
+        'SwiftXCTestComponentWithSharedLibraryLinkageIntegrationTest',
+        'SwiftXCTestComponentWithStaticLibraryLinkageIntegrationTest',
+        'SwiftXCTestComponentWithApplicationIntegrationTest',
+        'SwiftXCTestComponentWithoutComponentIntegrationTest'
+    ])
     def "can compile Swift 5 component on Swift 5 compiler"() {
         given:
         makeSingleProject()

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/BinaryBuildTypesIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/BinaryBuildTypesIntegrationTest.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.nativeplatform
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.NativePlatformsTestFixture
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
@@ -26,7 +26,6 @@ import org.gradle.test.preconditions.UnitTestPreconditions
 class BinaryBuildTypesIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
     def helloWorldApp = new CppHelloWorldApp()
 
-    @ToBeFixedForConfigurationCache
     def "creates debug and release variants"() {
         when:
         helloWorldApp.writeSources(file("src/main"))
@@ -89,7 +88,6 @@ model {
         }
     }
 
-    @ToBeFixedForConfigurationCache
     def "configure component for a single build type"() {
         when:
         helloWorldApp.writeSources(file("src/main"))
@@ -123,7 +121,6 @@ model {
     }
 
     @Requires(UnitTestPreconditions.CanInstallExecutable)
-    @ToBeFixedForConfigurationCache
     def "executable with build type depends on library with matching build type"() {
         when:
         helloWorldApp.executable.writeSources(file("src/main"))

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/BinaryConfigurationIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/BinaryConfigurationIntegrationTest.groovy
@@ -31,7 +31,6 @@ import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.VISUALCPP
 
 class BinaryConfigurationIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
 
-    @ToBeFixedForConfigurationCache
     def "can configure the binaries of a C++ application"() {
         given:
         buildFile << """
@@ -68,7 +67,6 @@ model {
         executable.exec().out == "Hello!"
     }
 
-    @ToBeFixedForConfigurationCache
     def "can build debug binaries for a C++ executable"() {
         given:
         buildFile << """
@@ -111,7 +109,6 @@ model {
     }
 
     @Requires(UnitTestPreconditions.CanInstallExecutable)
-    @ToBeFixedForConfigurationCache
     def "can configure the binaries of a C++ library"() {
         given:
         buildFile << """
@@ -215,7 +212,6 @@ model {
 
     @Issue("GRADLE-2973")
     @Requires(IntegTestPreconditions.IsParallelExecutor)
-    @ToBeFixedForConfigurationCache
     def "releases cache lock when compilation fails with --parallel"() {
         def helloWorldApp = new CppHelloWorldApp()
         given:
@@ -244,7 +240,6 @@ subprojects {
         failure.assertThatCause(CoreMatchers.not(CoreMatchers.containsString("Could not stop")))
     }
 
-    @ToBeFixedForConfigurationCache
     def "can configure output file for binaries"() {
         given:
         def app = new CppHelloWorldApp()
@@ -288,7 +283,6 @@ model {
     @Issue("https://github.com/gradle/gradle-native/issues/368")
     @RequiresInstalledToolChain(VISUALCPP)
     @Requires(UnitTestPreconditions.CanInstallExecutable)
-    @ToBeFixedForConfigurationCache
     def "can configure output file for shared library on MSVC"() {
         given:
         def app = new CppHelloWorldApp()
@@ -328,7 +322,6 @@ model {
     }
 
     @Requires(UnitTestPreconditions.CanInstallExecutable)
-    @ToBeFixedForConfigurationCache
     def "can link to #linkage library binary with custom output file"() {
         given:
         def app = new CppHelloWorldApp()

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/BinaryFlavorsIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/BinaryFlavorsIntegrationTest.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.nativeplatform
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.NativePlatformsTestFixture
 import org.gradle.nativeplatform.fixtures.app.ExeWithLibraryUsingLibraryHelloWorldApp
@@ -69,7 +69,6 @@ model {
         helloWorldApp.writeSources(file("src/main"), file("src/hello"), file("src/greetings"))
     }
 
-    @ToBeFixedForConfigurationCache
     def "can configure components for a single flavor"() {
         given:
         buildFile << """
@@ -95,7 +94,6 @@ model {
         installation("build/install/main").exec().out == FRENCH + " " + FRENCH
     }
 
-    @ToBeFixedForConfigurationCache
     def "builds executable for each defined flavor when not configured for component"() {
         when:
         succeeds "installMainEnglishExecutable", "installMainFrenchExecutable", "installMainGermanExecutable"
@@ -106,7 +104,6 @@ model {
         installation("build/install/main/german").assertInstalled()
     }
 
-    @ToBeFixedForConfigurationCache
     def "executable with flavors depends on library with matching flavors"() {
         when:
         buildFile << """

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/LibraryApiDependenciesIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/LibraryApiDependenciesIntegrationTest.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.nativeplatform
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.CppHelloWorldApp
 import org.gradle.nativeplatform.fixtures.app.ExeWithLibraryUsingLibraryHelloWorldApp
@@ -45,7 +45,6 @@ model {
 """
     }
 
-    @ToBeFixedForConfigurationCache
     def "can use api linkage via #notationName notation"() {
         given:
         def app = new CppHelloWorldApp()
@@ -86,7 +85,6 @@ model {
         "map"        | "library: 'helloApi', linkage: 'api'"
     }
 
-    @ToBeFixedForConfigurationCache
     def "executable compiles using functions defined in header-only utility library"() {
         given:
         file("src/util/headers/util.h") << """
@@ -120,7 +118,6 @@ model {
         installation("build/install/main").exec().out == "Hello from the utility library"
     }
 
-    @ToBeFixedForConfigurationCache
     def "executable compiles using functions defined in utility library with build type variants"() {
         given:
         file("src/util/debug/util.h") << """
@@ -170,7 +167,6 @@ model {
         installation("build/install/main/release").exec().out == "Hello from the release library"
     }
 
-    @ToBeFixedForConfigurationCache
     def "can choose alternative library implementation of api"() {
         given:
         def app = new CppHelloWorldApp()
@@ -206,7 +202,6 @@ model {
         installation("build/install/main").exec().out == app.alternateLibraryOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "can use api linkage for component graph with library dependency cycle"() {
         given:
         def app = new ExeWithLibraryUsingLibraryHelloWorldApp()
@@ -245,7 +240,6 @@ model {
         installation("build/install/main").exec().out == app.englishOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "can compile but not link when executable depends on api of library required for linking"() {
         given:
         def app = new CppHelloWorldApp()

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/LibraryBinariesIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/LibraryBinariesIntegrationTest.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.nativeplatform
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.CppHelloWorldApp
 import org.gradle.test.precondition.Requires
@@ -31,7 +31,6 @@ class LibraryBinariesIntegrationTest extends AbstractInstalledToolChainIntegrati
         settingsFile << "rootProject.name = 'test'"
     }
 
-    @ToBeFixedForConfigurationCache
     def "executable can use a mix of static and shared libraries"() {
         given:
         buildFile << """
@@ -108,7 +107,6 @@ model {
             .exec().out == "Hello staticHello shared"
     }
 
-    @ToBeFixedForConfigurationCache
     def "executable can use a combination of libraries from the same and other projects"() {
         given:
         settingsFile << """
@@ -206,7 +204,6 @@ project('exe') {
             .exec().out == "Hello main\nHello lib"
     }
 
-    @ToBeFixedForConfigurationCache
     def "source set library dependencies are not shared with other source sets"() {
         given:
         buildFile << """
@@ -283,7 +280,6 @@ model {
     }
 
     @Issue("GRADLE-2925")
-    @ToBeFixedForConfigurationCache
     def "headers for source set added to library binary are available to consuming binary"() {
         def app = new CppHelloWorldApp()
         given:

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/LibraryDependenciesIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/LibraryDependenciesIntegrationTest.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.nativeplatform
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.CppHelloWorldApp
 import org.gradle.nativeplatform.fixtures.app.ExeWithDiamondDependencyHelloWorldApp
@@ -92,7 +92,6 @@ project(":other") {
         "does not exist in referenced project" | "project: ':other', library: 'unknown'" | "Could not locate library 'unknown' in project ':other' required by 'main' in project ':exe'."
     }
 
-    @ToBeFixedForConfigurationCache
     def "can use #notationName notation to reference library in same project"() {
         given:
         def app = new CppHelloWorldApp()
@@ -125,7 +124,6 @@ model {
         "map"        | "library: 'hello'"
     }
 
-    @ToBeFixedForConfigurationCache
     def "can use map #notationName notation to reference library dependency of binary"() {
         given:
         def app = new CppHelloWorldApp()
@@ -158,7 +156,6 @@ model {
         "map"        | "library: 'hello'"
     }
 
-    @ToBeFixedForConfigurationCache
     def "can use map notation to reference static library in same project"() {
         given:
         def app = new CppHelloWorldApp()
@@ -186,7 +183,6 @@ model {
         executable("build/exe/main/main").exec().out == app.englishOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "can use map notation to reference library in different project"() {
         given:
         def app = new CppHelloWorldApp()
@@ -224,7 +220,6 @@ project(":lib") {
         installation("exe/build/install/main").exec().out == app.englishOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "can use map notation to reference library in different project with configure-on-demand"() {
         given:
         def app = new CppHelloWorldApp()
@@ -263,7 +258,6 @@ project(":lib") {
         installation("exe/build/install/main").exec().out == app.englishOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "can use map notation to transitively reference libraries in different projects"() {
         given:
         def app = new ExeWithLibraryUsingLibraryHelloWorldApp()
@@ -311,7 +305,6 @@ project(":greet") {
         installation("exe/build/install/main").exec().out == app.englishOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "can have component graph with project dependency cycle"() {
         given:
         def app = new ExeWithLibraryUsingLibraryHelloWorldApp()
@@ -355,7 +348,6 @@ project(":lib") {
         installation("exe/build/install/main").exec().out == app.englishOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "can have component graph with diamond dependency"() {
         given:
         def app = new ExeWithDiamondDependencyHelloWorldApp()
@@ -393,7 +385,6 @@ model {
         sharedLibrary("build/binaries/greetingsSharedLibrary/greetings").assertDoesNotExist()
     }
 
-    @ToBeFixedForConfigurationCache
     def "can have component graph with both static and shared variants of same library"() {
         given:
         def app = new ExeWithDiamondDependencyHelloWorldApp()

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeBinariesIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeBinariesIntegrationTest.groovy
@@ -51,7 +51,6 @@ model {
         executable("build/binaries/mainExecutable/main").assertDoesNotExist()
     }
 
-    @ToBeFixedForConfigurationCache
     def "assemble task constructs all buildable binaries"() {
         given:
         new CHelloWorldApp().writeSources(file("src/main"))
@@ -138,7 +137,6 @@ model {
               - Don't know how to build for platform 'unknown'.""")
     }
 
-    @ToBeFixedForConfigurationCache
     def "assemble executable from component with multiple language source sets"() {
         given:
         useMixedSources()
@@ -173,7 +171,6 @@ model {
         executable("build/exe/main/main").exec().out == helloWorldApp.englishOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "assemble executable binary directly from language source sets"() {
         given:
         useMixedSources()
@@ -217,7 +214,6 @@ model {
         helloWorldApp.writeSources(file("src/test"))
     }
 
-    @ToBeFixedForConfigurationCache
     def "build fails when link executable fails"() {
         given:
         buildFile << """
@@ -242,7 +238,6 @@ model {
         failure.assertThatCause(containsText("Linker failed while linking ${exeName}"))
     }
 
-    @ToBeFixedForConfigurationCache
     def "build fails when link library fails"() {
         given:
         buildFile << """
@@ -276,7 +271,6 @@ model {
         failure.assertThatCause(containsText("Linker failed while linking ${libName}"))
     }
 
-    @ToBeFixedForConfigurationCache
     def "build fails when create static library fails"() {
         given:
         buildFile << """
@@ -311,7 +305,6 @@ model {
     }
 
     @Requires(UnitTestPreconditions.CanInstallExecutable)
-    @ToBeFixedForConfigurationCache
     def "installed executable receives command-line parameters"() {
         buildFile << """
 apply plugin: 'c'

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeDependentComponentsIntegrationSpec.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeDependentComponentsIntegrationSpec.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.nativeplatform
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.ExeWithLibraryUsingLibraryHelloWorldApp
 
@@ -75,7 +75,6 @@ class NativeDependentComponentsIntegrationSpec extends AbstractInstalledToolChai
         'build'    | _
     }
 
-    @ToBeFixedForConfigurationCache
     def "#task triggers expected tasks only"() {
         when:
         succeeds task

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativePlatformSamplesIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativePlatformSamplesIntegrationTest.groovy
@@ -73,7 +73,6 @@ class NativePlatformSamplesIntegrationTest extends AbstractInstalledToolChainInt
         toolChain.resetEnvironment()
     }
 
-    @ToBeFixedForConfigurationCache
     def "lib"() {
         given:
         sample cppLib
@@ -98,7 +97,6 @@ class NativePlatformSamplesIntegrationTest extends AbstractInstalledToolChainInt
         staticLibrary(cppLib.dir.file("build/libs/main/static/main")).assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def flavors() {
         given:
         sample flavors
@@ -134,7 +132,6 @@ class NativePlatformSamplesIntegrationTest extends AbstractInstalledToolChainInt
     }
 
     @RequiresInstalledToolChain(SUPPORTS_32_AND_64)
-    @ToBeFixedForConfigurationCache
     def variants() {
         given:
         sample variants
@@ -166,7 +163,6 @@ class NativePlatformSamplesIntegrationTest extends AbstractInstalledToolChainInt
         releaseIA64.assertDoesNotExist()
     }
 
-    @ToBeFixedForConfigurationCache
     def "tool chains"() {
         given:
         sample toolChains
@@ -178,7 +174,6 @@ class NativePlatformSamplesIntegrationTest extends AbstractInstalledToolChainInt
         executable(toolChains.dir.file("build/exe/main/main")).exec().out == "Hello from ${toolChain.typeDisplayName}!\n"
     }
 
-    @ToBeFixedForConfigurationCache
     def multiProject() {
         given:
         sample multiProject
@@ -196,7 +191,6 @@ class NativePlatformSamplesIntegrationTest extends AbstractInstalledToolChainInt
     }
 
     @RequiresInstalledToolChain(GCC_COMPATIBLE)
-    @ToBeFixedForConfigurationCache
     def "target platforms"() {
         assumeTrue(toolchainUnderTest.meets(SUPPORTS_32))
 
@@ -232,7 +226,6 @@ model {
         executable(targetPlatforms.dir.file("build/exe/main/sparc/main")).exec().out == "Hello from ${toolChain.typeDisplayName}!\n"
     }
 
-    @ToBeFixedForConfigurationCache
     def prebuilt() {
         given:
         inDirectory(prebuilt.dir.file("3rd-party-lib/util"))
@@ -256,7 +249,6 @@ Util build type: RELEASE
 """
     }
 
-    @ToBeFixedForConfigurationCache
     @RequiresInstalledToolChain(GCC_COMPATIBLE) // latest clang seems to have issues:
     // /usr/bin/ld: /home/tcagent1/agent/work/e67123fb5b9af0ac/subprojects/platform-native/build/tmp/teŝt files/NativePlatf.Test/89jnk/sourceset-variant/build/objs/main/mainExecutablePlatformLinux/3aor34f2b62iejk2eq3fn5ikr/platform-linux.o:(.data+0x0): multiple definition of `platform_name';
     // /home/tcagent1/agent/work/e67123fb5b9af0ac/subprojects/platform-native/build/tmp/teŝt files/NativePlatf.Test/89jnk/sourceset-variant/build/objs/main/mainC/dey3oyi6y0a9luwot945rff8j/main.o:(.bss+0x0): first defined here

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/PrebuiltLibrariesIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/PrebuiltLibrariesIntegrationTest.groovy
@@ -60,7 +60,6 @@ model {
         run "assemble"
     }
 
-    @ToBeFixedForConfigurationCache
     def "can link to a prebuilt header-only library with api linkage"() {
         given:
         app.alternateLibrarySources*.writeToDir(file("src/main"))
@@ -91,7 +90,6 @@ model {
         installation("build/install/main").exec().out == app.alternateLibraryOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "can link to a prebuilt library with static and shared linkage"() {
         given:
         preBuildLibrary()
@@ -152,7 +150,6 @@ model {
         installation("build/install/mainStatic").exec().out == app.englishOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "searches all prebuilt library repositories"() {
         given:
         preBuildLibrary()
@@ -194,7 +191,6 @@ model {
         installation("build/install/main").exec().out == app.frenchOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "locates prebuilt library in another project"() {
         given:
         app.executable.writeSources(file("projectA/src/main"))

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/SharedLibrarySoNameIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/SharedLibrarySoNameIntegrationTest.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.nativeplatform
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.CppHelloWorldApp
@@ -43,7 +43,6 @@ model {
 """
     }
 
-    @ToBeFixedForConfigurationCache
     def "library soname is file name when installName is not set"() {
         when:
         succeeds "helloSharedLibrary"
@@ -53,7 +52,6 @@ model {
         sharedLibrary.soName == sharedLibrary.file.name
     }
 
-    @ToBeFixedForConfigurationCache
     def "library soname uses specified installName"() {
         given:
         buildFile << """
@@ -69,7 +67,6 @@ tasks.withType(LinkSharedLibrary) {
         sharedLibrary("build/libs/hello/shared/hello").soName == "hello-install-name"
     }
 
-    @ToBeFixedForConfigurationCache
     def "library soname defaults when installName is null"() {
         given:
         buildFile << """

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/platform/BinaryNativePlatformIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/platform/BinaryNativePlatformIntegrationTest.groovy
@@ -62,7 +62,6 @@ model {
         return [name: "x86-64", altName: "amd64"]
     }
 
-    @ToBeFixedForConfigurationCache
     def "build binary for a default target platform"() {
         given:
         def arch = currentArch()
@@ -78,7 +77,6 @@ model {
     }
 
     @RequiresInstalledToolChain(SUPPORTS_32)
-    @ToBeFixedForConfigurationCache
     def "configure component for a single target platform"() {
         when:
         buildFile << """
@@ -110,7 +108,6 @@ model {
         executable("build/exe/main/main").exec().out == "i386 ${os.familyName}" * 2
     }
 
-    @ToBeFixedForConfigurationCache
     def "defaults to current platform when platforms are defined but not targeted"() {
         def arch = currentArch()
         when:
@@ -138,7 +135,6 @@ model {
     }
 
     @RequiresInstalledToolChain(SUPPORTS_32)
-    @ToBeFixedForConfigurationCache
     def "library with matching platform is enforced by dependency resolution"() {
         given:
         testApp.executable.writeSources(file("src/exe"))
@@ -181,7 +177,6 @@ model {
         executable("build/exe/exe/exe").exec().out == "i386 ${os.familyName}" * 2
     }
 
-    @ToBeFixedForConfigurationCache
     def "library with no platform defined is correctly chosen by dependency resolution"() {
         def arch = currentArch()
 
@@ -212,7 +207,6 @@ model {
     }
 
     @RequiresInstalledToolChain(SUPPORTS_32_AND_64)
-    @ToBeFixedForConfigurationCache
     def "build binary for multiple target architectures"() {
         when:
         buildFile << """
@@ -261,7 +255,6 @@ model {
     }
 
     @RequiresInstalledToolChain(SUPPORTS_32)
-    @ToBeFixedForConfigurationCache
     def "can configure binary for multiple target operating systems"() {
         String currentOs
         if (os.windows) {
@@ -318,7 +311,6 @@ model {
         }
     }
 
-    @ToBeFixedForConfigurationCache
     def "fails with reasonable error message when trying to build for an #type"() {
         when:
         buildFile << """

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/platform/InstallExecutableIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/platform/InstallExecutableIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.nativeplatform.platform
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
@@ -47,7 +47,6 @@ model {
         testApp.writeSources(file("src/main"))
     }
 
-    @ToBeFixedForConfigurationCache
     def "can create installation for a different os than the current one"() {
         String installOS
         if (os.windows) {

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/sourceset/SourceSetCompileDependenciesIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/sourceset/SourceSetCompileDependenciesIntegrationTest.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.nativeplatform.sourceset
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 
 class SourceSetCompileDependenciesIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
@@ -67,7 +67,6 @@ model {
 """
     }
 
-    @ToBeFixedForConfigurationCache
     def "dependencies of 2 language source sets are not shared when compiling"() {
         given:
         buildFile << """
@@ -94,7 +93,6 @@ model {
         executable("build/exe/main/main").exec().out == "12\n"
     }
 
-    @ToBeFixedForConfigurationCache
     def "dependencies of language source set added to binary are not shared when compiling"() {
         given:
         buildFile << """
@@ -124,7 +122,6 @@ model {
         executable("build/exe/main/main").exec().out == "12\n"
     }
 
-    @ToBeFixedForConfigurationCache
     def "dependencies of binary are shared with all source sets when compiling"() {
         given:
         buildFile << """

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/sourceset/SourceSetDependenciesIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/sourceset/SourceSetDependenciesIntegrationTest.groovy
@@ -16,17 +16,17 @@
 
 package org.gradle.nativeplatform.sourceset
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.CHelloWorldApp
 import org.gradle.nativeplatform.fixtures.app.CppCallingCHelloWorldApp
+
 // TODO: Test incremental
 // TODO: Test dependency on functional source set
 // TODO: Test dependency on source set that is not HeaderExportingSourceSet
 // TODO: Sad day tests
 class SourceSetDependenciesIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
 
-    @ToBeFixedForConfigurationCache
     def "source dependency on source set of same type"() {
         def app = new CHelloWorldApp()
         app.executable.writeSources(file("src/main"))
@@ -56,7 +56,6 @@ model {
         executable("build/exe/main/main").exec().out == app.englishOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "source dependency on source set of headers"() {
         def app = new CHelloWorldApp()
         app.executable.writeSources(file("src/main"))
@@ -84,7 +83,6 @@ model {
         executable("build/exe/main/main").exec().out == app.englishOutput
     }
 
-    @ToBeFixedForConfigurationCache
     def "source dependency on source set of different type"() {
         def app = new CppCallingCHelloWorldApp()
         app.executable.writeSources(file("src/main"))

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/sourceset/SourceSetLinkDependenciesIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/sourceset/SourceSetLinkDependenciesIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.nativeplatform.sourceset
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
@@ -80,7 +80,6 @@ model {
 """
     }
 
-    @ToBeFixedForConfigurationCache
     def "library dependency of binary is available when linking all source sets"() {
         given:
         buildFile << """
@@ -106,7 +105,6 @@ model {
         installation("build/install/main").exec().out == "12\n"
     }
 
-    @ToBeFixedForConfigurationCache
     def "library dependency of 1 language source set is available to another when linking"() {
         given:
         buildFile << """
@@ -131,7 +129,6 @@ model {
         installation("build/install/main").exec().out == "12\n"
     }
 
-    @ToBeFixedForConfigurationCache
     def "dependencies of language source set added to binary are available when linking"() {
         given:
         buildFile << """

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/tasks/ExtractSymbolsIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/tasks/ExtractSymbolsIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.nativeplatform.tasks
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.NativeBinaryFixture
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
@@ -48,7 +48,6 @@ class ExtractSymbolsIntegrationTest extends AbstractInstalledToolChainIntegratio
         """
     }
 
-    @ToBeFixedForConfigurationCache
     def "extracts symbols from binary"() {
         when:
         succeeds ":extractSymbolsDebug"
@@ -58,7 +57,6 @@ class ExtractSymbolsIntegrationTest extends AbstractInstalledToolChainIntegratio
         fixture("build/symbols").assertHasDebugSymbolsFor(withoutHeaders(app.original))
     }
 
-    @ToBeFixedForConfigurationCache
     def "extract is skipped when there are no changes"() {
         when:
         succeeds ":extractSymbolsDebug"
@@ -74,7 +72,6 @@ class ExtractSymbolsIntegrationTest extends AbstractInstalledToolChainIntegratio
         fixture("build/symbols").assertHasDebugSymbolsFor(withoutHeaders(app.original))
     }
 
-    @ToBeFixedForConfigurationCache
     def "extract is re-executed when changes are made"() {
         when:
         succeeds ":extractSymbolsDebug"

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/tasks/StripSymbolsIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/tasks/StripSymbolsIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.nativeplatform.tasks
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.NativeBinaryFixture
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
@@ -48,7 +48,6 @@ class StripSymbolsIntegrationTest extends AbstractInstalledToolChainIntegrationS
         """
     }
 
-    @ToBeFixedForConfigurationCache
     def "strips symbols from binary"() {
         when:
         succeeds ":stripSymbolsDebug"
@@ -59,7 +58,6 @@ class StripSymbolsIntegrationTest extends AbstractInstalledToolChainIntegrationS
         binary("build/stripped").assertDoesNotHaveDebugSymbolsFor(withoutHeaders(app.original))
     }
 
-    @ToBeFixedForConfigurationCache
     def "strip is skipped when there are no changes"() {
         when:
         succeeds ":stripSymbolsDebug"
@@ -75,7 +73,6 @@ class StripSymbolsIntegrationTest extends AbstractInstalledToolChainIntegrationS
         binary("build/stripped").assertDoesNotHaveDebugSymbolsFor(withoutHeaders(app.original))
     }
 
-    @ToBeFixedForConfigurationCache
     def "strip is re-executed when changes are made"() {
         when:
         succeeds ":stripSymbolsDebug"

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/toolchain/CommonToolChainIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/toolchain/CommonToolChainIntegrationTest.groovy
@@ -16,14 +16,13 @@
 
 package org.gradle.nativeplatform.toolchain
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.CHelloWorldApp
 import spock.lang.Issue
 
 class CommonToolChainIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
     @Issue("https://github.com/gradle/gradle-native/issues/139")
-    @ToBeFixedForConfigurationCache
     def "can rely on working directory to be project directory"() {
         def app = new CHelloWorldApp()
 

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/toolchain/CommonToolchainCustomizationIntegTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/toolchain/CommonToolchainCustomizationIntegTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.nativeplatform.toolchain
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.CppHelloWorldApp
 
@@ -24,7 +24,6 @@ public class CommonToolchainCustomizationIntegTest extends AbstractInstalledTool
 
     def helloWorldApp = new CppHelloWorldApp()
 
-    @ToBeFixedForConfigurationCache
     def "can add action to tool chain that modifies tool arguments prior to execution"() {
         when:
         helloWorldApp.executable.writeSources(file("src/main"))

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/toolchain/GccToolChainCrossCompilationIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/toolchain/GccToolChainCrossCompilationIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.nativeplatform.toolchain
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
@@ -51,7 +51,6 @@ model {
         helloWorldApp.library.writeSources(file("src/hello"))
     }
 
-    @ToBeFixedForConfigurationCache
     def "uses naming scheme of target platform when cross-compiling"() {
         // TODO - use linux as the target when running on windows
         buildFile << """

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/toolchain/GccToolChainCustomisationIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/toolchain/GccToolChainCustomisationIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.nativeplatform.toolchain
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
@@ -56,7 +56,6 @@ model {
     }
 
     @RequiresInstalledToolChain(SUPPORTS_32)
-    @ToBeFixedForConfigurationCache
     def "can configure platform specific args"() {
         when:
         buildFile << """
@@ -110,7 +109,6 @@ model {
     }
 
     @Requires(UnitTestPreconditions.NotWindows)
-    @ToBeFixedForConfigurationCache
     def "can configure tool executables"() {
         def binDir = testDirectory.createDir("bin")
         wrapperTool(binDir, "c-compiler", toolChain.CCompiler, "-DFRENCH")
@@ -139,7 +137,6 @@ model {
     }
 
     @Requires(UnitTestPreconditions.NotWindows)
-    @ToBeFixedForConfigurationCache
     def "can configure platform specific executables"() {
         def binDir = testDirectory.createDir("bin")
         wrapperTool(binDir, "french-c-compiler", toolChain.CCompiler, "-DFRENCH")
@@ -209,7 +206,6 @@ model {
     }
 
     @Requires(UnitTestPreconditions.NotWindows)
-    @ToBeFixedForConfigurationCache
     def "can configure setTargets with alternate toolchain"() {
         def binDir = testDirectory.createDir("bin")
         wrapperTool(binDir, "french-c-compiler", toolChain.CCompiler, "-DFRENCH")

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/toolchain/GccToolChainDiscoveryIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/toolchain/GccToolChainDiscoveryIntegrationTest.groovy
@@ -54,7 +54,6 @@ model {
         helloWorldApp.library.writeSources(file("src/hello"))
     }
 
-    @ToBeFixedForConfigurationCache
     def "can build when language tools that are not required are not available"() {
         when:
         buildFile << """
@@ -94,7 +93,6 @@ model {
         succeeds "help"
     }
 
-    @ToBeFixedForConfigurationCache
     def "tool chain is not available when no tools are available"() {
         when:
         buildFile << """
@@ -126,7 +124,7 @@ model {
     }
 
     @Requires(IntegTestPreconditions.NotParallelExecutor)
-    @ToBeFixedForConfigurationCache
+    @ToBeFixedForConfigurationCache(because = "different failure reporting for vintage mode and storing to cache")
     def "fails when required language tool is not available but other language tools are available"() {
         when:
         buildFile << """
@@ -147,7 +145,6 @@ model {
         failure.assertThatCause(CoreMatchers.startsWith("Could not find C compiler 'does-not-exist'"))
     }
 
-    @ToBeFixedForConfigurationCache
     def "fails when required linker tool is not available but language tool is available"() {
         when:
         buildFile << """

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/toolchain/MultipleNativeToolChainIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/toolchain/MultipleNativeToolChainIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.nativeplatform.toolchain
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AvailableToolChains
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
@@ -41,7 +40,6 @@ plugins { id 'cpp' }
 
     @Requires(UnitTestPreconditions.CanInstallExecutable)
     @RequiresInstalledToolChain(ToolChainRequirement.GCC)
-    @ToBeFixedForConfigurationCache
     def "can build with multiple tool chains"() {
         AvailableToolChains.InstalledToolChain x86ToolChain = OperatingSystem.current().isWindows() ?
                 AvailableToolChains.getToolChain(ToolChainRequirement.VISUALCPP) :

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/toolchain/NativeToolChainDiscoveryIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/toolchain/NativeToolChainDiscoveryIntegrationTest.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.nativeplatform.toolchain
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.CppCompilerDetectingTestApp
 
@@ -31,7 +31,6 @@ class NativeToolChainDiscoveryIntegrationTest extends AbstractInstalledToolChain
         initScript.text = ""
     }
 
-    @ToBeFixedForConfigurationCache
     def "can discover tool chain in environment"() {
         given:
         toolChain.initialiseEnvironment()
@@ -68,7 +67,6 @@ model {
         toolChain.resetEnvironment()
     }
 
-    @ToBeFixedForConfigurationCache
     def "uses correct tool chain when explicitly configured"() {
         given:
         buildFile << """

--- a/platforms/native/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
+++ b/platforms/native/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
@@ -25,15 +25,12 @@ import org.gradle.internal.time.Time
 import org.gradle.nativeplatform.internal.CompilerOutputFileNamingSchemeFactory
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 import org.gradle.test.fixtures.file.TestFile
-import org.gradle.test.precondition.Requires
-import org.gradle.test.preconditions.UnitTestPreconditions
 
 /**
  * Runs a test separately for each installed tool chain.
  */
 @NativeToolchainTest
 @MultiVersionTestCategory
-@Requires(UnitTestPreconditions.NotMacOs)
 abstract class AbstractInstalledToolChainIntegrationSpec extends AbstractIntegrationSpec implements HostPlatform {
     static AvailableToolChains.InstalledToolChain toolChain
     File initScript

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/AbstractNativeUnitTestIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/AbstractNativeUnitTestIntegrationTest.groovy
@@ -27,7 +27,16 @@ import static org.gradle.nativeplatform.MachineArchitecture.X86
 import static org.gradle.nativeplatform.MachineArchitecture.X86_64
 
 abstract class AbstractNativeUnitTestIntegrationTest extends AbstractInstalledToolChainIntegrationSpec implements LanguageTaskNames {
-    @ToBeFixedForConfigurationCache
+    @ToBeFixedForConfigurationCache(bottomSpecs = [
+        'CppUnitTestWithApplicationIntegrationTest',
+        'CppUnitTestWithLibraryIntegrationTest',
+        'CppUnitTestWithoutComponentIntegrationTest',
+        'SwiftXCTestWithBothLibraryLinkageIntegrationTest',
+        'SwiftXCTestWithSharedLibraryLinkageIntegrationTest',
+        'SwiftXCTestWithStaticLibraryLinkageIntegrationTest',
+        'SwiftXCTestWithApplicationIntegrationTest',
+        'SwiftXCTestWithoutComponentIntegrationTest'
+    ])
     def "does nothing when no source files are present"() {
         given:
         makeSingleProject()

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cunit/CUnitDependentComponentsIntegrationSpec.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cunit/CUnitDependentComponentsIntegrationSpec.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.nativeplatform.test.cunit
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
@@ -91,7 +91,6 @@ class CUnitDependentComponentsIntegrationSpec extends AbstractInstalledToolChain
         return OperatingSystem.current().getStaticLibraryName("cunit")
     }
 
-    @ToBeFixedForConfigurationCache
     def "buildDependentsHello assemble and check all hello binaries"() {
         given:
         useConventionalSourceLocations()
@@ -104,7 +103,6 @@ class CUnitDependentComponentsIntegrationSpec extends AbstractInstalledToolChain
         executed ':helloSharedLibrary', ':helloStaticLibrary', ':helloTestCUnitExe', ':runHelloTestCUnitExe'
     }
 
-    @ToBeFixedForConfigurationCache
     def "buildDependentsHelloSharedLibrary assemble and check hello shared library"() {
         given:
         useConventionalSourceLocations()
@@ -118,7 +116,6 @@ class CUnitDependentComponentsIntegrationSpec extends AbstractInstalledToolChain
         notExecuted ':helloTestCUnitExe', ':runHelloTestCUnitExe'
     }
 
-    @ToBeFixedForConfigurationCache
     def "buildDependentsHelloStaticLibrary assemble and check hello static library"() {
         given:
         useConventionalSourceLocations()
@@ -131,7 +128,6 @@ class CUnitDependentComponentsIntegrationSpec extends AbstractInstalledToolChain
         executed ':helloStaticLibrary', ':helloTestCUnitExe', ':runHelloTestCUnitExe'
     }
 
-    @ToBeFixedForConfigurationCache
     def "buildDependentsHelloTestCUnitExe assemble and run test suite"() {
         given:
         useConventionalSourceLocations()

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cunit/CUnitIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cunit/CUnitIntegrationTest.groovy
@@ -89,7 +89,6 @@ model {
         return OperatingSystem.current().getStaticLibraryName("cunit")
     }
 
-    @ToBeFixedForConfigurationCache
     def "can build and run cunit test suite"() {
         given:
         useConventionalSourceLocations()
@@ -111,7 +110,6 @@ model {
         testResults.checkAssertions(3, 3, 0)
     }
 
-    @ToBeFixedForConfigurationCache
     def "assemble does not build or run tests"() {
         given:
         useConventionalSourceLocations()
@@ -126,7 +124,6 @@ model {
     }
 
     @Issue("GRADLE-3225")
-    @ToBeFixedForConfigurationCache
     def "can build and run cunit test suite with C and C++"() {
         given:
         useConventionalSourceLocations()
@@ -142,7 +139,6 @@ model {
             ":linkHelloTestCUnitExe", ":helloTestCUnitExe", ":runHelloTestCUnitExe"
     }
 
-    @ToBeFixedForConfigurationCache
     def "can configure via testSuite component"() {
         given:
         useConventionalSourceLocations()
@@ -236,7 +232,6 @@ model {
         )
     }
 
-    @ToBeFixedForConfigurationCache
     def "can supply cCompiler macro to cunit sources"() {
         given:
         useConventionalSourceLocations()
@@ -260,7 +255,6 @@ model {
         testResults.checkAssertions(1, 1, 0)
     }
 
-    @ToBeFixedForConfigurationCache
     def "can configure location of cunit test sources"() {
         given:
         useStandardConfig()
@@ -287,7 +281,6 @@ model {
         file("build/test-results/helloTest/CUnitAutomated-Listing.xml").assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "can configure location of cunit test sources before component is declared"() {
         given:
         app.library.writeSources(file("src/hello"))
@@ -314,7 +307,6 @@ model {
         file("build/test-results/helloTest/CUnitAutomated-Listing.xml").assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "variant-dependent sources are included in test binary"() {
         given:
         app.library.headerFiles*.writeToDir(file("src/hello"))
@@ -355,7 +347,6 @@ model {
         file("build/test-results/helloTest/CUnitAutomated-Listing.xml").assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "can configure variant-dependent test sources"() {
         given:
         useStandardConfig()
@@ -386,7 +377,6 @@ model {
         file("build/test-results/helloTest/CUnitAutomated-Listing.xml").assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "test suite skipped after successful run"() {
         given:
         useStandardConfig()
@@ -401,7 +391,6 @@ model {
         skipped ":helloTestCUnitExe", ":runHelloTestCUnitExe"
     }
 
-    @ToBeFixedForConfigurationCache
     def "can build and run cunit failing test suite"() {
         when:
         useStandardConfig()
@@ -427,7 +416,6 @@ model {
         file("build/test-results/helloTest/CUnitAutomated-Listing.xml").assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "build does not break for failing tests if ignoreFailures is true"() {
         when:
         useStandardConfig()
@@ -448,7 +436,6 @@ tasks.withType(RunTestExecutable) {
         file("build/test-results/helloTest/CUnitAutomated-Listing.xml").assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "test suite not skipped after failing run"() {
         given:
         useStandardConfig()
@@ -496,7 +483,6 @@ tasks.withType(RunTestExecutable) {
         }
     }
 
-    @ToBeFixedForConfigurationCache
     def "non-buildable binaries are not attached to check task"() {
         given:
         useConventionalSourceLocations()
@@ -527,7 +513,6 @@ model {
         executedAndNotSkipped ":runHelloTestCUnitExe"
     }
 
-    @ToBeFixedForConfigurationCache
     def "cunit run task is properly wired to binaries check tasks and lifecycle check task"() {
         given:
         useStandardConfig()

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cunit/CUnitSamplesIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cunit/CUnitSamplesIntegrationTest.groovy
@@ -52,7 +52,6 @@ class CUnitSamplesIntegrationTest extends AbstractInstalledToolChainIntegrationS
         output.contains "C unit exe 'operatorsTest:passing:cUnitExe'"
     }
 
-    @ToBeFixedForConfigurationCache
     def "cunit"() {
         given:
         // On windows, CUnit sample only works out of the box with VS2015

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/googletest/GoogleTestDependentComponentsIntegrationSpec.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/googletest/GoogleTestDependentComponentsIntegrationSpec.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.nativeplatform.test.googletest
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
@@ -113,7 +113,6 @@ class GoogleTestDependentComponentsIntegrationSpec extends AbstractInstalledTool
         app.googleTestTests.writeSources(file("src/helloTest"))
     }
 
-    @ToBeFixedForConfigurationCache
     def "buildDependentsHello assemble and check all hello binaries"() {
         given:
         useConventionalSourceLocations()
@@ -126,7 +125,6 @@ class GoogleTestDependentComponentsIntegrationSpec extends AbstractInstalledTool
         executed ':helloSharedLibrary', ':helloStaticLibrary', ':helloTestGoogleTestExe', ':runHelloTestGoogleTestExe'
     }
 
-    @ToBeFixedForConfigurationCache
     def "buildDependentsHelloSharedLibrary assemble and check hello shared library"() {
         given:
         useConventionalSourceLocations()
@@ -140,7 +138,6 @@ class GoogleTestDependentComponentsIntegrationSpec extends AbstractInstalledTool
         notExecuted ':helloTestGoogleTestExe', ':runHelloTestGoogleTestExe'
     }
 
-    @ToBeFixedForConfigurationCache
     def "buildDependentsHelloStaticLibrary assemble and check hello static library"() {
         given:
         useConventionalSourceLocations()
@@ -153,7 +150,6 @@ class GoogleTestDependentComponentsIntegrationSpec extends AbstractInstalledTool
         executed ':helloStaticLibrary', ':helloTestGoogleTestExe', ':runHelloTestGoogleTestExe'
     }
 
-    @ToBeFixedForConfigurationCache
     def "buildDependentsHelloTestCUnitExe assemble and run test suite"() {
         given:
         useConventionalSourceLocations()

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/googletest/GoogleTestIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/googletest/GoogleTestIntegrationTest.groovy
@@ -111,7 +111,6 @@ model {
         return OperatingSystem.current().getStaticLibraryName("gtest")
     }
 
-    @ToBeFixedForConfigurationCache
     def "can build and run googleTest test suite"() {
         given:
         useConventionalSourceLocations()
@@ -131,7 +130,6 @@ model {
         testResults.checkTestCases(1, 1, 0)
     }
 
-    @ToBeFixedForConfigurationCache
     def "assemble does not build or run tests"() {
         given:
         useConventionalSourceLocations()
@@ -146,7 +144,6 @@ model {
     }
 
     @Issue("GRADLE-3225")
-    @ToBeFixedForConfigurationCache
     def "can build and run googleTest test suite with C and C++ plugins"() {
         given:
         useConventionalSourceLocations()
@@ -163,7 +160,6 @@ model {
             ":linkHelloTestGoogleTestExe", ":helloTestGoogleTestExe", ":runHelloTestGoogleTestExe"
     }
 
-    @ToBeFixedForConfigurationCache
     def "can configure via testSuite component"() {
         given:
         useConventionalSourceLocations()
@@ -205,7 +201,6 @@ tasks.withType(RunTestExecutable) {
         testResults.checkTestCases(1, 1, 0)
     }
 
-    @ToBeFixedForConfigurationCache
     def "can supply cppCompiler macro to googleTest sources"() {
         given:
         useConventionalSourceLocations()
@@ -229,7 +224,6 @@ model {
         testResults.checkTestCases(1, 1, 0)
     }
 
-    @ToBeFixedForConfigurationCache
     def "can configure location of googleTest test sources"() {
         given:
         useStandardConfig()
@@ -255,7 +249,6 @@ model {
         succeeds "runHelloTestGoogleTestExe"
     }
 
-    @ToBeFixedForConfigurationCache
     def "can configure location of googleTest test sources before component is declared"() {
         given:
         app.library.writeSources(file("src/hello"))
@@ -281,7 +274,6 @@ model {
         succeeds "runHelloTestGoogleTestExe"
     }
 
-    @ToBeFixedForConfigurationCache
     def "variant-dependent sources are included in test binary"() {
         given:
         app.library.headerFiles*.writeToDir(file("src/hello"))
@@ -317,7 +309,6 @@ model {
         succeeds "runHelloTestGoogleTestExe"
     }
 
-    @ToBeFixedForConfigurationCache
     def "can configure variant-dependent test sources"() {
         given:
         useStandardConfig()
@@ -346,7 +337,6 @@ model {
         succeeds "runHelloTestGoogleTestExe"
     }
 
-    @ToBeFixedForConfigurationCache
     def "test suite skipped after successful run"() {
         given:
         useStandardConfig()
@@ -361,7 +351,6 @@ model {
         skipped ":helloTestGoogleTestExe", ":runHelloTestGoogleTestExe"
     }
 
-    @ToBeFixedForConfigurationCache
     def "can build and run googleTest failing test suite"() {
         when:
         useStandardConfig()
@@ -384,7 +373,6 @@ model {
         testResults.checkTestCases(1, 0, 1)
     }
 
-    @ToBeFixedForConfigurationCache
     def "build does not break for failing tests if ignoreFailures is true"() {
         when:
         useStandardConfig()
@@ -404,7 +392,6 @@ tasks.withType(RunTestExecutable) {
         file("build/test-results/helloTest/test_detail.xml").assertExists()
     }
 
-    @ToBeFixedForConfigurationCache
     def "test suite not skipped after failing run"() {
         given:
         useStandardConfig()
@@ -450,7 +437,6 @@ tasks.withType(RunTestExecutable) {
         }
     }
 
-    @ToBeFixedForConfigurationCache
     def "non-buildable binaries are not attached to check task"() {
         given:
         useConventionalSourceLocations()
@@ -481,7 +467,6 @@ model {
         executedAndNotSkipped ":runHelloTestGoogleTestExe"
     }
 
-    @ToBeFixedForConfigurationCache
     def "google test run task is properly wired to binaries check tasks and lifecycle check task"() {
         given:
         useStandardConfig()

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/googletest/GoogleTestSamplesIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/googletest/GoogleTestSamplesIntegrationTest.groovy
@@ -18,7 +18,6 @@
 package org.gradle.nativeplatform.test.googletest
 
 import org.gradle.integtests.fixtures.Sample
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
@@ -39,7 +38,6 @@ class GoogleTestSamplesIntegrationTest extends AbstractInstalledToolChainIntegra
         return new Sample(testDirectoryProvider, "native-binaries/${name}/groovy", name)
     }
 
-    @ToBeFixedForConfigurationCache
     def "googleTest"() {
         given:
         // On windows, GoogleTest sample only works out of the box with VS2015

--- a/platforms/native/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
+++ b/platforms/native/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
@@ -19,6 +19,7 @@ package org.gradle.nativeplatform.test.xctest.plugins;
 import com.google.common.collect.Lists;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFile;
@@ -248,7 +249,12 @@ public abstract class XCTestConventionPlugin implements Plugin<Project> {
                     task.from(binary.getSwiftSource());
                     task.into(project.provider(() -> task.getTemporaryDir()));
                     task.include("LinuxMain.swift");
-                    task.rename(it -> "main.swift");
+                    task.rename(new Transformer<String, String>() {
+                        @Override
+                        public String transform(String it) {
+                            return "main.swift";
+                        }
+                    });
                 });
                 compile.getSource().from(project.files(renameLinuxMainTask).getAsFileTree().matching(patterns -> patterns.include("**/*.swift")));
             }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/WellBehavedPluginTest.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/WellBehavedPluginTest.groovy
@@ -46,8 +46,6 @@ abstract class WellBehavedPluginTest extends AbstractIntegrationSpec {
         "AntlrPluginIntegrationTest",
         "PlayApplicationPluginGoodBehaviourIntegrationTest",
         "PmdPluginIntegrationTest",
-        "CppLibraryPluginIntegrationTest",
-        "CppApplicationPluginIntegrationTest",
         "XcodePluginIntegrationTest",
         "IdeaPluginGoodBehaviourTest"
     ])
@@ -76,8 +74,6 @@ abstract class WellBehavedPluginTest extends AbstractIntegrationSpec {
         "AntlrPluginIntegrationTest",
         "PlayApplicationPluginGoodBehaviourIntegrationTest",
         "PmdPluginIntegrationTest",
-        "CppLibraryPluginIntegrationTest",
-        "CppApplicationPluginIntegrationTest",
         "XcodePluginIntegrationTest",
         "IdeaPluginGoodBehaviourTest"
     ])


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context

The unit test plugins are not yet compatible and there are some tests that could be made compatible.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
