### PR TITLE
List deprecation warnings still expected when failing deprecation warning check in tests

### DIFF
--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ResultAssertion.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ResultAssertion.java
@@ -173,7 +173,16 @@ public class ResultAssertion implements Action<ExecutionResult> {
                 i = skipStackTrace(lines, i);
             } else if (line.matches(".*\\s+deprecated.*")) {
                 if (checkDeprecations && expectedGenericDeprecationWarnings <= 0) {
-                    throw new AssertionError(String.format("%s line %d contains a deprecation warning: %s%n=====%n%s%n=====%n", displayName, i + 1, line, output));
+                    StringBuilder message = new StringBuilder(String.format("%s line %d contains an unexpected deprecation warning:%n - %s", displayName, i + 1, line));
+                    if (expectedDeprecationWarnings.isEmpty() && maybeExpectedDeprecationWarnings.isEmpty()) {
+                        message.append(String.format("%nNo deprecation warnings were expected at this point."));
+                    } else {
+                        message.append(String.format("%nExpected deprecation warnings:"));
+                        expectedDeprecationWarnings.forEach(warning -> message.append(String.format("%n - %s", warning)));
+                        maybeExpectedDeprecationWarnings.forEach(warning -> message.append(String.format("%n - (optional) %s", warning)));
+                    }
+                    message.append(String.format("%n=====%n%s%n=====%n", output));
+                    throw new AssertionError(message.toString());
                 }
                 expectedGenericDeprecationWarnings--;
                 // skip over stack trace


### PR DESCRIPTION
When an unexpected deprecation is found on the console while executing a test, do not just print the unexpected warning, print the expected warnings, too. Doing so should make it easier to spot typos and other small discrepancies.

The output now should look like this:

```text
Failure: java.lang.AssertionError: Standard output line 1 contains an unexpected deprecation warning:
 - Executing Gradle on JVM versions 16 and lower has been deprecated. This will fail with an error in Gradle 9.0. Use JVM 17 or greater to execute Gradle. Projects can continue to use older JVM versions via toolchains. Consult the upgrading guide for further information: https://docs.gradle.org/9.0-20240812220000+0000/userguide/upgrading_version_8.html#minimum_daemon_jvm_version
Expected deprecation warnings:
 - Executing Gradle on JVM versions 16 and lower has been deprecated. This will fail with an error in Gradle 10.0. Use JVM 17 or greater to execute Gradle. Projects can continue to use older JVM versions via toolchains. Consult the upgrading guide for further information: https://docs.gradle.org/9.0-20240812220000+0000/userguide/upgrading_version_8.html#minimum_daemon_jvm_version
=====
<OUTPUT>
=====
```

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
