### PR TITLE
Fix documentation link for binary compatibility checks

### DIFF
--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/AbstractGradleViolationRule.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/AbstractGradleViolationRule.groovy
@@ -182,7 +182,7 @@ abstract class AbstractGradleViolationRule extends AbstractContextAwareViolation
                   <div class="well">
                       Sometimes, the change was made on the `release` branch but hasn't yet been published to the baseline version.
                       In that case, you can publish a new snapshot from the release branch. This will update `released-versions.json` on `master`.
-                      See <a href="https://docs.google.com/document/d/1KA5yI4HL18qOeXjXLTMMD_upkDbNUzTDGNfBGYdQlYw/edit#heading=h.9yqcmqviz47z">the documentation</a> for more details.
+                      See <a href="https://bt-internal-docs.grdev.net/gbt/how-to/release/release-troubleshooting/#binary-compatibility-check-failed-">the documentation</a> for more details.
                   </div>
                 </div>
                 </p>


### PR DESCRIPTION
The report used to link to a Google Doc for information; it should instead link to our internal documentation site.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
