### PR TITLE
Avoid duplicates in upgraded properties

### DIFF
--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/upgrades/UpgradedProperty.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/upgrades/UpgradedProperty.java
@@ -24,10 +24,10 @@ import java.util.List;
 import java.util.Objects;
 
 public class UpgradedProperty {
+    private final String containingType;
     private final String propertyName;
     private final String methodName;
     private final String methodDescriptor;
-    private final String containingType;
 
     /**
      * Was upgradedMethods originally, but got renamed to upgradedAccessors and then to replacedAccessors
@@ -65,6 +65,29 @@ public class UpgradedProperty {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        UpgradedProperty that = (UpgradedProperty) o;
+        return containingType.equals(that.containingType) && propertyName.equals(that.propertyName) && methodName.equals(that.methodName) && methodDescriptor.equals(that.methodDescriptor) && replacedAccessors.equals(that.replacedAccessors);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = containingType.hashCode();
+        result = 31 * result + propertyName.hashCode();
+        result = 31 * result + methodName.hashCode();
+        result = 31 * result + methodDescriptor.hashCode();
+        result = 31 * result + replacedAccessors.hashCode();
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "UpgradedProperty{" +
             "propertyName='" + propertyName + '\'' +
@@ -96,6 +119,27 @@ public class UpgradedProperty {
 
         public BinaryCompatibility getBinaryCompatibility() {
             return binaryCompatibility;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            ReplacedAccessor that = (ReplacedAccessor) o;
+            return name.equals(that.name) && descriptor.equals(that.descriptor) && binaryCompatibility == that.binaryCompatibility;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = name.hashCode();
+            result = 31 * result + descriptor.hashCode();
+            result = 31 * result + binaryCompatibility.hashCode();
+            return result;
         }
 
         @Override


### PR DESCRIPTION
Without this change we sometimes get duplicate entries in `current-upgraded-properties.json` representing upgraded properties. This PR is not a fix for the root cause (which is not obvious), but instead a workaround to avoid the following failure which seems to happen intermittently:

```text
Execution failed for task ':architecture-test:checkBinaryCompatibility'.
> A failure occurred while executing me.champeau.gradle.japicmp.JApiCmpWorkAction
   > Duplicate key org.gradle.process.BaseExecSpec#getCommandLine()Ljava/util/List; (attempted merging values UpgradedProperty{propertyName='commandLine', methodName='getCommandLine', methodDescriptor='()Ljava/util/List;', containingType='org.gradle.process.BaseExecSpec', replacedAccessors=[ReplacedAccessor{name='getCommandLine', descriptor='()Ljava/util/List;', binaryCompatibility='ACCESSORS_KEPT'}]} and UpgradedProperty{propertyName='commandLine', methodName='getCommandLine', methodDescriptor='()Ljava/util/List;', containingType='org.gradle.process.BaseExecSpec', replacedAccessors=[ReplacedAccessor{name='getCommandLine', descriptor='()Ljava/util/List;', binaryCompatibility='ACCESSORS_KEPT'}]})
```

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
