### PR TITLE
Publish binary compatibility report as TeamCity artifact

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -108,6 +108,7 @@ fun BuildType.applyDefaultSettings(os: Os = Os.LINUX, arch: Arch = Arch.AMD64, b
         build/tmp/teŝt files/** => $hiddenArtifactDestination/teŝt-files
         build/errorLogs/** => $hiddenArtifactDestination/errorLogs
         subprojects/internal-build-reports/build/reports/incubation/all-incubating.html => incubation-reports
+        testing/architecture-test/build/reports/binary-compatibility/report.html => binary-compatibility-reports
         build/reports/dependency-verification/** => dependency-verification-reports
         build/*/problem-report.html => problem-reports
     """.trimIndent()


### PR DESCRIPTION
This fixes https://github.com/gradle/gradle-private/issues/4290

Example: https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_SanityCheck/87049208?buildTab=artifacts#%2Fbinary-compatibility-reports;%2Fbinary-compatibility-reports