### PR TITLE
Run `:build-logic:java-api-extractor:publish` in promotion 

### DIFF
--- a/build-logic-commons/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
+++ b/build-logic-commons/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
@@ -168,5 +168,5 @@ fun publishNormalizedToLocalRepository() {
 tasks.register("promotionBuild") {
     description = "Build production distros, smoke test them and publish"
     group = "publishing"
-    dependsOn(":packageBuild", "publish")
+    dependsOn(":packageBuild", ":publishBuildLogic", "publish")
 }

--- a/build-logic/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
+++ b/build-logic/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
@@ -43,6 +43,7 @@ setupTimeoutMonitorOnCI()
 setupGlobalState()
 
 tasks.registerDistributionsPromotionTasks()
+tasks.registerPublishBuildLogicTasks()
 
 tasks.registerEarlyFeedbackRootLifecycleTasks()
 
@@ -107,6 +108,8 @@ fun TaskContainer.registerEarlyFeedbackRootLifecycleTasks() {
 
 /**
  * Task that are called by the (currently separate) promotion build running on CI.
+ * Promotion build runs `./gradlew promotionBuild`, which depends on this `:packageBuild` task.
+ * BuildDistribution job runs `./gradlew packageBuild` directly.
  */
 fun TaskContainer.registerDistributionsPromotionTasks() {
     register("packageBuild") {
@@ -115,6 +118,20 @@ fun TaskContainer.registerDistributionsPromotionTasks() {
         dependsOn(
             ":distributions-full:verifyIsProductionBuildEnvironment", ":distributions-full:buildDists", ":distributions-full:copyDistributionsToRootBuild",
             ":distributions-integ-tests:forkingIntegTest", ":docs:releaseNotes", ":docs:incubationReport", ":docs:checkDeadInternalLinks"
+        )
+    }
+}
+
+/**
+ * To publish packages in build-logic we need to do it separately.
+ * Promotion build runs `./gradlew promotionBuild`, which depends on this `:publishBuildLogic` task.
+ */
+fun TaskContainer.registerPublishBuildLogicTasks() {
+    register("publishBuildLogic") {
+        description = "Publish subprojects in build-logic"
+        group = "build"
+        dependsOn(
+            gradle.includedBuild("build-logic").task(":java-api-extractor:publish")
         )
     }
 }


### PR DESCRIPTION
Make `:build-logic:java-api-extractor:publish` part of `:packageBuild`, which is depended by `:promotionBuild`.

See https://builds.gradle.org/buildConfiguration/Gradle_Master_Promotion_PublishBranchSnapshotFromQuickFeedback/87051685