### PR TITLE
Fix problem summary rendering

### DIFF
--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/cc/impl/problems/JsonWriter.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/cc/impl/problems/JsonWriter.kt
@@ -23,7 +23,6 @@ class JsonWriter(private val writer: Writer) {
     private var nextItemNeedsComma = false
 
     fun jsonObject(body: () -> Unit) {
-        elementSeparator()
         beginObject()
         body()
         endObject()
@@ -79,6 +78,7 @@ class JsonWriter(private val writer: Writer) {
         jsonObjectList(list.iterator(), body)
     }
 
+    private
     fun <T> jsonObjectList(list: Iterator<T>, body: (T) -> Unit) {
         jsonList(list) {
             jsonObject {
@@ -134,11 +134,25 @@ class JsonWriter(private val writer: Writer) {
     private
     fun write(c: Char) = writer.append(c)
 
+    fun <T> jsonList(list: Iterable<T>, body: (T) -> Unit) {
+        jsonList(list.iterator(), body)
+    }
+
+    private
     fun <T> jsonList(list: Iterator<T>, body: (T) -> Unit) {
         beginArray()
         list.forEach {
-            body(it)
+            jsonListItem {
+                body(it)
+            }
         }
         endArray()
+    }
+
+    fun jsonListItem(body: () -> Unit) {
+        elementSeparator()
+        increaseLevel()
+        body()
+        decreaseLevel()
     }
 }

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/DecoratedReportProblem.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/DecoratedReportProblem.kt
@@ -36,20 +36,22 @@ data class DecoratedReportProblem(
 class DecoratedReportProblemJsonSource(private val problem: DecoratedReportProblem) : JsonSource {
     override fun writeToJson(jsonWriter: JsonWriter) {
         with(jsonWriter) {
-            jsonObject {
-                property("trace") {
-                    jsonObjectList(problem.trace.sequence.asIterable()) { trace ->
-                        writePropertyTrace(trace)
+            jsonListItem {
+                jsonObject {
+                    property("trace") {
+                        jsonObjectList(problem.trace.sequence.asIterable()) { trace ->
+                            writePropertyTrace(trace)
+                        }
                     }
-                }
-                property(problem.kind) {
-                    writeStructuredMessage(problem.message)
-                }
-                problem.docLink?.let {
-                    property("documentationLink", it)
-                }
-                problem.failure?.let {
-                    writeError(it)
+                    property(problem.kind) {
+                        writeStructuredMessage(problem.message)
+                    }
+                    problem.docLink?.let {
+                        property("documentationLink", it)
+                    }
+                    problem.failure?.let {
+                        writeError(it)
+                    }
                 }
             }
         }

--- a/platforms/ide/problems/src/main/kotlin/org/gradle/problems/internal/impl/DefaultProblemsReportCreator.kt
+++ b/platforms/ide/problems/src/main/kotlin/org/gradle/problems/internal/impl/DefaultProblemsReportCreator.kt
@@ -141,7 +141,7 @@ class JsonProblemWriter(private val problem: Problem, private val failureDecorat
                 val solutions = problem.solutions
                 if (solutions.isNotEmpty()) {
                     property("solutions") {
-                        jsonList(solutions.iterator()) { solution ->
+                        jsonList(solutions) { solution ->
                             writeStructuredMessage(
                                 StructuredMessage.Builder()
                                     .text(solution).build()

--- a/platforms/ide/problems/src/test/kotlin/org/gradle/problems/internal/impl/JsonWriterTest.kt
+++ b/platforms/ide/problems/src/test/kotlin/org/gradle/problems/internal/impl/JsonWriterTest.kt
@@ -29,16 +29,13 @@ import java.io.StringWriter
 class JsonWriterTest {
 
     @Test
-    fun `writer produces valid multilevel JSON`() {
+    fun `can produce valid multilevel json`() {
         assertThat(
             jsonModelFor {
                 jsonObject {
                     property("solutions") {
-                        jsonList(listOf("solo").iterator()) { solution ->
-                            writeStructuredMessage(
-                                StructuredMessage.Builder()
-                                    .text(solution).build()
-                            )
+                        jsonList(listOf("solo")) { solution ->
+                            writeStructuredMessage(StructuredMessage.Builder().text(solution).build())
                         }
                     }
                 }
@@ -49,6 +46,130 @@ class JsonWriterTest {
                     listOf(
                         mapOf("text" to "solo")
                     )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `no entries in list`() {
+        assertThat(
+            jsonModelFor {
+                jsonObject {
+                    property("solutions") {
+                        jsonList(listOf<String>()) { solution ->
+                            writeStructuredMessage(StructuredMessage.Builder().text(solution).build())
+                        }
+                    }
+                }
+            },
+            hasEntry("solutions", listOf<String>())
+        )
+    }
+
+    @Test
+    fun `single entry in list`() {
+        assertThat(
+            jsonModelFor {
+                jsonObject {
+                    property("solutions") {
+                        jsonList(listOf("one")) { solution ->
+                            writeStructuredMessage(StructuredMessage.Builder().text(solution).build())
+                        }
+                    }
+                }
+            },
+            hasEntry(
+                "solutions",
+                listOf(
+                    listOf(
+                        mapOf("text" to "one")
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `multiple entries in list`() {
+        assertThat(
+            jsonModelFor {
+                jsonObject {
+                    property("solutions") {
+                        jsonList(listOf("first", "second")) { solution ->
+                            writeStructuredMessage(StructuredMessage.Builder().text(solution).build())
+                        }
+                    }
+                }
+            },
+            hasEntry(
+                "solutions",
+                listOf(
+                    listOf(
+                        mapOf("text" to "first")
+                    ),
+                    listOf(
+                        mapOf("text" to "second")
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `no entries in object list`() {
+        assertThat(
+            jsonModelFor {
+                jsonObject {
+                    property("solutions") {
+                        jsonObjectList(listOf<String>()) { solution ->
+                            writeStructuredMessage(StructuredMessage.Builder().text(solution).build())
+                        }
+                    }
+                }
+            },
+            hasEntry("solutions", listOf<String>())
+        )
+    }
+
+    @Test
+    fun `single entry in object list`() {
+        assertThat(
+            jsonModelFor {
+                jsonObject {
+                    property("solutions") {
+                        jsonObjectList(listOf("solo")) { solution ->
+                            property("text", solution)
+                        }
+                    }
+                }
+            },
+            hasEntry(
+                "solutions",
+                listOf(
+                    mapOf("text" to "solo")
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `multiple entries in object list`() {
+        assertThat(
+            jsonModelFor {
+                jsonObject {
+                    property("solutions") {
+                        jsonObjectList(listOf("first", "second")) { solution ->
+                            property("text", solution)
+                        }
+                    }
+                }
+            },
+            hasEntry(
+                "solutions",
+                listOf(
+                    mapOf("text" to "first"),
+                    mapOf("text" to "second")
                 )
             )
         )


### PR DESCRIPTION
When the JSON writer wrote an array with two or more items, the result was missing the separator commas. This caused the problem summary page to contain an invalid JSON file and the page could not be rendered.

Fixes https://github.com/gradle/gradle/issues/30191
