### PR TITLE
Restore finalizer group ordinal from the configuration cache

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheTaskExecutionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheTaskExecutionIntegrationTest.groovy
@@ -65,7 +65,7 @@ class ConfigurationCacheTaskExecutionIntegrationTest extends AbstractConfigurati
 
     def "tasks that access project through provider created at execution time emit problems"() {
         given:
-         buildFile """
+        buildFile """
             tasks.register("bypassesSafeguards") {
                  def providerFactory = providers
                 doLast { task ->

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheTaskExecutionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheTaskExecutionIntegrationTest.groovy
@@ -302,4 +302,45 @@ class ConfigurationCacheTaskExecutionIntegrationTest extends AbstractConfigurati
         then:
         result.assertTasksExecuted ':b', ':a'
     }
+
+    def "clean task is scheduled correctly in the presence of finalizers with dependencies"() {
+        given:
+        buildFile '''
+            plugins {
+                id 'java'
+            }
+
+            abstract class TaskReader extends DefaultTask {
+                @InputFile abstract RegularFileProperty getFile()
+                @TaskAction def action() {}
+            }
+
+            abstract class TaskWriter extends DefaultTask {
+                @OutputFile abstract RegularFileProperty getFile()
+                @TaskAction def action() {
+                    file.get().asFile.text = "foo"
+                }
+            }
+
+            tasks.register("a", DefaultTask) {
+                finalizedBy("b")
+            }
+
+            def taskWriter = tasks.register("c", TaskWriter) {
+                file = project.layout.buildDirectory.file("output.txt")
+            }
+
+            tasks.register("b", TaskReader) {
+                file = taskWriter.get().file
+            }
+        '''
+
+        when:
+        2.times {
+            configurationCacheRun 'clean', 'a'
+        }
+
+        then:
+        file('build/output.txt').text == 'foo'
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/FinalizerGroup.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/FinalizerGroup.java
@@ -47,9 +47,13 @@ public class FinalizerGroup extends HasFinalizers {
     private boolean hasBeenScheduled;
 
     public FinalizerGroup(TaskNode node, NodeGroup delegate) {
-        this.ordinal = delegate.asOrdinal();
+        this(node, delegate, delegate.asOrdinal());
+    }
+
+    public FinalizerGroup(TaskNode node, NodeGroup delegate, @Nullable OrdinalGroup ordinal) {
         this.node = node;
         this.delegate = delegate;
+        this.ordinal = ordinal;
     }
 
     @Override


### PR DESCRIPTION
So the scheduler can correctly handle finalizer dependencies in the presence of a destroyer task like `clean`.

Fixes #30193

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
