### PR TITLE
Pull up artifact transform caching

### DIFF
--- a/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/LocalFileDependencyBackedArtifactSetCodec.kt
+++ b/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/LocalFileDependencyBackedArtifactSetCodec.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.serialize.codecs.dm
 
+import com.google.common.collect.ImmutableList
 import org.gradle.api.Action
 import org.gradle.api.artifacts.FileCollectionDependency
 import org.gradle.api.artifacts.component.ComponentIdentifier
@@ -410,7 +411,7 @@ object EmptyVariantTransformRegistry : VariantTransformRegistry {
         throw UnsupportedOperationException("Should not be called")
     }
 
-    override fun getRegistrations(): MutableList<TransformRegistration> {
+    override fun getRegistrations(): ImmutableList<TransformRegistration> {
         throw UnsupportedOperationException("Should not be called")
     }
 }

--- a/platforms/software/dependency-management/build.gradle.kts
+++ b/platforms/software/dependency-management/build.gradle.kts
@@ -98,6 +98,7 @@ dependencies {
     implementation(libs.asmCommons)
     implementation(libs.commonsIo)
     implementation(libs.commonsLang)
+    implementation(libs.commonsLang3)
     implementation(libs.fastutil)
     implementation(libs.gson)
     implementation(libs.httpcore)

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -85,7 +85,6 @@ import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory;
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
-import org.gradle.api.internal.artifacts.transform.ConsumerProvidedVariantFinder;
 import org.gradle.api.internal.artifacts.transform.DefaultTransformInvocationFactory;
 import org.gradle.api.internal.artifacts.transform.DefaultTransformRegistrationFactory;
 import org.gradle.api.internal.artifacts.transform.DefaultTransformedVariantFactory;
@@ -290,7 +289,6 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             registration.add(ResolutionStrategyFactory.class);
             registration.add(DefaultLocalComponentRegistry.class);
             registration.add(ProjectDependencyResolver.class);
-            registration.add(ConsumerProvidedVariantFinder.class);
             registration.add(DefaultVariantSelectorFactory.class);
             registration.add(DefaultConfigurationFactory.class);
             registration.add(DefaultComponentSelectorConverter.class);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -91,6 +91,7 @@ import org.gradle.api.internal.artifacts.transform.DefaultTransformedVariantFact
 import org.gradle.api.internal.artifacts.transform.DefaultVariantSelectorFactory;
 import org.gradle.api.internal.artifacts.transform.DefaultVariantTransformRegistry;
 import org.gradle.api.internal.artifacts.transform.ImmutableTransformWorkspaceServices;
+import org.gradle.api.internal.artifacts.transform.IsolatingTransformFinder;
 import org.gradle.api.internal.artifacts.transform.MutableTransformWorkspaceServices;
 import org.gradle.api.internal.artifacts.transform.TransformActionScheme;
 import org.gradle.api.internal.artifacts.transform.TransformExecutionListener;
@@ -290,6 +291,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             registration.add(DefaultLocalComponentRegistry.class);
             registration.add(ProjectDependencyResolver.class);
             registration.add(DefaultVariantSelectorFactory.class);
+            registration.add(IsolatingTransformFinder.class);
             registration.add(DefaultConfigurationFactory.class);
             registration.add(DefaultComponentSelectorConverter.class);
             registration.add(DefaultArtifactResolutionQueryFactory.class);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/VariantTransformRegistry.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/VariantTransformRegistry.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.transform.TransformAction;
 import org.gradle.api.artifacts.transform.TransformParameters;
@@ -32,5 +33,5 @@ public interface VariantTransformRegistry {
      */
     <T extends TransformParameters> void registerTransform(Class<? extends TransformAction<T>> actionType, Action<? super TransformSpec<T>> registrationAction);
 
-    List<TransformRegistration> getRegistrations();
+    ImmutableList<TransformRegistration> getRegistrations();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelector.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.transform;
 
+import org.gradle.api.internal.artifacts.VariantTransformRegistry;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.BrokenResolvedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
@@ -44,7 +45,7 @@ public class AttributeMatchingArtifactVariantSelector implements ArtifactVariant
 
     private final ImmutableAttributesSchema consumerSchema;
     private final TransformUpstreamDependenciesResolver dependenciesResolver;
-    private final ConsumerProvidedVariantFinder consumerProvidedVariantFinder;
+    private final VariantTransformRegistry transformRegistry;
     private final ImmutableAttributesFactory attributesFactory;
     private final AttributeSchemaServices attributeSchemaServices;
     private final TransformedVariantFactory transformedVariantFactory;
@@ -53,7 +54,7 @@ public class AttributeMatchingArtifactVariantSelector implements ArtifactVariant
     AttributeMatchingArtifactVariantSelector(
         ImmutableAttributesSchema consumerSchema,
         TransformUpstreamDependenciesResolver dependenciesResolver,
-        ConsumerProvidedVariantFinder consumerProvidedVariantFinder,
+        VariantTransformRegistry transformRegistry,
         ImmutableAttributesFactory attributesFactory,
         AttributeSchemaServices attributeSchemaServices,
         TransformedVariantFactory transformedVariantFactory,
@@ -61,7 +62,7 @@ public class AttributeMatchingArtifactVariantSelector implements ArtifactVariant
     ) {
         this.consumerSchema = consumerSchema;
         this.dependenciesResolver = dependenciesResolver;
-        this.consumerProvidedVariantFinder = consumerProvidedVariantFinder;
+        this.transformRegistry = transformRegistry;
         this.attributesFactory = attributesFactory;
         this.attributeSchemaServices = attributeSchemaServices;
         this.transformedVariantFactory = transformedVariantFactory;
@@ -90,7 +91,7 @@ public class AttributeMatchingArtifactVariantSelector implements ArtifactVariant
         }
 
         // We found no matches. Attempt to construct artifact transform chains which produce matching variants.
-        List<TransformedVariant> transformedVariants = consumerProvidedVariantFinder.findTransformedVariants(variants, componentRequested);
+        List<TransformedVariant> transformedVariants = attributeSchemaServices.getTransformSelector(matcher).findTransformedVariants(transformRegistry, variants, componentRequested);
 
         // If there are multiple potential artifact transform variants, perform attribute matching to attempt to find the best.
         if (transformedVariants.size() > 1) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelector.java
@@ -48,6 +48,7 @@ public class AttributeMatchingArtifactVariantSelector implements ArtifactVariant
     private final VariantTransformRegistry transformRegistry;
     private final ImmutableAttributesFactory attributesFactory;
     private final AttributeSchemaServices attributeSchemaServices;
+    private final IsolatingTransformFinder isolatingTransformFinder;
     private final TransformedVariantFactory transformedVariantFactory;
     private final ResolutionFailureHandler failureProcessor;
 
@@ -57,6 +58,7 @@ public class AttributeMatchingArtifactVariantSelector implements ArtifactVariant
         VariantTransformRegistry transformRegistry,
         ImmutableAttributesFactory attributesFactory,
         AttributeSchemaServices attributeSchemaServices,
+        IsolatingTransformFinder isolatingTransformFinder,
         TransformedVariantFactory transformedVariantFactory,
         ResolutionFailureHandler failureProcessor
     ) {
@@ -65,6 +67,7 @@ public class AttributeMatchingArtifactVariantSelector implements ArtifactVariant
         this.transformRegistry = transformRegistry;
         this.attributesFactory = attributesFactory;
         this.attributeSchemaServices = attributeSchemaServices;
+        this.isolatingTransformFinder = isolatingTransformFinder;
         this.transformedVariantFactory = transformedVariantFactory;
         this.failureProcessor = failureProcessor;
     }
@@ -91,7 +94,7 @@ public class AttributeMatchingArtifactVariantSelector implements ArtifactVariant
         }
 
         // We found no matches. Attempt to construct artifact transform chains which produce matching variants.
-        List<TransformedVariant> transformedVariants = attributeSchemaServices.getTransformSelector(matcher).findTransformedVariants(transformRegistry, variants, componentRequested);
+        List<TransformedVariant> transformedVariants = isolatingTransformFinder.findTransformedVariants(matcher, transformRegistry.getRegistrations(), variants, componentRequested);
 
         // If there are multiple potential artifact transform variants, perform attribute matching to attempt to find the best.
         if (transformedVariants.size() > 1) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinder.java
@@ -295,9 +295,10 @@ public class ConsumerProvidedVariantFinder {
             }
 
             List<CachedTransform> cachedTransforms = new ArrayList<>(transforms.size());
-            for (TransformRegistration registration : transforms) {
+            for (int i = 0; i < transforms.size(); i++) {
+                TransformRegistration registration = transforms.get(i);
                 cachedTransforms.add(new CachedTransform(
-                    transforms.indexOf(registration),
+                    i,
                     registration.getFrom(),
                     registration.getTo()
                 ));

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinder.java
@@ -16,71 +16,105 @@
 
 package org.gradle.api.internal.artifacts.transform;
 
+import org.apache.commons.lang3.function.TriFunction;
 import org.gradle.api.internal.artifacts.TransformRegistration;
 import org.gradle.api.internal.artifacts.VariantTransformRegistry;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
-import org.gradle.api.internal.attributes.AttributeSchemaServices;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
-import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchema;
 import org.gradle.api.internal.attributes.matching.AttributeMatcher;
 import org.gradle.internal.collections.ImmutableFilteredList;
-import org.gradle.internal.lazy.Lazy;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.BiFunction;
-import java.util.function.Supplier;
 
 /**
  * Finds all the variants that can be created from a given set of producer variants using
  * the consumer's variant transforms. Transforms can be chained. If multiple
  * chains can lead to the same outcome, the shortest paths are selected.
- *
- * Caches the results, as often the same request is made for many components in a
- * dependency graph.
+ * <p>
+ * This class is scoped to a given {@link AttributeMatcher} instance. This class may be used
+ * by multiple projects and/or dependency resolution instances, each with different
+ * registered transform sets, as long as they share a common attribute matcher.
+ * <p>
+ * Results are cached, as often the same request is made for many components in a
+ * dependency graph. The cache is independent of the source variant and registered
+ * transform instances by storing the index of the input parameters as the cache key
+ * and mapping input and output indices to the actual instances.
  */
 public class ConsumerProvidedVariantFinder {
-    private final VariantTransformRegistry variantTransforms;
+
+    private final AttributeMatcher matcher;
     private final ImmutableAttributesFactory attributesFactory;
-    private final CachingAttributeMatcher matcher;
     private final TransformCache transformCache;
 
     public ConsumerProvidedVariantFinder(
-        VariantTransformRegistry variantTransforms,
-        AttributesSchemaInternal schema,
-        ImmutableAttributesFactory attributesFactory,
-        AttributeSchemaServices attributeSchemaServices
+        AttributeMatcher matcher,
+        ImmutableAttributesFactory attributesFactory
     ) {
-        this.variantTransforms = variantTransforms;
+        this.matcher = matcher;
         this.attributesFactory = attributesFactory;
-        this.matcher = new CachingAttributeMatcher(() -> {
-            // TODO: This is incorrect. We fail to merge the consumer schema with the producer schema
-            // and therefore we miss producer rules when matching transforms.
-            // Instead, this class should be refactored to accept a matcher as a parameter,
-            // where the matcher has already been created with the consumer and producer schema.
-            ImmutableAttributesSchema immutable = attributeSchemaServices.getSchemaFactory().create(schema);
-            return attributeSchemaServices.getMatcher(immutable, ImmutableAttributesSchema.EMPTY);
-        });
-        this.transformCache = new TransformCache(this::doFindTransformedVariants);
+        this.transformCache = new TransformCache(attributesFactory, this::doFindTransformedVariants);
     }
 
     /**
-     * Executes the transform chain detection algorithm given a set of producer variants and the requested
-     * attributes. Only the transform chains of the shortest depth are returned, and all results are
-     * guaranteed to have the same depth.
+     * Executes the transform chain detection algorithm given a set of registered transforms,
+     * producer variants and the requested attributes. Only the transform chains of the shortest
+     * depth are returned, and all results are guaranteed to have the same depth.
      *
+     * @param variantTransforms The transforms to select from.
      * @param sources The set of producer variants.
      * @param requested The requested attributes.
      *
      * @return A collection of variant chains which, if applied to the corresponding source variant, will produce a
      *      variant compatible with the requested attributes.
      */
-    public List<TransformedVariant> findTransformedVariants(List<ResolvedVariant> sources, ImmutableAttributes requested) {
-        return transformCache.query(sources, requested);
+    public List<TransformedVariant> findTransformedVariants(
+        VariantTransformRegistry variantTransforms,
+        List<ResolvedVariant> sources,
+        ImmutableAttributes requested
+    ) {
+        return transformCache.query(requested, variantTransforms.getRegistrations(), sources);
+    }
+
+    /**
+     * Represents a transform step in the transform chain detection algorithm. This class is used in the cached
+     * result and only refers to the index of the source transform in the original registered transform list.
+     */
+    private static class CachedTransform {
+        private final int registrationIndex;
+        private final ImmutableAttributes from;
+        private final ImmutableAttributes to;
+        public CachedTransform(int registrationIndex, ImmutableAttributes from, ImmutableAttributes to) {
+            this.registrationIndex = registrationIndex;
+            this.from = from;
+            this.to = to;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            CachedTransform that = (CachedTransform) o;
+            return registrationIndex == that.registrationIndex &&
+                from.equals(that.from) &&
+                to.equals(that.to);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = registrationIndex;
+            result = 31 * result + from.hashCode();
+            result = 31 * result + to.hashCode();
+            return result;
+        }
     }
 
     /**
@@ -88,8 +122,8 @@ public class ConsumerProvidedVariantFinder {
      */
     private static class ChainNode {
         final ChainNode next;
-        final TransformRegistration transform;
-        public ChainNode(@Nullable ChainNode next, TransformRegistration transform) {
+        final CachedTransform transform;
+        public ChainNode(@Nullable ChainNode next, CachedTransform transform) {
             this.next = next;
             this.transform = transform;
         }
@@ -102,7 +136,7 @@ public class ConsumerProvidedVariantFinder {
     private static class ChainState {
         final ChainNode chain;
         final ImmutableAttributes requested;
-        final ImmutableFilteredList<TransformRegistration> transforms;
+        final ImmutableFilteredList<CachedTransform> transforms;
 
         /**
          * @param chain The candidate transform chain.
@@ -110,7 +144,7 @@ public class ConsumerProvidedVariantFinder {
          *      original user-requested attribute set after {@code chain} is applied to that previous variant.
          * @param transforms The remaining transforms which may be prepended to {@code chain} to produce a solution.
          */
-        public ChainState(@Nullable ChainNode chain, ImmutableAttributes requested, ImmutableFilteredList<TransformRegistration> transforms) {
+        public ChainState(@Nullable ChainNode chain, ImmutableAttributes requested, ImmutableFilteredList<CachedTransform> transforms) {
             this.chain = chain;
             this.requested = requested;
             this.transforms = transforms;
@@ -124,8 +158,8 @@ public class ConsumerProvidedVariantFinder {
      */
     private static class CachedVariant {
         private final int sourceIndex;
-        private final VariantDefinition chain;
-        public CachedVariant(int sourceIndex, VariantDefinition chain) {
+        private final List<Integer> chain;
+        public CachedVariant(int sourceIndex, List<Integer> chain) {
             this.sourceIndex = sourceIndex;
             this.chain = chain;
         }
@@ -138,27 +172,30 @@ public class ConsumerProvidedVariantFinder {
      * we have found a solution. Otherwise, if no solutions are found at this depth, we run the search at the next depth, with all
      * candidate transforms linked to the previous level's chains.
      */
-    private List<CachedVariant> doFindTransformedVariants(List<ImmutableAttributes> sources, ImmutableAttributes requested) {
+    private List<CachedVariant> doFindTransformedVariants(
+        ImmutableAttributes requested,
+        List<CachedTransform> transforms,
+        List<ImmutableAttributes> sources
+    ) {
         List<ChainState> toProcess = new ArrayList<>();
         List<ChainState> nextDepth = new ArrayList<>();
-        toProcess.add(new ChainState(null, requested, ImmutableFilteredList.allOf(variantTransforms.getRegistrations())));
+        toProcess.add(new ChainState(null, requested, ImmutableFilteredList.allOf(transforms)));
 
         List<CachedVariant> results = new ArrayList<>(1);
         while (results.isEmpty() && !toProcess.isEmpty()) {
             for (ChainState state : toProcess) {
                 // The set of transforms which could potentially produce a variant compatible with `requested`.
-                ImmutableFilteredList<TransformRegistration> candidates =
-                    state.transforms.matching(transform -> matcher.isMatchingCandidate(transform.getTo(), state.requested));
+                ImmutableFilteredList<CachedTransform> candidates =
+                    state.transforms.matching(transform -> matcher.isMatchingCandidate(transform.to, state.requested));
 
                 // For each candidate, attempt to find a source variant that the transform can use as its root.
-                for (TransformRegistration candidate : candidates) {
+                for (CachedTransform candidate : candidates) {
                     for (int i = 0; i < sources.size(); i++) {
                         ImmutableAttributes sourceAttrs = sources.get(i);
-                        if (matcher.isMatchingCandidate(sourceAttrs, candidate.getFrom())) {
-                            ImmutableAttributes rootAttrs = attributesFactory.concat(sourceAttrs, candidate.getTo());
+                        if (matcher.isMatchingCandidate(sourceAttrs, candidate.from)) {
+                            ImmutableAttributes rootAttrs = attributesFactory.concat(sourceAttrs, candidate.to);
                             if (matcher.isMatchingCandidate(rootAttrs, state.requested)) {
-                                DefaultVariantDefinition rootTransformedVariant = new DefaultVariantDefinition(null, rootAttrs, candidate.getTransformStep());
-                                VariantDefinition variantChain = createVariantChain(state.chain, rootTransformedVariant);
+                                List<Integer> variantChain = extractTransformIndices(candidate, state.chain);
                                 results.add(new CachedVariant(i, variantChain));
                             }
                         }
@@ -172,10 +209,10 @@ public class ConsumerProvidedVariantFinder {
 
                 // Construct new states for processing at the next depth in case we can't find any solutions at this depth.
                 for (int i = 0; i < candidates.size(); i++) {
-                    TransformRegistration candidate = candidates.get(i);
+                    CachedTransform candidate = candidates.get(i);
                     nextDepth.add(new ChainState(
                         new ChainNode(state.chain, candidate),
-                        attributesFactory.concat(state.requested, candidate.getFrom()),
+                        attributesFactory.concat(state.requested, candidate.from),
                         state.transforms.withoutIndexFrom(i, candidates)
                     ));
                 }
@@ -191,66 +228,149 @@ public class ConsumerProvidedVariantFinder {
     }
 
     /**
-     * Constructs a complete cacheable variant chain given a root transformed variant and the chain of variants
-     * to apply to that root variant.
+     * Constructs a complete cacheable variant chain given an initial transform and the chain of transforms
+     * to apply after it.
      *
-     * @param stateChain The transform chain from the search state to apply to the root transformed variant.
-     * @param root The root variant to apply the chain to.
+     * @param first The first transform to apply to the source variant.
+     * @param rest The transform chain from the search state to apply to after the first transform.
      *
-     * @return A variant chain representing the final transformed variant.
+     * @return A list of transform indices, where each index corresponds to a transform registration in the original
+     *      transform list. The indices are ordered such that the first index corresponds to the first transform to
+     *      apply to the source variant.
      */
-    private VariantDefinition createVariantChain(final ChainNode stateChain, DefaultVariantDefinition root) {
-        ChainNode node = stateChain;
-        DefaultVariantDefinition last = root;
+    private static List<Integer> extractTransformIndices(CachedTransform first, @Nullable ChainNode rest) {
+        List<Integer> indices = new ArrayList<>();
+        indices.add(first.registrationIndex);
+
+        ChainNode node = rest;
         while (node != null) {
-            last = new DefaultVariantDefinition(
-                last,
-                attributesFactory.concat(last.getTargetAttributes(), node.transform.getTo()),
-                node.transform.getTransformStep()
-            );
+            indices.add(node.transform.registrationIndex);
             node = node.next;
         }
-        return last;
+
+        return indices;
     }
 
     /**
      * Caches calls to the transform chain selection algorithm. The cached results are stored in
-     * a variant-independent manner, such that only the attributes of the input variants are cached.
-     * This way, if multiple calls are made with different variants but those variants have the same
-     * attributes, the cached results may be used.
+     * a transform-independent and variant-independent manner, such that only the indices of the
+     * registered transforms and input variants are cached. This way, if multiple calls are made
+     * with different transforms or variants, but they have the same attributes, the cached results
+     * may be used.
      */
     private static class TransformCache {
-        private final ConcurrentHashMap<CacheKey, List<CachedVariant>> cache = new ConcurrentHashMap<>();
-        private final BiFunction<List<ImmutableAttributes>, ImmutableAttributes, List<CachedVariant>> action;
 
-        public TransformCache(BiFunction<List<ImmutableAttributes>, ImmutableAttributes, List<CachedVariant>> action) {
+        private final ImmutableAttributesFactory attributesFactory;
+        private final TriFunction<ImmutableAttributes, List<CachedTransform>, List<ImmutableAttributes>, List<CachedVariant>> action;
+
+        private final ConcurrentHashMap<CacheKey, List<CachedVariant>> cache = new ConcurrentHashMap<>();
+
+        public TransformCache(
+            ImmutableAttributesFactory attributesFactory,
+            TriFunction<ImmutableAttributes, List<CachedTransform>, List<ImmutableAttributes>, List<CachedVariant>> action
+        ) {
+            this.attributesFactory = attributesFactory;
             this.action = action;
         }
 
         private List<TransformedVariant> query(
-            List<ResolvedVariant> sources, ImmutableAttributes requested
+            ImmutableAttributes requested,
+            List<TransformRegistration> transforms,
+            List<ResolvedVariant> sources
         ) {
+            CacheKey query = createQuery(requested, transforms, sources);
+
+            List<CachedVariant> cachedResult = cache.computeIfAbsent(query, key ->
+                action.apply(key.requested, key.transforms, key.variantAttributes)
+            );
+
+            return extractResult(cachedResult, transforms, sources);
+        }
+
+        private static CacheKey createQuery(ImmutableAttributes requested, List<TransformRegistration> transforms, List<ResolvedVariant> sources) {
+
             List<ImmutableAttributes> variantAttributes = new ArrayList<>(sources.size());
             for (ResolvedVariant variant : sources) {
                 variantAttributes.add(variant.getAttributes().asImmutable());
             }
-            List<CachedVariant> cached = cache.computeIfAbsent(new CacheKey(variantAttributes, requested), key -> action.apply(key.variantAttributes, key.requested));
-            List<TransformedVariant> output = new ArrayList<>(cached.size());
-            for (CachedVariant variant : cached) {
-                output.add(new TransformedVariant(sources.get(variant.sourceIndex), variant.chain));
+
+            List<CachedTransform> cachedTransforms = new ArrayList<>(transforms.size());
+            for (TransformRegistration registration : transforms) {
+                cachedTransforms.add(new CachedTransform(
+                    transforms.indexOf(registration),
+                    registration.getFrom(),
+                    registration.getTo()
+                ));
+            }
+
+            return new CacheKey(cachedTransforms, variantAttributes, requested);
+        }
+
+        private List<TransformedVariant> extractResult(
+            List<CachedVariant> cachedVariants,
+            List<TransformRegistration> transforms,
+            List<ResolvedVariant> sources
+        ) {
+            List<TransformedVariant> output = new ArrayList<>(cachedVariants.size());
+            for (CachedVariant variant : cachedVariants) {
+                ResolvedVariant source = sources.get(variant.sourceIndex);
+                VariantDefinition variantDefinition = createVariantChain(transforms, variant.chain, source.getAttributes());
+                output.add(new TransformedVariant(source, variantDefinition));
             }
             return output;
         }
 
+        private VariantDefinition createVariantChain(
+            List<TransformRegistration> transforms,
+            List<Integer> indices,
+            ImmutableAttributes sourceAttribute
+        ) {
+            assert !indices.isEmpty();
+
+            DefaultVariantDefinition previous = null;
+            ImmutableAttributes prevAttributes = sourceAttribute;
+
+            for (int i : indices) {
+                TransformRegistration transform = transforms.get(i);
+                previous = new DefaultVariantDefinition(
+                    previous,
+                    attributesFactory.concat(prevAttributes, transform.getTo()),
+                    transform.getTransformStep()
+                );
+                prevAttributes = previous.getTargetAttributes();
+            }
+
+            return previous;
+        }
+
         private static class CacheKey {
+            private final List<CachedTransform> transforms;
             private final List<ImmutableAttributes> variantAttributes;
             private final ImmutableAttributes requested;
+
             private final int hashCode;
 
-            public CacheKey(List<ImmutableAttributes> variantAttributes, ImmutableAttributes requested) {
+            public CacheKey(
+                List<CachedTransform> transforms,
+                List<ImmutableAttributes> variantAttributes,
+                ImmutableAttributes requested
+            ) {
+                this.transforms = transforms;
                 this.variantAttributes = variantAttributes;
                 this.requested = requested;
-                this.hashCode = 31 * variantAttributes.hashCode() + requested.hashCode();
+
+                this.hashCode = computeHashCode(transforms, variantAttributes, requested);
+            }
+
+            private static int computeHashCode(
+                List<CachedTransform> transforms,
+                List<ImmutableAttributes> variantAttributes,
+                ImmutableAttributes requested
+            ) {
+                int result = transforms.hashCode();
+                result = 31 * result + variantAttributes.hashCode();
+                result = 31 * result + requested.hashCode();
+                return result;
             }
 
             @Override
@@ -261,56 +381,11 @@ public class ConsumerProvidedVariantFinder {
                 if (o == null || getClass() != o.getClass()) {
                     return false;
                 }
+
                 CacheKey cacheKey = (CacheKey) o;
-                return variantAttributes.equals(cacheKey.variantAttributes) && requested.equals(cacheKey.requested);
-            }
-
-            @Override
-            public int hashCode() {
-                return hashCode;
-            }
-        }
-    }
-
-    /**
-     * Caches calls to {@link AttributeMatcher#isMatchingCandidate(ImmutableAttributes, ImmutableAttributes)}
-     */
-    private static class CachingAttributeMatcher {
-        private final Lazy<AttributeMatcher> matcher;
-        private final ConcurrentHashMap<CacheKey, Boolean> cache = new ConcurrentHashMap<>();
-
-        public CachingAttributeMatcher(Supplier<AttributeMatcher> matcher) {
-            // We need this lazy so that we only "lock in" the attributes as immutable
-            // only after the first time we request a transform chain. This is ugly
-            // TODO: Create a single instance of ConsumerProvidedVariantFinder per matcher
-            this.matcher = Lazy.locking().of(matcher);
-        }
-
-        public boolean isMatchingCandidate(ImmutableAttributes candidate, ImmutableAttributes requested) {
-            return cache.computeIfAbsent(new CacheKey(candidate, requested), key -> matcher.get().isMatchingCandidate(key.candidate, key.requested));
-        }
-
-        private static class CacheKey {
-            private final ImmutableAttributes candidate;
-            private final ImmutableAttributes requested;
-            private final int hashCode;
-
-            public CacheKey(ImmutableAttributes candidate, ImmutableAttributes requested) {
-                this.candidate = candidate;
-                this.requested = requested;
-                this.hashCode = 31 * candidate.hashCode() + requested.hashCode();
-            }
-
-            @Override
-            public boolean equals(Object o) {
-                if (this == o) {
-                    return true;
-                }
-                if (o == null || getClass() != o.getClass()) {
-                    return false;
-                }
-                CacheKey cacheKey = (CacheKey) o;
-                return candidate.equals(cacheKey.candidate) && requested.equals(cacheKey.requested);
+                return transforms.equals(cacheKey.transforms) &&
+                    variantAttributes.equals(cacheKey.variantAttributes) &&
+                    requested.equals(cacheKey.requested);
             }
 
             @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantSelectorFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantSelectorFactory.java
@@ -39,6 +39,7 @@ public class DefaultVariantSelectorFactory implements VariantSelectorFactory {
     private final VariantTransformRegistry transformRegistry;
     private final ImmutableAttributesFactory attributesFactory;
     private final AttributeSchemaServices attributeSchemaServices;
+    private final IsolatingTransformFinder transformFinder;
     private final TransformedVariantFactory transformedVariantFactory;
     private final ResolutionFailureHandler failureProcessor;
     private final DomainObjectContext domainObjectContext;
@@ -50,6 +51,7 @@ public class DefaultVariantSelectorFactory implements VariantSelectorFactory {
         VariantTransformRegistry transformRegistry,
         ImmutableAttributesFactory attributesFactory,
         AttributeSchemaServices attributeSchemaServices,
+        IsolatingTransformFinder transformFinder,
         TransformedVariantFactory transformedVariantFactory,
         ResolutionFailureHandler failureProcessor,
         DomainObjectContext domainObjectContext,
@@ -59,6 +61,7 @@ public class DefaultVariantSelectorFactory implements VariantSelectorFactory {
         this.transformRegistry = transformRegistry;
         this.attributesFactory = attributesFactory;
         this.attributeSchemaServices = attributeSchemaServices;
+        this.transformFinder = transformFinder;
         this.transformedVariantFactory = transformedVariantFactory;
         this.failureProcessor = failureProcessor;
         this.domainObjectContext = domainObjectContext;
@@ -95,6 +98,7 @@ public class DefaultVariantSelectorFactory implements VariantSelectorFactory {
             transformRegistry,
             attributesFactory,
             attributeSchemaServices,
+            transformFinder,
             transformedVariantFactory,
             failureProcessor
         );

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantSelectorFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantSelectorFactory.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.transform;
 import org.gradle.api.artifacts.ResolutionStrategy;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ResolverResults;
+import org.gradle.api.internal.artifacts.VariantTransformRegistry;
 import org.gradle.api.internal.artifacts.configurations.ResolutionHost;
 import org.gradle.api.internal.artifacts.configurations.ResolutionResultProvider;
 import org.gradle.api.internal.attributes.AttributeSchemaServices;
@@ -35,7 +36,7 @@ import javax.inject.Inject;
 
 public class DefaultVariantSelectorFactory implements VariantSelectorFactory {
 
-    private final ConsumerProvidedVariantFinder consumerProvidedVariantFinder;
+    private final VariantTransformRegistry transformRegistry;
     private final ImmutableAttributesFactory attributesFactory;
     private final AttributeSchemaServices attributeSchemaServices;
     private final TransformedVariantFactory transformedVariantFactory;
@@ -46,7 +47,7 @@ public class DefaultVariantSelectorFactory implements VariantSelectorFactory {
 
     @Inject
     public DefaultVariantSelectorFactory(
-        ConsumerProvidedVariantFinder consumerProvidedVariantFinder,
+        VariantTransformRegistry transformRegistry,
         ImmutableAttributesFactory attributesFactory,
         AttributeSchemaServices attributeSchemaServices,
         TransformedVariantFactory transformedVariantFactory,
@@ -55,7 +56,7 @@ public class DefaultVariantSelectorFactory implements VariantSelectorFactory {
         CalculatedValueContainerFactory calculatedValueContainerFactory,
         TaskDependencyFactory taskDependencyFactory
     ) {
-        this.consumerProvidedVariantFinder = consumerProvidedVariantFinder;
+        this.transformRegistry = transformRegistry;
         this.attributesFactory = attributesFactory;
         this.attributeSchemaServices = attributeSchemaServices;
         this.transformedVariantFactory = transformedVariantFactory;
@@ -91,7 +92,7 @@ public class DefaultVariantSelectorFactory implements VariantSelectorFactory {
         return new AttributeMatchingArtifactVariantSelector(
             consumerSchema,
             dependenciesResolver,
-            consumerProvidedVariantFinder,
+            transformRegistry,
             attributesFactory,
             attributeSchemaServices,
             transformedVariantFactory,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/IsolatingTransformFinder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/IsolatingTransformFinder.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.internal.artifacts.TransformRegistration;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
+import org.gradle.api.internal.attributes.AttributeSchemaServiceFactory;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.attributes.matching.AttributeMatcher;
+import org.gradle.internal.Pair;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class IsolatingTransformFinder {
+
+    private final ImmutableAttributesFactory attributesFactory;
+    private final AttributeSchemaServiceFactory serviceFactory;
+
+    private volatile Pair<ImmutableList<TransformRegistration>, ConsumerProvidedVariantFinder.CachedTransforms> cache;
+
+    public IsolatingTransformFinder(
+        ImmutableAttributesFactory attributesFactory,
+        AttributeSchemaServiceFactory serviceFactory
+    ) {
+        this.attributesFactory = attributesFactory;
+        this.serviceFactory = serviceFactory;
+    }
+
+    public List<TransformedVariant> findTransformedVariants(
+        AttributeMatcher matcher,
+        ImmutableList<TransformRegistration> variantTransforms,
+        List<ResolvedVariant> sources,
+        ImmutableAttributes requested
+    ) {
+        ConsumerProvidedVariantFinder consumerProvidedVariantFinder = serviceFactory.getTransformSelector(matcher);
+
+        Pair<ImmutableList<TransformRegistration>, ConsumerProvidedVariantFinder.CachedTransforms> cached = cache;
+        if (cached == null || cached.getLeft() != variantTransforms) {
+            cached = Pair.of(variantTransforms, consumerProvidedVariantFinder.cacheRegisteredTransforms(variantTransforms));
+            cache = cached;
+        }
+
+        List<ConsumerProvidedVariantFinder.CachedVariant> result = consumerProvidedVariantFinder.findTransformedVariants(requested, cached.getRight(), sources);
+        return extractResult(result, variantTransforms, sources);
+    }
+
+    private List<TransformedVariant> extractResult(
+        List<ConsumerProvidedVariantFinder.CachedVariant> cachedVariants,
+        List<TransformRegistration> transforms,
+        List<ResolvedVariant> sources
+    ) {
+        List<TransformedVariant> output = new ArrayList<>(cachedVariants.size());
+        for (ConsumerProvidedVariantFinder.CachedVariant variant : cachedVariants) {
+            ResolvedVariant source = sources.get(variant.sourceIndex);
+            VariantDefinition variantDefinition = createVariantChain(transforms, variant.chain, source.getAttributes());
+            output.add(new TransformedVariant(source, variantDefinition));
+        }
+        return output;
+    }
+
+    private VariantDefinition createVariantChain(
+        List<TransformRegistration> transforms,
+        List<Integer> indices,
+        ImmutableAttributes sourceAttribute
+    ) {
+        assert !indices.isEmpty();
+
+        DefaultVariantDefinition previous = null;
+        ImmutableAttributes prevAttributes = sourceAttribute;
+
+        for (int i : indices) {
+            TransformRegistration transform = transforms.get(i);
+            previous = new DefaultVariantDefinition(
+                previous,
+                attributesFactory.concat(prevAttributes, transform.getTo()),
+                transform.getTransformStep()
+            );
+            prevAttributes = previous.getTargetAttributes();
+        }
+
+        return previous;
+    }
+
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/AttributeSchemaServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/AttributeSchemaServices.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.attributes;
 
+import org.gradle.api.internal.artifacts.transform.ConsumerProvidedVariantFinder;
 import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchema;
 import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchemaFactory;
 import org.gradle.api.internal.attributes.matching.AttributeMatcher;
@@ -26,6 +27,9 @@ import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.inject.Inject;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Map;
 
 /**
  * A collection of services for creating and working with immutable attribute schemas.
@@ -33,14 +37,19 @@ import javax.inject.Inject;
 @ServiceScope(Scope.BuildSession.class)
 public class AttributeSchemaServices {
 
+    private final ImmutableAttributesFactory attributesFactory;
     private final ImmutableAttributesSchemaFactory attributesSchemaFactory;
 
     private final ConcurrentIdentityCache<ImmutableAttributesSchema, AttributeMatcher> matchers = new ConcurrentIdentityCache<>();
 
+    private final Map<AttributeMatcher, ConsumerProvidedVariantFinder> transformers = Collections.synchronizedMap(new IdentityHashMap<>());
+
     @Inject
     public AttributeSchemaServices(
+        ImmutableAttributesFactory attributesFactory,
         ImmutableAttributesSchemaFactory attributesSchemaFactory
     ) {
+        this.attributesFactory = attributesFactory;
         this.attributesSchemaFactory = attributesSchemaFactory;
     }
 
@@ -65,6 +74,16 @@ public class AttributeSchemaServices {
                     new DefaultAttributeSelectionSchema(key)
                 )
             )
+        );
+    }
+
+    /**
+     * Given an attribute matcher, return a selector that can determine artifact transform chains
+     * for a given set of request attributes, source variants, and registered transforms.
+     */
+    public ConsumerProvidedVariantFinder getTransformSelector(AttributeMatcher matcher) {
+        return transformers.computeIfAbsent(matcher, m ->
+            new ConsumerProvidedVariantFinder(m, attributesFactory)
         );
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/AttributeSchemaServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/AttributeSchemaServices.java
@@ -27,9 +27,9 @@ import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.inject.Inject;
-import java.util.Collections;
-import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 /**
  * A collection of services for creating and working with immutable attribute schemas.
@@ -41,8 +41,7 @@ public class AttributeSchemaServices {
     private final ImmutableAttributesSchemaFactory attributesSchemaFactory;
 
     private final ConcurrentIdentityCache<ImmutableAttributesSchema, AttributeMatcher> matchers = new ConcurrentIdentityCache<>();
-
-    private final Map<AttributeMatcher, ConsumerProvidedVariantFinder> transformers = Collections.synchronizedMap(new IdentityHashMap<>());
+    private final Map<AttributeMatcher, ConsumerProvidedVariantFinder> transformers = new ConcurrentHashMap<>();
 
     @Inject
     public AttributeSchemaServices(
@@ -85,6 +84,40 @@ public class AttributeSchemaServices {
         return transformers.computeIfAbsent(matcher, m ->
             new ConsumerProvidedVariantFinder(m, attributesFactory)
         );
+    }
+
+    /**
+     * A concurrent cache that bypasses the equals and hashcode methods of the key.
+     * Should be used only with keys that are known to be interned.
+     * <p>
+     * This is likely a more performant alternative to {@code Collections.synchronizedMap(new IdentityHashMap<>())}.
+     */
+    private static class ConcurrentIdentityCache<K, V> {
+        private final Map<IdentityKey<K>, V> map = new ConcurrentHashMap<>();
+
+        public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+            return map.computeIfAbsent(new IdentityKey<>(key), k -> mappingFunction.apply(key));
+        }
+    }
+
+    private static class IdentityKey<T> {
+
+        private final T value;
+
+        IdentityKey(T value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof IdentityKey && ((IdentityKey<?>) obj).value == value;
+        }
+
+        @Override
+        public int hashCode() {
+            return System.identityHashCode(value);
+        }
+
     }
 
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/matching/DefaultAttributeMatcher.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/matching/DefaultAttributeMatcher.java
@@ -33,8 +33,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  * An {@link AttributeMatcher}, which optimizes for the case of only comparing 0 or 1 candidates
@@ -51,7 +51,12 @@ public class DefaultAttributeMatcher implements AttributeMatcher {
      * cache the result of the query, because it's often the case that we ask for the same
      * disambiguation of attributes several times in a row (but with different candidates).
      */
-    private final ConcurrentMap<CachedQuery, int[]> cachedQueries = new ConcurrentHashMap<>();
+    private final Map<CachedQuery, int[]> cachedQueries = new ConcurrentHashMap<>();
+
+    /**
+     * Map of cached results of {@link #isMatchingCandidate(ImmutableAttributes, ImmutableAttributes)}.
+     */
+    private final Map<MatchingCacheKey, Boolean> matchingCandidateCache = new ConcurrentHashMap<>();
 
     public DefaultAttributeMatcher(AttributeSelectionSchema schema) {
         this.schema = schema;
@@ -64,7 +69,9 @@ public class DefaultAttributeMatcher implements AttributeMatcher {
 
     @Override
     public boolean isMatchingCandidate(ImmutableAttributes candidate, ImmutableAttributes requested) {
-        return allCommonAttributesSatisfy(candidate, requested, schema::matchValue);
+        return matchingCandidateCache.computeIfAbsent(new MatchingCacheKey(candidate, requested), key ->
+            allCommonAttributesSatisfy(candidate, requested, schema::matchValue)
+        );
     }
 
     @Override
@@ -257,4 +264,35 @@ public class DefaultAttributeMatcher implements AttributeMatcher {
                 '}';
         }
     }
+
+    private static class MatchingCacheKey {
+        private final ImmutableAttributes candidate;
+        private final ImmutableAttributes requested;
+        private final int hashCode;
+
+        public MatchingCacheKey(ImmutableAttributes candidate, ImmutableAttributes requested) {
+            this.candidate = candidate;
+            this.requested = requested;
+            this.hashCode = 31 * candidate.hashCode() + requested.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            MatchingCacheKey cacheKey = (MatchingCacheKey) o;
+            return candidate.equals(cacheKey.candidate) &&
+                requested.equals(cacheKey.requested);
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+    }
+
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactVariantSelectorFactoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactVariantSelectorFactoryTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.transform
 import com.google.common.collect.ImmutableList
 import org.gradle.api.artifacts.ResolutionStrategy
 import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
+import org.gradle.api.internal.artifacts.VariantTransformRegistry
 import org.gradle.api.internal.artifacts.configurations.ResolutionHost
 import org.gradle.api.internal.artifacts.configurations.ResolutionResultProvider
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor
@@ -48,12 +49,14 @@ class DefaultArtifactVariantSelectorFactoryTest extends Specification {
     def attributeMatcher = Mock(AttributeMatcher)
     def schemaServices = Mock(AttributeSchemaServices) {
         getMatcher(consumerSchema, producerSchema) >> attributeMatcher
+        getTransformSelector(attributeMatcher) >> matchingCache
     }
+    def transformRegistry = Mock(VariantTransformRegistry)
     def factory = Mock(ArtifactVariantSelector.ResolvedArtifactTransformer)
     def transformedVariantFactory = Mock(TransformedVariantFactory)
     def variantSelectionFailureProcessor = DependencyManagementTestUtil.newFailureHandler()
     def variantSelectorFactory = new DefaultVariantSelectorFactory(
-        matchingCache,
+        transformRegistry,
         AttributeTestUtil.attributesFactory(),
         schemaServices,
         transformedVariantFactory,
@@ -132,7 +135,7 @@ class DefaultArtifactVariantSelectorFactoryTest extends Specification {
 
         attributeMatcher.matchMultipleCandidates(ImmutableList.copyOf(variants), _, _) >> []
         attributeMatcher.matchMultipleCandidates(transformedVariants, _, _) >> transformedVariants
-        matchingCache.findTransformedVariants(_, _) >> transformedVariants
+        matchingCache.findTransformedVariants(_, _, _) >> transformedVariants
 
         def selector = newSelector()
 
@@ -169,7 +172,7 @@ Found the following transforms:
 
         attributeMatcher.matchMultipleCandidates(_, _, _) >> []
 
-        matchingCache.findTransformedVariants(_, _) >> []
+        matchingCache.findTransformedVariants(_, _, _) >> []
 
         expect:
         def result = newSelector().select(set, typeAttributes("dll"), true, factory)
@@ -193,7 +196,7 @@ Found the following transforms:
 
         attributeMatcher.matchMultipleCandidates(_, _, _) >> []
 
-        matchingCache.findTransformedVariants(_, _) >> []
+        matchingCache.findTransformedVariants(_, _, _) >> []
 
         when:
         def result = newSelector().select(set, typeAttributes("dll"), false, factory)

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/AttributeTestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/AttributeTestUtil.groovy
@@ -97,6 +97,6 @@ class AttributeTestUtil {
      * Creates a service factory, used for creating attribute matchers and variant transformers.
      */
     static AttributeSchemaServices services() {
-        new AttributeSchemaServices(new ImmutableAttributesSchemaFactory())
+        new AttributeSchemaServices(attributesFactory(), new ImmutableAttributesSchemaFactory())
     }
 }


### PR DESCRIPTION
Introduce ImmutableAttributeSchema, which can be compared with equality. We introduce a factory for these schemas which intern instances. Then, we introduce another factory for attribute matchers keyed on the input schema. This allows us to 'hoist' up various attribute matching caches to the build session scope.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
