### PR TITLE
Work around Gradle modifying system properties at configuration time

### DIFF
--- a/platforms/core-configuration/configuration-cache-base/src/test/kotlin/org/gradle/internal/cc/base/services/ConfigurationCacheEnvironmentChangeTrackerTest.kt
+++ b/platforms/core-configuration/configuration-cache-base/src/test/kotlin/org/gradle/internal/cc/base/services/ConfigurationCacheEnvironmentChangeTrackerTest.kt
@@ -19,12 +19,90 @@ package org.gradle.internal.cc.base.services
 import org.gradle.internal.code.DefaultUserCodeApplicationContext
 import org.gradle.internal.configuration.problems.DefaultProblemFactory
 import org.gradle.internal.problems.NoOpProblemDiagnosticsFactory
+import org.gradle.util.SetSystemProperties
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.nullValue
+import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
 
 
 class ConfigurationCacheEnvironmentChangeTrackerTest {
+    @Rule
+    @JvmField
+    val systemProperties = SetSystemProperties()
+
     private
     val tracker = ConfigurationCacheEnvironmentChangeTracker(DefaultProblemFactory(DefaultUserCodeApplicationContext(), NoOpProblemDiagnosticsFactory()))
+
+    @Test
+    fun `property set in tracking scope is considered changed`() {
+        tracker.withTrackingSystemPropertyChanges {
+            System.setProperty("some.property", "some.value")
+        }
+
+        assertTrue(tracker.isSystemPropertyMutated("some.property"))
+        assertThat(System.getProperty("some.property"), equalTo("some.value"))
+    }
+
+    @Test
+    fun `property changed in tracking scope is considered changed`() {
+        System.setProperty("some.property", "some.value")
+        tracker.withTrackingSystemPropertyChanges {
+            System.setProperty("some.property", "other.value")
+        }
+
+        assertTrue(tracker.isSystemPropertyMutated("some.property"))
+        assertThat(System.getProperty("some.property"), equalTo("other.value"))
+    }
+
+    @Test
+    fun `property removed in tracking scope is considered removed`() {
+        System.setProperty("some.property", "some.value")
+        tracker.withTrackingSystemPropertyChanges {
+            System.getProperties().remove("some.property")
+            Unit
+        }
+
+        assertTrue(isSystemPropertyRemoved("some.property"))
+        assertThat(System.getProperty("some.property"), nullValue())
+    }
+
+    @Test
+    fun `tracking scope returns the value`() {
+        val result = tracker.withTrackingSystemPropertyChanges {
+            1
+        }
+
+        assertThat(result, equalTo(1))
+    }
+
+    @Test
+    fun `property changes are tracked if an exception is thrown in the scope`() {
+        try {
+            tracker.withTrackingSystemPropertyChanges<String> {
+                System.setProperty("some.property", "some.value")
+                throw RuntimeException("expected")
+            }
+        } catch (ignored: Exception) {
+
+        }
+
+        assertTrue(tracker.isSystemPropertyMutated("some.property"))
+        assertThat(System.getProperty("some.property"), equalTo("some.value"))
+    }
+
+    @Test
+    fun `can use tracking scope after restoring`() {
+        tracker.loadFrom(emptyEnvironmentState())
+
+        tracker.withTrackingSystemPropertyChanges {
+            System.setProperty("some.property", "some.value")
+        }
+
+        assertThat(System.getProperty("some.property"), equalTo("some.value"))
+    }
 
     @Test
     fun `can load state after capturing`() {
@@ -49,4 +127,9 @@ class ConfigurationCacheEnvironmentChangeTrackerTest {
 
     private
     fun emptyEnvironmentState() = ConfigurationCacheEnvironmentChangeTracker.CachedEnvironmentState(cleared = false, updates = listOf(), removals = listOf())
+
+    private
+    fun isSystemPropertyRemoved(key: String): Boolean {
+        return tracker.getCachedState().removals.find { it.key == key } != null
+    }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheKotlinDslIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheKotlinDslIntegrationTest.groovy
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl
+
+
+import spock.lang.Issue
+
+class ConfigurationCacheKotlinDslIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+
+    @Issue("https://github.com/gradle/gradle/issues/30145")
+    def "compilation of kotlin dsl build script does not cause cache misses when all system properties are input"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+
+        buildKotlinFile """
+            System.getProperties().forEach { _, _ -> }  // Mark all properties as an input
+
+            tasks.register("run") {
+                doLast {
+                    println("idea.io.use.nio2=\${System.getProperty("idea.io.use.nio2")}")
+                }
+            }
+        """
+
+        when:
+        configurationCacheRun("run")
+
+        then:
+        configurationCache.assertStateStored()
+
+        when:
+        configurationCacheRun("run")
+
+        then:
+        configurationCache.assertStateLoaded()
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/30145")
+    def "compilation of kotlin dsl plugin does not cause cache misses when all system properties are input"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+
+        // We have to use Groovy scripts here to reproduce the original issue. Precompiled script compilation should be the first Kotlin compilation job done by Gradle.
+        settingsFile """
+            includeBuild("plugin")
+        """
+
+        buildFile("plugin/build.gradle", """
+            plugins {
+                id "org.gradle.kotlin.kotlin-dsl" version "5.1.0"  // TODO(mlopatkin): this should be the "current" Kotlin DSL version but it isn't available for Groovy scripts.
+            }
+
+            repositories {
+                gradlePluginPortal()
+            }
+        """)
+
+        file("plugin/src/main/kotlin/my.plugin.gradle.kts") << """
+            tasks.register("run") {
+                doLast {
+                    println("idea.io.use.nio2=\${System.getProperty("idea.io.use.nio2")}")
+                }
+            }
+        """
+
+        buildFile """
+            plugins {
+                id("my.plugin")
+            }
+            System.getProperties().forEach { k, v -> }  // Mark all properties as an input
+        """
+
+        when:
+        configurationCacheRun("run")
+
+        then:
+        configurationCache.assertStateStored()
+
+        when:
+        configurationCacheRun("run")
+
+        then:
+        configurationCache.assertStateLoaded()
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/services/VintageEnvironmentChangeTracker.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/services/VintageEnvironmentChangeTracker.kt
@@ -17,6 +17,7 @@
 package org.gradle.internal.cc.impl.services
 
 import org.gradle.initialization.EnvironmentChangeTracker
+import java.util.function.Supplier
 
 
 internal
@@ -27,4 +28,6 @@ class VintageEnvironmentChangeTracker : EnvironmentChangeTracker {
     override fun systemPropertyLoaded(key: Any, value: Any?, oldValue: Any?) = Unit
 
     override fun systemPropertyOverridden(key: Any) = Unit
+
+    override fun <T : Any> withTrackingSystemPropertyChanges(action: Supplier<out T>): T = action.get()
 }

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/CompilePrecompiledScriptPluginPlugins.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/CompilePrecompiledScriptPluginPlugins.kt
@@ -38,6 +38,7 @@ import org.gradle.initialization.GradlePropertiesController
 import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.kotlin.dsl.precompile.v1.PrecompiledPluginsBlock
 import org.gradle.kotlin.dsl.support.ImplicitImports
+import org.gradle.kotlin.dsl.support.KotlinCompilerEnvironment
 import org.gradle.kotlin.dsl.support.KotlinCompilerOptions
 import org.gradle.kotlin.dsl.support.compileKotlinScriptModuleTo
 import org.gradle.kotlin.dsl.support.kotlinCompilerOptions
@@ -106,7 +107,7 @@ abstract class CompilePrecompiledScriptPluginPlugins @Inject constructor(
         outputDir.withOutputDirectory { outputDir ->
             val scriptFiles = sourceFiles.map { it.path }
             if (scriptFiles.isNotEmpty())
-                environmentChangeTracker.withTrackingSystemPropertyChanges {
+                KotlinCompilerEnvironment.withEnvironment(environmentChangeTracker) {
                     compileKotlinScriptModuleTo(
                         outputDir,
                         compilerOptions.get(),

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
@@ -31,6 +31,7 @@ import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.exceptions.LocationAwareException
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.service.ServiceRegistry
+import org.gradle.kotlin.dsl.support.KotlinCompilerEnvironment
 import org.gradle.kotlin.dsl.support.KotlinCompilerOptions
 import org.gradle.kotlin.dsl.support.KotlinScriptHost
 import org.gradle.kotlin.dsl.support.ScriptCompilationException
@@ -133,7 +134,7 @@ class Interpreter(val host: Host) {
 
         fun hashOf(classPath: ClassPath): HashCode
 
-        fun runCompileBuildOperation(scriptPath: String, stage: String, action: () -> String): String
+        fun runCompileBuildOperation(scriptPath: String, stage: String, action: KotlinCompilerEnvironment.() -> String): String
 
         fun onScriptClassLoaded(scriptSource: ScriptSource, specializedProgram: Class<*>)
 

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompiler.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompiler.kt
@@ -34,6 +34,7 @@ import org.gradle.kotlin.dsl.support.CompiledKotlinSettingsBuildscriptBlock
 import org.gradle.kotlin.dsl.support.CompiledKotlinSettingsPluginManagementBlock
 import org.gradle.kotlin.dsl.support.CompiledKotlinSettingsScript
 import org.gradle.kotlin.dsl.support.ImplicitReceiver
+import org.gradle.kotlin.dsl.support.KotlinCompilerEnvironment
 import org.gradle.kotlin.dsl.support.KotlinCompilerOptions
 import org.gradle.kotlin.dsl.support.KotlinScriptHost
 import org.gradle.kotlin.dsl.support.bytecode.ALOAD
@@ -73,7 +74,7 @@ import kotlin.reflect.KClass
 
 
 internal
-typealias CompileBuildOperationRunner = (String, String, () -> String) -> String
+typealias CompileBuildOperationRunner = (String, String, KotlinCompilerEnvironment.() -> String) -> String
 
 
 /**
@@ -92,7 +93,7 @@ class ResidualProgramCompiler(
     private val implicitImports: List<String> = emptyList(),
     private val logger: Logger = interpreterLogger,
     private val temporaryFileProvider: TemporaryFileProvider,
-    private val compileBuildOperationRunner: CompileBuildOperationRunner = { _, _, action -> action() },
+    private val compileBuildOperationRunner: CompileBuildOperationRunner,
     private val stage1BlocksAccessorsClassPath: ClassPath = ClassPath.EMPTY,
     private val packageName: String? = null,
 ) {

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildServices.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildServices.kt
@@ -25,6 +25,7 @@ import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.initialization.loadercache.DefaultClasspathHasher
 import org.gradle.groovy.scripts.internal.ScriptSourceHasher
 import org.gradle.initialization.ClassLoaderScopeRegistry
+import org.gradle.initialization.EnvironmentChangeTracker
 import org.gradle.initialization.GradlePropertiesController
 import org.gradle.internal.buildoption.InternalOptions
 import org.gradle.internal.classloader.ClasspathHasher
@@ -111,7 +112,8 @@ object BuildServices : ServiceRegistrationProvider {
         gradlePropertiesController: GradlePropertiesController,
         transformFactoryForLegacy: ClasspathElementTransformFactoryForLegacy,
         gradleCoreTypeRegistry: GradleCoreInstrumentationTypeRegistry,
-        propertyUpgradeReportConfig: PropertyUpgradeReportConfig
+        propertyUpgradeReportConfig: PropertyUpgradeReportConfig,
+        environmentChangeTracker: EnvironmentChangeTracker,
     ): KotlinScriptEvaluator =
 
         StandardKotlinScriptEvaluator(
@@ -137,7 +139,8 @@ object BuildServices : ServiceRegistrationProvider {
             gradlePropertiesController,
             transformFactoryForLegacy,
             gradleCoreTypeRegistry,
-            propertyUpgradeReportConfig
+            propertyUpgradeReportConfig,
+            environmentChangeTracker,
         )
 
     @Provides

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
@@ -28,6 +28,7 @@ import org.gradle.cache.CacheOpenException
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.groovy.scripts.internal.ScriptSourceHasher
 import org.gradle.initialization.ClassLoaderScopeOrigin
+import org.gradle.initialization.EnvironmentChangeTracker
 import org.gradle.initialization.GradlePropertiesController
 import org.gradle.internal.buildoption.InternalFlag
 import org.gradle.internal.buildoption.InternalOptions
@@ -114,7 +115,8 @@ class StandardKotlinScriptEvaluator(
     private val gradlePropertiesController: GradlePropertiesController,
     private val transformFactoryForLegacy: ClasspathElementTransformFactoryForLegacy,
     private val gradleCoreTypeRegistry: GradleCoreInstrumentationTypeRegistry,
-    private val propertyUpgradeReportConfig: PropertyUpgradeReportConfig
+    private val propertyUpgradeReportConfig: PropertyUpgradeReportConfig,
+    private val environmentChangeTracker: EnvironmentChangeTracker,
 ) : KotlinScriptEvaluator {
 
     override fun evaluate(
@@ -203,8 +205,10 @@ class StandardKotlinScriptEvaluator(
             buildOperationRunner.call(object : CallableBuildOperation<String> {
 
                 override fun call(context: BuildOperationContext): String =
-                    action().also {
-                        context.setResult(object : Result {})
+                    environmentChangeTracker.withTrackingSystemPropertyChanges {
+                        action().also {
+                            context.setResult(object : Result {})
+                        }
                     }
 
                 override fun description(): BuildOperationDescriptor.Builder {

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
@@ -65,6 +65,7 @@ import org.gradle.kotlin.dsl.execution.Interpreter
 import org.gradle.kotlin.dsl.execution.ProgramId
 import org.gradle.kotlin.dsl.support.EmbeddedKotlinProvider
 import org.gradle.kotlin.dsl.support.ImplicitImports
+import org.gradle.kotlin.dsl.support.KotlinCompilerEnvironment
 import org.gradle.kotlin.dsl.support.KotlinCompilerOptions
 import org.gradle.kotlin.dsl.support.KotlinScriptHost
 import org.gradle.kotlin.dsl.support.ScriptCompilationException
@@ -160,7 +161,7 @@ class StandardKotlinScriptEvaluator(
 
     private
     val interpreter by lazy {
-        when(propertyUpgradeReportConfig.isEnabled) {
+        when (propertyUpgradeReportConfig.isEnabled) {
             true -> Interpreter(InterpreterHostWithoutInMemoryCache(gradlePropertiesController))
             false -> Interpreter(InterpreterHost(gradlePropertiesController))
         }
@@ -200,16 +201,17 @@ class StandardKotlinScriptEvaluator(
                     ).bin
                 } ?: ClassPath.EMPTY
 
-        override fun runCompileBuildOperation(scriptPath: String, stage: String, action: () -> String): String =
+        override fun runCompileBuildOperation(scriptPath: String, stage: String, action: KotlinCompilerEnvironment.() -> String): String =
 
             buildOperationRunner.call(object : CallableBuildOperation<String> {
 
                 override fun call(context: BuildOperationContext): String =
-                    environmentChangeTracker.withTrackingSystemPropertyChanges {
+                    KotlinCompilerEnvironment.withEnvironment(environmentChangeTracker) {
                         action().also {
                             context.setResult(object : Result {})
                         }
                     }
+
 
                 override fun description(): BuildOperationDescriptor.Builder {
                     val name = "Compile script ${scriptPath.substringAfterLast(File.separator)} ($stage)"

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompilerEnvironment.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompilerEnvironment.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.support
+
+import org.gradle.initialization.EnvironmentChangeTracker
+
+/**
+ * Provides an environment to safely run the Kotlin compilation.
+ */
+class KotlinCompilerEnvironment private constructor() {
+    // We only want external code to reach out to an instance of this class through withEnvironment.
+
+    companion object {
+        private val instance = KotlinCompilerEnvironment()
+
+        /**
+         * Runs the action while properly tracking environment changes caused by compilation.
+         */
+        fun <T> withEnvironment(environmentChangeTracker: EnvironmentChangeTracker, action: KotlinCompilerEnvironment.() -> T): T {
+            return environmentChangeTracker.withTrackingSystemPropertyChanges {
+                instance.action()
+            }
+        }
+    }
+}

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectAccessorsClassPathTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectAccessorsClassPathTest.kt
@@ -51,6 +51,7 @@ import org.gradle.kotlin.dsl.fixtures.AbstractDslTest
 import org.gradle.kotlin.dsl.fixtures.eval
 import org.gradle.kotlin.dsl.fixtures.testRuntimeClassPath
 import org.gradle.kotlin.dsl.fixtures.withClassLoaderFor
+import org.gradle.kotlin.dsl.fixtures.withTestCompilerEnvironment
 import org.gradle.kotlin.dsl.support.KotlinCompilerOptions
 import org.gradle.kotlin.dsl.support.compileToDirectory
 import org.gradle.kotlin.dsl.support.loggerFor
@@ -256,14 +257,16 @@ class ProjectAccessorsClassPathTest : AbstractDslTest() {
             newFolder("ignored")
         )
         require(
-            compileToDirectory(
-                binDir,
-                KotlinCompilerOptions(),
-                "bin",
-                kotlinFilesIn(srcDir),
-                loggerFor<ProjectAccessorsClassPathTest>(),
-                classPath.asFiles
-            )
+            withTestCompilerEnvironment {
+                compileToDirectory(
+                    binDir,
+                    KotlinCompilerOptions(),
+                    "bin",
+                    kotlinFilesIn(srcDir),
+                    loggerFor<ProjectAccessorsClassPathTest>(),
+                    classPath.asFiles
+                )
+            }
         )
     }
 

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
@@ -22,7 +22,6 @@ import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
 import org.gradle.api.Incubating
-import org.gradle.model.internal.asm.AsmConstants.ASM_LEVEL
 import org.gradle.internal.classloader.ClassLoaderUtils
 import org.gradle.internal.hash.Hashing
 import org.gradle.kotlin.dsl.accessors.TestWithClassPath
@@ -32,10 +31,12 @@ import org.gradle.kotlin.dsl.fixtures.codegen.ClassToKClassParameterizedType
 import org.gradle.kotlin.dsl.fixtures.codegen.GroovyNamedArguments
 import org.gradle.kotlin.dsl.fixtures.codegen.IncubatingFunction
 import org.gradle.kotlin.dsl.fixtures.codegen.IncubatingType
+import org.gradle.kotlin.dsl.fixtures.withTestCompilerEnvironment
 import org.gradle.kotlin.dsl.internal.sharedruntime.codegen.generateKotlinDslApiExtensionsSourceTo
 import org.gradle.kotlin.dsl.support.KotlinCompilerOptions
 import org.gradle.kotlin.dsl.support.bytecode.GradleJvmVersion
 import org.gradle.kotlin.dsl.support.compileToDirectory
+import org.gradle.model.internal.asm.AsmConstants.ASM_LEVEL
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.equalTo
@@ -474,16 +475,19 @@ fun compileKotlinApiExtensionsTo(
     logger: Logger,
 ) {
 
-    val success = compileToDirectory(
-        outputDirectory,
-        KotlinCompilerOptions(
-            jvmTarget = GradleJvmVersion.minimalJavaVersion
-        ),
-        "gradle-api-extensions",
-        sourceFiles,
-        logger,
-        classPath = classPath
-    )
+    val success = withTestCompilerEnvironment {
+        compileToDirectory(
+            outputDirectory,
+            KotlinCompilerOptions(
+                jvmTarget = GradleJvmVersion.minimalJavaVersion
+            ),
+            "gradle-api-extensions",
+            sourceFiles,
+            logger,
+            classPath = classPath
+        )
+    }
+
 
     if (!success) {
         throw IllegalStateException(

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/InterpreterTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/InterpreterTest.kt
@@ -38,6 +38,7 @@ import org.gradle.kotlin.dsl.fixtures.TestWithTempFiles
 import org.gradle.kotlin.dsl.fixtures.assertStandardOutputOf
 import org.gradle.kotlin.dsl.fixtures.classLoaderFor
 import org.gradle.kotlin.dsl.fixtures.testRuntimeClassPath
+import org.gradle.kotlin.dsl.fixtures.withTestCompilerEnvironment
 import org.gradle.kotlin.dsl.support.KotlinCompilerOptions
 import org.junit.Test
 import java.io.File
@@ -117,7 +118,7 @@ class InterpreterTest : TestWithTempFiles() {
 
             on { startCompilerOperation(any()) } doReturn compilerOperation
 
-            on { runCompileBuildOperation(any(), any(), any()) } doAnswer { it.getArgument<() -> String>(2)() }
+            on { runCompileBuildOperation(any(), any(), any()) } doAnswer { withTestCompilerEnvironment(it.getArgument(2)) }
 
             on {
                 cachedDirFor(

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/TestWithCompiler.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/TestWithCompiler.kt
@@ -32,6 +32,7 @@ import org.gradle.internal.hash.TestHashCodes
 import org.gradle.kotlin.dsl.fixtures.TestWithTempFiles
 import org.gradle.kotlin.dsl.fixtures.testRuntimeClassPath
 import org.gradle.kotlin.dsl.fixtures.withClassLoaderFor
+import org.gradle.kotlin.dsl.fixtures.withTestCompilerEnvironment
 import org.gradle.kotlin.dsl.support.KotlinCompilerOptions
 import org.gradle.kotlin.dsl.support.KotlinScriptHost
 import org.gradle.plugin.management.PluginManagementSpec
@@ -79,6 +80,9 @@ abstract class TestWithCompiler : TestWithTempFiles() {
             sourceHash,
             programKind,
             programTarget,
+            compileBuildOperationRunner = {_, _, action ->
+                withTestCompilerEnvironment(action)
+            },
             temporaryFileProvider = TestFiles.tmpDirTemporaryFileProvider(tmpDir.testDirectory)
         ).compile(program)
     }

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinScriptCompilerTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinScriptCompilerTest.kt
@@ -20,6 +20,7 @@ import com.nhaarman.mockito_kotlin.mock
 import org.gradle.kotlin.dsl.fixtures.TestWithTempFiles
 import org.gradle.kotlin.dsl.fixtures.testRuntimeClassPath
 import org.gradle.kotlin.dsl.fixtures.withClassLoaderFor
+import org.gradle.kotlin.dsl.fixtures.withTestCompilerEnvironment
 import org.gradle.kotlin.dsl.support.KotlinCompilerOptions
 import org.gradle.kotlin.dsl.support.compileKotlinScriptToDirectory
 import org.gradle.kotlin.dsl.support.scriptDefinitionFromTemplate
@@ -86,15 +87,17 @@ class KotlinScriptCompilerTest : TestWithTempFiles() {
         script: String,
         scriptDefinition: ScriptDefinition
     ) {
-        compileKotlinScriptToDirectory(
-            outputDir,
-            KotlinCompilerOptions(),
-            file("script.kts").apply {
-                writeText(script)
-            },
-            scriptDefinition,
-            testRuntimeClassPath.asFiles,
-            mock()
-        ) { it }
+        withTestCompilerEnvironment {
+            compileKotlinScriptToDirectory(
+                outputDir,
+                KotlinCompilerOptions(),
+                file("script.kts").apply {
+                    writeText(script)
+                },
+                scriptDefinition,
+                testRuntimeClassPath.asFiles,
+                mock()
+            ) { it }
+        }
     }
 }

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/normalization/KotlinApiClassExtractorTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/normalization/KotlinApiClassExtractorTest.kt
@@ -19,6 +19,7 @@ package org.gradle.kotlin.dsl.normalization
 import org.gradle.internal.tools.api.ApiClassExtractionException
 import org.gradle.internal.tools.api.ApiClassExtractor
 import org.gradle.kotlin.dsl.fixtures.TestWithTempFiles
+import org.gradle.kotlin.dsl.fixtures.withTestCompilerEnvironment
 import org.gradle.kotlin.dsl.support.KotlinCompilerOptions
 import org.gradle.kotlin.dsl.support.compileToDirectory
 import org.gradle.kotlin.dsl.support.loggerFor
@@ -310,14 +311,16 @@ class KotlinApiClassExtractorTest : TestWithTempFiles() {
         val sourceFile = newFile("$scriptName.kt", scriptBody)
 
         val binDir = newFolder("bin")
-        compileToDirectory(
-            binDir,
-            KotlinCompilerOptions(),
-            "test",
-            listOf(sourceFile),
-            loggerFor<KotlinApiClassExtractorTest>(),
-            emptyList()
-        )
+        withTestCompilerEnvironment {
+            compileToDirectory(
+                binDir,
+                KotlinCompilerOptions(),
+                "test",
+                listOf(sourceFile),
+                loggerFor<KotlinApiClassExtractorTest>(),
+                emptyList()
+            )
+        }
 
         return ClassFixture(scriptBody, binDir.toPath().resolve(scriptClass).toFile().readBytes())
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/EnvironmentChangeTracker.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/EnvironmentChangeTracker.java
@@ -20,6 +20,7 @@ import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.Nullable;
+import java.util.function.Supplier;
 
 @ServiceScope(Scope.BuildTree.class)
 public interface EnvironmentChangeTracker {
@@ -38,4 +39,11 @@ public interface EnvironmentChangeTracker {
      * System properties overridden by passing CLI argument
      * */
     void systemPropertyOverridden(Object key);
+
+    /**
+     * Runs code and records all mutations to system properties it causes. All mutated system properties keep their new values after this method returns.
+     *
+     * @param action the code that may mutate system properties
+     */
+    <T> T withTrackingSystemPropertyChanges(Supplier<? extends T> action);
 }


### PR DESCRIPTION
When compiling Kotlin scripts, Gradle sets up some system properties. However, because Gradle doesn't instrument the Kotlin runtime, these modifications go unnoticed to environment change tracker infrastructure. If any user code then observes these system properties after modification, it becomes part of the configuration cache fingerprint. Moreover, as nothing restores the changed values when checking the fingerprint, it never matches, causing a CC miss.

With this PR, a special "scope function" of EnvironmentChangeTracker can be used to detect changes made to system properties and update the state of the tracker accordingly. This isn't a perfect solution for concurrent use cases, but it should work well when there is only one "scope" that modifies system properties directly, and everything else is instrumented.

It is possible to enter the scope function after restoring the CC state, for example, for a precompiled script plugin project. There is no change tracking in this case.

Fixes #30145.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
