### PR TITLE
Minor performance improvements in dependency management

### DIFF
--- a/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/LocalFileDependencyBackedArtifactSetCodec.kt
+++ b/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/LocalFileDependencyBackedArtifactSetCodec.kt
@@ -218,8 +218,8 @@ class RecordingVariantSet(
         return EmptySchema.INSTANCE
     }
 
-    override fun getVariants(): Set<ResolvedVariant> {
-        return setOf(this)
+    override fun getVariants(): List<ResolvedVariant> {
+        return listOf(this)
     }
 
     override fun getOverriddenAttributes(): ImmutableAttributes {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultResolvedVariantSet.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultResolvedVariantSet.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.Describable;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
@@ -30,9 +30,9 @@ public class DefaultResolvedVariantSet implements ResolvedVariantSet {
     private final ComponentIdentifier componentIdentifier;
     private final AttributesSchemaInternal schema;
     private final ImmutableAttributes selectionAttributes;
-    private final ImmutableSet<ResolvedVariant> variants;
+    private final ImmutableList<ResolvedVariant> variants;
 
-    public DefaultResolvedVariantSet(ComponentIdentifier componentIdentifier, AttributesSchemaInternal schema, ImmutableAttributes selectionAttributes, ImmutableSet<ResolvedVariant> variants) {
+    public DefaultResolvedVariantSet(ComponentIdentifier componentIdentifier, AttributesSchemaInternal schema, ImmutableAttributes selectionAttributes, ImmutableList<ResolvedVariant> variants) {
         this.componentIdentifier = componentIdentifier;
         this.schema = schema;
         this.selectionAttributes = selectionAttributes;
@@ -65,7 +65,7 @@ public class DefaultResolvedVariantSet implements ResolvedVariantSet {
     }
 
     @Override
-    public ImmutableSet<ResolvedVariant> getVariants() {
+    public ImmutableList<ResolvedVariant> getVariants() {
         return variants;
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
@@ -51,6 +51,7 @@ import org.gradle.internal.operations.RunnableBuildOperation;
 import javax.annotation.Nonnull;
 import java.io.File;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -232,8 +233,8 @@ public abstract class LocalFileDependencyBackedArtifactSet implements Transforme
         }
 
         @Override
-        public Set<ResolvedVariant> getVariants() {
-            return Collections.singleton(this);
+        public List<ResolvedVariant> getVariants() {
+            return Collections.singletonList(this);
         }
 
         @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedVariantSet.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedVariantSet.java
@@ -22,7 +22,7 @@ import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 
 import javax.annotation.Nullable;
-import java.util.Set;
+import java.util.List;
 
 /**
  * Represents some provider of {@link ResolvedVariant} instances to select from.
@@ -42,9 +42,9 @@ public interface ResolvedVariantSet {
     AttributesSchemaInternal getSchema();
 
     /**
-     * The variants available for artifact selection when variant reselection is not enabled.
+     * The variants available for artifact selection.
      */
-    Set<ResolvedVariant> getVariants();
+    List<ResolvedVariant> getVariants();
 
     /**
      * The provider may have been selected thanks to a different attribute set than the one from

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantResolvingArtifactSet.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantResolvingArtifactSet.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.capabilities.Capability;
@@ -60,7 +60,7 @@ public class VariantResolvingArtifactSet implements ArtifactSet {
     private final GraphVariantSelector graphVariantSelector;
     private final AttributesSchemaInternal consumerSchema;
 
-    private final Lazy<ImmutableSet<ResolvedVariant>> ownArtifacts = Lazy.locking().of(this::calculateOwnArtifacts);
+    private final Lazy<ImmutableList<ResolvedVariant>> ownArtifacts = Lazy.locking().of(this::calculateOwnArtifacts);
 
     public VariantResolvingArtifactSet(
         VariantArtifactResolver variantResolver,
@@ -98,7 +98,7 @@ public class VariantResolvingArtifactSet implements ArtifactSet {
                 return ResolvedArtifactSet.EMPTY;
             }
 
-            ImmutableSet<ResolvedVariant> variants;
+            ImmutableList<ResolvedVariant> variants;
             try {
                 if (!spec.getSelectFromAllVariants()) {
                     variants = ownArtifacts.get();
@@ -126,11 +126,11 @@ public class VariantResolvingArtifactSet implements ArtifactSet {
         }
     }
 
-    public ImmutableSet<ResolvedVariant> calculateOwnArtifacts() {
+    public ImmutableList<ResolvedVariant> calculateOwnArtifacts() {
         if (artifacts.isEmpty()) {
             return getArtifactsForGraphVariant(variant);
         } else {
-            return ImmutableSet.of(variant.prepareForArtifactResolution().resolveAdhocVariant(variantResolver, artifacts));
+            return ImmutableList.of(variant.prepareForArtifactResolution().resolveAdhocVariant(variantResolver, artifacts));
         }
     }
 
@@ -142,7 +142,7 @@ public class VariantResolvingArtifactSet implements ArtifactSet {
      * same algorithm used during graph variant selection. This considers requested and declared
      * capabilities.</p>
      */
-    private ImmutableSet<ResolvedVariant> getArtifactVariantsForReselection(ImmutableAttributes requestAttributes) {
+    private ImmutableList<ResolvedVariant> getArtifactVariantsForReselection(ImmutableAttributes requestAttributes) {
         // First, find the graph variant containing the artifact variants to select among.
         VariantGraphResolveState graphVariant = graphVariantSelector.selectByAttributeMatchingLenient(
             requestAttributes,
@@ -155,7 +155,7 @@ public class VariantResolvingArtifactSet implements ArtifactSet {
         // It is fine if no graph variants satisfy our request.
         // Variant reselection allows no target variants to be found.
         if (graphVariant == null) {
-            return ImmutableSet.of();
+            return ImmutableList.of();
         }
 
         // Next, return all artifact variants for the selected graph variant.
@@ -165,10 +165,10 @@ public class VariantResolvingArtifactSet implements ArtifactSet {
     /**
      * Resolve all artifact variants for the given graph variant.
      */
-    private ImmutableSet<ResolvedVariant> getArtifactsForGraphVariant(VariantGraphResolveState graphVariant) {
+    private ImmutableList<ResolvedVariant> getArtifactsForGraphVariant(VariantGraphResolveState graphVariant) {
         VariantArtifactResolveState variantState = graphVariant.prepareForArtifactResolution();
         Set<? extends VariantResolveMetadata> artifactVariants = variantState.getArtifactVariants();
-        ImmutableSet.Builder<ResolvedVariant> resolved = ImmutableSet.builderWithExpectedSize(artifactVariants.size());
+        ImmutableList.Builder<ResolvedVariant> resolved = ImmutableList.builderWithExpectedSize(artifactVariants.size());
 
         ComponentArtifactResolveMetadata componentMetadata = component.prepareForArtifactResolution().getArtifactMetadata();
         if (exclusions.mayExcludeArtifacts()) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultAttributeMatcher.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultAttributeMatcher.java
@@ -89,13 +89,19 @@ public class DefaultAttributeMatcher implements AttributeMatcher {
             return true;
         }
 
-        return requested.keySet().stream().map(schema::tryRehydrate).allMatch(attribute -> {
+        for (Attribute<?> attribute : requested.keySet()) {
+            AttributeValue<?> requestedAttributeValue = requested.findEntry(attribute);
             AttributeValue<?> candidateAttributeValue = candidate.findEntry(attribute.getName());
-            AttributeValue<?> requestedAttributeValue = requested.findEntry(attribute.getName());
 
-            return !candidateAttributeValue.isPresent() || !requestedAttributeValue.isPresent() ||
-                predicate.test(attribute, requestedAttributeValue, candidateAttributeValue);
-        });
+            if (candidateAttributeValue.isPresent()) {
+                Attribute<?> typedAttribute = schema.tryRehydrate(attribute);
+                if (!predicate.test(typedAttribute, requestedAttributeValue, candidateAttributeValue)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelectorSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelectorSpec.groovy
@@ -93,7 +93,7 @@ class AttributeMatchingArtifactVariantSelectorSpec extends Specification {
 
         1 * variantSet.getSchema() >> attributesSchema
         1 * variantSet.getOverriddenAttributes() >> ImmutableAttributes.EMPTY
-        2 * attributeMatcher.matchMultipleCandidates(_, _, _) >> [variant, otherVariant]
+        1 * attributeMatcher.matchMultipleCandidates(_, _, _) >> [variant, otherVariant]
         2 * attributeMatcher.isMatchingValue(_, _, _) >> true
         0 * consumerProvidedVariantFinder._
     }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactVariantSelectorFactoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactVariantSelectorFactoryTest.groovy
@@ -57,7 +57,7 @@ class DefaultArtifactVariantSelectorFactoryTest extends Specification {
         def variant2 = resolvedVariant()
         def variant1Artifacts = Stub(ResolvedArtifactSet)
         def set = resolvedVariantSet()
-        def variants = [variant1, variant2] as Set
+        def variants = [variant1, variant2]
 
         given:
         set.schema >> producerSchema
@@ -78,7 +78,7 @@ class DefaultArtifactVariantSelectorFactoryTest extends Specification {
         def variant1 = resolvedVariant()
         def variant2 = resolvedVariant()
         def set = resolvedVariantSet()
-        def variants = [variant1, variant2] as Set
+        def variants = [variant1, variant2]
 
         given:
         set.asDescribable() >> Describables.of('<component>')
@@ -109,7 +109,7 @@ class DefaultArtifactVariantSelectorFactoryTest extends Specification {
         def variant1 = resolvedVariant()
         def variant2 = resolvedVariant()
         def set = resolvedVariantSet()
-        def variants = [variant1, variant2] as Set
+        def variants = [variant1, variant2]
         def transformedVariants = variants.collect { transformedVariant(it, requested)}
 
         given:
@@ -151,7 +151,7 @@ Found the following transforms:
         def variant1 = resolvedVariant()
         def variant2 = resolvedVariant()
         def set = resolvedVariantSet()
-        def variants = [variant1, variant2] as Set
+        def variants = [variant1, variant2]
 
         given:
         set.schema >> producerSchema
@@ -173,7 +173,7 @@ Found the following transforms:
         def variant1 = resolvedVariant()
         def variant2 = resolvedVariant()
         def set = resolvedVariantSet()
-        def variants = [variant1, variant2] as Set
+        def variants = [variant1, variant2]
 
         given:
         set.schema >> producerSchema


### PR DESCRIPTION
Avoid using a stream during attribute matching, as it performs unnecessary allocations Use List instead of Set, since the set semantics are not free and are visible in flamegraphs. We are not relying on any deduplication here from the set semantics

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
