### PR TITLE
Generate javadoc for all projects

### DIFF
--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.groovy-dsl-gradle-plugin.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.groovy-dsl-gradle-plugin.gradle.kts
@@ -22,6 +22,7 @@ plugins {
     id("gradlebuild.code-quality")
     id("gradlebuild.ci-reporting")
     id("gradlebuild.test-retry")
+    id("gradlebuild.private-javadoc")
 }
 
 java.configureJavaToolChain()

--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.kotlin-dsl-gradle-plugin.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.kotlin-dsl-gradle-plugin.gradle.kts
@@ -23,6 +23,7 @@ plugins {
     id("gradlebuild.detekt")
     id("gradlebuild.ci-reporting")
     id("gradlebuild.test-retry")
+    id("gradlebuild.private-javadoc")
 }
 
 java.configureJavaToolChain()

--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.code-quality.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.code-quality.gradle.kts
@@ -2,7 +2,6 @@ import groovy.lang.GroovySystem
 import net.ltgt.gradle.errorprone.CheckSeverity
 import net.ltgt.gradle.errorprone.errorprone
 import org.gradle.util.internal.VersionNumber
-import java.util.stream.Collectors
 
 /*
  * Copyright 2022 the original author or authors.

--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.java-shared-runtime.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.java-shared-runtime.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     id("gradlebuild.module-jar")
     id("gradlebuild.repositories")
     id("gradlebuild.reproducible-archives")
+    id("gradlebuild.private-javadoc")
 }
 
 description = "A plugin that sets up a Java code that is shared between build-logic and runtime"

--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.kotlin-shared-runtime.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.kotlin-shared-runtime.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     id("gradlebuild.detekt")
     id("gradlebuild.test-retry")
     id("gradlebuild.ci-reporting")
+    id("gradlebuild.private-javadoc")
 }
 
 description = "A plugin that sets up a Kotlin DSL code that is shared between build-logic and runtime"

--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.private-javadoc.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.private-javadoc.gradle.kts
@@ -14,34 +14,8 @@
  * limitations under the License.
  */
 
-import gradle.kotlin.dsl.accessors._13687bf53899272e089ef07734aa6040.check
-import gradle.kotlin.dsl.accessors._13687bf53899272e089ef07734aa6040.checkstyle
-import gradle.kotlin.dsl.accessors._13687bf53899272e089ef07734aa6040.codenarc
-import gradle.kotlin.dsl.accessors._caaef686956ef05d8c7d73205bf1c4b7.detekt
-import groovy.lang.GroovySystem
-import net.ltgt.gradle.errorprone.CheckSeverity
-import net.ltgt.gradle.errorprone.errorprone
-import org.gradle.api.artifacts.ComponentMetadataContext
-import org.gradle.api.artifacts.ComponentMetadataRule
-import org.gradle.api.attributes.LibraryElements
-import org.gradle.api.file.SourceDirectorySet
-import org.gradle.api.plugins.GroovyBasePlugin
-import org.gradle.api.plugins.JavaBasePlugin
-import org.gradle.api.plugins.quality.Checkstyle
-import org.gradle.api.plugins.quality.CodeNarc
-import org.gradle.api.provider.ListProperty
-import org.gradle.api.provider.Property
-import org.gradle.api.tasks.GroovySourceDirectorySet
-import org.gradle.api.tasks.SourceSet
-import org.gradle.api.tasks.SourceSetContainer
-import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.javadoc.Javadoc
-import org.gradle.api.tasks.testing.Test
 import org.gradle.external.javadoc.StandardJavadocDocletOptions
-import org.gradle.kotlin.dsl.*
-import org.gradle.plugin.devel.tasks.ValidatePlugins
-import org.gradle.util.internal.VersionNumber
-import javax.inject.Inject
 
 /*
  * Copyright 2022 the original author or authors.

--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.private-javadoc.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.private-javadoc.gradle.kts
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import gradle.kotlin.dsl.accessors._13687bf53899272e089ef07734aa6040.check
+import gradle.kotlin.dsl.accessors._13687bf53899272e089ef07734aa6040.checkstyle
+import gradle.kotlin.dsl.accessors._13687bf53899272e089ef07734aa6040.codenarc
+import gradle.kotlin.dsl.accessors._caaef686956ef05d8c7d73205bf1c4b7.detekt
+import groovy.lang.GroovySystem
+import net.ltgt.gradle.errorprone.CheckSeverity
+import net.ltgt.gradle.errorprone.errorprone
+import org.gradle.api.artifacts.ComponentMetadataContext
+import org.gradle.api.artifacts.ComponentMetadataRule
+import org.gradle.api.attributes.LibraryElements
+import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.plugins.GroovyBasePlugin
+import org.gradle.api.plugins.JavaBasePlugin
+import org.gradle.api.plugins.quality.Checkstyle
+import org.gradle.api.plugins.quality.CodeNarc
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.GroovySourceDirectorySet
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.api.tasks.javadoc.Javadoc
+import org.gradle.api.tasks.testing.Test
+import org.gradle.external.javadoc.StandardJavadocDocletOptions
+import org.gradle.kotlin.dsl.*
+import org.gradle.plugin.devel.tasks.ValidatePlugins
+import org.gradle.util.internal.VersionNumber
+import javax.inject.Inject
+
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Configures javadoc task for java projects, ensuring javadoc is compliant.
+// Javadoc is generated for private classes and methods, and files are allowed to omit javadoc.
+// These requirements are different than those of the public javadoc.
+// This does not configure the public Javadoc published to the website
+
+pluginManager.withPlugin("gradlebuild.code-quality") {
+    tasks {
+        named("codeQuality") {
+            dependsOn(tasks.withType<Javadoc>())
+        }
+    }
+}
+
+tasks.withType<Javadoc>().configureEach {
+    assert(name != "javadocAll") // This plugin should not be applied to the :docs project.
+
+    onlyIf("Do not run the task if there are no java sources") {
+        // Javadoc task will complain if we only have package-info.java files and no
+        // other java files (as is with some Kotlin projects)
+        !source.matching {
+            exclude("**/package-info.java")
+        }.isEmpty
+    }
+
+    options {
+        this as StandardJavadocDocletOptions
+
+        // Enable all javadoc warnings, except for:
+        // - missing: Classes and methods are not required to have javadoc
+        // - reference: We allow references to classes that are not part of the compilation
+        addBooleanOption("Xdoclint:all,-missing,-reference", true)
+
+        // Add support for custom tags
+        tags("apiNote:a:API Note:", "implSpec:a:Implementation Requirements:", "implNote:a:Implementation Note:")
+
+        // Process all source files for valid javadoc, not just public ones
+        addBooleanOption("private", true)
+        addBooleanOption("package", true)
+    }
+}

--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.private-javadoc.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.private-javadoc.gradle.kts
@@ -17,22 +17,6 @@
 import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.external.javadoc.StandardJavadocDocletOptions
 
-/*
- * Copyright 2022 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // Configures javadoc task for java projects, ensuring javadoc is compliant.
 // Javadoc is generated for private classes and methods, and files are allowed to omit javadoc.
 // These requirements are different than those of the public javadoc.
@@ -59,6 +43,10 @@ tasks.withType<Javadoc>().configureEach {
 
     options {
         this as StandardJavadocDocletOptions
+
+        encoding = "utf-8"
+        docEncoding = "utf-8"
+        charSet = "utf-8"
 
         // Enable all javadoc warnings, except for:
         // - missing: Classes and methods are not required to have javadoc

--- a/build-logic-commons/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
+++ b/build-logic-commons/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
@@ -59,10 +59,6 @@ fun configureJavadocVariant() {
     java {
         withJavadocJar()
     }
-    tasks.named<Javadoc>("javadoc") {
-        // See GradleJavadocsPlugin.generateJavadocs() and the javadocsAll task
-        (options as StandardJavadocDocletOptions).tags("apiNote:a:API Note:", "implSpec:a:Implementation Requirements:", "implNote:a:Implementation Note:")
-    }
 }
 
 fun MavenPublication.configureGradleModulePublication() {

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleDocumentationExtension.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleDocumentationExtension.java
@@ -59,7 +59,7 @@ public abstract class GradleDocumentationExtension {
     public abstract ConfigurableFileCollection getDocumentedSource();
 
     /**
-     * Source code root folders. Java, Groovy & Kotlin public API sources, including
+     * Source code root folders. Java, Groovy and Kotlin public API sources, including
      * generated code.
      */
     public abstract ConfigurableFileCollection getSourceRoots();

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleJavadocsPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleJavadocsPlugin.java
@@ -106,8 +106,6 @@ public abstract class GradleJavadocsPlugin implements Plugin<Project> {
                 "});</script>"
             );
 
-            options.addBooleanOption("html5", true);
-
             // TODO: This would be better to model as separate options
             options.addStringOption("Xdoclint:syntax,html", "-quiet");
             // TODO: This breaks the provider

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.java-library.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.java-library.gradle.kts
@@ -19,4 +19,5 @@ plugins {
     id("gradlebuild.jvm-library")
     id("gradlebuild.test-fixtures")
     id("gradlebuild.arch-test")
+    id("gradlebuild.private-javadoc")
 }

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.kotlin-library.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.kotlin-library.gradle.kts
@@ -24,6 +24,7 @@ plugins {
     kotlin("jvm")
     id("gradlebuild.jvm-library")
     id("gradlebuild.detekt")
+    id("gradlebuild.private-javadoc")
 }
 
 configurations.transitiveSourcesElements {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -46,7 +46,7 @@ import java.util.function.Supplier;
  * <p>
  *     Elements stored in collection property values are implemented via various implementations of {@link Collector}.
  * </p>
- * <h3>Collection suppliers</h3>
+ * <h2>Collection suppliers</h2>
  * The value of a collection property is represented at any time as an instance of an implementation of {@link CollectionSupplier}, namely:
  * <ul>
  *     <li>{@link EmptySupplier}, the initial value of a collection (or after {@link #empty()} is invoked)</li>
@@ -57,7 +57,7 @@ import java.util.function.Supplier;
  *     the collecting supplier will wrap a {@link Collector} that lazily represents the yet-to-be realized contents of the collection - see below for details</li>
  * </ul>
  *
- * <h3>Collectors</h3>
+ * <h2>Collectors</h2>
  * <p>
  *     While a collection property's contents are being built up, its value is represented by a {@link CollectingSupplier}.
  *     The collecting supplier will wrap a {@link Collector} instance that represents the various forms that elements can be added to a collection property (before the collection is finalized), namely:

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProvider.java
@@ -27,7 +27,7 @@ import java.util.concurrent.Callable;
 /**
  * A provider whose value is computed by a {@link Callable}.
  *
- * <h3>Configuration Cache Behavior</h3>
+ * <h2>Configuration Cache Behavior</h2>
  * <b>Eager</b>. The value is computed at store time and loaded from the cache.
  */
 public class DefaultProvider<T> extends AbstractMinimalProvider<T> {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
@@ -37,7 +37,7 @@ import java.util.function.BiFunction;
  *
  * <p>In other words, a provider does not provide a value, it provides a value whose content is in a particular state. This is discussed in more detail below.</p>
  *
- * <h1>The provider value</h1>
+ * <h2>The provider value</h2>
  *
  * <p>The value of a provider may be:</p>
  *
@@ -70,7 +70,7 @@ import java.util.function.BiFunction;
  * fixed once the task has executed. It would become an error to query a provider whose value is still "changing".
  * </p>
  *
- * <h1>The value content</h1>
+ * <h2>The value content</h2>
  *
  * <p>Each provider guarantees that the content of the value is in some particular state when the provider is queried.
  * Currently there are only two states that the various provider implementations can guarantee:

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueState.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueState.java
@@ -28,10 +28,10 @@ import java.util.function.Function;
 /**
  * Provides a state pattern implementation for values that are finalizable and support conventions.
  *
- * <h3>Finalization</h3>
+ * <h2>Finalization</h2>
  * See {@link org.gradle.api.provider.HasConfigurableValue} and {@link HasConfigurableValueInternal}.
  *
- * <h3>Conventions</h3>
+ * <h2>Conventions</h2>
  * See {@link org.gradle.api.provider.SupportsConvention}.
  *
  * @param <S> the type of the value

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/package-info.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/package-info.java
@@ -21,7 +21,7 @@
  *
  * <p>Properties are providers with configurable values.</p>
  *
- * <h3>Provider</h3>
+ * <h2>Provider</h2>
  *
  * <p>For the public API, see {@link org.gradle.api.provider.Provider Provider}.</p>
  *

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/isolated/IsolationScheme.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/isolated/IsolationScheme.java
@@ -98,10 +98,10 @@ public class IsolationScheme<IMPLEMENTATION, PARAMS> {
     /**
      * Walk the type hierarchy until we find the interface type and keep track the chain of the type parameters.
      *
-     * E.g.: For `interface Baz<T>`, interface `Bar<T extends CharSequence> extends Baz<T>` and `class Foo implements Bar<String>`,
-     * we'll have mapping `T extends CharSequence -> String` and `T -> String`.
+     * E.g.: For {@code interface Baz<T>}, interface {@code Bar<T extends CharSequence> extends Baz<T>} and {@code class Foo implements Bar<String>},
+     * we'll have mapping {@code T extends CharSequence -> String} and {@code T -> String}.
      *
-     * When we come to `Baz<T>`, we can then query the mapping for `T` and get `String`.
+     * When we come to {@code Baz<T>}, we can then query the mapping for {@code T} and get {@code String}.
      */
     @Nonnull
     private <T extends IMPLEMENTATION, P extends PARAMS> Class<P> inferParameterType(Class<T> implementationType, int typeArgumentIndex) {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/model/Managed.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/model/Managed.java
@@ -33,7 +33,7 @@ import java.lang.annotation.Target;
  * Managed types are mostly behaviour-less, as they are data.
  * Instances of managed types should effectively be considered value objects.
  *
- * <h3>Properties</h3>
+ * <h2>Properties</h2>
  * <p>
  * Managed types declare their structure as properties, via getter and setter methods.
  * Getter and setter methods are expected to conform to the well-known Java Bean naming conventions.
@@ -54,7 +54,7 @@ import java.lang.annotation.Target;
  * boolean isEnabled();
  * </pre>
  *
- * <h4>Supported property types</h4>
+ * <h2>Supported property types</h2>
  * <p>
  * The following JDK types are allowed:
  * <ul>
@@ -82,7 +82,7 @@ import java.lang.annotation.Target;
  * Properties of any other type must have their getter annotated with {@link Unmanaged}.
  * An unmanaged property is not transparent to the model infrastructure and is guaranteed to be immutable when realized.
  *
- * <h3>Named types</h3>
+ * <h2>Named types</h2>
  * <p>
  * Managed types may implement/extend the {@link org.gradle.api.Named} interface.
  * Any managed type implementing this interface will have its {@code name} attribute populated automatically
@@ -90,12 +90,12 @@ import java.lang.annotation.Target;
  * <p>
  * The {@link ModelMap} type requires that its elements are {@link org.gradle.api.Named}.
  *
- * <h3>Inheritance</h3>
+ * <h2>Inheritance</h2>
  * <p>
  * Managed types can be arranged into an inheritance hierarchy.
  * Every type in the hierarchy must conform to the constraints of managed types.
  *
- * <h3>Calculated read-only properties</h3>
+ * <h2>Calculated read-only properties</h2>
  * <p>
  * Managed types can contain getter methods that return calculated values, based on other properties.
  * For example, a “name” property may return the concatenation of a “firstName” and “lastName” property.
@@ -103,13 +103,13 @@ import java.lang.annotation.Target;
  * Alternatively, the managed type can be implemented as an abstract class with the calculated property implemented as a non-abstract getter method.
  * In both cases, the implementation of the calculated property getter may not call any setter method.
  *
- * <h3>Abstract classes</h3>
+ * <h2>Abstract classes</h2>
  * <p>
  * A managed type can be implemented as an abstract class.
  * All property getters and setters must be declared {@code abstract} (with the exception of calculated read-only properties).
  * The class cannot contain instance variables, constructors, or any methods that are not a getter or setter.
  *
- * <h3>Creating managed model elements</h3>
+ * <h2>Creating managed model elements</h2>
  * <p>
  * Please see {@link Model} for information on creating model elements of managed types.
  */

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/model/Model.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/model/Model.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  * The name is defined either by the name of the method, or the {@link #value} of this annotation.
  * The type is defined differently depending on whether the new element is {@link Managed} or not.
 
- * <h3>Creating managed model elements</h3>
+ * <h2>Creating managed model elements</h2>
  * <p>
  * If the element is to be of a managed type, the method must return {@code void} and receive the newly created instance as the <b>first</b> parameter.
  * All other parameters are considered <i>inputs</i>.
@@ -39,7 +39,7 @@ import java.lang.annotation.Target;
  * It is an error for a {@code @Model} rule to return {@code void} and for the first parameter to be annotated with {@link Path}.
  * It is an error for a {@code @Model} rule to specify a managed type as the return type.
 
- * <h3>Creating non-managed model elements</h3>
+ * <h2>Creating non-managed model elements</h2>
  * <p>
  * If the element is to be of a non-managed type, the method must return the newly created instance.
  * All parameters are considered <i>inputs</i>.

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/model/RuleSource.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/model/RuleSource.java
@@ -26,7 +26,7 @@ import org.gradle.api.Incubating;
  * <p>
  * Please consult the “Rule based model configuration” chapter of the Gradle User Manual for general information about “rules”.
  *
- * <h3>Rule methods</h3>
+ * <h2>Rule methods</h2>
  * <p>
  * Each method that is annotated with one of the following is considered a rule:
  * <ul>
@@ -54,7 +54,7 @@ import org.gradle.api.Incubating;
  * <p>
  * See {@link Model} for information on the significance of the return type of a {@link Model} method.
  *
- * <h4>Subjects and inputs</h4>
+ * <h3>Subjects and inputs</h3>
  * <p>
  * Method rules declare the subject and any inputs as parameters to the method.
  * With the exception of {@link Model} methods, the subject of the rule is the, required, first parameter and all subsequent parameters are inputs.
@@ -65,7 +65,7 @@ import org.gradle.api.Incubating;
  * If there is no {@link Path} annotation, a “by-type” binding will be attempted.
  * The binding scope is determined by how the rule source is applied.
  *
- * <h3>General class constraints</h3>
+ * <h2>General class constraints</h2>
  * <p>
  * Along with the constraints on individual rule methods by their associated annotation, the following are general constraints of rule source implementations:
  * <ul>

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/WorkInputListener.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/WorkInputListener.java
@@ -29,7 +29,6 @@ import java.util.EnumSet;
 public interface WorkInputListener {
     /**
      * Called when the execution of the given work item is imminent, or would have been if the primary inputs would not have been empty.
-     * <p>
      *
      * @param work the identity of the unit of work to be executed
      * @param relevantBehaviors the file system inputs relevant to the task execution

--- a/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/HashCode.java
+++ b/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/HashCode.java
@@ -28,8 +28,8 @@ import static org.gradle.internal.hash.HashCode.Usage.SAFE_TO_REUSE_BYTES;
 
 /**
  * An immutable hash code. Must be 4-255 bytes long.
- * <p>
- * <h3>Memory considerations</h3>
+ *
+ * <h2>Memory considerations</h2>
  * <p>
  * Hashes by default are stored in {@link ByteArrayBackedHashCode a byte array}.
  * For a 128-bit hash this results in 64 bytes of memory used for each {@code HashCode}.

--- a/platforms/core-execution/worker-main/src/main/java/org/gradle/process/internal/worker/child/ActionExecutionWorker.java
+++ b/platforms/core-execution/worker-main/src/main/java/org/gradle/process/internal/worker/child/ActionExecutionWorker.java
@@ -24,9 +24,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * <p>The final stage of worker start-up. Takes care of executing the worker action.</p>
+ * The final stage of worker start-up. Takes care of executing the worker action.
  *
- * <p>It is instantiated and called from {@link SystemApplicationClassLoaderWorker}.<p>
+ * <p>It is instantiated and called from {@link SystemApplicationClassLoaderWorker}.</p>
  */
 public class ActionExecutionWorker implements Action<WorkerProcessContext> {
     private static final Logger LOGGER = LoggerFactory.getLogger(ActionExecutionWorker.class);

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/work/DefaultConditionalExecutionQueue.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/work/DefaultConditionalExecutionQueue.java
@@ -122,7 +122,7 @@ public class DefaultConditionalExecutionQueue<T> implements ConditionalExecution
 
     /**
      * ExecutionRunners process items from the queue until there are no items left, at which point it will either wait for
-     * new items to arrive (if there are < max workers threads running) or exit, finishing the thread.
+     * new items to arrive (if there are less than max workers threads running) or exit, finishing the thread.
      */
     private class ExecutionRunner implements Runnable {
         @Override

--- a/platforms/core-runtime/build-process-services/src/main/java/org/gradle/api/internal/classpath/DefaultModuleRegistry.java
+++ b/platforms/core-runtime/build-process-services/src/main/java/org/gradle/api/internal/classpath/DefaultModuleRegistry.java
@@ -269,7 +269,8 @@ public class DefaultModuleRegistry implements ModuleRegistry, GlobalCacheRootsPr
      * <li>In Eclipse, they are in the bin/ folder.</li>
      * <li>In IDEA (native import), they are in the out/production/ folder.</li>
      * </ul>
-     * <li>In both cases we also include the static and generated resources of the project.</li>
+     *
+     * In both cases we also include the static and generated resources of the project.
      */
     private List<String> getClasspathSuffixesForProjectDir(String projectDirName) {
         List<String> suffixes = new ArrayList<>();

--- a/platforms/core-runtime/gradle-cli/src/main/java/org/gradle/launcher/cli/DefaultCommandLineActionFactory.java
+++ b/platforms/core-runtime/gradle-cli/src/main/java/org/gradle/launcher/cli/DefaultCommandLineActionFactory.java
@@ -258,7 +258,6 @@ public class DefaultCommandLineActionFactory implements CommandLineActionFactory
          * Another key:  Another value
          * [blank line]
          * </pre>
-         * </p>
          *
          * @param lines the lines to print
          */

--- a/platforms/core-runtime/internal-instrumentation-api/src/main/java/org/gradle/internal/instrumentation/api/annotations/ReplacesEagerProperty.java
+++ b/platforms/core-runtime/internal-instrumentation-api/src/main/java/org/gradle/internal/instrumentation/api/annotations/ReplacesEagerProperty.java
@@ -32,12 +32,12 @@ public @interface ReplacesEagerProperty {
     /**
      * Overrides original type that will be used for generated code.
      * By default, the original type is determined from the lazy property type, e.g.:
-     * Property[T] -> original type becomes T (also Property[Integer] -> Integer and not int)
-     * RegularFileProperty -> original type becomes File
-     * DirectoryProperty -> original type becomes File
-     * MapProperty[K, V] -> original type becomes Map[K, V]
-     * ListProperty[T] -> original type becomes List[T]
-     * ConfigurableFileCollection -> original type becomes FileCollection
+     * Property[T] - original type becomes T (also Property[Integer] becomes Integer and not int)
+     * RegularFileProperty - original type becomes File
+     * DirectoryProperty - original type becomes File
+     * MapProperty[K, V] - original type becomes Map[K, V]
+     * ListProperty[T] - original type becomes List[T]
+     * ConfigurableFileCollection - original type becomes FileCollection
      */
     Class<?> originalType() default DefaultValue.class;
 

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/events/PromptOutputEvent.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/events/PromptOutputEvent.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 /**
  * Requests that the client present the given prompt to the user and return the user's response as a single line of text.
  *
- * The response is delivered to the {@link UserInputReader} service.
+ * The response is delivered to the {@link org.gradle.api.internal.tasks.userinput.UserInputReader} service.
  */
 public abstract class PromptOutputEvent extends RenderableOutputEvent implements InteractiveEvent {
     public PromptOutputEvent(long timestamp) {

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/util/Log4jBannedVersion.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/util/Log4jBannedVersion.java
@@ -18,7 +18,7 @@ package org.gradle.internal.logging.util;
 
 /**
  * This class contains references to log4j-core which had a critical vulnerability,
- * see <a url="https://nvd.nist.gov/vuln/detail/CVE-2021-44228">CVE-2021-44228</a>.
+ * see <a href="https://nvd.nist.gov/vuln/detail/CVE-2021-44228">CVE-2021-44228</a>.
  */
 public class Log4jBannedVersion {
     public static final String LOG4J2_CORE_COORDINATES = "org.apache.logging.log4j:log4j-core";

--- a/platforms/core-runtime/process-memory-services/src/main/java/org/gradle/process/internal/health/memory/DefaultJvmMemoryInfo.java
+++ b/platforms/core-runtime/process-memory-services/src/main/java/org/gradle/process/internal/health/memory/DefaultJvmMemoryInfo.java
@@ -31,7 +31,7 @@ public class DefaultJvmMemoryInfo implements JvmMemoryInfo {
     }
 
     /**
-     * Currently committed memory of this process in bytes. May return different value depending on how the heap has expanded. The returned value is <= {@link #getMaxMemory()}
+     * Currently committed memory of this process in bytes. May return different value depending on how the heap has expanded. The returned value is less than or equal to {@link #getMaxMemory()}
      */
     long getCommittedMemory() {
         //querying runtime for each invocation

--- a/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/ServiceRegistrationProvider.java
+++ b/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/ServiceRegistrationProvider.java
@@ -66,7 +66,6 @@ package org.gradle.internal.service;
  * <p>
  * On top of the basic case of injecting dependencies, more advanced use-cases are also supported:
  * decoration, aggregation, owner registry injection.
- * <p>
  * <pre><code class="language-java">
  * &#64;Provides
  * protected MyService createMyService(
@@ -102,7 +101,6 @@ package org.gradle.internal.service;
  * <b>Owner dependency.</b>
  * When the parameter is of type {@link ServiceRegistry}, it will receive an instance of registry that owns the service.
  * See {@code ServiceRegistry ownerServiceRegistry} in the example.
- * <p>
  *
  * <h3>Service lookup order</h3>
  *

--- a/platforms/documentation/docs/build.gradle
+++ b/platforms/documentation/docs/build.gradle
@@ -12,7 +12,8 @@ import static gradlebuild.basics.BuildParamsKt.shouldRunBrokenForConfigurationCa
 import static gradlebuild.basics.Repositories_extensionsKt.googleApisJs
 
 plugins {
-    id 'gradlebuild.internal.java'
+    id("java-library") // This project is not really a java library. We shouldn't need to apply this.
+    id("gradlebuild.jvm-library")
     // TODO: Apply asciidoctor in documentation plugin instead.
     id 'org.asciidoctor.jvm.convert'
     id 'gradlebuild.documentation'

--- a/platforms/documentation/docs/build.gradle
+++ b/platforms/documentation/docs/build.gradle
@@ -12,7 +12,7 @@ import static gradlebuild.basics.BuildParamsKt.shouldRunBrokenForConfigurationCa
 import static gradlebuild.basics.Repositories_extensionsKt.googleApisJs
 
 plugins {
-    id("java-library") // This project is not really a java library. We shouldn't need to apply this.
+    id("java-library") // Needed for the dependency-analysis plugin. However, we should not need this. This is not a real library.
     id("gradlebuild.jvm-library")
     // TODO: Apply asciidoctor in documentation plugin instead.
     id 'org.asciidoctor.jvm.convert'

--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/operations/execution/ExecuteDeferredWorkProgressDetails.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/operations/execution/ExecuteDeferredWorkProgressDetails.java
@@ -27,7 +27,7 @@ public interface ExecuteDeferredWorkProgressDetails {
 
     /**
      * Type of work being executed.
-     * <p>
+     *
      * @since 8.7
      * @see ExecuteWorkBuildOperationType.Details#getWorkType()
      */

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/internal/PluginResolverFactory.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/internal/PluginResolverFactory.java
@@ -67,7 +67,6 @@ public class PluginResolverFactory {
      * <p>
      * The plugins will be searched in a chain from the first to the last until a plugin is found.
      * So, order matters.
-     * <p>
      * <ol>
      *     <li>{@link NoopPluginResolver} - Only used in tests.</li>
      *     <li>{@link CorePluginResolver} - distributed with Gradle</li>

--- a/platforms/extensibility/test-kit/src/testFixtures/groovy/org/gradle/testkit/runner/fixtures/HideEnvVariableValuesInDaemonLog.java
+++ b/platforms/extensibility/test-kit/src/testFixtures/groovy/org/gradle/testkit/runner/fixtures/HideEnvVariableValuesInDaemonLog.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 /**
  * Indicates that the feature that hides env variable values in daemon log to avoid leaking credentials.
  *
- * @see {@link org.gradle.launcher.daemon.server.exec.EstablishBuildEnvironment}
+ * @see org.gradle.launcher.daemon.server.exec.EstablishBuildEnvironment
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/generator/generator/Generator.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/generator/generator/Generator.java
@@ -19,7 +19,6 @@ import java.io.File;
 
 /**
  * Responsible for reading, configuring and writing a config object of type T to/from a file.
- * @param <T>
  */
 public interface Generator<T> {
     T read(File inputFile);

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/ProblemSpec.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/ProblemSpec.java
@@ -20,7 +20,6 @@ import org.gradle.api.Incubating;
 
 /**
  * Provides options to configure problems.
- * <p>
  *
  * @see ProblemReporter
  * @since 8.6
@@ -93,7 +92,6 @@ public interface ProblemSpec {
 
     /**
      * Declares that this problem is in a file with on a line at a certain position.
-     * <p>
      *
      * @param path the file location
      * @param line the one-indexed line number

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblems.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblems.java
@@ -23,7 +23,6 @@ public interface InternalProblems extends Problems {
 
     /**
      * Returns a reporter then provides additional problem service functionality specific for Gradle internals.
-     * <p>
      *
      * @return The reporter.
      */

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/ProblemDefinition.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/ProblemDefinition.java
@@ -33,7 +33,6 @@ import javax.annotation.Nullable;
  * </ul>
  * <p>
  * The category and the label uniquely identify the problem definition, the remaining fields only supply additional information.
- * <p>
  */
 public interface ProblemDefinition {
 

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/ProjectConnection.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/ProjectConnection.java
@@ -40,7 +40,7 @@ import java.util.List;
  * }
  * </pre>
  *
- * <h3>Thread safety information</h3>
+ * <h2>Thread safety information</h2>
  *
  * <p>All implementations of {@code ProjectConnection} are thread-safe, and may be shared by any number of threads.</p>
  *

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/TestExecutionException.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/TestExecutionException.java
@@ -18,7 +18,6 @@ package org.gradle.tooling;
 
 /**
  * Thrown when the {@link org.gradle.tooling.TestLauncher} cannot run tests, or when one or more tests fail.
- * <p>
  *
  * @since 2.6
  */

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/InternalBuildEnvironment.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/InternalBuildEnvironment.java
@@ -19,7 +19,6 @@ package org.gradle.tooling.internal.protocol;
 /**
  * Marker interface for the internal protocol purposes.
  * Corresponding client facing model is {@link org.gradle.tooling.model.build.BuildEnvironment}
- * <p>
  *
  * @since 1.0-milestone-8
  */

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/TargetGradleVersion.java
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/TargetGradleVersion.java
@@ -27,7 +27,7 @@ import java.lang.annotation.*;
 @Inherited
 public @interface TargetGradleVersion {
     /**
-     * The requested target Gradle version. Can use '>=nnn', '<=nnn', '&lt;nnn', '&gt;nnn', '=nnn', 'current' or '!current' or space-separated list of patterns.
+     * The requested target Gradle version. Can use '&gt;=nnn', '&lt;=nnn', '&lt;nnn', '&gt;nnn', '=nnn', 'current' or '!current' or space-separated list of patterns.
      */
     String value();
 }

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/TargetGradleVersion.java
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/TargetGradleVersion.java
@@ -27,7 +27,17 @@ import java.lang.annotation.*;
 @Inherited
 public @interface TargetGradleVersion {
     /**
-     * The requested target Gradle version. Can use '&gt;=nnn', '&lt;=nnn', '&lt;nnn', '&gt;nnn', '=nnn', 'current' or '!current' or space-separated list of patterns.
+     * The requested target Gradle version. Can use:
+     * <ul>
+     *     <li>{@code >=nnn}</li>
+     *     <li>{@code <=nnn}</li>
+     *     <li>{@code <nnn}</li>
+     *     <li>{@code >nnn}</li>
+     *     <li>{@code =nnn}</li>
+     *     <li>{@code current}</li>
+     *     <li>{@code !current}</li>
+     *     <li>space-separated list of patterns</li>
+     * </ul>
      */
     String value();
 }

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/TextUtil.java
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/TextUtil.java
@@ -24,7 +24,7 @@ public class TextUtil {
     /**
      * TODO - hack to avoid classloading issues. We should use org.gradle.util.internal.TextUtil
      *
-     * Currently we can't use it reliably because it causes CNF issues with cross version integration tests running against tooling api < 1.3.
+     * Currently we can't use it reliably because it causes CNF issues with cross version integration tests running against tooling api versions less than 1.3.
      */
     public static String escapeString(Object obj) {
         return obj.toString().replaceAll("\\\\", "\\\\\\\\");

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiVersion.java
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiVersion.java
@@ -27,7 +27,7 @@ import java.lang.annotation.*;
 @Inherited
 public @interface ToolingApiVersion {
     /**
-     * The requested tooling API version. Can use '>=nnn', '<=nnn', '&lt;nnn', '&gt;nnn', '=nnn', '!nnn', 'current' or '!current' or space-separated list of patterns.
+     * The requested tooling API version. Can use '&gt;=nnn', '&lt;=nnn', '&lt;nnn', '&gt;nnn', '=nnn', '!nnn', 'current' or '!current' or space-separated list of patterns.
      */
     String value();
 }

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiVersion.java
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiVersion.java
@@ -27,7 +27,18 @@ import java.lang.annotation.*;
 @Inherited
 public @interface ToolingApiVersion {
     /**
-     * The requested tooling API version. Can use '&gt;=nnn', '&lt;=nnn', '&lt;nnn', '&gt;nnn', '=nnn', '!nnn', 'current' or '!current' or space-separated list of patterns.
+     * The requested tooling API version. Can use:
+     * <ul>
+     *     <li>{@code >=nnn}</li>
+     *     <li>{@code <=nnn}</li>
+     *     <li>{@code <nnn}</li>
+     *     <li>{@code >nnn}</li>
+     *     <li>{@code =nnn}</li>
+     *     <li>{@code !nnn}</li>
+     *     <li>{@code current}</li>
+     *     <li>{@code !current}</li>
+     *     <li>space-separated list of patterns</li>
+     * </ul>
      */
     String value();
 }

--- a/platforms/jvm/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmInstallationMetadata.java
+++ b/platforms/jvm/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmInstallationMetadata.java
@@ -67,7 +67,7 @@ public interface JvmInstallationMetadata {
 
     /**
      * A wrapper around the raw value of the toolchain vendor.
-     * <p>
+     *
      * @see org.gradle.internal.jvm.inspection.ProbedSystemProperty#JAVA_VENDOR
      */
     JvmVendor getVendor();

--- a/platforms/jvm/language-java/build.gradle.kts
+++ b/platforms/jvm/language-java/build.gradle.kts
@@ -122,3 +122,12 @@ packageCycles {
 }
 
 integTest.usesJavadocCodeSnippets = true
+
+tasks.javadoc {
+    // This project accesses JDK internals.
+    // We need to add --add-exports flags for multiple packages to make this task pass.
+    // The javadoc options modeling API does not allow specifying multiple flags with
+    // the same key, meaning we cannot specify more than one exported package.
+    // Therefore, we disable failure on javadoc errors.
+    isFailOnError = false
+}

--- a/platforms/jvm/language-java/build.gradle.kts
+++ b/platforms/jvm/language-java/build.gradle.kts
@@ -125,9 +125,13 @@ integTest.usesJavadocCodeSnippets = true
 
 tasks.javadoc {
     // This project accesses JDK internals.
-    // We need to add --add-exports flags for multiple packages to make this task pass.
-    // The javadoc options modeling API does not allow specifying multiple flags with
-    // the same key, meaning we cannot specify more than one exported package.
-    // Therefore, we disable failure on javadoc errors.
+    // We would ideally add --add-exports flags for the required packages, however
+    // due to limitations in the javadoc modeling API, we cannot specify multiple
+    // flags for the same key.
+    // Instead, we disable failure on javadoc errors.
     isFailOnError = false
+    options {
+        this as StandardJavadocDocletOptions
+        addBooleanOption("quiet", true)
+    }
 }

--- a/platforms/jvm/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/LineEndingNormalizingInputStreamHasher.java
+++ b/platforms/jvm/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/LineEndingNormalizingInputStreamHasher.java
@@ -42,7 +42,6 @@ public class LineEndingNormalizingInputStreamHasher {
      *
      * @param inputStream The input stream to hash
      * @return An {@link Optional} containing the {@link HashCode} or empty if the file is binary
-     * @throws IOException
      */
     public Optional<HashCode> hashContent(InputStream inputStream) throws IOException {
         return hash(inputStream);
@@ -53,7 +52,6 @@ public class LineEndingNormalizingInputStreamHasher {
      *
      * @param file The file to hash
      * @return An {@link Optional} containing the {@link HashCode} or empty if the file is binary
-     * @throws IOException
      */
     public Optional<HashCode> hashContent(File file) throws IOException {
         try (FileInputStream inputStream = new FileInputStream(file)) {

--- a/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/AbstractTestFrameworkDetector.java
+++ b/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/AbstractTestFrameworkDetector.java
@@ -144,9 +144,12 @@ public abstract class AbstractTestFrameworkDetector<T extends TestClassVisitor> 
     }
 
     /**
-     * Uses a TestClassVisitor to detect whether the class in the testClassFile is a test class. <p/> If the class is not a test, this function will go up the inheritance tree to check if a parent
-     * class is a test class. First the package of the parent class is checked, if it is a java.lang or groovy.lang the class can't be a test class, otherwise the parent class is scanned. <p/> When a
-     * parent class is a test class all the extending classes are marked as test classes.
+     * Uses a TestClassVisitor to detect whether the class in the testClassFile is a test class.
+     * <p>
+     * If the class is not a test, this function will go up the inheritance tree to check if a parent
+     * class is a test class. First the package of the parent class is checked, if it is a java.lang or groovy.lang the class can't be a test class, otherwise the parent class is scanned.
+     * <p>
+     * When a parent class is a test class all the extending classes are marked as test classes.
      */
     private boolean processTestClass(File testClassFile, boolean superClass, Factory<String> fallbackClassNameProvider) {
         TestClass testClass = readClassFile(testClassFile, fallbackClassNameProvider);

--- a/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -1000,7 +1000,6 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
 
     /**
      * Specifies that JUnit4 should be used to discover and execute the tests.
-     * <p>
      *
      * @see #useJUnit(org.gradle.api.Action) Configure JUnit4 specific options.
      */
@@ -1067,7 +1066,6 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
 
     /**
      * Specifies that TestNG should be used to discover and execute the tests.
-     * <p>
      *
      * @see #useTestNG(org.gradle.api.Action) Configure TestNG specific options.
      */
@@ -1106,8 +1104,6 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
      * If we are setting a framework to its existing value, no-op so as not to overwrite existing options here.
      * We need to allow this especially for the default test task, so that existing builds that configure options and
      * then call useJunit() don't clear out their options.
-     *
-     * @param testFramework
      */
     void useTestFramework(TestFramework testFramework) {
         Class<?> currentFramework = this.testFramework.get().getClass();

--- a/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/platform/Architecture.java
+++ b/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/platform/Architecture.java
@@ -24,6 +24,7 @@ import org.gradle.internal.HasInternalProtocol;
  * A CPU architecture.
  *
  * <table>
+ *     <caption>Values</caption>
  *     <tr>
  *         <th>Instruction Set</th>
  *         <th>32-bit names</th>

--- a/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/platform/OperatingSystem.java
+++ b/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/platform/OperatingSystem.java
@@ -23,6 +23,7 @@ import org.gradle.api.tasks.Internal;
  * A machine operating system.
  *
  * <table>
+ * <caption>Values</caption>
  *     <tr>
  *         <th>Operating System</th>
  *         <th>Aliases</th>

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolverResults.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolverResults.java
@@ -26,8 +26,8 @@ import org.gradle.api.specs.Spec;
 /**
  * Immutable representation of the state of dependency resolution. Can represent the result of resolving build
  * dependencies or the result of a full dependency graph resolution.
- *
- * <p> In case of failures, both fatal and partial, exceptions are attached to the {@link VisitedGraphResults}. <p>
+ * <p>
+ * In case of failures, both fatal and partial, exceptions are attached to the {@link VisitedGraphResults}.
  */
 public interface ResolverResults {
     /**
@@ -58,7 +58,7 @@ public interface ResolverResults {
      * <ul>
      *     <li>{@link ResolvedConfiguration}</li>
      *     <li>{@link org.gradle.api.artifacts.LenientConfiguration}</li>
-     *     <li>{@link org.gradle.api.artifacts.Configuration#fileCollection(Spec)}</li> and related methods
+     *     <li>{@link org.gradle.api.artifacts.Configuration#fileCollection(Spec)} and related methods</li>
      * </ul>
      */
     interface LegacyResolverResults {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionResultProvider.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionResultProvider.java
@@ -21,7 +21,6 @@ import java.util.function.Function;
 /**
  * Some value that is calculated as part of dependency resolution, but which may have a partial or different value
  * when the execution graph is calculated.
- * @param <T>
  */
 public interface ResolutionResultProvider<T> {
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -423,7 +423,7 @@ public abstract class DefaultDependencyHandler implements DependencyHandlerInter
     }
 
     /**
-     * Implemented here instead as a default method of DependencyHandler like most of other methods with `Provider<MinimalExternalModuleDependency>` argument
+     * Implemented here instead as a default method of DependencyHandler like most of other methods with {@code Provider<MinimalExternalModuleDependency>} argument
      * since we don't want to expose enforcedPlatform on many places since we might deprecate enforcedPlatform in the future
      *
      * @param dependencyProvider the dependency provider

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorBuilder.java
@@ -227,7 +227,7 @@ public class GradlePomModuleDescriptorBuilder {
     /**
      * Determines the version of a dependency. Uses the specified version if declared for the as coordinate. If the version is not declared, try to resolve it from the dependency management section.
      * In case the version cannot be resolved with any of these methods:
-     * - If this is a direct dependency: throw an exception of type {@see org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.UnresolvedDependencyVersionException}.
+     * - If this is a direct dependency: throw an exception of type see {@link org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.UnresolvedDependencyVersionException}.
      * - If this is an optional dependency: return the empty version
      *
      * @param dependency Dependency

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/ModuleArtifactCache.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/ModuleArtifactCache.java
@@ -26,9 +26,10 @@ import java.util.List;
 public interface ModuleArtifactCache {
     /**
      * Adds a resolution to the index.
+     * <p>
+     * The incoming file is expected to be in the persistent local. This method will not move/copy the file there.
      *
-     * The incoming file is expected to be in the persistent local. This method will not move/copy the file there. <p>
-     *  @param key The key to cache this resolution under in the index. Cannot be null.
+     * @param key The key to cache this resolution under in the index. Cannot be null.
      * @param artifactFile The artifact file in the persistent file store. Cannot be null
      * @param moduleDescriptorHash The checksum (SHA1) of the related moduledescriptor.
      */

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicy.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicy.java
@@ -286,7 +286,7 @@ public class DefaultCachePolicy implements CachePolicy {
         }
 
         /**
-         * If the age < 0, then it's probable that we've had a clock shift. In this case, treat the age as 1ms.
+         * If the age is less than 0, then it's probable that we've had a clock shift. In this case, treat the age as 1ms.
          */
         private long correctForClockShift(long ageMillis) {
             if (ageMillis < 0) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/ArtifactResolutionDetails.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/ArtifactResolutionDetails.java
@@ -23,29 +23,28 @@ import javax.annotation.Nullable;
 /**
  * Details about an artifact resolution query. This is used whenever repository
  * content filtering is in place.
- * <p></p>
+ * <p>
  * This interface gives access to the details of the artifact query. There are two
  * cases when filtering can be called:
- * <p></p>
  * <ul>
  *     <li>when looking for a specific module version, for example org:foo:1.0</li>
  *     <li>when looking for the list of versions for a module, for example org:foo</li>
  * </ul>
- * <p></p>
+ * <p>
  * Listing is called when using dynamic versions (ranges, 1.+, ...).
- * <p></p>
+ * <p>
  * The module identifier will always be non-null. If what you want to express
  * is that a module cannot be found in a repository, independently of its version,
  * then it's enough to just look at the module id using {@link #getModuleId()}.
- * <p></p>
+ * <p>
  * However, if you have to differentiate depending on the version number (for example,
  * some versions of a module are found in one repository, others in a different repository),
  * then you must look at the version thanks to the {@link #getComponentId()} method. But
  * because there can also be version listings, you must also check for {@link #getModuleId()}.
- * <p></p>
+ * <p>
  * A {@link #isVersionListing() convenience method} makes it easier to find out if you
  * are in the version listing case, or module version case.
- * <p></p>
+ * <p>
  * Filtering is done by calling the {@link #notFound()} method: as soon as you know a module
  * cannot be found in a repository, call this method. Otherwise, Gradle will perform a request
  * to find out. It doesn't matter if the module is eventually not found, as Gradle would handle

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MavenDependencyDescriptor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MavenDependencyDescriptor.java
@@ -114,7 +114,7 @@ public class MavenDependencyDescriptor extends ExternalDependencyDescriptor {
     /**
      * When an optional dependency declares a classifier, that classifier is effectively ignored, and the optional
      * dependency will update the version of any dependency with matching GAV.
-     * (Same goes for <type> on optional dependencies: they are effectively ignored).
+     * (Same goes for {@code <type>} on optional dependencies: they are effectively ignored).
      *
      * Note that this doesn't really match with Maven, where an optional dependency with classifier will
      * provide a version for any other dependency with matching GAV + classifier.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/MultipleCandidateMatcher.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/MultipleCandidateMatcher.java
@@ -33,7 +33,6 @@ import java.util.function.IntFunction;
 
 /**
  * This is the heart of the attribute matching algorithm and is used whenever there are multiple candidates to choose from.
- * <p>
  * <ol>
  * <li>
  * For each candidate, check whether its attribute values are compatible (according to the {@link AttributeSelectionSchema}) with the values that were requested.
@@ -56,9 +55,7 @@ import java.util.function.IntFunction;
  * If there are one or more candidates left after disambiguation, return those.
  * </li>
  * </ol>
- * </p>
  *
- * <p>
  * Implementation notes:
  *
  * <p>For matching and disambiguating the requested values, we keep a table of candidate values to avoid recomputing them. The table has one row for each candidate and one column for each attribute.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/PersistentModuleSource.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/PersistentModuleSource.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 /**
  * Interface for module sources which need to be serialized with
  * the metadata descriptor. Adding or removing such a metadata source
- * requires updating the metadata cache store format ({@see CacheLayout}.
+ * requires updating the metadata cache store format (see {@link org.gradle.api.internal.artifacts.ivyservice.CacheLayout}).
  */
 public interface PersistentModuleSource extends ModuleSource {
     /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/MissingAttributeAmbiguousVariantsFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/MissingAttributeAmbiguousVariantsFailureDescriber.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
  */
 public abstract class MissingAttributeAmbiguousVariantsFailureDescriber extends AmbiguousVariantsFailureDescriber {
     /**
-     * Map from failure -> name of attribute that would distinguish each candidate.
+     * Map from failure to name of attribute that would distinguish each candidate.
      * This map exists to avoid re-discovering the unrequested attributes between the calls to `canDescribeFailure` and `describeFailure`.
      * Each failure will be added once (by identity), then removed during failure description.
      */

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resource/cached/CachedExternalResourceIndex.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resource/cached/CachedExternalResourceIndex.java
@@ -31,9 +31,8 @@ public interface CachedExternalResourceIndex<K> {
 
     /**
      * Adds a resolution to the index.
-     *
-     * The incoming file is expected to be in the persistent local. This method will not move/copy the file there.
      * <p>
+     * The incoming file is expected to be in the persistent local. This method will not move/copy the file there.
      *
      * @param key The key to cache this resolution under in the index. Cannot be null.
      * @param artifactFile The artifact file in the persistent file store. Cannot be null

--- a/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/IvyPublication.java
+++ b/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/IvyPublication.java
@@ -63,9 +63,9 @@ import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyPro
  * For any other tweaks to the publication, it is possible to modify the generated Ivy descriptor file prior to publication. This is done using
  * the {@link IvyModuleDescriptorSpec#withXml(org.gradle.api.Action)} method, normally via a Closure passed to the {@link #descriptor(org.gradle.api.Action)} method.
  * </p>
- * <h4>Example of publishing a java component with an added source jar and custom module description</h4>
  *
  * <pre class='autoTested'>
+ * // Example of publishing a java component with an added source jar and custom module description
  * plugins {
  *     id 'java'
  *     id 'ivy-publish'
@@ -107,7 +107,6 @@ public interface IvyPublication extends Publication {
 
     /**
      * The module descriptor that will be published.
-     * <p>
      *
      * @return The module descriptor that will be published.
      */

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPublication.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/MavenPublication.java
@@ -57,8 +57,9 @@ import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyPro
  * method or directly by an action (or closure) passed into {@link #pom(org.gradle.api.Action)}.
  * As a last resort, it is possible to modify the generated POM using the {@link MavenPom#withXml(org.gradle.api.Action)} method.
  * </p>
- * <h4>Example of publishing a Java module with a source artifact and a customized POM</h4>
+ *
  * <pre class='autoTested'>
+ * // Example of publishing a Java module with a source artifact and a customized POM
  * plugins {
  *     id 'java'
  *     id 'maven-publish'

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPublicationInternal.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPublicationInternal.java
@@ -38,11 +38,10 @@ public interface MavenPublicationInternal extends MavenPublication, PublicationI
      * Some components (e.g. Native) are published such that the module metadata references the original file name,
      * rather than the Maven-standard {artifactId}-{version}-{classifier}.{extension}.
      * This method enables this behaviour for the current publication.
+     * <p>
+     * Note: This internal API is used by KMP:
      *
-     *
-     * <p>Note: This internal API is used by KMP:
-     * <a href="https://github.com/JetBrains/kotlin/blob/5424c54fae7b4836506ec711edc0135392b445d6/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/Publishing.kt#L50">Usage</a></a>
-     * </p>
+     * @see <a href="https://github.com/JetBrains/kotlin/blob/5424c54fae7b4836506ec711edc0135392b445d6/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/Publishing.kt#L50">Usage</a>
      */
     void publishWithOriginalFileName();
 }

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPublicationInternal.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPublicationInternal.java
@@ -40,8 +40,7 @@ public interface MavenPublicationInternal extends MavenPublication, PublicationI
      * This method enables this behaviour for the current publication.
      * <p>
      * Note: This internal API is used by KMP:
-     *
-     * @see <a href="https://github.com/JetBrains/kotlin/blob/5424c54fae7b4836506ec711edc0135392b445d6/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/Publishing.kt#L50">Usage</a>
+     * <a href="https://github.com/JetBrains/kotlin/blob/5424c54fae7b4836506ec711edc0135392b445d6/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/Publishing.kt#L50">Usage</a>
      */
     void publishWithOriginalFileName();
 }

--- a/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/redirector/StandardOutputRedirector.java
+++ b/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/redirector/StandardOutputRedirector.java
@@ -21,7 +21,7 @@ public interface StandardOutputRedirector {
     /**
      * Starts redirection of System.out and System.err to the listener attached to
      * {@link #redirectStandardErrorTo(OutputListener)} and
-     * {@link #redirectStandardOutputTo(OutputListener)
+     * {@link #redirectStandardOutputTo(OutputListener)}
      */
     void start();
 

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/LocaleSafeDecimalFormat.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/LocaleSafeDecimalFormat.java
@@ -24,10 +24,6 @@ public class LocaleSafeDecimalFormat {
 
     /**
      * Regardless of the default locale, comma ('.') is used as decimal separator
-     *
-     * @param source
-     * @return
-     * @throws ParseException
      */
     public BigDecimal parse(String source) throws ParseException {
         DecimalFormatSymbols symbols = new DecimalFormatSymbols();

--- a/subprojects/core-api/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Project.java
@@ -67,7 +67,7 @@ import java.util.concurrent.Callable;
  * <p>This interface is the main API you use to interact with Gradle from your build file. From a <code>Project</code>,
  * you have programmatic access to all of Gradle's features.</p>
  *
- * <h3>Lifecycle</h3>
+ * <h2>Lifecycle</h2>
  *
  * <p>There is a one-to-one relationship between a <code>Project</code> and a <code>{@value #DEFAULT_BUILD_FILE}</code>
  * file. During build initialisation, Gradle assembles a <code>Project</code> object for each project which is to
@@ -90,14 +90,14 @@ import java.util.concurrent.Callable;
  *
  * </ul>
  *
- * <h3>Tasks</h3>
+ * <h2>Tasks</h2>
  *
  * <p>A project is essentially a collection of {@link Task} objects. Each task performs some basic piece of work, such
  * as compiling classes, or running unit tests, or zipping up a WAR file. You add tasks to a project using one of the
  * {@code create()} methods on {@link TaskContainer}, such as {@link TaskContainer#create(String)}.  You can locate existing
  * tasks using one of the lookup methods on {@link TaskContainer}, such as {@link org.gradle.api.tasks.TaskCollection#getByName(String)}.</p>
  *
- * <h3>Dependencies</h3>
+ * <h2>Dependencies</h2>
  *
  * <p>A project generally has a number of dependencies it needs in order to do its work.  Also, a project generally
  * produces a number of artifacts, which other projects can use. Those dependencies are grouped in configurations, and
@@ -108,19 +108,19 @@ import java.util.concurrent.Callable;
  * manage the artifacts. The {@link org.gradle.api.artifacts.dsl.RepositoryHandler} returned by {@link
  * #getRepositories()} method to manage the repositories.</p>
  *
- * <h3>Multi-project Builds</h3>
+ * <h2>Multi-project Builds</h2>
  *
  * <p>Projects are arranged into a hierarchy of projects. A project has a name, and a fully qualified path which
  * uniquely identifies it in the hierarchy.</p>
  *
- * <h3>Plugins</h3>
+ * <h2>Plugins</h2>
  *
  * <p>
  * Plugins can be used to modularise and reuse project configuration.
  * Plugins can be applied using the {@link PluginAware#apply(java.util.Map)} method, or by using the {@link org.gradle.plugin.use.PluginDependenciesSpec} plugins script block.
  * </p>
  *
- * <a id="properties"></a> <h3>Dynamic Project Properties</h3>
+ * <a id="properties"></a> <h2>Dynamic Project Properties</h2>
  *
  * <p>Gradle executes the project's build file against the <code>Project</code> instance to configure the project. Any
  * property or method which your script uses is delegated through to the associated <code>Project</code> object.  This
@@ -168,7 +168,7 @@ import java.util.concurrent.Callable;
  * <p>When writing a property, the project searches the above scopes in order, and sets the property in the first scope
  * it finds the property in. If not found, an exception is thrown. See {@link #setProperty(String, Object)} for more details.</p>
  *
- * <a id="extraproperties"></a> <h4>Extra Properties</h4>
+ * <a id="extraproperties"></a> <h3>Extra Properties</h3>
  *
  * All extra properties must be defined through the &quot;ext&quot; namespace. Once an extra property has been defined,
  * it is available directly on the owning object (in the below case the Project, Task, and sub-projects respectively) and can
@@ -191,7 +191,7 @@ import java.util.concurrent.Callable;
  * }
  * </pre>
  *
- * <h4>Dynamic Methods</h4>
+ * <h3>Dynamic Methods</h3>
  *
  * <p>A project has 5 method 'scopes', which it searches for methods:</p>
  *
@@ -472,6 +472,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * passed to this method to control how the task is created. The following options are available:</p>
      *
      * <table>
+     * <caption>Permitted map keys</caption>
      *
      * <tr><th>Option</th><th>Description</th><th>Default Value</th></tr>
      *
@@ -1193,8 +1194,8 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
 
     /**
      * Returns the configurations of this project.
-     *
-     * <h3>Examples:</h3> See docs for {@link ConfigurationContainer}
+     * <p>
+     * Examples: See docs for {@link ConfigurationContainer}
      *
      * @return The configuration of this project.
      */
@@ -1205,8 +1206,8 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      *
      * <p>This method executes the given closure against the {@link ConfigurationContainer}
      * for this project. The {@link ConfigurationContainer} is passed to the closure as the closure's delegate.
-     *
-     * <h3>Examples:</h3> See docs for {@link ConfigurationContainer}
+     * <p>
+     * Examples: See docs for {@link ConfigurationContainer}
      *
      * @param configureClosure the closure to use to configure the dependency configurations.
      */
@@ -1214,7 +1215,8 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
 
     /**
      * Returns a handler for assigning artifacts produced by the project to configurations.
-     * <h3>Examples:</h3>See docs for {@link ArtifactHandler}
+     * <p>
+     * Examples: See docs for {@link ArtifactHandler}
      */
     ArtifactHandler getArtifacts();
 
@@ -1563,9 +1565,8 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
     /**
      * Returns the dependency handler of this project. The returned dependency handler instance can be used for adding
      * new dependencies. For accessing already declared dependencies, the configurations can be used.
-     *
-     * <h3>Examples:</h3>
-     * See docs for {@link DependencyHandler}
+     * <p>
+     * Examples: See docs for {@link DependencyHandler}
      *
      * @return the dependency handler. Never returns null.
      * @see #getConfigurations()
@@ -1577,9 +1578,8 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      *
      * <p>This method executes the given closure against the {@link DependencyHandler} for this project. The {@link
      * DependencyHandler} is passed to the closure as the closure's delegate.
-     *
-     * <h3>Examples:</h3>
-     * See docs for {@link DependencyHandler}
+     * <p>
+     * Examples: See docs for {@link DependencyHandler}
      *
      * @param configureClosure the closure to use to configure the dependencies.
      */

--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -62,7 +62,7 @@ import java.util.Set;
  * and the task's name. Path elements are separated using the {@value org.gradle.api.Project#PATH_SEPARATOR}
  * character.</p>
  *
- * <h3>Task Actions</h3>
+ * <h2>Task Actions</h2>
  *
  * <p>A <code>Task</code> is made up of a sequence of {@link Action} objects. When the task is executed, each of the
  * actions is executed in turn, by calling {@link Action#execute}. You can add actions to a task by calling {@link
@@ -78,7 +78,7 @@ import java.util.Set;
  * next task by throwing a {@link org.gradle.api.tasks.StopExecutionException}. Using these exceptions allows you to
  * have precondition actions which skip execution of the task, or part of the task, if not true.</p>
  *
- * <a id="dependencies"></a><h3>Task Dependencies and Task Ordering</h3>
+ * <a id="dependencies"></a><h2>Task Dependencies and Task Ordering</h2>
  *
  * <p>A task may have dependencies on other tasks or might be scheduled to always run after another task.
  * Gradle ensures that all task dependencies and ordering rules are honored when executing tasks, so that the task is executed after
@@ -120,9 +120,9 @@ import java.util.Set;
  *
  * </ul>
  *
- * <h3>Using a Task in a Build File</h3>
+ * <h2>Using a Task in a Build File</h2>
  *
- * <a id="properties"></a> <h4>Dynamic Properties</h4>
+ * <a id="properties"></a> <h3>Dynamic Properties</h3>
  *
  * <p>A {@code Task} has 4 'scopes' for properties. You can access these properties by name from the build file or by
  * calling the {@link #property(String)} method. You can change the value of these properties by calling the {@link #setProperty(String, Object)} method.</p>
@@ -149,7 +149,7 @@ import java.util.Set;
  *
  * <p>A {@link Plugin} may add methods to a {@code Task} using its {@link org.gradle.api.plugins.Convention} object.</p>
  *
- * <h4>Parallel Execution</h4>
+ * <h3>Parallel Execution</h3>
  * <p>
  * By default, tasks are not executed in parallel unless a task is waiting on asynchronous work and another task (which
  * is not dependent) is ready to execute.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionConstraint.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionConstraint.java
@@ -27,7 +27,7 @@ import java.util.List;
  * Each of {@link #getPreferredVersion()}, {@link #getRequiredVersion()} and {@link #getStrictVersion()} is represented by a version String,
  * that can be compared against a module version to determine if the version matches.
  *
- * <h4>Version syntax</h4>
+ * <h2>Version syntax</h2>
  * <p>
  * Gradle supports different ways of declaring a version String:
  * <ul>
@@ -53,7 +53,7 @@ import java.util.List;
  *     <li>A Maven SNAPSHOT version identifier: e.g. 1.0-SNAPSHOT, 1.4.9-beta1-SNAPSHOT</li>
  * </ul>
  *
- * <h4>Version ordering</h4>
+ * <h2>Version ordering</h2>
  *
  * Versions have an implicit ordering. Version ordering is used to:
  * <ul>

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/Dependencies.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/Dependencies.java
@@ -38,7 +38,7 @@ import javax.inject.Inject;
  * @implNote Changes to this interface may require changes to the
  * {@link org.gradle.api.internal.artifacts.dsl.dependencies.DependenciesExtensionModule extension module for Groovy DSL} or
  * {@link org.gradle.kotlin.dsl.DependenciesExtensions extension functions for Kotlin DSL}.
- * <p>
+ *
  * @see <a href="https://docs.gradle.org/current/userguide/implementing_gradle_plugins_binary.html#custom_dependencies_blocks">Creating custom dependencies blocks.</a>
  *
  * @since 7.6

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
@@ -44,6 +44,7 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
      * The following parameter are accepted as keys for the map:
      *
      * <table>
+     * <caption>Shows property keys and associated values</caption>
      * <tr><th>Key</th>
      *     <th>Description of Associated Value</th></tr>
      * <tr><td><code>name</code></td>
@@ -156,6 +157,7 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
      * <p>The following parameter are accepted as keys for the map:
      *
      * <table>
+     * <caption>Shows property keys and associated values</caption>
      * <tr><th>Key</th>
      *     <th>Description of Associated Value</th></tr>
      * <tr><td><code>name</code></td>

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/IvyArtifactRepository.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/IvyArtifactRepository.java
@@ -102,7 +102,7 @@ public interface IvyArtifactRepository extends ArtifactRepository, UrlArtifactRe
      * <p>
      * Recognised values are as follows:
      * </p>
-     * <h4>'gradle'</h4>
+     * <h2>'gradle'</h2>
      * <p>
      * A Repository Layout that applies the following patterns:
      * </p>
@@ -110,7 +110,7 @@ public interface IvyArtifactRepository extends ArtifactRepository, UrlArtifactRe
      *     <li>Artifacts: <code>$baseUri/{@value #GRADLE_ARTIFACT_PATTERN}</code></li>
      *     <li>Ivy: <code>$baseUri/{@value #GRADLE_IVY_PATTERN}</code></li>
      * </ul>
-     * <h4>'maven'</h4>
+     * <h2>'maven'</h2>
      * <p>
      * A Repository Layout that applies the following patterns:
      * </p>
@@ -121,7 +121,7 @@ public interface IvyArtifactRepository extends ArtifactRepository, UrlArtifactRe
      * <p>
      * Following the Maven convention, the 'organisation' value is further processed by replacing '.' with '/'.
      * </p>
-     * <h4>'ivy'</h4>
+     * <h2>'ivy'</h2>
      * <p>
      * A Repository Layout that applies the following patterns:
      * </p>

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFilePermissions.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFilePermissions.java
@@ -133,9 +133,9 @@ public interface ConfigurableFilePermissions extends FilePermissions {
      *     <li><code>w</code> if WRITING is permitted, <code>-</code> if it is not; must be 2nd in the set</li>
      *     <li><code>x</code> if EXECUTING is permitted, <code>-</code> if it is not; must be 3rd in the set</li>
      * </ul>
-     * <p>
-     * Examples:
+     *
      * <table>
+     *   <caption>Examples of Unix style permissions</caption>
      *   <tr>
      *     <th>Numeric</th>
      *     <th>Symbolic</th>

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
@@ -50,7 +50,7 @@ import java.util.Arrays;
  * #DEFAULT_SETTINGS_FILE}</code> settings file. Before Gradle assembles the projects for a build, it creates a
  * <code>Settings</code> instance and executes the settings file against it.</p>
  *
- * <h3>Assembling a Multi-Project Build</h3>
+ * <h2>Assembling a Multi-Project Build</h2>
  *
  * <p>One of the purposes of the <code>Settings</code> object is to allow you to declare the projects which are to be
  * included in the build. You add projects to the build using the {@link #include(String...)} method.  There is always a
@@ -61,9 +61,9 @@ import java.util.Arrays;
  * <p>When a project is included in the build, a {@link ProjectDescriptor} is created. You can use this descriptor to
  * change the default values for several properties of the project.</p>
  *
- * <h3>Using Settings in a Settings File</h3>
+ * <h2>Using Settings in a Settings File</h2>
  *
- * <h4>Dynamic Properties</h4>
+ * <h3>Dynamic Properties</h3>
  *
  * <p>In addition to the properties of this interface, the {@code Settings} object makes some additional read-only
  * properties available to the settings script. This includes properties from the following sources:</p>

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
@@ -64,6 +64,7 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * to control how the task is created. The following options are available:</p>
      *
      * <table>
+     * <caption>Permitted map keys</caption>
      *
      * <tr><th>Option</th><th>Description</th><th>Default Value</th></tr>
      *

--- a/subprojects/core-api/src/main/java/org/gradle/internal/cache/MonitoredCleanupAction.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/cache/MonitoredCleanupAction.java
@@ -26,7 +26,6 @@ public interface MonitoredCleanupAction extends Describable {
     /**
      * Perform the cleanup action, returning true if any resources were actually cleaned up.
      *
-     * @param progressMonitor
      * @return true if resources were cleaned
      */
     boolean execute(CleanupProgressMonitor progressMonitor);

--- a/subprojects/core-api/src/main/java/org/gradle/plugin/use/PluginDependenciesSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/plugin/use/PluginDependenciesSpec.java
@@ -25,14 +25,14 @@ import org.gradle.api.provider.ProviderConvertible;
  * In a build script, the <code>plugins {}</code> script block API is of this type.
  * That is, you can use this API in the body of the plugins script block to declare plugins to be used for the script.
  * </p>
- * <h3>Relationship with the apply() method</h3>
+ * <h2>Relationship with the apply() method</h2>
  * <p>
  * The <code>plugins {}</code> block serves a similar purpose to the {@link org.gradle.api.plugins.PluginAware#apply(java.util.Map)} method
  * that can be used to apply a plugin directly to a {@code Project} object or similar.
  * A key difference is that plugins applied via the <code>plugins {}</code> block are conceptually applied to the script, and by extension the script target.
  * At this time there is no observable practical difference between the two approaches with regard to the end result.
  * </p>
- * <h3>Strict Syntax</h3>
+ * <h2>Strict Syntax</h2>
  * <p>
  * When used in a build script, the <code>plugins {}</code> block only allows a strict subset of the full build script programming language.
  * Only the API of this type can be used, and values must be literal (e.g. constant strings, not variables).
@@ -49,8 +49,8 @@ import org.gradle.api.provider.ProviderConvertible;
  * <li>{@link #id(String)}, {@link PluginDependencySpec#version(String)} and {@link PluginDependencySpec#apply(boolean)} methods must be called with a literal argument (i.e. not a variable)</li>
  * <li>The <code>plugins {}</code> script block must follow any <code>buildscript {}</code> script block, but must precede all other logic in the script</li>
  * </ul>
- * <h3>Available Plugins</h3>
- * <h4>Core Plugins</h4>
+ * <h2>Available Plugins</h2>
+ * <h3>Core Plugins</h3>
  * <p>
  * Core Gradle plugins are able to be applied using the <code>plugins {}</code> block.
  * Core plugins must be specified without a version number, and can have a <i>qualified</i> or <i>unqualified</i> id.
@@ -75,7 +75,7 @@ import org.gradle.api.provider.ProviderConvertible;
  * <p>
  * For the list of available core plugins for a particular Gradle version, please consult the user manual.
  * </p>
- * <h4>Community Plugins</h4>
+ * <h3>Community Plugins</h3>
  * <p>
  * Non-core plugins are available from the <a href="http://plugins.gradle.org">Gradle Plugin Portal</a>.
  * These plugins are contributed by users of Gradle to extend Gradle's functionality.
@@ -84,7 +84,7 @@ import org.gradle.api.provider.ProviderConvertible;
  * <p>
  * To use a community plugin, the fully qualified id must be specified along with a version.
  * </p>
- * <h3>Settings Script Usage</h3>
+ * <h2>Settings Script Usage</h2>
  * <p>
  * When used in a settings script, this API sets the default version of a plugin, allowing build scripts to
  * reference a plugin id without an associated version.

--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaExecSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaExecSpec.java
@@ -69,7 +69,6 @@ public interface JavaExecSpec extends JavaForkOptions, BaseExecSpec {
      * The fully qualified name of the Main class to be executed.
      * <p>
      * This does not need to be set if using an <a href="https://docs.oracle.com/javase/tutorial/deployment/jar/appman.html">Executable Jar</a> with a {@code Main-Class} attribute.
-     * <p>
      *
      * @since 6.4
      */

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DelegatingNamedDomainObjectSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DelegatingNamedDomainObjectSet.java
@@ -31,7 +31,7 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 
 /**
- * A {@Link NamedDomainObjectSet} which delegates all methods to a provided delegate.
+ * A {@link NamedDomainObjectSet} which delegates all methods to a provided delegate.
  */
 public class DelegatingNamedDomainObjectSet<T> extends DelegatingDomainObjectSet<T> implements NamedDomainObjectSet<T> {
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/FactoryNamedDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/FactoryNamedDomainObjectContainer.java
@@ -34,7 +34,7 @@ public class FactoryNamedDomainObjectContainer<T> extends AbstractNamedDomainObj
     // https://github.com/nebula-plugins/nebula-project-plugin/blob/f0f587f7b7014b6202875dc499dae05b0fc32344/src/main/groovy/nebula/plugin/responsible/gradle/NamedContainerProperOrder.groovy#L12-L31
 
     /**
-     * <p>Creates a container that instantiates using the given factory.<p>
+     * Creates a container that instantiates using the given factory.
      *
      * @param type The concrete type of element in the container (must implement {@link Named})
      * @param instantiator The instantiator to use to create any other collections based on this one
@@ -46,7 +46,7 @@ public class FactoryNamedDomainObjectContainer<T> extends AbstractNamedDomainObj
     }
 
     /**
-     * <p>Creates a container that instantiates using the given factory.<p>
+     * Creates a container that instantiates using the given factory.
      *
      * @param type The concrete type of element in the container
      * @param instantiator The instantiator to use to create any other collections based on this one
@@ -60,7 +60,7 @@ public class FactoryNamedDomainObjectContainer<T> extends AbstractNamedDomainObj
     }
 
     /**
-     * <p>Creates a container that instantiates using the given factory.<p>
+     * Creates a container that instantiates using the given factory.
      *
      * @param type The concrete type of element in the container (must implement {@link Named})
      * @param instantiator The instantiator to use to create any other collections based on this one
@@ -71,7 +71,7 @@ public class FactoryNamedDomainObjectContainer<T> extends AbstractNamedDomainObj
     }
 
     /**
-     * <p>Creates a container that instantiates using the given factory.<p>
+     * Creates a container that instantiates using the given factory.
      *
      * @param type The concrete type of element in the container
      * @param instantiator The instantiator to use to create any other collections based on this one

--- a/subprojects/core/src/main/java/org/gradle/api/internal/UserCodeAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/UserCodeAction.java
@@ -22,7 +22,6 @@ import org.gradle.api.InvalidUserCodeException;
 /**
  * A delegating {@link Action} implementation that wraps exceptions in InvalidUserCodeException.
  * Used to wrap a closure or action parameter that contains user-provided executable code.
- * @param <T>
  */
 public class UserCodeAction<T> implements Action<T> {
     private final String exceptionMessage;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependenciesExtensionModule.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependenciesExtensionModule.java
@@ -51,7 +51,6 @@ import java.util.Set;
  * <li>exposing an instance of {@link DependencyCollector} to add dependencies without explicitly calling {@link DependencyCollector#addConstraint(DependencyConstraint)} or {@link DependencyCollector#addConstraint(Provider)}</li>
  * <li>exposing an instance of {@link DependencyModifier} to modify dependencies without explicitly calling {@link DependencyModifier#modify(ModuleDependency)}</li>
  * </ul>
- * </p>
  *
  * <p>
  * There are {@code call(...)} equivalents for all the {@code add(...)} and {@code addConstraint(...)} methods in {@link DependencyCollector}.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/ValidationAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/ValidationAction.java
@@ -25,9 +25,9 @@ public interface ValidationAction {
     /**
      * Validates the given property value according to some rule.
      *
-     * @param propertyName
+     * @param propertyName the name of the property being validated
      * @param value a supplier of a non-null value - side effects are guaranteed to happen only once
-     * @param context
+     * @param context the context in which the validation is being performed
      */
     void validate(String propertyName, @Nonnull Supplier<Object> value, PropertyValidationContext context);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceRegistryInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceRegistryInternal.java
@@ -40,10 +40,6 @@ public interface BuildServiceRegistryInternal extends BuildServiceRegistry {
     /**
      * Same as #register(name, implementationType, parameters, maxUsages), but conditional.
      *
-     * @param name
-     * @param implementationType
-     * @param parameters
-     * @param maxUsages
      * @return the registered or already existing provider
      */
     BuildServiceProvider<?, ?> registerIfAbsent(String name, Class<? extends BuildService<?>> implementationType, @Nullable BuildServiceParameters parameters, int maxUsages);

--- a/subprojects/core/src/main/java/org/gradle/configuration/internal/ListenerBuildOperationDecorator.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/internal/ListenerBuildOperationDecorator.java
@@ -74,7 +74,7 @@ public interface ListenerBuildOperationDecorator {
 
     /**
      * Decorates a listener of unknown type.
-     * <p>
+     *
      * @param registrationPoint the place that the listener was registered - used in the operation description / details
      * @param listener the listener object to decorate
      * @see #decorate(String, Class, Object)

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
@@ -268,7 +268,7 @@ public class LocalTaskNode extends TaskNode {
      * Used to determine whether a {@link Node} consumes the <b>outcome</b> of a successor task vs. its output(s).
      *
      * @param dependency a non-successful successor node in the execution plan
-     * @return true if the successor node dependency was declared with an explicit dependsOn relationship, false otherwise (implying task output -> task input relationship)
+     * @return true if the successor node dependency was declared with an explicit dependsOn relationship, false otherwise (implying task output to task input relationship)
      */
     @Override
     protected boolean dependsOnOutcome(Node dependency) {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalGroupFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalGroupFactory.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Preserves identity of {@see OrdinalGroup} instances so there's a 1-to-1 mapping of ordinals to groups allowing groups
+ * Preserves identity of {@link OrdinalGroup} instances so there's a 1-to-1 mapping of ordinals to groups allowing groups
  * to be freely compared by identity.
  */
 @ServiceScope(Scope.Build.class)

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionGraphInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionGraphInternal.java
@@ -41,7 +41,7 @@ public interface TaskExecutionGraphInternal extends TaskExecutionGraph {
     void populate(FinalizedExecutionPlan plan);
 
     /**
-     * Executes the given work. Discards the contents of this graph when completed. Should call {@link #populate)} prior to
+     * Executes the given work. Discards the contents of this graph when completed. Should call {@link #populate(FinalizedExecutionPlan)} prior to
      * calling this method.
      */
     ExecutionResult<Void> execute(FinalizedExecutionPlan plan);

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/GroovyScriptClassCompiler.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/GroovyScriptClassCompiler.java
@@ -171,11 +171,11 @@ public class GroovyScriptClassCompiler implements ScriptClassCompiler, Closeable
 
     /**
      * We want to use build cache for script compilation, but build cache might not be available yet with early execution engine.
-     * Thus settings and init scripts are not using build cache for now.<br/><br/>
-     *
+     * Thus settings and init scripts are not using build cache for now.
+     * <p>
      * When we compile project build scripts, build cache is available, but we need to query execution engine with build cache support
-     * from the project services directly to use it.<br/><br/>
-     *
+     * from the project services directly to use it.
+     * <p>
      * TODO: Remove this and just inject execution engine once we unify execution engines in https://github.com/gradle/gradle/issues/27249
      */
     private ExecutionEngine getExecutionEngine(Object target) {

--- a/subprojects/core/src/main/java/org/gradle/initialization/MixInLegacyTypesClassLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/MixInLegacyTypesClassLoader.java
@@ -125,7 +125,7 @@ public class MixInLegacyTypesClassLoader extends TransformingClassLoader {
          * the converted classes only contain these kinds of constants.
          *
          * This is a mapping of the synthesized accessor name to the name of the backing field,
-         * i.e. "getFOO" -> "FOO"
+         * i.e. "getFOO" to "FOO"
          */
         private Map<String, String> missingStaticStringConstantGetters = new HashMap<String, String>();
         private Set<String> booleanGetGetters = new HashSet<String>();

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/ClassBoundCallInterceptor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/ClassBoundCallInterceptor.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * It only intercepts the calls where the receiver is the class of interest.
  * <p>
  * It is possible but not strictly necessary to use this interceptor to intercept constructors.
- * Due to the way constructor interception works, having an {@link InterceptScope#constructorsOf(Class)
+ * Due to the way constructor interception works, having an {@link InterceptScope#constructorsOf(Class)}
  * as a scope already guarantees that the invocation would have the given class object as the receiver.
  */
 public abstract class ClassBoundCallInterceptor extends AbstractCallInterceptor {

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/DefaultCallSiteDecorator.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/DefaultCallSiteDecorator.java
@@ -246,7 +246,7 @@ public class DefaultCallSiteDecorator implements CallSiteDecorator, CallIntercep
         /**
          * The default Groovy implementation replaces the entry in the call site array with what it creates based on the call kind. <p>
          *
-         * For example, see this code path: <p>
+         * For example, see this code path:
          * <ul>
          *     <li> {@link AbstractCallSite#callCurrent(GroovyObject, Object[])}
          *     <li> {@link org.codehaus.groovy.runtime.callsite.CallSiteArray#defaultCallCurrent}

--- a/subprojects/core/src/main/java/org/gradle/internal/xml/XmlValidation.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/xml/XmlValidation.java
@@ -117,7 +117,7 @@ public class XmlValidation {
     /**
      * Verifies if a codepoint is an allowed XML char.
      *
-     * @link https://www.w3.org/TR/REC-xml/#charsets
+     * @see <a href="https://www.w3.org/TR/REC-xml/#charsets">XML Charsets</a>
      * @param c codepoint
      * @return true when the codepoint is a valid XML char
      */

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
@@ -46,7 +46,7 @@ import static org.gradle.process.internal.util.LongCommandLineDetectionUtil.hasC
 /**
  * Default implementation for the ExecHandle interface.
  *
- * <h3>State flows</h3>
+ * <h2>State flows</h2>
  *
  * <ul>
  *   <li>INIT -&gt; STARTED -&gt; [SUCCEEDED|FAILED|ABORTED|DETACHED]</li>

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/internal/HtmlDependencyReporter.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/internal/HtmlDependencyReporter.java
@@ -41,7 +41,6 @@ import java.util.Set;
  * by replacing a placeholder @js@ by the name of the generated JS file.
  * The HTML file uses a JavaScript script to generate an interactive page from the data contained in
  * the JSON structure.
- * <p>
  *
  * @see JsonProjectDependencyRenderer
  */

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/compatibility/AbstractContextualMultiVersionTestInterceptor.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/compatibility/AbstractContextualMultiVersionTestInterceptor.java
@@ -43,8 +43,6 @@ import static com.google.common.collect.Iterators.getLast;
  *     </ul>
  *     </li>
  * </ul>
- *
- * @param <T>
  */
 public abstract class AbstractContextualMultiVersionTestInterceptor<T extends VersionedTool> extends AbstractMultiTestInterceptor {
     public static final String VERSIONS_SYSPROP_NAME = "org.gradle.integtest.versions";

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
  */
 public class GroupedOutputFixture {
     /**
-     * All tasks will start with > Task, captures everything starting with : and going until end of line
+     * All tasks will start with {@code > Task}, captures everything starting with : and going until end of line
      */
     private final static String TASK_HEADER = "> Task (:[\\w:]*) ?(FAILED|FROM-CACHE|UP-TO-DATE|SKIPPED|NO-SOURCE)?\\n";
     private final static String TRANSFORM_HEADER = "> Transform (file )?([^\\n]+) with ([^\\n]+)\\n";

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyModule.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyModule.java
@@ -84,10 +84,6 @@ public interface IvyModule extends Module {
 
     /**
      * Responsible for exclusions at configuration level
-     * @param group
-     * @param module
-     * @param configuration
-     * @return
      */
     IvyModule excludeFromConfig(String group, String module, String configuration);
 

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleBuildExperimentRunner.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleBuildExperimentRunner.java
@@ -66,8 +66,6 @@ import java.util.stream.Stream;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
- * {@inheritDoc}
- *
  * This runner uses Gradle profiler to execute the actual experiment.
  */
 @CompileStatic

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleBuildExperimentRunner.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleBuildExperimentRunner.java
@@ -66,6 +66,8 @@ import java.util.stream.Stream;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
+ * {@inheritDoc}
+ *
  * This runner uses Gradle profiler to execute the actual experiment.
  */
 @CompileStatic

--- a/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/AbstractTestDirectoryProvider.java
+++ b/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/AbstractTestDirectoryProvider.java
@@ -32,8 +32,8 @@ import java.util.regex.Pattern;
  * A JUnit rule which provides a unique temporary folder for the test.
  *
  * Note: to avoid 260 char path length limitation on Windows, we should keep the test dir path as short as possible,
- * ideally < 90 chars (from repo root to test dir root, e.g. "core/build/tmp/teŝt files/{TestClass}/{testMethod}/qqlj8"),
- * or < 40 chars for "{TestClass}/{testMethod}/qqlj8"
+ * ideally less than 90 chars (from repo root to test dir root, e.g. "core/build/tmp/teŝt files/{TestClass}/{testMethod}/qqlj8"),
+ * or less than 40 chars for "{TestClass}/{testMethod}/qqlj8"
  */
 public abstract class AbstractTestDirectoryProvider implements TestRule, TestDirectoryProvider {
     protected final TestFile root;


### PR DESCRIPTION
Run the `javadoc` task during `:codeQuality`.

Many existing classes have invalid javadoc. This commit updates all javadoc to be conformant and to pass when executing the `javadoc` task.

Many errors were related to invalid header tags, where the JDK is now more strict about the ordering of these tags. e.g. h3 cannot appear without an h2 appearing before.

Another common one was an extra `<p>` tag at the end of the javadoc.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
