### PR TITLE
Update auto-applied Gradle Plugin version to 3.18

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedDevelocityPlugin.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedDevelocityPlugin.java
@@ -28,7 +28,7 @@ public final class AutoAppliedDevelocityPlugin {
 
     public static final String GROUP = "com.gradle";
     public static final String NAME = "develocity-gradle-plugin";
-    public static final String VERSION = "3.17.6";
+    public static final String VERSION = "3.18";
 
 
     public static final PluginId ID = new DefaultPluginId("com.gradle.develocity");

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
@@ -147,7 +147,8 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
         "3.17.3",
         "3.17.4",
         "3.17.5",
-        "3.17.6"
+        "3.17.6",
+        "3.18"
     ]
 
     // Current injection scripts support Develocity plugin 3.3 and above


### PR DESCRIPTION
We can't update the plugin version the build is using, yet, since we can't update ge.gradle.org to 2024.2.