### PR TITLE
Ensure CC entries are correctly cleaned up

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheCleanupIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheCleanupIntegrationTest.groovy
@@ -28,6 +28,7 @@ class ConfigurationCacheCleanupIntegrationTest
     @Issue('https://github.com/gradle/gradle/issues/23957')
     def "cleanup deletes old entries"() {
         given: 'there are two configuration cache entries'
+        executer.requireOwnGradleUserHomeDir('needs its own journal')
         executer.requireIsolatedDaemons()
         buildFile '''
             task outdated
@@ -38,17 +39,17 @@ class ConfigurationCacheCleanupIntegrationTest
         configurationCacheRunNoDaemon 'recent'
         TestFile recent = single(subDirsOf(configurationCacheDir) - outdated)
 
-        and: 'they are 15 days old'
+        and: 'they are 8 days old'
         subDirsOf(configurationCacheDir).each { TestFile dir ->
-            writeLastFileAccessTimeToJournal dir, daysAgo(15)
+            writeLastFileAccessTimeToJournal dir, daysAgo(8)
         }
 
         and: 'but one was recently accessed'
         configurationCacheRunNoDaemon 'recent'
 
-        and: 'the last cleanup was 8 days ago'
-        writeJournalInceptionTimestamp daysAgo(8)
-        gcFile.createFile().lastModified = daysAgo(8)
+        and: 'the last cleanup was 2 days ago'
+        writeJournalInceptionTimestamp daysAgo(2)
+        gcFile.createFile().lastModified = daysAgo(2)
 
         expect: 'Gradle to preserve the recent entry and to delete the outdated one'
         boolean recentEntryIsReused = true
@@ -71,11 +72,11 @@ class ConfigurationCacheCleanupIntegrationTest
     }
 
     private TestFile getGcFile() {
-        return configurationCacheDir.file("gc.properties")
+        return configurationCacheDir.file('gc.properties')
     }
 
     private TestFile getConfigurationCacheDir() {
-        return file(".gradle/configuration-cache")
+        return file('.gradle/configuration-cache')
     }
 
     private static List<TestFile> subDirsOf(TestFile dir) {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheCleanupIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheCleanupIntegrationTest.groovy
@@ -53,10 +53,10 @@ class ConfigurationCacheCleanupIntegrationTest
         expect: 'Gradle to preserve the recent entry and to delete the outdated one'
         boolean recentEntryIsReused = true
         def cc = newConfigurationCacheFixture()
-        ConcurrentTestUtil.poll(60, 0, 10) {
+        ConcurrentTestUtil.poll(120, 0.5, 5) {
             configurationCacheRunNoDaemon 'recent'
             recentEntryIsReused &= cc.reused
-            assert !outdated.isDirectory()
+            assert !outdated.exists()
         }
         recentEntryIsReused
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheBuildOperationsFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheBuildOperationsFixture.groovy
@@ -19,6 +19,8 @@ package org.gradle.integtests.fixtures.configurationcache
 import org.gradle.integtests.fixtures.BuildOperationTreeQueries
 import org.gradle.internal.operations.trace.BuildOperationRecord
 
+import javax.annotation.Nullable
+
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.CoreMatchers.nullValue
 import static org.hamcrest.MatcherAssert.assertThat
@@ -30,6 +32,10 @@ class ConfigurationCacheBuildOperationsFixture {
 
     ConfigurationCacheBuildOperationsFixture(BuildOperationTreeQueries operations) {
         this.operations = operations
+    }
+
+    boolean getReused() {
+        storeOperation() == null && loadOperation() != null
     }
 
     void assertStateLoaded() {
@@ -65,10 +71,12 @@ class ConfigurationCacheBuildOperationsFixture {
         assertThat(storeOperation(), nullValue())
     }
 
+    @Nullable
     private BuildOperationRecord loadOperation() {
         operations.firstMatchingRegex("Load (configuration cache|instant execution) state")
     }
 
+    @Nullable
     private BuildOperationRecord storeOperation() {
         operations.firstMatchingRegex("Store (configuration cache|instant execution) state.*")
     }


### PR DESCRIPTION
Fixes #23957

CC entries were being deleted unconditionally after the cache retention period, whether they have been recently accessed or not.

This PR renews a CC entry TTL whenever it is loaded by marking CC directories as accessed upon load operations.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
