### PR TITLE
Polish failure message from DaemonClient

### DIFF
--- a/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/client/DaemonClient.java
+++ b/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/client/DaemonClient.java
@@ -173,8 +173,8 @@ public class DaemonClient implements BuildActionExecutor<BuildActionParameters, 
         } catch (DaemonInitialConnectException e) {
             // This means we could not connect to the daemon we just started.  fail and don't try again
             accumulatedExceptions.add(e);
-            throw new NoUsableDaemonFoundException("A new daemon was started but could not be connected to: " +
-                "pid=" + connection.getDaemon() + ", address= " + connection.getDaemon().getAddress() + ".",
+            throw new NoUsableDaemonFoundException("A new daemon was started but could not be connected to. This is unexpected.\n" +
+                "diagnostics: " + connection.getDaemon(),
                 accumulatedExceptions);
         } finally {
             connection.stop();

--- a/platforms/core-runtime/client-services/src/test/groovy/org/gradle/launcher/daemon/client/DaemonClientTest.groovy
+++ b/platforms/core-runtime/client-services/src/test/groovy/org/gradle/launcher/daemon/client/DaemonClientTest.groovy
@@ -228,7 +228,8 @@ class DaemonClientTest extends ConcurrentSpecification {
         1 * connection2.stop()
         0 * connection3.stop()
         def exception = thrown(NoUsableDaemonFoundException)
-        exception.message.contains 'A new daemon was started but could not be connected to'
+        exception.message.contains 'A new daemon was started but could not be connected to. This is unexpected.'
         exception.resolutions[0].contains new DocumentationRegistry().getDocumentationRecommendationFor("information", "troubleshooting", "network_connection")
+        exception.causes.size() == 2
     }
 }


### PR DESCRIPTION
When we fail to send a message to the newly started daemon, explicitly say that this is unexpected and adjust message to identify long, technical output as "diagnostics" instead of "pid".

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
