### PR TITLE
Avoid Mockk in build-logic tests

### DIFF
--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/kotlindsl/kotlin-dsl-upstream-candidates.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/kotlindsl/kotlin-dsl-upstream-candidates.kt
@@ -3,6 +3,7 @@
 package gradlebuild.basics.kotlindsl
 
 import org.gradle.api.Project
+import org.gradle.process.ExecOperations
 import java.io.ByteArrayOutputStream
 import java.io.File
 
@@ -28,7 +29,22 @@ fun Project.execAndGetStdout(workingDir: File, ignoreExitValue: Boolean, vararg 
 }
 
 
+fun ExecOperations.execAndGetStdout(workingDir: File, ignoreExitValue: Boolean, vararg args: String): String {
+    val out = ByteArrayOutputStream()
+    exec {
+        isIgnoreExitValue = ignoreExitValue
+        commandLine(*args)
+        standardOutput = out
+        this.workingDir = workingDir
+    }
+    return out.toString().trim()
+}
+
+
 fun Project.execAndGetStdoutIgnoringError(vararg args: String) = execAndGetStdout(File("."), true, *args)
 
 
 fun Project.execAndGetStdout(vararg args: String) = execAndGetStdout(File("."), false, *args)
+
+
+fun ExecOperations.execAndGetStdout(vararg args: String) = execAndGetStdout(File("."), false, *args)

--- a/build-logic-commons/build-platform/build.gradle.kts
+++ b/build-logic-commons/build-platform/build.gradle.kts
@@ -58,7 +58,6 @@ dependencies {
         api("com.google.code.findbugs:jsr305:3.0.2")
         api("commons-io:commons-io:2.8.0")
         api("commons-lang:commons-lang:2.6")
-        api("io.mockk:mockk:1.12.4")
         api("javax.activation:activation:1.1.1")
         api("javax.xml.bind:jaxb-api:2.3.1")
         api("com.sun.xml.bind:jaxb-core:2.2.11")

--- a/build-logic/performance-testing/build.gradle.kts
+++ b/build-logic/performance-testing/build.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("junit:junit")
-    testImplementation("io.mockk:mockk")
 }
 
 gradlePlugin {

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -44,6 +44,7 @@ import gradlebuild.performance.generator.tasks.JvmProjectGeneratorTask
 import gradlebuild.performance.generator.tasks.ProjectGeneratorTask
 import gradlebuild.performance.generator.tasks.TemplateProjectGeneratorTask
 import gradlebuild.performance.tasks.BuildCommitDistribution
+import gradlebuild.performance.tasks.DefaultCommandExecutor
 import gradlebuild.performance.tasks.DetermineBaselines
 import gradlebuild.performance.tasks.PerformanceTest
 import gradlebuild.performance.tasks.PerformanceTestReport
@@ -319,7 +320,8 @@ class PerformanceTestPlugin : Plugin<Project> {
         // extension.baselines -> determineBaselines.configuredBaselines
         // determineBaselines.determinedBaselines -> performanceTest.baselines
         // determineBaselines.determinedBaselines -> buildCommitDistribution.baselines
-        val determineBaselines = tasks.register("determineBaselines", DetermineBaselines::class, false)
+        val commandExecutor = objects.newInstance<DefaultCommandExecutor>()
+        val determineBaselines = tasks.register("determineBaselines", DetermineBaselines::class, false, commandExecutor)
         val buildCommitDistribution = tasks.register("buildCommitDistribution", BuildCommitDistribution::class)
         val buildCommitDistributionsDir = project.getBuildEnvironmentExtension().rootProjectBuildDir.dir("commit-distributions")
 

--- a/build-logic/performance-testing/src/test/kotlin/gradlebuild/performance/tasks/DetermineBaselinesTest.kt
+++ b/build-logic/performance-testing/src/test/kotlin/gradlebuild/performance/tasks/DetermineBaselinesTest.kt
@@ -16,15 +16,10 @@
 
 package gradlebuild.performance.tasks
 
-import gradlebuild.basics.kotlindsl.execAndGetStdout
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkStatic
 import org.gradle.internal.os.OperatingSystem
 // Using star import to workaround https://youtrack.jetbrains.com/issue/KTIJ-24390
 import org.gradle.kotlin.dsl.*
 import org.gradle.testfixtures.ProjectBuilder
-import org.junit.After
 import org.junit.Assume
 import org.junit.Before
 import org.junit.Test
@@ -38,18 +33,13 @@ class DetermineBaselinesTest {
     private
     val defaultPerformanceBaselines = "7.5-commit-123456"
 
+    private
+    val commandExecutor: TestCommandExecutor = TestCommandExecutor()
+        .registerCommand(listOf("git", "remote", "-v"), "origin https://github.com/gradle/gradle.git (fetch)")
+
     @Before
     fun setUp() {
         project.file("version.txt").writeText("1.0")
-
-        // mock project.execAndGetStdout
-        mockkStatic("gradlebuild.basics.kotlindsl.Kotlin_dsl_upstream_candidatesKt")
-        mockGitOperation(listOf("git", "remote", "-v"), "origin https://github.com/gradle/gradle.git (fetch)")
-    }
-
-    @After
-    fun cleanUp() {
-        unmockkStatic("gradlebuild.basics.kotlindsl.Kotlin_dsl_upstream_candidatesKt")
     }
 
     @Test
@@ -117,11 +107,11 @@ class DetermineBaselinesTest {
 
     private
     fun createDetermineBaselinesTask(isDistributed: Boolean) =
-        project.tasks.create("determineBaselines", DetermineBaselines::class.java, isDistributed)
+        project.tasks.create("determineBaselines", DetermineBaselines::class.java, isDistributed, commandExecutor)
 
     private
     fun mockGitOperation(args: List<String>, expectedOutput: String) =
-        every { project.execAndGetStdout(*(args.toTypedArray())) } returns expectedOutput
+        commandExecutor.registerCommand(args, expectedOutput)
 
     private
     fun verifyBaselineDetermination(currentBranch: String, isCoordinatorBuild: Boolean, configuredBaseline: String?, determinedBaseline: String) {
@@ -136,5 +126,27 @@ class DetermineBaselinesTest {
 
         // then
         Assertions.assertEquals(determinedBaseline, determineBaselinesTask.determinedBaselines.get())
+    }
+
+    private
+    class TestCommandExecutor : CommandExecutor {
+
+        private
+        val commands = mutableMapOf<List<String>, String>()
+
+        override fun execAndGetStdout(vararg args: String): String {
+            val argsList = args.toList()
+            if (commands[argsList] != null) {
+                return commands[argsList]!!
+            }
+
+            val knownCommands = commands.keys.joinToString("\n") { "    - " + it.joinToString(" ") }
+            error("Unexpected command: ${args.joinToString(" ")}. Known commands:\n$knownCommands")
+        }
+
+        fun registerCommand(args: List<String>, expectedOutput: String): TestCommandExecutor {
+            commands[args] = expectedOutput
+            return this
+        }
     }
 }

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -160,7 +160,6 @@
          <trusted-key id="53C935821AA6A755BD337DB53595395EB3D8E1BA" group="org.apache.logging.log4j"/>
          <trusted-key id="55E770230E69CC6DE143FB5B62C82E50836EB3EE" group="com.github.gundy" name="semver4j"/>
          <trusted-key id="5989BAF76217B843D66BE55B2D0E1FB8FE4B68B4" group="org.eclipse.jetty"/>
-         <trusted-key id="59B06224FD8912E36603BE79FEFE78456EDDC34A" group="io.mockk"/>
          <trusted-key id="5B7F3605A8CE471A9CA8DB7EC84125C13BF6F2F2" group="^org[.]ajoberstar($|([.].*))" regex="true"/>
          <trusted-key id="5CE325996A35213326AE2C68912D2C0ECCDA55C0" group="com.google.errorprone" name="error_prone_annotations"/>
          <trusted-key id="5DE533CB43DAF8BC3E372283E7AE839CD7C58886" group="org.eclipse.jetty"/>
@@ -297,7 +296,6 @@
             <trusting group="commons-beanutils"/>
             <trusting group="org.apache-extras.beanshell"/>
          </trusted-key>
-         <trusted-key id="DF49FA14952E59A7B21931EC8EDF2667D0ECFFAF" group="io.mockk"/>
          <trusted-key id="E62231331BCA7E1F292C9B88C1B12A5D99C0729D" group="org.jetbrains"/>
          <trusted-key id="E77417AC194160A3FABD04969A259C7EE636C5ED">
             <trusting group="com.google.errorprone" name="error_prone_annotations"/>


### PR DESCRIPTION
While upgrading to Java 21, mockk was having trouble mocking static methods. Bumping the mockk version did not solve the issue, and it was easier to get rid of mock rather than determine the root cause.

Instead, we update DetermineBaselines to accept a CommandExecutor and provide a test implementation during testing.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
