### PR TITLE
Separate attribute failure handling from attribute schemas

### DIFF
--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginArtifactRepositories.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginArtifactRepositories.java
@@ -23,13 +23,10 @@ import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.artifacts.DependencyResolutionServices;
 import org.gradle.api.internal.artifacts.JavaEcosystemSupport;
 import org.gradle.api.internal.artifacts.dsl.RepositoryHandlerInternal;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.internal.Factory;
 import org.gradle.plugin.use.resolve.internal.ArtifactRepositoriesPluginResolver;
 import org.gradle.plugin.use.resolve.internal.PluginArtifactRepositories;
 import org.gradle.plugin.use.resolve.internal.PluginResolver;
-
-import java.util.Objects;
 
 class DefaultPluginArtifactRepositories implements PluginArtifactRepositories {
     private final DependencyResolutionServices dependencyResolutionServices;
@@ -40,8 +37,7 @@ class DefaultPluginArtifactRepositories implements PluginArtifactRepositories {
         dependencyResolutionServices = factory.create();
         this.sharedRepositories = sharedRepositories;
 
-        AttributesSchemaInternal attributesSchema = (AttributesSchemaInternal) Objects.requireNonNull(dependencyResolutionServices).getAttributesSchema();
-        JavaEcosystemSupport.configureSchema(attributesSchema, dependencyResolutionServices.getObjectFactory());
+        JavaEcosystemSupport.configureSchema(dependencyResolutionServices.getAttributesSchema(), dependencyResolutionServices.getAttributeDescribers(), dependencyResolutionServices.getObjectFactory());
 
         RepositoryHandler repositoryHandler = dependencyResolutionServices.getResolveRepositoryHandler();
         for (ArtifactRepository repository : sharedRepositories) {

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginArtifactRepositories.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginArtifactRepositories.java
@@ -37,7 +37,7 @@ class DefaultPluginArtifactRepositories implements PluginArtifactRepositories {
         dependencyResolutionServices = factory.create();
         this.sharedRepositories = sharedRepositories;
 
-        JavaEcosystemSupport.configureSchema(dependencyResolutionServices.getAttributesSchema(), dependencyResolutionServices.getAttributeDescribers(), dependencyResolutionServices.getObjectFactory());
+        JavaEcosystemSupport.configureServices(dependencyResolutionServices.getAttributesSchema(), dependencyResolutionServices.getAttributeDescribers(), dependencyResolutionServices.getObjectFactory());
 
         RepositoryHandler repositoryHandler = dependencyResolutionServices.getResolveRepositoryHandler();
         for (ArtifactRepository repository : sharedRepositories) {

--- a/platforms/jvm/java-platform/src/integTest/groovy/org/gradle/internal/component/model/JavaEcosystemAttributeMatcherTest.groovy
+++ b/platforms/jvm/java-platform/src/integTest/groovy/org/gradle/internal/component/model/JavaEcosystemAttributeMatcherTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.attributes.Usage
 import org.gradle.api.attributes.java.TargetJvmVersion
 import org.gradle.api.internal.artifacts.JavaEcosystemSupport
 import org.gradle.api.internal.attributes.AttributeContainerInternal
+import org.gradle.api.internal.attributes.ConfigurableAttributeDescribers
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.internal.isolation.TestIsolatableFactory
@@ -40,11 +41,12 @@ import spock.lang.Specification
  */
 class JavaEcosystemAttributeMatcherTest extends Specification {
 
+    def describers = Mock(ConfigurableAttributeDescribers)
     def schema = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), new TestIsolatableFactory())
     def explanationBuilder = Stub(AttributeMatchingExplanationBuilder)
 
     def setup() {
-        JavaEcosystemSupport.configureSchema(schema, TestUtil.objectFactory())
+        JavaEcosystemSupport.configureSchema(schema, describers, TestUtil.objectFactory())
     }
 
     def "resolve compileClasspath with java plugin"() {

--- a/platforms/jvm/java-platform/src/integTest/groovy/org/gradle/internal/component/model/JavaEcosystemAttributeMatcherTest.groovy
+++ b/platforms/jvm/java-platform/src/integTest/groovy/org/gradle/internal/component/model/JavaEcosystemAttributeMatcherTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.api.attributes.Usage
 import org.gradle.api.attributes.java.TargetJvmVersion
 import org.gradle.api.internal.artifacts.JavaEcosystemSupport
 import org.gradle.api.internal.attributes.AttributeContainerInternal
-import org.gradle.api.internal.attributes.ConfigurableAttributeDescribers
+import org.gradle.api.internal.attributes.AttributeDescriberRegistry
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.internal.isolation.TestIsolatableFactory
@@ -41,12 +41,12 @@ import spock.lang.Specification
  */
 class JavaEcosystemAttributeMatcherTest extends Specification {
 
-    def describers = Mock(ConfigurableAttributeDescribers)
+    def describers = Mock(AttributeDescriberRegistry)
     def schema = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), new TestIsolatableFactory())
     def explanationBuilder = Stub(AttributeMatchingExplanationBuilder)
 
     def setup() {
-        JavaEcosystemSupport.configureSchema(schema, describers, TestUtil.objectFactory())
+        JavaEcosystemSupport.configureServices(schema, describers, TestUtil.objectFactory())
     }
 
     def "resolve compileClasspath with java plugin"() {

--- a/platforms/jvm/jvm-services/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
+++ b/platforms/jvm/jvm-services/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
@@ -33,7 +33,7 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.attributes.java.TargetJvmEnvironment;
 import org.gradle.api.attributes.java.TargetJvmVersion;
 import org.gradle.api.internal.ReusableAction;
-import org.gradle.api.internal.attributes.AttributesSchemaWithDescribers;
+import org.gradle.api.internal.attributes.ConfigurableAttributeDescribers;
 import org.gradle.api.model.ObjectFactory;
 
 import javax.inject.Inject;
@@ -86,13 +86,13 @@ public abstract class JavaEcosystemSupport {
     @Deprecated
     public static final String DEPRECATED_JAVA_RUNTIME_RESOURCES = "java-runtime-resources";
 
-    public static void configureSchema(AttributesSchema attributesSchema, final ObjectFactory objectFactory) {
+    public static void configureSchema(AttributesSchema attributesSchema, ConfigurableAttributeDescribers attributeDescribers, final ObjectFactory objectFactory) {
         configureUsage(attributesSchema, objectFactory);
         configureLibraryElements(attributesSchema, objectFactory);
         configureBundling(attributesSchema);
         configureTargetPlatform(attributesSchema);
         configureTargetEnvironment(attributesSchema);
-        configureConsumerDescriptors((AttributesSchemaWithDescribers) attributesSchema);
+        configureConsumerDescriptors(attributeDescribers);
         attributesSchema.attributeDisambiguationPrecedence(
                 Category.CATEGORY_ATTRIBUTE,
                 Usage.USAGE_ATTRIBUTE,
@@ -103,8 +103,8 @@ public abstract class JavaEcosystemSupport {
         );
     }
 
-    private static void configureConsumerDescriptors(AttributesSchemaWithDescribers attributesSchema) {
-        attributesSchema.addConsumerDescriber(new JavaEcosystemAttributesDescriber());
+    private static void configureConsumerDescriptors(ConfigurableAttributeDescribers describers) {
+        describers.addConsumerDescriber(new JavaEcosystemAttributesDescriber());
     }
 
     private static void configureTargetPlatform(AttributesSchema attributesSchema) {

--- a/platforms/jvm/jvm-services/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
+++ b/platforms/jvm/jvm-services/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
@@ -33,7 +33,7 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.attributes.java.TargetJvmEnvironment;
 import org.gradle.api.attributes.java.TargetJvmVersion;
 import org.gradle.api.internal.ReusableAction;
-import org.gradle.api.internal.attributes.ConfigurableAttributeDescribers;
+import org.gradle.api.internal.attributes.AttributeDescriberRegistry;
 import org.gradle.api.model.ObjectFactory;
 
 import javax.inject.Inject;
@@ -86,7 +86,15 @@ public abstract class JavaEcosystemSupport {
     @Deprecated
     public static final String DEPRECATED_JAVA_RUNTIME_RESOURCES = "java-runtime-resources";
 
-    public static void configureSchema(AttributesSchema attributesSchema, ConfigurableAttributeDescribers attributeDescribers, final ObjectFactory objectFactory) {
+    /**
+     * Configure the dependency management services so that they properly participate
+     * in dependency resolution for the Jvm ecosystem.
+     */
+    public static void configureServices(
+        AttributesSchema attributesSchema,
+        AttributeDescriberRegistry attributeDescribers,
+        ObjectFactory objectFactory
+    ) {
         configureUsage(attributesSchema, objectFactory);
         configureLibraryElements(attributesSchema, objectFactory);
         configureBundling(attributesSchema);
@@ -103,8 +111,8 @@ public abstract class JavaEcosystemSupport {
         );
     }
 
-    private static void configureConsumerDescriptors(ConfigurableAttributeDescribers describers) {
-        describers.addConsumerDescriber(new JavaEcosystemAttributesDescriber());
+    private static void configureConsumerDescriptors(AttributeDescriberRegistry describers) {
+        describers.addDescriber(new JavaEcosystemAttributesDescriber());
     }
 
     private static void configureTargetPlatform(AttributesSchema attributesSchema) {

--- a/platforms/jvm/platform-jvm/src/main/java/org/gradle/api/plugins/JvmEcosystemPlugin.java
+++ b/platforms/jvm/platform-jvm/src/main/java/org/gradle/api/plugins/JvmEcosystemPlugin.java
@@ -28,6 +28,7 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.internal.component.external.model.JavaEcosystemVariantDerivationStrategy;
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
 import org.gradle.internal.component.resolution.failure.type.NoCompatibleVariantsFailure;
 
 import javax.inject.Inject;
@@ -65,8 +66,10 @@ public abstract class JvmEcosystemPlugin implements Plugin<Project> {
 
     private void configureSchema(ProjectInternal project) {
         AttributesSchemaInternal attributesSchema = (AttributesSchemaInternal) project.getDependencies().getAttributesSchema();
-        JavaEcosystemSupport.configureSchema(attributesSchema, objectFactory);
-        attributesSchema.addFailureDescriber(NoCompatibleVariantsFailure.class, TargetJVMVersionOnLibraryTooNewFailureDescriber.class);
+
+        ResolutionFailureHandler handler = project.getServices().get(ResolutionFailureHandler.class);
+        JavaEcosystemSupport.configureSchema(attributesSchema, handler, objectFactory);
+        handler.addFailureDescriber(NoCompatibleVariantsFailure.class, TargetJVMVersionOnLibraryTooNewFailureDescriber.class);
 
         project.getDependencies().getArtifactTypes().create(ArtifactTypeDefinition.JAR_TYPE).getAttributes()
             .attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME))

--- a/platforms/jvm/platform-jvm/src/main/java/org/gradle/api/plugins/JvmEcosystemPlugin.java
+++ b/platforms/jvm/platform-jvm/src/main/java/org/gradle/api/plugins/JvmEcosystemPlugin.java
@@ -23,6 +23,7 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.artifacts.JavaEcosystemSupport;
 import org.gradle.api.internal.artifacts.dsl.ComponentMetadataHandlerInternal;
 import org.gradle.api.internal.artifacts.dsl.dependencies.TargetJVMVersionOnLibraryTooNewFailureDescriber;
+import org.gradle.api.internal.attributes.AttributeDescriberRegistry;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.model.ObjectFactory;
@@ -68,7 +69,9 @@ public abstract class JvmEcosystemPlugin implements Plugin<Project> {
         AttributesSchemaInternal attributesSchema = (AttributesSchemaInternal) project.getDependencies().getAttributesSchema();
 
         ResolutionFailureHandler handler = project.getServices().get(ResolutionFailureHandler.class);
-        JavaEcosystemSupport.configureSchema(attributesSchema, handler, objectFactory);
+        AttributeDescriberRegistry attributeDescribers = project.getServices().get(AttributeDescriberRegistry.class);
+
+        JavaEcosystemSupport.configureServices(attributesSchema, attributeDescribers, objectFactory);
         handler.addFailureDescriber(NoCompatibleVariantsFailure.class, TargetJVMVersionOnLibraryTooNewFailureDescriber.class);
 
         project.getDependencies().getArtifactTypes().create(ArtifactTypeDefinition.JAR_TYPE).getAttributes()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryInteractionDependencyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryInteractionDependencyResolveIntegrationTest.groovy
@@ -32,10 +32,9 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
     def setup() {
         // apply Java ecosystem rules
         buildFile << """
-            org.gradle.api.internal.artifacts.JavaEcosystemSupport.configureSchema(
-                dependencies.attributesSchema,
-                project.objects
-            )
+            plugins {
+                id("jvm-ecosystem")
+            }
         """
     }
 
@@ -82,8 +81,8 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
 
         repos += [(repoType): repo]
         """
-        repositories { 
-            ${isMaven ? 'maven' : 'ivy'} { 
+        repositories {
+            ${isMaven ? 'maven' : 'ivy'} {
                 url "${repo.uri}"
                 metadataSources { ${gradleMetadata ? 'gradleMetadata()' : isMaven ? 'mavenPom()' : 'ivyDescriptor()'} }
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -68,6 +68,7 @@ import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDepende
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.DependencyGraphResolver;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSetResolver;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariantCache;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.DependencyGraphBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.AdhocHandlingComponentResultSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.AttributeContainerSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorFactory;
@@ -99,6 +100,7 @@ import org.gradle.api.internal.artifacts.transform.VariantSelectorFactory;
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeRegistry;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
+import org.gradle.api.internal.attributes.ConfigurableAttributeDescribers;
 import org.gradle.api.internal.attributes.DefaultAttributesSchema;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -121,7 +123,6 @@ import org.gradle.internal.buildoption.InternalOptions;
 import org.gradle.internal.component.external.model.JavaEcosystemVariantDerivationStrategy;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
 import org.gradle.internal.component.model.GraphVariantSelector;
-import org.gradle.internal.component.resolution.failure.ResolutionFailureDescriberRegistry;
 import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.execution.ExecutionEngine;
@@ -228,11 +229,13 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             registration.add(DefaultConfigurationFactory.class);
             registration.add(DefaultComponentSelectorConverter.class);
             registration.add(DefaultArtifactResolutionQueryFactory.class);
+            registration.add(DependencyGraphResolver.class);
+            registration.add(DependencyGraphBuilder.class);
         }
 
         @Provides
-        AttributesSchemaInternal createConfigurationAttributesSchema(InstantiatorFactory instantiatorFactory, IsolatableFactory isolatableFactory, PlatformSupport platformSupport, ServiceRegistry serviceRegistry) {
-            DefaultAttributesSchema attributesSchema = instantiatorFactory.decorateLenient().newInstance(DefaultAttributesSchema.class, instantiatorFactory.inject(serviceRegistry), isolatableFactory);
+        AttributesSchemaInternal createConfigurationAttributesSchema(InstantiatorFactory instantiatorFactory, IsolatableFactory isolatableFactory, PlatformSupport platformSupport) {
+            DefaultAttributesSchema attributesSchema = instantiatorFactory.decorateLenient().newInstance(DefaultAttributesSchema.class, instantiatorFactory, isolatableFactory);
             platformSupport.configureSchema(attributesSchema);
             GradlePluginVariantsSupport.configureSchema(attributesSchema);
             return attributesSchema;
@@ -533,10 +536,13 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         }
 
         @Provides
-        ResolutionFailureHandler createResolutionFailureProcessor(InstantiatorFactory instantiatorFactory, ServiceRegistry serviceRegistry, InternalProblems problemsService) {
+        ResolutionFailureHandler createResolutionFailureHandler(InstantiatorFactory instantiatorFactory, ServiceRegistry serviceRegistry, InternalProblems problemsService) {
             InstanceGenerator instanceGenerator = instantiatorFactory.inject(serviceRegistry);
-            ResolutionFailureDescriberRegistry failureDescriberRegistry = ResolutionFailureDescriberRegistry.standardRegistry(instanceGenerator);
-            return new ResolutionFailureHandler(failureDescriberRegistry, problemsService);
+
+            ResolutionFailureHandler handler = new ResolutionFailureHandler(instanceGenerator, problemsService);
+            GradlePluginVariantsSupport.configureFailureHandler(handler);
+            PlatformSupport.configureFailureHandler(handler);
+            return handler;
         }
 
         @Provides
@@ -685,6 +691,11 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         @Override
         public DependencyFactory getDependencyFactory() {
             return services.get(DependencyFactory.class);
+        }
+
+        @Override
+        public ConfigurableAttributeDescribers getAttributeDescribers() {
+            return services.get(ResolutionFailureHandler.class);
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -100,7 +100,7 @@ import org.gradle.api.internal.artifacts.transform.VariantSelectorFactory;
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeRegistry;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
-import org.gradle.api.internal.attributes.ConfigurableAttributeDescribers;
+import org.gradle.api.internal.attributes.AttributeDescriberRegistry;
 import org.gradle.api.internal.attributes.DefaultAttributesSchema;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -231,6 +231,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             registration.add(DefaultArtifactResolutionQueryFactory.class);
             registration.add(DependencyGraphResolver.class);
             registration.add(DependencyGraphBuilder.class);
+            registration.add(AttributeDescriberRegistry.class);
         }
 
         @Provides
@@ -694,8 +695,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         }
 
         @Override
-        public ConfigurableAttributeDescribers getAttributeDescribers() {
-            return services.get(ResolutionFailureHandler.class);
+        public AttributeDescriberRegistry getAttributeDescribers() {
+            return services.get(AttributeDescriberRegistry.class);
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -43,12 +43,10 @@ import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleMetadataSe
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleSourcesSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.SuppliedComponentMetadataSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.DefaultProjectPublicationRegistry;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.DependencyGraphResolver;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSetResolver;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariantCache;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.DependencyGraphBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.AttributeContainerSerializer;
 import org.gradle.api.internal.artifacts.mvnsettings.DefaultLocalMavenRepositoryLocator;
 import org.gradle.api.internal.artifacts.mvnsettings.DefaultMavenFileLocations;
@@ -81,7 +79,6 @@ import org.gradle.api.internal.resources.ApiTextResourceAdapter;
 import org.gradle.api.internal.runtimeshaded.RuntimeShadedJarFactory;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.cache.internal.CleaningInMemoryCacheDecoratorFactory;
 import org.gradle.cache.internal.GeneratedGradleJarCache;
 import org.gradle.cache.internal.InMemoryCacheDecoratorFactory;
@@ -95,17 +92,12 @@ import org.gradle.internal.classpath.ClasspathBuilder;
 import org.gradle.internal.classpath.ClasspathWalker;
 import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
-import org.gradle.internal.component.model.GraphVariantSelector;
-import org.gradle.internal.component.resolution.failure.ResolutionFailureDescriberRegistry;
-import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.execution.ExecutionEngine;
 import org.gradle.internal.execution.InputFingerprinter;
 import org.gradle.internal.file.RelativeFilePathResolver;
 import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.hash.FileHasher;
-import org.gradle.internal.instantiation.InstanceGenerator;
-import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.management.DefaultDependencyResolutionManagement;
 import org.gradle.internal.management.DependencyResolutionManagementInternal;
@@ -147,9 +139,7 @@ class DependencyManagementBuildScopeServices implements ServiceRegistrationProvi
         registration.add(TransformStepNodeDependencyResolver.class);
         registration.add(DefaultProjectPublicationRegistry.class);
         registration.add(FileResourceConnector.class);
-        registration.add(DependencyGraphResolver.class);
         registration.add(ResolvedArtifactSetResolver.class);
-        registration.add(DependencyGraphBuilder.class);
         registration.add(ExternalModuleComponentResolverFactory.class);
     }
 
@@ -352,18 +342,6 @@ class DependencyManagementBuildScopeServices implements ServiceRegistrationProvi
                 return map.computeIfAbsent(key, mappingFunction);
             }
         };
-    }
-
-    @Provides
-    ResolutionFailureHandler createResolutionFailureProcessor(InstantiatorFactory instantiatorFactory, ServiceRegistry serviceRegistry, InternalProblems problemsService) {
-        InstanceGenerator instanceGenerator = instantiatorFactory.inject(serviceRegistry);
-        ResolutionFailureDescriberRegistry failureDescriberRegistry = ResolutionFailureDescriberRegistry.standardRegistry(instanceGenerator);
-        return new ResolutionFailureHandler(failureDescriberRegistry, problemsService);
-    }
-
-    @Provides
-    GraphVariantSelector createGraphVariantSelector(ResolutionFailureHandler resolutionFailureHandler) {
-        return new GraphVariantSelector(resolutionFailureHandler);
     }
 
     @Provides

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/GradlePluginVariantsSupport.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/GradlePluginVariantsSupport.java
@@ -19,22 +19,25 @@ package org.gradle.api.internal.artifacts.dsl.dependencies;
 import org.gradle.api.attributes.AttributeCompatibilityRule;
 import org.gradle.api.attributes.AttributeDisambiguationRule;
 import org.gradle.api.attributes.AttributeMatchingStrategy;
+import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.attributes.CompatibilityCheckDetails;
 import org.gradle.api.attributes.MultipleCandidatesDetails;
 import org.gradle.api.attributes.plugin.GradlePluginApiVersion;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
 import org.gradle.internal.component.resolution.failure.type.NoCompatibleVariantsFailure;
 import org.gradle.util.GradleVersion;
 
 public class GradlePluginVariantsSupport {
 
-    public static void configureSchema(AttributesSchemaInternal attributesSchema) {
+    public static void configureSchema(AttributesSchema attributesSchema) {
         AttributeMatchingStrategy<GradlePluginApiVersion> strategy = attributesSchema.attribute(GradlePluginApiVersion.GRADLE_PLUGIN_API_VERSION_ATTRIBUTE);
         strategy.getCompatibilityRules().add(TargetGradleVersionCompatibilityRule.class);
         strategy.getDisambiguationRules().add(TargetGradleVersionDisambiguationRule.class);
+    }
 
-        attributesSchema.addFailureDescriber(NoCompatibleVariantsFailure.class, NewerGradleNeededByPluginFailureDescriber.class);
-        attributesSchema.addFailureDescriber(NoCompatibleVariantsFailure.class, TargetJVMVersionOnPluginTooNewFailureDescriber.class);
+    public static void configureFailureHandler(ResolutionFailureHandler handler)  {
+        handler.addFailureDescriber(NoCompatibleVariantsFailure.class, NewerGradleNeededByPluginFailureDescriber.class);
+        handler.addFailureDescriber(NoCompatibleVariantsFailure.class, TargetJVMVersionOnPluginTooNewFailureDescriber.class);
     }
 
     public static class TargetGradleVersionCompatibilityRule implements AttributeCompatibilityRule<GradlePluginApiVersion> {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/NewerGradleNeededByPluginFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/NewerGradleNeededByPluginFailureDescriber.java
@@ -17,15 +17,15 @@
 package org.gradle.api.internal.artifacts.dsl.dependencies;
 
 import org.gradle.api.attributes.plugin.GradlePluginApiVersion;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
+import org.gradle.api.internal.attributes.AttributeDescriber;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor.AssessedAttribute;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor.AssessedCandidate;
 import org.gradle.internal.component.resolution.failure.describer.AbstractResolutionFailureDescriber;
 import org.gradle.internal.component.resolution.failure.describer.ResolutionFailureDescriber;
 import org.gradle.internal.component.resolution.failure.exception.AbstractResolutionFailureException;
 import org.gradle.internal.component.resolution.failure.exception.VariantSelectionByAttributesException;
-import org.gradle.internal.component.resolution.failure.type.NoCompatibleVariantsFailure;
 import org.gradle.internal.component.resolution.failure.interfaces.ResolutionFailure;
+import org.gradle.internal.component.resolution.failure.type.NoCompatibleVariantsFailure;
 import org.gradle.util.GradleVersion;
 
 import java.util.Comparator;
@@ -50,7 +50,7 @@ public abstract class NewerGradleNeededByPluginFailureDescriber extends Abstract
     }
 
     @Override
-    public AbstractResolutionFailureException describeFailure(NoCompatibleVariantsFailure failure, Optional<AttributesSchemaInternal> schema) {
+    public AbstractResolutionFailureException describeFailure(NoCompatibleVariantsFailure failure, List<AttributeDescriber> attributeDescribers) {
         GradleVersion minGradleApiVersionSupportedByPlugin = findMinGradleVersionSupportedByPlugin(failure.getCandidates());
         String message = buildPluginNeedsNewerGradleVersionFailureMsg(failure.describeRequestTarget(), minGradleApiVersionSupportedByPlugin);
         List<String> resolutions = buildResolutions(suggestUpdateGradle(minGradleApiVersionSupportedByPlugin), suggestDowngradePlugin(failure.describeRequestTarget()));

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/NewerGradleNeededByPluginFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/NewerGradleNeededByPluginFailureDescriber.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.dsl.dependencies;
 
 import org.gradle.api.attributes.plugin.GradlePluginApiVersion;
-import org.gradle.api.internal.attributes.AttributeDescriber;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor.AssessedAttribute;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor.AssessedCandidate;
 import org.gradle.internal.component.resolution.failure.describer.AbstractResolutionFailureDescriber;
@@ -50,7 +49,7 @@ public abstract class NewerGradleNeededByPluginFailureDescriber extends Abstract
     }
 
     @Override
-    public AbstractResolutionFailureException describeFailure(NoCompatibleVariantsFailure failure, List<AttributeDescriber> attributeDescribers) {
+    public AbstractResolutionFailureException describeFailure(NoCompatibleVariantsFailure failure) {
         GradleVersion minGradleApiVersionSupportedByPlugin = findMinGradleVersionSupportedByPlugin(failure.getCandidates());
         String message = buildPluginNeedsNewerGradleVersionFailureMsg(failure.describeRequestTarget(), minGradleApiVersionSupportedByPlugin);
         List<String> resolutions = buildResolutions(suggestUpdateGradle(minGradleApiVersionSupportedByPlugin), suggestDowngradePlugin(failure.describeRequestTarget()));

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/PlatformSupport.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/PlatformSupport.java
@@ -27,6 +27,7 @@ import org.gradle.api.internal.artifacts.repositories.metadata.MavenImmutableAtt
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.internal.component.external.model.ComponentVariant;
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
 import org.gradle.internal.component.resolution.failure.type.NoCompatibleVariantsFailure;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
@@ -57,7 +58,12 @@ public class PlatformSupport {
 
     public void configureSchema(AttributesSchemaInternal attributesSchema) {
         configureCategoryDisambiguationRule(attributesSchema);
-        attributesSchema.addFailureDescriber(NoCompatibleVariantsFailure.class, TargetJVMVersionOnLibraryTooNewFailureDescriber.class);
+    }
+    public static void configureFailureHandler(ResolutionFailureHandler handler) {
+        // TODO: This should not be here.
+        // This failure handler has nothing to do with platforms.
+        // This should live in JavaEcosystemSupport.
+        handler.addFailureDescriber(NoCompatibleVariantsFailure.class, TargetJVMVersionOnLibraryTooNewFailureDescriber.class);
     }
 
     private void configureCategoryDisambiguationRule(AttributesSchema attributesSchema) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/TargetJVMVersionOnLibraryTooNewFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/TargetJVMVersionOnLibraryTooNewFailureDescriber.java
@@ -19,16 +19,15 @@ package org.gradle.api.internal.artifacts.dsl.dependencies;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.attributes.java.TargetJvmVersion;
 import org.gradle.api.attributes.plugin.GradlePluginApiVersion;
+import org.gradle.api.internal.attributes.AttributeDescriber;
 import org.gradle.api.internal.attributes.AttributeValue;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.internal.component.resolution.failure.describer.ResolutionFailureDescriber;
 import org.gradle.internal.component.resolution.failure.exception.AbstractResolutionFailureException;
 import org.gradle.internal.component.resolution.failure.exception.VariantSelectionByAttributesException;
-import org.gradle.internal.component.resolution.failure.type.NoCompatibleVariantsFailure;
 import org.gradle.internal.component.resolution.failure.interfaces.ResolutionFailure;
+import org.gradle.internal.component.resolution.failure.type.NoCompatibleVariantsFailure;
 
 import java.util.List;
-import java.util.Optional;
 
 /**
  * A {@link ResolutionFailureDescriber} that describes a {@link ResolutionFailure} caused by a requested library
@@ -57,7 +56,7 @@ public abstract class TargetJVMVersionOnLibraryTooNewFailureDescriber extends Ab
     }
 
     @Override
-    public AbstractResolutionFailureException describeFailure(NoCompatibleVariantsFailure failure, Optional<AttributesSchemaInternal> schema) {
+    public AbstractResolutionFailureException describeFailure(NoCompatibleVariantsFailure failure, List<AttributeDescriber> attributeDescribers) {
         JavaVersion minJVMVersionSupported = findMinJVMSupported(failure.getCandidates()).orElseThrow(IllegalStateException::new);
         JavaVersion requestedJVMVersion = getJVMVersion(failure);
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/TargetJVMVersionOnLibraryTooNewFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/TargetJVMVersionOnLibraryTooNewFailureDescriber.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.artifacts.dsl.dependencies;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.attributes.java.TargetJvmVersion;
 import org.gradle.api.attributes.plugin.GradlePluginApiVersion;
-import org.gradle.api.internal.attributes.AttributeDescriber;
 import org.gradle.api.internal.attributes.AttributeValue;
 import org.gradle.internal.component.resolution.failure.describer.ResolutionFailureDescriber;
 import org.gradle.internal.component.resolution.failure.exception.AbstractResolutionFailureException;
@@ -56,7 +55,7 @@ public abstract class TargetJVMVersionOnLibraryTooNewFailureDescriber extends Ab
     }
 
     @Override
-    public AbstractResolutionFailureException describeFailure(NoCompatibleVariantsFailure failure, List<AttributeDescriber> attributeDescribers) {
+    public AbstractResolutionFailureException describeFailure(NoCompatibleVariantsFailure failure) {
         JavaVersion minJVMVersionSupported = findMinJVMSupported(failure.getCandidates()).orElseThrow(IllegalStateException::new);
         JavaVersion requestedJVMVersion = getJVMVersion(failure);
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/TargetJVMVersionOnPluginTooNewFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/TargetJVMVersionOnPluginTooNewFailureDescriber.java
@@ -19,15 +19,14 @@ package org.gradle.api.internal.artifacts.dsl.dependencies;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.attributes.java.TargetJvmVersion;
 import org.gradle.api.attributes.plugin.GradlePluginApiVersion;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
+import org.gradle.api.internal.attributes.AttributeDescriber;
 import org.gradle.internal.component.resolution.failure.describer.ResolutionFailureDescriber;
 import org.gradle.internal.component.resolution.failure.exception.AbstractResolutionFailureException;
 import org.gradle.internal.component.resolution.failure.exception.VariantSelectionByAttributesException;
-import org.gradle.internal.component.resolution.failure.type.NoCompatibleVariantsFailure;
 import org.gradle.internal.component.resolution.failure.interfaces.ResolutionFailure;
+import org.gradle.internal.component.resolution.failure.type.NoCompatibleVariantsFailure;
 
 import java.util.List;
-import java.util.Optional;
 
 /**
  * A {@link ResolutionFailureDescriber} that describes a {@link ResolutionFailure} caused by a requested <strong>plugin</strong>
@@ -58,7 +57,7 @@ public abstract class TargetJVMVersionOnPluginTooNewFailureDescriber extends Abs
     }
 
     @Override
-    public AbstractResolutionFailureException describeFailure(NoCompatibleVariantsFailure failure, Optional<AttributesSchemaInternal> schema) {
+    public AbstractResolutionFailureException describeFailure(NoCompatibleVariantsFailure failure, List<AttributeDescriber> attributeDescribers) {
         JavaVersion minJVMVersionSupported = findMinJVMSupported(failure.getCandidates()).orElseThrow(IllegalStateException::new);
         String message = buildNeedsNewerJDKFailureMsg(minJVMVersionSupported);
         List<String> resolutions = buildResolutions(suggestUpdateJVM(minJVMVersionSupported));

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/TargetJVMVersionOnPluginTooNewFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/TargetJVMVersionOnPluginTooNewFailureDescriber.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.artifacts.dsl.dependencies;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.attributes.java.TargetJvmVersion;
 import org.gradle.api.attributes.plugin.GradlePluginApiVersion;
-import org.gradle.api.internal.attributes.AttributeDescriber;
 import org.gradle.internal.component.resolution.failure.describer.ResolutionFailureDescriber;
 import org.gradle.internal.component.resolution.failure.exception.AbstractResolutionFailureException;
 import org.gradle.internal.component.resolution.failure.exception.VariantSelectionByAttributesException;
@@ -57,7 +56,7 @@ public abstract class TargetJVMVersionOnPluginTooNewFailureDescriber extends Abs
     }
 
     @Override
-    public AbstractResolutionFailureException describeFailure(NoCompatibleVariantsFailure failure, List<AttributeDescriber> attributeDescribers) {
+    public AbstractResolutionFailureException describeFailure(NoCompatibleVariantsFailure failure) {
         JavaVersion minJVMVersionSupported = findMinJVMSupported(failure.getCandidates()).orElseThrow(IllegalStateException::new);
         String message = buildNeedsNewerJDKFailureMsg(minJVMVersionSupported);
         List<String> resolutions = buildResolutions(suggestUpdateJVM(minJVMVersionSupported));

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -514,7 +514,7 @@ public class DependencyGraphBuilder {
             Set<VariantGraphResolveMetadata> incompatibleNodeMetadatas = incompatibleNodes.stream()
                 .map(NodeState::getMetadata)
                 .collect(Collectors.toSet());
-            AbstractResolutionFailureException variantsSelectionException = resolutionFailureHandler.incompatibleMultipleNodesValidationFailure(consumerSchema, selected.getMetadata(), incompatibleNodeMetadatas);
+            AbstractResolutionFailureException variantsSelectionException = resolutionFailureHandler.incompatibleMultipleNodesValidationFailure(matcher, selected.getMetadata(), incompatibleNodeMetadatas);
             for (EdgeState edge : module.getIncomingEdges()) {
                 edge.failWith(variantsSelectionException);
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelector.java
@@ -68,7 +68,7 @@ public class AttributeMatchingArtifactVariantSelector implements ArtifactVariant
         try {
             return doSelect(producer, allowNoMatchingVariants, resolvedArtifactTransformer, AttributeMatchingExplanationBuilder.logging(), requestAttributes);
         } catch (Exception t) {
-            return new BrokenResolvedArtifactSet(failureProcessor.unknownArtifactVariantSelectionFailure(schema, producer, requestAttributes, t));
+            return new BrokenResolvedArtifactSet(failureProcessor.unknownArtifactVariantSelectionFailure(producer, requestAttributes, t));
         }
     }
 
@@ -81,7 +81,7 @@ public class AttributeMatchingArtifactVariantSelector implements ArtifactVariant
         if (matches.size() == 1) {
             return matches.get(0).getArtifacts();
         } else if (matches.size() > 1) {
-            throw failureProcessor.ambiguousArtifactsFailure(schema, matcher, producer, componentRequested, matches);
+            throw failureProcessor.ambiguousArtifactsFailure(matcher, producer, componentRequested, matches);
         }
 
         // We found no matches. Attempt to construct artifact transform chains which produce matching variants.
@@ -98,14 +98,14 @@ public class AttributeMatchingArtifactVariantSelector implements ArtifactVariant
         }
 
         if (!transformedVariants.isEmpty()) {
-            throw failureProcessor.ambiguousArtifactTransformsFailure(schema, producer, componentRequested, transformedVariants);
+            throw failureProcessor.ambiguousArtifactTransformsFailure(producer, componentRequested, transformedVariants);
         }
 
         if (allowNoMatchingVariants) {
             return ResolvedArtifactSet.EMPTY;
         }
 
-        throw failureProcessor.noCompatibleArtifactFailure(schema, matcher, producer, componentRequested, variants);
+        throw failureProcessor.noCompatibleArtifactFailure(matcher, producer, componentRequested, variants);
     }
 
     /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/AttributesSchemaInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/AttributesSchemaInternal.java
@@ -17,14 +17,12 @@
 package org.gradle.api.internal.attributes;
 
 import org.gradle.api.attributes.Attribute;
-import org.gradle.internal.component.resolution.failure.interfaces.ResolutionFailure;
+import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.internal.component.model.AttributeMatcher;
-import org.gradle.internal.component.resolution.failure.describer.ResolutionFailureDescriber;
 
 import javax.annotation.Nullable;
-import java.util.List;
 
-public interface AttributesSchemaInternal extends AttributesSchemaWithDescribers {
+public interface AttributesSchemaInternal extends AttributesSchema {
     /**
      * Returns a matcher that uses the consumer rules from this schema, and the producer rules from the given schema.
      */
@@ -41,25 +39,4 @@ public interface AttributesSchemaInternal extends AttributesSchemaWithDescribers
 
     @Nullable
     Attribute<?> getAttributeByName(String name);
-
-    /**
-     * Adds a {@link ResolutionFailureDescriber} for the given failure type to the custom describers
-     * registered on this schema.
-     *
-     * If variant selection failures occur, these describers will be available to describe the failures.
-     *
-     * @param failureType The type of failure to describe
-     * @param describerType A describer that can potentially describe failures of the given type
-     * @param <FAILURE> The type of failure to describe
-     */
-    <FAILURE extends ResolutionFailure> void addFailureDescriber(Class<FAILURE> failureType, Class<? extends ResolutionFailureDescriber<FAILURE>> describerType);
-
-    /**
-     * Returns the list of custom {@link ResolutionFailureDescriber}s registered on this schema for the given failure type.
-     *
-     * @param failureType The type of failure to describe
-     * @param <FAILURE> The type of failure to describe
-     * @return The list of custom describers registered on this schema for the given failure type
-     */
-    <FAILURE extends ResolutionFailure> List<ResolutionFailureDescriber<FAILURE>> getFailureDescribers(Class<FAILURE> failureType);
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesSchema.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesSchema.java
@@ -27,10 +27,6 @@ import org.gradle.internal.component.model.AttributeSelectionUtils;
 import org.gradle.internal.component.model.DefaultAttributeMatcher;
 import org.gradle.internal.component.model.DefaultCompatibilityCheckResult;
 import org.gradle.internal.component.model.DefaultMultipleCandidateResult;
-import org.gradle.internal.component.resolution.failure.interfaces.ResolutionFailure;
-import org.gradle.internal.component.resolution.failure.ResolutionFailureDescriberRegistry;
-import org.gradle.internal.component.resolution.failure.describer.ResolutionFailureDescriber;
-import org.gradle.internal.instantiation.InstanceGenerator;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.isolation.IsolatableFactory;
 
@@ -52,23 +48,16 @@ import java.util.stream.IntStream;
 public class DefaultAttributesSchema implements AttributesSchemaInternal {
     private final InstantiatorFactory instantiatorFactory;
     private final IsolatableFactory isolatableFactory;
-    private final ResolutionFailureDescriberRegistry failureDescriberRegistry;
 
     private final Map<Attribute<?>, AttributeMatchingStrategy<?>> strategies = new HashMap<>();
     private final Map<String, Attribute<?>> attributesByName = new HashMap<>();
-    private final List<AttributeDescriber> consumerAttributeDescribers = new ArrayList<>();
     private final Set<Attribute<?>> precedence = new LinkedHashSet<>();
 
     private final Map<AttributesSchemaInternal, AttributeMatcher> matcherCache = new ConcurrentHashMap<>();
 
     public DefaultAttributesSchema(InstantiatorFactory instantiatorFactory, IsolatableFactory isolatableFactory) {
-        this(instantiatorFactory, instantiatorFactory.inject(), isolatableFactory);
-    }
-
-    public DefaultAttributesSchema(InstantiatorFactory instantiatorFactory, InstanceGenerator instanceGenerator, IsolatableFactory isolatableFactory) {
         this.instantiatorFactory = instantiatorFactory;
         this.isolatableFactory = isolatableFactory;
-        this.failureDescriberRegistry = ResolutionFailureDescriberRegistry.emptyRegistry(instanceGenerator);
     }
 
     @Override
@@ -139,16 +128,6 @@ public class DefaultAttributesSchema implements AttributesSchemaInternal {
     }
 
     @Override
-    public List<AttributeDescriber> getConsumerDescribers() {
-        return consumerAttributeDescribers;
-    }
-
-    @Override
-    public void addConsumerDescriber(AttributeDescriber describer) {
-        consumerAttributeDescribers.add(describer);
-    }
-
-    @Override
     public void attributeDisambiguationPrecedence(Attribute<?>... attributes) {
         for (Attribute<?> attribute : attributes) {
             if (!precedence.add(attribute)) {
@@ -172,16 +151,6 @@ public class DefaultAttributesSchema implements AttributesSchemaInternal {
     @Override
     public Attribute<?> getAttributeByName(String name) {
         return attributesByName.get(name);
-    }
-
-    @Override
-    public <FAILURE extends ResolutionFailure> void addFailureDescriber(Class<FAILURE> failureType, Class<? extends ResolutionFailureDescriber<FAILURE>> describerType) {
-        failureDescriberRegistry.registerDescriber(failureType, describerType);
-    }
-
-    @Override
-    public <FAILURE extends ResolutionFailure> List<ResolutionFailureDescriber<FAILURE>> getFailureDescribers(Class<FAILURE> failureType) {
-        return failureDescriberRegistry.getDescribers(failureType);
     }
 
     // TODO: Move this out into its own class so it can be unit tested directly.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/EmptySchema.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/EmptySchema.java
@@ -19,9 +19,7 @@ package org.gradle.api.internal.attributes;
 import org.gradle.api.Action;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeMatchingStrategy;
-import org.gradle.internal.component.resolution.failure.interfaces.ResolutionFailure;
 import org.gradle.internal.component.model.AttributeMatcher;
-import org.gradle.internal.component.resolution.failure.describer.ResolutionFailureDescriber;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -45,16 +43,6 @@ public class EmptySchema implements AttributesSchemaInternal {
     @Override
     public DisambiguationRule<Object> disambiguationRules(Attribute<?> attribute) {
         return disambiguationRule;
-    }
-
-    @Override
-    public List<AttributeDescriber> getConsumerDescribers() {
-        return Collections.emptyList();
-    }
-
-    @Override
-    public void addConsumerDescriber(AttributeDescriber describer) {
-        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -111,16 +99,6 @@ public class EmptySchema implements AttributesSchemaInternal {
     @Override
     public Attribute<?> getAttributeByName(String name) {
         return null;
-    }
-
-    @Override
-    public <FAILURE extends ResolutionFailure> void addFailureDescriber(Class<FAILURE> failureType, Class<? extends ResolutionFailureDescriber<FAILURE>> describerType) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public <FAILURE extends ResolutionFailure> List<ResolutionFailureDescriber<FAILURE>> getFailureDescribers(Class<FAILURE> failureType) {
-        return Collections.emptyList();
     }
 
     private static class DoNothingCompatibilityRule implements CompatibilityRule<Object> {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeDescriberSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeDescriberSelector.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Sets;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributeDescriber;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 
 import java.util.Comparator;
 import java.util.List;
@@ -28,16 +27,15 @@ import java.util.Map;
 import java.util.Set;
 
 public class AttributeDescriberSelector {
-    public static AttributeDescriber selectDescriber(AttributeContainerInternal consumerAttributes, AttributesSchemaInternal consumerSchema) {
-        List<AttributeDescriber> consumerDescribers = consumerSchema.getConsumerDescribers();
+    public static AttributeDescriber selectDescriber(AttributeContainerInternal consumerAttributes, List<AttributeDescriber> attributeDescribers) {
         Set<Attribute<?>> consumerAttributeSet = consumerAttributes.keySet();
         AttributeDescriber current = null;
         int maxSize = 0;
-        for (AttributeDescriber consumerDescriber : consumerDescribers) {
-            int size = Sets.intersection(consumerDescriber.getDescribableAttributes(), consumerAttributeSet).size();
+        for (AttributeDescriber describer : attributeDescribers) {
+            int size = Sets.intersection(describer.getDescribableAttributes(), consumerAttributeSet).size();
             if (size > maxSize) {
                 // Select the describer which handles the maximum number of attributes
-                current = consumerDescriber;
+                current = describer;
                 maxSize = size;
             }
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/GraphVariantSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/GraphVariantSelector.java
@@ -80,7 +80,7 @@ public class GraphVariantSelector {
             ComponentGraphResolveMetadata targetComponent = targetComponentState.getMetadata();
             AttributeMatcher attributeMatcher = consumerSchema.withProducer(targetComponent.getAttributesSchema());
             GraphSelectionCandidates candidates = targetComponentState.getCandidatesForGraphVariantSelection();
-            throw failureHandler.noCompatibleVariantsFailure(consumerSchema, attributeMatcher, targetComponentState, consumerAttributes, ImmutableCapabilities.of(explicitRequestedCapabilities), candidates);
+            throw failureHandler.noCompatibleVariantsFailure(attributeMatcher, targetComponentState, consumerAttributes, ImmutableCapabilities.of(explicitRequestedCapabilities), candidates);
         }
 
         return result;
@@ -103,7 +103,7 @@ public class GraphVariantSelector {
         List<? extends VariantGraphResolveState> allVariants = candidates.getVariantsForAttributeMatching();
         ImmutableList<VariantGraphResolveState> variantsProvidingRequestedCapabilities = filterVariantsByRequestedCapabilities(targetComponent, explicitRequestedCapabilities, allVariants, true);
         if (variantsProvidingRequestedCapabilities.isEmpty()) {
-            throw failureHandler.noVariantsWithMatchingCapabilitiesFailure(consumerSchema, attributeMatcher, targetComponentState, consumerAttributes, ImmutableCapabilities.of(explicitRequestedCapabilities), allVariants);
+            throw failureHandler.noVariantsWithMatchingCapabilitiesFailure(attributeMatcher, targetComponentState, consumerAttributes, ImmutableCapabilities.of(explicitRequestedCapabilities), allVariants);
         }
 
         List<VariantGraphResolveState> matches = attributeMatcher.matchMultipleCandidates(variantsProvidingRequestedCapabilities, consumerAttributes, AttributeMatchingExplanationBuilder.logging());
@@ -143,7 +143,7 @@ public class GraphVariantSelector {
         }
 
         if (!matches.isEmpty()) {
-            throw failureHandler.ambiguousVariantsFailure(consumerSchema, attributeMatcher, targetComponentState, consumerAttributes, ImmutableCapabilities.of(explicitRequestedCapabilities), matches);
+            throw failureHandler.ambiguousVariantsFailure(attributeMatcher, targetComponentState, consumerAttributes, ImmutableCapabilities.of(explicitRequestedCapabilities), matches);
         }
 
         return null;
@@ -158,7 +158,7 @@ public class GraphVariantSelector {
             // We wanted to do variant matching, but there were no variants in the target component.
             // So, we fell back to looking for the legacy (`default`) configuration, but it didn't exist.
             // So, there are no variants to select from, and selection fails here.
-            throw failureHandler.noVariantsFailure(consumerSchema, consumerSchema.matcher(), targetComponentState, consumerAttributes, ImmutableCapabilities.EMPTY, targetComponentState.getCandidatesForGraphVariantSelection());
+            throw failureHandler.noVariantsFailure(targetComponentState, consumerAttributes, ImmutableCapabilities.EMPTY);
         }
 
         validateVariantAttributes(conf, consumerAttributes, targetComponentState, consumerSchema);
@@ -199,7 +199,7 @@ public class GraphVariantSelector {
         if (!consumerAttributes.isEmpty() && !conf.getAttributes().isEmpty()) {
             // Need to validate that the selected configuration still matches the consumer attributes
             if (!attributeMatcher.isMatchingCandidate(conf.getAttributes(), consumerAttributes)) {
-                throw failureHandler.configurationNotCompatibleFailure(consumerSchema, attributeMatcher, targetComponentState, conf, consumerAttributes, conf.getCapabilities());
+                throw failureHandler.configurationNotCompatibleFailure(attributeMatcher, targetComponentState, conf, consumerAttributes, conf.getCapabilities());
             }
         }
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionFailureHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionFailureHandler.java
@@ -22,7 +22,9 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Resol
 import org.gradle.api.internal.artifacts.transform.AttributeMatchingArtifactVariantSelector;
 import org.gradle.api.internal.artifacts.transform.TransformedVariant;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.AttributeDescriber;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
+import org.gradle.api.internal.attributes.ConfigurableAttributeDescribers;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.catalog.problems.ResolutionFailureProblemId;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
@@ -42,21 +44,22 @@ import org.gradle.internal.component.resolution.failure.exception.AbstractResolu
 import org.gradle.internal.component.resolution.failure.interfaces.ResolutionFailure;
 import org.gradle.internal.component.resolution.failure.type.AmbiguousArtifactTransformsFailure;
 import org.gradle.internal.component.resolution.failure.type.AmbiguousArtifactsFailure;
-import org.gradle.internal.component.resolution.failure.type.NoCompatibleVariantsFailure;
-import org.gradle.internal.component.resolution.failure.type.IncompatibleMultipleNodesValidationFailure;
-import org.gradle.internal.component.resolution.failure.type.ConfigurationNotCompatibleFailure;
-import org.gradle.internal.component.resolution.failure.type.NoCompatibleArtifactFailure;
-import org.gradle.internal.component.resolution.failure.type.NoVariantsWithMatchingCapabilitiesFailure;
-import org.gradle.internal.component.resolution.failure.type.ConfigurationDoesNotExistFailure;
-import org.gradle.internal.component.resolution.failure.type.UnknownArtifactSelectionFailure;
 import org.gradle.internal.component.resolution.failure.type.AmbiguousVariantsFailure;
+import org.gradle.internal.component.resolution.failure.type.ConfigurationDoesNotExistFailure;
+import org.gradle.internal.component.resolution.failure.type.ConfigurationNotCompatibleFailure;
+import org.gradle.internal.component.resolution.failure.type.IncompatibleMultipleNodesValidationFailure;
+import org.gradle.internal.component.resolution.failure.type.NoCompatibleArtifactFailure;
+import org.gradle.internal.component.resolution.failure.type.NoCompatibleVariantsFailure;
+import org.gradle.internal.component.resolution.failure.type.NoVariantsWithMatchingCapabilitiesFailure;
+import org.gradle.internal.component.resolution.failure.type.UnknownArtifactSelectionFailure;
+import org.gradle.internal.instantiation.InstanceGenerator;
 import org.gradle.util.internal.TextUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.deprecation.Documentation.userManual;
@@ -80,15 +83,19 @@ import static org.gradle.internal.deprecation.Documentation.userManual;
  * @implNote The methods for reporting failures via this class are ordered to match the stages of the variant selection process and
  * within those stages alphabetically, with names aligned with the failure type hierarchy.  This makes it much easier to navigate.
  */
-public class ResolutionFailureHandler {
+public class ResolutionFailureHandler implements ConfigurableAttributeDescribers {
     public static final String DEFAULT_MESSAGE_PREFIX = "Review the variant matching algorithm at ";
 
-    private final ResolutionFailureDescriberRegistry defaultFailureDescribers;
     private final InternalProblems problemsService;
+    private final ResolutionFailureDescriberRegistry defaultFailureDescribers;
 
-    public ResolutionFailureHandler(ResolutionFailureDescriberRegistry failureDescriberRegistry, InternalProblems problemsService) {
-        this.defaultFailureDescribers = failureDescriberRegistry;
+    private final ResolutionFailureDescriberRegistry customFailureDescribers;
+    private final List<AttributeDescriber> consumerAttributeDescribers = new ArrayList<>();
+
+    public ResolutionFailureHandler(InstanceGenerator instanceGenerator, InternalProblems problemsService) {
         this.problemsService = problemsService;
+        this.defaultFailureDescribers = ResolutionFailureDescriberRegistry.standardRegistry(instanceGenerator);
+        this.customFailureDescribers = ResolutionFailureDescriberRegistry.emptyRegistry(instanceGenerator);
     }
 
     // region Component Selection failures
@@ -98,7 +105,6 @@ public class ResolutionFailureHandler {
 
     // region Variant Selection failures
     public AbstractResolutionFailureException configurationNotCompatibleFailure(
-        AttributesSchemaInternal schema,
         AttributeMatcher matcher,
         ComponentGraphResolveState targetComponent,
         VariantGraphResolveState targetConfiguration,
@@ -108,15 +114,16 @@ public class ResolutionFailureHandler {
         ResolutionCandidateAssessor resolutionCandidateAssessor = new ResolutionCandidateAssessor(requestedAttributes, matcher);
         List<AssessedCandidate> assessedCandidates = Collections.singletonList(resolutionCandidateAssessor.assessCandidate(targetConfiguration.getName(), targetConfigurationCapabilities, targetConfiguration.getAttributes()));
         ConfigurationNotCompatibleFailure failure = new ConfigurationNotCompatibleFailure(targetComponent.getId(), targetConfiguration.getName(), requestedAttributes, assessedCandidates);
-        return describeFailure(schema, failure);
+        return describeFailure(failure);
     }
+
     public AbstractResolutionFailureException configurationDoesNotExistFailure(ComponentGraphResolveState targetComponent, String targetConfigurationName) {
         ConfigurationDoesNotExistFailure failure = new ConfigurationDoesNotExistFailure(targetComponent.getId(), targetConfigurationName);
         return describeFailure(failure);
     }
 
     public AbstractResolutionFailureException ambiguousVariantsFailure(
-        AttributesSchemaInternal schema, AttributeMatcher matcher,
+        AttributeMatcher matcher,
         ComponentGraphResolveState targetComponent,
         AttributeContainerInternal requestedAttributes,
         ImmutableCapabilities requestedCapabilities,
@@ -125,26 +132,23 @@ public class ResolutionFailureHandler {
         ResolutionCandidateAssessor resolutionCandidateAssessor = new ResolutionCandidateAssessor(requestedAttributes, matcher);
         List<AssessedCandidate> assessedCandidates = resolutionCandidateAssessor.assessResolvedVariantStates(matchingVariants, targetComponent.getDefaultCapability());
         AmbiguousVariantsFailure failure = new AmbiguousVariantsFailure(targetComponent.getId(), requestedAttributes, requestedCapabilities, assessedCandidates);
-        return describeFailure(schema, failure);
+        return describeFailure(failure);
     }
 
     // TODO: This is the same logic as the noCompatibleVariantsFailure case for now.  We want to split the NoCompatibleVariantsFailureDescriber into
     // separate describers, with separate failures, for these different types.
     public AbstractResolutionFailureException noVariantsFailure(
-        AttributesSchemaInternal schema, AttributeMatcher matcher,
         ComponentGraphResolveState targetComponent,
         AttributeContainerInternal requestedAttributes,
-        ImmutableCapabilities requestedCapabilities,
-        GraphSelectionCandidates candidates
+        ImmutableCapabilities requestedCapabilities
     ) {
-        ResolutionCandidateAssessor resolutionCandidateAssessor = new ResolutionCandidateAssessor(requestedAttributes, matcher);
-        List<AssessedCandidate> assessedCandidates = resolutionCandidateAssessor.assessGraphSelectionCandidates(candidates);
+        List<AssessedCandidate> assessedCandidates = Collections.emptyList();
         NoCompatibleVariantsFailure failure = new NoCompatibleVariantsFailure(targetComponent.getId(), requestedAttributes, requestedCapabilities, assessedCandidates);
-        return describeFailure(schema, failure);
+        return describeFailure(failure);
     }
 
     public AbstractResolutionFailureException noCompatibleVariantsFailure(
-        AttributesSchemaInternal schema, AttributeMatcher matcher,
+        AttributeMatcher matcher,
         ComponentGraphResolveState targetComponent,
         AttributeContainerInternal requestedAttributes,
         ImmutableCapabilities requestedCapabilities,
@@ -153,11 +157,11 @@ public class ResolutionFailureHandler {
         ResolutionCandidateAssessor resolutionCandidateAssessor = new ResolutionCandidateAssessor(requestedAttributes, matcher);
         List<AssessedCandidate> assessedCandidates = resolutionCandidateAssessor.assessGraphSelectionCandidates(candidates);
         NoCompatibleVariantsFailure failure = new NoCompatibleVariantsFailure(targetComponent.getId(), requestedAttributes, requestedCapabilities, assessedCandidates);
-        return describeFailure(schema, failure);
+        return describeFailure(failure);
     }
 
     public AbstractResolutionFailureException noVariantsWithMatchingCapabilitiesFailure(
-        AttributesSchemaInternal schema, AttributeMatcher matcher,
+        AttributeMatcher matcher,
         ComponentGraphResolveState targetComponent,
         ImmutableAttributes requestedAttributes,
         ImmutableCapabilities requestedCapabilities,
@@ -166,42 +170,42 @@ public class ResolutionFailureHandler {
         ResolutionCandidateAssessor resolutionCandidateAssessor = new ResolutionCandidateAssessor(requestedAttributes, matcher);
         List<AssessedCandidate> assessedCandidates = resolutionCandidateAssessor.assessResolvedVariantStates(candidates, targetComponent.getDefaultCapability());
         NoVariantsWithMatchingCapabilitiesFailure failure = new NoVariantsWithMatchingCapabilitiesFailure(targetComponent.getId(), requestedAttributes, requestedCapabilities, assessedCandidates);
-        return describeFailure(schema, failure);
+        return describeFailure(failure);
     }
     // endregion Variant Selection failures
 
     // region Graph Validation failures
-    public AbstractResolutionFailureException incompatibleMultipleNodesValidationFailure(AttributesSchemaInternal schema, ComponentGraphResolveMetadata selectedComponent, Set<VariantGraphResolveMetadata> incompatibleNodes) {
-        ResolutionCandidateAssessor resolutionCandidateAssessor = new ResolutionCandidateAssessor(ImmutableAttributes.EMPTY, schema.matcher());
+    public AbstractResolutionFailureException incompatibleMultipleNodesValidationFailure(AttributeMatcher matcher, ComponentGraphResolveMetadata selectedComponent, Set<VariantGraphResolveMetadata> incompatibleNodes) {
+        ResolutionCandidateAssessor resolutionCandidateAssessor = new ResolutionCandidateAssessor(ImmutableAttributes.EMPTY, matcher);
         List<AssessedCandidate> assessedCandidates = resolutionCandidateAssessor.assessNodeMetadatas(incompatibleNodes);
         IncompatibleMultipleNodesValidationFailure failure = new IncompatibleMultipleNodesValidationFailure(selectedComponent, incompatibleNodes, assessedCandidates);
-        return describeFailure(schema, failure);
+        return describeFailure(failure);
     }
     // endregion Graph Validation failures
 
     // region Artifact Selection failures
-    public AbstractResolutionFailureException ambiguousArtifactTransformsFailure(AttributesSchemaInternal schema, ResolvedVariantSet targetVariantSet, ImmutableAttributes requestedAttributes, List<TransformedVariant> transformedVariants) {
+    public AbstractResolutionFailureException ambiguousArtifactTransformsFailure(ResolvedVariantSet targetVariantSet, ImmutableAttributes requestedAttributes, List<TransformedVariant> transformedVariants) {
         AmbiguousArtifactTransformsFailure failure = new AmbiguousArtifactTransformsFailure(getOrCreateVariantSetComponentIdentifier(targetVariantSet), targetVariantSet.asDescribable().getDisplayName(), requestedAttributes, transformedVariants);
-        return describeFailure(schema, failure);
+        return describeFailure(failure);
     }
 
-    public AbstractResolutionFailureException noCompatibleArtifactFailure(AttributesSchemaInternal schema, AttributeMatcher matcher, ResolvedVariantSet targetVariantSet, ImmutableAttributes requestedAttributes, List<? extends ResolvedVariant> candidateVariants) {
+    public AbstractResolutionFailureException noCompatibleArtifactFailure(AttributeMatcher matcher, ResolvedVariantSet targetVariantSet, ImmutableAttributes requestedAttributes, List<? extends ResolvedVariant> candidateVariants) {
         ResolutionCandidateAssessor resolutionCandidateAssessor = new ResolutionCandidateAssessor(requestedAttributes, matcher);
         List<AssessedCandidate> assessedCandidates = resolutionCandidateAssessor.assessResolvedVariants(candidateVariants);
         NoCompatibleArtifactFailure failure = new NoCompatibleArtifactFailure(getOrCreateVariantSetComponentIdentifier(targetVariantSet), targetVariantSet.asDescribable().getDisplayName(), requestedAttributes, assessedCandidates);
-        return describeFailure(schema, failure);
+        return describeFailure(failure);
     }
 
-    public AbstractResolutionFailureException ambiguousArtifactsFailure(AttributesSchemaInternal schema, AttributeMatcher matcher, ResolvedVariantSet targetVariantSet, ImmutableAttributes requestedAttributes, List<? extends ResolvedVariant> matchingVariants) {
+    public AbstractResolutionFailureException ambiguousArtifactsFailure(AttributeMatcher matcher, ResolvedVariantSet targetVariantSet, ImmutableAttributes requestedAttributes, List<? extends ResolvedVariant> matchingVariants) {
         ResolutionCandidateAssessor resolutionCandidateAssessor = new ResolutionCandidateAssessor(requestedAttributes, matcher);
         List<AssessedCandidate> assessedCandidates = resolutionCandidateAssessor.assessResolvedVariants(matchingVariants);
         AmbiguousArtifactsFailure failure = new AmbiguousArtifactsFailure(getOrCreateVariantSetComponentIdentifier(targetVariantSet), targetVariantSet.asDescribable().getDisplayName(), requestedAttributes, assessedCandidates);
-        return describeFailure(schema, failure);
+        return describeFailure(failure);
     }
 
-    public AbstractResolutionFailureException unknownArtifactVariantSelectionFailure(AttributesSchemaInternal schema, ResolvedVariantSet targetVariantSet, ImmutableAttributes requestAttributes, Exception cause) {
+    public AbstractResolutionFailureException unknownArtifactVariantSelectionFailure(ResolvedVariantSet targetVariantSet, ImmutableAttributes requestAttributes, Exception cause) {
         UnknownArtifactSelectionFailure failure = new UnknownArtifactSelectionFailure(getOrCreateVariantSetComponentIdentifier(targetVariantSet), targetVariantSet.asDescribable().getDisplayName(), requestAttributes, cause);
-        return describeFailure(schema, failure);
+        return describeFailure(failure);
     }
 
     private ComponentIdentifier getOrCreateVariantSetComponentIdentifier(ResolvedVariantSet resolvedVariantSet) {
@@ -209,27 +213,36 @@ public class ResolutionFailureHandler {
     }
     // endregion Artifact Selection failures
 
+    /**
+     * Adds a {@link ResolutionFailureDescriber} for the given failure type to the custom describers
+     * registered on this failure handler.
+     *
+     * If variant selection failures occur, these describers will be available to describe the failures.
+     *
+     * @param failureType The type of failure to describe
+     * @param describerType A describer that can potentially describe failures of the given type
+     *
+     * @param <FAILURE> The type of failure to describe
+     */
+    public <FAILURE extends ResolutionFailure> void addFailureDescriber(Class<FAILURE> failureType, Class<? extends ResolutionFailureDescriber<FAILURE>> describerType) {
+        customFailureDescribers.registerDescriber(failureType, describerType);
+    }
+
+    @Override
+    public void addConsumerDescriber(AttributeDescriber describer) {
+        consumerAttributeDescribers.add(describer);
+    }
+
     private <FAILURE extends ResolutionFailure> AbstractResolutionFailureException describeFailure(FAILURE failure) {
         @SuppressWarnings("unchecked")
         Class<FAILURE> failureType = (Class<FAILURE>) failure.getClass();
-        List<ResolutionFailureDescriber<FAILURE>> describers = defaultFailureDescribers.getDescribers(failureType);
-        return describeFailure(describers, failure, Optional.empty());
-    }
-
-    private <FAILURE extends ResolutionFailure> AbstractResolutionFailureException describeFailure(AttributesSchemaInternal schema, FAILURE failure) {
-        @SuppressWarnings("unchecked")
-        Class<FAILURE> failureType = (Class<FAILURE>) failure.getClass();
-        List<ResolutionFailureDescriber<FAILURE>> describers = new ArrayList<>();
-        describers.addAll(schema.getFailureDescribers(failureType));
-        describers.addAll(defaultFailureDescribers.getDescribers(failureType));
-        return describeFailure(describers, failure, Optional.of(schema));
-    }
-
-    private <FAILURE extends ResolutionFailure> AbstractResolutionFailureException describeFailure(List<ResolutionFailureDescriber<FAILURE>> describers, FAILURE failure, @SuppressWarnings("OptionalUsedAsFieldOrParameterType") Optional<AttributesSchemaInternal> schema) {
-        return describers.stream()
+        return Stream.concat(
+                customFailureDescribers.getDescribers(failureType).stream(),
+                defaultFailureDescribers.getDescribers(failureType).stream()
+            )
             .filter(describer -> describer.canDescribeFailure(failure))
             .findFirst()
-            .map(describer -> describer.describeFailure(failure, schema))
+            .map(describer -> describer.describeFailure(failure, consumerAttributeDescribers))
             .map(this::reportExceptionAsProblem)
             .orElseThrow(() -> new IllegalStateException("No describer found for failure: " + failure)); // TODO: a default describer at the end of the list that catches everything instead?
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/AmbiguousArtifactTransformsFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/AmbiguousArtifactTransformsFailureDescriber.java
@@ -21,7 +21,7 @@ import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
 import org.gradle.api.internal.artifacts.transform.TransformedVariant;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
+import org.gradle.api.internal.attributes.AttributeDescriber;
 import org.gradle.internal.component.resolution.failure.exception.ArtifactSelectionException;
 import org.gradle.internal.component.resolution.failure.type.AmbiguousArtifactTransformsFailure;
 import org.gradle.internal.logging.text.TreeFormatter;
@@ -29,7 +29,6 @@ import org.gradle.internal.logging.text.TreeFormatter;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
@@ -41,7 +40,7 @@ public abstract class AmbiguousArtifactTransformsFailureDescriber extends Abstra
     private static final String AMBIGUOUS_TRANSFORMATION_SECTION = "sub:transform-ambiguity";
 
     @Override
-    public ArtifactSelectionException describeFailure(AmbiguousArtifactTransformsFailure failure, Optional<AttributesSchemaInternal> schema) {
+    public ArtifactSelectionException describeFailure(AmbiguousArtifactTransformsFailure failure, List<AttributeDescriber> attributeDescribers) {
         String message = buildFailureMsg(failure);
         List<String> resolutions = buildResolutions(suggestSpecificDocumentation(AMBIGUOUS_TRANSFORMATION_PREFIX, AMBIGUOUS_TRANSFORMATION_SECTION), suggestReviewAlgorithm());
         return new ArtifactSelectionException(message, failure, resolutions);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/AmbiguousArtifactTransformsFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/AmbiguousArtifactTransformsFailureDescriber.java
@@ -21,7 +21,6 @@ import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
 import org.gradle.api.internal.artifacts.transform.TransformedVariant;
-import org.gradle.api.internal.attributes.AttributeDescriber;
 import org.gradle.internal.component.resolution.failure.exception.ArtifactSelectionException;
 import org.gradle.internal.component.resolution.failure.type.AmbiguousArtifactTransformsFailure;
 import org.gradle.internal.logging.text.TreeFormatter;
@@ -40,7 +39,7 @@ public abstract class AmbiguousArtifactTransformsFailureDescriber extends Abstra
     private static final String AMBIGUOUS_TRANSFORMATION_SECTION = "sub:transform-ambiguity";
 
     @Override
-    public ArtifactSelectionException describeFailure(AmbiguousArtifactTransformsFailure failure, List<AttributeDescriber> attributeDescribers) {
+    public ArtifactSelectionException describeFailure(AmbiguousArtifactTransformsFailure failure) {
         String message = buildFailureMsg(failure);
         List<String> resolutions = buildResolutions(suggestSpecificDocumentation(AMBIGUOUS_TRANSFORMATION_PREFIX, AMBIGUOUS_TRANSFORMATION_SECTION), suggestReviewAlgorithm());
         return new ArtifactSelectionException(message, failure, resolutions);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/AmbiguousArtifactsFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/AmbiguousArtifactsFailureDescriber.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.component.resolution.failure.describer;
 
 import org.gradle.api.internal.attributes.AttributeDescriber;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.internal.component.model.AttributeDescriberSelector;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor.AssessedCandidate;
 import org.gradle.internal.component.resolution.failure.exception.ArtifactSelectionException;
@@ -26,7 +25,6 @@ import org.gradle.internal.component.resolution.failure.type.AmbiguousVariantsFa
 import org.gradle.internal.logging.text.TreeFormatter;
 
 import java.util.List;
-import java.util.Optional;
 
 /**
  * A {@link ResolutionFailureDescriber} that describes an {@link AmbiguousVariantsFailure}.
@@ -36,8 +34,8 @@ public abstract class AmbiguousArtifactsFailureDescriber extends AbstractResolut
     private static final String AMBIGUOUS_VARIANTS_SECTION = "sub:variant-ambiguity";
 
     @Override
-    public ArtifactSelectionException describeFailure(AmbiguousArtifactsFailure failure, Optional<AttributesSchemaInternal> schema) {
-        AttributeDescriber describer = AttributeDescriberSelector.selectDescriber(failure.getRequestedAttributes(), schema.orElseThrow(IllegalArgumentException::new));
+    public ArtifactSelectionException describeFailure(AmbiguousArtifactsFailure failure, List<AttributeDescriber> attributeDescribers) {
+        AttributeDescriber describer = AttributeDescriberSelector.selectDescriber(failure.getRequestedAttributes(), attributeDescribers);
         String message = buildFailureMsg(failure, describer);
         List<String> resolutions = buildResolutions(suggestSpecificDocumentation(AMBIGUOUS_VARIANTS_PREFIX, AMBIGUOUS_VARIANTS_SECTION), suggestReviewAlgorithm());
         return new ArtifactSelectionException(message, failure, resolutions);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/AmbiguousArtifactsFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/AmbiguousArtifactsFailureDescriber.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.resolution.failure.describer;
 
 import org.gradle.api.internal.attributes.AttributeDescriber;
+import org.gradle.api.internal.attributes.AttributeDescriberRegistry;
 import org.gradle.internal.component.model.AttributeDescriberSelector;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor.AssessedCandidate;
 import org.gradle.internal.component.resolution.failure.exception.ArtifactSelectionException;
@@ -24,6 +25,7 @@ import org.gradle.internal.component.resolution.failure.type.AmbiguousArtifactsF
 import org.gradle.internal.component.resolution.failure.type.AmbiguousVariantsFailure;
 import org.gradle.internal.logging.text.TreeFormatter;
 
+import javax.inject.Inject;
 import java.util.List;
 
 /**
@@ -33,9 +35,18 @@ public abstract class AmbiguousArtifactsFailureDescriber extends AbstractResolut
     private static final String AMBIGUOUS_VARIANTS_PREFIX = "Ambiguity errors are explained in more detail at ";
     private static final String AMBIGUOUS_VARIANTS_SECTION = "sub:variant-ambiguity";
 
+    private final AttributeDescriberRegistry attributeDescribers;
+
+    @Inject
+    public AmbiguousArtifactsFailureDescriber(
+        AttributeDescriberRegistry attributeDescribers
+    ) {
+        this.attributeDescribers = attributeDescribers;
+    }
+
     @Override
-    public ArtifactSelectionException describeFailure(AmbiguousArtifactsFailure failure, List<AttributeDescriber> attributeDescribers) {
-        AttributeDescriber describer = AttributeDescriberSelector.selectDescriber(failure.getRequestedAttributes(), attributeDescribers);
+    public ArtifactSelectionException describeFailure(AmbiguousArtifactsFailure failure) {
+        AttributeDescriber describer = AttributeDescriberSelector.selectDescriber(failure.getRequestedAttributes(), attributeDescribers.getDescribers());
         String message = buildFailureMsg(failure, describer);
         List<String> resolutions = buildResolutions(suggestSpecificDocumentation(AMBIGUOUS_VARIANTS_PREFIX, AMBIGUOUS_VARIANTS_SECTION), suggestReviewAlgorithm());
         return new ArtifactSelectionException(message, failure, resolutions);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/AmbiguousVariantsFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/AmbiguousVariantsFailureDescriber.java
@@ -17,18 +17,16 @@
 package org.gradle.internal.component.resolution.failure.describer;
 
 import org.gradle.api.internal.attributes.AttributeDescriber;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.internal.component.model.AttributeDescriberSelector;
-import org.gradle.internal.component.resolution.failure.formatting.CapabilitiesDescriber;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 import org.gradle.internal.component.resolution.failure.exception.VariantSelectionByAttributesException;
+import org.gradle.internal.component.resolution.failure.formatting.CapabilitiesDescriber;
 import org.gradle.internal.component.resolution.failure.type.AmbiguousVariantsFailure;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.logging.text.TreeFormatter;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.TreeMap;
 
 import static org.gradle.internal.exceptions.StyledException.style;
@@ -41,14 +39,14 @@ public abstract class AmbiguousVariantsFailureDescriber extends AbstractResoluti
     private static final String AMBIGUOUS_VARIANTS_SECTION = "sub:variant-ambiguity";
 
     @Override
-    public VariantSelectionByAttributesException describeFailure(AmbiguousVariantsFailure failure, Optional<AttributesSchemaInternal> schema) {
-        String message = buildFailureMsg(failure, schema.orElseThrow(IllegalArgumentException::new));
+    public VariantSelectionByAttributesException describeFailure(AmbiguousVariantsFailure failure, List<AttributeDescriber> attributeDescribers) {
+        String message = buildFailureMsg(failure, attributeDescribers);
         List<String> resolutions = buildResolutions(suggestSpecificDocumentation(AMBIGUOUS_VARIANTS_PREFIX, AMBIGUOUS_VARIANTS_SECTION), suggestReviewAlgorithm());
         return new VariantSelectionByAttributesException(message, failure, resolutions);
     }
 
-    protected String buildFailureMsg(AmbiguousVariantsFailure failure, AttributesSchemaInternal schema) {
-        AttributeDescriber describer = AttributeDescriberSelector.selectDescriber(failure.getRequestedAttributes(), schema);
+    protected String buildFailureMsg(AmbiguousVariantsFailure failure, List<AttributeDescriber> attributeDescribers) {
+        AttributeDescriber describer = AttributeDescriberSelector.selectDescriber(failure.getRequestedAttributes(), attributeDescribers);
         TreeFormatter formatter = new TreeFormatter();
         Map<String, ResolutionCandidateAssessor.AssessedCandidate> ambiguousVariants = summarizeAmbiguousVariants(failure, describer, formatter, true);
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/AmbiguousVariantsFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/AmbiguousVariantsFailureDescriber.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.resolution.failure.describer;
 
 import org.gradle.api.internal.attributes.AttributeDescriber;
+import org.gradle.api.internal.attributes.AttributeDescriberRegistry;
 import org.gradle.internal.component.model.AttributeDescriberSelector;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 import org.gradle.internal.component.resolution.failure.exception.VariantSelectionByAttributesException;
@@ -25,6 +26,7 @@ import org.gradle.internal.component.resolution.failure.type.AmbiguousVariantsFa
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.logging.text.TreeFormatter;
 
+import javax.inject.Inject;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -38,9 +40,18 @@ public abstract class AmbiguousVariantsFailureDescriber extends AbstractResoluti
     private static final String AMBIGUOUS_VARIANTS_PREFIX = "Ambiguity errors are explained in more detail at ";
     private static final String AMBIGUOUS_VARIANTS_SECTION = "sub:variant-ambiguity";
 
+    private final AttributeDescriberRegistry attributeDescribers;
+
+    @Inject
+    public AmbiguousVariantsFailureDescriber(
+        AttributeDescriberRegistry attributeDescribers
+    ) {
+        this.attributeDescribers = attributeDescribers;
+    }
+
     @Override
-    public VariantSelectionByAttributesException describeFailure(AmbiguousVariantsFailure failure, List<AttributeDescriber> attributeDescribers) {
-        String message = buildFailureMsg(failure, attributeDescribers);
+    public VariantSelectionByAttributesException describeFailure(AmbiguousVariantsFailure failure) {
+        String message = buildFailureMsg(failure, attributeDescribers.getDescribers());
         List<String> resolutions = buildResolutions(suggestSpecificDocumentation(AMBIGUOUS_VARIANTS_PREFIX, AMBIGUOUS_VARIANTS_SECTION), suggestReviewAlgorithm());
         return new VariantSelectionByAttributesException(message, failure, resolutions);
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ConfigurationDoesNotExistFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ConfigurationDoesNotExistFailureDescriber.java
@@ -19,19 +19,19 @@ package org.gradle.internal.component.resolution.failure.describer;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.ProjectComponentIdentifierInternal;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
+import org.gradle.api.internal.attributes.AttributeDescriber;
 import org.gradle.internal.component.resolution.failure.exception.VariantSelectionByNameException;
 import org.gradle.internal.component.resolution.failure.type.ConfigurationDoesNotExistFailure;
 import org.gradle.util.Path;
 
-import java.util.Optional;
+import java.util.List;
 
 /**
  * A {@link ResolutionFailureDescriber} that describes a {@link ConfigurationDoesNotExistFailure}.
  */
 public abstract class ConfigurationDoesNotExistFailureDescriber extends AbstractResolutionFailureDescriber<ConfigurationDoesNotExistFailure> {
     @Override
-    public VariantSelectionByNameException describeFailure(ConfigurationDoesNotExistFailure failure, Optional<AttributesSchemaInternal> schema) {
+    public VariantSelectionByNameException describeFailure(ConfigurationDoesNotExistFailure failure, List<AttributeDescriber> attributeDescribers) {
         String message = buildFailureMsg(failure);
 
         ImmutableList.Builder<String> resolutions = ImmutableList.builder();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ConfigurationDoesNotExistFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ConfigurationDoesNotExistFailureDescriber.java
@@ -19,19 +19,16 @@ package org.gradle.internal.component.resolution.failure.describer;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.ProjectComponentIdentifierInternal;
-import org.gradle.api.internal.attributes.AttributeDescriber;
 import org.gradle.internal.component.resolution.failure.exception.VariantSelectionByNameException;
 import org.gradle.internal.component.resolution.failure.type.ConfigurationDoesNotExistFailure;
 import org.gradle.util.Path;
-
-import java.util.List;
 
 /**
  * A {@link ResolutionFailureDescriber} that describes a {@link ConfigurationDoesNotExistFailure}.
  */
 public abstract class ConfigurationDoesNotExistFailureDescriber extends AbstractResolutionFailureDescriber<ConfigurationDoesNotExistFailure> {
     @Override
-    public VariantSelectionByNameException describeFailure(ConfigurationDoesNotExistFailure failure, List<AttributeDescriber> attributeDescribers) {
+    public VariantSelectionByNameException describeFailure(ConfigurationDoesNotExistFailure failure) {
         String message = buildFailureMsg(failure);
 
         ImmutableList.Builder<String> resolutions = ImmutableList.builder();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ConfigurationNotCompatibleFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ConfigurationNotCompatibleFailureDescriber.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.component.resolution.failure.describer;
 
 import org.gradle.api.internal.attributes.AttributeDescriber;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.internal.component.model.AttributeDescriberSelector;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor.AssessedCandidate;
@@ -27,7 +26,6 @@ import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.logging.text.TreeFormatter;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.gradle.internal.exceptions.StyledException.style;
 
@@ -39,8 +37,8 @@ public abstract class ConfigurationNotCompatibleFailureDescriber extends Abstrac
     private static final String INCOMPATIBLE_VARIANTS_SECTION = "sub:variant-incompatible";
 
     @Override
-    public VariantSelectionByNameException describeFailure(ConfigurationNotCompatibleFailure failure, Optional<AttributesSchemaInternal> schema) {
-        AttributeDescriber describer = AttributeDescriberSelector.selectDescriber(failure.getRequestedAttributes(), schema.orElseThrow(IllegalArgumentException::new));
+    public VariantSelectionByNameException describeFailure(ConfigurationNotCompatibleFailure failure, List<AttributeDescriber> attributeDescribers) {
+        AttributeDescriber describer = AttributeDescriberSelector.selectDescriber(failure.getRequestedAttributes(), attributeDescribers);
         String message = buildFailureMsg(failure, describer);
         List<String> resolutions = buildResolutions(suggestSpecificDocumentation(INCOMPATIBLE_VARIANTS_PREFIX, INCOMPATIBLE_VARIANTS_SECTION), suggestReviewAlgorithm());
         return new VariantSelectionByNameException(message, failure, resolutions);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ConfigurationNotCompatibleFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ConfigurationNotCompatibleFailureDescriber.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.resolution.failure.describer;
 
 import org.gradle.api.internal.attributes.AttributeDescriber;
+import org.gradle.api.internal.attributes.AttributeDescriberRegistry;
 import org.gradle.internal.component.model.AttributeDescriberSelector;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor.AssessedCandidate;
@@ -25,6 +26,7 @@ import org.gradle.internal.component.resolution.failure.type.ConfigurationNotCom
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.logging.text.TreeFormatter;
 
+import javax.inject.Inject;
 import java.util.List;
 
 import static org.gradle.internal.exceptions.StyledException.style;
@@ -36,9 +38,18 @@ public abstract class ConfigurationNotCompatibleFailureDescriber extends Abstrac
     private static final String INCOMPATIBLE_VARIANTS_PREFIX = "Incompatible variant errors are explained in more detail at ";
     private static final String INCOMPATIBLE_VARIANTS_SECTION = "sub:variant-incompatible";
 
+    private final AttributeDescriberRegistry attributeDescribers;
+
+    @Inject
+    public ConfigurationNotCompatibleFailureDescriber(
+        AttributeDescriberRegistry attributeDescribers
+    ) {
+        this.attributeDescribers = attributeDescribers;
+    }
+
     @Override
-    public VariantSelectionByNameException describeFailure(ConfigurationNotCompatibleFailure failure, List<AttributeDescriber> attributeDescribers) {
-        AttributeDescriber describer = AttributeDescriberSelector.selectDescriber(failure.getRequestedAttributes(), attributeDescribers);
+    public VariantSelectionByNameException describeFailure(ConfigurationNotCompatibleFailure failure) {
+        AttributeDescriber describer = AttributeDescriberSelector.selectDescriber(failure.getRequestedAttributes(), attributeDescribers.getDescribers());
         String message = buildFailureMsg(failure, describer);
         List<String> resolutions = buildResolutions(suggestSpecificDocumentation(INCOMPATIBLE_VARIANTS_PREFIX, INCOMPATIBLE_VARIANTS_SECTION), suggestReviewAlgorithm());
         return new VariantSelectionByNameException(message, failure, resolutions);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/IncompatibleMultipleNodesValidationFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/IncompatibleMultipleNodesValidationFailureDescriber.java
@@ -19,7 +19,7 @@ package org.gradle.internal.component.resolution.failure.describer;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.gradle.api.attributes.Attribute;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
+import org.gradle.api.internal.attributes.AttributeDescriber;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor.AssessedCandidate;
 import org.gradle.internal.component.resolution.failure.exception.GraphValidationException;
@@ -27,7 +27,6 @@ import org.gradle.internal.component.resolution.failure.type.IncompatibleMultipl
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * A {@link ResolutionFailureDescriber} that describes an {@link IncompatibleMultipleNodesValidationFailure}.
@@ -37,7 +36,7 @@ public abstract class IncompatibleMultipleNodesValidationFailureDescriber extend
     private static final String INCOMPATIBLE_VARIANTS_SECTION = "sub:variant-incompatible";
 
     @Override
-    public GraphValidationException describeFailure(IncompatibleMultipleNodesValidationFailure failure, Optional<AttributesSchemaInternal> schema) {
+    public GraphValidationException describeFailure(IncompatibleMultipleNodesValidationFailure failure, List<AttributeDescriber> attributeDescribers) {
         String msg = buildIncompatibleArtifactVariantsFailureMsg(failure);
         List<String> resolutions = buildResolutions(suggestSpecificDocumentation(INCOMPATIBLE_VARIANTS_PREFIX, INCOMPATIBLE_VARIANTS_SECTION), suggestReviewAlgorithm());
         return new GraphValidationException(msg, failure, resolutions);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/IncompatibleMultipleNodesValidationFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/IncompatibleMultipleNodesValidationFailureDescriber.java
@@ -19,7 +19,6 @@ package org.gradle.internal.component.resolution.failure.describer;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.gradle.api.attributes.Attribute;
-import org.gradle.api.internal.attributes.AttributeDescriber;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor.AssessedCandidate;
 import org.gradle.internal.component.resolution.failure.exception.GraphValidationException;
@@ -36,7 +35,7 @@ public abstract class IncompatibleMultipleNodesValidationFailureDescriber extend
     private static final String INCOMPATIBLE_VARIANTS_SECTION = "sub:variant-incompatible";
 
     @Override
-    public GraphValidationException describeFailure(IncompatibleMultipleNodesValidationFailure failure, List<AttributeDescriber> attributeDescribers) {
+    public GraphValidationException describeFailure(IncompatibleMultipleNodesValidationFailure failure) {
         String msg = buildIncompatibleArtifactVariantsFailureMsg(failure);
         List<String> resolutions = buildResolutions(suggestSpecificDocumentation(INCOMPATIBLE_VARIANTS_PREFIX, INCOMPATIBLE_VARIANTS_SECTION), suggestReviewAlgorithm());
         return new GraphValidationException(msg, failure, resolutions);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/MissingAttributeAmbiguousVariantsFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/MissingAttributeAmbiguousVariantsFailureDescriber.java
@@ -18,7 +18,6 @@ package org.gradle.internal.component.resolution.failure.describer;
 
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.internal.attributes.AttributeDescriber;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.internal.component.model.AttributeDescriberSelector;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 import org.gradle.internal.component.resolution.failure.type.AmbiguousVariantsFailure;
@@ -75,11 +74,11 @@ public abstract class MissingAttributeAmbiguousVariantsFailureDescriber extends 
     }
 
     @Override
-    protected String buildFailureMsg(AmbiguousVariantsFailure failure, AttributesSchemaInternal schema) {
+    protected String buildFailureMsg(AmbiguousVariantsFailure failure, List<AttributeDescriber> attributeDescribers) {
         String distinguishingAttribute = suggestableDistinctAttributes.remove(failure);
         assert distinguishingAttribute != null;
 
-        AttributeDescriber describer = AttributeDescriberSelector.selectDescriber(failure.getRequestedAttributes(), schema);
+        AttributeDescriber describer = AttributeDescriberSelector.selectDescriber(failure.getRequestedAttributes(), attributeDescribers);
         TreeFormatter formatter = new TreeFormatter();
         summarizeAmbiguousVariants(failure, describer, formatter, false);
         buildSpecificAttributeSuggestionMsg(failure, distinguishingAttribute, formatter);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/MissingAttributeAmbiguousVariantsFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/MissingAttributeAmbiguousVariantsFailureDescriber.java
@@ -18,11 +18,13 @@ package org.gradle.internal.component.resolution.failure.describer;
 
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.internal.attributes.AttributeDescriber;
+import org.gradle.api.internal.attributes.AttributeDescriberRegistry;
 import org.gradle.internal.component.model.AttributeDescriberSelector;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 import org.gradle.internal.component.resolution.failure.type.AmbiguousVariantsFailure;
 import org.gradle.internal.logging.text.TreeFormatter;
 
+import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -46,6 +48,13 @@ public abstract class MissingAttributeAmbiguousVariantsFailureDescriber extends 
      * Each failure will be added once (by identity), then removed during failure description.
      */
     private final IdentityHashMap<AmbiguousVariantsFailure, String> suggestableDistinctAttributes = new IdentityHashMap<>();
+
+    @Inject
+    public MissingAttributeAmbiguousVariantsFailureDescriber(
+        AttributeDescriberRegistry attributeDescribers
+    ) {
+        super(attributeDescribers);
+    }
 
     @Override
     public boolean canDescribeFailure(AmbiguousVariantsFailure failure) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/NoCompatibleArtifactFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/NoCompatibleArtifactFailureDescriber.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.component.resolution.failure.describer;
 
 import org.gradle.api.internal.attributes.AttributeDescriber;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.internal.component.model.AttributeDescriberSelector;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor.AssessedCandidate;
 import org.gradle.internal.component.resolution.failure.exception.ArtifactSelectionException;
@@ -26,7 +25,6 @@ import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.logging.text.TreeFormatter;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.gradle.internal.exceptions.StyledException.style;
 
@@ -38,14 +36,14 @@ public abstract class NoCompatibleArtifactFailureDescriber extends AbstractResol
     private static final String NO_MATCHING_VARIANTS_SECTION = "sub:variant-no-match";
 
     @Override
-    public ArtifactSelectionException describeFailure(NoCompatibleArtifactFailure failure, Optional<AttributesSchemaInternal> schema) {
-        String message = buildFailureMsg(failure, schema.orElseThrow(IllegalArgumentException::new));
+    public ArtifactSelectionException describeFailure(NoCompatibleArtifactFailure failure, List<AttributeDescriber> attributeDescribers) {
+        String message = buildFailureMsg(failure, attributeDescribers);
         List<String> resolutions = buildResolutions(suggestSpecificDocumentation(NO_MATCHING_VARIANTS_PREFIX, NO_MATCHING_VARIANTS_SECTION), suggestReviewAlgorithm());
         return new ArtifactSelectionException(message, failure, resolutions);
     }
 
-    private String buildFailureMsg(NoCompatibleArtifactFailure failure, AttributesSchemaInternal schema) {
-        AttributeDescriber describer = AttributeDescriberSelector.selectDescriber(failure.getRequestedAttributes(), schema);
+    private String buildFailureMsg(NoCompatibleArtifactFailure failure, List<AttributeDescriber> attributeDescribers) {
+        AttributeDescriber describer = AttributeDescriberSelector.selectDescriber(failure.getRequestedAttributes(), attributeDescribers);
         TreeFormatter formatter = new TreeFormatter();
         formatter.node("No variants of " + style(StyledTextOutput.Style.Info, failure.describeRequestTarget()) + " match the consumer attributes");
         formatter.startChildren();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/NoCompatibleArtifactFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/NoCompatibleArtifactFailureDescriber.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.resolution.failure.describer;
 
 import org.gradle.api.internal.attributes.AttributeDescriber;
+import org.gradle.api.internal.attributes.AttributeDescriberRegistry;
 import org.gradle.internal.component.model.AttributeDescriberSelector;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor.AssessedCandidate;
 import org.gradle.internal.component.resolution.failure.exception.ArtifactSelectionException;
@@ -24,6 +25,7 @@ import org.gradle.internal.component.resolution.failure.type.NoCompatibleArtifac
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.logging.text.TreeFormatter;
 
+import javax.inject.Inject;
 import java.util.List;
 
 import static org.gradle.internal.exceptions.StyledException.style;
@@ -35,9 +37,18 @@ public abstract class NoCompatibleArtifactFailureDescriber extends AbstractResol
     private static final String NO_MATCHING_VARIANTS_PREFIX = "No matching variant errors are explained in more detail at ";
     private static final String NO_MATCHING_VARIANTS_SECTION = "sub:variant-no-match";
 
+    private final AttributeDescriberRegistry attributeDescribers;
+
+    @Inject
+    public NoCompatibleArtifactFailureDescriber(
+        AttributeDescriberRegistry attributeDescribers
+    ) {
+        this.attributeDescribers = attributeDescribers;
+    }
+
     @Override
-    public ArtifactSelectionException describeFailure(NoCompatibleArtifactFailure failure, List<AttributeDescriber> attributeDescribers) {
-        String message = buildFailureMsg(failure, attributeDescribers);
+    public ArtifactSelectionException describeFailure(NoCompatibleArtifactFailure failure) {
+        String message = buildFailureMsg(failure, attributeDescribers.getDescribers());
         List<String> resolutions = buildResolutions(suggestSpecificDocumentation(NO_MATCHING_VARIANTS_PREFIX, NO_MATCHING_VARIANTS_SECTION), suggestReviewAlgorithm());
         return new ArtifactSelectionException(message, failure, resolutions);
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/NoCompatibleVariantsFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/NoCompatibleVariantsFailureDescriber.java
@@ -17,17 +17,15 @@
 package org.gradle.internal.component.resolution.failure.describer;
 
 import org.gradle.api.internal.attributes.AttributeDescriber;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.internal.component.model.AttributeDescriberSelector;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
-import org.gradle.internal.component.resolution.failure.formatting.StyledAttributeDescriber;
 import org.gradle.internal.component.resolution.failure.exception.VariantSelectionByAttributesException;
+import org.gradle.internal.component.resolution.failure.formatting.StyledAttributeDescriber;
 import org.gradle.internal.component.resolution.failure.type.NoCompatibleVariantsFailure;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.logging.text.TreeFormatter;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.gradle.internal.exceptions.StyledException.style;
 
@@ -41,8 +39,8 @@ public abstract class NoCompatibleVariantsFailureDescriber extends AbstractResol
     private static final String NO_VARIANTS_EXIST_SECTION = "sec:resolvable-consumable-configs";
 
     @Override
-    public VariantSelectionByAttributesException describeFailure(NoCompatibleVariantsFailure failure, Optional<AttributesSchemaInternal> schema) {
-        AttributeDescriber describer = AttributeDescriberSelector.selectDescriber(failure.getRequestedAttributes(), schema.orElseThrow(IllegalArgumentException::new));
+    public VariantSelectionByAttributesException describeFailure(NoCompatibleVariantsFailure failure, List<AttributeDescriber> attributeDescribers) {
+        AttributeDescriber describer = AttributeDescriberSelector.selectDescriber(failure.getRequestedAttributes(), attributeDescribers);
         FailureSubType failureSubType = FailureSubType.determineFailureSubType(failure);
         String message = buildFailureMsg(new StyledAttributeDescriber(describer), failure, failureSubType);
         List<String> resolutions = buildResolutions(failureSubType);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/NoCompatibleVariantsFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/NoCompatibleVariantsFailureDescriber.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.resolution.failure.describer;
 
 import org.gradle.api.internal.attributes.AttributeDescriber;
+import org.gradle.api.internal.attributes.AttributeDescriberRegistry;
 import org.gradle.internal.component.model.AttributeDescriberSelector;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 import org.gradle.internal.component.resolution.failure.exception.VariantSelectionByAttributesException;
@@ -25,6 +26,7 @@ import org.gradle.internal.component.resolution.failure.type.NoCompatibleVariant
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.logging.text.TreeFormatter;
 
+import javax.inject.Inject;
 import java.util.List;
 
 import static org.gradle.internal.exceptions.StyledException.style;
@@ -38,9 +40,18 @@ public abstract class NoCompatibleVariantsFailureDescriber extends AbstractResol
     private static final String NO_VARIANTS_EXIST_PREFIX = "Creating consumable variants is explained in more detail at ";
     private static final String NO_VARIANTS_EXIST_SECTION = "sec:resolvable-consumable-configs";
 
+    private final AttributeDescriberRegistry attributeDescribers;
+
+    @Inject
+    public NoCompatibleVariantsFailureDescriber(
+        AttributeDescriberRegistry attributeDescribers
+    ) {
+        this.attributeDescribers = attributeDescribers;
+    }
+
     @Override
-    public VariantSelectionByAttributesException describeFailure(NoCompatibleVariantsFailure failure, List<AttributeDescriber> attributeDescribers) {
-        AttributeDescriber describer = AttributeDescriberSelector.selectDescriber(failure.getRequestedAttributes(), attributeDescribers);
+    public VariantSelectionByAttributesException describeFailure(NoCompatibleVariantsFailure failure) {
+        AttributeDescriber describer = AttributeDescriberSelector.selectDescriber(failure.getRequestedAttributes(), attributeDescribers.getDescribers());
         FailureSubType failureSubType = FailureSubType.determineFailureSubType(failure);
         String message = buildFailureMsg(new StyledAttributeDescriber(describer), failure, failureSubType);
         List<String> resolutions = buildResolutions(failureSubType);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/NoVariantsWithMatchingCapabilitiesFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/NoVariantsWithMatchingCapabilitiesFailureDescriber.java
@@ -16,21 +16,20 @@
 
 package org.gradle.internal.component.resolution.failure.describer;
 
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
-import org.gradle.internal.component.resolution.failure.formatting.CapabilitiesDescriber;
+import org.gradle.api.internal.attributes.AttributeDescriber;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 import org.gradle.internal.component.resolution.failure.exception.VariantSelectionByAttributesException;
+import org.gradle.internal.component.resolution.failure.formatting.CapabilitiesDescriber;
 import org.gradle.internal.component.resolution.failure.type.NoVariantsWithMatchingCapabilitiesFailure;
 
 import java.util.List;
-import java.util.Optional;
 
 /**
  * A {@link ResolutionFailureDescriber} that describes a {@link NoVariantsWithMatchingCapabilitiesFailure}.
  */
 public abstract class NoVariantsWithMatchingCapabilitiesFailureDescriber extends AbstractResolutionFailureDescriber<NoVariantsWithMatchingCapabilitiesFailure> {
     @Override
-    public VariantSelectionByAttributesException describeFailure(NoVariantsWithMatchingCapabilitiesFailure failure, Optional<AttributesSchemaInternal> schema) {
+    public VariantSelectionByAttributesException describeFailure(NoVariantsWithMatchingCapabilitiesFailure failure, List<AttributeDescriber> attributeDescribers) {
         String message = buildFailureMsg(failure);
         List<String> resolutions = buildResolutions(suggestReviewAlgorithm());
         return new VariantSelectionByAttributesException(message, failure, resolutions);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/NoVariantsWithMatchingCapabilitiesFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/NoVariantsWithMatchingCapabilitiesFailureDescriber.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.component.resolution.failure.describer;
 
-import org.gradle.api.internal.attributes.AttributeDescriber;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 import org.gradle.internal.component.resolution.failure.exception.VariantSelectionByAttributesException;
 import org.gradle.internal.component.resolution.failure.formatting.CapabilitiesDescriber;
@@ -29,7 +28,7 @@ import java.util.List;
  */
 public abstract class NoVariantsWithMatchingCapabilitiesFailureDescriber extends AbstractResolutionFailureDescriber<NoVariantsWithMatchingCapabilitiesFailure> {
     @Override
-    public VariantSelectionByAttributesException describeFailure(NoVariantsWithMatchingCapabilitiesFailure failure, List<AttributeDescriber> attributeDescribers) {
+    public VariantSelectionByAttributesException describeFailure(NoVariantsWithMatchingCapabilitiesFailure failure) {
         String message = buildFailureMsg(failure);
         List<String> resolutions = buildResolutions(suggestReviewAlgorithm());
         return new VariantSelectionByAttributesException(message, failure, resolutions);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ResolutionFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ResolutionFailureDescriber.java
@@ -16,11 +16,11 @@
 
 package org.gradle.internal.component.resolution.failure.describer;
 
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
+import org.gradle.api.internal.attributes.AttributeDescriber;
 import org.gradle.internal.component.resolution.failure.exception.AbstractResolutionFailureException;
 import org.gradle.internal.component.resolution.failure.interfaces.ResolutionFailure;
 
-import java.util.Optional;
+import java.util.List;
 
 /**
  * Describe a certain type of resolution failure, by providing concise and specific human-readable
@@ -48,11 +48,12 @@ public interface ResolutionFailureDescriber<FAILURE extends ResolutionFailure> {
      * for the given failure.
      *
      * @param failure the failure to describe
-     * @param schema the schema of the attributes that were used to select the variant, if available
+     * @param attributeDescribers describes individual attributes
+     *
      * @return the exception that describes the failure
      *
      * @implSpec Testing {@link #canDescribeFailure(ResolutionFailure)} should <strong>NOT</strong> be done by
      * implementations of this method; ensuring this is done first is the responsibility of the caller.
      */
-    AbstractResolutionFailureException describeFailure(FAILURE failure, @SuppressWarnings("OptionalUsedAsFieldOrParameterType") Optional<AttributesSchemaInternal> schema);
+    AbstractResolutionFailureException describeFailure(FAILURE failure, List<AttributeDescriber> attributeDescribers);
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ResolutionFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ResolutionFailureDescriber.java
@@ -16,11 +16,8 @@
 
 package org.gradle.internal.component.resolution.failure.describer;
 
-import org.gradle.api.internal.attributes.AttributeDescriber;
 import org.gradle.internal.component.resolution.failure.exception.AbstractResolutionFailureException;
 import org.gradle.internal.component.resolution.failure.interfaces.ResolutionFailure;
-
-import java.util.List;
 
 /**
  * Describe a certain type of resolution failure, by providing concise and specific human-readable
@@ -48,12 +45,11 @@ public interface ResolutionFailureDescriber<FAILURE extends ResolutionFailure> {
      * for the given failure.
      *
      * @param failure the failure to describe
-     * @param attributeDescribers describes individual attributes
      *
      * @return the exception that describes the failure
      *
      * @implSpec Testing {@link #canDescribeFailure(ResolutionFailure)} should <strong>NOT</strong> be done by
      * implementations of this method; ensuring this is done first is the responsibility of the caller.
      */
-    AbstractResolutionFailureException describeFailure(FAILURE failure, List<AttributeDescriber> attributeDescribers);
+    AbstractResolutionFailureException describeFailure(FAILURE failure);
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/UnknownArtifactSelectionFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/UnknownArtifactSelectionFailureDescriber.java
@@ -16,12 +16,11 @@
 
 package org.gradle.internal.component.resolution.failure.describer;
 
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
+import org.gradle.api.internal.attributes.AttributeDescriber;
 import org.gradle.internal.component.resolution.failure.exception.ArtifactSelectionException;
 import org.gradle.internal.component.resolution.failure.type.UnknownArtifactSelectionFailure;
 
 import java.util.List;
-import java.util.Optional;
 
 /**
  * A {@link ResolutionFailureDescriber} that describes an {@link UnknownArtifactSelectionFailure}.
@@ -32,7 +31,7 @@ import java.util.Optional;
  */
 public abstract class UnknownArtifactSelectionFailureDescriber extends AbstractResolutionFailureDescriber<UnknownArtifactSelectionFailure> {
     @Override
-    public ArtifactSelectionException describeFailure(UnknownArtifactSelectionFailure failure, Optional<AttributesSchemaInternal> schema) {
+    public ArtifactSelectionException describeFailure(UnknownArtifactSelectionFailure failure, List<AttributeDescriber> attributeDescribers) {
         final ArtifactSelectionException result;
         if (failure.getCause() instanceof ArtifactSelectionException) {
             result = (ArtifactSelectionException) failure.getCause();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/UnknownArtifactSelectionFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/UnknownArtifactSelectionFailureDescriber.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.component.resolution.failure.describer;
 
-import org.gradle.api.internal.attributes.AttributeDescriber;
 import org.gradle.internal.component.resolution.failure.exception.ArtifactSelectionException;
 import org.gradle.internal.component.resolution.failure.type.UnknownArtifactSelectionFailure;
 
@@ -31,7 +30,7 @@ import java.util.List;
  */
 public abstract class UnknownArtifactSelectionFailureDescriber extends AbstractResolutionFailureDescriber<UnknownArtifactSelectionFailure> {
     @Override
-    public ArtifactSelectionException describeFailure(UnknownArtifactSelectionFailure failure, List<AttributeDescriber> attributeDescribers) {
+    public ArtifactSelectionException describeFailure(UnknownArtifactSelectionFailure failure) {
         final ArtifactSelectionException result;
         if (failure.getCause() instanceof ArtifactSelectionException) {
             result = (ArtifactSelectionException) failure.getCause();

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -51,7 +51,6 @@ import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.problems.internal.InternalProblems
 import org.gradle.api.specs.Spec
 import org.gradle.internal.Describables
-import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.internal.component.external.descriptor.DefaultExclude
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.ImmutableCapabilities
@@ -71,6 +70,7 @@ import org.gradle.internal.component.model.GraphVariantSelector
 import org.gradle.internal.component.model.IvyArtifactName
 import org.gradle.internal.component.model.LocalComponentDependencyMetadata
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.internal.exceptions.DefaultMultiCauseException
 import org.gradle.internal.model.CalculatedValue
 import org.gradle.internal.operations.BuildOperationExecutor
@@ -132,8 +132,7 @@ class DependencyGraphBuilderTest extends Specification {
         TestUtil.calculatedValueContainerFactory()
     )
 
-    def failureDescriberRegistry = DependencyManagementTestUtil.standardResolutionFailureDescriberRegistry()
-    def variantSelector = new GraphVariantSelector(new ResolutionFailureHandler(failureDescriberRegistry, Stub(InternalProblems)))
+    def variantSelector = new GraphVariantSelector(new ResolutionFailureHandler(TestUtil.instantiatorFactory().inject(TestUtil.services()), Stub(InternalProblems)))
 
     DependencyGraphBuilder builder = new DependencyGraphBuilder(
         moduleExclusions,

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -48,7 +48,6 @@ import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact
 import org.gradle.api.internal.attributes.AttributeDesugaring
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.ImmutableAttributes
-import org.gradle.api.problems.internal.InternalProblems
 import org.gradle.api.specs.Spec
 import org.gradle.internal.Describables
 import org.gradle.internal.component.external.descriptor.DefaultExclude
@@ -70,7 +69,6 @@ import org.gradle.internal.component.model.GraphVariantSelector
 import org.gradle.internal.component.model.IvyArtifactName
 import org.gradle.internal.component.model.LocalComponentDependencyMetadata
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata
-import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.internal.exceptions.DefaultMultiCauseException
 import org.gradle.internal.model.CalculatedValue
 import org.gradle.internal.operations.BuildOperationExecutor
@@ -132,7 +130,7 @@ class DependencyGraphBuilderTest extends Specification {
         TestUtil.calculatedValueContainerFactory()
     )
 
-    def variantSelector = new GraphVariantSelector(new ResolutionFailureHandler(TestUtil.instantiatorFactory().inject(TestUtil.services()), Stub(InternalProblems)))
+    def variantSelector = new GraphVariantSelector(DependencyManagementTestUtil.newFailureHandler())
 
     DependencyGraphBuilder builder = new DependencyGraphBuilder(
         moduleExclusions,

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
@@ -27,13 +27,13 @@ import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.notations.ComponentIdentifierParserFactory
 import org.gradle.api.internal.notations.DependencyMetadataNotationParser
 import org.gradle.api.problems.internal.InternalProblems
-import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.internal.component.external.descriptor.Configuration
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata
 import org.gradle.internal.component.external.model.maven.MutableMavenModuleResolveMetadata
 import org.gradle.internal.component.model.GraphVariantSelector
 import org.gradle.internal.component.model.LocalComponentDependencyMetadata
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.SnapshotTestUtil
 import org.gradle.util.TestUtil
@@ -161,8 +161,7 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
         def componentSelector = newSelector(DefaultModuleIdentifier.newId(consumerIdentifier.group, consumerIdentifier.name), new DefaultMutableVersionConstraint(consumerIdentifier.version))
         def consumer = new LocalComponentDependencyMetadata(componentSelector, null, [] as List, [], false, false, true, false, false, null)
         def state = DependencyManagementTestUtil.modelGraphResolveFactory().stateFor(immutable)
-        def failureDescriberRegistry = DependencyManagementTestUtil.standardResolutionFailureDescriberRegistry()
-        def variantSelector = new GraphVariantSelector(new ResolutionFailureHandler(failureDescriberRegistry, Stub(InternalProblems)))
+        def variantSelector = new GraphVariantSelector(new ResolutionFailureHandler(TestUtil.instantiatorFactory().inject(TestUtil.services()), Stub(InternalProblems)))
 
         def variant = consumer.selectVariants(variantSelector, attributes, state, schema, [] as Set).variants[0]
         variant.metadata.dependencies

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
@@ -26,14 +26,12 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradlePomM
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.notations.ComponentIdentifierParserFactory
 import org.gradle.api.internal.notations.DependencyMetadataNotationParser
-import org.gradle.api.problems.internal.InternalProblems
 import org.gradle.internal.component.external.descriptor.Configuration
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata
 import org.gradle.internal.component.external.model.maven.MutableMavenModuleResolveMetadata
 import org.gradle.internal.component.model.GraphVariantSelector
 import org.gradle.internal.component.model.LocalComponentDependencyMetadata
-import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.SnapshotTestUtil
 import org.gradle.util.TestUtil
@@ -161,7 +159,7 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
         def componentSelector = newSelector(DefaultModuleIdentifier.newId(consumerIdentifier.group, consumerIdentifier.name), new DefaultMutableVersionConstraint(consumerIdentifier.version))
         def consumer = new LocalComponentDependencyMetadata(componentSelector, null, [] as List, [], false, false, true, false, false, null)
         def state = DependencyManagementTestUtil.modelGraphResolveFactory().stateFor(immutable)
-        def variantSelector = new GraphVariantSelector(new ResolutionFailureHandler(TestUtil.instantiatorFactory().inject(TestUtil.services()), Stub(InternalProblems)))
+        def variantSelector = new GraphVariantSelector(DependencyManagementTestUtil.newFailureHandler())
 
         def variant = consumer.selectVariants(variantSelector, attributes, state, schema, [] as Set).variants[0]
         variant.metadata.dependencies

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelectorSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelectorSpec.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.artifacts.transform
 
-import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
+
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.BrokenResolvedArtifactSet
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant
@@ -25,11 +25,11 @@ import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.problems.internal.InternalProblems
 import org.gradle.internal.Describables
-
-import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.internal.component.model.AttributeMatcher
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.internal.component.resolution.failure.exception.ArtifactSelectionException
 import org.gradle.util.AttributeTestUtil
+import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 class AttributeMatchingArtifactVariantSelectorSpec extends Specification {
@@ -60,8 +60,7 @@ class AttributeMatchingArtifactVariantSelectorSpec extends Specification {
     }
 
     def factory = Mock(ArtifactVariantSelector.ResolvedArtifactTransformer)
-    def failureDescriberRegistry = DependencyManagementTestUtil.standardResolutionFailureDescriberRegistry()
-    def failureProcessor = new ResolutionFailureHandler(failureDescriberRegistry, Stub(InternalProblems))
+    def failureProcessor = new ResolutionFailureHandler(TestUtil.instantiatorFactory().inject(TestUtil.services()), Stub(InternalProblems))
 
     def 'direct match on variant means no finder interaction'() {
         given:

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelectorSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelectorSpec.groovy
@@ -16,20 +16,17 @@
 
 package org.gradle.api.internal.artifacts.transform
 
-
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.BrokenResolvedArtifactSet
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariantSet
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.ImmutableAttributes
-import org.gradle.api.problems.internal.InternalProblems
 import org.gradle.internal.Describables
 import org.gradle.internal.component.model.AttributeMatcher
-import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.internal.component.resolution.failure.exception.ArtifactSelectionException
 import org.gradle.util.AttributeTestUtil
-import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 class AttributeMatchingArtifactVariantSelectorSpec extends Specification {
@@ -60,7 +57,7 @@ class AttributeMatchingArtifactVariantSelectorSpec extends Specification {
     }
 
     def factory = Mock(ArtifactVariantSelector.ResolvedArtifactTransformer)
-    def failureProcessor = new ResolutionFailureHandler(TestUtil.instantiatorFactory().inject(TestUtil.services()), Stub(InternalProblems))
+    def failureProcessor = DependencyManagementTestUtil.newFailureHandler()
 
     def 'direct match on variant means no finder interaction'() {
         given:

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactVariantSelectorFactoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactVariantSelectorFactoryTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.transform
 
 import com.google.common.collect.ImmutableList
-import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant
@@ -32,6 +31,7 @@ import org.gradle.internal.component.model.AttributeMatchingExplanationBuilder
 import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.internal.component.resolution.failure.exception.ArtifactSelectionException
 import org.gradle.util.AttributeTestUtil
+import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE
@@ -48,8 +48,7 @@ class DefaultArtifactVariantSelectorFactoryTest extends Specification {
     def factory = Mock(ArtifactVariantSelector.ResolvedArtifactTransformer)
     def dependenciesResolverFactory = Stub(TransformUpstreamDependenciesResolverFactory)
     def transformedVariantFactory = Mock(TransformedVariantFactory)
-    def failureDescriberRegistry = DependencyManagementTestUtil.standardResolutionFailureDescriberRegistry()
-    def variantSelectionFailureProcessor = new ResolutionFailureHandler(failureDescriberRegistry, Stub(InternalProblems))
+    def variantSelectionFailureProcessor = new ResolutionFailureHandler(TestUtil.instantiatorFactory().inject(TestUtil.services()), Stub(InternalProblems))
     def variantSelectorFactory = new DefaultVariantSelectorFactory(matchingCache, consumerSchema, AttributeTestUtil.attributesFactory(), transformedVariantFactory, variantSelectionFailureProcessor)
 
     def "selects producer variant with requested attributes"() {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactVariantSelectorFactoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactVariantSelectorFactoryTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.transform
 
 import com.google.common.collect.ImmutableList
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant
@@ -24,14 +25,11 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Resol
 import org.gradle.api.internal.attributes.AttributeContainerInternal
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.ImmutableAttributes
-import org.gradle.api.problems.internal.InternalProblems
 import org.gradle.internal.Describables
 import org.gradle.internal.component.model.AttributeMatcher
 import org.gradle.internal.component.model.AttributeMatchingExplanationBuilder
-import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.internal.component.resolution.failure.exception.ArtifactSelectionException
 import org.gradle.util.AttributeTestUtil
-import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE
@@ -48,7 +46,7 @@ class DefaultArtifactVariantSelectorFactoryTest extends Specification {
     def factory = Mock(ArtifactVariantSelector.ResolvedArtifactTransformer)
     def dependenciesResolverFactory = Stub(TransformUpstreamDependenciesResolverFactory)
     def transformedVariantFactory = Mock(TransformedVariantFactory)
-    def variantSelectionFailureProcessor = new ResolutionFailureHandler(TestUtil.instantiatorFactory().inject(TestUtil.services()), Stub(InternalProblems))
+    def variantSelectionFailureProcessor = DependencyManagementTestUtil.newFailureHandler()
     def variantSelectorFactory = new DefaultVariantSelectorFactory(matchingCache, consumerSchema, AttributeTestUtil.attributesFactory(), transformedVariantFactory, variantSelectionFailureProcessor)
 
     def "selects producer variant with requested attributes"() {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -24,14 +24,12 @@ import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
-import org.gradle.api.internal.artifacts.dsl.dependencies.GradlePluginVariantsSupport
 import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstraintMetadataImpl
 import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependencyMetadataImpl
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.notations.DependencyMetadataNotationParser
 import org.gradle.api.problems.internal.InternalProblems
-import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.internal.component.external.descriptor.MavenScope
 import org.gradle.internal.component.external.model.ivy.IvyDependencyDescriptor
 import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor
@@ -39,6 +37,7 @@ import org.gradle.internal.component.external.model.maven.MavenDependencyType
 import org.gradle.internal.component.model.GraphVariantSelector
 import org.gradle.internal.component.model.LocalComponentDependencyMetadata
 import org.gradle.internal.component.model.VariantGraphResolveMetadata
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.SnapshotTestUtil
 import org.gradle.util.TestUtil
@@ -60,8 +59,6 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
     @Shared
         attributes = AttributeTestUtil.attributesFactory().of(Attribute.of("someAttribute", String), "someValue")
     @Shared
-        schema = createSchema()
-    @Shared
         mavenMetadataFactory = DependencyManagementTestUtil.mavenMetadataFactory()
     @Shared
         ivyMetadataFactory = DependencyManagementTestUtil.ivyMetadataFactory()
@@ -70,13 +67,6 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
 
     protected static <T> VariantMetadataRules.VariantAction<T> variantAction(String variantName, Action<? super T> action) {
         new VariantMetadataRules.VariantAction<T>(variantName, action)
-    }
-
-    private DefaultAttributesSchema createSchema() {
-        def schema = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
-        DependencyManagementTestUtil.platformSupport().configureSchema(schema)
-        GradlePluginVariantsSupport.configureSchema(schema)
-        schema
     }
 
     abstract boolean addAllDependenciesAsConstraints()
@@ -289,8 +279,8 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
         def componentSelector = newSelector(consumerIdentifier.module, new DefaultMutableVersionConstraint(consumerIdentifier.version))
         def consumer = new LocalComponentDependencyMetadata(componentSelector, null, [] as List, [], false, false, true, false, false, null)
         def state = DependencyManagementTestUtil.modelGraphResolveFactory().stateFor(immutable)
-        def failureDescriberRegistry = DependencyManagementTestUtil.standardResolutionFailureDescriberRegistry()
-        def variantSelector = new GraphVariantSelector(new ResolutionFailureHandler(failureDescriberRegistry, Stub(InternalProblems)))
+        def variantSelector = new GraphVariantSelector(new ResolutionFailureHandler(TestUtil.instantiatorFactory().inject(TestUtil.services()), Stub(InternalProblems)))
+        def schema = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
 
         return consumer.selectVariants(variantSelector, attributes, state, schema, [] as Set).variants[0].metadata
     }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -29,7 +29,6 @@ import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependencyM
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.notations.DependencyMetadataNotationParser
-import org.gradle.api.problems.internal.InternalProblems
 import org.gradle.internal.component.external.descriptor.MavenScope
 import org.gradle.internal.component.external.model.ivy.IvyDependencyDescriptor
 import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor
@@ -37,7 +36,6 @@ import org.gradle.internal.component.external.model.maven.MavenDependencyType
 import org.gradle.internal.component.model.GraphVariantSelector
 import org.gradle.internal.component.model.LocalComponentDependencyMetadata
 import org.gradle.internal.component.model.VariantGraphResolveMetadata
-import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.SnapshotTestUtil
 import org.gradle.util.TestUtil
@@ -279,7 +277,7 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
         def componentSelector = newSelector(consumerIdentifier.module, new DefaultMutableVersionConstraint(consumerIdentifier.version))
         def consumer = new LocalComponentDependencyMetadata(componentSelector, null, [] as List, [], false, false, true, false, false, null)
         def state = DependencyManagementTestUtil.modelGraphResolveFactory().stateFor(immutable)
-        def variantSelector = new GraphVariantSelector(new ResolutionFailureHandler(TestUtil.instantiatorFactory().inject(TestUtil.services()), Stub(InternalProblems)))
+        def variantSelector = new GraphVariantSelector(DependencyManagementTestUtil.newFailureHandler())
         def schema = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
 
         return consumer.selectVariants(variantSelector, attributes, state, schema, [] as Set).variants[0].metadata

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
@@ -26,16 +26,15 @@ import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.AttributeCompatibilityRule
 import org.gradle.api.attributes.CompatibilityCheckDetails
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
-import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions
 import org.gradle.api.internal.attributes.AttributeContainerInternal
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.problems.internal.InternalProblems
-import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.internal.component.external.descriptor.DefaultExclude
 import org.gradle.internal.component.external.model.ImmutableCapabilities
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.internal.component.resolution.failure.exception.VariantSelectionByAttributesException
 import org.gradle.internal.component.resolution.failure.exception.VariantSelectionByNameException
 import org.gradle.util.AttributeTestUtil
@@ -49,7 +48,7 @@ import static org.gradle.util.internal.TextUtil.toPlatformLineSeparators
 
 class LocalComponentDependencyMetadataTest extends Specification {
     AttributesSchemaInternal attributesSchema = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
-    GraphVariantSelector variantSelector = new GraphVariantSelector(new ResolutionFailureHandler(DependencyManagementTestUtil.standardResolutionFailureDescriberRegistry(), Stub(InternalProblems)))
+    GraphVariantSelector variantSelector = new GraphVariantSelector(new ResolutionFailureHandler(TestUtil.instantiatorFactory().inject(TestUtil.services()), Stub(InternalProblems)))
 
     ComponentIdentifier toComponentId = Stub(ComponentIdentifier) {
         getDisplayName() >> "[target]"

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
@@ -26,15 +26,14 @@ import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.AttributeCompatibilityRule
 import org.gradle.api.attributes.CompatibilityCheckDetails
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions
 import org.gradle.api.internal.attributes.AttributeContainerInternal
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.attributes.ImmutableAttributes
-import org.gradle.api.problems.internal.InternalProblems
 import org.gradle.internal.component.external.descriptor.DefaultExclude
 import org.gradle.internal.component.external.model.ImmutableCapabilities
-import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.internal.component.resolution.failure.exception.VariantSelectionByAttributesException
 import org.gradle.internal.component.resolution.failure.exception.VariantSelectionByNameException
 import org.gradle.util.AttributeTestUtil
@@ -48,7 +47,7 @@ import static org.gradle.util.internal.TextUtil.toPlatformLineSeparators
 
 class LocalComponentDependencyMetadataTest extends Specification {
     AttributesSchemaInternal attributesSchema = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
-    GraphVariantSelector variantSelector = new GraphVariantSelector(new ResolutionFailureHandler(TestUtil.instantiatorFactory().inject(TestUtil.services()), Stub(InternalProblems)))
+    GraphVariantSelector variantSelector = new GraphVariantSelector(DependencyManagementTestUtil.newFailureHandler())
 
     ComponentIdentifier toComponentId = Stub(ComponentIdentifier) {
         getDisplayName() >> "[target]"

--- a/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/DependencyManagementTestUtil.groovy
+++ b/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/DependencyManagementTestUtil.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts
 
-import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
@@ -25,8 +24,6 @@ import org.gradle.api.internal.attributes.AttributeDesugaring
 import org.gradle.internal.component.external.model.ModuleComponentGraphResolveStateFactory
 import org.gradle.internal.component.external.model.PreferJavaRuntimeVariant
 import org.gradle.internal.component.model.ComponentIdGenerator
-import org.gradle.internal.component.resolution.failure.ResolutionFailureDescriberRegistry
-import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.TestUtil
 
@@ -56,13 +53,6 @@ class DependencyManagementTestUtil {
 
     static ComponentSelectionDescriptorFactory componentSelectionDescriptorFactory() {
         return new TestComponentDescriptorFactory()
-    }
-
-    static ResolutionFailureDescriberRegistry standardResolutionFailureDescriberRegistry() {
-        def registry = new DefaultServiceRegistry().with {
-            add(DocumentationRegistry.class, new DocumentationRegistry())
-        }
-        return ResolutionFailureDescriberRegistry.standardRegistry(TestUtil.instantiatorFactory().inject(registry))
     }
 
 }

--- a/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/DependencyManagementTestUtil.groovy
+++ b/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/DependencyManagementTestUtil.groovy
@@ -20,10 +20,14 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
+import org.gradle.api.internal.attributes.AttributeDescriberRegistry
 import org.gradle.api.internal.attributes.AttributeDesugaring
+import org.gradle.api.problems.internal.DefaultProblems
+import org.gradle.api.problems.internal.NoOpProblemEmitter
 import org.gradle.internal.component.external.model.ModuleComponentGraphResolveStateFactory
 import org.gradle.internal.component.external.model.PreferJavaRuntimeVariant
 import org.gradle.internal.component.model.ComponentIdGenerator
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.TestUtil
 
@@ -55,4 +59,10 @@ class DependencyManagementTestUtil {
         return new TestComponentDescriptorFactory()
     }
 
+    static ResolutionFailureHandler newFailureHandler() {
+        def services = TestUtil.createTestServices {
+            it.add(AttributeDescriberRegistry)
+        }
+        new ResolutionFailureHandler(TestUtil.instantiatorFactory().inject(services), new DefaultProblems([new NoOpProblemEmitter()]))
+    }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/attributes/AttributeDescriberRegistry.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/attributes/AttributeDescriberRegistry.java
@@ -15,7 +15,20 @@
  */
 package org.gradle.api.internal.attributes;
 
-public interface ConfigurableAttributeDescribers {
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
-    void addConsumerDescriber(AttributeDescriber describer);
+public class AttributeDescriberRegistry {
+
+    private final List<AttributeDescriber> consumerAttributeDescribers = new ArrayList<>();
+
+    public void addDescriber(AttributeDescriber describer) {
+        consumerAttributeDescribers.add(describer);
+    }
+
+    public List<AttributeDescriber> getDescribers() {
+        return Collections.unmodifiableList(consumerAttributeDescribers);
+    }
+
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/attributes/ConfigurableAttributeDescribers.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/attributes/ConfigurableAttributeDescribers.java
@@ -15,13 +15,7 @@
  */
 package org.gradle.api.internal.attributes;
 
-import org.gradle.api.attributes.AttributesSchema;
-
-import java.util.List;
-
-public interface AttributesSchemaWithDescribers extends AttributesSchema {
-
-    List<AttributeDescriber> getConsumerDescribers();
+public interface ConfigurableAttributeDescribers {
 
     void addConsumerDescriber(AttributeDescriber describer);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DependencyResolutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DependencyResolutionServices.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.dsl.DependencyLockingHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.attributes.AttributesSchema;
+import org.gradle.api.internal.attributes.ConfigurableAttributeDescribers;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.model.ObjectFactory;
 
@@ -46,4 +47,6 @@ public interface DependencyResolutionServices {
     ObjectFactory getObjectFactory();
 
     DependencyFactory getDependencyFactory();
+
+    ConfigurableAttributeDescribers getAttributeDescribers();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DependencyResolutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DependencyResolutionServices.java
@@ -21,7 +21,7 @@ import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.dsl.DependencyLockingHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.attributes.AttributesSchema;
-import org.gradle.api.internal.attributes.ConfigurableAttributeDescribers;
+import org.gradle.api.internal.attributes.AttributeDescriberRegistry;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.model.ObjectFactory;
 
@@ -48,5 +48,5 @@ public interface DependencyResolutionServices {
 
     DependencyFactory getDependencyFactory();
 
-    ConfigurableAttributeDescribers getAttributeDescribers();
+    AttributeDescriberRegistry getAttributeDescribers();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
@@ -81,7 +81,7 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
         this.classLoaderScope = classLoaderScope;
         this.dependencyLockingHandler = dependencyResolutionServices.getDependencyLockingHandler();
         this.buildLogicBuilder = buildLogicBuilder;
-        JavaEcosystemSupport.configureSchema(dependencyResolutionServices.getAttributesSchema(), dependencyResolutionServices.getObjectFactory());
+        JavaEcosystemSupport.configureSchema(dependencyResolutionServices.getAttributesSchema(), dependencyResolutionServices.getAttributeDescribers(), dependencyResolutionServices.getObjectFactory());
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
@@ -81,7 +81,7 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
         this.classLoaderScope = classLoaderScope;
         this.dependencyLockingHandler = dependencyResolutionServices.getDependencyLockingHandler();
         this.buildLogicBuilder = buildLogicBuilder;
-        JavaEcosystemSupport.configureSchema(dependencyResolutionServices.getAttributesSchema(), dependencyResolutionServices.getAttributeDescribers(), dependencyResolutionServices.getObjectFactory());
+        JavaEcosystemSupport.configureServices(dependencyResolutionServices.getAttributesSchema(), dependencyResolutionServices.getAttributeDescribers(), dependencyResolutionServices.getObjectFactory());
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/TargetJvmVersionRulesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/TargetJvmVersionRulesTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.attributes.AttributesSchema
 import org.gradle.api.attributes.java.TargetJvmVersion
 import org.gradle.api.internal.attributes.CompatibilityCheckResult
 import org.gradle.api.internal.attributes.CompatibilityRule
+import org.gradle.api.internal.attributes.ConfigurableAttributeDescribers
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.attributes.DisambiguationRule
 import org.gradle.api.internal.attributes.MultipleCandidatesResult
@@ -34,7 +35,7 @@ class TargetJvmVersionRulesTest extends Specification {
 
     def setup() {
         AttributesSchema schema = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
-        JavaEcosystemSupport.configureSchema(schema, TestUtil.objectFactory())
+        JavaEcosystemSupport.configureSchema(schema, Mock(ConfigurableAttributeDescribers), TestUtil.objectFactory())
         compatibilityRules = schema.compatibilityRules(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE)
         disambiguationRules = schema.disambiguationRules(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE)
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/TargetJvmVersionRulesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/TargetJvmVersionRulesTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.api.attributes.AttributesSchema
 import org.gradle.api.attributes.java.TargetJvmVersion
 import org.gradle.api.internal.attributes.CompatibilityCheckResult
 import org.gradle.api.internal.attributes.CompatibilityRule
-import org.gradle.api.internal.attributes.ConfigurableAttributeDescribers
+import org.gradle.api.internal.attributes.AttributeDescriberRegistry
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.attributes.DisambiguationRule
 import org.gradle.api.internal.attributes.MultipleCandidatesResult
@@ -35,7 +35,7 @@ class TargetJvmVersionRulesTest extends Specification {
 
     def setup() {
         AttributesSchema schema = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
-        JavaEcosystemSupport.configureSchema(schema, Mock(ConfigurableAttributeDescribers), TestUtil.objectFactory())
+        JavaEcosystemSupport.configureServices(schema, Mock(AttributeDescriberRegistry), TestUtil.objectFactory())
         compatibilityRules = schema.compatibilityRules(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE)
         disambiguationRules = schema.disambiguationRules(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE)
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultScriptHandlerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultScriptHandlerTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.internal.artifacts.configurations.ConfigurationRolesForMig
 import org.gradle.api.internal.artifacts.configurations.RoleBasedConfigurationContainerInternal
 import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeContainer
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
+import org.gradle.api.internal.attributes.ConfigurableAttributeDescribers
 import org.gradle.api.internal.provider.Providers
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.internal.classloader.ClasspathUtil
@@ -44,6 +45,7 @@ class DefaultScriptHandlerTest extends Specification {
     def depMgmtServices = Mock(DependencyResolutionServices) {
         getAttributesSchema() >> Stub(AttributesSchemaInternal)
         getObjectFactory() >> objectFactory
+        getAttributeDescribers() >> Stub(ConfigurableAttributeDescribers)
     }
     def resolutionContext = new ScriptClassPathResolutionContext(0L, Providers.notDefined(), dependencyHandler)
     def baseClassLoader = new ClassLoader() {}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultScriptHandlerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultScriptHandlerTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.api.internal.artifacts.configurations.ConfigurationRolesForMig
 import org.gradle.api.internal.artifacts.configurations.RoleBasedConfigurationContainerInternal
 import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeContainer
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
-import org.gradle.api.internal.attributes.ConfigurableAttributeDescribers
+import org.gradle.api.internal.attributes.AttributeDescriberRegistry
 import org.gradle.api.internal.provider.Providers
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.internal.classloader.ClasspathUtil
@@ -45,7 +45,7 @@ class DefaultScriptHandlerTest extends Specification {
     def depMgmtServices = Mock(DependencyResolutionServices) {
         getAttributesSchema() >> Stub(AttributesSchemaInternal)
         getObjectFactory() >> objectFactory
-        getAttributeDescribers() >> Stub(ConfigurableAttributeDescribers)
+        getAttributeDescribers() >> Stub(AttributeDescriberRegistry)
     }
     def resolutionContext = new ScriptClassPathResolutionContext(0L, Providers.notDefined(), dependencyHandler)
     def baseClassLoader = new ClassLoader() {}


### PR DESCRIPTION
Upcoming optimizations will de-duplicate attribute schemas, making them immutable and allowing different project components to share the same attribute schemas, and thus sharing their associated matching caches.

This commit removes resolution failure describers and attribute describers from the attribute schemas as they do not contribute to the attribute matching process -- only to handling errors in attribute matching. As such, they should not live with the attribute schema, which will be used as the key to these shared caches.

Instead, these describers have been moved to the ResolutionFailureHandler. Now, the failure handler acts as both the project-scoped state storing how to handle each error, as well as the class responsible for executing those failure describers.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
