### PR TITLE
Fail if Asciidoc content has Markdown style links

### DIFF
--- a/build-logic/documentation/src/test/groovy/gradlebuild/docs/FindBrokenInternalLinksTest.groovy
+++ b/build-logic/documentation/src/test/groovy/gradlebuild/docs/FindBrokenInternalLinksTest.groovy
@@ -160,6 +160,20 @@ The `link:{javadocPath}/org/gradle/api/attributes/AttributesSchema.html#setAttri
         assertNoDeadLinks()
     }
 
+    def "finds Markdown style links"() {
+        given:
+        sampleDoc << """
+=== Markdown Style Links
+[Invalid markdown link](https://docs.gradle.org/nowhere)
+        """
+
+        when:
+        run('checkDeadInternalLinks').buildAndFail()
+
+        then:
+        assertFoundDeadLinks([DeadLink.forMarkdownLink(sampleDoc, "[Invalid markdown link](https://docs.gradle.org/nowhere)")])
+    }
+
     private File createJavadocForClass(String path) {
         new File(docsRoot, "javadoc/${path}.html").tap {
             parentFile.mkdirs()
@@ -214,6 +228,10 @@ The `link:{javadocPath}/org/gradle/api/attributes/AttributesSchema.html#setAttri
 
         static DeadLink forJavadoc(File file, String path) {
             return new DeadLink(file, "Missing Javadoc file for $path in ${file.name}" + (path.startsWith("javadoc") ? " (You may need to remove the leading `javadoc` path component)" : ""))
+        }
+
+        static DeadLink forMarkdownLink(File file, String link) {
+            return new DeadLink(file, "Markdown-style links are not supported: $link")
         }
     }
 }

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/plugins/implementing_gradle_plugins_binary.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/plugins/implementing_gradle_plugins_binary.adoc
@@ -666,6 +666,7 @@ include::sample[dir="snippets/developingPlugins/pluginWithVariants/kotlin",files
 include::sample[dir="snippets/developingPlugins/pluginWithVariants/groovy",files="build.gradle[tags=consume-plugin-variant]"]
 ====
 
+[[reporting_problems]]
 == Reporting problems
 
 Plugins can report problems through Gradle's problem-reporting APIs.

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -256,7 +256,7 @@ We added a check to automatically disable file-system watching on macOS 11 (Big 
 
 ==== Possible change to JDK8-based compiler output when annotation processors are used
 
-The Java compilation infrastructure has been updated to use the [Problems API](https://docs.gradle.org/8.6/userguide/implementing_gradle_plugins.html#reporting_problems).
+The Java compilation infrastructure has been updated to use the <<implementing_gradle_plugins_binary.adoc#reporting_problems,Problems API>>.
 This change will supply the Tooling API clients with structured, rich information about compilation issues.
 
 The feature should not have any visible impact on the usual build output, with JDK8 being an exception.


### PR DESCRIPTION
And fix the one violation left \o/

Fixes #30209