### PR TITLE
Fix the cpp-unit plugin to be configuration cache compatible

### DIFF
--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -60,7 +60,7 @@ vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv -->
 
 The Swift and C++ plugins are now configuration cache compatible.
 
-The `cpp-unit` and `xctest` plugins are not yet compatible.
+The `xctest` and `visual-studio` plugins are not yet compatible.
 
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ADD RELEASE FEATURES ABOVE

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -54,13 +54,15 @@ ADD RELEASE FEATURES BELOW
 vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv -->
 
 <a name="native-plugin-improvements"></a>
-### Swift and C++ plugin improvements
+### Core plugin improvements
 
-#### Configuration cache compatibility
+Gradle provides core plugins for build authors, offering essential tools to simplify project setup and configuration across various languages and platforms.
 
-The Swift and C++ plugins are now configuration cache compatible.
+#### Configuration cache compatibility for Swift and C++ plugins
 
-The `xctest` and `visual-studio` plugins are not yet compatible.
+The [Swift](userguide/swift_application_plugin.html) and [C++](userguide/cpp_application_plugin.html) core plugins are now [configuration cache](userguide/performance.html#enable_configuration_cache) compatible.
+
+The [`xctest`](userguide/xctest_plugin.html) and [`visual-studio`](userguide/visual_studio_plugin.html) plugins are not yet compatible.
 
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ADD RELEASE FEATURES ABOVE

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppDependenciesIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppDependenciesIntegrationTest.groovy
@@ -57,7 +57,7 @@ class CppDependenciesIntegrationTest extends AbstractInstalledToolChainIntegrati
 
     // NOTE: This method is named in a short way because of the maximum path length
     // on Windows.
-    @ToBeFixedForConfigurationCache
+    @ToBeFixedForConfigurationCache(because = "source dependencies")
     def "from VCS"() {
         given:
         createDirs("app")

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppSystemHeaderDiscoveryIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppSystemHeaderDiscoveryIntegrationTest.groovy
@@ -16,28 +16,25 @@
 
 package org.gradle.language.cpp
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
-import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 
+import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 
 class CppSystemHeaderDiscoveryIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
 
-    @ToBeFixedForConfigurationCache
     def "discovers C and C++ standard library headers"() {
         def outputFile = file("dirs.txt")
         buildFile << """
             plugins { id 'cpp-application' }
             task sysHeaders {
+                def out = file("${outputFile.toURI()}")
+                def headers = provider { tasks.compileDebugCpp.systemIncludes }
                 doLast {
-                    def out = file("${outputFile.toURI()}")
-                    out.text = tasks.compileDebugCpp.systemIncludes.join('\\n')
+                    out.text = headers.get().join('\\n')
                 }
             }
         """
 
         when:
-        //TODO this fails in CI (for unknown reasons) with project access checks based on configuration barrier
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
         succeeds("sysHeaders")
 
         then:

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/tasks/CppUnexportMainSymbolIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/tasks/CppUnexportMainSymbolIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.language.cpp.tasks
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.SourceFile
 import org.gradle.language.nativeplatform.tasks.AbstractUnexportMainSymbolIntegrationTest
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
@@ -34,7 +33,6 @@ import spock.lang.Issue
 class CppUnexportMainSymbolIntegrationTest extends AbstractUnexportMainSymbolIntegrationTest {
     @RequiresInstalledToolChain(ToolChainRequirement.VISUALCPP)
     @Issue("https://github.com/gradle/gradle-native/issues/277")
-    @ToBeFixedForConfigurationCache
     def "can relocate Windows specific _wmain symbol"() {
         makeSingleProject()
         file("src/main/cpp/main.cpp") << """

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/nativeplatform/tasks/AbstractUnexportMainSymbolIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/nativeplatform/tasks/AbstractUnexportMainSymbolIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.language.nativeplatform.tasks
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.NativeBinaryFixture
 import org.gradle.nativeplatform.fixtures.app.IncrementalElement
@@ -56,7 +56,6 @@ abstract class AbstractUnexportMainSymbolIntegrationTest extends AbstractInstall
     protected abstract List<String> getMainSymbols()
 
     @Issue("https://github.com/gradle/gradle-native/issues/304")
-    @ToBeFixedForConfigurationCache
     def "clean build works"() {
         makeSingleProject()
         componentUnderTest.writeToProject(testDirectory)
@@ -66,7 +65,6 @@ abstract class AbstractUnexportMainSymbolIntegrationTest extends AbstractInstall
     }
 
     @Issue("https://github.com/gradle/gradle-native/issues/297")
-    @ToBeFixedForConfigurationCache
     def "unexport is incremental"() {
         makeSingleProject()
         componentUnderTest.writeToProject(testDirectory)
@@ -88,7 +86,6 @@ abstract class AbstractUnexportMainSymbolIntegrationTest extends AbstractInstall
         result.assertTasksNotSkipped(developmentBinaryCompileTask, ":unexport")
     }
 
-    @ToBeFixedForConfigurationCache
     def "relocate _main symbol with main.<ext>"() {
         makeSingleProject()
         componentUnderTest.writeToProject(testDirectory)
@@ -99,7 +96,6 @@ abstract class AbstractUnexportMainSymbolIntegrationTest extends AbstractInstall
         assertMainSymbolIsNotExported(objectFile("build/relocated/main"))
     }
 
-    @ToBeFixedForConfigurationCache
     def "relocate _main symbol with notMain.<ext>"() {
         makeSingleProject()
         getMainFile("notMain").writeToProject(testDirectory)
@@ -110,7 +106,6 @@ abstract class AbstractUnexportMainSymbolIntegrationTest extends AbstractInstall
         assertMainSymbolIsNotExported(objectFile("build/relocated/notMain"))
     }
 
-    @ToBeFixedForConfigurationCache
     def "relocate _main symbol with multiple files"() {
         makeSingleProject()
         componentWithOtherFileUnderTest.writeToProject(testDirectory)
@@ -122,7 +117,6 @@ abstract class AbstractUnexportMainSymbolIntegrationTest extends AbstractInstall
         file("build/relocated").assertHasDescendants(objectFile("main").name, objectFile("other").name)
     }
 
-    @ToBeFixedForConfigurationCache
     def "relocate _main symbol works incrementally"() {
         makeSingleProject()
         componentUnderTest.writeToProject(testDirectory)
@@ -161,7 +155,6 @@ abstract class AbstractUnexportMainSymbolIntegrationTest extends AbstractInstall
         mainObject.lastModified() > oldTimestamp
     }
 
-    @ToBeFixedForConfigurationCache
     def "can relocate when there is no main symbol"() {
         makeSingleProject()
         componentWithoutMainUnderTest.writeToProject(testDirectory)

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/nativeplatform/tasks/AbstractUnexportMainSymbolIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/nativeplatform/tasks/AbstractUnexportMainSymbolIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.language.nativeplatform.tasks
 
-
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.NativeBinaryFixture
 import org.gradle.nativeplatform.fixtures.app.IncrementalElement

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/AbstractSwiftIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/AbstractSwiftIntegrationTest.groovy
@@ -90,7 +90,6 @@ abstract class AbstractSwiftIntegrationTest extends AbstractSwiftComponentIntegr
     }
 
     // TODO Move this to AbstractCppComponentIntegrationTest when unit test works properly with architecture
-    @ToBeFixedForConfigurationCache
     def "ignores duplicate target machines"() {
         given:
         makeSingleProject()
@@ -101,9 +100,11 @@ abstract class AbstractSwiftIntegrationTest extends AbstractSwiftComponentIntegr
         buildFile << configureTargetMachines("machines.${currentHostOperatingSystemFamilyDsl}", "machines.${currentHostOperatingSystemFamilyDsl}")
         buildFile << """
             task verifyTargetMachines {
+                def targetMachines = ${componentUnderTestDsl}.targetMachines
+                def hostMachine = machines.${currentHostOperatingSystemFamilyDsl}
                 doLast {
-                    assert ${componentUnderTestDsl}.targetMachines.get().size() == 1
-                    assert ${componentUnderTestDsl}.targetMachines.get() == [machines.${currentHostOperatingSystemFamilyDsl}] as Set
+                    assert targetMachines.get().size() == 1
+                    assert targetMachines.get() == [hostMachine] as Set
                 }
             }
         """

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/AbstractSwiftIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/AbstractSwiftIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.language.swift
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.SourceElement

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftApplicationDependenciesIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftApplicationDependenciesIntegrationTest.groovy
@@ -19,8 +19,10 @@ package org.gradle.language.swift
 import org.gradle.language.AbstractNativeProductionComponentDependenciesIntegrationTest
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
+import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
+@DoesNotSupportNonAsciiPaths(reason = "swiftc does not support these paths")
 class SwiftApplicationDependenciesIntegrationTest extends AbstractNativeProductionComponentDependenciesIntegrationTest {
     @Override
     protected void makeComponentWithLibrary() {
@@ -43,7 +45,7 @@ class SwiftApplicationDependenciesIntegrationTest extends AbstractNativeProducti
 
         file('lib/build.gradle') << """
             apply plugin: 'swift-library'
-            
+
             group = 'org.gradle.test'
             version = '1.0'
         """

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftCachingIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftCachingIntegrationTest.groovy
@@ -21,9 +21,11 @@ import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationS
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.SwiftAppWithLibraries
+import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 import org.gradle.test.fixtures.file.TestFile
 
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
+@DoesNotSupportNonAsciiPaths(reason = "swiftc does not support these paths")
 class SwiftCachingIntegrationTest extends AbstractInstalledToolChainIntegrationSpec implements DirectoryBuildCacheFixture {
 
     def app = new SwiftAppWithLibraries()

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftDependenciesCppInteroperabilityIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftDependenciesCppInteroperabilityIntegrationTest.groovy
@@ -25,7 +25,7 @@ import org.gradle.vcs.fixtures.GitFileRepository
 class SwiftDependenciesCppInteroperabilityIntegrationTest extends AbstractSwiftMixedLanguageIntegrationTest {
     def app = new SwiftAppWithCppLibrary()
 
-    @ToBeFixedForConfigurationCache
+    @ToBeFixedForConfigurationCache(because = "source dpendencies")
     def "can depend on both swift and cpp libraries from VCS"() {
         given:
         createDirs("app")

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftDependenciesCppInteroperabilityIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftDependenciesCppInteroperabilityIntegrationTest.groovy
@@ -25,7 +25,7 @@ import org.gradle.vcs.fixtures.GitFileRepository
 class SwiftDependenciesCppInteroperabilityIntegrationTest extends AbstractSwiftMixedLanguageIntegrationTest {
     def app = new SwiftAppWithCppLibrary()
 
-    @ToBeFixedForConfigurationCache(because = "source dpendencies")
+    @ToBeFixedForConfigurationCache(because = "source dependencies")
     def "can depend on both swift and cpp libraries from VCS"() {
         given:
         createDirs("app")

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftDependenciesIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftDependenciesIntegrationTest.groovy
@@ -53,7 +53,7 @@ class SwiftDependenciesIntegrationTest extends AbstractInstalledToolChainIntegra
         assertAppHasOutputFor("release")
     }
 
-    @ToBeFixedForConfigurationCache
+    @ToBeFixedForConfigurationCache(because = "source dependencies")
     def "can depend on swift libraries from VCS"() {
         given:
         createDirs("app")

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftDependenciesIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftDependenciesIntegrationTest.groovy
@@ -21,9 +21,11 @@ import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationS
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.SwiftAppWithLibraries
+import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 import org.gradle.vcs.fixtures.GitFileRepository
 
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
+@DoesNotSupportNonAsciiPaths(reason = "swiftc does not support these paths")
 class SwiftDependenciesIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
     def app = new SwiftAppWithLibraries()
 

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalCompileIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalCompileIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.language.swift
 
 import org.gradle.integtests.fixtures.CompilationOutputsFixture
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.AvailableToolChains
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
@@ -111,7 +110,6 @@ class SwiftIncrementalCompileIntegrationTest extends AbstractInstalledToolChainI
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_4_OR_OLDER)
-    @ToBeFixedForConfigurationCache
     def 'removing a file rebuilds everything'() {
         given:
         def outputs = new CompilationOutputsFixture(file("build/obj/main/debug"), [".o"])
@@ -245,8 +243,7 @@ class SwiftIncrementalCompileIntegrationTest extends AbstractInstalledToolChainI
         outputs.recompiledClasses('main', 'sum', 'greeter', 'multiply')
     }
 
-    @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_4)
-    @ToBeFixedForConfigurationCache
+    @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_5)
     def 'changing Swift language level rebuilds everything'() {
         given:
         def outputs = new CompilationOutputsFixture(file("build/obj/main/debug"), [".o"])
@@ -259,12 +256,13 @@ class SwiftIncrementalCompileIntegrationTest extends AbstractInstalledToolChainI
                 if (project.hasProperty("swift4")) {
                     sourceCompatibility = SwiftVersion.SWIFT4
                 } else {
-                    sourceCompatibility = SwiftVersion.SWIFT3
+                    sourceCompatibility = SwiftVersion.SWIFT5
                 }
             }
          """
 
-        outputs.snapshot { succeeds("compileDebugSwift") }
+        // build for Swift5
+        outputs.snapshot { succeeds("compileDebugSwift", "--info") }
 
         expect:
         // rebuild for Swift4
@@ -272,7 +270,7 @@ class SwiftIncrementalCompileIntegrationTest extends AbstractInstalledToolChainI
         outputs.recompiledClasses('main', 'sum', 'greeter', 'multiply')
 
         and:
-        // rebuild for Swift3
+        // rebuild for Swift5
         succeeds("compileDebugSwift")
         outputs.recompiledClasses('main', 'sum', 'greeter', 'multiply')
     }

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalCompileIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalCompileIntegrationTest.groovy
@@ -22,9 +22,11 @@ import org.gradle.nativeplatform.fixtures.AvailableToolChains
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.SwiftApp
+import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 import org.junit.Assume
 
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
+@DoesNotSupportNonAsciiPaths(reason = "swiftc does not support these paths")
 class SwiftIncrementalCompileIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
     def setup() {
         // Useful for diagnosing swiftc incremental compile failures

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftLibraryDependenciesIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftLibraryDependenciesIntegrationTest.groovy
@@ -20,8 +20,10 @@ package org.gradle.language.swift
 import org.gradle.language.AbstractNativeLibraryDependenciesIntegrationTest
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
+import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
+@DoesNotSupportNonAsciiPaths(reason = "swiftc does not support these paths")
 class SwiftLibraryDependenciesIntegrationTest extends AbstractNativeLibraryDependenciesIntegrationTest {
     def "can compile against a library with implementation dependencies"() {
         createDirs("lib1", "lib2")

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftParallelExecutionIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftParallelExecutionIntegrationTest.groovy
@@ -21,8 +21,10 @@ import org.gradle.language.AbstractNativeParallelIntegrationTest
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.SwiftApp
+import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
+@DoesNotSupportNonAsciiPaths(reason = "swiftc does not support these paths")
 class SwiftParallelExecutionIntegrationTest extends AbstractNativeParallelIntegrationTest {
     def app = new SwiftApp()
 

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/tasks/SwiftUnexportMainSymbolIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/tasks/SwiftUnexportMainSymbolIntegrationTest.groovy
@@ -25,8 +25,10 @@ import org.gradle.nativeplatform.fixtures.app.IncrementalSwiftElement
 import org.gradle.nativeplatform.fixtures.app.SourceElement
 import org.gradle.nativeplatform.fixtures.app.SourceFileElement
 import org.gradle.nativeplatform.fixtures.app.SwiftLib
+import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
+@DoesNotSupportNonAsciiPaths(reason = "swiftc does not support these paths")
 class SwiftUnexportMainSymbolIntegrationTest extends AbstractUnexportMainSymbolIntegrationTest {
     @Override
     protected void makeSingleProject() {

--- a/platforms/native/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/UnexportMainSymbol.java
+++ b/platforms/native/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/UnexportMainSymbol.java
@@ -33,11 +33,13 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.language.swift.tasks.internal.SymbolHider;
+import org.gradle.process.ExecOperations;
 import org.gradle.process.ExecSpec;
 import org.gradle.work.ChangeType;
 import org.gradle.work.FileChange;
 import org.gradle.work.InputChanges;
 
+import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 
@@ -112,7 +114,7 @@ public abstract class UnexportMainSymbol extends DefaultTask {
                 throw UncheckedException.throwAsUncheckedException(e);
             }
         } else {
-            getProject().exec(new Action<ExecSpec>() {
+            getExecOperations().exec(new Action<ExecSpec>() {
                 @Override
                 public void execute(ExecSpec execSpec) {
                     // TODO: should use target platform to make this decision
@@ -138,4 +140,7 @@ public abstract class UnexportMainSymbol extends DefaultTask {
     private File relocatedObject(File object) {
         return outputDirectory.file(object.getName()).get().getAsFile();
     }
+
+    @Inject
+    protected abstract ExecOperations getExecOperations();
 }

--- a/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeUnitTestComponentDependenciesIntegrationTest.groovy
+++ b/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeUnitTestComponentDependenciesIntegrationTest.groovy
@@ -27,7 +27,9 @@ abstract class AbstractNativeUnitTestComponentDependenciesIntegrationTest extend
         """
     }
 
-    @ToBeFixedForConfigurationCache
+    @ToBeFixedForConfigurationCache(bottomSpecs = [
+        'XCTestWithApplicationDependenciesIntegrationTest'
+    ])
     def "can define implementation dependencies on production component"() {
         given:
         createDirs("lib")

--- a/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
+++ b/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
@@ -24,12 +24,6 @@ import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.util.internal.GUtil
 
 abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguageComponentIntegrationTest {
-    @ToBeFixedForConfigurationCache(bottomSpecs = [
-        'CppUnitTestComponentWithBothLibraryLinkageIntegrationTest',
-        'CppUnitTestComponentWithSharedLibraryLinkageIntegrationTest',
-        'CppUnitTestComponentWithStaticLibraryLinkageIntegrationTest',
-        'CppUnitTestComponentWithoutComponentIntegrationTest'
-    ])
     def "can build on current operating system family and architecture when explicitly specified"() {
         given:
         makeSingleProject()
@@ -99,12 +93,6 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
         failure.assertHasCause("A target machine needs to be specified for the ${GUtil.toWords(componentUnderTestDsl, (char) ' ')}.")
     }
 
-    @ToBeFixedForConfigurationCache(bottomSpecs = [
-        'CppUnitTestComponentWithBothLibraryLinkageIntegrationTest',
-        'CppUnitTestComponentWithSharedLibraryLinkageIntegrationTest',
-        'CppUnitTestComponentWithStaticLibraryLinkageIntegrationTest',
-        'CppUnitTestComponentWithoutComponentIntegrationTest'
-    ])
     def "can build for current machine when multiple target machines are specified"() {
         given:
         makeSingleProject()
@@ -119,12 +107,6 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32_AND_64)
-    @ToBeFixedForConfigurationCache(bottomSpecs = [
-        'CppUnitTestComponentWithBothLibraryLinkageIntegrationTest',
-        'CppUnitTestComponentWithSharedLibraryLinkageIntegrationTest',
-        'CppUnitTestComponentWithStaticLibraryLinkageIntegrationTest',
-        'CppUnitTestComponentWithoutComponentIntegrationTest'
-    ])
     def "can build for multiple target machines"() {
         given:
         makeSingleProject()
@@ -142,11 +124,10 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
     }
 
     @ToBeFixedForConfigurationCache(bottomSpecs = [
-        'CppUnitTestComponentWithBothLibraryLinkageIntegrationTest',
-        'CppUnitTestComponentWithSharedLibraryLinkageIntegrationTest',
         'CppUnitTestComponentWithStaticLibraryLinkageIntegrationTest',
-        'CppUnitTestComponentWithoutComponentIntegrationTest'
-    ])
+        'CppUnitTestComponentWithBothLibraryLinkageIntegrationTest',
+        'CppUnitTestComponentWithSharedLibraryLinkageIntegrationTest'
+    ], because = "may compile main and test binaries concurrently so may fail with multiple exceptions")
     def "fails when no target architecture can be built"() {
         given:
         makeSingleProject()
@@ -161,12 +142,6 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
         failure.assertHasCause("No tool chain is available to build C++")
     }
 
-    @ToBeFixedForConfigurationCache(bottomSpecs = [
-        'CppUnitTestComponentWithBothLibraryLinkageIntegrationTest',
-        'CppUnitTestComponentWithSharedLibraryLinkageIntegrationTest',
-        'CppUnitTestComponentWithStaticLibraryLinkageIntegrationTest',
-        'CppUnitTestComponentWithoutComponentIntegrationTest'
-    ])
     def "can build current architecture when other, non-buildable architectures are specified"() {
         given:
         makeSingleProject()
@@ -203,12 +178,6 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
         succeeds "verifyTargetMachineCount"
     }
 
-    @ToBeFixedForConfigurationCache(bottomSpecs = [
-        'CppUnitTestComponentWithBothLibraryLinkageIntegrationTest',
-        'CppUnitTestComponentWithSharedLibraryLinkageIntegrationTest',
-        'CppUnitTestComponentWithStaticLibraryLinkageIntegrationTest',
-        'CppUnitTestComponentWithoutComponentIntegrationTest'
-    ])
     def "can specify unbuildable architecture as a component target machine"() {
         given:
         makeSingleProject()

--- a/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/swift/AbstractSwiftComponentIntegrationTest.groovy
+++ b/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/swift/AbstractSwiftComponentIntegrationTest.groovy
@@ -23,9 +23,11 @@ import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.SourceElement
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 import org.hamcrest.CoreMatchers
 
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
+@DoesNotSupportNonAsciiPaths(reason = "swiftc does not support these paths")
 abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLanguageComponentIntegrationTest {
 
     @ToBeFixedForConfigurationCache(bottomSpecs = [
@@ -341,6 +343,18 @@ abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLangu
             return "macOS"
         } else {
             return osFamily
+        }
+    }
+
+    protected String getCurrentHostOperatingSystemName() {
+        return DefaultNativePlatform.getCurrentOperatingSystem().toFamilyName()
+    }
+
+    protected String getCurrentHostArchName() {
+        if (DefaultNativePlatform.getCurrentArchitecture().arm64) {
+            return "aarch64"
+        } else {
+            return "x86-64"
         }
     }
 

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/AbstractNativeUnitTestIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/AbstractNativeUnitTestIntegrationTest.groovy
@@ -28,9 +28,6 @@ import static org.gradle.nativeplatform.MachineArchitecture.X86_64
 
 abstract class AbstractNativeUnitTestIntegrationTest extends AbstractInstalledToolChainIntegrationSpec implements LanguageTaskNames {
     @ToBeFixedForConfigurationCache(bottomSpecs = [
-        'CppUnitTestWithApplicationIntegrationTest',
-        'CppUnitTestWithLibraryIntegrationTest',
-        'CppUnitTestWithoutComponentIntegrationTest',
         'SwiftXCTestWithBothLibraryLinkageIntegrationTest',
         'SwiftXCTestWithSharedLibraryLinkageIntegrationTest',
         'SwiftXCTestWithStaticLibraryLinkageIntegrationTest',
@@ -49,7 +46,13 @@ abstract class AbstractNativeUnitTestIntegrationTest extends AbstractInstalledTo
         result.assertTasksSkipped(tasksToCompileComponentUnderTest, tasksToBuildAndRunUnitTest, ":test", ":check")
     }
 
-    @ToBeFixedForConfigurationCache
+    @ToBeFixedForConfigurationCache(bottomSpecs = [
+        'SwiftXCTestWithBothLibraryLinkageIntegrationTest',
+        'SwiftXCTestWithSharedLibraryLinkageIntegrationTest',
+        'SwiftXCTestWithStaticLibraryLinkageIntegrationTest',
+        'SwiftXCTestWithApplicationIntegrationTest',
+        'SwiftXCTestWithoutComponentIntegrationTest'
+    ])
     def "runs tests when #task lifecycle task executes"() {
         given:
         makeSingleProject()
@@ -70,7 +73,13 @@ abstract class AbstractNativeUnitTestIntegrationTest extends AbstractInstalledTo
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32_AND_64)
-    @ToBeFixedForConfigurationCache
+    @ToBeFixedForConfigurationCache(bottomSpecs = [
+        'SwiftXCTestWithBothLibraryLinkageIntegrationTest',
+        'SwiftXCTestWithSharedLibraryLinkageIntegrationTest',
+        'SwiftXCTestWithStaticLibraryLinkageIntegrationTest',
+        'SwiftXCTestWithApplicationIntegrationTest',
+        'SwiftXCTestWithoutComponentIntegrationTest'
+    ])
     def "runs tests when #task lifecycle task executes and target machines are specified on the component under test"() {
         Assume.assumeFalse(componentUnderTestDsl == null)
 
@@ -95,7 +104,13 @@ abstract class AbstractNativeUnitTestIntegrationTest extends AbstractInstalledTo
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32_AND_64)
-    @ToBeFixedForConfigurationCache
+    @ToBeFixedForConfigurationCache(bottomSpecs = [
+        'SwiftXCTestWithBothLibraryLinkageIntegrationTest',
+        'SwiftXCTestWithSharedLibraryLinkageIntegrationTest',
+        'SwiftXCTestWithStaticLibraryLinkageIntegrationTest',
+        'SwiftXCTestWithApplicationIntegrationTest',
+        'SwiftXCTestWithoutComponentIntegrationTest'
+    ])
     def "runs tests when #task lifecycle task executes and target machines are specified on both main component and test component"() {
         Assume.assumeFalse(componentUnderTestDsl == null)
 
@@ -119,7 +134,13 @@ abstract class AbstractNativeUnitTestIntegrationTest extends AbstractInstalledTo
         "build" | X86_64               | [":test", ":check", ":build", getTasksToAssembleComponentUnderTest(X86_64), ":assemble"]
     }
 
-    @ToBeFixedForConfigurationCache
+    @ToBeFixedForConfigurationCache(bottomSpecs = [
+        'SwiftXCTestWithBothLibraryLinkageIntegrationTest',
+        'SwiftXCTestWithSharedLibraryLinkageIntegrationTest',
+        'SwiftXCTestWithStaticLibraryLinkageIntegrationTest',
+        'SwiftXCTestWithApplicationIntegrationTest',
+        'SwiftXCTestWithoutComponentIntegrationTest'
+    ])
     def "runs tests when #task lifecycle task executes and target machines are specified on the test component only"() {
         given:
         makeSingleProject()
@@ -157,7 +178,13 @@ abstract class AbstractNativeUnitTestIntegrationTest extends AbstractInstalledTo
         failure.assertHasCause("The target machine ${currentOsFamilyName}:${otherArchitecture} was specified for the unit test, but this target machine was not specified on the component under test.")
     }
 
-    @ToBeFixedForConfigurationCache
+    @ToBeFixedForConfigurationCache(bottomSpecs = [
+        'SwiftXCTestWithBothLibraryLinkageIntegrationTest',
+        'SwiftXCTestWithSharedLibraryLinkageIntegrationTest',
+        'SwiftXCTestWithStaticLibraryLinkageIntegrationTest',
+        'SwiftXCTestWithApplicationIntegrationTest',
+        'SwiftXCTestWithoutComponentIntegrationTest'
+    ])
     def "skips test tasks as up-to-date when nothing changes between invocation"() {
         given:
         makeSingleProject()

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestWithoutComponentIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestWithoutComponentIntegrationTest.groovy
@@ -57,7 +57,13 @@ class CppUnitTestWithoutComponentIntegrationTest extends AbstractCppUnitTestInte
         // Ok
     }
 
-    @ToBeFixedForConfigurationCache
+    @ToBeFixedForConfigurationCache(bottomSpecs = [
+        'SwiftXCTestWithBothLibraryLinkageIntegrationTest',
+        'SwiftXCTestWithSharedLibraryLinkageIntegrationTest',
+        'SwiftXCTestWithStaticLibraryLinkageIntegrationTest',
+        'SwiftXCTestWithApplicationIntegrationTest',
+        'SwiftXCTestWithoutComponentIntegrationTest'
+    ])
     def "test fails when test executable returns non-zero status"() {
         buildFile << """
             apply plugin: 'cpp-unit-test'

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/AbstractSwiftXCTestComponentIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/AbstractSwiftXCTestComponentIntegrationTest.groovy
@@ -32,6 +32,9 @@ abstract class AbstractSwiftXCTestComponentIntegrationTest extends AbstractSwift
     def setup() {
         // TODO: Temporarily disable XCTests with Swift3 on macOS
         Assume.assumeFalse(OperatingSystem.current().isMacOsX() && toolChain.version.major == 3)
+
+        // Need XCTest available to run these tests
+        XCTestInstallation.assumeInstalled()
     }
 
     def "check task warns when current operating system family is excluded"() {

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/AbstractSwiftXCTestIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/AbstractSwiftXCTestIntegrationTest.groovy
@@ -22,9 +22,11 @@ import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.XCTestSourceElement
 import org.gradle.nativeplatform.test.AbstractNativeUnitTestIntegrationTest
+import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 import org.junit.Assume
 
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
+@DoesNotSupportNonAsciiPaths(reason = "swiftc does not support these paths")
 abstract class AbstractSwiftXCTestIntegrationTest extends AbstractNativeUnitTestIntegrationTest implements XCTestExecutionResult, SwiftTaskNames {
     def setup() {
         // TODO: Temporarily disable XCTests with Swift3 on macOS

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/AbstractSwiftXCTestIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/AbstractSwiftXCTestIntegrationTest.groovy
@@ -31,6 +31,9 @@ abstract class AbstractSwiftXCTestIntegrationTest extends AbstractNativeUnitTest
     def setup() {
         // TODO: Temporarily disable XCTests with Swift3 on macOS
         Assume.assumeFalse(OperatingSystem.current().isMacOsX() && toolChain.version.major == 3)
+
+        // Need XCTest available to run these tests
+        XCTestInstallation.assumeInstalled()
     }
 
     @Override

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestErrorHandlingIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestErrorHandlingIntegrationTest.groovy
@@ -27,11 +27,14 @@ import org.gradle.nativeplatform.fixtures.app.SwiftAppWithLibrariesAndXCTest
 import org.gradle.nativeplatform.fixtures.app.XCTestCaseElement
 import org.gradle.nativeplatform.fixtures.app.XCTestSourceElement
 import org.gradle.nativeplatform.fixtures.app.XCTestSourceFileElement
+import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
+import org.gradle.util.internal.VersionNumber
 
 import static org.gradle.integtests.fixtures.TestExecutionResult.EXECUTION_FAILURE
 import static org.gradle.util.Matchers.containsText
 
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
+@DoesNotSupportNonAsciiPaths(reason = "swiftc does not support these paths")
 class SwiftXCTestErrorHandlingIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
 
     @ToBeFixedForConfigurationCache
@@ -76,7 +79,10 @@ class SwiftXCTestErrorHandlingIntegrationTest extends AbstractInstalledToolChain
         def testFailure = testExecutionResult.testClass("Gradle Test Run :app:xcTest")
         testFailure.assertTestFailed(EXECUTION_FAILURE, containsText("finished with non-zero exit value"))
         if (OperatingSystem.current().isMacOsX()) {
-            testFailure.assertStderr(containsText("The bundle “AppTest.xctest” couldn’t be loaded because it is damaged or missing necessary resources"))
+            if (toolChain.version < VersionNumber.version(5, 9)) {
+                testFailure.assertStderr(containsText("The bundle “AppTest.xctest” couldn’t be loaded because it is damaged or missing necessary resources"))
+            }
+            // Else, there is no stderr/stdout produced by newer versions
         } else {
             testFailure.assertStderr(containsText("cannot open shared object file"))
         }

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestErrorHandlingIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestErrorHandlingIntegrationTest.groovy
@@ -36,6 +36,10 @@ import static org.gradle.util.Matchers.containsText
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
 @DoesNotSupportNonAsciiPaths(reason = "swiftc does not support these paths")
 class SwiftXCTestErrorHandlingIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
+    def setup() {
+        // Need XCTest available to run these tests
+        XCTestInstallation.assumeInstalled()
+    }
 
     @ToBeFixedForConfigurationCache
     def "fails when working directory is invalid"() {

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestIntegrationTest.groovy
@@ -51,6 +51,9 @@ apply plugin: 'xctest'
 """
         // TODO: Temporarily disable XCTests with Swift3 on macOS
         Assume.assumeFalse(OperatingSystem.current().isMacOsX() && toolChain.version.major == 3)
+
+        // Need XCTest available to run these tests
+        XCTestInstallation.assumeInstalled()
     }
 
     @ToBeFixedForConfigurationCache

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestIntegrationTest.groovy
@@ -39,9 +39,11 @@ import org.gradle.nativeplatform.fixtures.app.SwiftXCTestWithDepAndCustomXCTestS
 import org.gradle.nativeplatform.fixtures.app.XCTestCaseElement
 import org.gradle.nativeplatform.fixtures.app.XCTestSourceElement
 import org.gradle.nativeplatform.fixtures.app.XCTestSourceFileElement
+import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 import org.junit.Assume
 
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
+@DoesNotSupportNonAsciiPaths(reason = "swiftc does not support these paths")
 class SwiftXCTestIntegrationTest extends AbstractInstalledToolChainIntegrationSpec implements XCTestExecutionResult, SwiftTaskNames {
     def setup() {
         buildFile << """

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestDependenciesIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestDependenciesIntegrationTest.groovy
@@ -25,6 +25,11 @@ import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
 @DoesNotSupportNonAsciiPaths(reason = "swiftc does not support these paths")
 class XCTestDependenciesIntegrationTest extends AbstractNativeDependenciesIntegrationTest implements SwiftTaskNames {
+    def setup() {
+        // Need XCTest available to run these tests
+        XCTestInstallation.assumeInstalled()
+    }
+
     @Override
     protected void makeComponentWithLibrary() {
         buildFile << """

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestDependenciesIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestDependenciesIntegrationTest.groovy
@@ -20,8 +20,10 @@ import org.gradle.language.AbstractNativeDependenciesIntegrationTest
 import org.gradle.language.swift.SwiftTaskNames
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
+import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
+@DoesNotSupportNonAsciiPaths(reason = "swiftc does not support these paths")
 class XCTestDependenciesIntegrationTest extends AbstractNativeDependenciesIntegrationTest implements SwiftTaskNames {
     @Override
     protected void makeComponentWithLibrary() {

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestInstallation.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestInstallation.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.test.xctest
+
+import org.gradle.internal.os.OperatingSystem
+import org.junit.Assume
+
+class XCTestInstallation {
+    static boolean isInstalled() {
+        if (OperatingSystem.current().isMacOsX()) {
+            // XCTest is bundled with XCode, so the test cannot be run if XCode is not installed
+            def result = ["xcrun", "--show-sdk-platform-path"].execute().waitFor()
+            // If it fails, assume XCode is not installed
+            return result == 0
+        } else {
+            return true
+        }
+    }
+
+    /**
+     * Verifies that XCTest is installed. Currently, this just checks whether XCode is installed.
+     */
+    static void assumeInstalled() {
+        if (!installed) {
+            println "XCode is not installed"
+            Assume.assumeTrue("XCode should be installed", false)
+        }
+    }
+}

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestInstallation.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestInstallation.groovy
@@ -19,6 +19,9 @@ package org.gradle.nativeplatform.test.xctest
 import org.gradle.internal.os.OperatingSystem
 import org.junit.Assume
 
+/**
+ * This class probes for an XCTest installation in a location where it will be discovered by the Swift plugins.
+ */
 class XCTestInstallation {
     static boolean isInstalled() {
         if (OperatingSystem.current().isMacOsX()) {

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestWithApplicationDependenciesIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestWithApplicationDependenciesIntegrationTest.groovy
@@ -21,8 +21,10 @@ import org.gradle.language.swift.SwiftTaskNames
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.SwiftXCTestWithDepAndCustomXCTestSuite
+import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
+@DoesNotSupportNonAsciiPaths(reason = "swiftc does not support these paths")
 class XCTestWithApplicationDependenciesIntegrationTest extends AbstractNativeUnitTestComponentDependenciesIntegrationTest implements SwiftTaskNames {
     @Override
     protected void makeTestSuiteAndComponentWithLibrary() {

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestWithApplicationDependenciesIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestWithApplicationDependenciesIntegrationTest.groovy
@@ -26,6 +26,11 @@ import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
 @DoesNotSupportNonAsciiPaths(reason = "swiftc does not support these paths")
 class XCTestWithApplicationDependenciesIntegrationTest extends AbstractNativeUnitTestComponentDependenciesIntegrationTest implements SwiftTaskNames {
+    def setup() {
+        // Need XCTest available to run these tests
+        XCTestInstallation.assumeInstalled()
+    }
+
     @Override
     protected void makeTestSuiteAndComponentWithLibrary() {
         buildFile << """

--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/CppApplicationInitIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/CppApplicationInitIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.buildinit.plugins
 
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.nativeplatform.fixtures.AvailableToolChains
 import org.gradle.nativeplatform.fixtures.ExecutableFixture
 
@@ -30,7 +29,6 @@ class CppApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
     @Override
     String subprojectName() { 'app' }
 
-    @ToBeFixedForConfigurationCache(because = "cpp-application plugin")
     def "creates sample source if no source present with #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'cpp-application', '--dsl', scriptDsl.id)
@@ -58,7 +56,6 @@ class CppApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
         scriptDsl << ScriptDslFixture.SCRIPT_DSLS
     }
 
-    @ToBeFixedForConfigurationCache(because = "cpp-application plugin")
     def "creates sample source if project name is specified with #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'cpp-application', '--project-name', 'app', '--dsl', scriptDsl.id)
@@ -86,7 +83,6 @@ class CppApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
         scriptDsl << ScriptDslFixture.SCRIPT_DSLS
     }
 
-    @ToBeFixedForConfigurationCache(because = "cpp-application plugin")
     def "source generation is skipped when cpp sources detected with #scriptDsl build scripts"() {
         setup:
         subprojectDir.file("src/main/cpp/hola.cpp") << """

--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/CppLibraryInitIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/CppLibraryInitIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.buildinit.plugins
 
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.nativeplatform.fixtures.AvailableToolChains
 import org.gradle.nativeplatform.fixtures.SharedLibraryFixture
 import org.gradle.test.precondition.Requires
@@ -32,7 +31,6 @@ class CppLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
     @Override
     String subprojectName() { 'lib' }
 
-    @ToBeFixedForConfigurationCache(because = "cpp-library plugin")
     def "creates sample source if no source present with #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'cpp-library', '--dsl', scriptDsl.id)
@@ -62,7 +60,6 @@ class CppLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
         scriptDsl << ScriptDslFixture.SCRIPT_DSLS
     }
 
-    @ToBeFixedForConfigurationCache(because = "cpp-library plugin")
     def "creates sample source if project name is specified with #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'cpp-library', '--project-name', 'greeting', '--dsl', scriptDsl.id)
@@ -93,7 +90,6 @@ class CppLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
     }
 
 
-    @ToBeFixedForConfigurationCache(because = "cpp-library plugin")
     def "source generation is skipped when cpp sources detected with #scriptDsl build scripts"() {
         setup:
         subprojectDir.file("src/main/cpp/hola.cpp") << """


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context

Also fix a number of Swift and XCTest tests with newer XCode versions.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
