### PR TITLE
Fix flaky StaleOutputIntegrationTest

### DIFF
--- a/platforms/core-execution/execution-e2e-tests/src/integTest/groovy/org/gradle/integtests/StaleOutputIntegrationTest.groovy
+++ b/platforms/core-execution/execution-e2e-tests/src/integTest/groovy/org/gradle/integtests/StaleOutputIntegrationTest.groovy
@@ -113,7 +113,7 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
         succeeds(taskWithSources.taskPath)
 
         then:
-        overlappingOutputFile.exists()
+        overlappingOutputFile.parentFile.exists()
         taskWithSources.onlyOutputFileHasBeenRemoved()
         executedAndNotSkipped(taskWithSources.taskPath)
     }


### PR DESCRIPTION
`StaleOutputIntegrationTest` has been flaky for a long time: https://ge.gradle.org/scans/tests?search.relativeStartTime=P28D&search.timeZoneId=Asia%2FShanghai&tests.container=org.gradle.integtests.StaleOutputIntegrationTest

Judging from the test case name "the output directory is not deleted if there are overlapping outputs", we should check the directory not the file itself.