### PR TITLE
Mark `@LeaksFileHandles` for NativeServicesIntegrationTest

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/NativeServicesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/NativeServicesIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.daemon.DaemonLogsAnalyzer
 import org.gradle.internal.nativeintegration.jansi.JansiStorageLocator
+import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
@@ -57,6 +58,7 @@ class NativeServicesIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @ToBeImplemented("https://github.com/gradle/gradle/issues/28203")
+    @LeaksFileHandles
     def "native services are #description with systemProperties == #systemProperties"() {
         given:
         // We set Gradle User Home to a different temporary directory that is outside


### PR DESCRIPTION
This is the most flaky tests, with "Couldn't delete test dir" error: https://ge.gradle.org/scans/tests?search.relativeStartTime=P7D&search.timeZoneId=Europe%2FBerlin&tests.container=org.gradle.NativeServicesIntegrationTest&tests.expandedTests=WzIsMV0&tests.test=native%20services%20are%20not%20initialized%20with%20systemProperties%20%3D%3D%20%5B-Dorg.gradle.native%3Dfalse%5D