### PR TITLE
Remove ProcessLauncher dependency from Gradle core

### DIFF
--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
@@ -19,14 +19,12 @@ import net.rubygrapefruit.platform.Native;
 import net.rubygrapefruit.platform.NativeException;
 import net.rubygrapefruit.platform.NativeIntegrationUnavailableException;
 import net.rubygrapefruit.platform.Process;
-import net.rubygrapefruit.platform.ProcessLauncher;
 import net.rubygrapefruit.platform.SystemInfo;
 import net.rubygrapefruit.platform.WindowsRegistry;
 import net.rubygrapefruit.platform.file.FileEvents;
 import net.rubygrapefruit.platform.file.FileSystems;
 import net.rubygrapefruit.platform.file.Files;
 import net.rubygrapefruit.platform.file.PosixFiles;
-import net.rubygrapefruit.platform.internal.DefaultProcessLauncher;
 import net.rubygrapefruit.platform.memory.Memory;
 import net.rubygrapefruit.platform.terminal.Terminals;
 import org.gradle.api.JavaVersion;
@@ -446,18 +444,6 @@ public class NativeServices implements ServiceRegistrationProvider {
             }
         }
         return notAvailable(Memory.class, operatingSystem);
-    }
-
-    @Provides
-    protected ProcessLauncher createProcessLauncher() {
-        if (useNativeIntegrations) {
-            try {
-                return net.rubygrapefruit.platform.Native.get(ProcessLauncher.class);
-            } catch (NativeIntegrationUnavailableException e) {
-                LOGGER.debug("Native-platform process launcher is not available. Continuing with fallback.");
-            }
-        }
-        return new DefaultProcessLauncher();
     }
 
     @Provides

--- a/platforms/core-runtime/native/src/test/groovy/org/gradle/internal/nativeintegration/services/NativeServicesTest.groovy
+++ b/platforms/core-runtime/native/src/test/groovy/org/gradle/internal/nativeintegration/services/NativeServicesTest.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.internal.nativeintegration.services
 
-import net.rubygrapefruit.platform.ProcessLauncher
+
 import net.rubygrapefruit.platform.SystemInfo
 import net.rubygrapefruit.platform.WindowsRegistry
 import org.gradle.api.internal.file.temp.TemporaryFileProvider
@@ -76,11 +76,6 @@ class NativeServicesTest extends Specification {
     def "makes a SystemInfo available"() {
         expect:
         services.get(SystemInfo) != null
-    }
-
-    def "makes a ProcessLauncher available"() {
-        expect:
-        services.get(ProcessLauncher) != null
     }
 
     def "makes a TemporaryFileProvider available"() {

--- a/subprojects/core/build.gradle.kts
+++ b/subprojects/core/build.gradle.kts
@@ -126,7 +126,6 @@ dependencies {
     api(libs.guava)
     api(libs.inject)
     api(libs.jsr305)
-    api(libs.nativePlatform)
 
     implementation(projects.io)
     implementation(projects.inputTracking)
@@ -134,6 +133,7 @@ dependencies {
     implementation(projects.serviceRegistryBuilder)
     implementation(projects.problemsRendering)
 
+    implementation(libs.nativePlatform)
     implementation(libs.asmCommons)
     implementation(libs.commonsIo)
     implementation(libs.commonsLang)

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
@@ -17,13 +17,11 @@
 package org.gradle.process.internal;
 
 import com.google.common.base.Joiner;
-import net.rubygrapefruit.platform.ProcessLauncher;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.event.ListenerBroadcast;
-import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.gradle.process.ExecResult;
 import org.gradle.process.internal.shutdown.ShutdownHooks;
@@ -90,7 +88,6 @@ public class DefaultExecHandle implements ExecHandle, ProcessSettings {
     private final StreamsHandler outputHandler;
     private final StreamsHandler inputHandler;
     private final boolean redirectErrorStream;
-    private final ProcessLauncher processLauncher;
     private int timeoutMillis;
     private boolean daemon;
 
@@ -139,9 +136,9 @@ public class DefaultExecHandle implements ExecHandle, ProcessSettings {
         this.stateChanged = lock.newCondition();
         this.state = ExecHandleState.INIT;
         this.buildCancellationToken = buildCancellationToken;
-        processLauncher = NativeServices.getInstance().get(ProcessLauncher.class);
-        shutdownHookAction = new ExecHandleShutdownHookAction(this);
-        broadcast = new ListenerBroadcast<ExecHandleListener>(ExecHandleListener.class);
+        this.shutdownHookAction = new ExecHandleShutdownHookAction(this);
+        this.broadcast = new ListenerBroadcast<ExecHandleListener>(ExecHandleListener.class);
+
         broadcast.addAll(listeners);
     }
 
@@ -265,7 +262,7 @@ public class DefaultExecHandle implements ExecHandle, ProcessSettings {
 
             broadcast.getSource().beforeExecutionStarted(this);
             execHandleRunner = new ExecHandleRunner(
-                this, new CompositeStreamsHandler(), processLauncher, executor, CurrentBuildOperationRef.instance().get()
+                this, new CompositeStreamsHandler(), executor, CurrentBuildOperationRef.instance().get()
             );
             executor.execute(execHandleRunner);
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/ExecHandleRunner.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/ExecHandleRunner.java
@@ -16,7 +16,7 @@
 
 package org.gradle.process.internal;
 
-import net.rubygrapefruit.platform.ProcessLauncher;
+import net.rubygrapefruit.platform.NativeException;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.internal.operations.BuildOperationRef;
@@ -32,7 +32,6 @@ public class ExecHandleRunner implements Runnable {
     private final ProcessBuilderFactory processBuilderFactory;
     private final DefaultExecHandle execHandle;
     private final Lock lock = new ReentrantLock();
-    private final ProcessLauncher processLauncher;
     private final Executor executor;
 
     private Process process;
@@ -41,7 +40,9 @@ public class ExecHandleRunner implements Runnable {
     private volatile BuildOperationRef associatedBuildOperation;
 
     public ExecHandleRunner(
-        DefaultExecHandle execHandle, StreamsHandler streamsHandler, ProcessLauncher processLauncher, Executor executor,
+        DefaultExecHandle execHandle,
+        StreamsHandler streamsHandler,
+        Executor executor,
         BuildOperationRef associatedBuildOperation
     ) {
         if (execHandle == null) {
@@ -49,7 +50,6 @@ public class ExecHandleRunner implements Runnable {
         }
         this.execHandle = execHandle;
         this.streamsHandler = streamsHandler;
-        this.processLauncher = processLauncher;
         this.executor = executor;
         this.associatedBuildOperation = associatedBuildOperation;
         this.processBuilderFactory = new ProcessBuilderFactory();
@@ -119,11 +119,19 @@ public class ExecHandleRunner implements Runnable {
                 throw new IllegalStateException("Process has already been aborted");
             }
             ProcessBuilder processBuilder = processBuilderFactory.createProcessBuilder(execHandle);
-            Process process = processLauncher.start(processBuilder);
+            Process process = start(processBuilder);
             streamsHandler.connectStreams(process, execHandle.getDisplayName(), executor);
             this.process = process;
         } finally {
             lock.unlock();
+        }
+    }
+
+    private Process start(ProcessBuilder processBuilder) {
+        try {
+            return processBuilder.start();
+        } catch (Exception e) {
+            throw new NativeException(String.format("Could not start '%s'", processBuilder.command().get(0)), e);
         }
     }
 


### PR DESCRIPTION
From Adam:
It was something to do with old JVMs on windows leaking file handles into child processes. We probably don't need it any more.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
