### PR TITLE
Cache ProjectDerivedCapability name

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ProjectDerivedCapability.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ProjectDerivedCapability.java
@@ -28,6 +28,8 @@ public class ProjectDerivedCapability implements CapabilityInternal {
     private final Project project;
     private final String featureName;
 
+    private volatile String capabilityName;
+
     public ProjectDerivedCapability(Project project) {
         this(project, null);
     }
@@ -44,8 +46,17 @@ public class ProjectDerivedCapability implements CapabilityInternal {
 
     @Override
     public String getName() {
-        String name = notNull("name", project.getName());
-        return featureName == null ? name : name + "-" + TextUtil.camelToKebabCase(featureName);
+        if (capabilityName == null) {
+            capabilityName = computeCapabilityName(project, featureName);
+        }
+        return capabilityName;
+    }
+
+    private static String computeCapabilityName(Project project, @Nullable String featureName) {
+        if (featureName == null) {
+            return project.getName();
+        }
+        return project.getName() + "-" + TextUtil.camelToKebabCase(featureName);
     }
 
     @Override


### PR DESCRIPTION
getName gets called quite often when requesting test fixtures from a target project.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
