### PR TITLE
Deprecate selecting variant by configuration name for non-ivy external components

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -113,11 +113,12 @@ val files = myConfig.files
 [[selecting_variant_by_configuration_name]]
 ==== Selecting Maven variants by configuration name
 
-Starting in Gradle 9.0, selecting variants by name from non-ivy external components will be forbidden.
-Selecting variants by name from local components will still be permitted, however this pattern is discouraged.
+Starting in Gradle 9.0, selecting variants by name from non-Ivy external components will be forbidden.
+
+Selecting variants by name from local components will still be permitted; however, this pattern is discouraged.
 For local components, variant aware dependency resolution should be preferred over selecting variants by name.
 
-The following dependencies will fail to resolve when targeting a non-ivy external component:
+The following dependencies will fail to resolve when targeting a non-Ivy external component:
 
 [source,groovy]
 ----

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -110,6 +110,25 @@ val myConfig = buildscript.configurations.detachedConfiguration(
 val files = myConfig.files
 ----
 
+[[selecting_variant_by_configuration_name]]
+==== Selecting Maven variants by configuration name
+
+Starting in Gradle 9.0, selecting variants by name from non-ivy external components will be forbidden.
+Selecting variants by name from local components will still be permitted, however this pattern is discouraged.
+For local components, variant aware dependency resolution should be preferred over selecting variants by name.
+
+The following dependencies will fail to resolve when targeting a non-ivy external component:
+
+[source,groovy]
+----
+dependencies {
+    implementation(group: "com.example", name: "example", version: "1.0", configuration: "conf")
+    implementation("com.example:example:1.0") {
+        targetConfiguration = "conf"
+    }
+}
+----
+
 [[adding_to_configuration_container]]
 ==== Deprecated manually adding to configuration container
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ExternalModuleVariantsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ExternalModuleVariantsIntegrationTest.groovy
@@ -53,7 +53,6 @@ class ExternalModuleVariantsIntegrationTest extends AbstractDependencyResolution
                 compile 'test:test:1.2@thing'
                 compile 'test:test:1.2:util'
                 compile 'test:test:1.2:util@aar'
-                compile('test:test-api:1.2') { targetConfiguration = 'compile' }
             }
             task show {
                 def artifacts = configurations.compile.incoming.artifacts
@@ -78,7 +77,6 @@ class ExternalModuleVariantsIntegrationTest extends AbstractDependencyResolution
         outputContains("test-1.2.thing {artifactType=thing, org.gradle.status=release}")
         outputContains("test-1.2-util.jar {artifactType=jar, org.gradle.status=release}")
         outputContains("test-1.2-util.aar {artifactType=aar, org.gradle.status=release}")
-        outputContains("test-api-1.2.jar {artifactType=jar, org.gradle.status=release}")
     }
 
     def "artifacts in an Ivy repo have standard attributes defined based on their type"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryInteractionDependencyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryInteractionDependencyResolveIntegrationTest.groovy
@@ -239,7 +239,7 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
         [chain, testVariant] << [REPO_TYPES.permutations(), TEST_VARIANTS.keySet()].combinations()
     }
 
-    def "explicit compile configuration selection works for a chain of pure maven dependencies"() {
+    def "resolution works for a chain of pure maven dependencies"() {
         given:
         def modules = ['mavenCompile1', 'mavenCompile2', 'mavenCompile3']
         setupRepositories(modules)
@@ -249,7 +249,7 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
         buildFile << """
             dependencies {
                 configurations.conf.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
-                conf group: 'org', name: 'mavenCompile1', version: '1.0', configuration: 'compile'
+                conf group: 'org', name: 'mavenCompile1', version: '1.0'
             }
         """
         expectChainInteractions(modules, modules)
@@ -271,7 +271,7 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
         }
     }
 
-    def "explicit compile configuration selection with Gradle metadata is propagates to Maven dependencies"() {
+    def "resolution with Gradle metadata propagates to Maven dependencies"() {
         given:
         def modules = ['mavenCompile1', 'mavenCompile2', 'maven-gradle', 'maven']
         setupRepositories(modules)
@@ -281,7 +281,7 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
         buildFile << """
             dependencies {
                 configurations.conf.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
-                conf group: 'org', name: 'mavenCompile1', version: '1.0', configuration: 'compile'
+                conf group: 'org', name: 'mavenCompile1', version: '1.0'
             }
         """
         expectChainInteractions(modules, modules)
@@ -294,7 +294,7 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
                     module "org:mavenCompile1-api-dependency:1.0"
                     module("org:mavenCompile2:1.0") {
                         module "org:mavenCompile2-api-dependency:1.0"
-                        module("org:maven-gradle:1.0") { // Attribute matching is used here
+                        module("org:maven-gradle:1.0") {
                             module "org:maven-gradle-api-dependency:1.0"
                             module("org:maven:1.0") {
                                 module "org:maven-api-dependency:1.0"
@@ -306,7 +306,7 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
         }
     }
 
-    def "explicit #conf configuration selection still works for maven dependencies"() {
+    def "resolution works for maven dependencies"() {
         given:
         def modules = ['maven', 'mavenCompile1', 'maven-gradle', 'mavenCompile2']
         setupRepositories(modules)
@@ -316,20 +316,18 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
         buildFile << """
             dependencies {
                 configurations.conf.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
-                conf group: 'org', name: 'maven', version: '1.0', configuration: '$conf'
+                conf group: 'org', name: 'maven', version: '1.0'
             }
         """
-        expectChainInteractions(modules, modules, 'api', conf)
+        expectChainInteractions(modules, modules, 'api')
 
         then:
         succeeds 'checkDep'
         resolve.expectGraph {
             root(':', ':test:') {
-                module("org:maven:1.0:$conf") {
+                module("org:maven:1.0") {
                     module "org:maven-api-dependency:1.0"
-                    module "org:maven-runtime-dependency:1.0"
                     module("org:mavenCompile1:1.0") {
-                        //form here on, attribute matching is used
                         module "org:mavenCompile1-api-dependency:1.0"
                         module("org:maven-gradle:1.0") {
                             module "org:maven-gradle-api-dependency:1.0"
@@ -341,9 +339,6 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
                 }
             }
         }
-
-        where:
-        conf << ['runtime', 'test']
     }
 
     def "explicit configuration selection in ivy modules is NOT supported if targeting a #target module"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesAndProjectDependencySubstitutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesAndProjectDependencySubstitutionIntegrationTest.groovy
@@ -140,7 +140,7 @@ project(':child2') {
         }
     }
 
-    def "a dependency on compile scope of maven module includes the default of target project when they are present"() {
+    def "a dependency on maven module includes the default of target project when they are present"() {
         mavenRepo.module("org.test", "m1", "1.0").publish()
         mavenRepo.module("org.test", "m2", "1.0").publish()
         mavenRepo.module("org.test", "maven", "1.0")
@@ -151,7 +151,7 @@ project(':child2') {
         buildFile << """
 project(':child1') {
     dependencies {
-        conf group: 'org.test', name: 'maven', version: '1.0', configuration: 'compile'
+        conf group: 'org.test', name: 'maven', version: '1.0'
     }
     configurations.conf.resolutionStrategy.dependencySubstitution {
         substitute module('org.test:replaced:1.0') using project(':child2')
@@ -191,7 +191,7 @@ project(':child2') {
     }
 
     @ToBeFixedForConfigurationCache(because = "broken file collection")
-    def "a dependency on compile scope of maven module includes the runtime dependencies of target project that is using the Java plugin"() {
+    def "a dependency on maven module includes the runtime dependencies of target project that is using the Java plugin"() {
         mavenRepo.module("org.test", "m1", "1.0").publish()
         mavenRepo.module("org.test", "m2", "1.0").publish()
         mavenRepo.module("org.test", "maven", "1.0")
@@ -201,7 +201,7 @@ project(':child2') {
         buildFile << """
 project(':child1') {
     dependencies {
-        conf group: 'org.test', name: 'maven', version: '1.0', configuration: 'compile'
+        conf group: 'org.test', name: 'maven', version: '1.0'
     }
     configurations.conf.resolutionStrategy.dependencySubstitution {
         substitute module('org.test:replaced:1.0') using project(':child2')

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesIntegrationTest.groovy
@@ -110,6 +110,7 @@ dependencies {
 """
 
         expect:
+        executer.expectDocumentedDeprecationWarning("Selecting a variant by configuration name from a non-ivy external component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#selecting_variant_by_configuration_name")
         succeeds 'checkDep'
         resolve.expectGraph {
             root(':', ':testproject:') {
@@ -154,6 +155,7 @@ dependencies {
 }
 """
         expect:
+        executer.expectDocumentedDeprecationWarning("Selecting a variant by configuration name from a non-ivy external component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#selecting_variant_by_configuration_name")
         succeeds 'checkDep'
         resolve.expectGraph {
             root(':', ':testproject:') {
@@ -202,6 +204,7 @@ dependencies {
 }
 """
         expect:
+        executer.expectDocumentedDeprecationWarning("Selecting a variant by configuration name from a non-ivy external component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#selecting_variant_by_configuration_name")
         succeeds 'checkDep'
         resolve.expectGraph {
             root(':', ':testproject:') {
@@ -258,6 +261,7 @@ dependencies {
 }
 """
         expect:
+        executer.expectDocumentedDeprecationWarning("Selecting a variant by configuration name from a non-ivy external component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#selecting_variant_by_configuration_name")
         succeeds 'checkDep'
         resolve.expectGraph {
             root(':', ':testproject:') {
@@ -298,6 +302,7 @@ dependencies {
 }
 """
         expect:
+        executer.expectDocumentedDeprecationWarning("Selecting a variant by configuration name from a non-ivy external component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#selecting_variant_by_configuration_name")
         succeeds 'checkDep'
         resolve.expectGraph {
             root(':', ':testproject:') {
@@ -327,6 +332,7 @@ dependencies {
 }
 """
         expect:
+        executer.expectDocumentedDeprecationWarning("Selecting a variant by configuration name from a non-ivy external component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#selecting_variant_by_configuration_name")
         succeeds 'checkDep'
         resolve.expectGraph {
             root(':', ':testproject:') {
@@ -355,6 +361,7 @@ dependencies {
 }
 """
         expect:
+        executer.expectDocumentedDeprecationWarning("Selecting a variant by configuration name from a non-ivy external component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#selecting_variant_by_configuration_name")
         succeeds 'checkDep'
         resolve.expectGraph {
             root(':', ':testproject:') {
@@ -375,6 +382,7 @@ dependencies {
 }
 """
         expect:
+        executer.expectDocumentedDeprecationWarning("Selecting a variant by configuration name from a non-ivy external component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#selecting_variant_by_configuration_name")
         fails 'checkDep'
         failure.assertHasCause("Could not resolve test:target:1.0.\nRequired by:\n    root project :")
         failure.assertHasCause("A dependency was declared on configuration 'x86_windows' of 'test:target:1.0' but no variant with that configuration name exists.")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesIntegrationTest.groovy
@@ -110,7 +110,7 @@ dependencies {
 """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("Selecting a variant by configuration name from a non-ivy external component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#selecting_variant_by_configuration_name")
+        executer.expectDocumentedDeprecationWarning("Selecting a variant by configuration name from a non-Ivy external component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#selecting_variant_by_configuration_name")
         succeeds 'checkDep'
         resolve.expectGraph {
             root(':', ':testproject:') {
@@ -155,7 +155,7 @@ dependencies {
 }
 """
         expect:
-        executer.expectDocumentedDeprecationWarning("Selecting a variant by configuration name from a non-ivy external component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#selecting_variant_by_configuration_name")
+        executer.expectDocumentedDeprecationWarning("Selecting a variant by configuration name from a non-Ivy external component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#selecting_variant_by_configuration_name")
         succeeds 'checkDep'
         resolve.expectGraph {
             root(':', ':testproject:') {
@@ -204,7 +204,7 @@ dependencies {
 }
 """
         expect:
-        executer.expectDocumentedDeprecationWarning("Selecting a variant by configuration name from a non-ivy external component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#selecting_variant_by_configuration_name")
+        executer.expectDocumentedDeprecationWarning("Selecting a variant by configuration name from a non-Ivy external component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#selecting_variant_by_configuration_name")
         succeeds 'checkDep'
         resolve.expectGraph {
             root(':', ':testproject:') {
@@ -261,7 +261,7 @@ dependencies {
 }
 """
         expect:
-        executer.expectDocumentedDeprecationWarning("Selecting a variant by configuration name from a non-ivy external component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#selecting_variant_by_configuration_name")
+        executer.expectDocumentedDeprecationWarning("Selecting a variant by configuration name from a non-Ivy external component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#selecting_variant_by_configuration_name")
         succeeds 'checkDep'
         resolve.expectGraph {
             root(':', ':testproject:') {
@@ -302,7 +302,7 @@ dependencies {
 }
 """
         expect:
-        executer.expectDocumentedDeprecationWarning("Selecting a variant by configuration name from a non-ivy external component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#selecting_variant_by_configuration_name")
+        executer.expectDocumentedDeprecationWarning("Selecting a variant by configuration name from a non-Ivy external component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#selecting_variant_by_configuration_name")
         succeeds 'checkDep'
         resolve.expectGraph {
             root(':', ':testproject:') {
@@ -332,7 +332,7 @@ dependencies {
 }
 """
         expect:
-        executer.expectDocumentedDeprecationWarning("Selecting a variant by configuration name from a non-ivy external component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#selecting_variant_by_configuration_name")
+        executer.expectDocumentedDeprecationWarning("Selecting a variant by configuration name from a non-Ivy external component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#selecting_variant_by_configuration_name")
         succeeds 'checkDep'
         resolve.expectGraph {
             root(':', ':testproject:') {
@@ -361,7 +361,7 @@ dependencies {
 }
 """
         expect:
-        executer.expectDocumentedDeprecationWarning("Selecting a variant by configuration name from a non-ivy external component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#selecting_variant_by_configuration_name")
+        executer.expectDocumentedDeprecationWarning("Selecting a variant by configuration name from a non-Ivy external component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#selecting_variant_by_configuration_name")
         succeeds 'checkDep'
         resolve.expectGraph {
             root(':', ':testproject:') {
@@ -382,7 +382,7 @@ dependencies {
 }
 """
         expect:
-        executer.expectDocumentedDeprecationWarning("Selecting a variant by configuration name from a non-ivy external component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#selecting_variant_by_configuration_name")
+        executer.expectDocumentedDeprecationWarning("Selecting a variant by configuration name from a non-Ivy external component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#selecting_variant_by_configuration_name")
         fails 'checkDep'
         failure.assertHasCause("Could not resolve test:target:1.0.\nRequired by:\n    root project :")
         failure.assertHasCause("A dependency was declared on configuration 'x86_windows' of 'test:target:1.0' but no variant with that configuration name exists.")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MixedMavenAndIvyModulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MixedMavenAndIvyModulesIntegrationTest.groovy
@@ -86,7 +86,7 @@ dependencies {
         }
     }
 
-    def "a dependency on compile scope of maven module includes default of required ivy module when they are present"() {
+    def "a dependency on maven module includes default of required ivy module when they are present"() {
         def inDefault = ivyRepo.module("org.test", "in-default", "1.0").publish()
         def m1 = ivyRepo.module("org.test", "m1", "1.0")
             .configuration("compile")
@@ -113,7 +113,7 @@ dependencies {
 
         buildFile << """
 dependencies {
-    conf group: 'org.test', name: 'maven', version: '1.0', configuration: 'compile'
+    conf group: 'org.test', name: 'maven', version: '1.0'
 }
 """
         expect:
@@ -236,7 +236,7 @@ dependencies {
 
         buildFile << """
 dependencies {
-    conf group: 'org.test', name: 'maven', version: '1.0', configuration: 'compile'
+    conf group: 'org.test', name: 'maven', version: '1.0'
 }
 configurations.conf.resolutionStrategy.force('org.test:ivy:1.2')
 """
@@ -283,7 +283,7 @@ configurations.conf.resolutionStrategy.force('org.test:ivy:1.2')
 
         buildFile << """
 dependencies {
-    conf group: 'org.test', name: 'maven', version: '1.0', configuration: 'compile'
+    conf group: 'org.test', name: 'maven', version: '1.0'
 }
 """
         expect:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/AbstractDependencyMetadataRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/AbstractDependencyMetadataRulesIntegrationTest.groovy
@@ -49,12 +49,28 @@ abstract class AbstractDependencyMetadataRulesIntegrationTest extends AbstractMo
         }
 
         buildFile << """
-            configurations { $variantToTest { attributes { attribute(Attribute.of('format', String), 'custom') } } }
-
-            dependencies {
-                $variantToTest group: 'org.test', name: 'moduleA', version: '1.0' ${publishedModulesHaveAttributes ? "" : ", configuration: '$variantToTest'"}
+            configurations {
+                $variantToTest {
+                    attributes {
+                        attribute(Attribute.of('format', String), 'custom')
+                    }
+                }
             }
         """
+
+        if (useMaven() || publishedModulesHaveAttributes) {
+            buildFile << """
+                dependencies {
+                    $variantToTest group: 'org.test', name: 'moduleA', version: '1.0'
+                }
+            """
+        } else {
+            buildFile << """
+                dependencies {
+                    $variantToTest group: 'org.test', name: 'moduleA', version: '1.0', configuration: '$variantToTest'
+                }
+            """
+        }
     }
 
     def "#thing can be added using #notation notation"() {
@@ -778,7 +794,7 @@ abstract class AbstractDependencyMetadataRulesIntegrationTest extends AbstractMo
             configurations { anotherConfiguration { attributes { attribute(Attribute.of('format', String), 'custom') } } }
 
             dependencies {
-                anotherConfiguration group: 'org.test', name: 'moduleA', version: '1.0' ${publishedModulesHaveAttributes ? "" : ", configuration: '$variantToTest'"}
+                anotherConfiguration group: 'org.test', name: 'moduleA', version: '1.0' ${publishedModulesHaveAttributes || useMaven() ? "" : ", configuration: '$variantToTest'"}
             }
 
             dependencies {
@@ -831,7 +847,7 @@ abstract class AbstractDependencyMetadataRulesIntegrationTest extends AbstractMo
             }
 
             dependencies {
-                $variantToTest group: 'org.test', name: 'moduleB', version: '1.1' ${publishedModulesHaveAttributes ? "" : ", configuration: '$variantToTest'"}
+                $variantToTest group: 'org.test', name: 'moduleB', version: '1.1' ${publishedModulesHaveAttributes || useMaven() ? "" : ", configuration: '$variantToTest'"}
 
                 components {
                     withModule('org.test:moduleA', ModifyRule)
@@ -896,7 +912,7 @@ abstract class AbstractDependencyMetadataRulesIntegrationTest extends AbstractMo
             }
 
             dependencies {
-                $variantToTest group: 'org.test', name: 'moduleB', version: '1.1' ${publishedModulesHaveAttributes ? "" : ", configuration: '$variantToTest'"}
+                $variantToTest group: 'org.test', name: 'moduleB', version: '1.1' ${publishedModulesHaveAttributes || useMaven() ? "" : ", configuration: '$variantToTest'"}
 
                 components {
                     withModule('org.test:moduleA', ModifyRule)

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantAttributesRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantAttributesRulesIntegrationTest.groovy
@@ -50,11 +50,21 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
             def formatAttribute = Attribute.of('format', String)
 
             configurations { $variantToTest { attributes { attribute(formatAttribute, 'custom') } } }
-
-            dependencies {
-                $variantToTest group: 'org.test', name: 'moduleA', version: '1.0' ${publishedModulesHaveAttributes ? "" : ", configuration: '$variantToTest'"}
-            }
         """
+
+        if (useIvy()) {
+            buildFile << """
+                dependencies {
+                    $variantToTest group: 'org.test', name: 'moduleA', version: '1.0' ${publishedModulesHaveAttributes ? "" : ", configuration: '$variantToTest'"}
+                }
+            """
+        } else {
+            buildFile << """
+                dependencies {
+                    $variantToTest group: 'org.test', name: 'moduleA', version: '1.0'
+                }
+            """
+        }
     }
 
     def "can add attributes"() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/DefaultIvyComponentGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/DefaultIvyComponentGraphResolveState.java
@@ -17,16 +17,21 @@
 package org.gradle.internal.component.external.model.ivy;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.internal.component.external.model.DefaultModuleComponentGraphResolveState;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentIdGenerator;
 import org.gradle.internal.component.model.ConfigurationGraphResolveState;
 import org.gradle.internal.component.model.ConfigurationMetadata;
+import org.gradle.internal.component.model.GraphSelectionCandidates;
 import org.gradle.internal.component.model.ModuleConfigurationMetadata;
+import org.gradle.internal.component.model.VariantGraphResolveState;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * External component state implementation for ivy components.
@@ -53,11 +58,29 @@ public class DefaultIvyComponentGraphResolveState extends DefaultModuleComponent
         }
     }
 
+    @Nullable
+    private VariantGraphResolveState getConfigurationAsVariant(String name) {
+        ConfigurationGraphResolveState configuration = getConfiguration(name);
+        if (configuration == null) {
+            return null;
+        }
+        return configuration.asVariant();
+    }
+
+
     @Override
     public IvyComponentArtifactResolveMetadata getArtifactMetadata() {
         @SuppressWarnings("deprecation")
         IvyModuleResolveMetadata legacyMetadata = getLegacyMetadata();
         return new DefaultIvyComponentArtifactResolveMetadata(legacyMetadata);
+    }
+
+    @Override
+    public GraphSelectionCandidates getCandidatesForGraphVariantSelection() {
+        return new IvyGraphSelectionCandidates(
+            super.getCandidatesForGraphVariantSelection(),
+            this::getConfigurationAsVariant
+        );
     }
 
     private static class DefaultIvyComponentArtifactResolveMetadata extends ExternalArtifactResolveMetadata implements IvyComponentArtifactResolveMetadata {
@@ -78,4 +101,35 @@ public class DefaultIvyComponentGraphResolveState extends DefaultModuleComponent
             return null;
         }
     }
+
+    private static class IvyGraphSelectionCandidates implements GraphSelectionCandidates {
+        private final GraphSelectionCandidates candidates;
+        private final Function<String, VariantGraphResolveState> configurationSupplier;
+
+        public IvyGraphSelectionCandidates(
+            GraphSelectionCandidates candidates,
+            Function<String, VariantGraphResolveState> configurationSupplier
+        ) {
+            this.candidates = candidates;
+            this.configurationSupplier = configurationSupplier;
+        }
+
+        @Override
+        public List<? extends VariantGraphResolveState> getVariantsForAttributeMatching() {
+            return candidates.getVariantsForAttributeMatching();
+        }
+
+        @Nullable
+        @Override
+        public VariantGraphResolveState getLegacyVariant() {
+            return getVariantByConfigurationName(Dependency.DEFAULT_CONFIGURATION);
+        }
+
+        @Nullable
+        @Override
+        public VariantGraphResolveState getVariantByConfigurationName(String name) {
+            return configurationSupplier.apply(name);
+        }
+    }
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentGraphResolveState.java
@@ -19,6 +19,7 @@ package org.gradle.internal.component.local.model;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.gradle.api.Transformer;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
@@ -39,6 +40,7 @@ import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.component.model.VariantArtifactGraphResolveMetadata;
 import org.gradle.internal.component.model.VariantArtifactResolveState;
+import org.gradle.internal.component.model.VariantGraphResolveState;
 import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.model.CalculatedValue;
 import org.gradle.internal.model.CalculatedValueCache;
@@ -400,6 +402,12 @@ public class DefaultLocalComponentGraphResolveState extends AbstractComponentGra
         @Override
         public List<? extends LocalVariantGraphResolveState> getVariantsForAttributeMatching() {
             return variantsWithAttributes;
+        }
+
+        @Nullable
+        @Override
+        public VariantGraphResolveState getLegacyVariant() {
+            return getVariantByConfigurationName(Dependency.DEFAULT_CONFIGURATION);
         }
 
         @Nullable

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultExternalComponentGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultExternalComponentGraphResolveState.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.model;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
@@ -30,6 +31,7 @@ import org.gradle.internal.component.external.model.ExternalComponentGraphResolv
 import org.gradle.internal.component.external.model.ExternalComponentGraphResolveState;
 import org.gradle.internal.component.external.model.ExternalComponentResolveMetadata;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.lazy.Lazy;
 import org.gradle.internal.resolve.resolver.VariantArtifactResolver;
 
@@ -238,8 +240,24 @@ public class DefaultExternalComponentGraphResolveState<G extends ExternalCompone
 
         @Nullable
         @Override
+        public VariantGraphResolveState getLegacyVariant() {
+            return doGetVariantByConfigurationName(Dependency.DEFAULT_CONFIGURATION);
+        }
+
+        @Nullable
+        @Override
         public VariantGraphResolveState getVariantByConfigurationName(String name) {
-            // TODO: Deprecate this method for non-ivy components.
+
+            DeprecationLogger.deprecateBehaviour("Selecting a variant by configuration name from a non-ivy external component.")
+                .willBecomeAnErrorInGradle9()
+                .withUpgradeGuideSection(8, "selecting_variant_by_configuration_name")
+                .nagUser();
+
+            return doGetVariantByConfigurationName(name);
+        }
+
+        @Nullable
+        private VariantGraphResolveState doGetVariantByConfigurationName(String name) {
             ModuleConfigurationMetadata configuration = (ModuleConfigurationMetadata) component.getMetadata().getConfiguration(name);
             if (configuration == null) {
                 return null;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultExternalComponentGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultExternalComponentGraphResolveState.java
@@ -248,7 +248,7 @@ public class DefaultExternalComponentGraphResolveState<G extends ExternalCompone
         @Override
         public VariantGraphResolveState getVariantByConfigurationName(String name) {
 
-            DeprecationLogger.deprecateBehaviour("Selecting a variant by configuration name from a non-ivy external component.")
+            DeprecationLogger.deprecateBehaviour("Selecting a variant by configuration name from a non-Ivy external component.")
                 .willBecomeAnErrorInGradle9()
                 .withUpgradeGuideSection(8, "selecting_variant_by_configuration_name")
                 .nagUser();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/GraphSelectionCandidates.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/GraphSelectionCandidates.java
@@ -16,8 +16,6 @@
 
 package org.gradle.internal.component.model;
 
-import org.gradle.api.artifacts.Dependency;
-
 import javax.annotation.Nullable;
 import java.util.List;
 
@@ -33,9 +31,7 @@ public interface GraphSelectionCandidates {
      * Returns the variant to use when attribute-based variant selection is not enabled.
      */
     @Nullable
-    default VariantGraphResolveState getLegacyVariant() {
-        return getVariantByConfigurationName(Dependency.DEFAULT_CONFIGURATION);
-    }
+    VariantGraphResolveState getLegacyVariant();
 
     /**
      * Returns the variant that is identified by the given configuration name.

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
@@ -386,6 +386,11 @@ Configuration 'bar':
         }
 
         @Override
+        VariantGraphResolveState getLegacyVariant() {
+            getVariantByConfigurationName(Dependency.DEFAULT_CONFIGURATION)
+        }
+
+        @Override
         VariantGraphResolveState getVariantByConfigurationName(String name) {
             variants.find { it -> it.name == name }
         }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependency.java
@@ -160,15 +160,22 @@ public interface ModuleDependency extends Dependency, HasConfigurableAttributes<
     ModuleDependency setTransitive(boolean transitive);
 
     /**
-     * Returns the requested target configuration of this dependency. This is the name of the configuration in the target module that should be used when
-     * selecting the matching configuration. If {@code null}, a default configuration should be used.
+     * Returns the requested target configuration of this dependency.
+     * <p>
+     * If non-null, this overrides variant-aware dependency resolution and selects the
+     * variant in the target component matching the requested configuration name.
      */
     @Nullable
     String getTargetConfiguration();
 
     /**
-     * Sets the requested target configuration of this dependency. This is the name of the configuration in the target module that should be used when
-     * selecting the matching configuration. If {@code null}, a default configuration will be used.
+     * Sets the requested target configuration of this dependency.
+     * <p>
+     * This overrides variant-aware dependency resolution and selects the variant in the
+     * target component matching the requested configuration name.
+     * <p>
+     * Using this method is <strong>discouraged</strong> except for selecting
+     * configurations from Ivy components.
      *
      * @since 4.0
      */

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -120,19 +120,21 @@ import java.util.Map;
  *
  * <pre class='autoTested'>
  * plugins {
- *     id 'java' // so that I can declare 'implementation' dependencies
+ *     id("java-library")
  * }
  *
  * dependencies {
- *   //configuring dependency to specific configuration of the module
- *   implementation configuration: 'someConf', group: 'org.someOrg', name: 'someModule', version: '1.0'
+ *   // Configuring dependency to specific configuration of the module
+ *   // This notation should _only_ be used for Ivy dependencies
+ *   implementation(group: "org.someOrg", name: "someModule", version: "1.0", configuration: "someConf")
  *
- *   //configuring dependency on 'someLib' module
+ *   // Configuring dependency on 'someLib' module
  *   implementation(group: 'org.myorg', name: 'someLib', version:'1.0') {
- *     //explicitly adding the dependency artifact:
+ *     // Explicitly adding the dependency artifact:
+ *     // Prefer variant-aware dependency resolution
  *     artifact {
- *       //useful when some artifact properties unconventional
- *       name = 'someArtifact' //artifact name different than module name
+ *       // Useful when some artifact properties unconventional
+ *       name = 'someArtifact' // Artifact name different than module name
  *       extension = 'someExt'
  *       type = 'someType'
  *       classifier = 'someClassifier'


### PR DESCRIPTION
This effectively deprecates selecting variants by configuration name for maven components. Previously, users were able to select maven "configurations" such as runtime, compile, or test, using the configuration: notation when declaring the dependency.

Maven does not have the concept of configurations. Variant derivation works well for maven and we are sticking to it.

This leaves only ivy components and local components as the only components that support variant selection via configuration name. Eventually, local components will also get this same restriction. Only ivy components should allow variant-by-name selection, as that is a core aspect of its resolution model.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
