### PR TITLE
Remove discouraged getPlugins() calls from doc snippets

### DIFF
--- a/platforms/documentation/docs/src/snippets/developingPlugins/capabilitiesVsConventions/groovy/buildSrc/src/main/java/MyPlugin.java
+++ b/platforms/documentation/docs/src/snippets/developingPlugins/capabilitiesVsConventions/groovy/buildSrc/src/main/java/MyPlugin.java
@@ -3,7 +3,7 @@ import org.gradle.api.Project;
 
 public class MyPlugin implements Plugin<Project> {
     public void apply(Project project) {
-        project.getPlugins().apply(MyBasePlugin.class);
+        project.getPluginManager().apply(MyBasePlugin.class);
 
         // define conventions
     }

--- a/platforms/documentation/docs/src/snippets/developingPlugins/reactingToPlugins/groovy/buildSrc/src/main/java/InhouseConventionJavaPlugin.java
+++ b/platforms/documentation/docs/src/snippets/developingPlugins/reactingToPlugins/groovy/buildSrc/src/main/java/InhouseConventionJavaPlugin.java
@@ -1,14 +1,13 @@
 import java.util.Arrays;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 
 // tag::snippet[]
 public class InhouseConventionJavaPlugin implements Plugin<Project> {
     public void apply(Project project) {
-        project.getPlugins().withType(JavaPlugin.class, javaPlugin -> {
+        project.getPluginManager().withPlugin("java", javaPlugin -> {
             SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
             SourceSet main = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME);
             main.getJava().setSrcDirs(Arrays.asList("src"));

--- a/platforms/documentation/docs/src/snippets/developingPlugins/reactingToPlugins/groovy/buildSrc/src/main/java/InhouseStrongOpinionConventionJavaPlugin.java
+++ b/platforms/documentation/docs/src/snippets/developingPlugins/reactingToPlugins/groovy/buildSrc/src/main/java/InhouseStrongOpinionConventionJavaPlugin.java
@@ -9,7 +9,7 @@ import org.gradle.api.tasks.SourceSetContainer;
 public class InhouseStrongOpinionConventionJavaPlugin implements Plugin<Project> {
     public void apply(Project project) {
         // Careful! Eagerly appyling plugins has downsides, and is not always recommended.
-        project.getPlugins().apply(JavaPlugin.class);
+        project.getPluginManager().apply(JavaPlugin.class);
         SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
         SourceSet main = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME);
         main.getJava().setSrcDirs(Arrays.asList("src"));

--- a/platforms/documentation/docs/src/snippets/java/toolchain-management/groovy/buildSrc/src/main/java/org/myorg/JavaToolchainResolverPlugin.java
+++ b/platforms/documentation/docs/src/snippets/java/toolchain-management/groovy/buildSrc/src/main/java/org/myorg/JavaToolchainResolverPlugin.java
@@ -12,7 +12,7 @@ public abstract class JavaToolchainResolverPlugin implements Plugin<Settings> { 
     protected abstract JavaToolchainResolverRegistry getToolchainResolverRegistry(); // <2>
 
     public void apply(Settings settings) {
-        settings.getPlugins().apply("jvm-toolchain-management"); // <3>
+        settings.getPluginManager().apply("jvm-toolchain-management"); // <3>
 
         JavaToolchainResolverRegistry registry = getToolchainResolverRegistry();
         registry.register(JavaToolchainResolverImplementation.class);

--- a/platforms/documentation/docs/src/snippets/java/toolchain-management/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/java/toolchain-management/groovy/settings.gradle
@@ -37,7 +37,7 @@ abstract class MadeUpPlugin implements Plugin<Settings> {
     protected abstract JavaToolchainResolverRegistry getToolchainResolverRegistry();
 
     void apply(Settings settings) {
-        settings.getPlugins().apply("jvm-toolchain-management")
+        settings.getPluginManager().apply("jvm-toolchain-management")
 
         JavaToolchainResolverRegistry registry = getToolchainResolverRegistry()
         registry.register(MadeUpResolver.class)

--- a/platforms/documentation/docs/src/snippets/java/toolchain-management/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/java/toolchain-management/kotlin/settings.gradle.kts
@@ -42,7 +42,7 @@ abstract class MadeUpPlugin: Plugin<Settings> {
     protected abstract val toolchainResolverRegistry: JavaToolchainResolverRegistry
 
     override fun apply(settings: Settings) {
-        settings.plugins.apply("jvm-toolchain-management")
+        settings.getPluginManager().apply("jvm-toolchain-management")
 
         val registry: JavaToolchainResolverRegistry = toolchainResolverRegistry
         registry.register(MadeUpResolver::class.java)


### PR DESCRIPTION
### Context
The JavaDoc of `getPlugins()` recommends not to use it even though it is not deprecated technically.
In that light it seems unlucky to use it in doc samples.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- n/a Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- n/a Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
