### PR TITLE
Mark flaky test cases in JavaProjectIntegrationTest

### DIFF
--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/integtests/JavaProjectIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/integtests/JavaProjectIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests
 import org.gradle.integtests.fixtures.AbstractIntegrationTest
 import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.executer.ExecutionFailure
+import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.TestFile
 import org.junit.Test
 
@@ -174,6 +175,7 @@ class JavaProjectIntegrationTest extends AbstractIntegrationTest {
 
     @Test
     @ToBeFixedForIsolatedProjects(because = "allprojects, configure projects from root")
+    @Flaky(because = "https://github.com/gradle/gradle-private/issues/4442")
     void "can recursively build dependent and dependee projects"() {
         createDirs("a", "b", "c")
         testFile("settings.gradle") << "include 'a', 'b', 'c'"
@@ -248,6 +250,7 @@ class JavaProjectIntegrationTest extends AbstractIntegrationTest {
 
     @Test
     @ToBeFixedForIsolatedProjects(because = "allprojects, configure projects from root")
+    @Flaky(because = "https://github.com/gradle/gradle-private/issues/4442")
     void "project dependency does not drag in source jar from target project"() {
         createDirs("a", "b")
         testFile("settings.gradle") << "include 'a', 'b'"


### PR DESCRIPTION
See https://github.com/gradle/gradle-private/issues/4442
