### PR TITLE
TeamCity: fix missing default value for DslContext parameter 'Branch'

### DIFF
--- a/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
+++ b/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
@@ -48,12 +48,7 @@ data class VersionedSettingsBranch(val branchName: String) {
         val OLD_RELEASE_PATTERN = "release(\\d+)x".toRegex()
 
         fun fromDslContext(): VersionedSettingsBranch {
-            val branch = DslContext.getParameter("Branch")
-            // TeamCity uses a dummy name when first running the DSL
-            if (branch.contains("placeholder-1")) {
-                return VersionedSettingsBranch(MASTER_BRANCH)
-            }
-            return VersionedSettingsBranch(branch)
+            return VersionedSettingsBranch(DslContext.getParameter("Branch", "placeholder"))
         }
 
         private fun determineNightlyPromotionTriggerHour(branchName: String) = when (branchName) {


### PR DESCRIPTION
Apply workaround for [TW-89052](https://youtrack.jetbrains.com/issue/TW-89052/Unable-to-specify-context-parameters-for-versioned-settings-Editing-of-the-project-settings-is-disabled)

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
