### PR TITLE
Document potential failure with JREs and `JavaCompile`

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -42,7 +42,10 @@ The previous step will help you identify potential problems by issuing deprecati
 
 ==== `JavaCompile` tasks may fail when using a JRE even if compilation is not necessary
 
-The `JavaCompile` tasks may fail when using a JRE instead of a JDK in more cases. The toolchain resolution code was changed to enforce the presence of a compiler when being asked for one. However, the `java-base` plugin used the `JavaCompile` compiler to determine the default source and target compatibility when `sourceCompatibility`/`targetCompatibility` or `release` were not set. Now that the compiler cannot be resolved, this default causes the build to fail when only given a JRE, even if no compilation needs to occur (for example, with no sources).
+The `JavaCompile` tasks may sometimes fail when using a JRE instead of a JDK.
+This is due to changes in the toolchain resolution code, which enforces the presence of a compiler when one is requested.
+The `java-base` plugin uses the `JavaCompile` tasks it creates to determine the default source and target compatibility when `sourceCompatibility`/`targetCompatibility` or `release` are not set.
+With the new enforcement, the absence of a compiler causes this to fail when only a JRE is provided, even if no compilation is needed (e.g., in projects with no sources).
 
 This can be fixed by setting the `sourceCompatibility`/`targetCompatibility` explicitly in the `java` extension, or by setting `sourceCompatibility`/`targetCompatibility` or `release` in the relevant task(s).
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -40,6 +40,12 @@ The previous step will help you identify potential problems by issuing deprecati
 
 === Potential breaking changes
 
+==== `JavaCompile` tasks may fail when using a JRE even if compilation is not necessary
+
+The `JavaCompile` tasks may fail when using a JRE instead of a JDK in more cases. The toolchain resolution code was changed to enforce the presence of a compiler when being asked for one. However, the `java-base` plugin used the `JavaCompile` compiler to determine the default source and target compatibility when `sourceCompatibility`/`targetCompatibility` or `release` were not set. Now that the compiler cannot be resolved, this default causes the build to fail when only given a JRE, even if no compilation needs to occur (for example, with no sources).
+
+This can be fixed by setting the `sourceCompatibility`/`targetCompatibility` explicitly in the `java` extension, or by setting `sourceCompatibility`/`targetCompatibility` or `release` in the relevant task(s).
+
 ==== Upgrade to Kotlin 1.9.24
 
 The embedded Kotlin has been updated from 1.9.23 to link:https://github.com/JetBrains/kotlin/releases/tag/v1.9.24[Kotlin 1.9.24].


### PR DESCRIPTION
Resolves #30264.

Other options were investigated, but changing the fallback of `java-base` or other options were considered too risky or hacky.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
