### PR TITLE
Deprecate `Javadoc.isVerbose`/`setVerbose`

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -273,6 +273,11 @@ The affected properties are:
 - link:{javadocPath}/org/gradle/language/scala/tasks/BaseScalaCompileOptions.html#getForkOptions()[BaseScalaCompileOptions.getForkOptions]
 - link:{javadocPath}/org/gradle/language/scala/tasks/BaseScalaCompileOptions.html#getIncrementalOptions()[BaseScalaCompileOptions.getIncrementalOptions]
 
+[[deprecated_javadoc_verbose]]
+==== Deprecated `Javadoc.isVerbose()` and `Javadoc.setVerbose(boolean)`
+
+These methods duplicate the functionality of `Javadoc.getOptions().isVerbose()` and `Javadoc.getOptions().verbose()`, and do not document that setting `false` does not do anything.
+
 [[changes_8.10]]
 == Upgrading from 8.9 and earlier
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -276,7 +276,11 @@ The affected properties are:
 [[deprecated_javadoc_verbose]]
 ==== Deprecated `Javadoc.isVerbose()` and `Javadoc.setVerbose(boolean)`
 
-These methods duplicate the functionality of `Javadoc.getOptions().isVerbose()` and `Javadoc.getOptions().verbose()`, and do not document that setting `false` does not do anything.
+These methods on link:{javadocPath}/org/gradle/api/tasks/javadoc/Javadoc.html[Javadoc] have been deprecated and will be removed in Gradle 9.0.
+
+- link:{javadocPath}/org/gradle/api/tasks/javadoc/Javadoc.html#isVerbose()[isVerbose()] is replaced by link:{javadocPath}/org/gradle/external/javadoc/MinimalJavadocOptions.html#isVerbose()[getOptions().isVerbose()]
+- Calling link:{javadocPath}/org/gradle/api/tasks/javadoc/Javadoc.html#setVerbose(boolean)[setVerbose(boolean)] with `true` is replaced by link:{javadocPath}/org/gradle/external/javadoc/MinimalJavadocOptions.html#verbose()[getOptions().verbose()]
+    - Calling `setVerbose(false)` did nothing.
 
 [[changes_8.10]]
 == Upgrading from 8.9 and earlier

--- a/platforms/jvm/language-java/build.gradle.kts
+++ b/platforms/jvm/language-java/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
     implementation(projects.jvmServices)
     implementation(projects.logging)
     implementation(projects.loggingApi)
+    implementation(projects.logging)
     implementation(projects.modelCore)
     implementation(projects.toolingApi)
     implementation(projects.problemsRendering)

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocIntegrationTest.groovy
@@ -625,7 +625,7 @@ Joe!""")
         writeSourceFile()
 
         when:
-        executer.expectDocumentedDeprecationWarning("The Javadoc.isVerbose() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the getOptions().isVerbose() method instead. It may be necessary to cast the options to CoreJavadocOptions to access the replacement method. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_javadoc_verbose")
+        executer.expectDocumentedDeprecationWarning("The Javadoc.isVerbose() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the getOptions().isVerbose() method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_javadoc_verbose")
 
         then:
         succeeds("javadoc")
@@ -644,7 +644,7 @@ Joe!""")
         writeSourceFile()
 
         when:
-        executer.expectDocumentedDeprecationWarning("The Javadoc.setVerbose(true) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the getOptions().verbose() method instead. It may be necessary to cast the options to CoreJavadocOptions to access the replacement method. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_javadoc_verbose")
+        executer.expectDocumentedDeprecationWarning("The Javadoc.setVerbose(true) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the getOptions().verbose() method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_javadoc_verbose")
 
         then:
         succeeds("javadoc")
@@ -662,7 +662,7 @@ Joe!""")
         writeSourceFile()
 
         when:
-        executer.expectDocumentedDeprecationWarning("The Javadoc.setVerbose(false) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Passing false to this method does nothing. You may want to call getOptions().quiet(). It may be necessary to cast the options to CoreJavadocOptions to access this method. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_javadoc_verbose")
+        executer.expectDocumentedDeprecationWarning("The Javadoc.setVerbose(false) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Passing false to this method does nothing. You may want to call getOptions().quiet(). Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_javadoc_verbose")
 
         then:
         succeeds("javadoc")

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocIntegrationTest.groovy
@@ -613,6 +613,61 @@ Joe!""")
         file("build/docs/javadoc/pkg/internal/IFoo.html").assertDoesNotExist()
     }
 
+    def "isVerbose is deprecated"() {
+        buildFile << """
+            plugins {
+                id 'java'
+            }
+            javadoc {
+                print("Javadoc is verbose: " + isVerbose())
+            }
+        """
+        writeSourceFile()
+
+        when:
+        executer.expectDocumentedDeprecationWarning("The Javadoc.isVerbose() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the getOptions().isVerbose() method instead. It may be necessary to cast the options to CoreJavadocOptions to access the replacement method. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_javadoc_verbose")
+
+        then:
+        succeeds("javadoc")
+        outputContains("Javadoc is verbose: false")
+    }
+
+    def "setVerbose(true) is deprecated"() {
+        buildFile << """
+            plugins {
+                id 'java'
+            }
+            javadoc {
+                setVerbose(true)
+            }
+        """
+        writeSourceFile()
+
+        when:
+        executer.expectDocumentedDeprecationWarning("The Javadoc.setVerbose(true) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the getOptions().verbose() method instead. It may be necessary to cast the options to CoreJavadocOptions to access the replacement method. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_javadoc_verbose")
+
+        then:
+        succeeds("javadoc")
+    }
+
+    def "setVerbose(false) is deprecated with additional details"() {
+        buildFile << """
+            plugins {
+                id 'java'
+            }
+            javadoc {
+                setVerbose(false)
+            }
+        """
+        writeSourceFile()
+
+        when:
+        executer.expectDocumentedDeprecationWarning("The Javadoc.setVerbose(false) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Passing false to this method does nothing. You may want to call getOptions().quiet(). It may be necessary to cast the options to CoreJavadocOptions to access this method. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_javadoc_verbose")
+
+        then:
+        succeeds("javadoc")
+    }
+
     private TestFile writeSourceFile() {
         file("src/main/java/Foo.java") << "public class Foo {}"
     }

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
@@ -45,7 +45,9 @@ import org.gradle.api.tasks.javadoc.internal.JavadocSpec;
 import org.gradle.api.tasks.javadoc.internal.JavadocToolAdapter;
 import org.gradle.external.javadoc.MinimalJavadocOptions;
 import org.gradle.external.javadoc.StandardJavadocDocletOptions;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.file.Deleter;
+import org.gradle.internal.instrumentation.api.annotations.NotToBeReplacedByLazyProperty;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 import org.gradle.internal.jvm.DefaultModularitySpec;
 import org.gradle.internal.jvm.JavaModuleDetector;
@@ -309,8 +311,13 @@ public abstract class Javadoc extends SourceTask {
      * @see #setVerbose(boolean)
      */
     @Internal
-    @ToBeReplacedByLazyProperty
+    @NotToBeReplacedByLazyProperty(because = "deprecated and replaced by options.verbose")
     public boolean isVerbose() {
+        DeprecationLogger.deprecateMethod(Javadoc.class, "isVerbose()")
+            .withAdvice("Please use the getOptions().isVerbose() method instead. It may be necessary to cast the options to CoreJavadocOptions to access the replacement method.")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(8, "deprecated_javadoc_verbose")
+            .nagUser();
         return options.isVerbose();
     }
 
@@ -322,7 +329,18 @@ public abstract class Javadoc extends SourceTask {
      */
     public void setVerbose(boolean verbose) {
         if (verbose) {
+            DeprecationLogger.deprecateMethod(Javadoc.class, "setVerbose(true)")
+                .withAdvice("Please use the getOptions().verbose() method instead. It may be necessary to cast the options to CoreJavadocOptions to access the replacement method.")
+                .willBeRemovedInGradle9()
+                .withUpgradeGuideSection(8, "deprecated_javadoc_verbose")
+                .nagUser();
             options.verbose();
+        } else {
+            DeprecationLogger.deprecateMethod(Javadoc.class, "setVerbose(false)")
+                .withAdvice("Passing false to this method does nothing. You may want to call getOptions().quiet(). It may be necessary to cast the options to CoreJavadocOptions to access this method.")
+                .willBeRemovedInGradle9()
+                .withUpgradeGuideSection(8, "deprecated_javadoc_verbose")
+                .nagUser();
         }
     }
 

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
@@ -47,7 +47,6 @@ import org.gradle.external.javadoc.MinimalJavadocOptions;
 import org.gradle.external.javadoc.StandardJavadocDocletOptions;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.file.Deleter;
-import org.gradle.internal.instrumentation.api.annotations.NotToBeReplacedByLazyProperty;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 import org.gradle.internal.jvm.DefaultModularitySpec;
 import org.gradle.internal.jvm.JavaModuleDetector;
@@ -309,12 +308,13 @@ public abstract class Javadoc extends SourceTask {
      * Returns whether Javadoc generation is accompanied by verbose output.
      *
      * @see #setVerbose(boolean)
+     * @deprecated This method duplicates the functionality of {@code getOptions().isVerbose()}. It will be removed in Gradle 9.0.
      */
+    @Deprecated
     @Internal
-    @NotToBeReplacedByLazyProperty(because = "deprecated and replaced by options.verbose")
     public boolean isVerbose() {
         DeprecationLogger.deprecateMethod(Javadoc.class, "isVerbose()")
-            .withAdvice("Please use the getOptions().isVerbose() method instead. It may be necessary to cast the options to CoreJavadocOptions to access the replacement method.")
+            .replaceWith("getOptions().isVerbose()")
             .willBeRemovedInGradle9()
             .withUpgradeGuideSection(8, "deprecated_javadoc_verbose")
             .nagUser();
@@ -326,18 +326,20 @@ public abstract class Javadoc extends SourceTask {
      * (by the underlying Ant task). Thus it is not handled by our logging.
      *
      * @param verbose Whether the output should be verbose.
+     * @deprecated This method duplicates the functionality of {@code getOptions().verbose()}. It will be removed in Gradle 9.0.
      */
+    @Deprecated
     public void setVerbose(boolean verbose) {
         if (verbose) {
             DeprecationLogger.deprecateMethod(Javadoc.class, "setVerbose(true)")
-                .withAdvice("Please use the getOptions().verbose() method instead. It may be necessary to cast the options to CoreJavadocOptions to access the replacement method.")
+                .replaceWith("getOptions().verbose()")
                 .willBeRemovedInGradle9()
                 .withUpgradeGuideSection(8, "deprecated_javadoc_verbose")
                 .nagUser();
             options.verbose();
         } else {
             DeprecationLogger.deprecateMethod(Javadoc.class, "setVerbose(false)")
-                .withAdvice("Passing false to this method does nothing. You may want to call getOptions().quiet(). It may be necessary to cast the options to CoreJavadocOptions to access this method.")
+                .withAdvice("Passing false to this method does nothing. You may want to call getOptions().quiet().")
                 .willBeRemovedInGradle9()
                 .withUpgradeGuideSection(8, "deprecated_javadoc_verbose")
                 .nagUser();

--- a/platforms/jvm/language-java/src/test/groovy/org/gradle/api/tasks/javadoc/JavadocTest.groovy
+++ b/platforms/jvm/language-java/src/test/groovy/org/gradle/api/tasks/javadoc/JavadocTest.groovy
@@ -66,7 +66,7 @@ class JavadocTest extends AbstractProjectBuilderSpec {
     def "execution with additional options uses the tool"() {
         task.getJavadocTool().set(tool)
         task.setMaxMemory("max-memory")
-        task.setVerbose(true)
+        task.options.verbose()
 
         when:
         execute(task)


### PR DESCRIPTION
Fixes #30308

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
