### PR TITLE
Fix invalid syntax that broke deprecation linking to anchor

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -2610,7 +2610,7 @@ beforeSettings {
 =====
 ====
 
-[no_relative_paths_for_java_executables]
+[[no_relative_paths_for_java_executables]]
 ==== Deprecated using relative paths to specify Java executables
 Using relative file paths to point to Java executables is now deprecated and will become an error in Gradle 9.
 This is done to reduce confusion about what such relative paths should resolve against.


### PR DESCRIPTION
Tiny documentation-only change I found when looking through deprecations.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
