### PR TITLE
Add missing anchors that are used by deprecations

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -90,6 +90,7 @@ val myConfig = buildscript.configurations.detachedConfiguration(
 val files = myConfig.files
 ----
 
+[[adding_to_configuration_container]]
 ==== Deprecated manually adding to configuration container
 
 Starting in Gradle 9.0, manually adding configuration instances to a configuration container will result in an error.
@@ -102,6 +103,7 @@ Calling the following methods on link:{javadocPath}/org/gradle/api/artifacts/Con
 - addLater(Provider)
 - addAllLater(Provider)
 
+[[deprecated_abstract_options]]
 ==== Deprecated `AbstractOptions`
 
 The `AbstractOptions` class has been deprecated and will be removed in Gradle 9.0.
@@ -133,6 +135,7 @@ tasks.withType(JavaCompile) {
 }
 ----
 
+[[deprecated_content_equals]]
 ==== Deprecated `Dependency#contentEquals(Dependency)`
 
 The link:{javadocPath}/org/gradle/api/artifacts/Dependency.html#contentEquals(org.gradle.api.artifacts.Dependency)[Dependency#contentEquals(Dependency)] method has been deprecated and will be removed in Gradle 9.0.


### PR DESCRIPTION
Some deprecations added in `master` didn't have matching links.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
