### PR TITLE
Prevent generating accessors if the name is not a valid Kotlin identifier

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
@@ -290,13 +290,9 @@ class AccessorNameSpec private constructor(val original: String) {
          * Else, return `null`.
          */
         internal
-        fun createOrNull(original: String): AccessorNameSpec? {
-            return if (isLegalAccessorName(original)) {
-                AccessorNameSpec(original)
-            } else {
-                null
-            }
-        }
+        fun createOrNull(original: String): AccessorNameSpec? =
+            if (isLegalAccessorName(original)) AccessorNameSpec(original)
+            else null
 
         private
         fun isLegalAccessorName(name: String): Boolean =
@@ -362,6 +358,8 @@ fun typedAccessorSpec(schemaEntry: ProjectSchemaEntry<TypeAccessibility>): Typed
 
 private
 fun documentInaccessibilityReasons(name: AccessorNameSpec, typeAccess: TypeAccessibility.Inaccessible): String =
-    "`${name.kotlinIdentifier}` is not accessible in a type safe way because:\n${typeAccess.reasons.joinToString("\n") { reason ->
-        "         * - ${reason.explanation}"
-    }}"
+    "`${name.kotlinIdentifier}` is not accessible in a type safe way because:\n${
+        typeAccess.reasons.joinToString("\n") { reason ->
+            "         * - ${reason.explanation}"
+        }
+    }"

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
@@ -268,14 +268,14 @@ val thisExtensions =
     "(this as ${ExtensionAware::class.java.name}).extensions"
 
 
-@Suppress("deprecation")
+@Suppress("DEPRECATION")
 private
 val thisConvention =
     "((this as? Project)?.convention ?: (this as ${org.gradle.api.internal.HasConvention::class.java.name}).convention)"
 
 
 internal
-data class AccessorNameSpec(val original: String) {
+class AccessorNameSpec private constructor(val original: String) {
 
     val kotlinIdentifier
         get() = original
@@ -283,6 +283,49 @@ data class AccessorNameSpec(val original: String) {
     val stringLiteral by unsafeLazy {
         stringLiteralFor(original)
     }
+
+    companion object {
+        /**
+         * Create a new [AccessorNameSpec], if [original] is valid.
+         * Else, return `null`.
+         */
+        internal
+        fun createOrNull(original: String): AccessorNameSpec? {
+            return if (isLegalAccessorName(original)) {
+                AccessorNameSpec(original)
+            } else {
+                null
+            }
+        }
+
+        private
+        fun isLegalAccessorName(name: String): Boolean =
+            isKotlinIdentifier("`$name`")
+                && name.indexOfAny(invalidNameChars) < 0
+
+        private
+        val invalidNameChars = charArrayOf('.', '/', '\\')
+
+        private
+        fun isKotlinIdentifier(candidate: String): Boolean =
+            KotlinLexer().run {
+                start(candidate)
+                tokenStart == 0
+                    && tokenEnd == candidate.length
+                    && tokenType == KtTokens.IDENTIFIER
+            }
+    }
+
+    override fun toString(): String = "AccessorNameSpec(original=$original)"
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as AccessorNameSpec
+        return original == other.original
+    }
+
+    override fun hashCode(): Int = original.hashCode()
 }
 
 
@@ -305,20 +348,16 @@ fun escapeStringTemplateDollarSign(string: String) =
 
 
 private
-fun accessorNameSpec(originalName: String) =
-    AccessorNameSpec(originalName)
+fun typedAccessorSpec(schemaEntry: ProjectSchemaEntry<TypeAccessibility>): TypedAccessorSpec? {
+    val accessorName = AccessorNameSpec.createOrNull(schemaEntry.name) ?: return null
+    return when (schemaEntry.target) {
+        is TypeAccessibility.Accessible ->
+            TypedAccessorSpec(schemaEntry.target, accessorName, schemaEntry.type)
 
-
-internal
-fun typedAccessorSpec(schemaEntry: ProjectSchemaEntry<TypeAccessibility>) =
-    schemaEntry.takeIf { isLegalAccessorName(it.name) }?.target?.run {
-        when (this) {
-            is TypeAccessibility.Accessible ->
-                TypedAccessorSpec(this, accessorNameSpec(schemaEntry.name), schemaEntry.type)
-            is TypeAccessibility.Inaccessible ->
-                null
-        }
+        is TypeAccessibility.Inaccessible ->
+            null
     }
+}
 
 
 private
@@ -326,23 +365,3 @@ fun documentInaccessibilityReasons(name: AccessorNameSpec, typeAccess: TypeAcces
     "`${name.kotlinIdentifier}` is not accessible in a type safe way because:\n${typeAccess.reasons.joinToString("\n") { reason ->
         "         * - ${reason.explanation}"
     }}"
-
-
-internal
-fun isLegalAccessorName(name: String): Boolean =
-    isKotlinIdentifier("`$name`")
-        && name.indexOfAny(invalidNameChars) < 0
-
-
-private
-val invalidNameChars = charArrayOf('.', '/', '\\')
-
-
-private
-fun isKotlinIdentifier(candidate: String): Boolean =
-    KotlinLexer().run {
-        start(candidate)
-        tokenStart == 0
-            && tokenEnd == candidate.length
-            && tokenType == KtTokens.IDENTIFIER
-    }

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/Emitter.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/Emitter.kt
@@ -209,16 +209,9 @@ fun accessorsFor(schema: ProjectSchema<TypeAccessibility>): Sequence<Accessor> =
             yieldAll(uniqueAccessorsFor(tasks).map(Accessor::ForTask))
             yieldAll(uniqueAccessorsFor(containerElements).map(Accessor::ForContainerElement))
 
-            val configurationNames = configurations
-                .asSequence()
-                .mapNotNull {
-                    val accessorNameSpec = AccessorNameSpec.createOrNull(it.target)
-                    if (accessorNameSpec == null) {
-                        null
-                    } else {
-                        it.map { accessorNameSpec }
-                    }
-                }
+            val configurationNames = configurations.asSequence().mapNotNull { entry ->
+                AccessorNameSpec.createOrNull(entry.target)?.let { accessorNameSpec -> entry.map { accessorNameSpec } }
+            }
             yieldAll(
                 uniqueAccessorsFrom(
                     configurationNames.map { it.target }.map(::configurationAccessorSpec)

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/Emitter.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/Emitter.kt
@@ -209,13 +209,23 @@ fun accessorsFor(schema: ProjectSchema<TypeAccessibility>): Sequence<Accessor> =
             yieldAll(uniqueAccessorsFor(tasks).map(Accessor::ForTask))
             yieldAll(uniqueAccessorsFor(containerElements).map(Accessor::ForContainerElement))
 
-            val configurationNames = configurations.map { it.map(::AccessorNameSpec) }.asSequence()
+            val configurationNames = configurations
+                .asSequence()
+                .mapNotNull {
+                    val accessorNameSpec = AccessorNameSpec.createOrNull(it.target)
+                    if (accessorNameSpec == null) {
+                        null
+                    } else {
+                        it.map { accessorNameSpec }
+                    }
+                }
             yieldAll(
                 uniqueAccessorsFrom(
                     configurationNames.map { it.target }.map(::configurationAccessorSpec)
                 ).map(Accessor::ForContainerElement)
             )
             yieldAll(configurationNames.map(Accessor::ForConfiguration))
+
             yieldAll(uniqueAccessorsFor(modelDefaults).map(Accessor::ForModelDefault))
         }
     }

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/tasks/PrintAccessorsTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/tasks/PrintAccessorsTest.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.kotlin.dsl.accessors.tasks
 
+import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.initialization.SharedModelDefaults
 import org.gradle.api.plugins.ExtraPropertiesExtension
@@ -24,14 +25,12 @@ import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.kotlin.dsl.accessors.ConfigurationEntry
-
 import org.gradle.kotlin.dsl.accessors.TypedProjectSchema
 import org.gradle.kotlin.dsl.accessors.entry
 import org.gradle.kotlin.dsl.fixtures.standardOutputOf
-
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-
+import org.hamcrest.text.IsBlankString.blankString
 import org.junit.Test
 
 
@@ -74,6 +73,29 @@ class PrintAccessorsTest {
                 textFromResource("PrintAccessors-expected-output.txt")
             )
         )
+    }
+
+    @Test
+    fun `does not print accessors with invalid Kotlin identifiers`() {
+
+        val actualAccessors = standardOutputOf {
+            printAccessorsFor(
+                TypedProjectSchema(
+                    extensions = listOf(),
+                    conventions = listOf(),
+                    tasks = listOf(
+                        entry<TaskContainer, DefaultTask>("dots.not.allowed")
+                    ),
+                    configurations = listOf(
+                        ConfigurationEntry("dots.not.allowed"),
+                    ),
+                    containerElements = listOf(),
+                    modelDefaults = listOf()
+                )
+            )
+        }.withoutTrailingWhitespace()
+
+        assertThat(actualAccessors, blankString())
     }
 
     private


### PR DESCRIPTION
fix https://github.com/gradle/gradle/issues/30340


### Context

Users will benefit from this change because Gradle will not generate invalid code that cannot compile.

Dear Gradle reviewers: if you want to make any changes, please go ahead and make them. I have enabled permission to modify the branch, and it's easier if you make the changes directly.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
