### PR TITLE
Allow SourceTask.source to be a ConfigurableFileTree (WIP)

### DIFF
--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
@@ -19,8 +19,8 @@ package org.gradle.api.internal.file;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.Action;
-import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.ConfigurableFileTree;
+import org.gradle.api.internal.file.collections.ConfigurableFileCollectionInternal;
 import org.gradle.api.internal.file.collections.DefaultConfigurableFileCollection;
 import org.gradle.api.internal.file.collections.DefaultConfigurableFileTree;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
@@ -109,18 +109,19 @@ public class DefaultFileCollectionFactory implements FileCollectionFactory {
     }
 
     @Override
-    public ConfigurableFileCollection configurableFiles() {
+    public ConfigurableFileCollectionInternal configurableFiles() {
         return new DefaultConfigurableFileCollection(null, fileResolver, taskDependencyFactory, patternSetFactory, propertyHost);
     }
 
     @Override
-    public ConfigurableFileCollection configurableFiles(String displayName) {
+    public ConfigurableFileCollectionInternal configurableFiles(String displayName) {
         return new DefaultConfigurableFileCollection(displayName, fileResolver, taskDependencyFactory, patternSetFactory, propertyHost);
     }
 
     @Override
     public ConfigurableFileTree fileTree() {
-        return new DefaultConfigurableFileTree(fileResolver, listener, patternSetFactory, taskDependencyFactory, directoryFileTreeFactory);
+        // TODO Add overload with a display name
+        return new DefaultConfigurableFileTree(configurableFiles(), patternSetFactory, listener, taskDependencyFactory);
     }
 
     @Override
@@ -318,7 +319,7 @@ public class DefaultFileCollectionFactory implements FileCollectionFactory {
             if (item instanceof FileCollectionInternal) {
                 ((FileCollectionInternal) item).describeContents(formatter);
             } else if (item instanceof ArrayList) {
-                for (Object child : (List) item) {
+                for (Object child : (List<?>) item) {
                     appendItem(formatter, child);
                 }
             } else {

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionFactory.java
@@ -170,6 +170,7 @@ public interface FileCollectionFactory {
     /**
      * Creates a {@link ConfigurableFileTree} instance with no base dir specified.
      */
+    // TODO Rename to `configurableFileTree()`
     ConfigurableFileTree fileTree();
 
     /**

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/ConfigurableFileCollectionInternal.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/ConfigurableFileCollectionInternal.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file.collections;
+
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.internal.file.FileCollectionInternal;
+import org.gradle.api.internal.provider.HasConfigurableValueInternal;
+
+public interface ConfigurableFileCollectionInternal extends ConfigurableFileCollection, FileCollectionInternal, HasConfigurableValueInternal {
+}

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/ConfigurableFileTreeInternal.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/ConfigurableFileTreeInternal.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file.collections;
+
+import org.gradle.api.file.ConfigurableFileTree;
+import org.gradle.api.internal.file.FileTreeInternal;
+import org.gradle.api.tasks.util.PatternSet;
+
+public interface ConfigurableFileTreeInternal extends ConfigurableFileTree, FileTreeInternal {
+    PatternSet getPatternSet();
+}

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -60,7 +60,7 @@ import java.util.function.Supplier;
 /**
  * A {@link org.gradle.api.file.FileCollection} which resolves a set of paths relative to a {@link org.gradle.api.internal.file.FileResolver}.
  */
-public class DefaultConfigurableFileCollection extends CompositeFileCollection implements ConfigurableFileCollection, Managed, HasConfigurableValueInternal, LazyGroovySupport {
+public class DefaultConfigurableFileCollection extends CompositeFileCollection implements ConfigurableFileCollectionInternal, Managed, HasConfigurableValueInternal, LazyGroovySupport {
     private static final EmptyCollector EMPTY_COLLECTOR = new EmptyCollector();
     private final PathSet filesWrapper;
     private final String displayName;

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
@@ -91,6 +91,7 @@ import static org.gradle.internal.instrumentation.model.ParameterKindInfo.METHOD
 import static org.gradle.internal.instrumentation.model.ParameterKindInfo.RECEIVER;
 import static org.gradle.internal.instrumentation.processor.AbstractInstrumentationProcessor.PROJECT_NAME_OPTIONS;
 import static org.gradle.internal.instrumentation.processor.codegen.GradleLazyType.FILE_COLLECTION;
+import static org.gradle.internal.instrumentation.processor.codegen.GradleLazyType.FILE_TREE;
 import static org.gradle.internal.instrumentation.processor.codegen.GradleReferencedType.isAssignableToFileSystemLocation;
 import static org.gradle.internal.instrumentation.processor.modelreader.impl.AnnotationUtils.isAnnotationOfType;
 import static org.gradle.internal.instrumentation.processor.modelreader.impl.TypeUtils.extractMethodDescriptor;
@@ -503,6 +504,8 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
         switch (gradleLazyType) {
             case CONFIGURABLE_FILE_COLLECTION:
                 return FILE_COLLECTION.asClassName();
+            case CONFIGURABLE_FILE_TREE:
+                return FILE_TREE.asClassName();
             case DIRECTORY_PROPERTY:
             case REGULAR_FILE_PROPERTY:
                 return ClassName.get(File.class);

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/GradleLazyType.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/GradleLazyType.java
@@ -22,7 +22,9 @@ import com.squareup.javapoet.TypeName;
 
 public enum GradleLazyType {
     CONFIGURABLE_FILE_COLLECTION("org.gradle.api.file.ConfigurableFileCollection"),
+    CONFIGURABLE_FILE_TREE("org.gradle.api.file.ConfigurableFileTree"),
     FILE_COLLECTION("org.gradle.api.file.FileCollection"),
+    FILE_TREE("org.gradle.api.file.FileTree"),
     DIRECTORY_PROPERTY("org.gradle.api.file.DirectoryProperty"),
     REGULAR_FILE_PROPERTY("org.gradle.api.file.RegularFileProperty"),
     LIST_PROPERTY("org.gradle.api.provider.ListProperty"),

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/Checkstyle.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/Checkstyle.java
@@ -19,9 +19,9 @@ import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.FileTree;
 import org.gradle.api.plugins.quality.internal.CheckstyleAction;
 import org.gradle.api.plugins.quality.internal.CheckstyleActionParameters;
 import org.gradle.api.plugins.quality.internal.CheckstyleReportsImpl;
@@ -182,11 +182,8 @@ public abstract class Checkstyle extends AbstractCodeQualityTask implements Repo
      * executed.</p>
      */
     @Override
-    @ToBeReplacedByLazyProperty
     @PathSensitive(PathSensitivity.RELATIVE)
-    public FileTree getSource() {
-        return super.getSource();
-    }
+    public abstract ConfigurableFileTree getSource();
 
     /**
      * The class path containing the Checkstyle library to be used.

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/CheckstylePlugin.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/CheckstylePlugin.java
@@ -137,6 +137,6 @@ public abstract class CheckstylePlugin extends AbstractCodeQualityPlugin<Checkst
     protected void configureForSourceSet(final SourceSet sourceSet, Checkstyle task) {
         task.setDescription("Run Checkstyle analysis for " + sourceSet.getName() + " classes");
         task.setClasspath(sourceSet.getOutput().plus(sourceSet.getCompileClasspath()));
-        task.setSource(sourceSet.getAllJava());
+        task.getSource().setFrom(sourceSet.getAllJava());
     }
 }

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/CodeNarc.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/CodeNarc.java
@@ -17,8 +17,8 @@ package org.gradle.api.plugins.quality;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
+import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.FileTree;
 import org.gradle.api.plugins.quality.internal.CodeNarcAction;
 import org.gradle.api.plugins.quality.internal.CodeNarcActionParameters;
 import org.gradle.api.plugins.quality.internal.CodeNarcReportsImpl;
@@ -81,10 +81,7 @@ public abstract class CodeNarc extends AbstractCodeQualityTask implements Report
      */
     @Override
     @PathSensitive(PathSensitivity.RELATIVE)
-    @ToBeReplacedByLazyProperty
-    public FileTree getSource() {
-        return super.getSource();
-    }
+    public abstract ConfigurableFileTree getSource();
 
     /**
      * The CodeNarc configuration file to use.

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/CodeNarcPlugin.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/CodeNarcPlugin.java
@@ -146,7 +146,7 @@ public abstract class CodeNarcPlugin extends AbstractCodeQualityPlugin<CodeNarc>
     protected void configureForSourceSet(final SourceSet sourceSet, CodeNarc task) {
         task.setDescription("Run CodeNarc analysis for " + sourceSet.getName() + " classes");
         SourceDirectorySet groovySourceSet =  sourceSet.getExtensions().getByType(GroovySourceDirectorySet.class);
-        task.setSource(groovySourceSet.matching(filter -> filter.include("**/*.groovy")));
+        task.getSource().setFrom(groovySourceSet.matching(filter -> filter.include("**/*.groovy")));
     }
 
     private static String appropriateCodeNarcVersion() {

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/Pmd.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/Pmd.java
@@ -19,8 +19,8 @@ import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.FileTree;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.quality.internal.PmdAction;
 import org.gradle.api.plugins.quality.internal.PmdActionParameters;
@@ -178,10 +178,7 @@ public abstract class Pmd extends AbstractCodeQualityTask implements Reporting<P
      */
     @Override
     @PathSensitive(PathSensitivity.RELATIVE)
-    @ToBeReplacedByLazyProperty
-    public FileTree getSource() {
-        return super.getSource();
-    }
+    public abstract ConfigurableFileTree getSource();
 
     /**
      * The class path containing the PMD library to be used.

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/PmdPlugin.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/PmdPlugin.java
@@ -208,7 +208,7 @@ public abstract class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
     @Override
     protected void configureForSourceSet(final SourceSet sourceSet, final Pmd task) {
         task.setDescription("Run PMD analysis for " + sourceSet.getName() + " classes");
-        task.setSource(sourceSet.getAllJava());
+        task.getSource().setFrom(sourceSet.getAllJava());
         ConventionMapping taskMapping = task.getConventionMapping();
         RoleBasedConfigurationContainerInternal configurations = project.getConfigurations();
 

--- a/platforms/jvm/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
+++ b/platforms/jvm/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
@@ -18,9 +18,9 @@ package org.gradle.api.tasks.javadoc;
 
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.UncheckedIOException;
+import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileSystemOperations;
-import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.file.temp.TemporaryFileProvider;
 import org.gradle.api.internal.project.IsolatedAntBuilder;
 import org.gradle.api.internal.tasks.AntGroovydoc;
@@ -139,10 +139,7 @@ public abstract class Groovydoc extends SourceTask {
      */
     @PathSensitive(PathSensitivity.RELATIVE)
     @Override
-    @ToBeReplacedByLazyProperty
-    public FileTree getSource() {
-        return super.getSource();
-    }
+    public abstract ConfigurableFileTree getSource();
 
     /**
      * Returns the directory to generate the documentation into.

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
@@ -19,8 +19,8 @@ package org.gradle.api.tasks.javadoc;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
+import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.FileTree;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.internal.tasks.compile.CompilationSourceDirs;
@@ -221,10 +221,7 @@ public abstract class Javadoc extends SourceTask {
      */
     @PathSensitive(PathSensitivity.RELATIVE)
     @Override
-    @ToBeReplacedByLazyProperty
-    public FileTree getSource() {
-        return super.getSource();
-    }
+    public abstract ConfigurableFileTree getSource();
 
     /**
      * Configures the javadoc executable to be used to generate javadoc documentation.

--- a/platforms/jvm/plugins-groovy/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
+++ b/platforms/jvm/plugins-groovy/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
@@ -46,7 +46,6 @@ import org.gradle.jvm.toolchain.JavaToolchainService;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
-
 import java.util.function.Supplier;
 
 import static org.gradle.api.internal.lambdas.SerializableLambdas.spec;
@@ -159,7 +158,7 @@ public abstract class GroovyBasePlugin implements Plugin<Project> {
             JvmPluginsHelper.compileAgainstJavaOutputs(groovyCompile, sourceSet, objectFactory);
             JvmPluginsHelper.configureAnnotationProcessorPath(sourceSet, groovySource, groovyCompile.getOptions(), project);
             groovyCompile.setDescription("Compiles the " + groovySource + ".");
-            groovyCompile.setSource(groovySource);
+            groovyCompile.getSource().setFrom(groovySource);
             groovyCompile.getJavaLauncher().convention(getJavaLauncher(project));
 
             groovyCompile.getGroovyOptions().getDisabledGlobalASTTransformations().convention(Sets.newHashSet("groovy.grape.GrabAnnotationTransformation"));

--- a/platforms/jvm/plugins-groovy/src/main/java/org/gradle/api/plugins/GroovyPlugin.java
+++ b/platforms/jvm/plugins-groovy/src/main/java/org/gradle/api/plugins/GroovyPlugin.java
@@ -50,7 +50,7 @@ public abstract class GroovyPlugin implements Plugin<Project> {
             groovyDoc.setClasspath(mainFeature.getSourceSet().getOutput().plus(mainFeature.getSourceSet().getCompileClasspath()));
 
             SourceDirectorySet groovySourceSet = mainFeature.getSourceSet().getExtensions().getByType(GroovySourceDirectorySet.class);
-            groovyDoc.setSource(groovySourceSet);
+            groovyDoc.getSource().setFrom(groovySourceSet);
         });
     }
 }

--- a/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -28,10 +28,10 @@ import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.GeneratedSubclasses;
 import org.gradle.api.internal.IConventionAware;
-import org.gradle.api.internal.artifacts.configurations.RoleBasedConfigurationCreationRequest;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationRole;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationRoles;
 import org.gradle.api.internal.artifacts.configurations.RoleBasedConfigurationContainerInternal;
+import org.gradle.api.internal.artifacts.configurations.RoleBasedConfigurationCreationRequest;
 import org.gradle.api.internal.artifacts.configurations.UsageDescriber;
 import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.internal.plugins.DslObject;
@@ -222,7 +222,7 @@ public abstract class JavaBasePlugin implements Plugin<Project> {
 
             JvmPluginsHelper.configureAnnotationProcessorPath(sourceSet, javaSource, javaCompile.getOptions(), project);
             javaCompile.setDescription("Compiles " + javaSource + ".");
-            javaCompile.setSource(javaSource);
+            javaCompile.getSource().setFrom(javaSource);
 
             Provider<JavaToolchainSpec> toolchainOverrideSpec = project.provider(() ->
                 JavaCompileExecutableUtils.getExecutableOverrideToolchainSpec(javaCompile, objectFactory));

--- a/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
+++ b/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
@@ -67,7 +67,7 @@ public class JvmPluginsHelper {
     @Deprecated
     public static void configureForSourceSet(final SourceSet sourceSet, final SourceDirectorySet sourceDirectorySet, AbstractCompile compile, CompileOptions options, final Project target) {
         compile.setDescription("Compiles the " + sourceDirectorySet.getDisplayName() + ".");
-        compile.setSource(sourceSet.getJava());
+        compile.getSource().setFrom(sourceSet.getJava());
 
         compileAgainstJavaOutputs(compile, sourceSet, target.getObjects());
         configureAnnotationProcessorPath(sourceSet, sourceDirectorySet, options, target);
@@ -120,7 +120,7 @@ public class JvmPluginsHelper {
                 javadoc.setDescription("Generates Javadoc API documentation for the " + displayName + ".");
                 javadoc.setGroup(JvmConstants.DOCUMENTATION_GROUP);
                 javadoc.setClasspath(sourceSet.getOutput().plus(sourceSet.getCompileClasspath()));
-                javadoc.setSource(sourceSet.getAllJava());
+                javadoc.getSource().setFrom(sourceSet.getAllJava());
                 if (javaPluginExtension != null) {
                     javadoc.getConventionMapping().map("destinationDir", () -> javaPluginExtension.getDocsDir().dir(javadocTaskName).get().getAsFile());
                     javadoc.getModularity().getInferModulePath().convention(javaPluginExtension.getModularity().getInferModulePath());

--- a/platforms/jvm/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
+++ b/platforms/jvm/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
@@ -222,7 +222,7 @@ public abstract class ScalaBasePlugin implements Plugin<Project> {
             JvmPluginsHelper.compileAgainstJavaOutputs(scalaCompile, sourceSet, objectFactory);
             JvmPluginsHelper.configureAnnotationProcessorPath(sourceSet, scalaSource, scalaCompile.getOptions(), project);
             scalaCompile.setDescription("Compiles the " + scalaSource + ".");
-            scalaCompile.setSource(scalaSource);
+            scalaCompile.getSource().setFrom(scalaSource);
             scalaCompile.getJavaLauncher().convention(getJavaLauncher(project));
 
             configureIncrementalAnalysis(project, sourceSet, incrementalAnalysis, scalaCompile);

--- a/platforms/jvm/scala/src/main/java/org/gradle/api/plugins/scala/ScalaPlugin.java
+++ b/platforms/jvm/scala/src/main/java/org/gradle/api/plugins/scala/ScalaPlugin.java
@@ -70,7 +70,7 @@ public abstract class ScalaPlugin implements Plugin<Project> {
                 files.from(feature.getSourceSet().getCompileClasspath());
                 return files;
             });
-            scalaDoc.setSource(feature.getSourceSet().getExtensions().getByType(ScalaSourceDirectorySet.class));
+            scalaDoc.getSource().setFrom(feature.getSourceSet().getExtensions().getByType(ScalaSourceDirectorySet.class));
             scalaDoc.getCompilationOutputs().from(feature.getSourceSet().getOutput());
         });
         project.getTasks().register(SCALA_DOC_TASK_NAME, ScalaDoc.class, scalaDoc -> {

--- a/platforms/jvm/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDoc.java
+++ b/platforms/jvm/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDoc.java
@@ -16,6 +16,7 @@
 package org.gradle.api.tasks.scala;
 
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.project.IsolatedAntBuilder;
@@ -98,10 +99,7 @@ public abstract class ScalaDoc extends SourceTask {
      */
     @PathSensitive(PathSensitivity.RELATIVE)
     @Override
-    @ToBeReplacedByLazyProperty
-    public FileTree getSource() {
-        return super.getSource();
-    }
+    public abstract ConfigurableFileTree getSource();
 
     /**
      * Returns the compilation outputs needed by Scaladoc filtered to include <a href="https://docs.scala-lang.org/scala3/guides/tasty-overview.html">TASTy</a> files.

--- a/platforms/jvm/scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
+++ b/platforms/jvm/scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
@@ -22,7 +22,7 @@ import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.file.FileTree;
+import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.tasks.compile.CleaningJavaCompiler;
@@ -51,7 +51,6 @@ import org.gradle.internal.buildevents.BuildStartedTime;
 import org.gradle.internal.classpath.CachedClasspathTransformer;
 import org.gradle.internal.classpath.DefaultClassPath;
 import org.gradle.internal.file.Deleter;
-import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.jvm.toolchain.JavaToolchainService;
@@ -246,10 +245,7 @@ public abstract class AbstractScalaCompile extends AbstractCompile implements Ha
     @Override
     // Java source files are supported, too. Therefore, we should care about the relative path.
     @PathSensitive(PathSensitivity.RELATIVE)
-    @ToBeReplacedByLazyProperty
-    public FileTree getSource() {
-        return super.getSource();
-    }
+    public abstract ConfigurableFileTree getSource();
 
     /**
      * The Java major version of the JVM the Scala compiler is running on.

--- a/platforms/software/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java
+++ b/platforms/software/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java
@@ -92,7 +92,7 @@ public abstract class AntlrPlugin implements Plugin<Project> {
                         public void execute(AntlrTask antlrTask) {
                             antlrTask.setDescription("Processes the " + sourceSet.getName() + " Antlr grammars.");
                             // 4) set up convention mapping for default sources (allows user to not have to specify)
-                            antlrTask.setSource(antlrSourceSet);
+                            antlrTask.getSource().setFrom(antlrSourceSet);
                             antlrTask.setOutputDirectory(outputDirectory);
                         }
                     });

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileTree.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileTree.java
@@ -18,47 +18,27 @@ package org.gradle.api.file;
 import org.gradle.api.Buildable;
 import org.gradle.api.tasks.util.PatternFilterable;
 
-import java.io.File;
-import java.util.Set;
-
 /**
- * <p>A {@link FileTree} with a single base directory, which can be configured and modified.</p>
+ * <p>A configurable {@link FileTree}.</p>
  *
  * <p>You can obtain a {@code ConfigurableFileTree} instance by calling {@link org.gradle.api.Project#fileTree(java.util.Map)}.</p>
  */
-public interface ConfigurableFileTree extends FileTree, DirectoryTree, PatternFilterable, Buildable {
+public interface ConfigurableFileTree extends FileTree, ConfigurableFileCollection, PatternFilterable, Buildable {
     /**
      * Specifies base directory for this file tree using the given path. The path is evaluated as per {@link
      * org.gradle.api.Project#file(Object)}.
      *
      * @param dir The base directory.
      * @return this
-     */
-    ConfigurableFileTree from(Object dir);
-
-    /**
-     * Returns the base directory of this file tree.
-     *
-     * @return The base directory. Never returns null.
      */
     @Override
-    File getDir();
+    ConfigurableFileTree from(Object... dir);
 
-    /**
-     * Specifies base directory for this file tree using the given path. The path is evaluated as per {@link
-     * org.gradle.api.Project#file(Object)}.
-     *
-     * @param dir The base directory.
-     * @return this
-     */
-    ConfigurableFileTree setDir(Object dir);
+    @Override
+    ConfigurableFileTree convention(Iterable<?> paths);
 
-    /**
-     * Returns the set of tasks which build the files of this collection.
-     *
-     * @return The set. Returns an empty set when there are no such tasks.
-     */
-    Set<Object> getBuiltBy();
+    @Override
+    ConfigurableFileTree convention(Object... paths);
 
     /**
      * Sets the tasks which build the files of this collection.
@@ -66,6 +46,7 @@ public interface ConfigurableFileTree extends FileTree, DirectoryTree, PatternFi
      * @param tasks The tasks. These are evaluated as per {@link org.gradle.api.Task#dependsOn(Object...)}.
      * @return this
      */
+    @Override
     ConfigurableFileTree setBuiltBy(Iterable<?> tasks);
 
     /**
@@ -74,5 +55,6 @@ public interface ConfigurableFileTree extends FileTree, DirectoryTree, PatternFi
      * @param tasks The tasks. These are evaluated as per {@link org.gradle.api.Task#dependsOn(Object...)}.
      * @return this
      */
+    @Override
     ConfigurableFileTree builtBy(Object... tasks);
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
@@ -38,7 +38,7 @@ import org.gradle.internal.reflect.validation.ValidationMessageChecker
 
 import static com.google.common.base.CaseFormat.UPPER_CAMEL
 import static com.google.common.base.CaseFormat.UPPER_UNDERSCORE
-import static org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache.Skip.*
+import static org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache.Skip.INVESTIGATE
 
 class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec implements ValidationMessageChecker {
 
@@ -317,7 +317,7 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
             attributes == ['DIRECTORY_SENSITIVITY_DEFAULT', 'FINGERPRINTING_STRATEGY_CLASSPATH', 'LINE_ENDING_SENSITIVITY_DEFAULT']
         }
 
-        with(aCompileJava.stableSources) {
+        with(aCompileJava.source) {
             hash != null
             normalization == "RELATIVE_PATH"
             attributes == ['DIRECTORY_SENSITIVITY_IGNORE_DIRECTORIES', 'FINGERPRINTING_STRATEGY_RELATIVE_PATH', 'LINE_ENDING_SENSITIVITY_NORMALIZE_LINE_ENDINGS']
@@ -376,7 +376,7 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
                 !containsKey("children")
             }
         }
-        with(bCompileJava.stableSources) {
+        with(bCompileJava.source) {
             hash != null
             roots.size() == 2
             with(roots[0]) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskExecutionIntegrationTest.groovy
@@ -453,14 +453,14 @@ class CachedTaskExecutionIntegrationTest extends AbstractIntegrationSpec impleme
         outputContains("Appending additional implementation to build cache key:")
         outputContains("Appending input value fingerprint for 'options.fork'")
         outputContains("Appending input file fingerprints for 'classpath'")
-        def sourcesDebugLogging = "Appending input file fingerprints for 'stableSources' to build cache key: "
+        def sourcesDebugLogging = "Appending input file fingerprints for 'source' to build cache key: "
         outputContains(sourcesDebugLogging)
         outputContains("Build cache key for task ':compileJava' is ")
         outputContains("Appending output property name to build cache key: destinationDir")
 
-        def stableInputsFingerprintLog = result.getOutputLineThatContains(sourcesDebugLogging)
-        stableInputsFingerprintLog.contains("RELATIVE_PATH{${testDirectory.absolutePath}")
-        stableInputsFingerprintLog.contains("Hello.java='Hello.java' / ")
+        def inputsFingerprintLog = result.getOutputLineThatContains(sourcesDebugLogging)
+        inputsFingerprintLog.contains("RELATIVE_PATH{${testDirectory.absolutePath}")
+        inputsFingerprintLog.contains("Hello.java='Hello.java' / ")
     }
 
     def "only the build cache key is reported at the info level"() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/ValidationActions.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/ValidationActions.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.tasks.properties;
 
 import org.apache.commons.lang.StringUtils;
-import org.gradle.api.file.ConfigurableFileTree;
+import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.GeneratedSubclass;
 import org.gradle.api.problems.ProblemSpec;
 import org.gradle.api.problems.Severity;
@@ -327,8 +327,8 @@ public enum ValidationActions implements ValidationAction {
     }
 
     private static File toDirectory(PropertyValidationContext context, Object value) {
-        if (value instanceof ConfigurableFileTree) {
-            return ((ConfigurableFileTree) value).getDir();
+        if (value instanceof FileTree) {
+            return ((FileTree) value).getSingleFile();
         }
         return toFile(context, value);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/SourceTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/SourceTask.java
@@ -18,18 +18,15 @@ package org.gradle.api.tasks;
 
 import groovy.lang.Closure;
 import org.gradle.api.NonNullApi;
-import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.file.FileTree;
+import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.internal.ConventionTask;
+import org.gradle.api.internal.file.collections.ConfigurableFileTreeInternal;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.util.PatternFilterable;
-import org.gradle.api.tasks.util.PatternSet;
-import org.gradle.internal.Factory;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 import org.gradle.work.DisableCachingByDefault;
 
-import javax.inject.Inject;
 import java.util.Set;
 
 /**
@@ -38,21 +35,10 @@ import java.util.Set;
 @NonNullApi
 @DisableCachingByDefault(because = "Super-class, not to be instantiated directly")
 public abstract class SourceTask extends ConventionTask implements PatternFilterable {
-    private ConfigurableFileCollection sourceFiles = getProject().getObjects().fileCollection();
-    private final PatternFilterable patternSet;
-
-    public SourceTask() {
-        patternSet = getPatternSetFactory().create();
-    }
-
-    @Inject
-    protected Factory<PatternSet> getPatternSetFactory() {
-        throw new UnsupportedOperationException();
-    }
-
     @Internal
     protected PatternFilterable getPatternSet() {
-        return patternSet;
+        // TODO Find a better way to expose the pattern set
+        return ((ConfigurableFileTreeInternal) getSource()).getPatternSet();
     }
 
     /**
@@ -68,30 +54,27 @@ public abstract class SourceTask extends ConventionTask implements PatternFilter
     @InputFiles
     @SkipWhenEmpty
     @IgnoreEmptyDirectories
-    @ToBeReplacedByLazyProperty
     @PathSensitive(PathSensitivity.ABSOLUTE)
-    public FileTree getSource() {
-        return sourceFiles.getAsFileTree().matching(patternSet);
-    }
+    public abstract ConfigurableFileTree getSource();
 
-    /**
-     * Sets the source for this task.
-     *
-     * @param source The source.
-     * @since 4.0
-     */
-    public void setSource(FileTree source) {
-        setSource((Object) source);
-    }
-
-    /**
-     * Sets the source for this task. The given source object is evaluated as per {@link org.gradle.api.Project#files(Object...)}.
-     *
-     * @param source The source.
-     */
-    public void setSource(Object source) {
-        sourceFiles = getProject().getObjects().fileCollection().from(source);
-    }
+//    /**
+//     * Sets the source for this task.
+//     *
+//     * @param source The source.
+//     * @since 4.0
+//     */
+//    public void setSource(FileTree source) {
+//        setSource((Object) source);
+//    }
+//
+//    /**
+//     * Sets the source for this task. The given source object is evaluated as per {@link org.gradle.api.Project#files(Object...)}.
+//     *
+//     * @param source The source.
+//     */
+//    public void setSource(Object source) {
+//        getSource().setFrom(source);
+//    }
 
     /**
      * Adds some source to this task. The given source objects will be evaluated as per {@link org.gradle.api.Project#files(Object...)}.
@@ -100,7 +83,7 @@ public abstract class SourceTask extends ConventionTask implements PatternFilter
      * @return this
      */
     public SourceTask source(Object... sources) {
-        sourceFiles.from(sources);
+        getSource().from(sources);
         return this;
     }
 
@@ -109,7 +92,7 @@ public abstract class SourceTask extends ConventionTask implements PatternFilter
      */
     @Override
     public SourceTask include(String... includes) {
-        patternSet.include(includes);
+        getSource().include(includes);
         return this;
     }
 
@@ -118,7 +101,7 @@ public abstract class SourceTask extends ConventionTask implements PatternFilter
      */
     @Override
     public SourceTask include(Iterable<String> includes) {
-        patternSet.include(includes);
+        getSource().include(includes);
         return this;
     }
 
@@ -127,7 +110,7 @@ public abstract class SourceTask extends ConventionTask implements PatternFilter
      */
     @Override
     public SourceTask include(Spec<FileTreeElement> includeSpec) {
-        patternSet.include(includeSpec);
+        getSource().include(includeSpec);
         return this;
     }
 
@@ -136,7 +119,7 @@ public abstract class SourceTask extends ConventionTask implements PatternFilter
      */
     @Override
     public SourceTask include(Closure includeSpec) {
-        patternSet.include(includeSpec);
+        getSource().include(includeSpec);
         return this;
     }
 
@@ -145,7 +128,7 @@ public abstract class SourceTask extends ConventionTask implements PatternFilter
      */
     @Override
     public SourceTask exclude(String... excludes) {
-        patternSet.exclude(excludes);
+        getSource().exclude(excludes);
         return this;
     }
 
@@ -154,7 +137,7 @@ public abstract class SourceTask extends ConventionTask implements PatternFilter
      */
     @Override
     public SourceTask exclude(Iterable<String> excludes) {
-        patternSet.exclude(excludes);
+        getSource().exclude(excludes);
         return this;
     }
 
@@ -163,7 +146,7 @@ public abstract class SourceTask extends ConventionTask implements PatternFilter
      */
     @Override
     public SourceTask exclude(Spec<FileTreeElement> excludeSpec) {
-        patternSet.exclude(excludeSpec);
+        getSource().exclude(excludeSpec);
         return this;
     }
 
@@ -172,7 +155,7 @@ public abstract class SourceTask extends ConventionTask implements PatternFilter
      */
     @Override
     public SourceTask exclude(Closure excludeSpec) {
-        patternSet.exclude(excludeSpec);
+        getSource().exclude(excludeSpec);
         return this;
     }
 
@@ -183,7 +166,7 @@ public abstract class SourceTask extends ConventionTask implements PatternFilter
     @Internal
     @ToBeReplacedByLazyProperty
     public Set<String> getIncludes() {
-        return patternSet.getIncludes();
+        return getSource().getIncludes();
     }
 
     /**
@@ -191,7 +174,7 @@ public abstract class SourceTask extends ConventionTask implements PatternFilter
      */
     @Override
     public SourceTask setIncludes(Iterable<String> includes) {
-        patternSet.setIncludes(includes);
+        getSource().setIncludes(includes);
         return this;
     }
 
@@ -202,7 +185,7 @@ public abstract class SourceTask extends ConventionTask implements PatternFilter
     @Internal
     @ToBeReplacedByLazyProperty
     public Set<String> getExcludes() {
-        return patternSet.getExcludes();
+        return getSource().getExcludes();
     }
 
     /**
@@ -210,7 +193,7 @@ public abstract class SourceTask extends ConventionTask implements PatternFilter
      */
     @Override
     public SourceTask setExcludes(Iterable<String> excludes) {
-        patternSet.setExcludes(excludes);
+        getSource().setExcludes(excludes);
         return this;
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/tasks/SourceTaskTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/tasks/SourceTaskTest.groovy
@@ -33,7 +33,7 @@ class SourceTaskTest extends AbstractTaskTest {
         file2.createNewFile()
 
         task.source = file1
-        task.source = task.source + project.layout.files(file2)
+        task.source.from(project.layout.files(file2))
 
         expect:
         task.source.asList() == [file1, file2]


### PR DESCRIPTION
This is a breaking change to `SourceTask`, `JavaCompile`, `Javadoc` and a few other tasks' APIs.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
