### PR TITLE
Fix typo on user manual

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/plugins/implementing_gradle_plugins_precompiled.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/plugins/implementing_gradle_plugins_precompiled.adoc
@@ -148,9 +148,9 @@ include::sample[dir="snippets/plugins/greeting/groovy", files="buildSrc/src/main
 ====
 
 `extension.message.convention(...)` sets a convention for the `message` property of the extension.
-This convention specifies that the value of `message` should default to the content of a file named `defaultGreeting.txt` located in the build directory of the project.
+This convention specifies that the value of `message` should default to `"Hello from Gradle"`.
 
-If the `message` property is not explicitly set, its value will be automatically set to the content of `defaultGreeting.txt`.
+If the `message` property is not explicitly set, its value will be automatically set to `"Hello from Gradle"`.
 
 [[sec:mapping_extension_properties_to_task_properties]]
 == Mapping extension properties to task properties


### PR DESCRIPTION
Fix a typo in the "Implementing Pre-compiled Script Plugins" section on user manual. Description didn't match snippet.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

In the [user manual](https://docs.gradle.org/current/userguide/implementing_gradle_plugins_precompiled.html#sec:plugin_conventions) we have a snippet of code that contains:
```kotlin
extension.message.convention("Hello from Gradle")
```

And below that we have the text:
> `extension.message.convention(…​)` sets a convention for the `message` property of the extension. This convention specifies that the value of `message` should default to the content of a file named `defaultGreeting.txt` located in the build directory of the project.
>
> If the `message` property is not explicitly set, its value will be automatically set to the content of `defaultGreeting.txt`.

Since there is no `defaultGreeting.txt` in the snippet, I'm proposing to change the text to:

> `extension.message.convention(...)` sets a convention for the `message` property of the extension.
This convention specifies that the value of `message` should default to `"Hello from Gradle"`.
>
> If the `message` property is not explicitly set, its value will be automatically set to `"Hello from Gradle"`.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
