### PR TITLE
Introduce `org.gradle.internal.operations.trace.tree` internal flag

### DIFF
--- a/platforms/core-runtime/build-operations-trace/build.gradle.kts
+++ b/platforms/core-runtime/build-operations-trace/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     api(libs.guava)
 
     implementation(projects.baseServices)
+    implementation(projects.buildOption)
 
     implementation(libs.groovyJson)
     implementation(libs.jsr305)

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationsFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationsFixture.groovy
@@ -40,6 +40,8 @@ class BuildOperationsFixture extends BuildOperationTreeQueries {
         executer.beforeExecute {
             this.tree = null
             executer.withArgument("-D$BuildOperationTrace.SYSPROP=$path")
+            // disable memory hungry tree generation
+            executer.withArgument("-D$BuildOperationTrace.TREE_SYSPROP=false")
         }
     }
 


### PR DESCRIPTION
To allow opting-out of memory hungry trace tree generation and make it possible to extract build operations trace from large builds.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
