### PR TITLE
Load empty immutable collections from CC as singletons

### DIFF
--- a/platforms/core-configuration/guava-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/guava/ImmutableListCodec.kt
+++ b/platforms/core-configuration/guava-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/guava/ImmutableListCodec.kt
@@ -32,6 +32,9 @@ object ImmutableListCodec : Codec<ImmutableList<Any>> {
 
     override suspend fun ReadContext.decode(): ImmutableList<Any>? {
         val size = readSmallInt()
+        if (size == 0) {
+            return ImmutableList.of()
+        }
         val builder = ImmutableList.builderWithExpectedSize<Any>(size)
         repeat(size) {
             val value = readNonNull<Any>()

--- a/platforms/core-configuration/guava-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/guava/ImmutableMapCodec.kt
+++ b/platforms/core-configuration/guava-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/guava/ImmutableMapCodec.kt
@@ -31,6 +31,9 @@ object ImmutableMapCodec : Codec<ImmutableMap<Any, Any>> {
 
     override suspend fun ReadContext.decode(): ImmutableMap<Any, Any>? {
         val size = readSmallInt()
+        if (size == 0) {
+            return ImmutableMap.of()
+        }
         val builder = ImmutableMap.builderWithExpectedSize<Any, Any>(size)
         repeat(size) {
             val key = read()!!

--- a/platforms/core-configuration/guava-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/guava/ImmutableSetCodec.kt
+++ b/platforms/core-configuration/guava-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/guava/ImmutableSetCodec.kt
@@ -31,6 +31,9 @@ object ImmutableSetCodec : Codec<ImmutableSet<Any>> {
 
     override suspend fun ReadContext.decode(): ImmutableSet<Any>? {
         val size = readSmallInt()
+        if (size == 0) {
+            return ImmutableSet.of()
+        }
         val builder = ImmutableSet.builderWithExpectedSize<Any>(size)
         repeat(size) {
             val value = read()!!


### PR DESCRIPTION
This PR makes a cache hit around `17%` faster on `perf-android-large-2` `assembleDebug`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
