### PR TITLE
Store each `ImmutableAttributes` instance to CC only once per context

### DIFF
--- a/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/AttributeContainerCodecs.kt
+++ b/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/AttributeContainerCodecs.kt
@@ -25,6 +25,8 @@ import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext
+import org.gradle.internal.serialize.graph.decodePreservingSharedIdentity
+import org.gradle.internal.serialize.graph.encodePreservingSharedIdentityOf
 import org.gradle.internal.serialize.graph.readCollection
 import org.gradle.internal.serialize.graph.readNonNull
 import org.gradle.internal.serialize.graph.writeCollection
@@ -52,11 +54,15 @@ class ImmutableAttributesCodec(
 ) : Codec<ImmutableAttributes> {
 
     override suspend fun WriteContext.encode(value: ImmutableAttributes) {
-        writeAttributes(value)
+        encodePreservingSharedIdentityOf(value) {
+            writeAttributes(it)
+        }
     }
 
     override suspend fun ReadContext.decode(): ImmutableAttributes =
-        readAttributesUsing(attributesFactory, managedFactories).asImmutable()
+        decodePreservingSharedIdentity {
+            readAttributesUsing(attributesFactory, managedFactories).asImmutable()
+        }
 }
 
 


### PR DESCRIPTION
As a first step toward storing each instance only once across the whole build tree.

This PR makes a cache hit around `15%` faster on `perf-android-large-2` `assembleDebug`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
