### PR TITLE
Make gbt-td.grdev.net default TD backend

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -268,7 +268,7 @@ fun configureTests() {
 
         extensions.findByType<DevelocityTestConfiguration>()?.testDistribution {
             this as TestDistributionConfigurationInternal
-            server = uri(testDistributionServerUrl.orElse("https://ge.gradle.org"))
+            server = uri(testDistributionServerUrl.orElse("https://gbt-td.grdev.net"))
 
             if (project.testDistributionEnabled && !isUnitTest() && !isPerformanceProject() && !isNativeProject() && !isKotlinDslToolingBuilders()) {
                 enabled = true


### PR DESCRIPTION
So that people don't need extra parameter when running locally.