### PR TITLE
Easily create build scoped detached resolver instances

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
@@ -30,7 +30,6 @@ import org.gradle.api.internal.artifacts.DependencyManagementServices
 import org.gradle.api.internal.artifacts.dependencies.DefaultFileCollectionDependency
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactoryInternal.ClassPathNotation
 import org.gradle.api.internal.file.FileCollectionFactory
-import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.initialization.ScriptClassPathResolver
 import org.gradle.api.internal.initialization.StandaloneDomainObjectContext
 import org.gradle.api.internal.project.ProjectInternal
@@ -437,15 +436,13 @@ abstract class GeneratePrecompiledScriptPluginAccessors @Inject internal constru
         // But since we do some artifact transform caching via BuildService,
         // that would add some complexity when wiring GeneratePrecompiledScriptPluginAccessors task.
         val dependencyManagementServices = gradle.serviceOf<DependencyManagementServices>()
-        val fileCollectionFactory = gradle.serviceOf<FileCollectionFactory>()
         val dependencyResolutionServices = dependencyManagementServices.newDetachedResolver(
-            gradle.serviceOf<FileResolver>(),
-            fileCollectionFactory,
             StandaloneDomainObjectContext.PLUGINS
         )
 
         val dependencies = dependencyResolutionServices.dependencyHandler
         val configurations = dependencyResolutionServices.configurationContainer
+        val fileCollectionFactory = gradle.serviceOf<FileCollectionFactory>()
         val configuration = createBuildLogicClassPathConfiguration(dependencies, configurations, fileCollectionFactory)
 
         val resolver = gradle.serviceOf<ScriptClassPathResolver>()

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/internal/PluginUseServices.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/internal/PluginUseServices.java
@@ -156,7 +156,6 @@ public class PluginUseServices extends AbstractGradleModuleServices {
 
         @Provides
         ClientInjectedClasspathPluginResolver createInjectedClassPathPluginResolver(
-            FileResolver fileResolver,
             DependencyManagementServices dependencyManagementServices,
             ClassLoaderScopeRegistry classLoaderScopeRegistry,
             PluginInspector pluginInspector,
@@ -168,11 +167,10 @@ public class PluginUseServices extends AbstractGradleModuleServices {
             if (injectedPluginClasspath.getClasspath().isEmpty()) {
                 return ClientInjectedClasspathPluginResolver.EMPTY;
             }
-            Factory<DependencyResolutionServices> dependencyResolutionServicesFactory = () -> makeDependencyResolutionServices(
-                fileResolver,
-                fileCollectionFactory,
-                dependencyManagementServices
-            );
+
+            Factory<DependencyResolutionServices> dependencyResolutionServicesFactory =
+                () -> dependencyManagementServices.newDetachedResolver(StandaloneDomainObjectContext.PLUGINS);
+
             return new DefaultInjectedClasspathPluginResolver(
                 classLoaderScopeRegistry.getCoreAndPluginsScope(),
                 scriptClassPathResolver,
@@ -191,23 +189,12 @@ public class PluginUseServices extends AbstractGradleModuleServices {
 
         @Provides
         PluginDependencyResolutionServices createPluginDependencyResolutionServices(
-            FileResolver fileResolver,
-            FileCollectionFactory fileCollectionFactory,
             DependencyManagementServices dependencyManagementServices
         ) {
-            return new PluginDependencyResolutionServices(() -> makeDependencyResolutionServices(
-                fileResolver,
-                fileCollectionFactory,
-                dependencyManagementServices
-            ));
+            return new PluginDependencyResolutionServices(() ->
+                dependencyManagementServices.newDetachedResolver(StandaloneDomainObjectContext.PLUGINS)
+            );
         }
 
-        private static DependencyResolutionServices makeDependencyResolutionServices(
-            final FileResolver fileResolver,
-            final FileCollectionFactory fileCollectionFactory,
-            final DependencyManagementServices dependencyManagementServices
-        ) {
-            return dependencyManagementServices.newDetachedResolver(fileResolver, fileCollectionFactory, StandaloneDomainObjectContext.PLUGINS);
-        }
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -101,8 +101,8 @@ import org.gradle.api.internal.artifacts.transform.TransformRegistrationFactory;
 import org.gradle.api.internal.artifacts.transform.VariantSelectorFactory;
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeRegistry;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.AttributeDescriberRegistry;
+import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.DefaultAttributesSchema;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -176,6 +176,25 @@ public class DefaultDependencyManagementServices implements DependencyManagement
     }
 
     @Override
+    public DependencyResolutionServices newDetachedResolver(DomainObjectContext owner) {
+        return newDetachedResolver(
+            parent.get(FileResolver.class),
+            parent.get(FileCollectionFactory.class),
+            owner
+        );
+    }
+
+    @Override
+    public DependencyResolutionServices newBuildscriptResolver(DomainObjectContext owner) {
+        return newDetachedResolver(
+            parent.get(FileResolver.class),
+            parent.get(FileCollectionFactory.class),
+            owner,
+            new AnonymousModule()
+        );
+    }
+
+    @Override
     public DependencyResolutionServices newDetachedResolver(
         FileResolver resolver,
         FileCollectionFactory fileCollectionFactory,
@@ -196,16 +215,6 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         });
 
         return services;
-    }
-
-    @Override
-    public DependencyResolutionServices newBuildscriptResolver(FileResolver resolver, FileCollectionFactory fileCollectionFactory, DomainObjectContext owner) {
-        return newDetachedResolver(
-            resolver,
-            fileCollectionFactory,
-            owner,
-            new AnonymousModule()
-        );
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -67,7 +67,6 @@ import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.catalog.DefaultDependenciesAccessors;
 import org.gradle.api.internal.catalog.DependenciesAccessorsWorkspaceProvider;
 import org.gradle.api.internal.file.FileCollectionFactory;
-import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.temp.TemporaryFileProvider;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.internal.notations.ClientModuleNotationParserFactory;
@@ -148,16 +147,12 @@ class DependencyManagementBuildScopeServices implements ServiceRegistrationProvi
         Instantiator instantiator,
         UserCodeApplicationContext context,
         DependencyManagementServices dependencyManagementServices,
-        FileResolver fileResolver,
-        FileCollectionFactory fileCollectionFactory,
         ObjectFactory objects,
         CollectionCallbackActionDecorator collectionCallbackActionDecorator
     ) {
         return instantiator.newInstance(DefaultDependencyResolutionManagement.class,
             context,
             dependencyManagementServices,
-            fileResolver,
-            fileCollectionFactory,
             objects,
             collectionCallbackActionDecorator
         );

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/management/DefaultDependencyResolutionManagement.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/management/DefaultDependencyResolutionManagement.java
@@ -36,8 +36,6 @@ import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.artifacts.DependencyManagementServices;
 import org.gradle.api.internal.artifacts.DependencyResolutionServices;
 import org.gradle.api.internal.artifacts.dsl.ComponentMetadataHandlerInternal;
-import org.gradle.api.internal.file.FileCollectionFactory;
-import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.initialization.StandaloneDomainObjectContext;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.logging.Logger;
@@ -74,15 +72,13 @@ public class DefaultDependencyResolutionManagement implements DependencyResoluti
     public DefaultDependencyResolutionManagement(
         UserCodeApplicationContext context,
         DependencyManagementServices dependencyManagementServices,
-        FileResolver fileResolver,
-        FileCollectionFactory fileCollectionFactory,
         ObjectFactory objects,
         CollectionCallbackActionDecorator collectionCallbackActionDecorator
     ) {
         this.context = context;
         this.repositoryMode = objects.property(RepositoriesMode.class).convention(RepositoriesMode.PREFER_PROJECT);
         this.rulesMode = objects.property(RulesMode.class).convention(RulesMode.PREFER_PROJECT);
-        this.dependencyResolutionServices = Lazy.locking().of(() -> dependencyManagementServices.newDetachedResolver(fileResolver, fileCollectionFactory, StandaloneDomainObjectContext.ANONYMOUS));
+        this.dependencyResolutionServices = Lazy.locking().of(() -> dependencyManagementServices.newDetachedResolver(StandaloneDomainObjectContext.ANONYMOUS));
         this.librariesExtensionName = objects.property(String.class).convention("libs");
         this.projectsExtensionName = objects.property(String.class).convention("projects");
         this.versionCatalogs = objects.newInstance(DefaultVersionCatalogBuilderContainer.class, collectionCallbackActionDecorator, objects, context, dependencyResolutionServices);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementServices.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementServices.java
@@ -44,21 +44,22 @@ public interface DependencyManagementServices {
      * @return A new dependency resolution instance. This instance comes with its own configuration container,
      * repositories, attribute schema, and other resolution services.
      */
-    DependencyResolutionServices newDetachedResolver(
-        FileResolver resolver,
-        FileCollectionFactory fileCollectionFactory,
-        DomainObjectContext owner
-    );
+    DependencyResolutionServices newDetachedResolver(DomainObjectContext owner);
 
     /**
-     * Similar to {@link #newDetachedResolver(FileResolver, FileCollectionFactory, DomainObjectContext)},
-     * but allows creating consumable configurations.
+     * Similar to {@link #newDetachedResolver(DomainObjectContext)}, but allows creating consumable configurations.
      * <p>
      * Creating any configuration in a buildscript is deprecated, however, we must allow creating consumable
      * configurations for backwards compatibility. Migrate usages of this method to
-     * {@link #newDetachedResolver(FileResolver, FileCollectionFactory, DomainObjectContext)} in Gradle 9.0.
+     * {@link #newDetachedResolver(DomainObjectContext)} in Gradle 9.0.
      */
-    DependencyResolutionServices newBuildscriptResolver(
+    DependencyResolutionServices newBuildscriptResolver(DomainObjectContext owner);
+
+    /**
+     * Similar to {@link #newDetachedResolver(DomainObjectContext)}, but allows specifying
+     * how file are resolved.
+     */
+    DependencyResolutionServices newDetachedResolver(
         FileResolver resolver,
         FileCollectionFactory fileCollectionFactory,
         DomainObjectContext owner

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandlerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandlerFactory.java
@@ -26,29 +26,19 @@ import org.gradle.groovy.scripts.ScriptSource;
 
 public class DefaultScriptHandlerFactory implements ScriptHandlerFactory {
     private final DependencyManagementServices dependencyManagementServices;
-    private final FileCollectionFactory fileCollectionFactory;
     private final BuildLogicBuilder buildLogicBuilder;
-    private final FileResolver fileResolver;
 
     public DefaultScriptHandlerFactory(
         DependencyManagementServices dependencyManagementServices,
-        FileResolver fileResolver,
-        FileCollectionFactory fileCollectionFactory,
         BuildLogicBuilder buildLogicBuilder
     ) {
         this.dependencyManagementServices = dependencyManagementServices;
-        this.fileResolver = fileResolver;
-        this.fileCollectionFactory = fileCollectionFactory;
         this.buildLogicBuilder = buildLogicBuilder;
     }
 
     @Override
     public ScriptHandlerInternal create(ScriptSource scriptSource, ClassLoaderScope classLoaderScope, DomainObjectContext context) {
-        DependencyResolutionServices services = dependencyManagementServices.newBuildscriptResolver(
-            fileResolver,
-            fileCollectionFactory,
-            context
-        );
+        DependencyResolutionServices services = dependencyManagementServices.newBuildscriptResolver(context);
         return getDefaultScriptHandler(scriptSource, classLoaderScope, services);
     }
 
@@ -56,6 +46,8 @@ public class DefaultScriptHandlerFactory implements ScriptHandlerFactory {
     public ScriptHandlerInternal createProjectScriptHandler(
         ScriptSource scriptSource,
         ClassLoaderScope classLoaderScope,
+        FileResolver fileResolver,
+        FileCollectionFactory fileCollectionFactory,
         ProjectInternal project
     ) {
         DependencyResolutionServices services = dependencyManagementServices.newProjectBuildscriptResolver(

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ScriptHandlerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ScriptHandlerFactory.java
@@ -17,6 +17,8 @@
 package org.gradle.api.internal.initialization;
 
 import org.gradle.api.internal.DomainObjectContext;
+import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.groovy.scripts.ScriptSource;
 
@@ -40,6 +42,8 @@ public interface ScriptHandlerFactory {
     ScriptHandlerInternal createProjectScriptHandler(
         ScriptSource scriptSource,
         ClassLoaderScope classLoaderScope,
+        FileResolver fileResolver,
+        FileCollectionFactory fileCollectionFactory,
         ProjectInternal project
     );
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -311,11 +311,16 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
     ) {
         ScriptHandlerFactory factory = new DefaultScriptHandlerFactory(
             dependencyManagementServices,
-            fileResolver,
-            fileCollectionFactory,
             buildLogicBuilder
         );
-        return factory.createProjectScriptHandler(project.getBuildScriptSource(), project.getClassLoaderScope(), project);
+
+        return factory.createProjectScriptHandler(
+            project.getBuildScriptSource(),
+            project.getClassLoaderScope(),
+            fileResolver,
+            fileCollectionFactory,
+            project
+        );
     }
 
     @Provides


### PR DESCRIPTION
Make it easier to create build scoped, completely detached, dependency management instances to be solely used for resolution. In cases were build scoped resolvers are already used and where we already passed in build scoped file resolvers and file collection factories, we can move to new convenience methods that automatically use the build scoped file resolvers.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
