### PR TITLE
Emit task build operations on --dry-run

### DIFF
--- a/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationTrace.java
+++ b/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationTrace.java
@@ -27,6 +27,7 @@ import groovy.json.JsonOutput;
 import groovy.json.JsonSlurper;
 import org.gradle.StartParameter;
 import org.gradle.api.NonNullApi;
+import org.gradle.api.Task;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.operations.BuildOperationDescriptor;
@@ -498,6 +499,7 @@ public class BuildOperationTrace implements Stoppable {
         return new JsonGenerator.Options()
             .addConverter(new JsonClassConverter())
             .addConverter(new JsonThrowableConverter())
+            .excludeFieldsByType(Task.class)
             .build();
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformStepNode.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformStepNode.java
@@ -38,6 +38,7 @@ import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.operations.CallableBuildOperation;
+import org.gradle.internal.operations.RunnableBuildOperation;
 import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.operations.dependencies.transforms.ExecutePlannedTransformStepBuildOperationType;
 import org.gradle.operations.dependencies.transforms.PlannedTransformStepIdentity;
@@ -77,6 +78,24 @@ public abstract class TransformStepNode extends CreationOrderedNode implements S
         this.artifact = artifact;
         this.upstreamDependencies = upstreamDependencies;
         this.transformStepNodeId = transformStepNodeId;
+    }
+
+    @Override
+    public void dryRun(BuildOperationRunner buildOperationRunner) {
+        buildOperationRunner.run(new RunnableBuildOperation() {
+            @Override
+            public void run(BuildOperationContext context) {
+                context.setResult(RESULT);
+            }
+
+            @Override
+            public BuildOperationDescriptor.Builder description() {
+                String transformStepName = transformStep.getDisplayName();
+                return BuildOperationDescriptor.displayName("Transform " + transformStepName)
+                    .metadata(BuildOperationCategory.TRANSFORM)
+                    .details(new ExecutePlannedTransformStepBuildOperationDetails(TransformStepNode.this, transformStepName, transformStepName));
+            }
+        });
     }
 
     public long getTransformStepNodeId() {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildCommandLineArgsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildCommandLineArgsIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.integtests.composite
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.test.fixtures.maven.MavenModule
+import org.gradle.util.internal.ToBeImplemented
 
 /**
  * Tests for resolving dependency artifacts with substitution within a composite build.
@@ -146,7 +147,7 @@ includeBuild '../buildB'
         assertTaskExecuted(":buildB", ":jar")
     }
 
-    // Included build tasks are incorrect executed with `--dry-run`. See gradle/composite-builds#113
+    @ToBeImplemented("https://github.com/gradle/gradle/issues/2517")
     def "does not execute task actions when dry run specified on composite build"() {
         given:
         dependency 'org.test:buildB:1.0'

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/execution/ExecuteTaskBuildOperationTypeIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/execution/ExecuteTaskBuildOperationTypeIntegrationTest.groovy
@@ -48,6 +48,29 @@ class ExecuteTaskBuildOperationTypeIntegrationTest extends AbstractIntegrationSp
         op.result.upToDateMessages == []
     }
 
+    def "emits operation for task execution with --dry-run"() {
+        when:
+        buildFile """
+            task t {}
+        """
+        succeeds "t", "--dry-run"
+
+        then:
+        def op = operations.first(ExecuteTaskBuildOperationType) {
+            it.details.taskPath == ":t"
+        }
+        op.details.buildPath == ":"
+        op.details.taskClass == DefaultTask.name
+        op.details.taskId != null
+
+        op.result.cachingDisabledReasonCategory == "UNKNOWN"
+        op.result.cachingDisabledReasonMessage == "Cacheability was not determined"
+        op.result.skipMessage == "SKIPPED"
+        op.result.actionable == false
+        op.result.originBuildInvocationId == null
+        op.result.upToDateMessages == null
+    }
+
     def "emits operation result for failed task execution"() {
         when:
         buildFile """

--- a/subprojects/core/src/main/java/org/gradle/execution/DryRunBuildWorkExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DryRunBuildWorkExecutor.java
@@ -18,37 +18,155 @@ package org.gradle.execution;
 import org.gradle.api.Task;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.project.taskfactory.TaskIdentity;
+import org.gradle.api.internal.tasks.TaskExecutionOutcome;
+import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType;
+import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.execution.plan.FinalizedExecutionPlan;
 import org.gradle.internal.build.ExecutionResult;
-import org.gradle.internal.logging.text.StyledTextOutput;
-import org.gradle.internal.logging.text.StyledTextOutputFactory;
+import org.gradle.internal.operations.BuildOperationCategory;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationRunner;
+import org.gradle.internal.operations.RunnableBuildOperation;
+import org.gradle.operations.execution.CachingDisabledReasonCategory;
+import org.gradle.util.Path;
+
+import javax.annotation.Nullable;
+import java.util.List;
 
 /**
  * A {@link BuildWorkExecutor} that disables all selected tasks before they are executed.
  */
 public class DryRunBuildWorkExecutor implements BuildWorkExecutor {
-    private final StyledTextOutputFactory textOutputFactory;
+    private final BuildOperationRunner buildOperationRunner;
     private final BuildWorkExecutor delegate;
 
-    public DryRunBuildWorkExecutor(StyledTextOutputFactory textOutputFactory, BuildWorkExecutor delegate) {
-        this.textOutputFactory = textOutputFactory;
+    public DryRunBuildWorkExecutor(BuildOperationRunner buildOperationRunner, BuildWorkExecutor delegate) {
+        this.buildOperationRunner = buildOperationRunner;
         this.delegate = delegate;
     }
 
     @Override
     public ExecutionResult<Void> execute(GradleInternal gradle, FinalizedExecutionPlan plan) {
         if (gradle.getStartParameter().isDryRun()) {
+            // Using verbose to show the task headers
+            gradle.getStartParameter().setConsoleOutput(ConsoleOutput.Verbose);
             for (Task task : plan.getContents().getTasks()) {
-                textOutputFactory.create(DryRunBuildWorkExecutor.class)
-                    .append(((TaskInternal) task).getIdentityPath().getPath())
-                    .append(" ")
-                    .style(StyledTextOutput.Style.ProgressStatus)
-                    .append("SKIPPED")
-                    .println();
+                TaskInternal taskInternal = (TaskInternal) task;
+                // Emit the build operation, so the tasks show up in Build Scan as well
+                buildOperationRunner.run(new RunnableBuildOperation() {
+                    @Override
+                    public void run(BuildOperationContext context) {
+                        context.setStatus("SKIPPED");
+                        context.setResult(new DryRunTaskResult(taskInternal.hasTaskActions()));
+                    }
+
+                    @Override
+                    public BuildOperationDescriptor.Builder description() {
+                        Path identityPath = taskInternal.getIdentityPath();
+                        return BuildOperationDescriptor.displayName("Task " + identityPath)
+                            .name(identityPath.toString())
+                            .progressDisplayName(identityPath.toString())
+                            .metadata(BuildOperationCategory.TASK)
+                            .details(new DryRunTaskDetails(taskInternal.getTaskIdentity()));
+                    }
+                });
             }
             return ExecutionResult.succeeded();
         } else {
             return delegate.execute(gradle, plan);
+        }
+    }
+
+    public static class DryRunTaskDetails implements ExecuteTaskBuildOperationType.Details {
+        private final TaskIdentity<?> taskIdentity;
+
+        public DryRunTaskDetails(TaskIdentity<?> taskIdentity) {
+            this.taskIdentity = taskIdentity;
+        }
+
+        @Override
+        public String getBuildPath() {
+            return taskIdentity.getBuildPath();
+        }
+
+        @Override
+        public String getTaskPath() {
+            return taskIdentity.getTaskPath();
+        }
+
+        @Override
+        public long getTaskId() {
+            return taskIdentity.getId();
+        }
+
+        @Override
+        public Class<?> getTaskClass() {
+            return taskIdentity.getTaskType();
+        }
+    }
+
+    private static class DryRunTaskResult implements ExecuteTaskBuildOperationType.Result {
+        private final boolean hasTaskActions;
+
+        public DryRunTaskResult(boolean hasTaskActions) {
+            this.hasTaskActions = hasTaskActions;
+        }
+
+        @Nullable
+        @Override
+        public String getSkipMessage() {
+            return TaskExecutionOutcome.SKIPPED.getMessage();
+        }
+
+        @Override
+        public String getSkipReasonMessage() {
+            return "Dry run";
+        }
+
+        @Override
+        public boolean isActionable() {
+            return hasTaskActions;
+        }
+
+        @Nullable
+        @Override
+        public String getOriginBuildInvocationId() {
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public byte[] getOriginBuildCacheKeyBytes() {
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public Long getOriginExecutionTime() {
+            return null;
+        }
+
+        @Override
+        public String getCachingDisabledReasonMessage() {
+            return "Cacheability was not determined";
+        }
+
+        @Override
+        public String getCachingDisabledReasonCategory() {
+            return CachingDisabledReasonCategory.UNKNOWN.name();
+        }
+
+        @Nullable
+        @Override
+        public List<String> getUpToDateMessages() {
+            return null;
+        }
+
+        @Override
+        public boolean isIncremental() {
+            return false;
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/DryRunBuildWorkExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DryRunBuildWorkExecutor.java
@@ -15,25 +15,12 @@
  */
 package org.gradle.execution;
 
-import org.gradle.api.Task;
 import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.TaskInternal;
-import org.gradle.api.internal.project.taskfactory.TaskIdentity;
-import org.gradle.api.internal.tasks.TaskExecutionOutcome;
-import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType;
 import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.execution.plan.FinalizedExecutionPlan;
+import org.gradle.execution.plan.Node;
 import org.gradle.internal.build.ExecutionResult;
-import org.gradle.internal.operations.BuildOperationCategory;
-import org.gradle.internal.operations.BuildOperationContext;
-import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationRunner;
-import org.gradle.internal.operations.RunnableBuildOperation;
-import org.gradle.operations.execution.CachingDisabledReasonCategory;
-import org.gradle.util.Path;
-
-import javax.annotation.Nullable;
-import java.util.List;
 
 /**
  * A {@link BuildWorkExecutor} that disables all selected tasks before they are executed.
@@ -52,121 +39,14 @@ public class DryRunBuildWorkExecutor implements BuildWorkExecutor {
         if (gradle.getStartParameter().isDryRun()) {
             // Using verbose to show the task headers
             gradle.getStartParameter().setConsoleOutput(ConsoleOutput.Verbose);
-            for (Task task : plan.getContents().getTasks()) {
-                TaskInternal taskInternal = (TaskInternal) task;
-                // Emit the build operation, so the tasks show up in Build Scan as well
-                buildOperationRunner.run(new RunnableBuildOperation() {
-                    @Override
-                    public void run(BuildOperationContext context) {
-                        context.setStatus("SKIPPED");
-                        context.setResult(new DryRunTaskResult(taskInternal.hasTaskActions()));
-                    }
-
-                    @Override
-                    public BuildOperationDescriptor.Builder description() {
-                        Path identityPath = taskInternal.getIdentityPath();
-                        return BuildOperationDescriptor.displayName("Task " + identityPath)
-                            .name(identityPath.toString())
-                            .progressDisplayName(identityPath.toString())
-                            .metadata(BuildOperationCategory.TASK)
-                            .details(new DryRunTaskDetails(taskInternal.getTaskIdentity()));
-                    }
-                });
-            }
+            plan.getContents().getScheduledNodes().visitNodes((nodes, __) -> {
+                for (Node node : nodes) {
+                    node.dryRun(buildOperationRunner);
+                }
+            });
             return ExecutionResult.succeeded();
         } else {
             return delegate.execute(gradle, plan);
-        }
-    }
-
-    public static class DryRunTaskDetails implements ExecuteTaskBuildOperationType.Details {
-        private final TaskIdentity<?> taskIdentity;
-
-        public DryRunTaskDetails(TaskIdentity<?> taskIdentity) {
-            this.taskIdentity = taskIdentity;
-        }
-
-        @Override
-        public String getBuildPath() {
-            return taskIdentity.getBuildPath();
-        }
-
-        @Override
-        public String getTaskPath() {
-            return taskIdentity.getTaskPath();
-        }
-
-        @Override
-        public long getTaskId() {
-            return taskIdentity.getId();
-        }
-
-        @Override
-        public Class<?> getTaskClass() {
-            return taskIdentity.getTaskType();
-        }
-    }
-
-    private static class DryRunTaskResult implements ExecuteTaskBuildOperationType.Result {
-        private final boolean hasTaskActions;
-
-        public DryRunTaskResult(boolean hasTaskActions) {
-            this.hasTaskActions = hasTaskActions;
-        }
-
-        @Nullable
-        @Override
-        public String getSkipMessage() {
-            return TaskExecutionOutcome.SKIPPED.getMessage();
-        }
-
-        @Override
-        public String getSkipReasonMessage() {
-            return "Dry run";
-        }
-
-        @Override
-        public boolean isActionable() {
-            return hasTaskActions;
-        }
-
-        @Nullable
-        @Override
-        public String getOriginBuildInvocationId() {
-            return null;
-        }
-
-        @Nullable
-        @Override
-        public byte[] getOriginBuildCacheKeyBytes() {
-            return null;
-        }
-
-        @Nullable
-        @Override
-        public Long getOriginExecutionTime() {
-            return null;
-        }
-
-        @Override
-        public String getCachingDisabledReasonMessage() {
-            return "Cacheability was not determined";
-        }
-
-        @Override
-        public String getCachingDisabledReasonCategory() {
-            return CachingDisabledReasonCategory.UNKNOWN.name();
-        }
-
-        @Nullable
-        @Override
-        public List<String> getUpToDateMessages() {
-            return null;
-        }
-
-        @Override
-        public boolean isIncremental() {
-            return false;
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/DryRunBuildWorkExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DryRunBuildWorkExecutor.java
@@ -26,11 +26,11 @@ import org.gradle.internal.logging.text.StyledTextOutputFactory;
 /**
  * A {@link BuildWorkExecutor} that disables all selected tasks before they are executed.
  */
-public class DryRunBuildExecutionAction implements BuildWorkExecutor {
+public class DryRunBuildWorkExecutor implements BuildWorkExecutor {
     private final StyledTextOutputFactory textOutputFactory;
     private final BuildWorkExecutor delegate;
 
-    public DryRunBuildExecutionAction(StyledTextOutputFactory textOutputFactory, BuildWorkExecutor delegate) {
+    public DryRunBuildWorkExecutor(StyledTextOutputFactory textOutputFactory, BuildWorkExecutor delegate) {
         this.textOutputFactory = textOutputFactory;
         this.delegate = delegate;
     }
@@ -39,7 +39,7 @@ public class DryRunBuildExecutionAction implements BuildWorkExecutor {
     public ExecutionResult<Void> execute(GradleInternal gradle, FinalizedExecutionPlan plan) {
         if (gradle.getStartParameter().isDryRun()) {
             for (Task task : plan.getContents().getTasks()) {
-                textOutputFactory.create(DryRunBuildExecutionAction.class)
+                textOutputFactory.create(DryRunBuildWorkExecutor.class)
                     .append(((TaskInternal) task).getIdentityPath().getPath())
                     .append(" ")
                     .style(StyledTextOutput.Style.ProgressStatus)

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.tasks.VerificationException;
 import org.gradle.execution.plan.edges.DependencyNodesSet;
 import org.gradle.execution.plan.edges.DependentNodesSet;
+import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.resources.ResourceLock;
 
 import javax.annotation.Nullable;
@@ -355,6 +356,9 @@ public abstract class Node {
             state = ExecutionState.NOT_SCHEDULED;
             dependenciesState = DependenciesState.NOT_COMPLETE;
         }
+    }
+
+    public void dryRun(BuildOperationRunner buildOperationRunner) {
     }
 
     public void setExecutionFailure(Throwable failure) {

--- a/subprojects/core/src/main/java/org/gradle/internal/execution/DefaultWorkExecutionTracker.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/execution/DefaultWorkExecutionTracker.java
@@ -18,7 +18,6 @@ package org.gradle.internal.execution;
 
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationDetails;
-import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType;
 import org.gradle.internal.operations.BuildOperationAncestryTracker;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationListener;
@@ -100,7 +99,7 @@ public class DefaultWorkExecutionTracker implements WorkExecutionTracker, Closea
                 runningTransformActions.remove(mandatoryIdOf(buildOperation));
             } else {
                 Object details = buildOperation.getDetails();
-                if (details instanceof ExecuteTaskBuildOperationType.Details) {
+                if (details instanceof ExecuteTaskBuildOperationDetails) {
                     Object removed = runningTasks.remove(mandatoryIdOf(buildOperation));
                     if (removed == null) {
                         throw new IllegalStateException(format("Task build operation %s was finished without being started.", buildOperation));

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -42,7 +42,7 @@ import org.gradle.execution.BuildOperationFiringBuildWorkerExecutor;
 import org.gradle.execution.BuildTaskScheduler;
 import org.gradle.execution.BuildWorkExecutor;
 import org.gradle.execution.DefaultTasksBuildTaskScheduler;
-import org.gradle.execution.DryRunBuildExecutionAction;
+import org.gradle.execution.DryRunBuildWorkExecutor;
 import org.gradle.execution.ProjectConfigurer;
 import org.gradle.execution.SelectedTaskExecutionAction;
 import org.gradle.execution.TaskNameResolvingBuildTaskScheduler;
@@ -93,7 +93,7 @@ public class GradleScopeServices implements ServiceRegistrationProvider {
     @Provides
     BuildWorkExecutor createBuildExecuter(StyledTextOutputFactory textOutputFactory, BuildOperationRunner buildOperationRunner) {
         return new BuildOperationFiringBuildWorkerExecutor(
-            new DryRunBuildExecutionAction(textOutputFactory,
+            new DryRunBuildWorkExecutor(textOutputFactory,
                 new SelectedTaskExecutionAction()),
             buildOperationRunner);
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -64,7 +64,6 @@ import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.instantiation.InstantiatorFactory;
-import org.gradle.internal.logging.text.StyledTextOutputFactory;
 import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.Provides;
@@ -91,9 +90,9 @@ public class GradleScopeServices implements ServiceRegistrationProvider {
     }
 
     @Provides
-    BuildWorkExecutor createBuildExecuter(StyledTextOutputFactory textOutputFactory, BuildOperationRunner buildOperationRunner) {
+    BuildWorkExecutor createBuildExecuter(BuildOperationRunner buildOperationRunner) {
         return new BuildOperationFiringBuildWorkerExecutor(
-            new DryRunBuildWorkExecutor(textOutputFactory,
+            new DryRunBuildWorkExecutor(buildOperationRunner,
                 new SelectedTaskExecutionAction()),
             buildOperationRunner);
     }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/DryRunBuildWorkExecutorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/DryRunBuildWorkExecutorTest.groovy
@@ -27,14 +27,14 @@ import spock.lang.Specification
 
 import static org.gradle.util.internal.WrapUtil.toList
 
-class DryRunBuildExecutionActionTest extends Specification {
+class DryRunBuildWorkExecutorTest extends Specification {
     private static final String EOL = SystemProperties.instance.lineSeparator
     def delegate = Mock(BuildWorkExecutor)
     def executionPlan = Mock(FinalizedExecutionPlan)
     def gradle = Mock(GradleInternal)
     def startParameter = Mock(StartParameterInternal)
     def textOutputFactory = new TestStyledTextOutputFactory()
-    def action = new DryRunBuildExecutionAction(textOutputFactory, delegate)
+    def action = new DryRunBuildWorkExecutor(textOutputFactory, delegate)
 
     def setup() {
         _ * gradle.getStartParameter() >> startParameter
@@ -43,7 +43,7 @@ class DryRunBuildExecutionActionTest extends Specification {
     def "print all selected tasks before proceeding when dry run is enabled"() {
         def task1 = Mock(TaskInternal.class)
         def task2 = Mock(TaskInternal.class)
-        def category = DryRunBuildExecutionAction.class.name
+        def category = DryRunBuildWorkExecutor.class.name
         def contents = Mock(QueryableExecutionPlan)
 
         given:


### PR DESCRIPTION
So the dry run tasks show up in build scans. Trying to fix https://github.com/gradle/gradle/issues/15850.
