### PR TITLE
Extract shared "origin" timestamp for zip entries

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/zip.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/zip.kt
@@ -16,7 +16,7 @@
 
 package org.gradle.kotlin.dsl.support
 
-import org.gradle.api.internal.file.archive.ZipCopyAction.CONSTANT_TIME_FOR_ZIP_ENTRIES
+import org.gradle.api.internal.file.archive.ZipEntryConstants.CONSTANT_TIME_FOR_ZIP_ENTRIES
 
 import org.gradle.internal.file.PathTraversalChecker.safePathName
 import org.gradle.util.internal.TextUtil.normaliseFileSeparators

--- a/platforms/core-runtime/files/src/main/java/org/gradle/api/internal/file/archive/ZipEntryConstants.java
+++ b/platforms/core-runtime/files/src/main/java/org/gradle/api/internal/file/archive/ZipEntryConstants.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file.archive;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
+public class ZipEntryConstants {
+
+    /**
+     * Note that setting the January 1st 1980 (or even worse, "0", as time) won't work due
+     * to Java 8 doing some interesting time processing: It checks if this date is before January 1st 1980
+     * and if it is it starts setting some extra fields in the zip. Java 7 does not do that - but in the
+     * zip not the milliseconds are saved but values for each of the date fields - but no time zone. And
+     * 1980 is the first year which can be saved.
+     * If you use January 1st 1980 then it is treated as a special flag in Java 8.
+     * Moreover, only even seconds can be stored in the zip file. Java 8 uses the upper half of
+     * some other long to store the remaining millis while Java 7 doesn't do that. So make sure
+     * that your seconds are even.
+     * Moreover, parsing happens via `new Date(millis)` in {@code java.util.zip.ZipUtils#javaToDosTime()} so we
+     * must use default timezone and locale.
+     *
+     * The date is 1980 February 1st CET.
+     */
+    public static final long CONSTANT_TIME_FOR_ZIP_ENTRIES = new GregorianCalendar(1980, Calendar.FEBRUARY, 1, 0, 0, 0).getTimeInMillis();
+
+    private ZipEntryConstants() {}
+
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java
@@ -33,26 +33,17 @@ import org.gradle.api.tasks.bundling.Zip;
 import org.gradle.internal.IoActions;
 
 import java.io.File;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
 
 public class ZipCopyAction implements CopyAction {
+
     /**
-     * Note that setting the January 1st 1980 (or even worse, "0", as time) won't work due
-     * to Java 8 doing some interesting time processing: It checks if this date is before January 1st 1980
-     * and if it is it starts setting some extra fields in the zip. Java 7 does not do that - but in the
-     * zip not the milliseconds are saved but values for each of the date fields - but no time zone. And
-     * 1980 is the first year which can be saved.
-     * If you use January 1st 1980 then it is treated as a special flag in Java 8.
-     * Moreover, only even seconds can be stored in the zip file. Java 8 uses the upper half of
-     * some other long to store the remaining millis while Java 7 doesn't do that. So make sure
-     * that your seconds are even.
-     * Moreover, parsing happens via `new Date(millis)` in {@link java.util.zip.ZipUtils}#javaToDosTime() so we
-     * must use default timezone and locale.
+     * This field is internal API and should not be used in build scripts.
+     * It is deprecated in order to allow graceful transition for potential users.
      *
-     * The date is 1980 February 1st CET.
+     * @see ZipEntryConstants#CONSTANT_TIME_FOR_ZIP_ENTRIES
      */
-    public static final long CONSTANT_TIME_FOR_ZIP_ENTRIES = new GregorianCalendar(1980, Calendar.FEBRUARY, 1, 0, 0, 0).getTimeInMillis();
+    @Deprecated
+    public static final long CONSTANT_TIME_FOR_ZIP_ENTRIES = ZipEntryConstants.CONSTANT_TIME_FOR_ZIP_ENTRIES;
 
     private final File zipFile;
     private final ZipCompressor compressor;
@@ -142,6 +133,6 @@ public class ZipCopyAction implements CopyAction {
     }
 
     private long getArchiveTimeFor(FileCopyDetails details) {
-        return preserveFileTimestamps ? details.getLastModified() : CONSTANT_TIME_FOR_ZIP_ENTRIES;
+        return preserveFileTimestamps ? details.getLastModified() : ZipEntryConstants.CONSTANT_TIME_FOR_ZIP_ENTRIES;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/InPlaceClasspathBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/InPlaceClasspathBuilder.java
@@ -22,7 +22,7 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.gradle.api.GradleException;
 import org.gradle.api.NonNullApi;
-import org.gradle.api.internal.file.archive.ZipCopyAction;
+import org.gradle.api.internal.file.archive.ZipEntryConstants;
 import org.gradle.internal.classpath.ClasspathEntryVisitor.Entry.CompressionMethod;
 import org.gradle.util.internal.GFileUtils;
 
@@ -102,7 +102,7 @@ public class InPlaceClasspathBuilder implements ClasspathBuilder {
 
         private ZipArchiveEntry newZipEntryWithFixedTime(String name) {
             ZipArchiveEntry entry = new ZipArchiveEntry(name);
-            entry.setTime(ZipCopyAction.CONSTANT_TIME_FOR_ZIP_ENTRIES);
+            entry.setTime(ZipEntryConstants.CONSTANT_TIME_FOR_ZIP_ENTRIES);
             return entry;
         }
 

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/JarUtils.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/JarUtils.groovy
@@ -80,7 +80,7 @@ class JarUtils {
      */
     static class JarBuilder {
         /**
-         * @see org.gradle.api.internal.file.archive.ZipCopyAction#CONSTANT_TIME_FOR_ZIP_ENTRIES
+         * @see org.gradle.api.internal.file.archive.ZipEntryConstants#CONSTANT_TIME_FOR_ZIP_ENTRIES
          */
         private static final long CONSTANT_TIME_FOR_ZIP_ENTRIES = LocalDateTime.parse("1980-02-01T00:00:00.00").atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/AbstractModule.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/AbstractModule.groovy
@@ -19,7 +19,7 @@ package org.gradle.test.fixtures
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream
 import org.apache.commons.io.FilenameUtils
-import org.gradle.api.internal.file.archive.ZipCopyAction
+import org.gradle.api.internal.file.archive.ZipEntryConstants
 import org.gradle.internal.IoActions
 import org.gradle.internal.hash.HashFunction
 import org.gradle.internal.hash.Hashing
@@ -30,7 +30,7 @@ abstract class AbstractModule implements Module {
     /**
      Last modified date for writeZipped to be able to create zipFiles with identical hashes
      */
-    private static Date lmd = new Date(ZipCopyAction.CONSTANT_TIME_FOR_ZIP_ENTRIES)
+    private static Date lmd = new Date(ZipEntryConstants.CONSTANT_TIME_FOR_ZIP_ENTRIES)
 
     private boolean hasModuleMetadata
     private Closure<?> onEveryFile


### PR DESCRIPTION
Preparation before further `:core` platformization.

The constant was used in many places, outside of the scope of the `ZipCopyAction`.

It is also, unfortunately, used in the gradle/gradle build logic:
https://github.com/gradle/gradle/blob/bb91a0a9646c1c139465f2bc2bf40d643e9895b0/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/classanalysis/AnalyzeAndShade.kt#L20