### PR TITLE
Fix flaky JavaToolchainBuildOperationsIntegrationTest

### DIFF
--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
@@ -56,7 +56,7 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         if (configureToolchain == "without") {
             jdkMetadata = AvailableJavaHomes.getJvmInstallationMetadata(Jvm.current())
         } else {
-            jdkMetadata = AvailableJavaHomes.getJvmInstallationMetadata(AvailableJavaHomes.differentJdk)
+            jdkMetadata = AvailableJavaHomes.getJvmInstallationMetadata(AvailableJavaHomes.differentVersion)
 
             if (configureToolchain == "with java plugin") {
                 configureJavaPluginToolchainVersion(jdkMetadata)


### PR DESCRIPTION
`JavaToolchainBuildOperationsIntegrationTest` is pretty flaky because when there are multiple JDKs with same major version installed on the agent, toolchain will select a random one and fail the assertion. This PR fixes it by only searching for JDKs that are "unique" in its major version.


https://ge.gradle.org/scans/tests?search.timeZoneId=Asia%2FShanghai&tests.container=org.gradle.api.tasks.JavaToolchainBuildOperationsIntegrationTest&tests.test=emits%20toolchain%20usages%20for%20a%20build%20with%20java%20plugin%20configured%20toolchain%20for%20%27:compileJava%27%20task