### PR TITLE
Simplify `Class(Encoder|Decoder)` contract

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/isolation/IsolatedActionSerializer.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/isolation/IsolatedActionSerializer.kt
@@ -25,6 +25,8 @@ import org.gradle.internal.configuration.problems.PropertyProblem
 import org.gradle.internal.extensions.stdlib.invert
 import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.extensions.stdlib.useToRun
+import org.gradle.internal.serialize.Decoder
+import org.gradle.internal.serialize.Encoder
 import org.gradle.internal.serialize.graph.BeanStateReaderLookup
 import org.gradle.internal.serialize.graph.BeanStateWriterLookup
 import org.gradle.internal.serialize.graph.ClassDecoder
@@ -33,8 +35,6 @@ import org.gradle.internal.serialize.graph.CloseableWriteContext
 import org.gradle.internal.serialize.graph.DefaultReadContext
 import org.gradle.internal.serialize.graph.DefaultWriteContext
 import org.gradle.internal.serialize.graph.IsolateOwner
-import org.gradle.internal.serialize.graph.ReadContext
-import org.gradle.internal.serialize.graph.WriteContext
 import org.gradle.internal.serialize.graph.readNonNull
 import org.gradle.internal.serialize.graph.runReadOperation
 import org.gradle.internal.serialize.graph.runWriteOperation
@@ -151,7 +151,7 @@ class EnvironmentEncoder : ClassEncoder {
     private
     val refs = IdentityHashMap<Class<*>, Int>()
 
-    override fun WriteContext.encodeClass(type: Class<*>) {
+    override fun Encoder.encodeClass(type: Class<*>) {
         writeSmallInt(refs.computeIfAbsent(type) { refs.size })
     }
 
@@ -164,7 +164,7 @@ private
 class EnvironmentDecoder(
     val environment: Map<Int, Any>
 ) : ClassDecoder {
-    override fun ReadContext.decodeClass(): Class<*> =
+    override fun Decoder.decodeClass(): Class<*> =
         environment[readSmallInt()]?.uncheckedCast()!!
 }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/ClassPathEncodingExtensions.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/ClassPathEncodingExtensions.kt
@@ -40,7 +40,7 @@ fun Encoder.writeClassPath(classPath: ClassPath) {
 }
 
 
-internal
+private
 fun Encoder.writeDefaultClassPath(classPath: ClassPath) {
     writeCollection(classPath.asFiles) {
         writeFile(it)
@@ -48,7 +48,7 @@ fun Encoder.writeDefaultClassPath(classPath: ClassPath) {
 }
 
 
-internal
+private
 fun Encoder.writeTransformedClassPath(classPath: TransformedClassPath) {
     writeCollection(classPath.asFiles.zip(classPath.asTransformedFiles)) {
         writeFile(it.first)
@@ -68,7 +68,7 @@ fun Decoder.readClassPath(): ClassPath {
 }
 
 
-internal
+private
 fun Decoder.readDefaultClassPath(): ClassPath {
     val size = readSmallInt()
     val builder = DefaultClassPath.builderWithExactSize(size)
@@ -79,7 +79,7 @@ fun Decoder.readDefaultClassPath(): ClassPath {
 }
 
 
-internal
+private
 fun Decoder.readTransformedClassPath(): ClassPath {
     val size = readSmallInt()
     val builder = TransformedClassPath.builderWithExactSize(size)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/DefaultClassDecoder.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/DefaultClassDecoder.kt
@@ -18,17 +18,17 @@ package org.gradle.internal.cc.impl.serialize
 
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.initialization.ClassLoaderScopeOrigin
-import org.gradle.initialization.ClassLoaderScopeRegistry
 import org.gradle.internal.Describables
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.graph.ClassDecoder
-import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.ReadIdentities
-import org.gradle.internal.serialize.graph.ownerService
 
 
 internal
-class DefaultClassDecoder : ClassDecoder {
+class DefaultClassDecoder(
+    private val defaultClassLoaderScope: ClassLoaderScope
+) : ClassDecoder {
 
     private
     val classes = ReadIdentities()
@@ -36,7 +36,7 @@ class DefaultClassDecoder : ClassDecoder {
     private
     val scopes = ReadIdentities()
 
-    override fun ReadContext.decodeClass(): Class<*> {
+    override fun Decoder.decodeClass(): Class<*> {
         val id = readSmallInt()
         val type = classes.getInstance(id)
         if (type != null) {
@@ -49,7 +49,7 @@ class DefaultClassDecoder : ClassDecoder {
         return newType
     }
 
-    override fun ReadContext.decodeClassLoader(): ClassLoader? =
+    override fun Decoder.decodeClassLoader(): ClassLoader? =
         if (readBoolean()) {
             val scope = readScope()
             if (readBoolean()) {
@@ -62,7 +62,7 @@ class DefaultClassDecoder : ClassDecoder {
         }
 
     private
-    fun ReadContext.readScope(): ClassLoaderScope {
+    fun Decoder.readScope(): ClassLoaderScope {
         val id = readSmallInt()
         val scope = scopes.getInstance(id)
         if (scope != null) {
@@ -72,7 +72,7 @@ class DefaultClassDecoder : ClassDecoder {
         val parent = if (readBoolean()) {
             readScope()
         } else {
-            ownerService<ClassLoaderScopeRegistry>().coreAndPluginsScope
+            defaultClassLoaderScope
         }
 
         val name = readString()
@@ -96,7 +96,7 @@ class DefaultClassDecoder : ClassDecoder {
     }
 
     private
-    fun ReadContext.readHashCode() = if (readBoolean()) {
+    fun Decoder.readHashCode() = if (readBoolean()) {
         HashCode.fromBytes(readBinary())
     } else {
         null

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/DefaultClassEncoder.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/DefaultClassEncoder.kt
@@ -19,9 +19,9 @@ package org.gradle.internal.cc.impl.serialize
 import org.gradle.initialization.ClassLoaderScopeOrigin
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.serialize.Encoder
 import org.gradle.internal.serialize.graph.ClassEncoder
 import org.gradle.internal.serialize.graph.ClassLoaderRole
-import org.gradle.internal.serialize.graph.WriteContext
 import org.gradle.internal.serialize.graph.WriteIdentities
 
 
@@ -62,7 +62,7 @@ class DefaultClassEncoder(
     private
     val scopes = WriteIdentities()
 
-    override fun WriteContext.encodeClass(type: Class<*>) {
+    override fun Encoder.encodeClass(type: Class<*>) {
         val id = classes.getId(type)
         if (id != null) {
             writeSmallInt(id)
@@ -74,21 +74,19 @@ class DefaultClassEncoder(
         }
     }
 
-    override fun WriteContext.encodeClassLoader(classLoader: ClassLoader?): Boolean {
+    override fun Encoder.encodeClassLoader(classLoader: ClassLoader?) {
         val scope = classLoader?.let { scopeLookup.scopeFor(it) }
         if (scope == null) {
             writeBoolean(false)
-            return false
         } else {
             writeBoolean(true)
             writeScope(scope.first)
             writeBoolean(scope.second.local)
-            return true
         }
     }
 
     private
-    fun WriteContext.writeScope(scope: ClassLoaderScopeSpec) {
+    fun Encoder.writeScope(scope: ClassLoaderScopeSpec) {
         val id = scopes.getId(scope)
         if (id != null) {
             writeSmallInt(id)
@@ -117,7 +115,7 @@ class DefaultClassEncoder(
     }
 
     private
-    fun WriteContext.writeHashCode(hashCode: HashCode?) {
+    fun Encoder.writeHashCode(hashCode: HashCode?) {
         if (hashCode == null) {
             writeBoolean(false)
         } else {

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialization/codecs/AbstractUserTypeCodecTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialization/codecs/AbstractUserTypeCodecTest.kt
@@ -150,7 +150,7 @@ abstract class AbstractUserTypeCodecTest {
             beanStateReaderLookup = beanStateReaderLookupForTesting(),
             logger = mock(),
             problemsListener = mock(),
-            classDecoder = DefaultClassDecoder()
+            classDecoder = DefaultClassDecoder(mock())
         )
 
     private

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
@@ -62,7 +62,7 @@ interface WriteContext : MutableIsolateContext, Encoder {
     /**
      * @see ClassEncoder.encodeClassLoader
      */
-    fun writeClassLoader(classLoader: ClassLoader?): Boolean = false
+    fun writeClassLoader(classLoader: ClassLoader?) = Unit
 }
 
 

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
@@ -99,7 +99,7 @@ class DefaultWriteContext(
         }
     }
 
-    override fun writeClassLoader(classLoader: ClassLoader?): Boolean = classEncoder.run {
+    override fun writeClassLoader(classLoader: ClassLoader?) = classEncoder.run {
         encodeClassLoader(classLoader)
     }
 
@@ -113,26 +113,24 @@ value class ClassLoaderRole(val local: Boolean)
 
 
 interface ClassEncoder {
-    fun WriteContext.encodeClass(type: Class<*>)
+    fun Encoder.encodeClass(type: Class<*>)
 
     /**
      * Tries to encode the given [classLoader].
-     *
-     * @return `true` when the given [ClassLoader] is not `null` and could be encoded, `false` otherwise.
      */
-    fun WriteContext.encodeClassLoader(classLoader: ClassLoader?): Boolean = false
+    fun Encoder.encodeClassLoader(classLoader: ClassLoader?) = Unit
 }
 
 
 interface ClassDecoder {
-    fun ReadContext.decodeClass(): Class<*>
+    fun Decoder.decodeClass(): Class<*>
 
     /**
      * Decodes a [ClassLoader] previously encoded via [ClassEncoder.encodeClassLoader].
      *
      * @return the previously encoded [ClassLoader] or `null` when [ClassEncoder.encodeClassLoader] returns `false`
      */
-    fun ReadContext.decodeClassLoader(): ClassLoader? = null
+    fun Decoder.decodeClassLoader(): ClassLoader? = null
 }
 
 


### PR DESCRIPTION
So they can be used without a full `(Write|Read)Context`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
