### PR TITLE
Revert "Make gbt-td.grdev.net default TD backend"

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -268,7 +268,7 @@ fun configureTests() {
 
         extensions.findByType<DevelocityTestConfiguration>()?.testDistribution {
             this as TestDistributionConfigurationInternal
-            server = uri(testDistributionServerUrl.orElse("https://gbt-td.grdev.net"))
+            server = uri(testDistributionServerUrl.orElse("https://ge.gradle.org"))
 
             if (project.testDistributionEnabled && !isUnitTest() && !isPerformanceProject() && !isNativeProject() && !isKotlinDslToolingBuilders()) {
                 enabled = true


### PR DESCRIPTION
This reverts commit f9d6858f7a19d68eafae65766b5ceb0da3444df3.
