### PR TITLE
Fix build cache expiry reported to Build Scans

### DIFF
--- a/platforms/core-execution/build-cache/src/integTest/groovy/org/gradle/caching/internal/FinalizeBuildCacheConfigurationBuildOperationIntegrationTest.groovy
+++ b/platforms/core-execution/build-cache/src/integTest/groovy/org/gradle/caching/internal/FinalizeBuildCacheConfigurationBuildOperationIntegrationTest.groovy
@@ -51,7 +51,7 @@ class FinalizeBuildCacheConfigurationBuildOperationIntegrationTest extends Abstr
 
         result.local.className == 'org.gradle.caching.local.DirectoryBuildCache'
         result.local.config.location == cacheDir.absoluteFile.toString()
-        result.local.config.removeUnusedEntries == "after 3 days"
+        result.local.config."remove unused entries" == "after 3 days"
         result.local.type == 'directory'
         result.local.push == true
 
@@ -94,7 +94,7 @@ class FinalizeBuildCacheConfigurationBuildOperationIntegrationTest extends Abstr
 
         result.local.className == 'org.gradle.caching.local.DirectoryBuildCache'
         result.local.config.location == cacheDir.absoluteFile.toString()
-        result.local.config.removeUnusedEntries == "after 5 days"
+        result.local.config."remove unused entries" == "after 5 days"
         result.local.type == 'directory'
         result.local.push == true
 
@@ -108,7 +108,7 @@ class FinalizeBuildCacheConfigurationBuildOperationIntegrationTest extends Abstr
         new File(initDir, "cache-settings.gradle") << """
             beforeSettings { settings ->
                 settings.caches {
-                    buildCache.removeEntriesUnusedSince = java.time.ZonedDateTime.of(2024, 11, 10, 9,35, 44, 0, java.time.ZoneId.of("UTC")).toInstant().toEpochMilli()
+                    buildCache.removeUnusedEntriesOlderThan = java.time.ZonedDateTime.of(2024, 11, 10, 9,35, 44, 0, java.time.ZoneId.of("UTC")).toInstant().toEpochMilli()
                 }
             }
         """
@@ -137,7 +137,7 @@ class FinalizeBuildCacheConfigurationBuildOperationIntegrationTest extends Abstr
 
         result.local.className == 'org.gradle.caching.local.DirectoryBuildCache'
         result.local.config.location == cacheDir.absoluteFile.toString()
-        result.local.config.removeUnusedEntries == "at 2024-11-10 09:35:44 UTC"
+        result.local.config."remove unused entries" == "older than 2024-11-10 09:35:44 UTC"
         result.local.type == 'directory'
         result.local.push == true
 

--- a/platforms/core-execution/build-cache/src/integTest/groovy/org/gradle/caching/internal/FinalizeBuildCacheConfigurationBuildOperationIntegrationTest.groovy
+++ b/platforms/core-execution/build-cache/src/integTest/groovy/org/gradle/caching/internal/FinalizeBuildCacheConfigurationBuildOperationIntegrationTest.groovy
@@ -60,15 +60,14 @@ class FinalizeBuildCacheConfigurationBuildOperationIntegrationTest extends Abstr
 
     def "local build cache configuration includes entry retention interval"() {
         given:
-        def initDir = new File(executer.gradleUserHomeDir, "init.d")
-        initDir.mkdirs()
-        new File(initDir, "cache-settings.gradle") << """
+        initScriptFile << """
             beforeSettings { settings ->
                 settings.caches {
                     buildCache.removeUnusedEntriesAfterDays = 5
                 }
             }
         """
+        executer.usingInitScript(initScriptFile)
 
         def cacheDir = temporaryFolder.file("cache-dir").createDir()
         settingsFile << """
@@ -103,15 +102,14 @@ class FinalizeBuildCacheConfigurationBuildOperationIntegrationTest extends Abstr
 
     def "local build cache configuration includes entry retention timestamp"() {
         given:
-        def initDir = new File(executer.gradleUserHomeDir, "init.d")
-        initDir.mkdirs()
-        new File(initDir, "cache-settings.gradle") << """
+        initScriptFile  << """
             beforeSettings { settings ->
                 settings.caches {
                     buildCache.removeUnusedEntriesOlderThan = java.time.ZonedDateTime.of(2024, 11, 10, 9,35, 44, 0, java.time.ZoneId.of("UTC")).toInstant().toEpochMilli()
                 }
             }
         """
+        executer.usingInitScript(initScriptFile)
 
         def cacheDir = temporaryFolder.file("cache-dir").createDir()
         settingsFile << """

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheResourceConfigurationInternal.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheResourceConfigurationInternal.java
@@ -26,7 +26,7 @@ public interface CacheResourceConfigurationInternal extends CacheResourceConfigu
      * Specifies the timestamp after which an entry must have been used in order to be retained in the cache.
      * Any entries not used more recently than this timestamp will be candidates for eviction.
      */
-    void setRemoveEntriesUnusedSince(long timestamp);
+    void setRemoveUnusedEntriesOlderThan(long timestamp);
 
     /**
      * Configures the retention strategy that determines when an unused entry can be removed from the cache.

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsContinuousIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsContinuousIntegrationTest.groovy
@@ -103,11 +103,11 @@ class CacheConfigurationsContinuousIntegrationTest extends AbstractContinuousInt
                 settings.caches {
                     markingStrategy = MarkingStrategy.NONE
                     cleanup = Cleanup.DISABLED
-                    releasedWrappers.removeEntriesUnusedSince = retentionTimestamp
-                    snapshotWrappers.removeEntriesUnusedSince = retentionTimestamp
-                    downloadedResources.removeEntriesUnusedSince = retentionTimestamp
-                    createdResources.removeEntriesUnusedSince = retentionTimestamp
-                    buildCache.removeEntriesUnusedSince = retentionTimestamp
+                    releasedWrappers.removeUnusedEntriesOlderThan = retentionTimestamp
+                    snapshotWrappers.removeUnusedEntriesOlderThan = retentionTimestamp
+                    downloadedResources.removeUnusedEntriesOlderThan = retentionTimestamp
+                    createdResources.removeUnusedEntriesOlderThan = retentionTimestamp
+                    buildCache.removeUnusedEntriesOlderThan = retentionTimestamp
                 }
             }
         """

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsIntegrationTest.groovy
@@ -120,11 +120,11 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
                 settings.caches {
                     markingStrategy = MarkingStrategy.NONE
                     cleanup = Cleanup.DISABLED
-                    releasedWrappers.removeEntriesUnusedSince = ${releasedDistTimestamp}
-                    snapshotWrappers.removeEntriesUnusedSince = ${snapshotDistTimestamp}
-                    downloadedResources.removeEntriesUnusedSince = ${downloadedResourcesTimestamp}
-                    createdResources.removeEntriesUnusedSince = ${createdResourcesTimestamp}
-                    buildCache.removeEntriesUnusedSince = ${createdResourcesTimestamp}
+                    releasedWrappers.removeUnusedEntriesOlderThan = ${releasedDistTimestamp}
+                    snapshotWrappers.removeUnusedEntriesOlderThan = ${snapshotDistTimestamp}
+                    downloadedResources.removeUnusedEntriesOlderThan = ${downloadedResourcesTimestamp}
+                    createdResources.removeUnusedEntriesOlderThan = ${createdResourcesTimestamp}
+                    buildCache.removeUnusedEntriesOlderThan = ${createdResourcesTimestamp}
                 }
             }
         """
@@ -167,7 +167,7 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
         'cleanup'                                          | 'cleanup'         | 'Cleanup.DISABLED'
         // 'buildCache' is indicative of all `CacheResourceConfigurations` instances
         'buildCache.removeUnusedEntriesAfterDays'          | 'entryRetention'  | "${MODIFIED_AGE_IN_DAYS_FOR_BUILD_CACHE_ENTRIES}"
-        'buildCache.removeEntriesUnusedSince'              | 'entryRetention'  | "${MODIFIED_AGE_IN_DAYS_FOR_BUILD_CACHE_ENTRIES}"
+        'buildCache.removeUnusedEntriesOlderThan'              | 'entryRetention'  | "${MODIFIED_AGE_IN_DAYS_FOR_BUILD_CACHE_ENTRIES}"
     }
 
     static String modifyCacheConfiguration(String property, String value) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskIntegrationTest.groovy
@@ -32,7 +32,7 @@ class CachedTaskIntegrationTest extends AbstractIntegrationSpec implements Direc
         succeeds "cacheable", "--info"
 
         expect:
-        outputContains "Using local directory build cache for the root build (location = ${cacheDir}, removeUnusedEntriesAfter = 7 days)."
+        outputContains "Using local directory build cache for the root build (location = ${cacheDir}, removeUnusedEntries = after 7 days)."
     }
 
     def "cache entry contains expected contents"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskIntegrationTest.groovy
@@ -32,7 +32,7 @@ class CachedTaskIntegrationTest extends AbstractIntegrationSpec implements Direc
         succeeds "cacheable", "--info"
 
         expect:
-        outputContains "Using local directory build cache for the root build (location = ${cacheDir}, removeUnusedEntries = after 7 days)."
+        outputContains "Using local directory build cache for the root build (location = ${cacheDir}, remove unused entries = after 7 days)."
     }
 
     def "cache entry contains expected contents"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/caching/configuration/internal/BuildCacheCompositeConfigurationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/caching/configuration/internal/BuildCacheCompositeConfigurationIntegrationTest.groovy
@@ -111,9 +111,9 @@ class BuildCacheCompositeConfigurationIntegrationTest extends AbstractIntegratio
 
         and:
         if (isNotConfigCache()) {
-            outputContains "Using local directory build cache for build ':i2:i3' (location = ${i3Cache.cacheDir}, removeUnusedEntries = after 7 days)."
+            outputContains "Using local directory build cache for build ':i2:i3' (location = ${i3Cache.cacheDir}, remove unused entries = after 7 days)."
         }
-        outputContains "Using local directory build cache for the root build (location = ${mainCache.cacheDir}, removeUnusedEntries = after 7 days)."
+        outputContains "Using local directory build cache for the root build (location = ${mainCache.cacheDir}, remove unused entries = after 7 days)."
 
         and:
         def expectedCacheDirs = [":": mainCache.cacheDir]

--- a/subprojects/core/src/integTest/groovy/org/gradle/caching/configuration/internal/BuildCacheCompositeConfigurationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/caching/configuration/internal/BuildCacheCompositeConfigurationIntegrationTest.groovy
@@ -111,9 +111,9 @@ class BuildCacheCompositeConfigurationIntegrationTest extends AbstractIntegratio
 
         and:
         if (isNotConfigCache()) {
-            outputContains "Using local directory build cache for build ':i2:i3' (location = ${i3Cache.cacheDir}, removeUnusedEntriesAfter = 7 days)."
+            outputContains "Using local directory build cache for build ':i2:i3' (location = ${i3Cache.cacheDir}, removeUnusedEntries = after 7 days)."
         }
-        outputContains "Using local directory build cache for the root build (location = ${mainCache.cacheDir}, removeUnusedEntriesAfter = 7 days)."
+        outputContains "Using local directory build cache for the root build (location = ${mainCache.cacheDir}, removeUnusedEntries = after 7 days)."
 
         and:
         def expectedCacheDirs = [":": mainCache.cacheDir]

--- a/subprojects/core/src/integTest/groovy/org/gradle/caching/configuration/internal/BuildCacheConfigurationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/caching/configuration/internal/BuildCacheConfigurationIntegrationTest.groovy
@@ -273,7 +273,7 @@ class BuildCacheConfigurationIntegrationTest extends AbstractIntegrationSpec {
         succeeds("customTask", "--info")
 
         then:
-        outputContains("Using local directory build cache for the root build (pull-only, location = ${file("local-cache")}, removeUnusedEntries = after 7 days).")
+        outputContains("Using local directory build cache for the root build (pull-only, location = ${file("local-cache")}, remove unused entries = after 7 days).")
 
         and:
         localBuildCache.empty

--- a/subprojects/core/src/integTest/groovy/org/gradle/caching/configuration/internal/BuildCacheConfigurationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/caching/configuration/internal/BuildCacheConfigurationIntegrationTest.groovy
@@ -273,7 +273,7 @@ class BuildCacheConfigurationIntegrationTest extends AbstractIntegrationSpec {
         succeeds("customTask", "--info")
 
         then:
-        outputContains("Using local directory build cache for the root build (pull-only, location = ${file("local-cache")}, removeUnusedEntriesAfter = 7 days).")
+        outputContains("Using local directory build cache for the root build (pull-only, location = ${file("local-cache")}, removeUnusedEntries = after 7 days).")
 
         and:
         localBuildCache.empty

--- a/subprojects/core/src/main/java/org/gradle/api/internal/cache/DefaultCacheConfigurations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/cache/DefaultCacheConfigurations.java
@@ -241,14 +241,14 @@ abstract public class DefaultCacheConfigurations implements CacheConfigurationsI
         }
 
         @Override
-        public void setRemoveEntriesUnusedSince(long timestamp) {
+        public void setRemoveUnusedEntriesOlderThan(long timestamp) {
             getEntryRetention().set(EntryRetention.absolute(timestamp));
         }
 
         @Override
         public void setRemoveUnusedEntriesAfterDays(int removeUnusedEntriesAfterDays) {
             if (removeUnusedEntriesAfterDays < 1) {
-                throw new IllegalArgumentException(name + " cannot be set to retain entries for " + removeUnusedEntriesAfterDays + " days.  For time frames shorter than one day, use the 'removeEntriesUnusedSince' property.");
+                throw new IllegalArgumentException(name + " cannot be set to retain entries for " + removeUnusedEntriesAfterDays + " days.  For time frames shorter than one day, use the 'removeUnusedEntriesOlderThan' property.");
             }
             long daysInMillis = TimeUnit.DAYS.toMillis(removeUnusedEntriesAfterDays);
             getEntryRetention().set(EntryRetention.relative(daysInMillis));

--- a/subprojects/core/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheEntryRetention.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheEntryRetention.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.caching.local.internal;
+
+import org.gradle.api.internal.cache.CacheConfigurationsInternal;
+import org.gradle.api.internal.cache.CacheResourceConfigurationInternal;
+import org.gradle.caching.local.DirectoryBuildCache;
+import org.gradle.internal.time.TimeFormatting;
+import org.gradle.internal.time.TimestampSuppliers;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+public class DirectoryBuildCacheEntryRetention {
+    private final Supplier<Long> entryRetentionTimestampSupplier;
+    private final String description;
+
+    public DirectoryBuildCacheEntryRetention(DirectoryBuildCache directoryBuildCache, CacheConfigurationsInternal cacheConfigurations) {
+        @SuppressWarnings("deprecation")
+        int deprecatedRemoveUnusedEntriesAfter = directoryBuildCache.getRemoveUnusedEntriesAfterDays();
+
+        // Use the deprecated retention period if configured on `DirectoryBuildCache`, or use the core 'buildCache' cleanup configuration if not.
+        // If the deprecated property remains at the default, we can safely use the central value (which has the same default).
+        if (deprecatedRemoveUnusedEntriesAfter != CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_BUILD_CACHE_ENTRIES) {
+            this.entryRetentionTimestampSupplier = TimestampSuppliers.daysAgo(deprecatedRemoveUnusedEntriesAfter);
+            this.description = "after " + deprecatedRemoveUnusedEntriesAfter + " days";
+            return;
+        }
+
+        CacheResourceConfigurationInternal buildCacheConfig = cacheConfigurations.getBuildCache();
+        this.entryRetentionTimestampSupplier = buildCacheConfig.getEntryRetentionTimestampSupplier();
+        this.description = describeEntryRetention(buildCacheConfig.getEntryRetention().get());
+    }
+
+    public Supplier<Long> getEntryRetentionTimestampSupplier() {
+        return entryRetentionTimestampSupplier;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    private static String describeEntryRetention(CacheResourceConfigurationInternal.EntryRetention entryRetention) {
+        long entryRetentionMillis = entryRetention.getTimeInMillis();
+
+        if (entryRetention.isRelative()) {
+            long expiryDays = TimeUnit.MILLISECONDS.toDays(entryRetentionMillis);
+            if (expiryDays >= 2) {
+                return "after " + expiryDays + " days";
+            } else {
+                return "after " + TimeFormatting.formatDurationTerse(entryRetentionMillis);
+            }
+        }
+
+        // Always render the timestamp in UTC
+        return "at " + Instant.ofEpochMilli(entryRetentionMillis).atZone(ZoneId.of("UTC")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss z"));
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheEntryRetention.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheEntryRetention.java
@@ -70,6 +70,6 @@ public class DirectoryBuildCacheEntryRetention {
         }
 
         // Always render the timestamp in UTC
-        return "at " + Instant.ofEpochMilli(entryRetentionMillis).atZone(ZoneId.of("UTC")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss z"));
+        return "older than " + Instant.ofEpochMilli(entryRetentionMillis).atZone(ZoneId.of("UTC")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss z"));
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactory.java
@@ -86,7 +86,7 @@ public class DirectoryBuildCacheServiceFactory implements BuildCacheServiceFacto
 
         describer.type(DIRECTORY_BUILD_CACHE_TYPE).
             config("location", target.getAbsolutePath()).
-            config("removeUnusedEntries", entryExpiration.getDescription());
+            config("remove unused entries", entryExpiration.getDescription());
 
         PersistentCache persistentCache = unscopedCacheBuilderFactory
             .cache(target)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
@@ -43,7 +43,7 @@ class DefaultCacheConfigurationsTest extends Specification {
         config.entryRetentionTimestampSupplier.get() == clock.currentTime - daysToMillis(3)
 
         when:
-        config.removeEntriesUnusedSince = 1000
+        config.removeUnusedEntriesOlderThan = 1000
 
         then:
         config.entryRetentionTimestampSupplier.get() == 1000

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.api.internal.cache
 import org.gradle.api.cache.Cleanup
 import org.gradle.api.cache.MarkingStrategy
 import org.gradle.cache.internal.LegacyCacheCleanupEnablement
-import org.gradle.internal.time.Clock
+import org.gradle.internal.time.FixedClock
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
@@ -295,13 +295,5 @@ class DefaultCacheConfigurationsTest extends Specification {
 
     def daysToMillis(int days) {
         return TimeUnit.DAYS.toMillis(days)
-    }
-
-    class FixedClock implements Clock {
-        long time = System.currentTimeMillis()
-        @Override
-        long getCurrentTime() {
-            return time
-        }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheEntryRetentionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheEntryRetentionTest.groovy
@@ -70,7 +70,7 @@ class DirectoryBuildCacheEntryRetentionTest extends Specification {
     def "uses cache retention set to absolute timestamp"() {
         when:
         def timestamp = ZonedDateTime.of(2024, 11, 10, 9,35, 44, 0, ZoneId.of("UTC")).toInstant().toEpochMilli()
-        cacheConfigurations.buildCache.removeEntriesUnusedSince = timestamp
+        cacheConfigurations.buildCache.removeUnusedEntriesOlderThan = timestamp
 
         and:
         1 * directoryBuildCache.getRemoveUnusedEntriesAfterDays() >> CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_BUILD_CACHE_ENTRIES
@@ -79,7 +79,7 @@ class DirectoryBuildCacheEntryRetentionTest extends Specification {
         then:
         def expiration = new DirectoryBuildCacheEntryRetention(directoryBuildCache, cacheConfigurations)
         expiration.entryRetentionTimestampSupplier.get() == timestamp
-        expiration.description == "at 2024-11-10 09:35:44 UTC"
+        expiration.description == "older than 2024-11-10 09:35:44 UTC"
     }
 
     def "describes entry expiration less than one day"() {

--- a/subprojects/core/src/test/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheEntryRetentionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheEntryRetentionTest.groovy
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.caching.local.internal
+
+import org.gradle.api.internal.cache.CacheConfigurationsInternal
+import org.gradle.api.internal.cache.CacheResourceConfigurationInternal
+import org.gradle.api.internal.cache.DefaultCacheConfigurations
+import org.gradle.cache.internal.LegacyCacheCleanupEnablement
+import org.gradle.caching.local.DirectoryBuildCache
+import org.gradle.internal.time.FixedClock
+import org.gradle.util.TestUtil
+import spock.lang.Specification
+
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.util.concurrent.TimeUnit
+
+class DirectoryBuildCacheEntryRetentionTest extends Specification {
+    def clock = new FixedClock()
+    def directoryBuildCache = Mock(DirectoryBuildCache)
+    def cacheConfigurations = TestUtil.objectFactory().newInstance(DefaultCacheConfigurations.class, Mock(LegacyCacheCleanupEnablement), clock)
+
+    def "uses directory build cache expiry when set to value other than default"() {
+        when:
+        cacheConfigurations.buildCache.removeUnusedEntriesAfterDays = 1
+
+        and:
+        1 * directoryBuildCache.getRemoveUnusedEntriesAfterDays() >> 10
+        0 * _
+
+        then:
+        def expiration = new DirectoryBuildCacheEntryRetention(directoryBuildCache, cacheConfigurations)
+        equalWithinOneSecond(expiration.entryRetentionTimestampSupplier.get(), System.currentTimeMillis() - TimeUnit.DAYS.toMillis(10))
+        expiration.description == "after 10 days"
+    }
+
+    def "uses cache retention configured for #description"() {
+        when:
+        cacheConfigurations.buildCache.removeUnusedEntriesAfterDays = expiryDays
+
+        and:
+        1 * directoryBuildCache.getRemoveUnusedEntriesAfterDays() >> CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_BUILD_CACHE_ENTRIES
+        0 * _
+
+        then:
+        def expiration = new DirectoryBuildCacheEntryRetention(directoryBuildCache, cacheConfigurations)
+        expiration.entryRetentionTimestampSupplier.get() == clock.currentTime - TimeUnit.DAYS.toMillis(expiryDays)
+        expiration.description == description
+
+        where:
+        expiryDays | description
+        12         | "after 12 days"
+        1          | "after 24h"
+    }
+
+    def "uses cache retention set to absolute timestamp"() {
+        when:
+        def timestamp = ZonedDateTime.of(2024, 11, 10, 9,35, 44, 0, ZoneId.of("UTC")).toInstant().toEpochMilli()
+        cacheConfigurations.buildCache.removeEntriesUnusedSince = timestamp
+
+        and:
+        1 * directoryBuildCache.getRemoveUnusedEntriesAfterDays() >> CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_BUILD_CACHE_ENTRIES
+        0 * _
+
+        then:
+        def expiration = new DirectoryBuildCacheEntryRetention(directoryBuildCache, cacheConfigurations)
+        expiration.entryRetentionTimestampSupplier.get() == timestamp
+        expiration.description == "at 2024-11-10 09:35:44 UTC"
+    }
+
+    def "describes entry expiration less than one day"() {
+        given:
+        def cacheExpirySecs = 2 * 3600 + 25 * 60 + 44
+
+        when:
+        cacheConfigurations.buildCache.entryRetention.set(CacheResourceConfigurationInternal.EntryRetention.relative(cacheExpirySecs * 1000))
+
+        and:
+        1 * directoryBuildCache.getRemoveUnusedEntriesAfterDays() >> CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_BUILD_CACHE_ENTRIES
+        0 * _
+
+        then:
+        def expiration = new DirectoryBuildCacheEntryRetention(directoryBuildCache, cacheConfigurations)
+        expiration.entryRetentionTimestampSupplier.get() == clock.currentTime - cacheExpirySecs * 1000
+        expiration.description == "after 2h 25m 44s"
+    }
+
+    // Since we are relying on System.currentTimeMillis(), we can't assert the exact value
+    private static equalWithinOneSecond(long actualMillis, long expectedMillis) {
+        return Math.abs(expectedMillis - actualMillis) < 1000
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactoryTest.groovy
@@ -16,8 +16,10 @@
 
 package org.gradle.caching.local.internal
 
+import org.gradle.api.cache.Cleanup
 import org.gradle.api.internal.cache.CacheConfigurationsInternal
 import org.gradle.api.internal.file.FileResolver
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.cache.CacheBuilder
 import org.gradle.cache.CacheCleanupStrategy
@@ -42,6 +44,9 @@ class DirectoryBuildCacheServiceFactoryTest extends Specification {
     def globalScopedCache = Mock(GlobalScopedCacheBuilderFactory)
     def resolver = Mock(FileResolver)
     def fileAccessTimeJournal = Mock(FileAccessTimeJournal)
+    def cacheCleanup = Stub(Property) {
+        get() >> Cleanup.DEFAULT
+    }
     def cacheConfigurations = Mock(CacheConfigurationsInternal)
     def cacheCleanupStrategyFactory = Mock(CacheCleanupStrategyFactory)
     def factory = new DirectoryBuildCacheServiceFactory(cacheRepository, globalScopedCache, resolver, fileAccessTimeJournal, cacheConfigurations, cacheCleanupStrategyFactory)
@@ -60,6 +65,7 @@ class DirectoryBuildCacheServiceFactoryTest extends Specification {
         1 * config.getRemoveUnusedEntriesAfterDays() >> 10
         1 * globalScopedCache.baseDirForCrossVersionCache("build-cache-1") >> cacheDir
         1 * cacheRepository.cache(cacheDir) >> cacheBuilder
+        1 * cacheConfigurations.getCleanup() >> cacheCleanup
         1 * cacheConfigurations.getCleanupFrequency() >> Mock(Provider)
         1 * cacheCleanupStrategyFactory.create(_, _) >> Mock(CacheCleanupStrategy)
         0 * _
@@ -76,6 +82,7 @@ class DirectoryBuildCacheServiceFactoryTest extends Specification {
         1 * config.getRemoveUnusedEntriesAfterDays() >> 10
         1 * resolver.resolve(cacheDir) >> cacheDir
         1 * cacheRepository.cache(cacheDir) >> cacheBuilder
+        1 * cacheConfigurations.getCleanup() >> cacheCleanup
         1 * cacheConfigurations.getCleanupFrequency() >> Mock(Provider)
         1 * cacheCleanupStrategyFactory.create(_, _) >> Mock(CacheCleanupStrategy)
         0 * _

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/internal/time/FixedClock.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/internal/time/FixedClock.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.time;
+
+
+public class FixedClock implements Clock {
+    long current;
+
+    public FixedClock() {
+        this(System.currentTimeMillis());
+    }
+
+    public FixedClock(long startTime) {
+        current = startTime;
+    }
+
+    @Override
+    public long getCurrentTime() {
+        return current;
+    }
+}


### PR DESCRIPTION
Fixes #30260 

### Context
When using an init-script to configure Build Cache cleanup and expiry, Gradle currently reports the wrong value for 'removeUnusedEntriesAfter'. This incorrect value is then rendered in Build Scans. 

This PR fixes this issue by reporting on the value that is actually used to determine TTL for build cache entries, whether it is configured via the (deprecated) `DirectoryBuildCache.removeUnusedEntriesAfterDays` or via an [init-script that configures cache cleanup](https://docs.gradle.org/current/userguide/directory_layout.html#dir:gradle_user_home:configure_cache_cleanup).

If the cache-cleanup init-script is used in the usual manner to configure cache expiry as a number of days, we now correct render the expiry as "after X days". ([Example scan](https://scans.gradle.com/s/rm4cegnccryfs/performance/build-cache#local-cache-remove-unused-entries))
If the cache-cleanup init-script uses an internal property to set the cache expiry time to a timestamp we render this as "at DDDD-MM-YY HH:MM:SS UTC". ([Example scan](https://scans.gradle.com/s/kmehjltxqg46a/performance/build-cache#local-cache-remove-unused-entries))

Note that the second scenario is currently used by the `setup-gradle` action in order to minimise the number of entries retained in the local build cache.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
