### PR TITLE
Remove build-logic and build-logic-commons checks from `sanityCheck` to unblock `master`

### DIFF
--- a/build-logic/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
+++ b/build-logic/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
@@ -92,8 +92,9 @@ fun TaskContainer.registerEarlyFeedbackRootLifecycleTasks() {
         description = "Run all basic checks (without tests) - to be run locally and on CI for early feedback"
         group = "verification"
         dependsOn(
-            gradle.includedBuild("build-logic-commons").task(":check"),
-            gradle.includedBuild("build-logic").task(":check"),
+            // TODO: fix https://github.com/gradle/gradle-private/issues/4456
+            // gradle.includedBuild("build-logic-commons").task(":check"),
+            // gradle.includedBuild("build-logic").task(":check"),
             ":docs:checkstyleApi",
             ":internal-build-reports:allIncubationReportsZip",
             ":architecture-test:checkBinaryCompatibility",


### PR DESCRIPTION
Before we solve https://github.com/gradle/gradle-private/issues/4456, let's disable `build-logic:check` and `build-logic-commons:check` to unblock `master`.