### PR TITLE
DRV: switch Performance test's --channel to be passed by environment instead of on the command line

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
@@ -68,7 +68,7 @@ class PerformanceTest(
                 allowEmpty = true,
                 description = "The baselines you want to run performance tests against. Empty means default baseline."
             )
-            param("performance.channel", performanceTestBuildSpec.channel())
+            param("env.PERFORMANCE_CHANNEL", performanceTestBuildSpec.channel())
             param("env.PERFORMANCE_DB_PASSWORD_TCAGENT", "%performance.db.password.tcagent%")
             when (os) {
                 Os.WINDOWS -> param("env.PATH", "%env.PATH%;C:/Program Files/7-zip")
@@ -94,7 +94,7 @@ class PerformanceTest(
                         workingDir = os.perfTestWorkingDir
                         gradleParams = (
                             performanceTestCommandLine(
-                                "${if (repeatIndex == 0) "clean" else ""} ${performanceTestTaskNames.joinToString(" ") { "$it --channel %performance.channel% ${type.extraParameters}" }}",
+                                "${if (repeatIndex == 0) "clean" else ""} ${performanceTestTaskNames.joinToString(" ") { "$it ${type.extraParameters}" }}",
                                 "%performance.baselines%",
                                 extraParameters,
                                 os,

--- a/.teamcity/src/main/kotlin/configurations/PerformanceTestsPass.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTestsPass.kt
@@ -46,7 +46,7 @@ class PerformanceTestsPass(model: CIBuildModel, performanceTestProject: Performa
             )
             param("env.PERFORMANCE_DB_PASSWORD_TCAGENT", "%performance.db.password.tcagent%")
             param("performance.db.username", "tcagent")
-            param("performance.channel", performanceTestSpec.channel())
+            param("env.PERFORMANCE_CHANNEL", performanceTestSpec.channel())
         }
 
         features {
@@ -73,7 +73,7 @@ testing/$performanceProjectName/build/performance-test-results.zip
 
             gradleRunnerStep(
                 model,
-                ":$performanceProjectName:$taskName --channel %performance.channel%",
+                ":$performanceProjectName:$taskName",
                 extraParameters = listOf(
                     "-Porg.gradle.performance.branchName" to "%teamcity.build.branch%",
                     "-Porg.gradle.performance.db.url" to "%performance.db.url%",

--- a/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
@@ -98,8 +98,8 @@ class PerformanceTestBuildTypeTest {
             (
                 listOf(
                     "clean",
-                    ":performance:largeTestProjectPerformanceTest --channel %performance.channel% ",
-                    ":performance:smallTestProjectPerformanceTest --channel %performance.channel% ",
+                    ":performance:largeTestProjectPerformanceTest",
+                    ":performance:smallTestProjectPerformanceTest",
                     "extraParameters"
                 ) + expectedRunnerParams
                 ).joinToString(" "),
@@ -163,8 +163,8 @@ class PerformanceTestBuildTypeTest {
             (
                 listOf(
                     "clean",
-                    ":performance:largeTestProjectPerformanceTest --channel %performance.channel% ",
-                    ":performance:smallTestProjectPerformanceTest --channel %performance.channel% ",
+                    ":performance:largeTestProjectPerformanceTest",
+                    ":performance:smallTestProjectPerformanceTest",
                     "extraParameters"
                 ) + expectedRunnerParams
                 ).joinToString(" "),

--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -40,6 +40,7 @@ import gradlebuild.basics.BuildParams.MAX_PARALLEL_FORKS
 import gradlebuild.basics.BuildParams.MAX_TEST_DISTRIBUTION_LOCAL_EXECUTORS
 import gradlebuild.basics.BuildParams.MAX_TEST_DISTRIBUTION_REMOTE_EXECUTORS
 import gradlebuild.basics.BuildParams.PERFORMANCE_BASELINES
+import gradlebuild.basics.BuildParams.PERFORMANCE_CHANNEL_ENV
 import gradlebuild.basics.BuildParams.PERFORMANCE_DB_PASSWORD
 import gradlebuild.basics.BuildParams.PERFORMANCE_DB_PASSWORD_ENV
 import gradlebuild.basics.BuildParams.PERFORMANCE_DB_URL
@@ -112,6 +113,7 @@ object BuildParams {
     const val PERFORMANCE_TEST_VERBOSE = "performanceTest.verbose"
     const val PERFORMANCE_DB_PASSWORD = "org.gradle.performance.db.password"
     const val PERFORMANCE_DB_PASSWORD_ENV = "PERFORMANCE_DB_PASSWORD_TCAGENT"
+    const val PERFORMANCE_CHANNEL_ENV = "PERFORMANCE_CHANNEL"
     const val PERFORMANCE_DB_URL = "org.gradle.performance.db.url"
     const val PERFORMANCE_DB_USERNAME = "org.gradle.performance.db.username"
     const val PERFORMANCE_DEPENDENCY_BUILD_IDS = "org.gradle.performance.dependencyBuildIds"
@@ -285,6 +287,8 @@ val Project.performanceDependencyBuildIds: Provider<String>
 val Project.performanceBaselines: String?
     get() = stringPropertyOrNull(PERFORMANCE_BASELINES)
 
+val Project.performanceChannel: Provider<String>
+    get() = environmentVariable(PERFORMANCE_CHANNEL_ENV)
 
 val Project.performanceDbPassword: Provider<String>
     get() = environmentVariable(PERFORMANCE_DB_PASSWORD_ENV)

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
@@ -29,6 +29,7 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
@@ -69,7 +70,6 @@ abstract class PerformanceTest extends DistributionTest {
     @OutputDirectory
     File debugArtifactsDirectory = new File(getProject().getBuildDir(), getName())
 
-    /************** properties configured by command line arguments ***************/
     @Nullable
     @Optional
     @Input
@@ -90,11 +90,9 @@ abstract class PerformanceTest extends DistributionTest {
     @Input
     String checks
 
-    @Nullable
     @Internal
-    String channel
+    abstract Property<String> getChannel()
 
-    /************** properties configured by PerformanceTestPlugin ***************/
     @Internal
     String buildId
 
@@ -127,8 +125,8 @@ abstract class PerformanceTest extends DistributionTest {
     PerformanceTest() {
         getJvmArgumentProviders().add(new PerformanceTestJvmArgumentsProvider())
         getOutputs().doNotCacheIf("baselines contain version 'flakiness-detection-commit', 'last' or 'nightly'", { containsSpecialVersions() })
-        getOutputs().doNotCacheIf("flakiness detection", { flakinessDetection })
-        getOutputs().upToDateWhen { !containsSpecialVersions() && !flakinessDetection }
+        getOutputs().doNotCacheIf("flakiness detection", { isFlakinessDetection().get() })
+        getOutputs().upToDateWhen { !containsSpecialVersions() && !isFlakinessDetection().get() }
 
         projectName.set(project.name)
     }
@@ -140,8 +138,8 @@ abstract class PerformanceTest extends DistributionTest {
             .any { NON_CACHEABLE_VERSIONS.contains(it) }
     }
 
-    private boolean isFlakinessDetection() {
-        return channel.startsWith("flakiness-detection")
+    private Provider<Boolean> isFlakinessDetection() {
+        return channel.map {it.startsWith("flakiness-detection") }.orElse(false)
     }
 
     @Override
@@ -169,7 +167,7 @@ abstract class PerformanceTest extends DistributionTest {
                 reportDir,
                 [resultsJson],
                 databaseParameters,
-                channel,
+                channel.get(),
                 [] as Set,
                 branchName,
                 commitId.get(),
@@ -236,11 +234,6 @@ abstract class PerformanceTest extends DistributionTest {
     @Option(option = "checks", description = "Tells which regressions to check. One of [none, speed, all]")
     void setChecks(@Nullable String checks) {
         this.checks = checks
-    }
-
-    @Option(option = "channel", description = "Channel to use when running the performance test. By default, 'commits'.")
-    void setChannel(@Nullable String channel) {
-        this.channel = channel
     }
 
     @Option(option = "profiler", description = "Allows configuring a profiler to use. The same options as for Gradle profilers --profiler command line option are available and 'none' to disable profiling")

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -26,6 +26,7 @@ import gradlebuild.basics.getBuildEnvironmentExtension
 import gradlebuild.basics.includePerformanceTestScenarios
 import gradlebuild.basics.logicalBranch
 import gradlebuild.basics.performanceBaselines
+import gradlebuild.basics.performanceChannel
 import gradlebuild.basics.performanceDependencyBuildIds
 import gradlebuild.basics.performanceGeneratorMaxProjects
 import gradlebuild.basics.performanceTestVerbose
@@ -195,7 +196,7 @@ class PerformanceTestPlugin : Plugin<Project> {
             reportDir = project.layout.buildDirectory.dir(this@configureEach.name)
             databaseParameters = project.propertiesForPerformanceDb
             branchName = buildBranch
-            channel.convention(branchName.map { "commits-$it" })
+            channel = project.performanceChannel.orElse(branchName.map { "commits-$it" })
             val prefix = channel.map { channelName ->
                 val osIndependentPrefix = if (channelName.startsWith("flakiness-detection")) {
                     "flakiness-detection"
@@ -407,7 +408,7 @@ class PerformanceTestExtension(
         registeredPerformanceTests.add(
             createPerformanceTest("${testProject}PerformanceAdHocTest", generatorTask) {
                 description = "Runs ad-hoc performance tests on $testProject - can be used locally"
-                channel = "adhoc"
+                channel.set("adhoc")
                 outputs.doNotCacheIf("Is adhoc performance test") { true }
                 mustRunAfter(currentlyRegisteredTestProjects)
                 testSpecificConfigurator(this)
@@ -421,7 +422,7 @@ class PerformanceTestExtension(
         registeredPerformanceTests.add(
             createPerformanceTest("${testProject}PerformanceTest", generatorTask) {
                 description = "Runs performance tests on $testProject - supposed to be used on CI"
-                channel = "commits$channelSuffix"
+                channel.set("commits$channelSuffix")
 
                 extensions.findByType<DevelocityTestConfiguration>()?.testRetry?.maxRetries = 1
 
@@ -450,6 +451,7 @@ class PerformanceTestExtension(
             reportDir = project.layout.buildDirectory.file("${this.name}/${Config.performanceTestReportsDir}").get().asFile
             resultsJson = project.layout.buildDirectory.file("${this.name}/${Config.performanceTestResultsJson}").get().asFile
             addDatabaseParameters(project.propertiesForPerformanceDb)
+            channel = project.performanceChannel
             testClassesDirs = performanceSourceSet.output.classesDirs
             classpath = performanceSourceSet.runtimeClasspath
 

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/PerformanceTestReport.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/PerformanceTestReport.kt
@@ -74,7 +74,6 @@ abstract class PerformanceTestReport : DefaultTask() {
     @get:Input
     abstract val branchName: Property<String>
 
-    @get:Option(option = "channel", description = "Channel to use when querying performance test results. By default, 'commits'.")
     @get:Input
     abstract val channel: Property<String>
 


### PR DESCRIPTION
On CI --channel has a very high cardinality (often contains the commit-ish) preventing DRV from aggregating builds

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
