### PR TITLE
Make cache entry-retention settings compatible with configuration-cache

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
@@ -26,6 +26,7 @@ import org.gradle.api.internal.FeaturePreviews
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.SettingsInternal.BUILD_SRC
 import org.gradle.api.internal.cache.CacheConfigurationsInternal
+import org.gradle.api.internal.cache.CacheResourceConfigurationInternal.EntryRetention
 import org.gradle.api.provider.Provider
 import org.gradle.api.services.internal.BuildServiceProvider
 import org.gradle.api.services.internal.RegisteredBuildServiceProvider
@@ -726,16 +727,11 @@ class ConfigurationCacheState(
     private
     suspend fun WriteContext.writeCacheConfigurations(gradle: GradleInternal) {
         gradle.settings.caches.let { cacheConfigurations ->
-            write(cacheConfigurations.releasedWrappers.entryRetentionAge)
-            write(cacheConfigurations.releasedWrappers.entryRetentionTimestamp)
-            write(cacheConfigurations.snapshotWrappers.entryRetentionAge)
-            write(cacheConfigurations.snapshotWrappers.entryRetentionTimestamp)
-            write(cacheConfigurations.downloadedResources.entryRetentionAge)
-            write(cacheConfigurations.downloadedResources.entryRetentionTimestamp)
-            write(cacheConfigurations.createdResources.entryRetentionAge)
-            write(cacheConfigurations.createdResources.entryRetentionTimestamp)
-            write(cacheConfigurations.buildCache.entryRetentionAge)
-            write(cacheConfigurations.buildCache.entryRetentionTimestamp)
+            write(cacheConfigurations.releasedWrappers.entryRetention)
+            write(cacheConfigurations.snapshotWrappers.entryRetention)
+            write(cacheConfigurations.downloadedResources.entryRetention)
+            write(cacheConfigurations.createdResources.entryRetention)
+            write(cacheConfigurations.buildCache.entryRetention)
             write(cacheConfigurations.cleanup)
             write(cacheConfigurations.markingStrategy)
         }
@@ -744,16 +740,11 @@ class ConfigurationCacheState(
     private
     suspend fun ReadContext.readCacheConfigurations(gradle: GradleInternal) {
         gradle.settings.caches.let { cacheConfigurations ->
-            cacheConfigurations.releasedWrappers.entryRetentionAge.value(readNonNull<Provider<Long>>())
-            cacheConfigurations.releasedWrappers.entryRetentionTimestamp.value(readNonNull<Provider<Long>>())
-            cacheConfigurations.snapshotWrappers.entryRetentionAge.value(readNonNull<Provider<Long>>())
-            cacheConfigurations.snapshotWrappers.entryRetentionTimestamp.value(readNonNull<Provider<Long>>())
-            cacheConfigurations.downloadedResources.entryRetentionAge.value(readNonNull<Provider<Long>>())
-            cacheConfigurations.downloadedResources.entryRetentionTimestamp.value(readNonNull<Provider<Long>>())
-            cacheConfigurations.createdResources.entryRetentionAge.value(readNonNull<Provider<Long>>())
-            cacheConfigurations.createdResources.entryRetentionTimestamp.value(readNonNull<Provider<Long>>())
-            cacheConfigurations.buildCache.entryRetentionAge.value(readNonNull<Provider<Long>>())
-            cacheConfigurations.buildCache.entryRetentionTimestamp.value(readNonNull<Provider<Long>>())
+            cacheConfigurations.releasedWrappers.entryRetention.value(readNonNull<Provider<EntryRetention>>())
+            cacheConfigurations.snapshotWrappers.entryRetention.value(readNonNull<Provider<EntryRetention>>())
+            cacheConfigurations.downloadedResources.entryRetention.value(readNonNull<Provider<EntryRetention>>())
+            cacheConfigurations.createdResources.entryRetention.value(readNonNull<Provider<EntryRetention>>())
+            cacheConfigurations.buildCache.entryRetention.value(readNonNull<Provider<EntryRetention>>())
             cacheConfigurations.cleanup.value(readNonNull<Provider<Cleanup>>())
             cacheConfigurations.markingStrategy.value(readNonNull<Provider<MarkingStrategy>>())
         }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
@@ -726,11 +726,11 @@ class ConfigurationCacheState(
     private
     suspend fun WriteContext.writeCacheConfigurations(gradle: GradleInternal) {
         gradle.settings.caches.let { cacheConfigurations ->
-            write(cacheConfigurations.releasedWrappers.removeUnusedEntriesOlderThan)
-            write(cacheConfigurations.snapshotWrappers.removeUnusedEntriesOlderThan)
-            write(cacheConfigurations.downloadedResources.removeUnusedEntriesOlderThan)
-            write(cacheConfigurations.createdResources.removeUnusedEntriesOlderThan)
-            write(cacheConfigurations.buildCache.removeUnusedEntriesOlderThan)
+            write(cacheConfigurations.releasedWrappers.entryRetentionMillis)
+            write(cacheConfigurations.snapshotWrappers.entryRetentionMillis)
+            write(cacheConfigurations.downloadedResources.entryRetentionMillis)
+            write(cacheConfigurations.createdResources.entryRetentionMillis)
+            write(cacheConfigurations.buildCache.entryRetentionMillis)
             write(cacheConfigurations.cleanup)
             write(cacheConfigurations.markingStrategy)
         }
@@ -739,11 +739,11 @@ class ConfigurationCacheState(
     private
     suspend fun ReadContext.readCacheConfigurations(gradle: GradleInternal) {
         gradle.settings.caches.let { cacheConfigurations ->
-            cacheConfigurations.releasedWrappers.removeUnusedEntriesOlderThan.value(readNonNull<Provider<Long>>())
-            cacheConfigurations.snapshotWrappers.removeUnusedEntriesOlderThan.value(readNonNull<Provider<Long>>())
-            cacheConfigurations.downloadedResources.removeUnusedEntriesOlderThan.value(readNonNull<Provider<Long>>())
-            cacheConfigurations.createdResources.removeUnusedEntriesOlderThan.value(readNonNull<Provider<Long>>())
-            cacheConfigurations.buildCache.removeUnusedEntriesOlderThan.value(readNonNull<Provider<Long>>())
+            cacheConfigurations.releasedWrappers.entryRetentionMillis.value(readNonNull<Provider<Long>>())
+            cacheConfigurations.snapshotWrappers.entryRetentionMillis.value(readNonNull<Provider<Long>>())
+            cacheConfigurations.downloadedResources.entryRetentionMillis.value(readNonNull<Provider<Long>>())
+            cacheConfigurations.createdResources.entryRetentionMillis.value(readNonNull<Provider<Long>>())
+            cacheConfigurations.buildCache.entryRetentionMillis.value(readNonNull<Provider<Long>>())
             cacheConfigurations.cleanup.value(readNonNull<Provider<Cleanup>>())
             cacheConfigurations.markingStrategy.value(readNonNull<Provider<MarkingStrategy>>())
         }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
@@ -726,11 +726,16 @@ class ConfigurationCacheState(
     private
     suspend fun WriteContext.writeCacheConfigurations(gradle: GradleInternal) {
         gradle.settings.caches.let { cacheConfigurations ->
-            write(cacheConfigurations.releasedWrappers.entryRetentionMillis)
-            write(cacheConfigurations.snapshotWrappers.entryRetentionMillis)
-            write(cacheConfigurations.downloadedResources.entryRetentionMillis)
-            write(cacheConfigurations.createdResources.entryRetentionMillis)
-            write(cacheConfigurations.buildCache.entryRetentionMillis)
+            write(cacheConfigurations.releasedWrappers.entryRetentionAge)
+            write(cacheConfigurations.releasedWrappers.entryRetentionTimestamp)
+            write(cacheConfigurations.snapshotWrappers.entryRetentionAge)
+            write(cacheConfigurations.snapshotWrappers.entryRetentionTimestamp)
+            write(cacheConfigurations.downloadedResources.entryRetentionAge)
+            write(cacheConfigurations.downloadedResources.entryRetentionTimestamp)
+            write(cacheConfigurations.createdResources.entryRetentionAge)
+            write(cacheConfigurations.createdResources.entryRetentionTimestamp)
+            write(cacheConfigurations.buildCache.entryRetentionAge)
+            write(cacheConfigurations.buildCache.entryRetentionTimestamp)
             write(cacheConfigurations.cleanup)
             write(cacheConfigurations.markingStrategy)
         }
@@ -739,11 +744,16 @@ class ConfigurationCacheState(
     private
     suspend fun ReadContext.readCacheConfigurations(gradle: GradleInternal) {
         gradle.settings.caches.let { cacheConfigurations ->
-            cacheConfigurations.releasedWrappers.entryRetentionMillis.value(readNonNull<Provider<Long>>())
-            cacheConfigurations.snapshotWrappers.entryRetentionMillis.value(readNonNull<Provider<Long>>())
-            cacheConfigurations.downloadedResources.entryRetentionMillis.value(readNonNull<Provider<Long>>())
-            cacheConfigurations.createdResources.entryRetentionMillis.value(readNonNull<Provider<Long>>())
-            cacheConfigurations.buildCache.entryRetentionMillis.value(readNonNull<Provider<Long>>())
+            cacheConfigurations.releasedWrappers.entryRetentionAge.value(readNonNull<Provider<Long>>())
+            cacheConfigurations.releasedWrappers.entryRetentionTimestamp.value(readNonNull<Provider<Long>>())
+            cacheConfigurations.snapshotWrappers.entryRetentionAge.value(readNonNull<Provider<Long>>())
+            cacheConfigurations.snapshotWrappers.entryRetentionTimestamp.value(readNonNull<Provider<Long>>())
+            cacheConfigurations.downloadedResources.entryRetentionAge.value(readNonNull<Provider<Long>>())
+            cacheConfigurations.downloadedResources.entryRetentionTimestamp.value(readNonNull<Provider<Long>>())
+            cacheConfigurations.createdResources.entryRetentionAge.value(readNonNull<Provider<Long>>())
+            cacheConfigurations.createdResources.entryRetentionTimestamp.value(readNonNull<Provider<Long>>())
+            cacheConfigurations.buildCache.entryRetentionAge.value(readNonNull<Provider<Long>>())
+            cacheConfigurations.buildCache.entryRetentionTimestamp.value(readNonNull<Provider<Long>>())
             cacheConfigurations.cleanup.value(readNonNull<Provider<Cleanup>>())
             cacheConfigurations.markingStrategy.value(readNonNull<Provider<MarkingStrategy>>())
         }

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/workspace/impl/CacheBasedImmutableWorkspaceProvider.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/workspace/impl/CacheBasedImmutableWorkspaceProvider.java
@@ -94,7 +94,7 @@ public class CacheBasedImmutableWorkspaceProvider implements ImmutableWorkspaceP
         return new LeastRecentlyUsedCacheCleanup(
             new SingleDepthFilesFinder(treeDepthToTrackAndCleanup),
             fileAccessTimeJournal,
-            cacheConfigurations.getCreatedResources().getRemoveUnusedEntriesOlderThanAsSupplier()
+            cacheConfigurations.getCreatedResources().getEntryRetentionTimestampSupplier()
         );
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/WritableArtifactCacheLockingAccessCoordinator.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/WritableArtifactCacheLockingAccessCoordinator.java
@@ -76,7 +76,7 @@ public class WritableArtifactCacheLockingAccessCoordinator implements ArtifactCa
     private Supplier<Long> getMaxAgeTimestamp(CacheConfigurationsInternal cacheConfigurations) {
         Integer maxAgeProperty = Integer.getInteger("org.gradle.internal.cleanup.external.max.age");
         if (maxAgeProperty == null) {
-            return cacheConfigurations.getDownloadedResources().getRemoveUnusedEntriesOlderThanAsSupplier();
+            return cacheConfigurations.getDownloadedResources().getEntryRetentionTimestampSupplier();
         } else {
             return TimestampSuppliers.daysAgo(maxAgeProperty);
         }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheLockingAccessCoordinatorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheLockingAccessCoordinatorTest.groovy
@@ -50,7 +50,7 @@ class DefaultArtifactCacheLockingAccessCoordinatorTest extends Specification {
     def cacheConfigurations = Stub(CacheConfigurationsInternal) {
         getDownloadedResources() >> Stub(CacheResourceConfigurationInternal) {
             //noinspection UnnecessaryQualifiedReference
-            getRemoveUnusedEntriesOlderThanAsSupplier() >> TimestampSuppliers.daysAgo(CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES)
+            getEntryRetentionTimestampSupplier() >> TimestampSuppliers.daysAgo(CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES)
         }
     }
     def cacheCleanupStrategyFactory = new DefaultCacheCleanupStrategyFactory(new TestBuildOperationRunner())

--- a/subprojects/core-api/src/main/java/org/gradle/api/cache/CacheResourceConfiguration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/cache/CacheResourceConfiguration.java
@@ -27,10 +27,9 @@ import org.gradle.internal.HasInternalProtocol;
 @Incubating
 @HasInternalProtocol
 public interface CacheResourceConfiguration {
-
     /**
-     * Sets the timestamp before which unused entries will be removed to be calculated exactly
-     * the given number of days previous to the current time.
+     * Sets the interval (in days) after which unused entries will be considered stale and removed from the cache.
+     * Any entries not used within this interval will be candidates for eviction.
      */
     void setRemoveUnusedEntriesAfterDays(int removeUnusedEntriesAfterDays);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheResourceConfigurationInternal.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheResourceConfigurationInternal.java
@@ -23,29 +23,52 @@ import java.util.function.Supplier;
 
 public interface CacheResourceConfigurationInternal extends CacheResourceConfiguration {
     /**
-     * Configures the age (in milliseconds) when an unused entry can be removed from the cache.
-     * This is a relative-time value and is persisted in the build configuration.
+     * Specifies the timestamp after which an entry must have been used in order to be retained in the cache.
+     * Any entries not used more recently than this timestamp will be candidates for eviction.
+     */
+    void setRemoveEntriesUnusedSince(long timestamp);
+
+    /**
+     * Configures the retention strategy that determines when an unused entry can be removed from the cache.
+     *
+     * The retention can either be:
+     * - Absolute: remove any entries not used since this timestamp
+     * - Relative: remove any entries not used in the past X milliseconds
      *
      * See {@link #setRemoveUnusedEntriesAfterDays(int)}.
      */
-    Property<Long> getEntryRetentionAge();
-
-    /**
-     * Configures the timestamp at which unused entries will be considered stale and removed from the cache.
-     * Any entries not used since this timestamp will be candidates for eviction.
-     * This is an absolute time value and is persisted in the build configuration.
-     *
-     * A value configured for this property will take precedence over `entryRetentionAge`.
-     */
-    Property<Long> getEntryRetentionTimestamp();
+    Property<EntryRetention> getEntryRetention();
 
     /**
      * Provides the timestamp (in millis since epoch) before which an unused entry can be removed from the cache.
-     * If {@link #getEntryRetentionTimestamp()} is configured, then this value is used.
-     * Otherwise, the value of {@link #getEntryRetentionAge()} is subtracted from the current time.
-     *
      * This is an absolute-time value and is recalculated from the configuration on each build execution.
      */
     Supplier<Long> getEntryRetentionTimestampSupplier();
+
+    class EntryRetention {
+        private final boolean isRelative;
+        private final long timeInMillis;
+
+        public EntryRetention(boolean isRelative, long timeInMillis) {
+            this.isRelative = isRelative;
+            this.timeInMillis = timeInMillis;
+        }
+
+        public static EntryRetention relative(long timeInMillis) {
+            return new EntryRetention(true, timeInMillis);
+        }
+
+        public static EntryRetention absolute(long timeInMillis) {
+            return new EntryRetention(false, timeInMillis);
+        }
+
+        public boolean isRelative() {
+            return isRelative;
+        }
+
+        public long getTimeInMillis() {
+            return timeInMillis;
+        }
+    }
 
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheResourceConfigurationInternal.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheResourceConfigurationInternal.java
@@ -28,10 +28,22 @@ public interface CacheResourceConfigurationInternal extends CacheResourceConfigu
      *
      * See {@link #setRemoveUnusedEntriesAfterDays(int)}.
      */
-    Property<Long> getEntryRetentionMillis();
+    Property<Long> getEntryRetentionAge();
+
+    /**
+     * Configures the timestamp at which unused entries will be considered stale and removed from the cache.
+     * Any entries not used since this timestamp will be candidates for eviction.
+     * This is an absolute time value and is persisted in the build configuration.
+     *
+     * A value configured for this property will take precedence over `entryRetentionAge`.
+     */
+    Property<Long> getEntryRetentionTimestamp();
 
     /**
      * Provides the timestamp (in millis since epoch) before which an unused entry can be removed from the cache.
+     * If {@link #getEntryRetentionTimestamp()} is configured, then this value is used.
+     * Otherwise, the value of {@link #getEntryRetentionAge()} is subtracted from the current time.
+     *
      * This is an absolute-time value and is recalculated from the configuration on each build execution.
      */
     Supplier<Long> getEntryRetentionTimestampSupplier();

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheResourceConfigurationInternal.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheResourceConfigurationInternal.java
@@ -22,12 +22,18 @@ import org.gradle.api.provider.Property;
 import java.util.function.Supplier;
 
 public interface CacheResourceConfigurationInternal extends CacheResourceConfiguration {
-    Supplier<Long> getRemoveUnusedEntriesOlderThanAsSupplier();
-
     /**
-     * Configures the timestamp before which an unused entry will be removed from the cache.
+     * Configures the age (in milliseconds) when an unused entry can be removed from the cache.
+     * This is a relative-time value and is persisted in the build configuration.
      *
      * See {@link #setRemoveUnusedEntriesAfterDays(int)}.
      */
-    Property<Long> getRemoveUnusedEntriesOlderThan();
+    Property<Long> getEntryRetentionMillis();
+
+    /**
+     * Provides the timestamp (in millis since epoch) before which an unused entry can be removed from the cache.
+     * This is an absolute-time value and is recalculated from the configuration on each build execution.
+     */
+    Supplier<Long> getEntryRetentionTimestampSupplier();
+
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsContinuousIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsContinuousIntegrationTest.groovy
@@ -99,14 +99,15 @@ class CacheConfigurationsContinuousIntegrationTest extends AbstractContinuousInt
             beforeSettings { settings ->
                 def retentionFile = new File(settings.rootDir, '${retentionFileName}')
                 def retentionFileProperty = settings.services.get(ObjectFactory).fileProperty().fileValue(retentionFile)
-                def retentionTimeStampProvider = settings.providers.fileContents(retentionFileProperty).asText.map { it as long }
+                def retentionTimestamp = settings.providers.fileContents(retentionFileProperty).asText.get() as long
                 settings.caches {
                     markingStrategy = MarkingStrategy.NONE
                     cleanup = Cleanup.DISABLED
-                    releasedWrappers.removeUnusedEntriesOlderThan = retentionTimeStampProvider
-                    snapshotWrappers.removeUnusedEntriesOlderThan = retentionTimeStampProvider
-                    downloadedResources.removeUnusedEntriesOlderThan = retentionTimeStampProvider
-                    createdResources.removeUnusedEntriesOlderThan = retentionTimeStampProvider
+                    releasedWrappers.removeEntriesUnusedSince = retentionTimestamp
+                    snapshotWrappers.removeEntriesUnusedSince = retentionTimestamp
+                    downloadedResources.removeEntriesUnusedSince = retentionTimestamp
+                    createdResources.removeEntriesUnusedSince = retentionTimestamp
+                    buildCache.removeEntriesUnusedSince = retentionTimestamp
                 }
             }
         """
@@ -121,10 +122,11 @@ class CacheConfigurationsContinuousIntegrationTest extends AbstractContinuousInt
                     def caches = services.get(CacheConfigurations)
                     caches.with {
                         assert markingStrategy.get() == MarkingStrategy.NONE
-                        releasedWrappers { assert removeUnusedEntriesOlderThan.get() == retentionTimestamp }
-                        snapshotWrappers { assert removeUnusedEntriesOlderThan.get() == retentionTimestamp }
-                        downloadedResources { assert removeUnusedEntriesOlderThan.get() == retentionTimestamp}
-                        createdResources { assert removeUnusedEntriesOlderThan.get() == retentionTimestamp }
+                        releasedWrappers { assert entryRetention.get().timeInMillis == retentionTimestamp }
+                        snapshotWrappers { assert entryRetention.get().timeInMillis == retentionTimestamp }
+                        downloadedResources { assert entryRetention.get().timeInMillis == retentionTimestamp}
+                        createdResources { assert entryRetention.get().timeInMillis == retentionTimestamp }
+                        buildCache { assert entryRetention.get().timeInMillis == retentionTimestamp }
                     }
                 }
             }
@@ -256,10 +258,13 @@ class CacheConfigurationsContinuousIntegrationTest extends AbstractContinuousInt
         getGcFile(currentCacheDir).assertDoesNotExist()
     }
 
-    static String assertValueIsSameInDays(configuredDaysAgo) {
+    static String assertValueIsSameInDays(int configuredDaysAgo) {
         return """
-            def timestamp = removeUnusedEntriesOlderThan.get()
-            def daysAgo = java.util.concurrent.TimeUnit.MILLISECONDS.toDays(System.currentTimeMillis() - timestamp)
+            def retentionValue = entryRetention.get()
+            assert retentionValue.relative == true
+
+            def timestamp = retentionValue.timeInMillis
+            def daysAgo = java.util.concurrent.TimeUnit.MILLISECONDS.toDays(timestamp)
             assert daysAgo == ${configuredDaysAgo}
         """
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsIntegrationTest.groovy
@@ -17,7 +17,8 @@
 package org.gradle.api.internal.cache
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.internal.time.TimestampSuppliers
+
+import java.util.concurrent.TimeUnit
 
 class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
     private static final int MODIFIED_AGE_IN_DAYS_FOR_RELEASED_DISTS = CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_RELEASED_DISTS + 1
@@ -53,7 +54,7 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
                 snapshotWrappers { ${assertValueIsSameInDays(MODIFIED_AGE_IN_DAY_FOR_SNAPSHOT_DISTS)} }
                 downloadedResources { ${assertValueIsSameInDays(MODIFIED_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES)} }
                 createdResources { ${assertValueIsSameInDays(MODIFIED_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES)} }
-                createdResources { ${assertValueIsSameInDays(MODIFIED_AGE_IN_DAYS_FOR_BUILD_CACHE_ENTRIES)} }
+                buildCache { ${assertValueIsSameInDays(MODIFIED_AGE_IN_DAYS_FOR_BUILD_CACHE_ENTRIES)} }
             }
         """
 
@@ -82,11 +83,11 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
                 doLast {
                     def caches = services.get(CacheConfigurations)
                     caches.with {
-                        println "cacheTimestamps : {" + releasedWrappers.removeUnusedEntriesOlderThanAsSupplier.get() +
-                                                  "," + snapshotWrappers.removeUnusedEntriesOlderThanAsSupplier.get() +
-                                                  "," + downloadedResources.removeUnusedEntriesOlderThanAsSupplier.get() +
-                                                  "," + createdResources.removeUnusedEntriesOlderThanAsSupplier.get() +
-                                                  "," + buildCache.removeUnusedEntriesOlderThanAsSupplier.get() + "}"
+                        println "cacheTimestamps : {" + releasedWrappers.entryRetentionTimestampSupplier.get() +
+                                                  "," + snapshotWrappers.entryRetentionTimestampSupplier.get() +
+                                                  "," + downloadedResources.entryRetentionTimestampSupplier.get() +
+                                                  "," + createdResources.entryRetentionTimestampSupplier.get() +
+                                                  "," + buildCache.entryRetentionTimestampSupplier.get() + "}"
                     }
                 }
             }
@@ -102,14 +103,15 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
         secondRunTimestamps != firstRunTimestamps
     }
 
-    def "can configure caches to a custom timestamp"() {
+    def "can configure caches to a custom entry retention"() {
         def initDir = new File(executer.gradleUserHomeDir, "init.d")
         initDir.mkdirs()
 
-        def releasedDistTimestamp = TimestampSuppliers.daysAgo(MODIFIED_AGE_IN_DAYS_FOR_RELEASED_DISTS).get()
-        def snapshotDistTimestamp = TimestampSuppliers.daysAgo(MODIFIED_AGE_IN_DAY_FOR_SNAPSHOT_DISTS).get()
-        def downloadedResourcesTimestamp = TimestampSuppliers.daysAgo(MODIFIED_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES).get()
-        def createdResourcesTimestamp = TimestampSuppliers.daysAgo(MODIFIED_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES).get()
+        def releasedDistTimestamp = TimeUnit.DAYS.toMillis(MODIFIED_AGE_IN_DAYS_FOR_RELEASED_DISTS)
+        def snapshotDistTimestamp = TimeUnit.DAYS.toMillis(MODIFIED_AGE_IN_DAY_FOR_SNAPSHOT_DISTS)
+        def downloadedResourcesTimestamp = TimeUnit.DAYS.toMillis(MODIFIED_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES)
+        def createdResourcesTimestamp = TimeUnit.DAYS.toMillis(MODIFIED_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES)
+        def buildCacheResourcesTimestamp = TimeUnit.DAYS.toMillis(MODIFIED_AGE_IN_DAYS_FOR_BUILD_CACHE_ENTRIES)
 
         new File(initDir, "cache-settings.gradle") << """
             import java.util.function.Supplier
@@ -118,20 +120,22 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
                 settings.caches {
                     markingStrategy = MarkingStrategy.NONE
                     cleanup = Cleanup.DISABLED
-                    releasedWrappers.removeUnusedEntriesOlderThan = ${releasedDistTimestamp}
-                    snapshotWrappers.removeUnusedEntriesOlderThan = ${snapshotDistTimestamp}
-                    downloadedResources.removeUnusedEntriesOlderThan = ${downloadedResourcesTimestamp}
-                    createdResources.removeUnusedEntriesOlderThan = ${createdResourcesTimestamp}
+                    releasedWrappers.entryRetentionMillis = ${releasedDistTimestamp}L
+                    snapshotWrappers.entryRetentionMillis = ${snapshotDistTimestamp}L
+                    downloadedResources.entryRetentionMillis = ${downloadedResourcesTimestamp}L
+                    createdResources.entryRetentionMillis = ${createdResourcesTimestamp}L
+                    buildCache.entryRetentionMillis = ${buildCacheResourcesTimestamp}L
                 }
             }
         """
         settingsFile << """
             caches {
                 assert markingStrategy.get() == MarkingStrategy.NONE
-                assert releasedWrappers.removeUnusedEntriesOlderThan.get() == ${releasedDistTimestamp}
-                assert snapshotWrappers.removeUnusedEntriesOlderThan.get() == ${snapshotDistTimestamp}
-                assert downloadedResources.removeUnusedEntriesOlderThan.get() == ${downloadedResourcesTimestamp}
-                assert createdResources.removeUnusedEntriesOlderThan.get() == ${createdResourcesTimestamp}
+                assert releasedWrappers.entryRetentionMillis.get() == ${releasedDistTimestamp}
+                assert snapshotWrappers.entryRetentionMillis.get() == ${snapshotDistTimestamp}
+                assert downloadedResources.entryRetentionMillis.get() == ${downloadedResourcesTimestamp}
+                assert createdResources.entryRetentionMillis.get() == ${createdResourcesTimestamp}
+                assert buildCache.entryRetentionMillis.get() == ${buildCacheResourcesTimestamp}
             }
         """
 
@@ -151,14 +155,14 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
         failureCauseContains(String.format(DefaultCacheConfigurations.UNSAFE_MODIFICATION_ERROR, errorProperty))
 
         where:
-        property                                           | errorProperty                  | value
-        'markingStrategy'                                  | 'markingStrategy'              | 'MarkingStrategy.NONE'
-        'cleanup'                                          | 'cleanup'                      | 'Cleanup.DISABLED'
-        'releasedWrappers.removeUnusedEntriesAfterDays'    | 'removeUnusedEntriesOlderThan' | "${MODIFIED_AGE_IN_DAYS_FOR_RELEASED_DISTS}"
-        'snapshotWrappers.removeUnusedEntriesAfterDays'    | 'removeUnusedEntriesOlderThan' | "${MODIFIED_AGE_IN_DAY_FOR_SNAPSHOT_DISTS}"
-        'downloadedResources.removeUnusedEntriesAfterDays' | 'removeUnusedEntriesOlderThan' | "${MODIFIED_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES}"
-        'createdResources.removeUnusedEntriesAfterDays'    | 'removeUnusedEntriesOlderThan' | "${MODIFIED_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES}"
-        'buildCache.removeUnusedEntriesAfterDays'          | 'removeUnusedEntriesOlderThan' | "${MODIFIED_AGE_IN_DAYS_FOR_BUILD_CACHE_ENTRIES}"
+        property                                           | errorProperty          | value
+        'markingStrategy'                                  | 'markingStrategy'      | 'MarkingStrategy.NONE'
+        'cleanup'                                          | 'cleanup'              | 'Cleanup.DISABLED'
+        'releasedWrappers.removeUnusedEntriesAfterDays'    | 'entryRetentionMillis' | "${MODIFIED_AGE_IN_DAYS_FOR_RELEASED_DISTS}"
+        'snapshotWrappers.removeUnusedEntriesAfterDays'    | 'entryRetentionMillis' | "${MODIFIED_AGE_IN_DAY_FOR_SNAPSHOT_DISTS}"
+        'downloadedResources.removeUnusedEntriesAfterDays' | 'entryRetentionMillis' | "${MODIFIED_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES}"
+        'createdResources.removeUnusedEntriesAfterDays'    | 'entryRetentionMillis' | "${MODIFIED_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES}"
+        'buildCache.removeUnusedEntriesAfterDays'          | 'entryRetentionMillis' | "${MODIFIED_AGE_IN_DAYS_FOR_BUILD_CACHE_ENTRIES}"
     }
 
     static String modifyCacheConfiguration(String property, String value) {
@@ -169,8 +173,8 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
 
     static String assertValueIsSameInDays(int configuredDaysAgo) {
         return """
-            def timestamp = removeUnusedEntriesOlderThan.get()
-            def daysAgo = java.util.concurrent.TimeUnit.MILLISECONDS.toDays(System.currentTimeMillis() - timestamp)
+            def timestamp = entryRetentionMillis.get()
+            def daysAgo = java.util.concurrent.TimeUnit.MILLISECONDS.toDays(timestamp)
             assert daysAgo == ${configuredDaysAgo}
         """
     }

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/GradleUserHomeCleanupService.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/GradleUserHomeCleanupService.java
@@ -59,8 +59,8 @@ public class GradleUserHomeCleanupService implements Stoppable {
         boolean wasCleanedUp = execute(
             new VersionSpecificCacheCleanupAction(
                 cacheBaseDir,
-                cacheConfigurations.getReleasedWrappers().getRemoveUnusedEntriesOlderThanAsSupplier(),
-                cacheConfigurations.getSnapshotWrappers().getRemoveUnusedEntriesOlderThanAsSupplier(),
+                cacheConfigurations.getReleasedWrappers().getEntryRetentionTimestampSupplier(),
+                cacheConfigurations.getSnapshotWrappers().getEntryRetentionTimestampSupplier(),
                 deleter,
                 cacheConfigurations.getCleanupFrequency().get()
             )

--- a/subprojects/core/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactory.java
@@ -93,7 +93,7 @@ public class DirectoryBuildCacheServiceFactory implements BuildCacheServiceFacto
         // Use the deprecated retention period if configured on `DirectoryBuildCache`, or use the central 'buildCache' cleanup config if not.
         // If the deprecated property remains at the default, we can safely use the central value (which has the same default).
         Supplier<Long> removeUnusedEntriesOlderThan = removeUnusedEntriesAfterDays == CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_BUILD_CACHE_ENTRIES
-            ? cacheConfigurations.getBuildCache().getRemoveUnusedEntriesOlderThanAsSupplier()
+            ? cacheConfigurations.getBuildCache().getEntryRetentionTimestampSupplier()
             : TimestampSuppliers.daysAgo(removeUnusedEntriesAfterDays);
 
         PersistentCache persistentCache = unscopedCacheBuilderFactory

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
@@ -82,7 +82,7 @@ public class DefaultClasspathTransformerCacheFactory implements ClasspathTransfo
                 new LeastRecentlyUsedCacheCleanup(
                     new SingleDepthFilesFinder(FILE_TREE_DEPTH_TO_TRACK_AND_CLEANUP),
                     fileAccessTimeJournal,
-                    cacheConfigurations.getCreatedResources().getRemoveUnusedEntriesOlderThanAsSupplier()
+                    cacheConfigurations.getCreatedResources().getEntryRetentionTimestampSupplier()
                 )
             ).build();
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
@@ -49,35 +49,35 @@ class DefaultCacheConfigurationsTest extends Specification {
 
         then:
         def e = thrown(IllegalStateException)
-        assertCannotConfigureErrorIsThrown(e, "entryRetentionMillis")
+        assertCannotConfigureErrorIsThrown(e, "entryRetentionAge")
 
         when:
         cacheConfigurations.downloadedResources.setRemoveUnusedEntriesAfterDays(1)
 
         then:
         e = thrown(IllegalStateException)
-        assertCannotConfigureErrorIsThrown(e, "entryRetentionMillis")
+        assertCannotConfigureErrorIsThrown(e, "entryRetentionAge")
 
         when:
         cacheConfigurations.releasedWrappers.setRemoveUnusedEntriesAfterDays(1)
 
         then:
         e = thrown(IllegalStateException)
-        assertCannotConfigureErrorIsThrown(e, "entryRetentionMillis")
+        assertCannotConfigureErrorIsThrown(e, "entryRetentionAge")
 
         when:
         cacheConfigurations.snapshotWrappers.setRemoveUnusedEntriesAfterDays(1)
 
         then:
         e = thrown(IllegalStateException)
-        assertCannotConfigureErrorIsThrown(e, "entryRetentionMillis")
+        assertCannotConfigureErrorIsThrown(e, "entryRetentionAge")
 
         when:
         cacheConfigurations.buildCache.setRemoveUnusedEntriesAfterDays(1)
 
         then:
         e = thrown(IllegalStateException)
-        assertCannotConfigureErrorIsThrown(e, "entryRetentionMillis")
+        assertCannotConfigureErrorIsThrown(e, "entryRetentionAge")
     }
 
     def "cannot modify cache configurations via property unless mutable (method: #method)"() {
@@ -85,11 +85,11 @@ class DefaultCacheConfigurationsTest extends Specification {
         long secondValue = 1
 
         when:
-        cacheConfigurations.createdResources.entryRetentionMillis."${method}"(firstValue)
-        cacheConfigurations.downloadedResources.entryRetentionMillis."${method}"(firstValue)
-        cacheConfigurations.releasedWrappers.entryRetentionMillis."${method}"(firstValue)
-        cacheConfigurations.snapshotWrappers.entryRetentionMillis."${method}"(firstValue)
-        cacheConfigurations.buildCache.entryRetentionMillis."${method}"(firstValue)
+        cacheConfigurations.createdResources.entryRetentionAge."${method}"(firstValue)
+        cacheConfigurations.downloadedResources.entryRetentionAge."${method}"(firstValue)
+        cacheConfigurations.releasedWrappers.entryRetentionAge."${method}"(firstValue)
+        cacheConfigurations.snapshotWrappers.entryRetentionAge."${method}"(firstValue)
+        cacheConfigurations.buildCache.entryRetentionAge."${method}"(firstValue)
         cacheConfigurations.cleanup."${method}"(Cleanup.DISABLED)
         cacheConfigurations.markingStrategy."${method}"(MarkingStrategy.NONE)
 
@@ -100,39 +100,46 @@ class DefaultCacheConfigurationsTest extends Specification {
         cacheConfigurations.finalizeConfigurationValues()
 
         and:
-        cacheConfigurations.createdResources.entryRetentionMillis."${method}"(secondValue)
+        cacheConfigurations.createdResources.entryRetentionAge."${method}"(secondValue)
 
         then:
         def e = thrown(IllegalStateException)
-        assertCannotConfigureErrorIsThrown(e, "entryRetentionMillis")
+        assertCannotConfigureErrorIsThrown(e, "entryRetentionAge")
 
         when:
-        cacheConfigurations.downloadedResources.entryRetentionMillis."${method}"(secondValue)
+        cacheConfigurations.downloadedResources.entryRetentionAge."${method}"(secondValue)
 
         then:
         e = thrown(IllegalStateException)
-        assertCannotConfigureErrorIsThrown(e, "entryRetentionMillis")
+        assertCannotConfigureErrorIsThrown(e, "entryRetentionAge")
 
         when:
-        cacheConfigurations.releasedWrappers.entryRetentionMillis."${method}"(secondValue)
+        cacheConfigurations.releasedWrappers.entryRetentionAge."${method}"(secondValue)
 
         then:
         e = thrown(IllegalStateException)
-        assertCannotConfigureErrorIsThrown(e, "entryRetentionMillis")
+        assertCannotConfigureErrorIsThrown(e, "entryRetentionAge")
 
         when:
-        cacheConfigurations.snapshotWrappers.entryRetentionMillis."${method}"(secondValue)
+        cacheConfigurations.snapshotWrappers.entryRetentionAge."${method}"(secondValue)
 
         then:
         e = thrown(IllegalStateException)
-        assertCannotConfigureErrorIsThrown(e, "entryRetentionMillis")
+        assertCannotConfigureErrorIsThrown(e, "entryRetentionAge")
 
         when:
-        cacheConfigurations.buildCache.entryRetentionMillis."${method}"(secondValue)
+        cacheConfigurations.buildCache.entryRetentionAge."${method}"(secondValue)
 
         then:
         e = thrown(IllegalStateException)
-        assertCannotConfigureErrorIsThrown(e, "entryRetentionMillis")
+        assertCannotConfigureErrorIsThrown(e, "entryRetentionAge")
+
+        when:
+        cacheConfigurations.buildCache.entryRetentionTimestamp."${method}"(secondValue)
+
+        then:
+        e = thrown(IllegalStateException)
+        assertCannotConfigureErrorIsThrown(e, "entryRetentionTimestamp")
 
         when:
         cacheConfigurations.cleanup."${method}"(Cleanup.DEFAULT)
@@ -162,11 +169,11 @@ class DefaultCacheConfigurationsTest extends Specification {
 
         and:
         def twoDays = TimeUnit.DAYS.toMillis(2)
-        cacheConfigurations.createdResources.entryRetentionMillis.set(twoDays)
-        cacheConfigurations.downloadedResources.entryRetentionMillis.set(twoDays)
-        cacheConfigurations.releasedWrappers.entryRetentionMillis.set(twoDays)
-        cacheConfigurations.snapshotWrappers.entryRetentionMillis.set(twoDays)
-        cacheConfigurations.buildCache.entryRetentionMillis.set(twoDays)
+        cacheConfigurations.createdResources.entryRetentionAge.set(twoDays)
+        cacheConfigurations.downloadedResources.entryRetentionAge.set(twoDays)
+        cacheConfigurations.releasedWrappers.entryRetentionAge.set(twoDays)
+        cacheConfigurations.snapshotWrappers.entryRetentionAge.set(twoDays)
+        cacheConfigurations.buildCache.entryRetentionAge.set(twoDays)
 
         then:
         def twoDaysAgo = clock.currentTime - twoDays
@@ -217,27 +224,41 @@ class DefaultCacheConfigurationsTest extends Specification {
 
         and:
         def twoDays = TimeUnit.DAYS.toMillis(2)
-        cacheConfigurations.createdResources.entryRetentionMillis.set(twoDays)
-        cacheConfigurations.downloadedResources.entryRetentionMillis.set(twoDays)
-        cacheConfigurations.releasedWrappers.entryRetentionMillis.set(twoDays)
-        cacheConfigurations.snapshotWrappers.entryRetentionMillis.set(twoDays)
+        def threeDaysAgo = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(3)
+        cacheConfigurations.createdResources.entryRetentionAge.set(twoDays)
+        cacheConfigurations.downloadedResources.entryRetentionAge.set(twoDays)
+        cacheConfigurations.releasedWrappers.entryRetentionAge.set(twoDays)
+        cacheConfigurations.snapshotWrappers.entryRetentionAge.set(twoDays)
+        cacheConfigurations.buildCache.entryRetentionAge.set(twoDays)
+        cacheConfigurations.createdResources.entryRetentionTimestamp.set(threeDaysAgo)
+        cacheConfigurations.downloadedResources.entryRetentionTimestamp.set(threeDaysAgo)
+        cacheConfigurations.releasedWrappers.entryRetentionTimestamp.set(threeDaysAgo)
+        cacheConfigurations.snapshotWrappers.entryRetentionTimestamp.set(threeDaysAgo)
+        cacheConfigurations.buildCache.entryRetentionTimestamp.set(threeDaysAgo)
         cacheConfigurations.markingStrategy.set(MarkingStrategy.NONE)
 
         then:
-        mutableCacheConfigurations.createdResources.entryRetentionMillis.get() == twoDays
-        mutableCacheConfigurations.downloadedResources.entryRetentionMillis.get() == twoDays
-        mutableCacheConfigurations.releasedWrappers.entryRetentionMillis.get() == twoDays
-        mutableCacheConfigurations.snapshotWrappers.entryRetentionMillis.get() == twoDays
+        mutableCacheConfigurations.createdResources.entryRetentionAge.get() == twoDays
+        mutableCacheConfigurations.downloadedResources.entryRetentionAge.get() == twoDays
+        mutableCacheConfigurations.releasedWrappers.entryRetentionAge.get() == twoDays
+        mutableCacheConfigurations.snapshotWrappers.entryRetentionAge.get() == twoDays
+        mutableCacheConfigurations.buildCache.entryRetentionAge.get() == twoDays
+        mutableCacheConfigurations.createdResources.entryRetentionTimestamp.get() == threeDaysAgo
+        mutableCacheConfigurations.downloadedResources.entryRetentionTimestamp.get() == threeDaysAgo
+        mutableCacheConfigurations.releasedWrappers.entryRetentionTimestamp.get() == threeDaysAgo
+        mutableCacheConfigurations.snapshotWrappers.entryRetentionTimestamp.get() == threeDaysAgo
+        mutableCacheConfigurations.buildCache.entryRetentionTimestamp.get() == threeDaysAgo
         mutableCacheConfigurations.markingStrategy.get() == MarkingStrategy.NONE
     }
 
     def "will not require cleanup unless configured"() {
         when:
         def twoDays = TimeUnit.DAYS.toMillis(2)
-        cacheConfigurations.createdResources.entryRetentionMillis.set(twoDays)
-        cacheConfigurations.downloadedResources.entryRetentionMillis.set(twoDays)
-        cacheConfigurations.releasedWrappers.entryRetentionMillis.set(twoDays)
-        cacheConfigurations.snapshotWrappers.entryRetentionMillis.set(twoDays)
+        cacheConfigurations.createdResources.entryRetentionAge.set(twoDays)
+        cacheConfigurations.downloadedResources.entryRetentionAge.set(twoDays)
+        cacheConfigurations.releasedWrappers.entryRetentionAge.set(twoDays)
+        cacheConfigurations.snapshotWrappers.entryRetentionAge.set(twoDays)
+        cacheConfigurations.buildCache.entryRetentionAge.set(twoDays)
         cacheConfigurations.cleanup.set(Cleanup.ALWAYS)
 
         then:

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceTest.groovy
@@ -56,10 +56,10 @@ class GradleUserHomeCleanupServiceTest extends Specification implements GradleUs
     }
 
     def releasedWrappers = Stub(CacheResourceConfigurationInternal) {
-        getRemoveUnusedEntriesOlderThanAsSupplier() >> TimestampSuppliers.daysAgo(CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_RELEASED_DISTS)
+        getEntryRetentionTimestampSupplier() >> TimestampSuppliers.daysAgo(CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_RELEASED_DISTS)
     }
     def snapshotWrappers = Stub(CacheResourceConfigurationInternal) {
-        getRemoveUnusedEntriesOlderThanAsSupplier() >> TimestampSuppliers.daysAgo(CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_SNAPSHOT_DISTS)
+        getEntryRetentionTimestampSupplier() >> TimestampSuppliers.daysAgo(CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_SNAPSHOT_DISTS)
     }
     def cacheConfigurations = Stub(CacheConfigurationsInternal) {
         getReleasedWrappers() >> releasedWrappers
@@ -110,7 +110,7 @@ class GradleUserHomeCleanupServiceTest extends Specification implements GradleUs
         cleanupService.cleanup()
 
         then:
-        releasedWrappers.getRemoveUnusedEntriesOlderThanAsSupplier() >> TimestampSuppliers.daysAgo(TWICE_DEFAULT_MAX_AGE_IN_DAYS - 1)
+        releasedWrappers.getEntryRetentionTimestampSupplier() >> TimestampSuppliers.daysAgo(TWICE_DEFAULT_MAX_AGE_IN_DAYS - 1)
 
         and:
         oldCacheDir.assertDoesNotExist()
@@ -130,7 +130,7 @@ class GradleUserHomeCleanupServiceTest extends Specification implements GradleUs
         cleanupService.cleanup()
 
         then:
-        releasedWrappers.getRemoveUnusedEntriesOlderThanAsSupplier() >> TimestampSuppliers.daysAgo(TWICE_DEFAULT_MAX_AGE_IN_DAYS)
+        releasedWrappers.getEntryRetentionTimestampSupplier() >> TimestampSuppliers.daysAgo(TWICE_DEFAULT_MAX_AGE_IN_DAYS)
         usedGradleVersions.getUsedGradleVersions() >> ([ GradleVersion.version('2.3.4') ] as SortedSet)
 
         and:

--- a/testing/architecture-test/src/changes/archunit-store/internal-api-nullability.txt
+++ b/testing/architecture-test/src/changes/archunit-store/internal-api-nullability.txt
@@ -291,6 +291,7 @@ Class <org.gradle.api.internal.artifacts.verification.verifier.VerificationFailu
 Class <org.gradle.api.internal.cache.CacheConfigurationsInternal> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (CacheConfigurationsInternal.java:0)
 Class <org.gradle.api.internal.cache.CacheDirTagMarkingStrategy> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (CacheDirTagMarkingStrategy.java:0)
 Class <org.gradle.api.internal.cache.CacheDirUtil> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (CacheDirUtil.java:0)
+Class <org.gradle.api.internal.cache.CacheResourceConfigurationInternal$EntryRetention> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (CacheResourceConfigurationInternal.java:0)
 Class <org.gradle.api.internal.cache.CacheResourceConfigurationInternal> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (CacheResourceConfigurationInternal.java:0)
 Class <org.gradle.api.internal.cache.CleanupInternal> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (CleanupInternal.java:0)
 Class <org.gradle.api.internal.cache.DefaultCacheConfigurations$ContextualErrorMessageProperty> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (DefaultCacheConfigurations.java:0)


### PR DESCRIPTION
Previously, we were immediately converting the `removeUnusedEntriesAfter` setting
to an absolute timestamp. This timestamp was then persisted in the configuration cache.
This resulted in #30467.

With this change, we retain the `removeUnusedEntriesAfter` as an interval in ms,
and only convert to an absolute timestamp when constructing the cache instance.
This means that the interval is always based on the current build execution, rather
than the time when the configuration was persisted for CC.

To support the force-cleanup mechanism of the `setup-gradle` GitHub Action, a new `removeEntriesUnusedSince` method is added to specify an absolute timestamp for cache-cleanup.

The `entryRetention` property is introduced that holds an `EntryRetention` instance with a timestamp and a flag indicating absolute vs relative.

Fixes #30467