### PR TITLE
Avoid test dir name starting with digit

### DIFF
--- a/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/AbstractTestDirectoryProvider.java
+++ b/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/AbstractTestDirectoryProvider.java
@@ -166,7 +166,9 @@ public abstract class AbstractTestDirectoryProvider implements TestRule, TestDir
         while (true) {
             // Use a random prefix to avoid reusing test directories
             String randomPrefix = Integer.toString(RANDOM.nextInt(MAX_RANDOM_PART_VALUE), ALL_DIGITS_AND_LETTERS_RADIX);
-            if (WINDOWS_RESERVED_NAMES.matcher(randomPrefix).matches()) {
+            if (WINDOWS_RESERVED_NAMES.matcher(randomPrefix).matches() || Character.isDigit(randomPrefix.charAt(0))) {
+                // project name starting with digit may cause troubles:
+                // Cannot generate project dependency accessors because project '1mg78' doesn't follow the naming convention: [a-zA-Z]([A-Za-z0-9\-_])*
                 continue;
             }
             TestFile dir = root.file(getPrefix(), randomPrefix);


### PR DESCRIPTION
Because of this error:

```
Cannot generate project dependency accessors because project '1mg78'
doesn't follow the naming convention: [a-zA-Z]([A-Za-z0-9\-_])*
```

Example: https://ge.gradle.org/s/fio3uhsdgdces/tests/task/:soak:forkingIntegTest/details/org.gradle.kotlin.dsl.caching.ScriptCachingIntegrationTest/writes%20build%20cache%20entries?focused-exception-line=0-64&top-execution=1