### PR TITLE
Fix pom parser for relocation containing variables

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenPomRelocationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenPomRelocationIntegrationTest.groovy
@@ -107,6 +107,27 @@ class MavenPomRelocationIntegrationTest extends AbstractHttpDependencyResolution
         file("compileClasspath").assertHasDescendants("artifactC-1.0.jar")
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/30468")
+    def "can resolve module with a relocation containing variables"() {
+        given:
+        def moduleA = publishPomWithRelocation('some-group', 'artifactA', null, 'artifactB', '${project.version}')
+        def moduleB = mavenHttpRepo.module('some-group', 'artifactB', "1.0").publish()
+
+        and:
+        createBuildFileWithDependency('some-group', 'artifactA')
+
+        and:
+        moduleA.pom.expectGet()
+        moduleB.pom.expectGet()
+        moduleB.artifact.expectGet()
+
+        when:
+        run "retrieve"
+
+        then:
+        file("compileClasspath").assertHasDescendants("artifactB-1.0.jar")
+    }
+
     def "fails to resolve module if published artifact does not exist with relocated coordinates"() {
         given:
         def original = publishPomWithRelocation('groupA', 'artifactA', 'notExist', 'notExist')

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
@@ -373,9 +373,9 @@ public class PomReader implements PomParent {
             String relocGroupId = getFirstChildText(relocation, GROUP_ID);
             String relocArtId = getFirstChildText(relocation, ARTIFACT_ID);
             String relocVersion = getFirstChildText(relocation, VERSION);
-            relocGroupId = relocGroupId == null ? getGroupId() : relocGroupId;
-            relocArtId = relocArtId == null ? getArtifactId() : relocArtId;
-            relocVersion = relocVersion == null ? getVersion() : relocVersion;
+            relocGroupId = relocGroupId == null ? getGroupId() : replaceProps(relocGroupId);
+            relocArtId = relocArtId == null ? getArtifactId() : replaceProps(relocArtId);
+            relocVersion = relocVersion == null ? getVersion() : replaceProps(relocVersion);
             return DefaultModuleVersionIdentifier.newId(relocGroupId, relocArtId, relocVersion);
         }
     }


### PR DESCRIPTION
Fixes #30468

### Context

Currently gradle is not able to parse pom containing variables such as `${project.version}` in the relocation section

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
