### PR TITLE
Use project identity for equality check

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -611,7 +611,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
             return false;
         }
         if (other instanceof ProjectInternal) {
-            return getIdentityPath().equals(((ProjectInternal) other).getIdentityPath());
+            return getIdentity() == ((ProjectInternal) other).getIdentity();
         }
         return false;
     }
@@ -696,6 +696,11 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     @Override
     public ProjectInternal findProject(ProjectInternal referrer, String path) {
         return getCrossProjectModelAccess().findProject(referrer, this, path);
+    }
+
+    @Override
+    public Object getIdentity() {
+        return this;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
@@ -438,6 +438,11 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
     }
 
     @Override
+    public Object getIdentity() {
+        return delegate.getIdentity();
+    }
+
+    @Override
     public void beforeEvaluate(Action<? super Project> action) {
         onMutableStateAccess("beforeEvaluate");
         delegate.beforeEvaluate(action);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
@@ -100,6 +100,8 @@ public interface ProjectInternal extends Project, ProjectIdentifier, HasScriptSe
     @Nullable
     ProjectInternal findProject(ProjectInternal referrer, String path);
 
+    Object getIdentity();
+
     Set<? extends ProjectInternal> getSubprojects(ProjectInternal referrer);
 
     void subprojects(ProjectInternal referrer, Action<? super Project> configureAction);

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -995,12 +995,12 @@ def scriptMethod(Closure closure) {
         Project wrapped = LifecycleAwareProject.from(project, child1, gradleLifecycleActionExecutor, instantiatorMock)
         Project overwrapped = LifecycleAwareProject.from(wrapped, child1, gradleLifecycleActionExecutor, instantiatorMock)
         then:
-        project.equals(wrapped)
-        wrapped.equals(project)
-        project.equals(overwrapped)
-        overwrapped.equals(project)
-        wrapped.equals(overwrapped)
-        overwrapped.equals(wrapped)
+        project == wrapped
+        wrapped == project
+        project == overwrapped
+        overwrapped == project
+        wrapped == overwrapped
+        overwrapped == wrapped
     }
 
     def mapUsageForWrappers() {
@@ -1016,6 +1016,20 @@ def scriptMethod(Closure closure) {
         map[wrapped] = "bar"
         then:
         map[project] == "bar"
+    }
+
+    def wrappersAreIdenticalToDelegates() {
+        when:
+        Project wrapped = LifecycleAwareProject.from(project, child1, gradleLifecycleActionExecutor, instantiatorMock)
+        Project overwrapped = LifecycleAwareProject.from(wrapped, child1, gradleLifecycleActionExecutor, instantiatorMock)
+        then:
+        project.getIdentity() === wrapped.getIdentity()
+        project.getIdentity() === overwrapped.getIdentity()
+    }
+
+    def identityOfProject() {
+        expect:
+        project.getIdentity() === project
     }
 
     static boolean assertLifecycleAwareWithReferrer(Project referrer, @DelegatesTo(Project.class) Closure navigate) {


### PR DESCRIPTION
Current `identityPath`-based equality contract of Projects has a possible flaw - `identityPath`s may have collisions in some complex build trees, with using KotlinDSL. However, the burden of proofing the collision is not a part of this PR.

This PR effectively briging back referencial equality check for comparing Projects instead of structural check based on `identityPath`, to avoid an influence of the `identityPath` collision, when Projects are using as a keys.