### PR TITLE
Update Develocity Gradle Plugin to 3.18.1

### DIFF
--- a/build-logic-commons/build-platform/build.gradle.kts
+++ b/build-logic-commons/build-platform/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     constraints {
         api("org.gradle.guides:gradle-guides-plugin:0.23")
         api("org.apache.ant:ant:1.10.14") // Bump the version brought in transitively by gradle-guides-plugin
-        api("com.gradle:develocity-gradle-plugin:3.18") // Run `build-logic-settings/update-develocity-plugin-version.sh <new-version>` to update
+        api("com.gradle:develocity-gradle-plugin:3.18.1") // Run `build-logic-settings/update-develocity-plugin-version.sh <new-version>` to update
         api("com.gradle.publish:plugin-publish-plugin:1.2.1")
         api("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:1.0.1")
         api("me.champeau.gradle:japicmp-gradle-plugin:0.4.1")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,7 +28,7 @@ pluginManagement {
 
 plugins {
     id("gradlebuild.build-environment")
-    id("com.gradle.develocity").version("3.18") // Run `build-logic-settings/update-develocity-plugin-version.sh <new-version>` to update
+    id("com.gradle.develocity").version("3.18.1") // Run `build-logic-settings/update-develocity-plugin-version.sh <new-version>` to update
     id("io.github.gradle.gradle-enterprise-conventions-plugin").version("0.10.1")
     id("org.gradle.toolchains.foojay-resolver-convention").version ("0.8.0")
 }

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedDevelocityPlugin.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedDevelocityPlugin.java
@@ -28,7 +28,7 @@ public final class AutoAppliedDevelocityPlugin {
 
     public static final String GROUP = "com.gradle";
     public static final String NAME = "develocity-gradle-plugin";
-    public static final String VERSION = "3.18";
+    public static final String VERSION = "3.18.1";
 
 
     public static final PluginId ID = new DefaultPluginId("com.gradle.develocity");

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
@@ -148,7 +148,8 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
         "3.17.4",
         "3.17.5",
         "3.17.6",
-        "3.18"
+        "3.18",
+        "3.18.1"
     ]
 
     // Current injection scripts support Develocity plugin 3.3 and above


### PR DESCRIPTION
This PR updates Develocity Gradle Plugin to the latest 3.18.1 version