### PR TITLE
Fix failing TeamCity unit test

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
@@ -92,9 +92,12 @@ class PerformanceTest(
                         name = "GRADLE_RUNNER${if (repeatIndex == 0) "" else "_2"}"
                         tasks = ""
                         workingDir = os.perfTestWorkingDir
+
+                        val typeExtraParameters = if (type.extraParameters.isEmpty()) "" else " ${type.extraParameters}"
+
                         gradleParams = (
                             performanceTestCommandLine(
-                                "${if (repeatIndex == 0) "clean" else ""} ${performanceTestTaskNames.joinToString(" ") { "$it ${type.extraParameters}" }}",
+                                "${if (repeatIndex == 0) "clean" else ""} ${performanceTestTaskNames.joinToString(" ") { "$it$typeExtraParameters" }}",
                                 "%performance.baselines%",
                                 extraParameters,
                                 os,


### PR DESCRIPTION
In the past if the type extra parameters is empty, there will be two spaces rendered, like:

```
:performance:largeTestProjectPerformanceTest  :performance:smallTestProjectPerformanceTest  extraParameters
```
