### PR TITLE
Avoid more list factory methods

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/model/internal/core/ModelPath.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/model/internal/core/ModelPath.java
@@ -20,12 +20,12 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CharMatcher;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
-import com.google.common.collect.Lists;
-import javax.annotation.concurrent.ThreadSafe;
 import org.gradle.api.GradleException;
 import org.gradle.internal.exceptions.Contextual;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.StringTokenizer;
@@ -311,7 +311,7 @@ public class ModelPath implements Iterable<String>, Comparable<ModelPath> {
 
     private static String[] splitPath(String path) {
         // Let's make sure we never need to reallocate
-        List<String> components = Lists.newArrayListWithCapacity(path.length());
+        List<String> components = new ArrayList<>(path.length());
         StringTokenizer tokenizer = new StringTokenizer(path, ".");
         while (tokenizer.hasMoreTokens()) {
             String component = tokenizer.nextToken();

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/Actions.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/Actions.java
@@ -17,12 +17,12 @@
 package org.gradle.internal;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import org.gradle.api.Action;
 import org.gradle.api.specs.Spec;
 
 import javax.annotation.Nullable;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -91,7 +91,7 @@ public abstract class Actions {
      */
     @SafeVarargs
     public static <T> Action<T> composite(Action<? super T>... actions) {
-        List<Action<? super T>> filtered = Lists.newArrayListWithCapacity(actions.length);
+        List<Action<? super T>> filtered = new ArrayList<Action<? super T>>(actions.length);
         for (Action<? super T> action : actions) {
             if (doesSomething(action)) {
                 filtered.add(action);

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/FileUtils.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/FileUtils.java
@@ -23,6 +23,7 @@ import org.gradle.api.UncheckedIOException;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -106,7 +107,7 @@ public class FileUtils {
     public static Collection<? extends File> calculateRoots(Iterable<? extends File> files) {
         List<File> sortedFiles = Lists.newArrayList(files);
         Collections.sort(sortedFiles, FILE_SEGMENT_COMPARATOR);
-        List<File> result = Lists.newArrayListWithExpectedSize(sortedFiles.size());
+        List<File> result = new ArrayList<File>(sortedFiles.size());
 
         File currentRoot = null;
         for (File file : sortedFiles) {

--- a/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/ListSerializer.java
+++ b/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/ListSerializer.java
@@ -15,8 +15,7 @@
  */
 package org.gradle.internal.serialize;
 
-import com.google.common.collect.Lists;
-
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -33,6 +32,6 @@ public class ListSerializer<T> extends AbstractCollectionSerializer<T, List<T>> 
         if (size == 0) {
             return Collections.emptyList();
         }
-        return Lists.newArrayListWithCapacity(size);
+        return new ArrayList<T>(size);
     }
 }

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
@@ -268,7 +268,7 @@ public abstract class EclipsePlugin extends IdePlugin {
                     @Override
                     public Collection<Configuration> call() {
                         SourceSetContainer sourceSets = project.getExtensions().getByType(JavaPluginExtension.class).getSourceSets();
-                        List<Configuration> sourceSetsConfigurations = Lists.newArrayListWithCapacity(sourceSets.size() * 2);
+                        List<Configuration> sourceSetsConfigurations = new ArrayList<>(sourceSets.size() * 2);
                         ConfigurationContainer configurations = project.getConfigurations();
                         for (SourceSet sourceSet : sourceSets) {
                             sourceSetsConfigurations.add(configurations.getByName(sourceSet.getCompileClasspathConfigurationName()));

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
@@ -19,7 +19,6 @@ package org.gradle.plugins.ide.eclipse.model.internal;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.LinkedHashMultimap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -169,7 +168,7 @@ public class EclipseDependenciesCreator {
          * that, so defer that until later.
          */
         public List<AbstractClasspathEntry> getDependencies() {
-            List<AbstractClasspathEntry> dependencies = Lists.newArrayListWithCapacity(projects.size() + modules.size() + files.size());
+            List<AbstractClasspathEntry> dependencies = new ArrayList<>(projects.size() + modules.size() + files.size());
             dependencies.addAll(projects);
             dependencies.addAll(modules);
             dependencies.addAll(files);

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/WtpComponentFactory.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/WtpComponentFactory.java
@@ -16,7 +16,6 @@
 
 package org.gradle.plugins.ide.eclipse.model.internal;
 
-import com.google.common.collect.Lists;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
@@ -170,7 +169,7 @@ public class WtpComponentFactory {
          * that, so defer that until later.
          */
         public List<WbDependentModule> getEntries() {
-            List<WbDependentModule> entries = Lists.newArrayListWithCapacity(projectEntries.size() + moduleEntries.size() + fileEntries.size());
+            List<WbDependentModule> entries = new ArrayList<>(projectEntries.size() + moduleEntries.size() + fileEntries.size());
             entries.addAll(projectEntries);
             entries.addAll(moduleEntries);
             entries.addAll(fileEntries);

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/IdeDependencySet.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/IdeDependencySet.java
@@ -17,7 +17,6 @@ package org.gradle.plugins.ide.internal.resolver;
 
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.collect.MultimapBuilder;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Table;
@@ -45,6 +44,7 @@ import org.gradle.language.base.artifact.SourcesArtifact;
 import org.gradle.language.java.artifact.JavadocArtifact;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -212,7 +212,7 @@ public class IdeDependencySet {
         }
 
         private List<Class<? extends Artifact>> getAuxiliaryArtifactTypes(IdeDependencyVisitor visitor) {
-            List<Class<? extends Artifact>> types = Lists.newArrayListWithCapacity(2);
+            List<Class<? extends Artifact>> types = new ArrayList<>(2);
             if (visitor.downloadSources()) {
                 types.add(SourcesArtifact.class);
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializer.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.capabilities.Capability;
@@ -31,6 +30,7 @@ import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.Serializer;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -59,7 +59,7 @@ public class ModuleComponentSelectorSerializer implements Serializer<ModuleCompo
         String preferred = decoder.readString();
         String strictly = decoder.readString();
         int cpt = decoder.readSmallInt();
-        List<String> rejects = Lists.newArrayListWithCapacity(cpt);
+        List<String> rejects = new ArrayList<>(cpt);
         for (int i = 0; i < cpt; i++) {
             rejects.add(decoder.readString());
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraint.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraint.java
@@ -15,12 +15,12 @@
  */
 package org.gradle.api.internal.artifacts.dependencies;
 
-import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.VersionConstraintInternal;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -31,7 +31,7 @@ public class DefaultMutableVersionConstraint extends AbstractVersionConstraint i
     private String preferredVersion;
     private String strictVersion;
     private String branch;
-    private final List<String> rejectedVersions = Lists.newArrayListWithExpectedSize(1);
+    private final List<String> rejectedVersions = new ArrayList<>(1);
 
     public DefaultMutableVersionConstraint(VersionConstraint versionConstraint) {
         this(versionConstraint.getPreferredVersion(), versionConstraint.getRequiredVersion(), versionConstraint.getStrictVersion(), versionConstraint.getRejectedVersions(), versionConstraint.getBranch());

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ClassBasedMetadataRuleWrapper.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ClassBasedMetadataRuleWrapper.java
@@ -16,19 +16,19 @@
 
 package org.gradle.api.internal.artifacts.dsl;
 
-import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.ComponentMetadataDetails;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.action.ConfigurableRule;
 import org.gradle.internal.rules.SpecRuleAction;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
 class ClassBasedMetadataRuleWrapper implements MetadataRuleWrapper {
-    private final List<SpecConfigurableRule> classRules = Lists.newArrayListWithExpectedSize(5);
+    private final List<SpecConfigurableRule> classRules = new ArrayList<>(5);
 
     ClassBasedMetadataRuleWrapper(SpecConfigurableRule classRule) {
         this.classRules.add(classRule);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ComponentMetadataRuleContainer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ComponentMetadataRuleContainer.java
@@ -16,13 +16,13 @@
 
 package org.gradle.api.internal.artifacts.dsl;
 
-import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.ComponentMetadataDetails;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.NoOpDerivationStrategy;
 import org.gradle.internal.component.external.model.VariantDerivationStrategy;
 import org.gradle.internal.rules.SpecRuleAction;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -32,7 +32,7 @@ import java.util.function.Consumer;
  * Container for registered ComponentMetadataRules, either class based or closure / action based.
  */
 class ComponentMetadataRuleContainer implements Iterable<MetadataRuleWrapper> {
-    private final List<MetadataRuleWrapper> rules = Lists.newArrayListWithExpectedSize(10);
+    private final List<MetadataRuleWrapper> rules = new ArrayList<>(10);
     private MetadataRuleWrapper lastAdded;
     private boolean classBasedRulesOnly = true;
     private VariantDerivationStrategy variantDerivationStrategy = NoOpDerivationStrategy.getInstance();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.dsl;
 
-import com.google.common.collect.Lists;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserCodeException;
@@ -38,6 +37,7 @@ import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.util.internal.ConfigureUtil;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -232,7 +232,7 @@ public class DefaultRepositoryHandler extends DefaultArtifactRepositoryContainer
 
     public static class ExclusiveContentRepositorySpec implements ExclusiveContentRepository {
         private final RepositoryHandler repositories;
-        private final List<Factory<? extends ArtifactRepository>> forRepositories = Lists.newArrayListWithExpectedSize(2);
+        private final List<Factory<? extends ArtifactRepository>> forRepositories = new ArrayList<>(2);
         private Action<? super InclusiveRepositoryContentDescriptor> filter;
 
         public ExclusiveContentRepositorySpec(RepositoryHandler repositories) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
-import com.google.common.collect.Lists;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ComponentMetadataSupplierDetails;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
@@ -106,7 +105,7 @@ public class DynamicVersionResolver {
         LOGGER.debug("Attempting to resolve version for {} using repositories {}", requested, repositoryNames);
         List<Throwable> errors = new ArrayList<>();
 
-        List<RepositoryResolveState> resolveStates = Lists.newArrayListWithCapacity(repositories.size());
+        List<RepositoryResolveState> resolveStates = new ArrayList<>(repositories.size());
         for (ModuleComponentRepository<ModuleComponentGraphResolveState> repository : repositories) {
             resolveStates.add(new RepositoryResolveState(versionedComponentChooser, dependency, repository, versionSelector, rejectedVersionSelector, versionParser, consumerAttributes, attributesFactory, componentMetadataProcessor, componentMetadataSupplierRuleExecutor, cachePolicy));
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyModuleDescriptorConverter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyModuleDescriptorConverter.java
@@ -78,7 +78,7 @@ public class IvyModuleDescriptorConverter {
     }
 
     public List<Exclude> extractExcludes(ModuleDescriptor ivyDescriptor) {
-        List<Exclude> result = Lists.newArrayListWithCapacity(ivyDescriptor.getAllExcludeRules().length);
+        List<Exclude> result = new ArrayList<>(ivyDescriptor.getAllExcludeRules().length);
         for (ExcludeRule excludeRule : ivyDescriptor.getAllExcludeRules()) {
             result.add(forIvyExclude(excludeRule));
         }
@@ -86,7 +86,7 @@ public class IvyModuleDescriptorConverter {
     }
 
     public List<IvyDependencyDescriptor> extractDependencies(ModuleDescriptor ivyDescriptor) {
-        List<IvyDependencyDescriptor> result = Lists.newArrayListWithCapacity(ivyDescriptor.getDependencies().length);
+        List<IvyDependencyDescriptor> result = new ArrayList<>(ivyDescriptor.getDependencies().length);
         for (DependencyDescriptor dependencyDescriptor : ivyDescriptor.getDependencies()) {
             addDependency(result, dependencyDescriptor);
         }
@@ -94,7 +94,7 @@ public class IvyModuleDescriptorConverter {
     }
 
     public List<Configuration> extractConfigurations(ModuleDescriptor ivyDescriptor) {
-        List<Configuration> result = Lists.newArrayListWithCapacity(ivyDescriptor.getConfigurations().length);
+        List<Configuration> result = new ArrayList<>(ivyDescriptor.getConfigurations().length);
         for (org.apache.ivy.core.module.descriptor.Configuration ivyConfiguration : ivyDescriptor.getConfigurations()) {
             addConfiguration(result, ivyConfiguration);
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice.modulecache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedHashMultimap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.SetMultimap;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
@@ -583,7 +582,7 @@ public class ModuleMetadataSerializer {
 
         private List<Artifact> readArtifacts() throws IOException {
             int size = readCount();
-            List<Artifact> result = Lists.newArrayListWithCapacity(size);
+            List<Artifact> result = new ArrayList<>(size);
             for (int i = 0; i < size; i++) {
                 IvyArtifactName ivyArtifactName = IvyArtifactNameSerializer.INSTANCE.read(decoder);
                 result.add(new Artifact(ivyArtifactName, readStringSet()));
@@ -593,7 +592,7 @@ public class ModuleMetadataSerializer {
 
         private List<IvyDependencyDescriptor> readIvyDependencies() throws IOException {
             int len = readCount();
-            List<IvyDependencyDescriptor> result = Lists.newArrayListWithCapacity(len);
+            List<IvyDependencyDescriptor> result = new ArrayList<>(len);
             for (int i = 0; i < len; i++) {
                 result.add(readIvyDependency());
             }
@@ -625,7 +624,7 @@ public class ModuleMetadataSerializer {
 
         private List<Artifact> readDependencyArtifactDescriptors() throws IOException {
             int size = readCount();
-            List<Artifact> result = Lists.newArrayListWithCapacity(size);
+            List<Artifact> result = new ArrayList<>(size);
             for (int i = 0; i < size; i++) {
                 IvyArtifactName ivyArtifactName = IvyArtifactNameSerializer.INSTANCE.read(decoder);
                 result.add(new Artifact(ivyArtifactName, readStringSet()));
@@ -635,7 +634,7 @@ public class ModuleMetadataSerializer {
 
         private List<Exclude> readDependencyExcludes() throws IOException {
             int len = readCount();
-            List<Exclude> result = Lists.newArrayListWithCapacity(len);
+            List<Exclude> result = new ArrayList<>(len);
             for (int i = 0; i < len; i++) {
                 DefaultExclude rule = readExcludeRule();
                 result.add(rule);
@@ -663,7 +662,7 @@ public class ModuleMetadataSerializer {
 
         private List<MavenDependencyDescriptor> readMavenDependencies(Map<Integer, MavenDependencyDescriptor> deduplicationDependencyCache) throws IOException {
             int len = readCount();
-            List<MavenDependencyDescriptor> result = Lists.newArrayListWithCapacity(len);
+            List<MavenDependencyDescriptor> result = new ArrayList<>(len);
             for (int i = 0; i < len; i++) {
                 result.add(readMavenDependency(deduplicationDependencyCache));
             }
@@ -690,7 +689,7 @@ public class ModuleMetadataSerializer {
 
         private List<ExcludeMetadata> readMavenDependencyExcludes() throws IOException {
             int len = readCount();
-            List<ExcludeMetadata> result = Lists.newArrayListWithCapacity(len);
+            List<ExcludeMetadata> result = new ArrayList<>(len);
             for (int i = 0; i < len; i++) {
                 String moduleOrg = readString();
                 String moduleName = readString();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCapabilitiesResolution.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCapabilitiesResolution.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy;
 
-import com.google.common.collect.Lists;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.artifacts.CapabilityResolutionDetails;
@@ -35,6 +34,7 @@ import org.gradle.internal.component.external.model.DefaultComponentVariantIdent
 import org.gradle.internal.component.external.model.DefaultImmutableCapability;
 import org.gradle.internal.typeconversion.NotationParser;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -43,7 +43,7 @@ public class DefaultCapabilitiesResolution implements CapabilitiesResolutionInte
 
     private final NotationParser<Object, Capability> capabilityNotationParser;
     private final NotationParser<Object, ComponentIdentifier> componentNotationParser;
-    private final List<CapabilityAction> actions = Lists.newArrayListWithExpectedSize(2);
+    private final List<CapabilityAction> actions = new ArrayList<>(2);
 
     public DefaultCapabilitiesResolution(NotationParser<Object, Capability> capabilityNotationParser,
                                          NotationParser<Object, ComponentIdentifier> componentNotationParser) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
@@ -317,7 +316,7 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
 
     @Override
     public List<ComponentState> getDependents() {
-        List<ComponentState> incoming = Lists.newArrayListWithCapacity(nodes.size());
+        List<ComponentState> incoming = new ArrayList<>(nodes.size());
         for (NodeState node : nodes) {
             for (EdgeState dependencyEdge : node.getIncomingEdges()) {
                 incoming.add(dependencyEdge.getFrom().getComponent());
@@ -329,7 +328,7 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
     @Override
     public Collection<? extends ModuleVersionIdentifier> getAllVersions() {
         Collection<ComponentState> moduleVersions = module.getAllVersions();
-        List<ModuleVersionIdentifier> out = Lists.newArrayListWithCapacity(moduleVersions.size());
+        List<ModuleVersionIdentifier> out = new ArrayList<>(moduleVersions.size());
         for (ComponentState moduleVersion : moduleVersions) {
             out.add(moduleVersion.id);
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
@@ -44,8 +43,8 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflict
 import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
-import org.gradle.api.specs.Spec;
 import org.gradle.api.internal.attributes.matching.AttributeMatcher;
+import org.gradle.api.specs.Spec;
 import org.gradle.internal.component.model.ComponentGraphResolveMetadata;
 import org.gradle.internal.component.model.ComponentIdGenerator;
 import org.gradle.internal.component.model.DependencyMetadata;
@@ -212,7 +211,7 @@ public class DependencyGraphBuilder {
                 for (ModuleResolveState state : resolveState.getModules()) {
                     if (state.getId().getGroup().equals(capability.getGroup()) && state.getId().getName().equals(capability.getName())) {
                         Collection<ComponentState> versions = state.getVersions();
-                        implicitProvidersForCapability = Lists.newArrayListWithExpectedSize(versions.size());
+                        implicitProvidersForCapability = new ArrayList<>(versions.size());
                         for (ComponentState version : versions) {
                             List<NodeState> nodes = version.getNodes();
                             for (NodeState nodeState : nodes) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformGraphResolveState.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
@@ -36,6 +35,7 @@ import org.gradle.internal.component.model.DefaultExternalComponentGraphResolveS
 import org.gradle.internal.component.model.VariantGraphResolveState;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -125,7 +125,7 @@ public class LenientPlatformGraphResolveState extends DefaultExternalComponentGr
 
         private List<ModuleDependencyMetadata> registerPlatformEdge(@Nullable List<ModuleDependencyMetadata> result, Set<ModuleResolveState> modules, ModuleComponentIdentifier leafId, ModuleComponentSelector leafSelector, ComponentIdentifier platformId, boolean force) {
             if (result == null) {
-                result = Lists.newArrayListWithExpectedSize(modules.size());
+                result = new ArrayList<>(modules.size());
             }
             result.add(new LenientPlatformDependencyMetadata(
                 resolveState,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/MessageBuilderHelper.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/MessageBuilderHelper.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
 import com.google.common.collect.Iterators;
-import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 
@@ -34,9 +33,9 @@ abstract class MessageBuilderHelper {
     }
 
     static Collection<String> pathTo(EdgeState edge, boolean includeLast) {
-        List<List<EdgeState>> acc = Lists.newArrayListWithExpectedSize(1);
+        List<List<EdgeState>> acc = new ArrayList<>(1);
         pathTo(edge, new ArrayList<>(), acc, new HashSet<>());
-        List<String> result = Lists.newArrayListWithCapacity(acc.size());
+        List<String> result = new ArrayList<>(acc.size());
         for (List<EdgeState> path : acc) {
             EdgeState target = Iterators.getLast(path.iterator());
             StringBuilder sb = new StringBuilder();
@@ -86,7 +85,7 @@ abstract class MessageBuilderHelper {
         if (alreadySeen.add(component.getFrom())) {
             currentPath.add(0, component);
             for (EdgeState dependent : component.getFrom().getIncomingEdges()) {
-                List<EdgeState> otherPath = Lists.newArrayList(currentPath);
+                List<EdgeState> otherPath = new ArrayList<>(currentPath);
                 pathTo(dependent, otherPath, accumulator, alreadySeen);
             }
             if (component.getFrom().isRoot()) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
@@ -146,7 +145,7 @@ public class ModuleResolveState implements CandidateModule {
         if (areAllCandidatesForSelection(values)) {
             return values;
         }
-        List<ComponentState> versions = Lists.newArrayListWithCapacity(values.size());
+        List<ComponentState> versions = new ArrayList<>(values.size());
         for (ComponentState componentState : values) {
             if (componentState.isCandidateForConflictResolution()) {
                 versions.add(componentState);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedHashMultimap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang.StringUtils;
@@ -42,8 +41,8 @@ import org.gradle.api.internal.capabilities.ImmutableCapability;
 import org.gradle.api.internal.capabilities.ShadowedCapability;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.component.external.model.VirtualComponentIdentifier;
-import org.gradle.internal.component.local.model.LocalVariantGraphResolveMetadata;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
+import org.gradle.internal.component.local.model.LocalVariantGraphResolveMetadata;
 import org.gradle.internal.component.model.ComponentGraphResolveState;
 import org.gradle.internal.component.model.ComponentGraphSpecificResolveState;
 import org.gradle.internal.component.model.DelegatingDependencyMetadata;
@@ -499,7 +498,7 @@ public class NodeState implements DependencyGraphNode {
         if (from.isEmpty()) {
             return from;
         }
-        List<DependencyState> tmp = Lists.newArrayListWithCapacity(from.size());
+        List<DependencyState> tmp = new ArrayList<>(from.size());
         for (DependencyState dependencyState : from) {
             if (isExcluded(spec, dependencyState)) {
                 continue;
@@ -517,7 +516,7 @@ public class NodeState implements DependencyGraphNode {
         if (dependencies.isEmpty()) {
             return Collections.emptyList();
         }
-        List<DependencyState> tmp = Lists.newArrayListWithCapacity(dependencies.size());
+        List<DependencyState> tmp = new ArrayList<>(dependencies.size());
         for (DependencyMetadata dependency : dependencies) {
             tmp.add(cachedDependencyStateFor(dependency));
         }
@@ -1097,7 +1096,7 @@ public class NodeState implements DependencyGraphNode {
                 from.reselect();
             }
         } else {
-            for (EdgeState incoming : Lists.newArrayList(incomingEdges)) {
+            for (EdgeState incoming : new ArrayList<>(incomingEdges)) {
                 if (incoming.getDependencyState().getDependency().isEndorsingStrictVersions()) {
                     // pass my own component because we are already in the process of re-selecting it
                     incoming.getFrom().reselect();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RejectedModuleMessageBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RejectedModuleMessageBuilder.java
@@ -16,12 +16,12 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.result.ComponentSelectionDescriptor;
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -70,7 +70,7 @@ class RejectedModuleMessageBuilder {
         ComponentSelectionReasonInternal selectionReason = selector.getSelectionReason();
         if (selectionReason.hasCustomDescriptions()) {
             sb.append(" because of the following reason");
-            List<String> reasons = Lists.newArrayListWithExpectedSize(1);
+            List<String> reasons = new ArrayList<>(1);
             for (ComponentSelectionDescriptor componentSelectionDescriptor : selectionReason.getDescriptions()) {
                 ComponentSelectionDescriptorInternal next = (ComponentSelectionDescriptorInternal) componentSelectionDescriptor;
                 if (next.hasCustomDescription()) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.Lists;
 import org.gradle.api.Describable;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.ModuleIdentifier;
@@ -68,7 +67,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     private final DependencyState dependencyState;
     private final DependencyToComponentIdResolver resolver;
     private final ResolvedVersionConstraint versionConstraint;
-    private final List<ComponentSelectionDescriptorInternal> dependencyReasons = Lists.newArrayListWithExpectedSize(4);
+    private final List<ComponentSelectionDescriptorInternal> dependencyReasons = new ArrayList<>(4);
     private final boolean isProjectSelector;
     private final AttributeDesugaring attributeDesugaring;
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/VirtualPlatformState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/VirtualPlatformState.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
-import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
@@ -23,6 +22,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -34,7 +34,7 @@ public class VirtualPlatformState {
     private final ResolveOptimizations resolveOptimizations;
 
     private final Set<ModuleResolveState> participatingModules = new LinkedHashSet<>();
-    private final List<EdgeState> orphanEdges = Lists.newArrayListWithExpectedSize(2);
+    private final List<EdgeState> orphanEdges = new ArrayList<>(2);
 
     private boolean hasForcedParticipatingModule;
 
@@ -81,7 +81,7 @@ public class VirtualPlatformState {
     List<String> getCandidateVersions() {
         String forcedVersion = getForcedVersion();
         ComponentState selectedPlatformComponent = platformModule.getSelected();
-        List<String> sorted = Lists.newArrayListWithCapacity(participatingModules.size() + 1);
+        List<String> sorted = new ArrayList<>(participatingModules.size() + 1);
         sorted.add(selectedPlatformComponent.getVersion());
         for (ModuleResolveState module : participatingModules) {
             ComponentState selected = module.getSelected();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
@@ -17,7 +17,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflic
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import org.gradle.api.Action;
 import org.gradle.api.Describable;
 import org.gradle.api.artifacts.ModuleIdentifier;
@@ -31,6 +30,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.Compone
 import org.gradle.api.internal.capabilities.CapabilityInternal;
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
@@ -63,7 +63,7 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
             // We don't remove them from the list in the first place because it proved to be
             // slower than filtering as needed.
             ModuleIdentifier rootId = null;
-            final List<NodeState> candidatesForConflict = Lists.newArrayListWithCapacity(nodes.size());
+            final List<NodeState> candidatesForConflict = new ArrayList<>(nodes.size());
             for (NodeState ns : nodes) {
                 if (ns.isSelected()) {
                     candidatesForConflict.add(ns);
@@ -242,7 +242,7 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
         }
 
         private Collection<NodeState> conflictedNodes(NodeState node, Collection<NodeState> nodes) {
-            List<NodeState> conflictedNodes = Lists.newArrayList(nodes);
+            List<NodeState> conflictedNodes = new ArrayList<>(nodes);
             conflictedNodes.remove(node);
             return conflictedNodes;
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/VersionConflictResolutionDetails.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/VersionConflictResolutionDetails.java
@@ -16,13 +16,13 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts;
 
 import com.google.common.base.Objects;
-import com.google.common.collect.Lists;
 import org.gradle.api.Describable;
 import org.gradle.api.artifacts.result.ComponentSelectionCause;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -95,7 +95,7 @@ public class VersionConflictResolutionDetails implements Describable {
         List<VersionConflictResolutionDetails> byVersionConflictResolution = collectVersionConflictCandidates(descriptors);
         if (byVersionConflictResolution != null && byVersionConflictResolution.size()>1) {
             Set<ComponentResolutionState> allCandidates = mergeAllCandidates(byVersionConflictResolution);
-            List<ComponentSelectionDescriptorInternal> merged = Lists.newArrayListWithCapacity(descriptors.size()-1);
+            List<ComponentSelectionDescriptorInternal> merged = new ArrayList<>(descriptors.size()-1);
             boolean added = false;
             for (ComponentSelectionDescriptorInternal descriptor : descriptors) {
                 if (isByVersionConflict(descriptor)) {
@@ -125,7 +125,7 @@ public class VersionConflictResolutionDetails implements Describable {
         for (ComponentSelectionDescriptorInternal descriptor : descriptors) {
             if (isByVersionConflict(descriptor)) {
                 if (byVersionConflictResolution == null) {
-                    byVersionConflictResolution = Lists.newArrayListWithCapacity(descriptors.size());
+                    byVersionConflictResolution = new ArrayList<>(descriptors.size());
                 }
                 byVersionConflictResolution.add((VersionConflictResolutionDetails) descriptor.getDescribable());
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolver.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
@@ -208,7 +207,7 @@ public class SelectorStateResolver<T extends ComponentResolutionState> {
             ResolvedVersionConstraint versionConstraint = selector.getVersionConstraint();
             if (versionConstraint != null && versionConstraint.getRejectedSelector() != null) {
                 if (rejectSelectors == null) {
-                    rejectSelectors = Lists.newArrayListWithCapacity(selectors.size());
+                    rejectSelectors = new ArrayList<>(selectors.size());
                 }
                 rejectSelectors.add(versionConstraint.getRejectedSelector());
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverResults.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverResults.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors;
 
-import com.google.common.collect.Lists;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.LatestVersionSelector;
@@ -40,7 +39,7 @@ class SelectorStateResolverResults {
 
     public SelectorStateResolverResults(Comparator<Version> versionComparator, VersionParser versionParser, int size) {
         this.versionParser = versionParser;
-        this.results = Lists.newArrayListWithCapacity(size);
+        this.results = new ArrayList<>(size);
         this.versionComparator = versionComparator;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
@@ -113,7 +112,7 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
         String prefers = decoder.readString();
         String strictly = decoder.readString();
         int rejectCount = decoder.readSmallInt();
-        List<String> rejects = Lists.newArrayListWithCapacity(rejectCount);
+        List<String> rejects = new ArrayList<>(rejectCount);
         for (int i = 0; i < rejectCount; i++) {
             rejects.add(decoder.readString());
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 
-import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.UnresolvedDependency;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphComponent;
@@ -40,6 +39,7 @@ import org.gradle.internal.time.Time;
 import org.gradle.internal.time.Timer;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -222,7 +222,7 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
                             Long fromId = decoder.readSmallLong();
                             int size = decoder.readSmallInt();
                             if (size > 0) {
-                                List<ResolvedGraphDependency> deps = Lists.newArrayListWithExpectedSize(size);
+                                List<ResolvedGraphDependency> deps = new ArrayList<>(size);
                                 for (int i = 0; i < size; i++) {
                                     deps.add(dependencyResultSerializer.read(decoder, selectors, failures));
                                 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/GradleModuleMetadataCompatibilityConverter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/GradleModuleMetadataCompatibilityConverter.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts.repositories.metadata;
 
-import com.google.common.collect.Lists;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
@@ -29,6 +28,7 @@ import org.gradle.internal.component.external.model.MutableComponentVariant;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.snapshot.impl.CoercingStringValueSnapshot;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class GradleModuleMetadataCompatibilityConverter {
@@ -59,7 +59,7 @@ public class GradleModuleMetadataCompatibilityConverter {
                 for (ComponentVariant.File file : mutableVariant.getFiles()) {
                     if (file.getUri().contains("SNAPSHOT")) {
                         if (invalidFiles == null) {
-                            invalidFiles = Lists.newArrayListWithExpectedSize(2);
+                            invalidFiles = new ArrayList<>(2);
                         }
                         invalidFiles.add(file);
                     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/CrossBuildSignatureVerificationService.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/CrossBuildSignatureVerificationService.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.verification.signatures;
 
-import com.google.common.collect.Lists;
 import org.bouncycastle.openpgp.PGPPublicKey;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.cache.FileLockManager;
@@ -356,7 +355,7 @@ public class CrossBuildSignatureVerificationService implements SignatureVerifica
             int missingKeysLen = decoder.readSmallInt();
             List<String> missingKeys = null;
             if (missingKeysLen > 0) {
-                missingKeys = Lists.newArrayListWithCapacity(missingKeysLen);
+                missingKeys = new ArrayList<>(missingKeysLen);
                 for (int i = 0; i < missingKeysLen; i++) {
                     missingKeys.add(stringSerializer.read(decoder));
                 }
@@ -368,7 +367,7 @@ public class CrossBuildSignatureVerificationService implements SignatureVerifica
             int len = decoder.readSmallInt();
             List<PGPPublicKey> keys = null;
             if (len > 0) {
-                keys = Lists.newArrayListWithCapacity(len);
+                keys = new ArrayList<>(len);
                 for (int i = 0; i < len; i++) {
                     keys.add(publicKeySerializer.read(decoder));
                 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/SimpleGeneratedJavaClassCompiler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/SimpleGeneratedJavaClassCompiler.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.catalog;
 
-import com.google.common.collect.Lists;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.logging.text.TreeFormatter;
 
@@ -84,7 +83,7 @@ class SimpleGeneratedJavaClassCompiler {
     }
 
     private static List<File> outputSourceFilesToSourceDir(File srcDir, List<ClassSource> classes) throws IOException {
-        List<File> filesToCompile = Lists.newArrayListWithCapacity(classes.size());
+        List<File> filesToCompile = new ArrayList<>(classes.size());
         for (ClassSource classSource : classes) {
             String packageName = classSource.getPackageName();
             String className = classSource.getSimpleClassName();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleResolveMetadataSerializationHelper.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleResolveMetadataSerializationHelper.java
@@ -18,7 +18,6 @@ package org.gradle.internal.component.external.model;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
@@ -42,6 +41,7 @@ import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -115,7 +115,7 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
         for (int i = 0; i < variantsCount; i++) {
             String variantName = decoder.readString();
             int dependencyCount = decoder.readSmallInt();
-            List<GradleDependencyMetadata> dependencies = Lists.newArrayListWithExpectedSize(dependencyCount);
+            List<GradleDependencyMetadata> dependencies = new ArrayList<>(dependencyCount);
             for (int j = 0; j < dependencyCount; j++) {
                 dependencies.add(readDependencyMetadata(decoder));
             }
@@ -178,7 +178,7 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
 
     protected List<ExcludeMetadata> readMavenExcludes(Decoder decoder) throws IOException {
         int excludeCount = decoder.readSmallInt();
-        List<ExcludeMetadata> excludes = Lists.newArrayListWithCapacity(excludeCount);
+        List<ExcludeMetadata> excludes = new ArrayList<>(excludeCount);
         for (int i = 0; i < excludeCount; i++) {
             String group = decoder.readString();
             String name = decoder.readString();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyToRealisedModuleComponentResolveMetadataHelper.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyToRealisedModuleComponentResolveMetadataHelper.java
@@ -19,7 +19,6 @@ package org.gradle.internal.component.external.model;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
@@ -52,7 +51,7 @@ public class LazyToRealisedModuleComponentResolveMetadataHelper {
         if (variants.isEmpty()) {
             return ImmutableList.of();
         }
-        List<AbstractRealisedModuleComponentResolveMetadata.ImmutableRealisedVariantImpl> realisedVariants = Lists.newArrayListWithExpectedSize(variants.size());
+        List<AbstractRealisedModuleComponentResolveMetadata.ImmutableRealisedVariantImpl> realisedVariants = new ArrayList<>(variants.size());
         for (ComponentVariant variant : variants) {
             realisedVariants.add(applyRules(variant, variantMetadataRules, mutableMetadata.getId()));
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/RealisedIvyModuleResolveMetadataSerializationHelper.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/RealisedIvyModuleResolveMetadataSerializationHelper.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedHashMultimap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.SetMultimap;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
@@ -52,6 +51,7 @@ import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
@@ -257,7 +257,7 @@ public class RealisedIvyModuleResolveMetadataSerializationHelper extends Abstrac
 
     private List<Artifact> readDependencyArtifactDescriptors(Decoder decoder) throws IOException {
         int size = decoder.readSmallInt();
-        List<Artifact> result = Lists.newArrayListWithCapacity(size);
+        List<Artifact> result = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
             IvyArtifactName ivyArtifactName = IvyArtifactNameSerializer.INSTANCE.read(decoder);
             result.add(new Artifact(ivyArtifactName, readStringSet(decoder)));
@@ -267,7 +267,7 @@ public class RealisedIvyModuleResolveMetadataSerializationHelper extends Abstrac
 
     private List<Exclude> readDependencyExcludes(Decoder decoder) throws IOException {
         int len = decoder.readSmallInt();
-        List<Exclude> result = Lists.newArrayListWithCapacity(len);
+        List<Exclude> result = new ArrayList<>(len);
         for (int i = 0; i < len; i++) {
             DefaultExclude rule = readExcludeRule(decoder);
             result.add(rule);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/MutableModuleSources.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/MutableModuleSources.java
@@ -15,10 +15,10 @@
  */
 package org.gradle.internal.component.model;
 
-import com.google.common.collect.Lists;
 import org.gradle.internal.Cast;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -77,7 +77,7 @@ public class MutableModuleSources implements ModuleSources {
 
     private void maybeCreateStore() {
         if (moduleSources == null) {
-            moduleSources = Lists.newArrayListWithExpectedSize(2);
+            moduleSources = new ArrayList<>(2);
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.locking;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.StartParameter;
 import org.gradle.api.Action;
@@ -52,6 +51,7 @@ import org.gradle.internal.component.external.model.DefaultModuleComponentSelect
 import org.gradle.internal.resource.local.FileResourceListener;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -215,7 +215,7 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
     }
 
     private List<String> getModulesOrdered(Collection<ModuleComponentIdentifier> resolvedComponents) {
-        List<String> modules = Lists.newArrayListWithCapacity(resolvedComponents.size());
+        List<String> modules = new ArrayList<>(resolvedComponents.size());
         for (ModuleComponentIdentifier identifier : resolvedComponents) {
             if (!getIgnoredEntryFilter().isSatisfiedBy(identifier)) {
                 modules.add(converter.convertToLockNotation(identifier));

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/ModuleVersionNotFoundException.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/ModuleVersionNotFoundException.java
@@ -16,7 +16,6 @@
 package org.gradle.internal.resolve;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
@@ -26,6 +25,7 @@ import org.gradle.internal.exceptions.ResolutionProvider;
 import org.gradle.internal.logging.text.TreeFormatter;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -70,8 +70,8 @@ public class ModuleVersionNotFoundException extends ModuleVersionResolveExceptio
                     appendSizeLimited(builder, unmatchedVersions);
                 }
                 if (!rejectedVersions.isEmpty()) {
-                    Collection<RejectedVersion> byRule = Lists.newArrayListWithExpectedSize(rejectedVersions.size());
-                    Collection<RejectedVersion> byAttributes = Lists.newArrayListWithExpectedSize(rejectedVersions.size());
+                    Collection<RejectedVersion> byRule = new ArrayList<>(rejectedVersions.size());
+                    Collection<RejectedVersion> byAttributes = new ArrayList<>(rejectedVersions.size());
                     mapRejections(rejectedVersions, byRule, byAttributes);
                     if (!byRule.isEmpty()) {
                         builder.node("Versions rejected by component selection rules");

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/caching/CrossBuildCachingRuleExecutor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/caching/CrossBuildCachingRuleExecutor.java
@@ -16,7 +16,6 @@
 package org.gradle.internal.resolve.caching;
 
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
@@ -50,6 +49,7 @@ import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -150,7 +150,7 @@ public class CrossBuildCachingRuleExecutor<KEY, DETAILS, RESULT> implements Cach
      * @return a snapshot of the inputs
      */
     private HashCode computeExplicitInputsSnapshot(KEY key, ConfigurableRules<DETAILS> rules) {
-        List<Object> toBeSnapshotted = Lists.newArrayListWithExpectedSize(2 + 2 * rules.getConfigurableRules().size());
+        List<Object> toBeSnapshotted = new ArrayList<>(2 + 2 * rules.getConfigurableRules().size());
         toBeSnapshotted.add(keyToSnapshottable.transform(key));
         for (ConfigurableRule<DETAILS> rule : rules.getConfigurableRules()) {
             Class<? extends Action<DETAILS>> ruleClass = rule.getRuleClass();
@@ -259,7 +259,7 @@ public class CrossBuildCachingRuleExecutor<KEY, DETAILS, RESULT> implements Cach
 
         List<ImplicitInputRecord<?, ?>> readImplicitList(Decoder decoder) throws Exception {
             int cpt = decoder.readSmallInt();
-            List<ImplicitInputRecord<?, ?>> implicits = Lists.newArrayListWithCapacity(cpt);
+            List<ImplicitInputRecord<?, ?>> implicits = new ArrayList<>(cpt);
             for (int i = 0; i < cpt; i++) {
                 final Object in = readAny(decoder);
                 final Object out = readAny(decoder);

--- a/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/versionmapping/DefaultVersionMappingStrategy.java
+++ b/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/versionmapping/DefaultVersionMappingStrategy.java
@@ -16,7 +16,6 @@
 package org.gradle.api.publish.ivy.internal.versionmapping;
 
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserCodeException;
@@ -35,6 +34,7 @@ import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInte
 import org.gradle.internal.component.model.AttributeMatchingExplanationBuilder;
 
 import javax.inject.Inject;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -46,7 +46,7 @@ public class DefaultVersionMappingStrategy implements VersionMappingStrategyInte
     private final ConfigurationContainer configurations;
     private final AttributesSchemaInternal schema;
     private final ImmutableAttributesFactory attributesFactory;
-    private final List<Action<? super VariantVersionMappingStrategy>> mappingsForAllVariants = Lists.newArrayListWithExpectedSize(2);
+    private final List<Action<? super VariantVersionMappingStrategy>> mappingsForAllVariants = new ArrayList<>(2);
     private final Map<ImmutableAttributes, String> defaultConfigurations = new HashMap<>();
     private final Multimap<ImmutableAttributes, Action<? super VariantVersionMappingStrategy>> attributeBasedMappings = ArrayListMultimap.create();
 

--- a/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/versionmapping/DefaultVersionMappingStrategy.java
+++ b/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/versionmapping/DefaultVersionMappingStrategy.java
@@ -16,7 +16,6 @@
 package org.gradle.api.publish.internal.versionmapping;
 
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserCodeException;
@@ -32,6 +31,7 @@ import org.gradle.api.publish.VariantVersionMappingStrategy;
 import org.gradle.internal.component.model.AttributeMatchingExplanationBuilder;
 
 import javax.inject.Inject;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -43,7 +43,7 @@ public class DefaultVersionMappingStrategy implements VersionMappingStrategyInte
     private final ConfigurationContainer configurations;
     private final AttributesSchemaInternal schema;
     private final ImmutableAttributesFactory attributesFactory;
-    private final List<Action<? super VariantVersionMappingStrategy>> mappingsForAllVariants = Lists.newArrayListWithExpectedSize(2);
+    private final List<Action<? super VariantVersionMappingStrategy>> mappingsForAllVariants = new ArrayList<>(2);
     private final Map<ImmutableAttributes, String> defaultConfigurations = new HashMap<>();
     private final Multimap<ImmutableAttributes, Action<? super VariantVersionMappingStrategy>> attributeBasedMappings = ArrayListMultimap.create();
 

--- a/subprojects/core-api/src/main/java/org/gradle/util/CollectionUtils.java
+++ b/subprojects/core-api/src/main/java/org/gradle/util/CollectionUtils.java
@@ -20,7 +20,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.specs.Spec;
@@ -154,11 +153,11 @@ public abstract class CollectionUtils {
     }
 
     public static <T> List<T> filter(List<? extends T> list, Spec<? super T> filter) {
-        return filter(list, Lists.<T>newArrayListWithCapacity(list.size()), filter);
+        return filter(list, new ArrayList<>(list.size()), filter);
     }
 
     public static <T> List<T> filter(T[] array, Spec<? super T> filter) {
-        return filter(Arrays.asList(array), Lists.<T>newArrayListWithCapacity(array.length), filter);
+        return filter(Arrays.asList(array), new ArrayList<>(array.length), filter);
     }
 
 

--- a/subprojects/core/src/main/java/org/gradle/internal/xml/XmlTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/xml/XmlTransformer.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.internal.xml;
 
-import com.google.common.collect.Lists;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import groovy.util.IndentPrinter;
@@ -58,8 +57,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class XmlTransformer implements Transformer<String, String> {
-    private final List<Action<? super XmlProvider>> actions = new ArrayList<Action<? super XmlProvider>>();
-    private final List<Action<? super XmlProvider>> finalizers = Lists.newArrayListWithExpectedSize(2);
+    private final List<Action<? super XmlProvider>> actions = new ArrayList<>();
+    private final List<Action<? super XmlProvider>> finalizers = new ArrayList<>(2);
     private String indentation = "  ";
 
     public void addAction(Action<? super XmlProvider> provider) {

--- a/testing/architecture-test/src/test/java/org/gradle/architecture/test/GuavaCollectionFactoryUsageTest.java
+++ b/testing/architecture-test/src/test/java/org/gradle/architecture/test/GuavaCollectionFactoryUsageTest.java
@@ -39,6 +39,11 @@ public class GuavaCollectionFactoryUsageTest {
             .should()
             .callMethod(com.google.common.collect.Lists.class, "newArrayList")
             .orShould()
+            // newArrayListWithExpectedSize is especially bad, as it allocates an array with the given size + 5.
+            .callMethod(com.google.common.collect.Lists.class, "newArrayListWithExpectedSize", int.class)
+            .orShould()
+            .callMethod(com.google.common.collect.Lists.class, "newArrayListWithCapacity", int.class)
+            .orShould()
             .callMethod(com.google.common.collect.Lists.class, "newCopyOnWriteArrayList")
             .orShould()
             .callMethod(com.google.common.collect.Lists.class, "newLinkedList")


### PR DESCRIPTION
Forbid Lists.newArrayListWithExpectedSize and Lists.newArrayListWithCapacity

newArrayListWithCapacity is a simple wrapper around new ArrayList(size)

newArrayListWithExpectedSize is worse, as it adds an arbitrary padding to each size. So, newArrayListWithExpectedSize(1) will allocate an array of size 6.

Usages of both of these methods were replaced with simple new ArrayList<>() calls

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
