### PR TITLE
Fix flakiness in AbstractLineEndingSensitivityIntegrationSpec

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractLineEndingSensitivityIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractLineEndingSensitivityIntegrationSpec.groovy
@@ -29,6 +29,12 @@ abstract class AbstractLineEndingSensitivityIntegrationSpec extends AbstractInte
     public static final String TRANSFORM_EXECUTED = 'Transform producer.zip (project :producer) with AugmentTransform'
     public static final String TEXT_WITH_LINE_ENDINGS = "\nhere's a line\nhere's another line\n\n"
 
+    def setup() {
+        executer.beforeExecute {
+            requireOwnGradleUserHomeDir("Some non-incremental transforms would otherwise reuse outputs from previous builds on the same machine")
+        }
+    }
+
     abstract String getStatusForReusedOutput()
 
     abstract void execute(String... tasks)

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedLineEndingSensitivityIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedLineEndingSensitivityIntegrationSpec.groovy
@@ -16,11 +16,8 @@
 
 package org.gradle.api.tasks
 
-import org.gradle.test.fixtures.Flaky
 import org.gradle.util.internal.TextUtil
 
-
-@Flaky(because = "https://github.com/gradle/gradle-private/issues/4439")
 class CachedLineEndingSensitivityIntegrationSpec extends AbstractLineEndingSensitivityIntegrationSpec {
     def buildCachePath = TextUtil.normaliseFileSeparators(testDirectory.file("build-cache").absolutePath)
 


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-private/issues/4439

> This should have become flaky during Gradle 8.6, when we started running transforms in workspaces under the Gradle user home. Because integration tests reuse a single Gradle user home by default, and this test starts with asserting that it did run, we end up failing every time the test runs on a CI machine that already executed this test.
> 
> The other tests in the same class don't have this problem probably because they work with inputs that are specific to test, like the path of `buildDir` is included. It's all pretty much accidental, really.
> 
> There are different solutions possible:
> 
> 1. Stop checking if the initial step has actually executed, and just make sure it worked once before. That's not how tests should work, so let's rule this out.
> 2. Make the transform be an incremental transform, so it does not run in the GUH.
> 3. Run this particular test with a custom GUH.
> 4. Run all tests in that class with a custom GUH.
> 5. Run all transform integration tests with a custom GUH.
> 6. Rethink if reusing the same GUH in integration tests is a good idea in general, and maybe come up with a different way to do this.
> 
> I think for this issue 4) is a good step forward, though we should do the rethinking. GUH reuse is a poor-man's shortcut to escape ephemeral CI problems.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
