### PR TITLE
Move Java compilation error rendering to build failure message

### DIFF
--- a/platforms/core-runtime/build-process-services/src/main/java/org/gradle/api/internal/DefaultClassPathProvider.java
+++ b/platforms/core-runtime/build-process-services/src/main/java/org/gradle/api/internal/DefaultClassPathProvider.java
@@ -78,6 +78,7 @@ public class DefaultClassPathProvider implements ClassPathProvider {
         classpath = classpath.plus(moduleRegistry.getModule("gradle-language-jvm").getImplementationClasspath());
         classpath = classpath.plus(moduleRegistry.getModule("gradle-platform-base").getImplementationClasspath());
         classpath = classpath.plus(moduleRegistry.getModule("gradle-problems-api").getImplementationClasspath());
+        classpath = classpath.plus(moduleRegistry.getModule("gradle-problems-rendering").getImplementationClasspath());
         return classpath;
     }
 }

--- a/platforms/documentation/docs/src/snippets/java-library/module-disabled/tests/buildJavaModule.out
+++ b/platforms/documentation/docs/src/snippets/java-library/module-disabled/tests/buildJavaModule.out
@@ -14,13 +14,13 @@ FAILURE: Build failed with an exception.
 * What went wrong:
 Execution failed for task ':compileJava'.
 > Compilation failed; see the compiler output below.
-
   /home/user/gradle/samples/src/main/java/module-info.java:2: error: module not found: com.google.gson
       requires com.google.gson;          // real module
                          ^
   /home/user/gradle/samples/src/main/java/module-info.java:3: error: module not found: org.apache.commons.lang3
       requires org.apache.commons.lang3; // automatic module
                                  ^
+  2 errors
 
 * Try:
 > Run with --info option to get more log output.

--- a/platforms/ide/problems-rendering/src/main/java/org/gradle/problems/internal/rendering/ProblemRenderer.java
+++ b/platforms/ide/problems-rendering/src/main/java/org/gradle/problems/internal/rendering/ProblemRenderer.java
@@ -16,6 +16,7 @@
 
 package org.gradle.problems.internal.rendering;
 
+import org.gradle.api.NonNullApi;
 import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.internal.GeneralData;
 import org.gradle.api.problems.internal.Problem;
@@ -29,10 +30,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+@NonNullApi
 public class ProblemRenderer {
 
     private final PrintWriter output;
-    private int problemCount = 0;
 
     public ProblemRenderer(Writer writer) {
         output = new PrintWriter(writer);
@@ -49,7 +50,6 @@ public class ProblemRenderer {
         }
 
         renderingGroups.forEach((id, groupedProblems) -> renderProblemGroup(output, id, groupedProblems));
-        problemCount++;
     }
 
     public void render(Problem problem) {
@@ -67,7 +67,7 @@ public class ProblemRenderer {
             .orElse(Collections.emptyMap());
 
         if (additionalData.containsKey("formatted")) {
-            formatMultiline(output, additionalData.get("formatted"), 1);
+            formatMultiline(output, additionalData.get("formatted"), 0);
         } else {
             if (problem.getContextualLabel() != null) {
                 formatMultiline(output, problem.getContextualLabel(), 1);
@@ -87,9 +87,5 @@ public class ProblemRenderer {
             }
             output.printf("%s%n", line);
         }
-    }
-
-    public int getProblemCount() {
-        return problemCount;
     }
 }

--- a/platforms/ide/problems-rendering/src/test/groovy/org/gradle/problems/internal/rendering/ProblemRendererTest.groovy
+++ b/platforms/ide/problems-rendering/src/test/groovy/org/gradle/problems/internal/rendering/ProblemRendererTest.groovy
@@ -74,7 +74,7 @@ class ProblemRendererTest extends Specification {
         renderer.render(problem)
 
         then:
-        renderedTextLines[0] == "  formatted-problem-details"
+        renderedTextLines[0] == "formatted-problem-details"
     }
 
     def "individual problem with multiline formatted additional data will be indented correctly"() {
@@ -89,8 +89,8 @@ class ProblemRendererTest extends Specification {
         renderer.render(problem)
 
         then:
-        renderedTextLines[0] == "  formatted-problem-details"
-        renderedTextLines[1] == "  with multiple lines"
+        renderedTextLines[0] == "formatted-problem-details"
+        renderedTextLines[1] == "with multiple lines"
     }
 
     def "individual problem with details are displayed"() {

--- a/platforms/jvm/language-java/build.gradle.kts
+++ b/platforms/jvm/language-java/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     implementation(projects.loggingApi)
     implementation(projects.modelCore)
     implementation(projects.toolingApi)
+    implementation(projects.problemsRendering)
 
     api(libs.slf4jApi)
     implementation(libs.commonsLang)

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CompilationFailedException.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CompilationFailedException.java
@@ -18,10 +18,13 @@ package org.gradle.api.internal.tasks.compile;
 import org.gradle.api.problems.internal.Problem;
 import org.gradle.api.problems.internal.ProblemAwareFailure;
 import org.gradle.internal.exceptions.CompilationFailedIndicator;
+import org.gradle.problems.internal.rendering.ProblemRenderer;
 
 import javax.annotation.Nullable;
+import java.io.StringWriter;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 public class CompilationFailedException extends RuntimeException implements CompilationFailedIndicator, ProblemAwareFailure {
@@ -30,7 +33,7 @@ public class CompilationFailedException extends RuntimeException implements Comp
     public static final String COMPILATION_FAILED_DETAILS_BELOW = "Compilation failed; see the compiler output below.";
 
     private final ApiCompilerResult compilerPartialResult;
-    private final Collection<Problem> reportedProblems;
+    private final List<Problem> reportedProblems;
 
     public CompilationFailedException() {
         this((ApiCompilerResult) null);
@@ -54,10 +57,18 @@ public class CompilationFailedException extends RuntimeException implements Comp
         this.reportedProblems = Collections.emptyList();
     }
 
-    public CompilationFailedException(@Nullable ApiCompilerResult result, Collection<Problem> reportedProblems) {
-        super(COMPILATION_FAILED_DETAILS_BELOW);
+    public CompilationFailedException(ApiCompilerResult result, List<Problem> reportedProblems, String diagnosticCounts) {
+        super(exceptionMessage(COMPILATION_FAILED_DETAILS_BELOW + System.lineSeparator(), reportedProblems, diagnosticCounts));
         this.compilerPartialResult = result;
         this.reportedProblems = reportedProblems;
+    }
+
+    private static String exceptionMessage(String prefix, List<Problem> problems, String diagnosticCounts) {
+        StringWriter result = new StringWriter();
+        result.append(prefix);
+        new ProblemRenderer(result).render(problems);
+        result.append(diagnosticCounts);
+        return result.toString();
     }
 
     public Optional<ApiCompilerResult> getCompilerPartialResult() {

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
@@ -74,9 +74,12 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
             throw problemsService.getInternalReporter().rethrowing(ex, builder -> buildProblemFrom(ex, builder));
         }
         boolean success = task.call();
-        diagnosticToProblemListener.printDiagnosticCounts();
+        String diagnosticCounts = diagnosticToProblemListener.diagnosticCounts();
+        if (!"".equals(diagnosticCounts)) {
+            System.err.println(diagnosticCounts);
+        }
         if (!success) {
-            throw new CompilationFailedException(result, diagnosticToProblemListener.getReportedProblems());
+            throw new CompilationFailedException(result, diagnosticToProblemListener.getReportedProblems(), diagnosticCounts);
         }
         return result;
     }

--- a/subprojects/core/build.gradle.kts
+++ b/subprojects/core/build.gradle.kts
@@ -131,7 +131,6 @@ dependencies {
     implementation(projects.inputTracking)
     implementation(projects.modelGroovy)
     implementation(projects.serviceRegistryBuilder)
-    implementation(projects.problemsRendering)
 
     implementation(libs.nativePlatform)
     implementation(libs.asmCommons)

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -24,7 +24,6 @@ import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.api.logging.configuration.ShowStacktrace;
-import org.gradle.api.problems.internal.ProblemAwareFailure;
 import org.gradle.execution.MultipleBuildFailures;
 import org.gradle.initialization.BuildClientMetaData;
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
@@ -41,11 +40,9 @@ import org.gradle.internal.logging.text.BufferingStyledTextOutput;
 import org.gradle.internal.logging.text.LinePrefixingStyledTextOutput;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
-import org.gradle.problems.internal.rendering.ProblemRenderer;
 import org.gradle.util.internal.GUtil;
 
 import javax.annotation.Nonnull;
-import java.io.StringWriter;
 import java.util.ArrayDeque;
 import java.util.HashSet;
 import java.util.List;
@@ -194,8 +191,6 @@ public class BuildExceptionReporter implements Action<Throwable> {
 
     private static class ExceptionFormattingVisitor extends ExceptionContextVisitor {
         private final FailureDetails failureDetails;
-        private final StringWriter problemWriter = new StringWriter();
-        private final ProblemRenderer renderer = new ProblemRenderer(problemWriter);
 
         private final Set<Throwable> printedNodes = new HashSet<>();
         private int depth;
@@ -218,11 +213,6 @@ public class BuildExceptionReporter implements Action<Throwable> {
 
         @Override
         public void node(Throwable node) {
-            if (node instanceof ProblemAwareFailure) {
-                ProblemAwareFailure problemAwareFailure = (ProblemAwareFailure) node;
-                problemAwareFailure.getProblems().forEach(renderer::render);
-            }
-
             if (shouldBePrinted(node)) {
                 printedNodes.add(node);
                 if (null == node.getCause() || isUsefulMessage(getMessage(node))) {
@@ -298,10 +288,6 @@ public class BuildExceptionReporter implements Action<Throwable> {
 
         @Override
         protected void endVisiting() {
-            if (renderer.getProblemCount() > 0) {
-                failureDetails.details.format("%n%n");
-                failureDetails.details.text(problemWriter.toString());
-            }
             if (suppressedDuplicateBranchCount > 0) {
                 LinePrefixingStyledTextOutput output = getLinePrefixingStyledTextOutput(failureDetails);
                 boolean plural = suppressedDuplicateBranchCount > 1;

--- a/testing/architecture-test/src/changes/archunit-store/internal-api-nullability.txt
+++ b/testing/architecture-test/src/changes/archunit-store/internal-api-nullability.txt
@@ -4329,7 +4329,6 @@ Class <org.gradle.plugins.signing.signatory.internal.ConfigurableSignatoryProvid
 Class <org.gradle.plugins.signing.signatory.internal.ConfigurableSignatoryProvider> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (ConfigurableSignatoryProvider.java:0)
 Class <org.gradle.plugins.signing.signatory.internal.gnupg.GnupgSignatoryProvider> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (GnupgSignatoryProvider.java:0)
 Class <org.gradle.plugins.signing.signatory.internal.pgp.InMemoryPgpSignatoryProvider> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (InMemoryPgpSignatoryProvider.java:0)
-Class <org.gradle.problems.internal.rendering.ProblemRenderer> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (ProblemRenderer.java:0)
 Class <org.gradle.process.internal.AbstractExecHandleBuilder> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (AbstractExecHandleBuilder.java:0)
 Class <org.gradle.process.internal.BadExitCodeException> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (BadExitCodeException.java:0)
 Class <org.gradle.process.internal.CurrentProcess> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (CurrentProcess.java:0)

--- a/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -102,7 +102,6 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
         "persistent-cache",
         "problems",
         "problems-api",
-        "problems-rendering",
         "process-memory-services",
         "process-services",
         "resources",
@@ -138,7 +137,7 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
      * Change this whenever you add or remove subprojects for distribution-packaged plugins (lib/plugins).
      */
     int getPackagedPluginsJarCount() {
-        81
+        82
     }
 
     /**


### PR DESCRIPTION
Currently the java compiler messages were printed on the console as separate console printlines and not as part of the failure message. The consequence of that was that the compiler output was missing from the Build Scans failure page. There, the message only said `Compilation failed; see the compiler output below.`.

To fix that, this PR moves the compiler emitted warnings and errors to the exception message, and transitively to the build failure message. This won't change the console rendering, but fixes the Build Scans failure page. 

The PR also contains a slight adjustment: the failure message now contains the summary counts, ie how many warnings and failures the compiler found. 

Fixes https://github.com/gradle/gradle/issues/30406

<img width="1676" alt="image" src="https://github.com/user-attachments/assets/71745f71-b5b3-4b80-b7c9-f1db41588d38">
