### PR TITLE
build: update com.autonomousapps:dependency-analysis-gradle-plugin from 1.31.0 to 1.33.0

### DIFF
--- a/build-logic-commons/build-platform/build.gradle.kts
+++ b/build-logic-commons/build-platform/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
         api("org.jetbrains.kotlin:kotlin-gradle-plugin") { version { strictly(kotlinVersion) } }
         api(kotlin("compiler-embeddable")) { version { strictly(kotlinVersion) } }
         api("org.jlleitschuh.gradle:ktlint-gradle:10.3.0")
-        api("com.autonomousapps:dependency-analysis-gradle-plugin:1.31.0")
+        api("com.autonomousapps:dependency-analysis-gradle-plugin:1.33.0")
         api("com.squareup.okio:okio:3.4.0") {
             because("Bump version brought in by dependency-analysis-gradle-plugin, to resolve CVE-2022-3635")
         }

--- a/build-logic/root-build/build.gradle.kts
+++ b/build-logic/root-build/build.gradle.kts
@@ -14,5 +14,7 @@ dependencies {
         because("The CachesCleaner service is shared and needs to be on the root classpath")
     }
 
-    implementation("com.autonomousapps:dependency-analysis-gradle-plugin")
+    implementation("com.autonomousapps:dependency-analysis-gradle-plugin") {
+        exclude(group = "com.google.j2objc", module = "j2objc-annotations") // This has no use in Gradle
+    }
 }

--- a/build-logic/uber-plugins/build.gradle.kts
+++ b/build-logic/uber-plugins/build.gradle.kts
@@ -15,5 +15,7 @@ dependencies {
     implementation(projects.profiling)
 
     implementation(kotlin("gradle-plugin"))
-    implementation("com.autonomousapps:dependency-analysis-gradle-plugin")
+    implementation("com.autonomousapps:dependency-analysis-gradle-plugin") {
+        exclude(group = "com.google.j2objc", module = "j2objc-annotations") // This has no use in Gradle
+    }
 }


### PR DESCRIPTION
# [Version 1.33.0](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/blob/main/CHANGELOG.md#version-1330)

[Feat] Bundle kotlin-test to avoid false-positives.
[Fix] Merge dependency usages by identifier, not gav.
[Fix] Publish graph-support v0.3, fixing broken metadata.
[Fix] Improve performance of usesResByRes.
[Fix] Sort output of findDeclarations.
[Fix] Sort output of graphView tasks.
[Fix] Handle constant pool tag 17 (CONSTANT_DYNAMIC).
[Chore] Update latest stable AGP version to 8.5.1.

# [Version 1.32.0](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/blob/main/CHANGELOG.md#version-1320)

[New] Output dominator tree results in JSON format including size and total size of deps.
[New] Allow to force app behavior for pure Java projects.
[New] generateProjectGraph task.
[New] reason works for multi-capabilities.
[New] Print build file path in projectHealth console report.
[Fix] Enhance logging (more) when ConstantPoolParser throws exception.
[Fix] Do not dotty for path matching and remove prefix and suffix from binary class name.
[Fix] Fix Windows file separator incompatibility.
[Fix] Don't suggest adding testImplementation dependency on self.
[Fix] DAGP variants have a Category of 'dependency-analysis'.
[Fix] Sort an input map for better reproducibility.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
