### PR TITLE
Make Kotlin DSL script compilation configuration classes public

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinDslStandaloneScriptCompilationConfiguration.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinDslStandaloneScriptCompilationConfiguration.kt
@@ -27,7 +27,6 @@ import kotlin.script.experimental.api.isStandalone
 /**
  * Common script compilation configuration for Kotlin DSL standalone scripts.
  */
-internal
 abstract class KotlinDslStandaloneScriptCompilationConfiguration protected constructor(
     body: Builder.() -> Unit
 ) : ScriptCompilationConfiguration({

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinGradleScriptTemplate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinGradleScriptTemplate.kt
@@ -31,7 +31,6 @@ import kotlin.script.experimental.api.implicitReceivers
 import kotlin.script.templates.ScriptTemplateDefinition
 
 
-private
 class KotlinGradleScriptTemplateCompilationConfiguration : KotlinDslStandaloneScriptCompilationConfiguration({
     filePathPattern.put("(?:.+\\.)?init\\.gradle\\.kts")
     baseClass(KotlinGradleScriptTemplate::class)

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinProjectScriptTemplate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinProjectScriptTemplate.kt
@@ -33,7 +33,6 @@ import kotlin.script.experimental.api.implicitReceivers
 import kotlin.script.templates.ScriptTemplateDefinition
 
 
-private
 class KotlinProjectScriptTemplateCompilationConfiguration : KotlinDslStandaloneScriptCompilationConfiguration({
     filePathPattern.put(".+(?<!(^|\\.)(init|settings))\\.gradle\\.kts")
     baseClass(KotlinProjectScriptTemplate::class)

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScriptTemplate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScriptTemplate.kt
@@ -32,7 +32,6 @@ import kotlin.script.experimental.api.implicitReceivers
 import kotlin.script.templates.ScriptTemplateDefinition
 
 
-private
 class KotlinSettingsScriptTemplateCompilationConfiguration : KotlinDslStandaloneScriptCompilationConfiguration({
     filePathPattern.put("(?:.+\\.)?settings\\.gradle\\.kts")
     baseClass(KotlinSettingsScriptTemplate::class)

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/v1/PrecompiledScriptTemplates.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/v1/PrecompiledScriptTemplates.kt
@@ -190,7 +190,6 @@ open class PrecompiledProjectScript(
 }
 
 
-internal
 object PrecompiledInitScriptCompilationConfiguration : ScriptCompilationConfiguration({
     isStandalone(false)
     baseClass(PrecompiledInitScript::class)
@@ -199,7 +198,6 @@ object PrecompiledInitScriptCompilationConfiguration : ScriptCompilationConfigur
 })
 
 
-internal
 object PrecompiledSettingsScriptCompilationConfiguration : ScriptCompilationConfiguration({
     isStandalone(false)
     baseClass(PrecompiledSettingsScript::class)
@@ -208,7 +206,6 @@ object PrecompiledSettingsScriptCompilationConfiguration : ScriptCompilationConf
 })
 
 
-internal
 object PrecompiledProjectScriptCompilationConfiguration : ScriptCompilationConfiguration({
     isStandalone(false)
     baseClass(PrecompiledProjectScript::class)

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -23,6 +23,20 @@
             "changes": [
                 "Method added to public class"
             ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.KotlinDslStandaloneScriptCompilationConfiguration",
+            "member": "Class org.gradle.kotlin.dsl.KotlinDslStandaloneScriptCompilationConfiguration",
+            "acceptation": "Kotlin DSL public script compilation configuration",
+            "changes": [
+                "Interface has been added"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.KotlinDslStandaloneScriptCompilationConfiguration",
+            "member": "Constructor org.gradle.kotlin.dsl.KotlinDslStandaloneScriptCompilationConfiguration(kotlin.jvm.functions.Function1)",
+            "acceptation": "Kotlin DSL public script compilation configuration",
+            "changes": []
         }
     ]
 }


### PR DESCRIPTION
These are dynamically loaded by the Kotlin compiler scripting support and IDEs. These classes being non-public force these consumers to work around the visibility.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
