### PR TITLE
Fix typos in "Sharing Build Logic between Subprojects"

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/structuring/sharing_build_logic_between_subprojects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/structuring/sharing_build_logic_between_subprojects.adoc
@@ -220,7 +220,7 @@ The `shared.gradle(.kts)` file is also applied:
 // Apply any other configurations specific to your project
 
 // Use the build script defined in buildSrc
-apply(from = rootProject.file("buildSrc/shared.gradle"))
+apply(from = rootProject.file("buildSrc/shared.gradle.kts"))
 
 // Use the custom task defined in buildSrc
 tasks.register<MyCustomTask>("myCustomTask")

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/structuring/sharing_build_logic_between_subprojects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/structuring/sharing_build_logic_between_subprojects.adoc
@@ -210,7 +210,7 @@ class MyCustomTask extends DefaultTask {
 The `MyCustomTask` task is used in the build script of the `api` and `shared` projects.
 The task is automatically available because it's part of `buildSrc`.
 
-The `shared.build(.kts)` file is also applied:
+The `shared.gradle(.kts)` file is also applied:
 
 [.multi-language-sample]
 =====


### PR DESCRIPTION
Fixes typos in: https://docs.gradle.org/current/userguide/sharing_build_logic_between_subprojects.html


1. `shared.build(.kts)` should be `shared.gradle(.kts)`
2. In the Kotlin example `buildSrc/shared.gradle` should be `buildSrc/shared.gradle.kts` (regression from gradle@5b9e7221)

-----

![example](https://github.com/user-attachments/assets/9be1e8e2-0951-4a31-8f68-751a2a94162b)
