### PR TITLE
Remove ProblemReporter.rethrowing() method

### DIFF
--- a/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
+++ b/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
@@ -358,21 +358,6 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
         receivedProblem.exception.message == 'test'
     }
 
-    def "can rethrow an exception"() {
-        given:
-        withReportProblemTask """
-            problems.getReporter().rethrowing(new RuntimeException("test")) {
-                it.id('type', 'label')
-            }
-        """
-
-        when:
-        fails('reportProblem')
-
-        then:
-        receivedProblem.exception.message == 'test'
-    }
-
     def "can rethrow a caught exception"() {
         given:
         withReportProblemTask """
@@ -382,8 +367,8 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
                     .withException(new RuntimeException("test"))
                 }
             } catch (RuntimeException ex) {
-                problems.getReporter().rethrowing(ex) {
-                    it.id('type12', 'outer')
+                problems.getReporter().throwing {
+                    it.id('type12', 'outer').withException(ex)
                 }
             }
         """

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/ProblemReporter.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/ProblemReporter.java
@@ -48,14 +48,4 @@ public interface ProblemReporter {
      * @since 8.6
      */
     RuntimeException throwing(Action<ProblemSpec> spec);
-
-    /**
-     * Configures a new problem using an existing exception as input, reports it, and uses it to throw a new exception.
-     * <p>
-     * The spec must specify the problem label and the category. Any additional configuration is optional.
-     *
-     * @return never returns by throwing the exception, but using {@code throw} statement at the call site is encouraged to indicate the intent and benefit from local control flow.
-     * @since 8.6
-     */
-    RuntimeException rethrowing(RuntimeException e, Action<ProblemSpec> spec);
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemReporter.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemReporter.java
@@ -74,14 +74,6 @@ public class DefaultProblemReporter implements InternalProblemReporter {
     }
 
     @Override
-    public RuntimeException rethrowing(RuntimeException e, Action<ProblemSpec> spec) {
-        DefaultProblemBuilder problemBuilder = new DefaultProblemBuilder(problemStream, additionalDataBuilderFactory);
-        spec.execute(problemBuilder);
-        problemBuilder.withException(e);
-        throw throwError(e, problemBuilder.build());
-    }
-
-    @Override
     public Problem create(Action<InternalProblemSpec> action) {
         DefaultProblemBuilder defaultProblemBuilder = new DefaultProblemBuilder(problemStream, additionalDataBuilderFactory);
         action.execute(defaultProblemBuilder);

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
@@ -71,7 +71,9 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
         try {
             task = createCompileTask(spec, result);
         } catch (RuntimeException ex) {
-            throw problemsService.getInternalReporter().rethrowing(ex, builder -> buildProblemFrom(ex, builder));
+            throw problemsService.getInternalReporter().throwing(builder -> {
+                buildProblemFrom(ex, builder);
+            });
         }
         boolean success = task.call();
         diagnosticToProblemListener.printDiagnosticCounts();
@@ -124,7 +126,7 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
         return false;
     }
 
-    private void buildProblemFrom(RuntimeException ex, ProblemSpec spec) {
+    private static void buildProblemFrom(RuntimeException ex, ProblemSpec spec) {
         spec.severity(Severity.ERROR);
         spec.id("initialization-failed", "Java compilation initialization error", GradleCoreProblemGroup.compilation().java());
         spec.contextualLabel(ex.getLocalizedMessage());


### PR DESCRIPTION
The API is redundant. The the same results can be achieved with ProblemReporter.throwing().

Fixes https://github.com/gradle/gradle/issues/30544