### PR TITLE
Allow ipv6 addresses in repository urls

### DIFF
--- a/platforms/software/resources/src/main/java/org/gradle/internal/resource/ExternalResourceName.java
+++ b/platforms/software/resources/src/main/java/org/gradle/internal/resource/ExternalResourceName.java
@@ -229,7 +229,7 @@ public class ExternalResourceName implements Describable {
             builder.delete(index, builder.length());
         }
 
-        return encode(builder.toString(), true);
+        return builder.toString();
     }
 
     private static String encode(String path, boolean isPathSeg) {

--- a/platforms/software/resources/src/test/groovy/org/gradle/internal/resource/ExternalResourceNameTest.groovy
+++ b/platforms/software/resources/src/test/groovy/org/gradle/internal/resource/ExternalResourceNameTest.groovy
@@ -38,10 +38,13 @@ class ExternalResourceNameTest extends Specification {
         name.root.uri.toASCIIString() == expectedRoot
 
         where:
-        uri                           | expectedRoot        | expectedPath
-        "http://host:8080/path"       | "http://host:8080/" | "/path"
-        "http://host:8080/path?query" | "http://host:8080/" | "/path"
-        "http://host:8080?query"      | "http://host:8080"  | ""
+        uri                             | expectedRoot                    | expectedPath
+        "http://host:8080/path"         | "http://host:8080/"             | "/path"
+        "http://host:8080/path?query"   | "http://host:8080/"             | "/path"
+        "http://host:8080?query"        | "http://host:8080"              | ""
+        "http://127.0.0.1:8080"         | "http://127.0.0.1:8080"         | ""
+        "http://[0:0:0:0:0:0:0:1]:8080" | "http://[0:0:0:0:0:0:0:1]:8080" | ""
+        "http://[::1]:8080"             | "http://[::1]:8080"             | ""
     }
 
     def "can construct a resource name from URI and path"() {


### PR DESCRIPTION
Before repositories like `maven("http://[::1]/")` were not possible because the square brackets were url encoded.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
