### PR TITLE
Doc Sample Readme - Changed to desired link (gradle#30519)

### DIFF
--- a/platforms/documentation/docs/src/samples/writing-tasks/tasks-with-dependency-resolution-result-inputs/README.adoc
+++ b/platforms/documentation/docs/src/samples/writing-tasks/tasks-with-dependency-resolution-result-inputs/README.adoc
@@ -45,4 +45,4 @@ BUILD SUCCESSFUL in 1s
 ====
 
 For more information, see link:{userManualPath}/more_about_tasks.html[Authoring Tasks reference chapter].
-Additionally, see the link:{userManualPath}/incremental_build.html[Incremental Build] chapter and its link:{userManualPath}/incremental_build.html#sec:task_input_using_classpath_annotations[Using dependency resolution results] section.
+Additionally, see the link:{userManualPath}/incremental_build.html[Incremental Build] chapter and its link:{userManualPath}/incremental_build.html#sec:task_input_using_dependency_resolution_results[Using dependency resolution results] section.


### PR DESCRIPTION
Updated https://docs.gradle.org/current/samples/sample_tasks_with_dependency_resolution_result_inputs.html. Changed 'Using dependency resolution results' linked from https://docs.gradle.org/current/userguide/incremental_build.html#sec:task_input_using_classpath_annotations to https://docs.gradle.org/current/userguide/incremental_build.html#sec:task_input_using_dependency_resolution_results.