### PR TITLE
Use URI instead of deprecated URL constructor

### DIFF
--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild.update-versions.gradle.kts
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild.update-versions.gradle.kts
@@ -5,7 +5,7 @@ import gradlebuild.buildutils.model.ReleasedVersion
 import gradlebuild.buildutils.tasks.UpdateAgpVersions
 import gradlebuild.buildutils.tasks.UpdateKotlinVersions
 import gradlebuild.buildutils.tasks.UpdateReleasedVersions
-import java.net.URL
+import java.net.URI
 
 
 tasks.withType<UpdateReleasedVersions>().configureEach {
@@ -22,7 +22,7 @@ tasks.register<UpdateReleasedVersions>("updateReleasedVersions") {
 
 tasks.register<UpdateReleasedVersions>("updateReleasedVersionsToLatestNightly") {
     currentReleasedVersion = project.provider {
-        val jsonText = URL("https://services.gradle.org/versions/nightly").readText()
+        val jsonText = URI("https://services.gradle.org/versions/nightly").toURL().readText()
         println(jsonText)
         val versionInfo = Gson().fromJson(jsonText, VersionBuildTimeInfo::class.java)
         ReleasedVersion(versionInfo.version, versionInfo.buildTime)

--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild.wrapper.gradle.kts
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild.wrapper.gradle.kts
@@ -1,6 +1,6 @@
 import gradlebuild.basics.capitalize
 import com.google.gson.Gson
-import java.net.URL
+import java.net.URI
 
 wrapperUpdateTask("nightly", "nightly")
 wrapperUpdateTask("rc", "release-candidate")
@@ -27,7 +27,7 @@ fun Project.wrapperUpdateTask(name: String, label: String) {
 
     tasks.register(configureWrapperTaskName) {
         doLast {
-            val jsonText = URL("https://services.gradle.org/versions/$label").readText()
+            val jsonText = URI("https://services.gradle.org/versions/$label").toURL().readText()
             val versionInfo = Gson().fromJson(jsonText, VersionDownloadInfo::class.java)
             println("updating wrapper to $label version: ${versionInfo.version} (downloadUrl: ${versionInfo.downloadUrl})")
             wrapperTask.get().distributionUrl = versionInfo.downloadUrl


### PR DESCRIPTION
The `URL(String)` constructor is deprecated in Java 20.