### PR TITLE
Publish libraries using resolved coordinates

### DIFF
--- a/build-logic-commons/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
+++ b/build-logic-commons/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import org.gradle.api.publish.internal.component.ConfigurationVariantDetailsInternal
 import java.time.Year
 
 plugins {
@@ -25,15 +24,6 @@ plugins {
 }
 
 configureJavadocVariant()
-
-listOf(configurations["apiElements"], configurations["runtimeElements"]).forEach {
-    (components["java"] as AdhocComponentWithVariants).withVariantsFromConfiguration(it) {
-        this as ConfigurationVariantDetailsInternal
-        this.dependencyMapping {
-            publishResolvedCoordinates = true
-        }
-    }
-}
 
 publishing {
     publications {

--- a/build-logic-commons/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
+++ b/build-logic-commons/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import org.gradle.external.javadoc.StandardJavadocDocletOptions
+import org.gradle.api.publish.internal.component.ConfigurationVariantDetailsInternal
 import java.time.Year
 
 plugins {
@@ -25,6 +25,15 @@ plugins {
 }
 
 configureJavadocVariant()
+
+listOf(configurations["apiElements"], configurations["runtimeElements"]).forEach {
+    (components["java"] as AdhocComponentWithVariants).withVariantsFromConfiguration(it) {
+        this as ConfigurationVariantDetailsInternal
+        this.dependencyMapping {
+            publishResolvedCoordinates = true
+        }
+    }
+}
 
 publishing {
     publications {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.11-20240911001649+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.11-20240917001610+0000-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/platforms/jvm/normalization-java/build.gradle.kts
+++ b/platforms/jvm/normalization-java/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.publish.internal.component.ConfigurationVariantDetailsInternal
+
 plugins {
     id("gradlebuild.distribution.api-java")
     id("gradlebuild.publish-public-libraries")
@@ -31,6 +33,17 @@ dependencies {
     testImplementation(projects.internalTesting)
     testImplementation(testFixtures(projects.snapshots))
 }
+
+// TODO Put a comment here about what this does
+listOf(configurations["apiElements"], configurations["runtimeElements"]).forEach {
+    (components["java"] as AdhocComponentWithVariants).withVariantsFromConfiguration(it) {
+        this as ConfigurationVariantDetailsInternal
+        this.dependencyMapping {
+            publishResolvedCoordinates = true
+        }
+    }
+}
+
 tasks.isolatedProjectsIntegTest {
     enabled = false
 }


### PR DESCRIPTION
This uses the following new functionality to fix how `:normalization-java` and friends publish an incorrect dependency on `:java-api-extractor`. The dependency should point to the artifact ID `gradle-java-api-extractor` instead of `java-api-extractor`, because we publish our libraries with the `gradle-` prefix.

* https://github.com/gradle/gradle/pull/30410

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
