### PR TITLE
Centralize toolchain configuration for build-logic-commons

### DIFF
--- a/build-logic-commons/basics/build.gradle.kts
+++ b/build-logic-commons/basics/build.gradle.kts
@@ -6,13 +6,6 @@ description = "Provides plugins for configuring miscellaneous things (repositori
 
 group = "gradlebuild"
 
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
-        vendor = JvmVendorSpec.ADOPTIUM
-    }
-}
-
 dependencies {
     api("gradlebuild:build-environment")
     api(platform(projects.buildPlatform))

--- a/build-logic-commons/code-quality-rules/build.gradle.kts
+++ b/build-logic-commons/code-quality-rules/build.gradle.kts
@@ -19,13 +19,6 @@ plugins {
 }
 description = "Provides a custom CodeNarc rule used by the Gradle build"
 
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
-        vendor = JvmVendorSpec.ADOPTIUM
-    }
-}
-
 group = "gradlebuild"
 
 dependencies {

--- a/build-logic-commons/gradle-plugin/build.gradle.kts
+++ b/build-logic-commons/gradle-plugin/build.gradle.kts
@@ -6,13 +6,6 @@ group = "gradlebuild"
 
 description = "Provides plugins used to create a Gradle plugin with Groovy or Kotlin DSL within build-logic builds"
 
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
-        vendor = JvmVendorSpec.ADOPTIUM
-    }
-}
-
 dependencies {
     compileOnly("com.gradle:develocity-gradle-plugin")
 

--- a/build-logic-commons/module-identity/build.gradle.kts
+++ b/build-logic-commons/module-identity/build.gradle.kts
@@ -6,13 +6,6 @@ description = "Provides a plugin to define the version and name for subproject p
 
 group = "gradlebuild"
 
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
-        vendor = JvmVendorSpec.ADOPTIUM
-    }
-}
-
 dependencies {
     api(platform(projects.buildPlatform))
 

--- a/build-logic-commons/settings.gradle.kts
+++ b/build-logic-commons/settings.gradle.kts
@@ -45,3 +45,13 @@ include("gradle-plugin")
 include("publishing")
 
 rootProject.name = "build-logic-commons"
+
+// Make sure all the build-logic is compiled for the right Java version
+gradle.lifecycle.beforeProject {
+    pluginManager.withPlugin("java-base") {
+        the<JavaPluginExtension>().toolchain {
+            languageVersion = JavaLanguageVersion.of(11)
+            vendor = JvmVendorSpec.ADOPTIUM
+        }
+    }
+}


### PR DESCRIPTION
`build-logic-commons:publishing` was missing a toolchain configuration, causing problems when running the build on later Java versions.