### PR TITLE
Explore collecting stats for configuration data storage

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
@@ -264,7 +264,7 @@ class DefaultConfigurationCacheIO internal constructor(
         }
         println("STATS: ${stats.size}")
         stats.asSequence()
-            .filter { it.value.get() >= 1 }
+            .filter { it.value.get() > 1 }
             .sortedByDescending { it.value.get() }
             .take(100)
             .forEach {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
@@ -251,7 +251,7 @@ class DefaultConfigurationCacheIO internal constructor(
         if (startParameter.collectStats)
             DefaultCollector()
         else
-            NullCollector()
+            Collector.NULL_COLLECTOR
 
     private
     fun <T> writeConfigurationCacheState(
@@ -278,14 +278,14 @@ class DefaultConfigurationCacheIO internal constructor(
     interface Collector {
         fun collect(obj: Any?)
         fun printStats(context: String)
-    }
 
-
-    private
-    class NullCollector: Collector {
-        override fun collect(obj: Any?) {
-        }
-        override fun printStats(context: String) {
+        companion object {
+            val NULL_COLLECTOR = object : Collector {
+                override fun collect(obj: Any?) {
+                }
+                override fun printStats(context: String) {
+                }
+            }
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheStartParameter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheStartParameter.kt
@@ -104,6 +104,8 @@ class ConfigurationCacheStartParameter internal constructor(
      */
     val isParallelLoad = options.getInternalFlag("org.gradle.configuration-cache.internal.parallel-load", true)
 
+    val collectStats = options.getInternalFlag("org.gradle.configuration-cache.internal.collect-stats", false)
+
     val gradleProperties: Map<String, Any?>
         get() = startParameter.projectProperties
             .filterKeys { !Workarounds.isIgnoredStartParameterProperty(it) }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheStartParameter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheStartParameter.kt
@@ -104,7 +104,11 @@ class ConfigurationCacheStartParameter internal constructor(
      */
     val isParallelLoad = options.getInternalFlag("org.gradle.configuration-cache.internal.parallel-load", true)
 
-    val collectStats = options.getInternalFlag("org.gradle.configuration-cache.internal.collect-stats", false)
+    val collectStats = options.getInternalFlag("org.gradle.configuration-cache.internal.collect-stats", false).also { enabled ->
+        if (enabled) {
+            println("CC object stats collection enabled")
+        }
+    }
 
     val gradleProperties: Map<String, Any?>
         get() = startParameter.projectProperties

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialization/codecs/AbstractUserTypeCodecTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialization/codecs/AbstractUserTypeCodecTest.kt
@@ -29,6 +29,7 @@ import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.extensions.stdlib.useToRun
 import org.gradle.internal.io.NullOutputStream
 import org.gradle.internal.serialize.FlushableEncoder
+import org.gradle.internal.serialize.PositionAwareEncoder
 import org.gradle.internal.serialize.beans.services.BeanConstructors
 import org.gradle.internal.serialize.beans.services.DefaultBeanStateReaderLookup
 import org.gradle.internal.serialize.beans.services.DefaultBeanStateWriterLookup
@@ -134,7 +135,7 @@ abstract class AbstractUserTypeCodecTest {
     fun writeContextFor(encoder: FlushableEncoder, codec: Codec<Any?>, problemHandler: ProblemsListener) =
         DefaultWriteContext(
             codec = codec,
-            encoder = encoder,
+            encoder = encoder as PositionAwareEncoder,
             classEncoder = DefaultClassEncoder(mock()),
             beanStateWriterLookup = DefaultBeanStateWriterLookup(),
             logger = mock(),

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
@@ -40,6 +40,7 @@ interface BeanStateReaderLookup {
     fun beanStateReaderFor(beanType: Class<*>): BeanStateReader
 }
 
+typealias WriteListener = (Any?) -> Unit
 
 class DefaultWriteContext(
 
@@ -60,7 +61,9 @@ class DefaultWriteContext(
     private
     val classEncoder: ClassEncoder,
 
-    val stringEncoder: StringEncoder = InlineStringEncoder
+    val stringEncoder: StringEncoder = InlineStringEncoder,
+
+    var onWrite: WriteListener =  { }
 
 ) : AbstractIsolateContext<WriteIsolate>(codec, problemsListener), CloseableWriteContext, Encoder by encoder {
 
@@ -89,6 +92,7 @@ class DefaultWriteContext(
 
     override suspend fun write(value: Any?) {
         getCodec().run {
+            onWrite(value)
             encode(value)
         }
     }

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
@@ -64,7 +64,7 @@ class DefaultWriteContext(
 
     val stringEncoder: StringEncoder = InlineStringEncoder,
 
-    var onWrite: WriteListener =  { _: Any?, _: Long -> }
+    var onWrite: WriteListener = { _: Any?, _: Long? -> }
 
 ) : AbstractIsolateContext<WriteIsolate>(codec, problemsListener), CloseableWriteContext, Encoder by encoder {
 
@@ -193,7 +193,7 @@ class DefaultReadContext(
 
 ) : AbstractIsolateContext<ReadIsolate>(codec, problemsListener), CloseableReadContext, Decoder by decoder {
 
-    var onRead: IsolateContext.(Any?, Long) -> Unit = { _: Any?, _: Long -> }
+    var onRead: IsolateContext.(Any?, Long?) -> Unit = { _, _ -> }
 
     override val sharedIdentities = ReadIdentities()
 
@@ -230,7 +230,7 @@ class DefaultReadContext(
         decode()
     }.also {
         //TODO-RC include decoder offset
-        onRead(it, -1)
+        onRead(it, null)
     }
 
     override fun readClass(): Class<*> = classDecoder.run {

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
@@ -190,6 +190,8 @@ class DefaultReadContext(
 
 ) : AbstractIsolateContext<ReadIsolate>(codec, problemsListener), CloseableReadContext, Decoder by decoder {
 
+    var onRead: (Any?) -> Unit = { }
+
     override val sharedIdentities = ReadIdentities()
 
     private
@@ -223,7 +225,7 @@ class DefaultReadContext(
 
     override suspend fun read(): Any? = getCodec().run {
         decode()
-    }
+    }.also(onRead)
 
     override fun readClass(): Class<*> = classDecoder.run {
         decodeClass()


### PR DESCRIPTION
WIP

Sample:

```
gradle --dry-run -Dorg.gradle.configuration-cache.internal.collect-stats=true --configuration-cache -Dorg.gradle.configuration-cache.parallel=true assembleDebug -Dorg.gradle.configuration-cache.internal.recreate-cache=true  | grep "\[stats\]" | cut -c 1-280
[stats] Stats for Write: 8512371
[stats] 2424 (total: 292031944, max: 127539, min: 120002, avg: 1.2048E+5, stdDev: 864.39 in 2424 contexts) - org.jetbrains.kotlin.gradle.incremental.IncrementalModuleInfoBuildService$Parameters_Decorated@387f5892 - (IncrementalModuleInfoBuildService$Parameters_Decorated@387f5892)
[stats] 2424 (total: 291981396, max: 127517, min: 119982, avg: 1.2045E+5, stdDev: 864.13 in 2424 contexts) - property 'info' - (DefaultProperty@7434a561)
[stats] 2424 (total: 291957460, max: 127506, min: 119973, avg: 1.2044E+5, stdDev: 863.80 in 2424 contexts) - org.jetbrains.kotlin.incremental.IncrementalModuleInfo@68c4b552 - (IncrementalModuleInfo@68c4b552)
[stats] 2423 (total: 258073032, max: 112047, min: 106121, avg: 1.0651E+5, stdDev: 857.05 in 2423 contexts) - {/Users/rafael/sources/perf-android-large-2/module07/module39/module4/module5/build/tmp/kotlin-classes/debug=IncrementalModuleEntry(projectPath=:module07:module39:module4:
[stats] 2424 (total: 33743560, max: 15442, min: 13837, avg: 13921, stdDev: 38.608 in 2424 contexts) - {module008_debug=[IncrementalModuleEntry(projectPath=:module06:module008, name=module008_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module008/build, buil
[stats] 11867 (total: 8137872, max: 1520, min: 3, avg: 685.76, stdDev: 684.68 in 2563 contexts) - org.gradle.api.internal.file.RelativePathSpec@38e3bc52 - (RelativePathSpec@38e3bc52)
[stats] 5935 (total: 8091020, max: 1514, min: 1267, avg: 1363.3, stdDev: 68.705 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcher$Or@14e9f752 - (Or@14e9f752)
[stats] 5934 (total: 8046139, max: 1504, min: 1262, avg: 1355.9, stdDev: 67.557 in 2563 contexts) - [org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@750f2809, org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@5a2895b
[stats] 2425 (total: 7073957, max: 3253, min: 2900, avg: 2917.1, stdDev: 8.9141 in 2425 contexts) - [IncrementalModuleEntry(projectPath=:module07:module20:module01:module2:module1, name=module1_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module07/module20/module01/
[stats] 2425 (total: 6804195, max: 3154, min: 2791, avg: 2805.9, stdDev: 8.8423 in 2425 contexts) - [IncrementalModuleEntry(projectPath=:module02:module28:module2, name=module2_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module02/module28/module2/build, buildHistor
[stats] 2425 (total: 5544506, max: 2543, min: 2274, avg: 2286.4, stdDev: 6.2922 in 2425 contexts) - [IncrementalModuleEntry(projectPath=:module02:module38:module3, name=module3_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module02/module38/module3/build, buildHistor
[stats] 2425 (total: 4001431, max: 1845, min: 1637, avg: 1650.1, stdDev: 5.4876 in 2425 contexts) - [IncrementalModuleEntry(projectPath=:module18:module1:module26:module4, name=module4_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module18/module1/module26/module4/bu
[stats] 2423 (total: 2051320, max: 944, min: 841, avg: 846.60, stdDev: 2.5328 in 2423 contexts) - [IncrementalModuleEntry(projectPath=:module05:module01:module11:module5, name=module5_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module05/module01/module11/module5/bu
[stats] 2425 (total: 1819115, max: 851, min: 731, avg: 750.15, stdDev: 16.976 in 2425 contexts) - org.jetbrains.kotlin.compilerRunner.CompilerSystemPropertiesService$Parameters_Decorated@6d6229dc - (CompilerSystemPropertiesService$Parameters_Decorated@6d6229dc)
[stats] 2425 (total: 1765563, max: 827, min: 709, avg: 728.07, stdDev: 16.781 in 2425 contexts) - property 'properties' - (DefaultMapProperty@17c6617a)
[stats] 516443 (total: 1032886, max: 2, min: 2, avg: 2.0, stdDev: 0.0 in 2595 contexts) - build ':' - (DefaultBuildIdentifier@5a965c11)
[stats] 209682 (total: 910938, max: 143, min: 2, avg: 4.3444, stdDev: 13.141 in 2208 contexts) - {artifactType=android-classes-jar, com.android.build.api.attributes.AgpVersionAttr=8.0.0-rc01, com.android.build.api.attributes.BuildTypeAttr=debug, com.android.build.gradle.internal.
[stats] 2424 (total: 760788, max: 359, min: 311, avg: 313.86, stdDev: 1.1533 in 2424 contexts) - [IncrementalModuleEntry(projectPath=:module06:module009:module6, name=module6_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module009/module6/build, buildHistory
[stats] 6711 (total: 515917, max: 96, min: 66, avg: 76.876, stdDev: 9.0968 in 2667 contexts) - DefaultJvmInstallationMetadata{languageVersion=17, javaVersion='17.0.3', javaVendor='Eclipse Adoptium', runtimeName='OpenJDK Runtime Environment', runtimeVersion='17.0.3+7', jvmName='Op
[stats] 5934 (total: 469532, max: 92, min: 72, avg: 79.126, stdDev: 5.2876 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@750f2809 - (DefaultPatternMatcher@750f2809)
[stats] 147558 (total: 468340, max: 10, min: 3, avg: 3.1739, stdDev: 0.94868 in 2563 contexts) - {end-of-path} - (EndOfPathMatcher@342a1b35)
[stats] 5935 (total: 449462, max: 84, min: 72, avg: 75.731, stdDev: 2.9965 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@20641be9 - (DefaultPatternMatcher@20641be9)
[stats] 5935 (total: 424504, max: 83, min: 65, avg: 71.526, stdDev: 4.9838 in 2563 contexts) - {greedy next: {fixed-step: {prefix: {prefix: %} suffix: {suffix: %}}, next: {end-of-path}}} - (GreedyPathMatcher@1118762e)
[stats] 2424 (total: 421319, max: 195, min: 172, avg: 173.81, stdDev: 0.63611 in 2424 contexts) - [IncrementalModuleEntry(projectPath=:module04:module16:module7, name=module7_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module04/module16/module7/build, buildHistoryF
[stats] 3 (total: 418811, max: 209584, min: 2, avg: 1.3960E+5, stdDev: 98713) - file collection - (DefaultConfigurableFileCollection@be6db84)
[stats] 3 (total: 418760, max: 209556, min: 3, avg: 1.3959E+5, stdDev: 98701) - property 'testedVariantArtifacts$kotlin_gradle_plugin_common' - (DefaultProperty@3da07a47)
[stats] 2 (total: 418744, max: 209547, min: 209197, avg: 2.0937E+5, stdDev: 175.0) - file collection - (@2fb65d12)
[stats] 3 (total: 418423, max: 209390, min: 2, avg: 1.3947E+5, stdDev: 98622) - file collection - (DefaultConfigurableFileCollection@1841f96f)
[stats] 3 (total: 418372, max: 209362, min: 3, avg: 1.3946E+5, stdDev: 98609) - property 'testedVariantArtifacts$kotlin_gradle_plugin_common' - (DefaultProperty@2b3e8f0e)
[stats] 2 (total: 418356, max: 209353, min: 209003, avg: 2.0918E+5, stdDev: 175.0) - file collection - (@434b6b5f)
[stats] 2 (total: 408341, max: 204341, min: 204000, avg: 2.0417E+5, stdDev: 170.5) - org.jetbrains.kotlin.gradle.plugin.AndroidTestedVariantArtifactsFilter@141eab15 - (AndroidTestedVariantArtifactsFilter@141eab15)
[stats] 2 (total: 408314, max: 204324, min: 203990, avg: 2.0416E+5, stdDev: 167.0) - com.android.build.gradle.internal.dependency.ArtifactCollectionWithExtraArtifact@df8a1f5 - (ArtifactCollectionWithExtraArtifact@df8a1f5)
[stats] 2 (total: 408218, max: 204267, min: 203951, avg: 2.0411E+5, stdDev: 158.0) - org.gradle.api.internal.artifacts.configurations.DefaultArtifactCollection@feb8f5a - (DefaultArtifactCollection@feb8f5a)
[stats] 2 (total: 407961, max: 204151, min: 203810, avg: 2.0398E+5, stdDev: 170.5) - org.jetbrains.kotlin.gradle.plugin.AndroidTestedVariantArtifactsFilter@4fcdaa43 - (AndroidTestedVariantArtifactsFilter@4fcdaa43)
[stats] 2 (total: 407934, max: 204134, min: 203800, avg: 2.0397E+5, stdDev: 167.0) - com.android.build.gradle.internal.dependency.ArtifactCollectionWithExtraArtifact@97300e9 - (ArtifactCollectionWithExtraArtifact@97300e9)
[stats] 2 (total: 407838, max: 204077, min: 203761, avg: 2.0392E+5, stdDev: 158.0) - org.gradle.api.internal.artifacts.configurations.DefaultArtifactCollection@bc83170 - (DefaultArtifactCollection@bc83170)
[stats] 5935 (total: 404239, max: 75, min: 65, avg: 68.111, stdDev: 2.4987 in 2563 contexts) - {greedy next: {fixed-step: {prefix: {prefix: #} suffix: {suffix: #}}, next: {end-of-path}}} - (GreedyPathMatcher@60304452)
[stats] 5934 (total: 391190, max: 76, min: 60, avg: 65.923, stdDev: 4.7111 in 2563 contexts) - {fixed-step: {prefix: {prefix: %} suffix: {suffix: %}}, next: {end-of-path}} - (FixedStepPathMatcher@b0e0cf8)
[stats] 3 (total: 382955, max: 191656, min: 2, avg: 1.2765E+5, stdDev: 90262) - file collection - (DefaultConfigurableFileCollection@10842233)
[stats] 3 (total: 382904, max: 191628, min: 3, avg: 1.2763E+5, stdDev: 90249) - property 'testedVariantArtifacts$kotlin_gradle_plugin_common' - (DefaultProperty@3c332e81)
[stats] 2 (total: 382888, max: 191619, min: 191269, avg: 1.9144E+5, stdDev: 175.0) - file collection - (@11145cb1)
[stats] 2563 (total: 375290, max: 149, min: 136, avg: 146.43, stdDev: 2.3696 in 2563 contexts) - com.android.build.gradle.internal.SdkComponentsBuildService$Parameters_Decorated@2145cf24 - (SdkComponentsBuildService$Parameters_Decorated@2145cf24)
[stats] 2 (total: 373157, max: 186749, min: 186408, avg: 1.8658E+5, stdDev: 170.5) - org.jetbrains.kotlin.gradle.plugin.AndroidTestedVariantArtifactsFilter@46003104 - (AndroidTestedVariantArtifactsFilter@46003104)
[stats] 2 (total: 373130, max: 186732, min: 186398, avg: 1.8656E+5, stdDev: 167.0) - com.android.build.gradle.internal.dependency.ArtifactCollectionWithExtraArtifact@611ef3f4 - (ArtifactCollectionWithExtraArtifact@611ef3f4)
[stats] 2 (total: 373034, max: 186675, min: 186359, avg: 1.8652E+5, stdDev: 158.0) - org.gradle.api.internal.artifacts.configurations.DefaultArtifactCollection@185d8ea1 - (DefaultArtifactCollection@185d8ea1)
[stats] 5935 (total: 370878, max: 68, min: 60, avg: 62.490, stdDev: 1.9990 in 2563 contexts) - {fixed-step: {prefix: {prefix: #} suffix: {suffix: #}}, next: {end-of-path}} - (FixedStepPathMatcher@6c94e9da)
[stats] 18604 (total: 356783, max: 83, min: 3, avg: 19.178, stdDev: 29.169 in 2425 contexts) - 17.0.3 (Eclipse Adoptium 17.0.3+7) - (Jvm@63caabd7)
[stats] 115474 (total: 355865, max: 86, min: 2, avg: 3.0818, stdDev: 8.7911 in 1733 contexts) - {artifactType=processed-jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.jvm.version=17, org.gradle.libraryelements=jar, org.gradle.usage=java-api}
[stats] 46145 (total: 323214, max: 114, min: 2, avg: 7.0043, stdDev: 22.716 in 2141 contexts) - {artifactType=processed-jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.jvm.environment=standard-jvm, org.gradle.jvm.version=17, org.gradle.librar
[stats] 5935 (total: 317431, max: 59, min: 51, avg: 53.485, stdDev: 1.9983 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@d17151a - (DefaultPatternMatcher@d17151a)
[stats] 5935 (total: 298678, max: 53, min: 43, avg: 50.325, stdDev: 3.4806 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@5f824096 - (DefaultPatternMatcher@5f824096)
[stats] 5934 (total: 294086, max: 61, min: 43, avg: 49.559, stdDev: 5.0372 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@5a2895ba - (DefaultPatternMatcher@5a2895ba)
[stats] 5935 (total: 287758, max: 54, min: 46, avg: 48.485, stdDev: 1.9980 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@7289853c - (DefaultPatternMatcher@7289853c)
[stats] 5934 (total: 287700, max: 54, min: 46, avg: 48.483, stdDev: 1.9957 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@4e1a0504 - (DefaultPatternMatcher@4e1a0504)
[stats] 5935 (total: 285863, max: 53, min: 43, avg: 48.166, stdDev: 3.7023 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@651852d1 - (DefaultPatternMatcher@651852d1)
[stats] 5935 (total: 281341, max: 49, min: 45, avg: 47.404, stdDev: 1.9560 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@27ff324e - (DefaultPatternMatcher@27ff324e)
[stats] 5935 (total: 281341, max: 49, min: 45, avg: 47.404, stdDev: 1.9560 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@6aa81ab5 - (DefaultPatternMatcher@6aa81ab5)
[stats] 5935 (total: 280857, max: 56, min: 42, avg: 47.322, stdDev: 4.4750 in 2563 contexts) - {prefix: {prefix: %} suffix: {suffix: %}} - (HasPrefixAndSuffixPatternStep@184ee57d)
[stats] 5935 (total: 279723, max: 49, min: 43, avg: 47.131, stdDev: 2.3063 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@59d64d41 - (DefaultPatternMatcher@59d64d41)
[stats] 5935 (total: 273643, max: 53, min: 43, avg: 46.107, stdDev: 2.4941 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@30ea78ad - (DefaultPatternMatcher@30ea78ad)
[stats] 5934 (total: 273599, max: 53, min: 43, avg: 46.107, stdDev: 2.4935 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@56d6cd6f - (DefaultPatternMatcher@56d6cd6f)
[stats] 5934 (total: 273595, max: 53, min: 43, avg: 46.106, stdDev: 2.4925 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@15b51028 - (DefaultPatternMatcher@15b51028)
[stats] 5935 (total: 272208, max: 50, min: 44, avg: 45.865, stdDev: 1.5000 in 2563 contexts) - {greedy next: {fixed-step: {suffix: ~}, next: {end-of-path}}} - (GreedyPathMatcher@4790997a)
[stats] 5935 (total: 270416, max: 49, min: 41, avg: 45.563, stdDev: 2.7897 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@5c51671f - (DefaultPatternMatcher@5c51671f)
[stats] 5935 (total: 267853, max: 49, min: 41, avg: 45.131, stdDev: 2.9620 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@49263890 - (DefaultPatternMatcher@49263890)
[stats] 5935 (total: 267853, max: 49, min: 41, avg: 45.131, stdDev: 2.9620 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@2a667fd4 - (DefaultPatternMatcher@2a667fd4)
[stats] 5935 (total: 267853, max: 49, min: 41, avg: 45.131, stdDev: 2.9620 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@76e76e27 - (DefaultPatternMatcher@76e76e27)
[stats] 5935 (total: 267853, max: 49, min: 41, avg: 45.131, stdDev: 2.9620 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@73074b72 - (DefaultPatternMatcher@73074b72)
[stats] 5935 (total: 267853, max: 49, min: 41, avg: 45.131, stdDev: 2.9620 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@601a6bd5 - (DefaultPatternMatcher@601a6bd5)
[stats] 62217 (total: 267670, max: 41, min: 2, avg: 4.3022, stdDev: 7.4801 in 2536 contexts) - {artifactType=android-classes-jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api} - (DefaultImmutableAttributes@61f5e
[stats] 5935 (total: 265412, max: 49, min: 41, avg: 44.720, stdDev: 2.6176 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@745eb85a - (DefaultPatternMatcher@745eb85a)
[stats] 5935 (total: 260362, max: 48, min: 42, avg: 43.869, stdDev: 1.4999 in 2563 contexts) - {prefix: {prefix: #} suffix: {suffix: #}} - (HasPrefixAndSuffixPatternStep@24cdd002)
[stats] 5935 (total: 258085, max: 49, min: 41, avg: 43.485, stdDev: 1.9980 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@169e07ed - (DefaultPatternMatcher@169e07ed)
[stats] 5935 (total: 258077, max: 49, min: 41, avg: 43.484, stdDev: 1.9956 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@352d301 - (DefaultPatternMatcher@352d301)
[stats] 5935 (total: 258073, max: 49, min: 41, avg: 43.483, stdDev: 1.9944 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@60e48f56 - (DefaultPatternMatcher@60e48f56)
[stats] 5934 (total: 258032, max: 49, min: 41, avg: 43.484, stdDev: 1.9943 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@7109bdb6 - (DefaultPatternMatcher@7109bdb6)
[stats] 5934 (total: 258032, max: 49, min: 41, avg: 43.484, stdDev: 1.9943 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@28f2cfa6 - (DefaultPatternMatcher@28f2cfa6)
[stats] 5934 (total: 258032, max: 49, min: 41, avg: 43.484, stdDev: 1.9943 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@429de9ac - (DefaultPatternMatcher@429de9ac)
[stats] 5934 (total: 258032, max: 49, min: 41, avg: 43.484, stdDev: 1.9957 in 2563 contexts) - org.gradle.api.internal.file.pattern.PatternMatcherFactory$DefaultPatternMatcher@6fb20bf3 - (DefaultPatternMatcher@6fb20bf3)
[stats] 5934 (total: 248874, max: 52, min: 36, avg: 41.940, stdDev: 4.7385 in 2563 contexts) - {greedy next: {fixed-step: {match: .git}, next: {anything}}} - (GreedyPathMatcher@35a2e68f)
[stats] 5935 (total: 248450, max: 44, min: 36, avg: 41.862, stdDev: 2.7851 in 2563 contexts) - {greedy next: {fixed-step: {match: CVS}, next: {anything}}} - (GreedyPathMatcher@5a28cebe)
[stats] 5935 (total: 242535, max: 45, min: 39, avg: 40.865, stdDev: 1.4997 in 2563 contexts) - {greedy next: {fixed-step: {prefix: ._}, next: {end-of-path}}} - (GreedyPathMatcher@1c6b8ff8)
[stats] 5935 (total: 242529, max: 45, min: 39, avg: 40.864, stdDev: 1.4979 in 2563 contexts) - {greedy next: {fixed-step: {prefix: .#}, next: {end-of-path}}} - (GreedyPathMatcher@26d5b948)
[stats] 5935 (total: 238847, max: 43, min: 39, avg: 40.244, stdDev: 0.99976 in 2563 contexts) - {fixed-step: {suffix: ~}, next: {end-of-path}} - (FixedStepPathMatcher@5292b28d)
[stats] 5935 (total: 238198, max: 44, min: 36, avg: 40.134, stdDev: 2.9622 in 2563 contexts) - {greedy next: {fixed-step: {match: .svn}, next: {anything}}} - (GreedyPathMatcher@5b9e992e)
[stats] 23072 (total: 236604, max: 91, min: 2, avg: 10.255, stdDev: 25.818 in 2141 contexts) - {artifactType=android-classes-jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.jvm.environment=standard-jvm, org.gradle.jvm.version=17, org.gradle.l
[stats] 23072 (total: 236604, max: 91, min: 2, avg: 10.255, stdDev: 25.818 in 2141 contexts) - {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.jvm.environment=standard-jvm, org.gradle.jvm.version=17, org.gradle.libraryelements=j
[stats] 57739 (total: 235055, max: 71, min: 2, avg: 4.0710, stdDev: 11.773 in 1733 contexts) - {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.jvm.version=17, org.gradle.libraryelements=jar, org.gradle.usage=java-api} - (Default
[stats] 57739 (total: 235055, max: 71, min: 2, avg: 4.0710, stdDev: 11.773 in 1733 contexts) - {artifactType=android-classes-jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.jvm.version=17, org.gradle.libraryelements=jar, org.gradle.usage=java
[stats] 2 (total: 232047, max: 232044, min: 3, avg: 1.1602E+5, stdDev: 116.02E+3) - file collection - (DefaultConfigurableFileCollection@4ec0efb4)
[stats] 5935 (total: 230304, max: 40, min: 37, avg: 38.804, stdDev: 1.4672 in 2563 contexts) - {greedy next: {fixed-step: {match: .DS_Store}, next: {end-of-path}}} - (GreedyPathMatcher@3167da02)
[stats] 5935 (total: 230304, max: 40, min: 37, avg: 38.804, stdDev: 1.4672 in 2563 contexts) - {greedy next: {fixed-step: {match: .cvsignore}, next: {end-of-path}}} - (GreedyPathMatcher@28474b79)
[stats] 5935 (total: 229495, max: 40, min: 36, avg: 38.668, stdDev: 1.6291 in 2563 contexts) - {greedy next: {fixed-step: {match: .hgsub}, next: {end-of-path}}} - (GreedyPathMatcher@179981bb)
[stats] 5935 (total: 228422, max: 44, min: 36, avg: 38.487, stdDev: 1.9967 in 2563 contexts) - {greedy next: {fixed-step: {match: .bzr}, next: {anything}}} - (GreedyPathMatcher@631a1d54)
[stats] 5935 (total: 228418, max: 44, min: 36, avg: 38.487, stdDev: 1.9955 in 2563 contexts) - {greedy next: {fixed-step: {match: .hg}, next: {anything}}} - (GreedyPathMatcher@163f5588)
[stats] 5934 (total: 228386, max: 44, min: 36, avg: 38.488, stdDev: 1.9966 in 2563 contexts) - {greedy next: {fixed-step: {match: SCCS}, next: {anything}}} - (GreedyPathMatcher@3083b42)
[stats] 3 (total: 223087, max: 111722, min: 2, avg: 74362, stdDev: 52581) - file collection - (DefaultConfigurableFileCollection@7d3bf0aa)
[stats] 3 (total: 223036, max: 111694, min: 3, avg: 74345, stdDev: 52568) - property 'testedVariantArtifacts$kotlin_gradle_plugin_common' - (DefaultProperty@3305cb8d)
[stats] 2 (total: 223020, max: 111685, min: 111335, avg: 1.1151E+5, stdDev: 175.0) - file collection - (@75362f2a)
[stats] 5935 (total: 222751, max: 40, min: 34, avg: 37.532, stdDev: 2.0627 in 2563 contexts) - {greedy next: {fixed-step: {match: .gitattributes}, next: {end-of-path}}} - (GreedyPathMatcher@4078baf2)
[stats] End of stats for Write
[stats] Stats for Load: 25693202
[stats] 2 - IncrementalModuleEntry(projectPath=:module03:module09:module1:module2, name=module2_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module03/module09/module1/module2/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module03/module09/module
[stats] 2 - IncrementalModuleEntry(projectPath=:module02:module31:module1, name=module1_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module02/module31/module1/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module02/module31/module1/build/kotlin/k
[stats] 2 - SelfDescribingSpec{description='Task is enabled'} - (SelfDescribingSpec@26142850)
[stats] 2 - IncrementalModuleEntry(projectPath=:module02:module37:module06:module2, name=module2_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module02/module37/module06/module2/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module02/module37/modu
[stats] 2 - task ':module02:module33:module1:validateSigningDebug' - (ValidateSigningTask_Decorated@78c18305)
[stats] 2 - SelfDescribingSpec{description='Task is enabled'} - (SelfDescribingSpec@52448911)
[stats] 2 - org.jetbrains.kotlin.gradle.plugin.SubpluginOption@6e850a13 - (SubpluginOption@6e850a13)
[stats] 2 - project :module15:module22:module1 - (DefaultProjectComponentIdentifier@66c58b15)
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module080:module2, name=module2_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module080/module2/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module080/module2/build/kotli
[stats] 2 - IncrementalModuleEntry(projectPath=:module07:module25, name=module25_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module07/module25/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module07/module25/build/kotlin/kaptGenerateStubsDebugKo
[stats] 2 - SelfDescribingSpec{description='Task is enabled'} - (SelfDescribingSpec@27b76edc)
[stats] 2 - :module06:module144:module1 - (Path@54993263)
[stats] 2 - :module06:module178:module6 - (Path@27468d18)
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module139, name=module139_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module139/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module139/build/kotlin/kaptGenerateStubsDeb
[stats] 2 - org.gradle.api.internal.artifacts.transform.ComponentVariantIdentifier@fc78f1c - (ComponentVariantIdentifier@fc78f1c)
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module007:module2, name=module2_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module007/module2/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module007/module2/build/kotli
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module181:module4, name=module4_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module181/module4/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module181/module4/build/kotli
[stats] 2 - org.gradle.language.java.internal.JavaLanguageServices$JavaProjectScopeServices$1@55830609 - (@55830609)
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module107:module3, name=module3_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module107/module3/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module107/module3/build/kotli
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module252, name=module252_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module252/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module252/build/kotlin/kaptGenerateStubsDeb
[stats] 2 - project :module06:module340:module1 - (DefaultProjectComponentIdentifier@6624488d)
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module327:module2, name=module2_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module327/module2/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module327/module2/build/kotli
[stats] 2 - IncrementalModuleEntry(projectPath=:module05:module09:module2, name=module2_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module05/module09/module2/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module05/module09/module2/build/kotlin/k
[stats] 2 - org.gradle.api.internal.artifacts.transform.ComponentVariantIdentifier@4ead5ab1 - (ComponentVariantIdentifier@4ead5ab1)
[stats] 2 - IncrementalModuleEntry(projectPath=:module07:module80:module2, name=module2_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module07/module80/module2/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module07/module80/module2/build/kotlin/k
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module238:module2, name=module2_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module238/module2/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module238/module2/build/kotli
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module306:module4, name=module4_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module306/module4/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module306/module4/build/kotli
[stats] 2 - :module06:module207 - (Path@7091223f)
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module093:module2, name=module2_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module093/module2/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module093/module2/build/kotli
[stats] 2 - JavaToolchain(javaHome=/Users/rafael/.sdkman/candidates/java/17.0.3-tem) - (JavaToolchain@5ed5ab51)
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module006:module2, name=module2_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module006/module2/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module006/module2/build/kotli
[stats] 2 - project :module15:module01:module1 - (DefaultProjectComponentIdentifier@1604080a)
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module274:module1, name=module1_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module274/module1/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module274/module1/build/kotli
[stats] 2 - IncrementalModuleEntry(projectPath=:module22:module01:module18, name=module18_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module22/module01/module18/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module22/module01/module18/build/kotl
[stats] 2 - IncrementalModuleEntry(projectPath=:module07:module20:module03:module4, name=module4_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module07/module20/module03/module4/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module07/module20/modu
[stats] 2 - IncrementalModuleEntry(projectPath=:module18:module2:module32:module3, name=module3_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module18/module2/module32/module3/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module18/module2/module3
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module297:module2, name=module2_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module297/module2/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module297/module2/build/kotli
[stats] 2 - :module06:module161:module1 - (Path@2af5ebd1)
[stats] 2 - IncrementalModuleEntry(projectPath=:module04:module12:module5, name=module5_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module04/module12/module5/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module04/module12/module5/build/kotlin/k
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module034:module2, name=module2_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module034/module2/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module034/module2/build/kotli
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module172:module2, name=module2_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module172/module2/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module172/module2/build/kotli
[stats] 2 - IncrementalModuleEntry(projectPath=:module02:module29, name=module29_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module02/module29/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module02/module29/build/kotlin/kaptGenerateStubsDebugKo
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module065:module1, name=module1_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module065/module1/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module065/module1/build/kotli
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module153:module3, name=module3_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module153/module3/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module153/module3/build/kotli
[stats] 2 - IncrementalModuleEntry(projectPath=:module09:module2, name=module2_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module09/module2/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module09/module2/build/kotlin/kaptGenerateStubsDebugKotlin
[stats] 2 - IncrementalModuleEntry(projectPath=:module19:module2:module6:module3, name=module3_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module19/module2/module6/module3/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module19/module2/module6/m
[stats] 2 - IncrementalModuleEntry(projectPath=:module18:module2:module29:module1, name=module1_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module18/module2/module29/module1/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module18/module2/module2
[stats] 2 - :module06:module342:module3 - (Path@394a9522)
[stats] 2 - property(org.jetbrains.kotlin.gradle.tasks.DefaultKotlinJavaToolchain, fixed(class org.jetbrains.kotlin.gradle.tasks.DefaultKotlinJavaToolchain_Decorated, org.jetbrains.kotlin.gradle.tasks.DefaultKotlinJavaToolchain_Decorated@7cce4c90)) - (DefaultProperty@9b366c5)
[stats] 2 - file collection - (DefaultConfigurableFileCollection@23468c9)
[stats] 2 - IncrementalModuleEntry(projectPath=:module02:module03, name=module03_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module02/module03/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module02/module03/build/kotlin/kaptGenerateStubsDebugKo
[stats] 2 - IncrementalModuleEntry(projectPath=:module18:module2:module29:module4, name=module4_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module18/module2/module29/module4/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module18/module2/module2
[stats] 2 - IncrementalModuleEntry(projectPath=:module07:module20:module11:module2:module1, name=module1_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module07/module20/module11/module2/module1/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module
[stats] 2 - IncrementalModuleEntry(projectPath=:module03:module01:module1:module1, name=module1_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module03/module01/module1/module1/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module03/module01/module
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module338:module2, name=module2_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module338/module2/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module338/module2/build/kotli
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module119:module1, name=module1_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module119/module1/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module119/module1/build/kotli
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module191:module4, name=module4_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module191/module4/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module191/module4/build/kotli
[stats] 2 - :module06:module009:module5 - (Path@6912243f)
[stats] 2 - :module06:module301:module4 - (Path@56d5ab4d)
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module119:module1, name=module1_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module119/module1/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module119/module1/build/kotli
[stats] 2 - IncrementalModuleEntry(projectPath=:module07:module41:module3, name=module3_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module07/module41/module3/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module07/module41/module3/build/kotlin/k
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module016:module3, name=module3_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module016/module3/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module016/module3/build/kotli
[stats] 2 - org.gradle.api.internal.artifacts.transform.ComponentVariantIdentifier@26040806 - (ComponentVariantIdentifier@26040806)
[stats] 2 - IncrementalModuleEntry(projectPath=:module05:module01:module12:module3, name=module3_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module05/module01/module12/module3/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module05/module01/modu
[stats] 2 - IncrementalModuleEntry(projectPath=:module01:module02, name=module02_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module01/module02/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module01/module02/build/kotlin/kaptGenerateStubsDebugKo
[stats] 2 - org.gradle.api.internal.artifacts.transform.ComponentVariantIdentifier@47efdfb5 - (ComponentVariantIdentifier@47efdfb5)
[stats] 2 - IncrementalModuleEntry(projectPath=:module07:module85, name=module85_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module07/module85/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module07/module85/build/kotlin/kaptGenerateStubsDebugKo
[stats] 2 - IncrementalModuleEntry(projectPath=:module22:module01:module12, name=module12_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module22/module01/module12/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module22/module01/module12/build/kotl
[stats] 2 - IncrementalModuleEntry(projectPath=:module07:module20:module12:module3:module2, name=module2_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module07/module20/module12/module3/module2/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module
[stats] 2 - com.google.dagger:dagger:2.28 - (DefaultModuleComponentIdentifier@3458b158)
[stats] 2 - IncrementalModuleEntry(projectPath=:module21:module07, name=module07_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module21/module07/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module21/module07/build/kotlin/kaptGenerateStubsDebugKo
[stats] 2 - IncrementalModuleEntry(projectPath=:module07:module40, name=module40_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module07/module40/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module07/module40/build/kotlin/kaptGenerateStubsDebugKo
[stats] 2 - IncrementalModuleEntry(projectPath=:module02:module36:module4, name=module4_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module02/module36/module4/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module02/module36/module4/build/kotlin/k
[stats] 2 - :module06:module094:module3 - (Path@2f66cd90)
[stats] 2 - IncrementalModuleEntry(projectPath=:module07:module59:module04:module1, name=module1_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module07/module59/module04/module1/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module07/module59/modu
[stats] 2 - :module15:module36:module1 - (Path@7274e9c8)
[stats] 2 - IncrementalModuleEntry(projectPath=:module07:module77:module6, name=module6_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module07/module77/module6/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module07/module77/module6/build/kotlin/k
[stats] 2 - IncrementalModuleEntry(projectPath=:module07:module02, name=module02_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module07/module02/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module07/module02/build/kotlin/kaptGenerateStubsDebugKo
[stats] 2 - IncrementalModuleEntry(projectPath=:module05:module01:module02:module4, name=module4_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module05/module01/module02/module4/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module05/module01/modu
[stats] 2 - IncrementalModuleEntry(projectPath=:module07:module79, name=module79_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module07/module79/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module07/module79/build/kotlin/kaptGenerateStubsDebugKo
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module076:module4, name=module4_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module076/module4/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module076/module4/build/kotli
[stats] 2 - file collection - (DefaultConfigurableFileCollection@50993258)
[stats] 2 - IncrementalModuleEntry(projectPath=:module07:module59:module04:module1, name=module1_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module07/module59/module04/module1/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module07/module59/modu
[stats] 2 - :module15:module35:module1 - (Path@57bf7ef1)
[stats] 2 - IncrementalModuleEntry(projectPath=:module01:module02, name=module02_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module01/module02/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module01/module02/build/kotlin/kaptGenerateStubsDebugKo
[stats] 2 - IncrementalModuleEntry(projectPath=:module04:module18:module3, name=module3_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module04/module18/module3/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module04/module18/module3/build/kotlin/k
[stats] 2 - IncrementalModuleEntry(projectPath=:module07:module69:module5, name=module5_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module07/module69/module5/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module07/module69/module5/build/kotlin/k
[stats] 2 - IncrementalModuleEntry(projectPath=:module22:module01:module22:module2, name=module2_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module22/module01/module22/module2/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module22/module01/modu
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module145:module5, name=module5_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module145/module5/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module145/module5/build/kotli
[stats] 2 - :module06:module003:module3 - (Path@7593263f)
[stats] 2 - IncrementalModuleEntry(projectPath=:module02:module43:module2, name=module2_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module02/module43/module2/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module02/module43/module2/build/kotlin/k
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module074:module7, name=module7_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module074/module7/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module074/module7/build/kotli
[stats] 2 - IncrementalModuleEntry(projectPath=:module07:module40, name=module40_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module07/module40/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module07/module40/build/kotlin/kaptGenerateStubsDebugKo
[stats] 2 - IncrementalModuleEntry(projectPath=:module18:module1:module24:module2, name=module2_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module18/module1/module24/module2/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module18/module1/module2
[stats] 2 - :module04:module12:module5 - (Path@9fbf7e1)
[stats] 2 - :module06:module123:module3 - (Path@66ddbb68)
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module161:module2, name=module2_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module161/module2/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module161/module2/build/kotli
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module073:module5, name=module5_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module073/module5/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module073/module5/build/kotli
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module017:module2, name=module2_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module017/module2/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module017/module2/build/kotli
[stats] 2 - IncrementalModuleEntry(projectPath=:module06:module027:module2, name=module2_debug, buildDir=/Users/rafael/sources/perf-android-large-2/module06/module027/module2/build, buildHistoryFile=/Users/rafael/sources/perf-android-large-2/module06/module027/module2/build/kotli
[stats] End of stats for Load
```