### PR TITLE
Add missing status to ExternalResourceReadBuildOperationType.Result

### DIFF
--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/internal/resource/ExternalResourceReadBuildOperationType.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/internal/resource/ExternalResourceReadBuildOperationType.java
@@ -42,6 +42,17 @@ public final class ExternalResourceReadBuildOperationType implements BuildOperat
          */
         long getBytesRead();
 
+        /**
+         * Whether the resource is missing.
+         * <p>
+         * Missing means that the resource does not exist.
+         * For example, for an HTTP resource, a 404 response would mean that the resource is missing.
+         * See {@code org.gradle.api.resources.MissingResourceException}
+         *
+         * @since 8.11
+         */
+        boolean isMissing();
+
     }
 
     private ExternalResourceReadBuildOperationType() {

--- a/platforms/ide/tooling-api-builders/build.gradle.kts
+++ b/platforms/ide/tooling-api-builders/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
     implementation(projects.coreApi)
     implementation(projects.dependencyManagement)
     implementation(projects.launcher)
-    implementation(projects.resources)
     implementation(projects.testingBase)
     implementation(projects.testingJvm)
     implementation(projects.workers)

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/FileDownloadOperationMapper.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/FileDownloadOperationMapper.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.internal.provider.runner;
 
-import org.gradle.api.resources.MissingResourceException;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.build.event.BuildEventSubscriptions;
 import org.gradle.internal.build.event.types.AbstractOperationResult;
@@ -93,11 +92,11 @@ public class FileDownloadOperationMapper implements BuildOperationMapper<Externa
 
     @Nonnull
     private static AbstractOperationResult createFileDownloadResult(ExternalResourceReadBuildOperationType.Result operationResult, Throwable failure, long startTime, long endTime) {
+        if (operationResult.isMissing()) {
+            return new NotFoundFileDownloadSuccessResult(startTime, endTime);
+        }
         if (failure == null) {
             return new DefaultFileDownloadSuccessResult(startTime, endTime, operationResult.getBytesRead());
-        }
-        if (failure instanceof MissingResourceException) {
-            return new NotFoundFileDownloadSuccessResult(startTime, endTime);
         }
         return new DefaultFileDownloadFailureResult(startTime, endTime, singletonList(DefaultFailure.fromThrowable(failure)), operationResult.getBytesRead());
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyDownloadBuildOperationsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyDownloadBuildOperationsIntegrationTest.groovy
@@ -64,8 +64,10 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
         downloadOps.size() == 2
         downloadOps[0].details.location == m.pom.uri.toString()
         downloadOps[0].result.bytesRead == m.pom.file.length()
+        !downloadOps[0].result.missing
         downloadOps[1].details.location == m.artifact.uri.toString()
         downloadOps[1].result.bytesRead == m.artifact.file.length()
+        !downloadOps[0].result.missing
 
         // TODO - should have an event for graph resolution as well
 
@@ -153,8 +155,10 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
         downloadOps.size() == 4
         downloadOps[0].details.location == missing.rootMetaData.uri.toString()
         downloadOps[0].result.bytesRead == 0
+        downloadOps[0].result.missing
         downloadOps[1].details.location == m.rootMetaData.uri.toString()
         downloadOps[1].result.bytesRead == 0
+        downloadOps[1].result.missing
         downloadOps[2].details.location == m.pom.uri.toString()
         downloadOps[2].result.bytesRead == m.pom.file.length()
         downloadOps[3].details.location == m.artifact.uri.toString()
@@ -189,10 +193,12 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def downloadOps2 = buildOperations.all(ExternalResourceReadBuildOperationType)
         downloadOps2.size() == 2
-        downloadOps[0].details.location == missing.rootMetaData.uri.toString()
-        downloadOps[0].result.bytesRead == 0
-        downloadOps[1].details.location == m.rootMetaData.uri.toString()
-        downloadOps[1].result.bytesRead == 0
+        downloadOps2[0].details.location == missing.rootMetaData.uri.toString()
+        downloadOps2[0].result.bytesRead == 0
+        downloadOps2[0].result.missing
+        downloadOps2[1].details.location == m.rootMetaData.uri.toString()
+        downloadOps2[1].result.bytesRead == 0
+        downloadOps2[1].result.missing
 
         def artifactsOps2 = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps2.size() == 1
@@ -245,10 +251,13 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
         downloadOps.size() == 3
         downloadOps[0].details.location == m.rootMetaData.uri.toString()
         downloadOps[0].result.bytesRead == 0
+        downloadOps[0].result.missing
         downloadOps[1].details.location == m.pom.uri.toString()
         downloadOps[1].result.bytesRead == m.pom.file.length()
+        !downloadOps[1].result.missing
         downloadOps[2].details.location == m.artifact.uri.toString()
         downloadOps[2].result.bytesRead == m.artifact.file.length()
+        !downloadOps[2].result.missing
 
         def listOps = buildOperations.all(ExternalResourceListBuildOperationType)
         listOps.size() == 1
@@ -279,6 +288,7 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
         downloadOps2.size() == 1
         downloadOps2[0].details.location == m.rootMetaData.uri.toString()
         downloadOps2[0].result.bytesRead == 0
+        downloadOps2[0].result.missing
 
         def artifactsOps2 = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps2.size() == 1
@@ -324,8 +334,10 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
         downloadOps.size() == 2
         downloadOps[0].details.location == m.pom.uri.toString()
         downloadOps[0].result.bytesRead == m.pom.file.length()
+        !downloadOps[0].result.missing
         downloadOps[1].details.location == m.artifact.uri.toString()
         downloadOps[1].result.bytesRead == m.artifact.file.length()
+        !downloadOps[1].result.missing
 
         def artifactsOps = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps.size() == 3

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resource/transfer/ResourceOperation.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resource/transfer/ResourceOperation.java
@@ -24,7 +24,7 @@ import static org.gradle.internal.util.NumberUtil.formatBytes;
 public class ResourceOperation {
     public enum Type {
         download,
-        upload;
+        upload
     }
 
     private final BuildOperationContext context;


### PR DESCRIPTION
So the Develocity plugin and the TAPI doesn't need to look at the exception type.