### PR TITLE
Antlr plugin: Add antlrTool config to replace antlr config

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/core-plugins/antlr_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/core-plugins/antlr_plugin.adoc
@@ -78,6 +78,8 @@ ANTLR grammar files for the given source set.
 [[sec:antlr_dependency_management]]
 == Dependency management
 
+TODO: Rewrite this section once it is decided whether the `antlr` configuration will be planned for removal
+
 The ANTLR plugin adds an `antlr` dependency configuration which provides the ANTLR implementation to use. The following example shows how to use ANTLR version 3.
 
 .Declare ANTLR version

--- a/platforms/documentation/docs/src/snippets/antlr/useAntlrPlugin/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/antlr/useAntlrPlugin/groovy/build.gradle
@@ -10,8 +10,10 @@ repositories {
 }
 
 dependencies {
-    antlr "org.antlr:antlr:3.5.2" // use ANTLR version 3
-    // antlr "org.antlr:antlr4:4.5" // use ANTLR version 4
+    antlrTool "org.antlr:antlr:3.5.2"     // use ANTLR version 3
+    api "org.antlr:antlr-runtime:3.5.2"
+    // antlrTool "org.antlr:antlr4:4.5"   // use ANTLR version 4
+    // api "org.antlr:antlr4-runtime:4.5"
 // end::declare-dependency[]
     testImplementation 'junit:junit:4.13'
 // tag::declare-dependency[]

--- a/platforms/documentation/docs/src/snippets/antlr/useAntlrPlugin/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/antlr/useAntlrPlugin/kotlin/build.gradle.kts
@@ -10,8 +10,10 @@ repositories {
 }
 
 dependencies {
-    antlr("org.antlr:antlr:3.5.2")   // use ANTLR version 3
-    // antlr("org.antlr:antlr4:4.5") // use ANTLR version 4
+    antlrTool("org.antlr:antlr:3.5.2")     // use ANTLR version 3
+    api("org.antlr:antlr-runtime:3.5.2")
+    // antlrTool("org.antlr:antlr4:4.5")   // use ANTLR version 4
+    // api("org.antlr:antlr4-runtime:4.5")
 // end::declare-dependency[]
     testImplementation("junit:junit:4.13")
 // tag::declare-dependency[]

--- a/platforms/software/antlr/build.gradle.kts
+++ b/platforms/software/antlr/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     api(libs.inject)
 
     implementation(projects.baseServices)
+    implementation(projects.loggingApi)
     implementation(projects.platformJvm)
     implementation(projects.pluginsJavaBase)
     implementation(projects.pluginsJavaLibrary)

--- a/platforms/software/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/Antlr2PluginIntegrationTest.groovy
+++ b/platforms/software/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/Antlr2PluginIntegrationTest.groovy
@@ -61,6 +61,22 @@ class Antlr2PluginIntegrationTest extends AbstractAntlrIntegrationTest {
         assertGrammarSourceGenerated("UnpackagedGrammar")
     }
 
+    def "works using antlrTool instead of antlr"() {
+        buildFile.text = buildFile.text.replace("antlr '$antlrDependency'", "antlrTool '$antlrDependency'\n    api '$antlrDependency'")
+
+        goodGrammar()
+        goodProgram()
+
+        expect:
+        succeeds("generateGrammarSource")
+        assertAntlrVersion(2)
+        assertGrammarSourceGenerated("org/acme/TestGrammar")
+        assertGrammarSourceGenerated("org/acme/AnotherGrammar")
+        assertGrammarSourceGenerated("UnpackagedGrammar")
+
+        succeeds("build")
+    }
+
     private goodGrammar() {
         file("grammar-builder/src/main/antlr/TestGrammar.g") << """
             header {

--- a/platforms/software/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/Antlr3PluginIntegrationTest.groovy
+++ b/platforms/software/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/Antlr3PluginIntegrationTest.groovy
@@ -18,10 +18,27 @@ package org.gradle.api.plugins.antlr
 class Antlr3PluginIntegrationTest extends AbstractAntlrIntegrationTest {
 
     String antlrDependency = "org.antlr:antlr:3.5.2"
+    String runtimeDependency = "org.antlr:antlr-runtime:3.5.2"
 
     def "analyze good grammar"() {
         goodGrammar()
         goodProgram()
+        expect:
+        succeeds("generateGrammarSource")
+
+        assertGrammarSourceGenerated("AnotherGrammar")
+        assertGrammarSourceGenerated("org/acme/test/Test")
+        assertAntlrVersion(3)
+
+        succeeds("build")
+    }
+
+    def "works using antlrTool instead of antlr"() {
+        buildFile.text = buildFile.text.replace("antlr '$antlrDependency'", "antlrTool '$antlrDependency'\n    api '$runtimeDependency'")
+
+        goodGrammar()
+        goodProgram()
+
         expect:
         succeeds("generateGrammarSource")
 

--- a/platforms/software/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/Antlr4PluginIntegrationTest.groovy
+++ b/platforms/software/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/Antlr4PluginIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.plugins.antlr
 class Antlr4PluginIntegrationTest extends AbstractAntlrIntegrationTest {
 
     String antlrDependency = "org.antlr:antlr4:4.3"
+    String runtimeDependency = "org.antlr:antlr4-runtime:4.3"
 
     def "analyze good grammar"() {
         goodGrammar()
@@ -27,6 +28,22 @@ class Antlr4PluginIntegrationTest extends AbstractAntlrIntegrationTest {
         assertGrammarSourceGenerated("org/acme/Test")
         assertGrammarSourceGenerated("Another")
         assertAntlrVersion(4)
+        succeeds("build")
+    }
+
+    def "works using antlrTool instead of antlr"() {
+        buildFile.text = buildFile.text.replace("antlr '$antlrDependency'", "antlrTool '$antlrDependency'\n    api '$runtimeDependency'")
+
+        goodGrammar()
+        goodProgram()
+
+        expect:
+        succeeds("generateGrammarSource")
+
+        assertGrammarSourceGenerated("org/acme/Test")
+        assertGrammarSourceGenerated("Another")
+        assertAntlrVersion(4)
+
         succeeds("build")
     }
 

--- a/platforms/software/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java
+++ b/platforms/software/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java
@@ -17,6 +17,7 @@
 package org.gradle.api.plugins.antlr;
 
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -32,6 +33,7 @@ import org.gradle.api.tasks.SourceSet;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * A plugin for adding Antlr support to {@link org.gradle.api.plugins.JavaPlugin java projects}.
@@ -40,7 +42,29 @@ import java.io.File;
  */
 @SuppressWarnings("JavadocReference")
 public abstract class AntlrPlugin implements Plugin<Project> {
+    /**
+     * Adding a dependency to the antlr configuration will add it both to the classpath used for ANTLR code generation
+     * and to the project's api classpath (meaning code generation libraries will leak into the runtime classpath). It
+     * is generally preferable to use the antlrTool classpath.
+     */
     public static final String ANTLR_CONFIGURATION_NAME = "antlr";
+    /**
+     * The antlrTool configuration is where users should add the antlr library used for running ANTLR code generation.
+     * When using it, the corresponding runtime library for ANTLR (antlr for ANTLR 2, antlr-runtime for ANTLR 3, or
+     * antlr4-runtime for ANTLR 4) should be added as an api or implementation dependency.
+     *
+     * @since 8.11
+     */
+    @Incubating
+    public static final String ANTLR_TOOL_CONFIGURATION_NAME = "antlrTool";
+    /**
+     * The antlrToolClasspath configuration is the resolvable counterpart of antlrTool.
+     *
+     * @since 8.11
+     */
+    @Incubating
+    public static final String ANTLR_TOOL_CLASSPATH_CONFIGURATION_NAME = "antlrToolClasspath";
+    private static final String DEFAULT_ANTLR_ARTIFACT_COORDINATES = "antlr:antlr:2.7.7@jar";
     private final ObjectFactory objectFactory;
 
     @Inject
@@ -53,18 +77,35 @@ public abstract class AntlrPlugin implements Plugin<Project> {
     public void apply(final Project project) {
         project.getPluginManager().apply(JavaLibraryPlugin.class);
 
-        // set up a configuration named 'antlr' for the user to specify the antlr libs to use in case
-        // they want a specific version etc.
         final Configuration antlrConfiguration = ((ProjectInternal) project).getConfigurations().resolvableDependencyScopeUnlocked(ANTLR_CONFIGURATION_NAME)
             .setVisible(false);
+        final Configuration antlrToolConfiguration = ((ProjectInternal) project).getConfigurations().dependencyScope(ANTLR_TOOL_CONFIGURATION_NAME).get();
+        final Configuration antlrToolClasspathConfiguration = ((ProjectInternal) project).getConfigurations().resolvable(ANTLR_TOOL_CLASSPATH_CONFIGURATION_NAME).get();
 
-        antlrConfiguration.defaultDependencies(dependencies -> dependencies.add(project.getDependencies().create("antlr:antlr:2.7.7@jar")));
+        // Support people using the deprecated antlr configuration
+        antlrToolConfiguration.extendsFrom(antlrConfiguration);
+        antlrToolClasspathConfiguration.extendsFrom(antlrToolConfiguration);
+
+        AtomicBoolean hasWarnedAboutLegacyConf = new AtomicBoolean(false);
+        antlrConfiguration.getDependencies().configureEach(_dependency -> {
+            if (!hasWarnedAboutLegacyConf.getAndSet(true)) {
+                project.getLogger().warn("TODO write warning: Used the antlr configuration, should change that to antlrTool");
+            }
+        });
+
+        antlrConfiguration.defaultDependencies(dependencies -> {
+            if (antlrToolConfiguration.getDependencies().isEmpty()) {
+                project.getLogger().warn("TODO write warning: Used the default 2.7.7 version of antlr, should add explicit dependencies");
+                hasWarnedAboutLegacyConf.set(true);
+                dependencies.add(project.getDependencies().create(DEFAULT_ANTLR_ARTIFACT_COORDINATES));
+            }
+        });
 
         Configuration apiConfiguration = project.getConfigurations().getByName(JvmConstants.API_CONFIGURATION_NAME);
         apiConfiguration.extendsFrom(antlrConfiguration);
 
-        // Wire the antlr configuration into all antlr tasks
-        project.getTasks().withType(AntlrTask.class).configureEach(antlrTask -> antlrTask.getConventionMapping().map("antlrClasspath", () -> project.getConfigurations().getByName(ANTLR_CONFIGURATION_NAME)));
+        // Wire the antlrToolClasspath configuration into all antlr tasks
+        project.getTasks().withType(AntlrTask.class).configureEach(antlrTask -> antlrTask.getConventionMapping().map("antlrClasspath", () -> project.getConfigurations().getByName(ANTLR_TOOL_CLASSPATH_CONFIGURATION_NAME)));
 
         project.getExtensions().getByType(JavaPluginExtension.class).getSourceSets().all(
             new Action<SourceSet>() {


### PR DESCRIPTION
This is to address #820, i.e. the fact that the antlr plugin unnecessarily adds code generation jars to the project's runtime dependencies.

This adds new configurations `antlrTool` (for adding dependencies) and `antlrToolClasspath` (for resolving those dependencies). Adding an ANTLR library to `antlrTool` will _not_ add that library as a compile or runtime dependency; instead, users can depend on the corresponding runtime library using `api` or `implementation` as desired.

Users using the `antlr` configuration -- or not declaring any `antlr` dependency and using the default 2.7.7 dependency -- will have their builds continue to work as before, but will receive warnings encouraging them to move to the new approach.

**Feedback needed from the Gradle team before this PR can be finalized:** With the new approach, would it be a good idea to mark the `antlr` configuration as deprecated and expected to be removed in the next major version? Does that work for this PR timing-wise? I have held off on writing the warning messages (e.g. figuring out if I should use DeprecationLogger) and documentation changes until I know what can be done here. (Also, I don't know if I should mark the new string constants as `@Incubating` as the binary compatibility check recommends.)

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
To summarize #820: The antlr plugin uses the `antlr` configuration in two ways: 1) to define the classpath used when running ANTLR's code generation at build time, and 2) as a compile and runtime dependency for the generated code. This made sense for ANTLR 2, where the required library was the same, but ANTLR 3 and 4 have runtime libraries that are significantly smaller than what is used for code generation.

There has been [a workaround](https://github.com/gradle/gradle/issues/820#issuecomment-288838412) known for years, but it requires a moderate level of Gradle knowledge and has mostly been distributed via that GitHub issue.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes. _(AL: Waiting for feedback on how much the old configuration can be deprecated)_
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
