### PR TITLE
Fix flaky RichConsoleBuildResultReportingFunctionalTest

### DIFF
--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractConsoleBuildResultFunctionalTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractConsoleBuildResultFunctionalTest.groovy
@@ -92,9 +92,7 @@ BUILD SUCCESSFUL in [ \\dms]+
         succeeds('success')
 
         then:
-        result.plainTextOutput.matches """(?s).*build finished
-
-BUILD SUCCESSFUL in [ \\dms]+
+        result.plainTextOutput.matches """(?s).*build finished.*BUILD SUCCESSFUL in [ \\dms]+
 1 actionable task: 1 executed
 .*"""
     }


### PR DESCRIPTION
There might be extra texts output between "build finished" message and "BUILD SUCCESSFUL" marker. Refine the regex to catch such cases.

[Example](https://ge.gradle.org/s/g6ckko5wr547g/tests/task/:logging:embeddedIntegTest/details/org.gradle.internal.logging.console.taskgrouping.rich.RichConsoleBuildResultReportingFunctionalTest/outcome%20for%20successful%20build%20is%20logged%20after%20user%20logic%20has%20completed%20console%20attached%20to%20both%20stdout%20and%20stderr?top-execution=3): 

```
build finished

Problems report is available at: file:///C:/tcagent1/work/f63322e10dd6b396/platforms/core-runtime/logging/build/tmp/test%20files/RichConsole.Test/o1mn5/build/reports/problems/problem-report.html |  

BUILD SUCCESSFUL
```