### PR TITLE
Add glossary to single page user manual

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/userguide_single.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/userguide_single.adoc
@@ -136,7 +136,7 @@ include::scala_plugin.adoc[leveloffset=+2]
 [[part:dependency_management]]
 == **WORKING WITH DEPENDENCIES**
 
-include::dependency_management_terminology.adoc[leveloffset=+2]
+include::glossary.adoc[leveloffset=+2]
 
 == THE BASICS
 


### PR DESCRIPTION
Before a redirect to the glossary was added (via http-equiv meta tag) which at least in firefox lead to an immediate redirect to the glossary page. Therefore the single html user manual was not viewable.


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
