### PR TITLE
Deprecate Gradle.useLogger

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradle.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradle.kt
@@ -41,12 +41,12 @@ import org.gradle.api.plugins.ObjectConfigurationAction
 import org.gradle.api.plugins.PluginContainer
 import org.gradle.api.services.BuildServiceRegistry
 import org.gradle.configuration.ConfigurationTargetIdentifier
-import org.gradle.internal.extensions.core.serviceOf
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal
 import org.gradle.initialization.SettingsState
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.build.PublicBuildPath
 import org.gradle.internal.composite.IncludedBuildInternal
+import org.gradle.internal.extensions.core.serviceOf
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.util.Path
 import java.io.File
@@ -284,6 +284,8 @@ class CrossProjectConfigurationReportingGradle private constructor(
         // already reported as configuration cache problem, no need to override
         delegate.addBuildListener(buildListener)
 
+    @Suppress("DEPRECATION")
+    @Deprecated("Deprecated in Java")
     override fun useLogger(logger: Any) =
         delegate.useLogger(logger)
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
@@ -25,7 +25,10 @@ import org.gradle.api.internal.SettingsInternal.BUILD_SRC
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.provider.ConfigurationTimeBarrier
 import org.gradle.api.internal.tasks.execution.TaskExecutionAccessListener
+import org.gradle.execution.ExecutionAccessListener
 import org.gradle.internal.cc.impl.InputTrackingState
+import org.gradle.internal.cc.impl.Workarounds.canAccessConventions
+import org.gradle.internal.cc.impl.isSupportedListener
 import org.gradle.internal.configuration.problems.DocumentationSection
 import org.gradle.internal.configuration.problems.DocumentationSection.RequirementsBuildListeners
 import org.gradle.internal.configuration.problems.DocumentationSection.RequirementsExternalProcess
@@ -34,8 +37,6 @@ import org.gradle.internal.configuration.problems.ProblemFactory
 import org.gradle.internal.configuration.problems.ProblemsListener
 import org.gradle.internal.configuration.problems.PropertyTrace
 import org.gradle.internal.configuration.problems.StructuredMessage
-import org.gradle.internal.cc.impl.Workarounds.canAccessConventions
-import org.gradle.execution.ExecutionAccessListener
 import org.gradle.internal.execution.WorkExecutionTracker
 import org.gradle.internal.service.scopes.ListenerService
 import org.gradle.internal.service.scopes.Scope
@@ -151,7 +152,7 @@ class DefaultConfigurationCacheProblemsListener internal constructor(
     }
 
     override fun onBuildScopeListenerRegistration(listener: Any, invocationDescription: String, invocationSource: Any) {
-        if (isBuildSrcBuild(invocationSource)) {
+        if (isBuildSrcBuild(invocationSource) || isSupportedListener(listener)) {
             return
         }
         problems.onProblem(

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginTemplatesTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginTemplatesTest.kt
@@ -126,7 +126,7 @@ class PrecompiledScriptPluginTemplatesTest : AbstractPrecompiledScriptPluginTest
             "my-gradle-script.init.gradle.kts",
             """
 
-            useLogger("my-logger")
+            addListener("my-logger")
 
             """
         )
@@ -140,7 +140,7 @@ class PrecompiledScriptPluginTemplatesTest : AbstractPrecompiledScriptPluginTest
             )
         )
 
-        verify(gradle).useLogger("my-logger")
+        verify(gradle).addListener("my-logger")
     }
 
     @Test

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginTemplatesTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginTemplatesTest.kt
@@ -126,7 +126,7 @@ class PrecompiledScriptPluginTemplatesTest : AbstractPrecompiledScriptPluginTest
             "my-gradle-script.init.gradle.kts",
             """
 
-            addListener("my-logger")
+            addListener("my-listener")
 
             """
         )
@@ -140,7 +140,7 @@ class PrecompiledScriptPluginTemplatesTest : AbstractPrecompiledScriptPluginTest
             )
         )
 
-        verify(gradle).addListener("my-logger")
+        verify(gradle).addListener("my-listener")
     }
 
     @Test

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/GradleDelegate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/GradleDelegate.kt
@@ -144,6 +144,8 @@ abstract class GradleDelegate : Gradle {
     override fun removeListener(listener: Any) =
         delegate.removeListener(listener)
 
+    @Suppress("DEPRECATION")
+    @Deprecated("Will be removed in Gradle 9. Logging customization through listeners is no longer supported.")
     override fun useLogger(logger: Any) =
         delegate.useLogger(logger)
 

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/BuildOutcomeReportingBuildActionRunner.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/BuildOutcomeReportingBuildActionRunner.java
@@ -17,6 +17,7 @@
 package org.gradle.launcher.exec;
 
 import org.gradle.StartParameter;
+import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.tasks.execution.statistics.TaskExecutionStatisticsEventAdapter;
 import org.gradle.api.logging.Logging;
 import org.gradle.initialization.BuildRequestMetaData;
@@ -60,12 +61,17 @@ public class BuildOutcomeReportingBuildActionRunner implements BuildActionRunner
 
         BuildLogger buildLogger = buildLoggerFactory.create(Logging.getLogger(BuildLogger.class), startParameter, buildStartedTime, buildRequestMetaData);
         // Register as a 'logger' to support this being replaced by build logic.
-        buildController.beforeBuild(gradle -> gradle.useLogger(buildLogger));
+        buildController.beforeBuild(gradle -> callUseLogger(gradle, buildLogger));
 
         Result result = delegate.run(action, buildController);
 
         buildLogger.logResult(result.getBuildFailure());
         new TaskExecutionStatisticsReporter(styledTextOutputFactory).buildFinished(taskStatisticsCollector.getStatistics());
         return result;
+    }
+
+    @SuppressWarnings("deprecation")
+    private static void callUseLogger(GradleInternal gradle, BuildLogger logger) {
+        gradle.useLogger(logger);
     }
 }

--- a/platforms/core-runtime/logging/src/integTest/resources/org/gradle/internal/logging/LoggingIntegrationTest/logging/custom-logger-init.gradle
+++ b/platforms/core-runtime/logging/src/integTest/resources/org/gradle/internal/logging/LoggingIntegrationTest/logging/custom-logger-init.gradle
@@ -2,7 +2,8 @@ if (gradle.parent == null) {
     useLogger(new CustomLogger())
 }
 
-class CustomLogger extends BuildAdapter implements BuildListener, ProjectEvaluationListener, TaskExecutionListener, TaskActionListener {
+// InternalListener suppresses deprecation warnings which mess up the test
+class CustomLogger extends BuildAdapter implements BuildListener, ProjectEvaluationListener, TaskExecutionListener, TaskActionListener, org.gradle.internal.InternalListener {
     def logger = Logging.getLogger('init-script')
 
     public void buildFinished(BuildResult result) {

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/logging.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/logging.adoc
@@ -166,6 +166,8 @@ Any log messages your build classes write using these logging toolkits will be r
 
 [WARNING]
 ====
+This feature is deprecated and will be removed in the next major version without a replacement.
+
 The <<configuration_cache.adoc#config_cache,configuration cache>> limits the ability to customize Gradle's logging UI.
 The custom logger can only implement <<configuration_cache.adoc#config_cache:requirements:build_listeners,supported listener interfaces>>.
 These interfaces do not receive events when the configuration cache entry is reused because the configuration phase is skipped.

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -224,6 +224,15 @@ link:{javadocPath}/org/gradle/api/artifacts/ConfigurationContainer.html#detached
 
 This behavior has been deprecated and will become an error in Gradle 9.0.
 
+[[deprecated_use_logger]]
+==== Deprecated customized Gradle logging
+
+The link:{javadocPath}/org/gradle/api/invocation/Gradle.html#useLogger(java.lang.Object)[Gradle#useLogger(Object)] method has been deprecated and will be removed in Gradle 9.0.
+
+This method was originally intended to customize logs printed by Gradle.
+However, it only allows intercepting a subset of the logs and cannot work with the <<configuration_cache#config_cache:requirements:build_listeners,configuration cache>>.
+We do not plan to introduce a replacement for this feature.
+
 [[changes_8.10]]
 == Upgrading from 8.9 and earlier
 

--- a/platforms/documentation/docs/src/snippets/initScripts/customLogger/tests-groovy/customLogger.groovy.sample.conf
+++ b/platforms/documentation/docs/src/snippets/initScripts/customLogger/tests-groovy/customLogger.groovy.sample.conf
@@ -1,3 +1,5 @@
 executable: gradle
 args: "build --init-script=customLogger.init.gradle"
+# Customizing logging is deprecated
+flags: "--warning-mode=none"
 expected-output-file: customLogger.out

--- a/platforms/documentation/docs/src/snippets/initScripts/customLogger/tests-kotlin/customLogger.kotlin.sample.conf
+++ b/platforms/documentation/docs/src/snippets/initScripts/customLogger/tests-kotlin/customLogger.kotlin.sample.conf
@@ -1,3 +1,6 @@
 executable: gradle
 args: "build --init-script=customLogger.init.gradle.kts"
+# Customizing logging is deprecated
+flags: "--warning-mode=none"
 expected-output-file: customLogger.out
+allow-additional-output: true

--- a/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
@@ -352,7 +352,9 @@ public interface Gradle extends PluginAware, ExtensionAware {
      * provides with your own implementation, for certain types of events.
      *
      * @param logger The logger to use.
+     * @deprecated Will be removed in Gradle 9. Logging customization through listeners is no longer supported.
      */
+    @Deprecated
     void useLogger(Object logger);
 
     /**


### PR DESCRIPTION
The deprecation warning is emitted unconditionally, even when the same call site triggers a configuration cache problem. This is done for consistency and to highlight that the method is going to be removed soon by linking the upgrade guide.

The implementation of useLogger delegates emitting the warning to the DeprecatedFeaturesListener to keep all deprecation logic in one place.
