### PR TITLE
Skip serializing ResolutionResult if requested for consistent resolution

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -872,6 +872,12 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
             return Stream.empty();
         }
         assertThatConsistentResolutionIsPropertyConfigured();
+
+        // Hint to the configuration we are about to resolve that we will be immediately
+        // reading its resolution result. It should not serialize the result since reading
+        // it would immediately cause it to be deserialized.
+        consistentResolutionSource.getResolutionStrategy().skipResolvedGraphSerialization();
+
         return consistentResolutionSource.getIncoming()
             .getResolutionResult()
             .getAllComponents()

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyInternal.java
@@ -114,4 +114,15 @@ public interface ResolutionStrategyInternal extends ResolutionStrategy {
     void setIncludeAllSelectableVariantResults(boolean selectableVariantResults);
 
     boolean getIncludeAllSelectableVariantResults();
+
+    /**
+     * To be called whenever we know the resolved graph will be consumed, and therefore
+     * to skip serializing it -- as we know it will be immediately deserialized.
+     */
+    void skipResolvedGraphSerialization();
+
+    /**
+     * @see #skipResolvedGraphSerialization()
+     */
+    boolean shouldSkipResolvedGraphSerialization();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -208,7 +208,8 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         localComponentsVisitor.complete(ConfigurationInternal.InternalState.BUILD_DEPENDENCIES_RESOLVED);
 
         Set<UnresolvedDependency> unresolvedDependencies = failureCollector.complete(Collections.emptySet());
-        VisitedGraphResults graphResults = new DefaultVisitedGraphResults(resolutionResultBuilder.getResolutionResult(), unresolvedDependencies, null);
+        MinimalResolutionResult resolutionResult = resolutionResultBuilder.getResolutionResult(Collections.emptySet());
+        VisitedGraphResults graphResults = new DefaultVisitedGraphResults(resolutionResult, unresolvedDependencies, null);
 
         ResolutionHost resolutionHost = resolveContext.getResolutionHost();
         ArtifactVariantSelector artifactVariantSelector = artifactVariantSelectorFor(resolveContext);
@@ -237,10 +238,16 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         DefaultResolvedConfigurationBuilder oldModelBuilder = new DefaultResolvedConfigurationBuilder(oldTransientModelBuilder);
         ResolvedConfigurationDependencyGraphVisitor oldModelVisitor = new ResolvedConfigurationDependencyGraphVisitor(oldModelBuilder);
 
-        BinaryStore newModelStore = stores.nextBinaryStore();
-        Store<ResolvedComponentResultInternal> newModelCache = stores.newModelCache();
         ResolutionStrategyInternal resolutionStrategy = resolveContext.getResolutionStrategy();
-        StreamingResolutionResultBuilder newModelBuilder = new StreamingResolutionResultBuilder(newModelStore, newModelCache, attributeContainerSerializer, componentResultSerializer, componentSelectionDescriptorFactory, resolutionStrategy.getIncludeAllSelectableVariantResults());
+
+        ResolutionResultGraphVisitor resolutionResultVisitor;
+        if (resolutionStrategy.shouldSkipResolvedGraphSerialization()) {
+            resolutionResultVisitor = new InMemoryResolutionResultBuilder(resolutionStrategy.getIncludeAllSelectableVariantResults());
+        } else {
+            BinaryStore newModelStore = stores.nextBinaryStore();
+            Store<ResolvedComponentResultInternal> newModelCache = stores.newModelCache();
+            resolutionResultVisitor = new StreamingResolutionResultBuilder(newModelStore, newModelCache, attributeContainerSerializer, componentResultSerializer, componentSelectionDescriptorFactory, resolutionStrategy.getIncludeAllSelectableVariantResults());
+        }
 
         ResolvedLocalComponentsResultGraphVisitor localComponentsVisitor = new ResolvedLocalComponentsResultGraphVisitor(currentBuild, projectStateRegistry);
 
@@ -249,7 +256,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         ResolutionFailureCollector failureCollector = new ResolutionFailureCollector(componentSelectorConverter);
 
         ImmutableList.Builder<DependencyGraphVisitor> graphVisitors = ImmutableList.builder();
-        graphVisitors.add(newModelBuilder);
+        graphVisitors.add(resolutionResultVisitor);
         graphVisitors.add(localComponentsVisitor);
         graphVisitors.add(failureCollector);
 
@@ -297,7 +304,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         Set<Throwable> nonFatalFailures = nonFatalFailuresBuilder.build();
         Set<UnresolvedDependency> resolutionFailures = failureCollector.complete(lockingFailures);
 
-        MinimalResolutionResult resolutionResult = newModelBuilder.getResolutionResult(lockingFailures);
+        MinimalResolutionResult resolutionResult = resolutionResultVisitor.getResolutionResult(lockingFailures);
         Optional<? extends ResolveException> failure = resolutionHost.consolidateFailures("dependencies", nonFatalFailures);
         VisitedGraphResults graphResults = new DefaultVisitedGraphResults(resolutionResult, resolutionFailures, failure.orElse(null));
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/InMemoryResolutionResultBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/InMemoryResolutionResultBuilder.java
@@ -16,12 +16,12 @@
 
 package org.gradle.api.internal.artifacts.ivyservice;
 
+import org.gradle.api.artifacts.UnresolvedDependency;
 import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
-import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphComponent;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphEdge;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphVariant;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ResolutionResultGraphBuilder;
@@ -29,22 +29,25 @@ import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
 import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Dependency graph visitor that will build a {@link ResolutionResult} eagerly.
- * It is designed to be used during resolution for build dependencies.
- *
- * @see DefaultConfigurationResolver#resolveBuildDependencies(ResolveContext)
  */
-public class InMemoryResolutionResultBuilder implements DependencyGraphVisitor {
+public class InMemoryResolutionResultBuilder implements ResolutionResultGraphVisitor {
 
     private final ResolutionResultGraphBuilder resolutionResultBuilder = new ResolutionResultGraphBuilder();
     private final boolean includeAllSelectableVariantResults;
 
+    private boolean resultComputed;
+
     private long rootVariantId;
     private long rootComponentId;
     private ImmutableAttributes requestAttributes;
+    private boolean mayHaveVirtualPlatforms;
 
     public InMemoryResolutionResultBuilder(boolean includeAllSelectableVariantResults) {
         this.includeAllSelectableVariantResults = includeAllSelectableVariantResults;
@@ -55,6 +58,7 @@ public class InMemoryResolutionResultBuilder implements DependencyGraphVisitor {
         this.rootVariantId = root.getNodeId();
         this.rootComponentId = root.getOwner().getResultId();
         this.requestAttributes = root.getResolveState().getAttributes();
+        this.mayHaveVirtualPlatforms = root.getResolveOptimizations().mayHaveVirtualPlatforms();
     }
 
     @Override
@@ -62,8 +66,15 @@ public class InMemoryResolutionResultBuilder implements DependencyGraphVisitor {
         DependencyGraphComponent component = node.getOwner();
         resolutionResultBuilder.startVisitComponent(component.getResultId(), component.getSelectionReason(), component.getRepositoryName());
         resolutionResultBuilder.visitComponentDetails(component.getComponentId(), component.getModuleVersion());
+
         for (ResolvedGraphVariant variant : component.getSelectedVariants()) {
-            ResolvedVariantResult publicView = component.getResolveState().getPublicViewFor(variant.getResolveState(), null);
+            ResolvedVariantResult externalVariantPublicView = null;
+            ResolvedGraphVariant externalVariant = variant.getExternalVariant();
+            if (externalVariant != null) {
+                externalVariantPublicView = externalVariant.getComponentResolveState()
+                    .getPublicViewFor(externalVariant.getResolveState(), null);
+            }
+            ResolvedVariantResult publicView = component.getResolveState().getPublicViewFor(variant.getResolveState(), externalVariantPublicView);
             resolutionResultBuilder.visitSelectedVariant(variant.getNodeId(), publicView);
         }
 
@@ -78,14 +89,28 @@ public class InMemoryResolutionResultBuilder implements DependencyGraphVisitor {
 
     @Override
     public void visitEdges(DependencyGraphNode node) {
-        resolutionResultBuilder.visitOutgoingEdges(node.getOwner().getResultId(), node.getOutgoingEdges());
+        final Collection<? extends DependencyGraphEdge> dependencies = mayHaveVirtualPlatforms
+            ? node.getOutgoingEdges()
+                .stream()
+                .filter(dep -> !dep.isTargetVirtualPlatform())
+                .collect(Collectors.toList())
+            : node.getOutgoingEdges();
+        resolutionResultBuilder.visitOutgoingEdges(node.getOwner().getResultId(), dependencies);
     }
 
-    public MinimalResolutionResult getResolutionResult() {
+    @Override
+    public MinimalResolutionResult getResolutionResult(Set<UnresolvedDependency> dependencyLockingFailures) {
         if (requestAttributes == null) {
             throw new IllegalStateException("Resolution result not computed yet");
         }
-        ResolvedComponentResultInternal root = resolutionResultBuilder.getRoot(rootComponentId);
-        return new MinimalResolutionResult(rootVariantId, () -> root, requestAttributes);
+
+        if (resultComputed) {
+            throw new IllegalStateException("Resolution result already computed");
+        }
+        resultComputed = true;
+
+        resolutionResultBuilder.addDependencyLockingFailures(rootComponentId, dependencyLockingFailures);
+        ResolvedComponentResultInternal rootComponent = resolutionResultBuilder.getRoot(rootComponentId);
+        return new MinimalResolutionResult(rootVariantId, () -> rootComponent, requestAttributes);
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolutionResultGraphVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolutionResultGraphVisitor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice;
+
+import org.gradle.api.artifacts.UnresolvedDependency;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
+import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
+
+import java.util.Set;
+
+/**
+ * A graph visitor that produces a {@link MinimalResolutionResult} as a result.
+ */
+public interface ResolutionResultGraphVisitor extends DependencyGraphVisitor  {
+
+    /**
+     * Get the resolution result captured from the graph.
+     *
+     * @param unresolvedDependencies Additional failures to attach to the final resolution result.
+     */
+    MinimalResolutionResult getResolutionResult(Set<UnresolvedDependency> unresolvedDependencies);
+
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -82,6 +82,7 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     private final Property<Boolean> useGlobalDependencySubstitutionRules;
     private boolean selectableVariantResults = false;
     private boolean keepStateRequiredForGraphResolution = false;
+    private boolean skipResolvedGraphSerialization = false;
 
     @Inject
     public DefaultResolutionStrategy(
@@ -413,5 +414,15 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     @Override
     public void setKeepStateRequiredForGraphResolution(boolean keepStateRequiredForGraphResolution) {
         this.keepStateRequiredForGraphResolution = keepStateRequiredForGraphResolution;
+    }
+
+    @Override
+    public void skipResolvedGraphSerialization() {
+        skipResolvedGraphSerialization = true;
+    }
+
+    @Override
+    public boolean shouldSkipResolvedGraphSerialization() {
+        return skipResolvedGraphSerialization;
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
@@ -18,11 +18,11 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 
 import org.gradle.api.artifacts.UnresolvedDependency;
 import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.api.internal.artifacts.ivyservice.ResolutionResultGraphVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphComponent;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphEdge;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphDependency;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode;
 import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
@@ -50,7 +50,7 @@ import java.util.stream.Collectors;
 
 import static org.gradle.internal.UncheckedException.throwAsUncheckedException;
 
-public class StreamingResolutionResultBuilder implements DependencyGraphVisitor {
+public class StreamingResolutionResultBuilder implements ResolutionResultGraphVisitor {
     private final static byte ROOT = 1;
     private final static byte COMPONENT = 2;
     private final static byte SELECTOR = 4;
@@ -85,6 +85,7 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
         this.includeAllSelectableVariantResults = includeAllSelectableVariantResults;
     }
 
+    @Override
     public MinimalResolutionResult getResolutionResult(Set<UnresolvedDependency> dependencyLockingFailures) {
         BinaryStore.BinaryData data = store.done();
         RootFactory rootSource = new RootFactory(data, failures, cache, componentSelectorSerializer, dependencyResultSerializer, componentResultSerializer, dependencyLockingFailures);


### PR DESCRIPTION
The StreamingResolutionResultBuilder visits a resolved graph, captures any data needed to produce a ResolutionResult, and serializes it. Later on, if the user requests a ResolutionResult, we de-serialize and cache the result. We do this, because in most cases the ResultionResult is not used by the user.

However, when performing consistent resolution (as is done often in Android), we know the result will be immediately read and thus deserialized. In these cases, we can skip the serialization round-trip time and load the result directly into memory.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
