### PR TITLE
Update initscript init.d documentation (#30610)

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/other/init_scripts.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/other/init_scripts.adoc
@@ -45,9 +45,9 @@ There are several ways to invoke an init script (in order of priority):
 1. *Specify a file on the command line* with the option `-I` or `--init-script` followed by the path to the script.
 +
 The command line option can appear more than once, each time adding another init script. The build will fail if any files specified on the command line do not exist.
-2. *Put a file called `init.gradle(.kts)`* in the `__$<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>__/` directory.
-3. *Put a file called `init.gradle(.kts)`* in the `__$<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>__/init.d/` directory.
-4. *Put a file called `init.gradle(.kts)`* in the `$<<installation.adoc#sec:linux_macos_users_2,__GRADLE_HOME__>>/init.d/` directory.
+2. *Put a file called `yourfilename.init.gradle(.kts)`* in the `__$<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>__/` directory.
+3. *Put a file called `yourfilename.init.gradle(.kts)`* in the `__$<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>__/init.d/` directory.
+4. *Put a file called `yourfilename.init.gradle(.kts)`* in the `$<<installation.adoc#sec:linux_macos_users_2,__GRADLE_HOME__>>/init.d/` directory. Entries will be evaluated in alphabetic order.
 +
 This lets you package a custom Gradle distribution containing custom build logic and plugins. You can combine this with the <<gradle_wrapper.adoc#gradle_wrapper_reference,Gradle wrapper>> to make custom logic available to all builds in your enterprise.
 


### PR DESCRIPTION
Updated initscript documentation so as to denote the purpose of an init.d directory is to use multiple script files, not just a single init.gradle file.
