### PR TITLE
Introduce lightweight types for storing artifact transformation chain data in resolution failures

### DIFF
--- a/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationTrace.java
+++ b/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationTrace.java
@@ -27,6 +27,8 @@ import groovy.json.JsonOutput;
 import groovy.json.JsonSlurper;
 import org.gradle.StartParameter;
 import org.gradle.api.NonNullApi;
+import org.gradle.api.artifacts.component.BuildIdentifier;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.buildoption.DefaultInternalOptions;
 import org.gradle.internal.buildoption.InternalFlag;
@@ -510,14 +512,8 @@ public class BuildOperationTrace implements Stoppable {
         return new JsonGenerator.Options()
             .addConverter(new JsonClassConverter())
             .addConverter(new JsonThrowableConverter())
-            /*
-              From ResolutionFailureData, we want to exclude the actual failure field
-              from JSON serialization in the trace, because it can contain arbitrary
-              data including circular references that aren't serializable.  See the
-              note on AmbiguousArtifactTransformsFailure for more.  Once that class
-              is refactored, we should explore removing this exclusion.
-            */
-            .excludeFieldsByName("resolutionFailure")
+            .addConverter(new JsonAttributeContainerConverter())
+            .addConverter(new JsonBuildIdentifierConverter())
             .build();
     }
 
@@ -538,6 +534,47 @@ public class BuildOperationTrace implements Stoppable {
             }
             builder.put("stackTrace", Throwables.getStackTraceAsString(throwable));
             return builder.build();
+        }
+    }
+
+    /**
+     * A custom {@link JsonGenerator.Converter} is needed to deal with the fact that our {@link AttributeContainer} implementations
+     * have {@link AttributeContainer#getAttributes()} methods that return {@code this}.
+     *
+     * Attempting to serialize any of these causes a stack overflow, so
+     * just convert them to an easily serializable {@link Map} first.
+     */
+    @NonNullApi
+    private static final class JsonAttributeContainerConverter implements JsonGenerator.Converter {
+        @Override
+        public boolean handles(Class<?> type) {
+            return AttributeContainer.class.isAssignableFrom(type);
+        }
+
+        @Override
+        public Object convert(Object value, String key) {
+            return ((AttributeContainer) value).keySet(); // TODO: need to convert to a map manually (since asMap is only available on the internal type)
+        }
+    }
+
+    /**
+     * Avoid calling deprecated methods on {@link BuildIdentifier} when serializing it, which cause noise output in tests that
+     * feature resolution failures that contain this type as fields.
+     *
+     * TODO: Remove this in Gradle 9, once {@link BuildIdentifier#isCurrentBuild()} and {@link BuildIdentifier#getName()} are removed.
+     */
+    @SuppressWarnings("DeprecatedIsStillUsed")
+    @Deprecated
+    @NonNullApi
+    private static final class JsonBuildIdentifierConverter implements JsonGenerator.Converter {
+        @Override
+        public boolean handles(Class<?> type) {
+            return BuildIdentifier.class.isAssignableFrom(type);
+        }
+
+        @Override
+        public Object convert(Object value, String key) {
+            return ((BuildIdentifier) value).getBuildPath();
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -130,6 +130,7 @@ import org.gradle.internal.component.external.model.JavaEcosystemVariantDerivati
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
 import org.gradle.internal.component.model.GraphVariantSelector;
 import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
+import org.gradle.internal.component.resolution.failure.transform.TransformedVariantConverter;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.execution.ExecutionEngine;
 import org.gradle.internal.execution.ExecutionEngine.IdentityCacheResult;
@@ -299,6 +300,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             registration.add(DependencyGraphBuilder.class);
             registration.add(AttributeDescriberRegistry.class);
             registration.add(GraphVariantSelector.class);
+            registration.add(TransformedVariantConverter.class);
         }
 
         @Provides
@@ -604,10 +606,10 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         }
 
         @Provides
-        ResolutionFailureHandler createResolutionFailureHandler(InstantiatorFactory instantiatorFactory, ServiceRegistry serviceRegistry, InternalProblems problemsService) {
+        ResolutionFailureHandler createResolutionFailureHandler(InstantiatorFactory instantiatorFactory, ServiceRegistry serviceRegistry, InternalProblems problemsService, TransformedVariantConverter transformedVariantConverter) {
             InstanceGenerator instanceGenerator = instantiatorFactory.inject(serviceRegistry);
 
-            ResolutionFailureHandler handler = new ResolutionFailureHandler(instanceGenerator, problemsService);
+            ResolutionFailureHandler handler = new ResolutionFailureHandler(instanceGenerator, problemsService, transformedVariantConverter);
             GradlePluginVariantsSupport.configureFailureHandler(handler);
             PlatformSupport.configureFailureHandler(handler);
             return handler;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transform.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transform.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.transform;
 
 import org.gradle.api.Describable;
+import org.gradle.api.artifacts.transform.TransformAction;
 import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
@@ -36,7 +37,7 @@ import java.io.File;
  * This encapsulates the public interface {@link org.gradle.api.artifacts.transform.TransformAction} into an internal type.
  */
 public interface Transform extends Describable, TaskDependencyContainer {
-    Class<?> getImplementationClass();
+    Class<? extends TransformAction<?>> getImplementationClass();
 
     ImmutableAttributes getFromAttributes();
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionFailureHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionFailureHandler.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.resolution.failure;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.capability.CapabilitySelector;
 import org.gradle.api.internal.artifacts.capability.FeatureCapabilitySelector;
@@ -48,6 +49,8 @@ import org.gradle.internal.component.resolution.failure.ResolutionCandidateAsses
 import org.gradle.internal.component.resolution.failure.describer.ResolutionFailureDescriber;
 import org.gradle.internal.component.resolution.failure.exception.AbstractResolutionFailureException;
 import org.gradle.internal.component.resolution.failure.interfaces.ResolutionFailure;
+import org.gradle.internal.component.resolution.failure.transform.TransformedVariantConverter;
+import org.gradle.internal.component.resolution.failure.transform.TransformationChainData;
 import org.gradle.internal.component.resolution.failure.type.AmbiguousArtifactTransformsFailure;
 import org.gradle.internal.component.resolution.failure.type.AmbiguousArtifactsFailure;
 import org.gradle.internal.component.resolution.failure.type.AmbiguousVariantsFailure;
@@ -88,10 +91,16 @@ import java.util.stream.Stream;
 public class ResolutionFailureHandler {
     public static final String DEFAULT_MESSAGE_PREFIX = "Review the variant matching algorithm at ";
 
+    private final InternalProblems problemsService;
+    private final TransformedVariantConverter transformedVariantConverter;
+
     private final ResolutionFailureDescriberRegistry defaultFailureDescribers;
     private final ResolutionFailureDescriberRegistry customFailureDescribers;
 
-    public ResolutionFailureHandler(InstanceGenerator instanceGenerator, InternalProblems problemsService) {
+    public ResolutionFailureHandler(InstanceGenerator instanceGenerator, InternalProblems problems, TransformedVariantConverter transformedVariantConverter) {
+        this.problemsService = problems;
+        this.transformedVariantConverter = transformedVariantConverter;
+
         this.defaultFailureDescribers = ResolutionFailureDescriberRegistry.standardRegistry(instanceGenerator);
         this.customFailureDescribers = ResolutionFailureDescriberRegistry.emptyRegistry(instanceGenerator);
 
@@ -207,7 +216,8 @@ public class ResolutionFailureHandler {
         ImmutableAttributes requestedAttributes,
         List<TransformedVariant> transformedVariants
     ) {
-        AmbiguousArtifactTransformsFailure failure = new AmbiguousArtifactTransformsFailure(getOrCreateVariantSetComponentIdentifier(targetVariantSet), targetVariantSet.asDescribable().getDisplayName(), requestedAttributes, transformedVariants);
+        ImmutableList<TransformationChainData> transformationChainDatas = transformedVariantConverter.convert(transformedVariants);
+        AmbiguousArtifactTransformsFailure failure = new AmbiguousArtifactTransformsFailure(getOrCreateVariantSetComponentIdentifier(targetVariantSet), targetVariantSet.asDescribable().getDisplayName(), requestedAttributes, transformationChainDatas);
         return describeFailure(failure);
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/AmbiguousArtifactTransformsFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/AmbiguousArtifactTransformsFailureDescriber.java
@@ -19,9 +19,9 @@ package org.gradle.internal.component.resolution.failure.describer;
 import com.google.common.collect.Ordering;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
-import org.gradle.api.internal.artifacts.transform.TransformedVariant;
 import org.gradle.internal.component.resolution.failure.exception.ArtifactSelectionException;
+import org.gradle.internal.component.resolution.failure.transform.SourceVariantData;
+import org.gradle.internal.component.resolution.failure.transform.TransformationChainData;
 import org.gradle.internal.component.resolution.failure.type.AmbiguousArtifactTransformsFailure;
 import org.gradle.internal.logging.text.TreeFormatter;
 
@@ -51,31 +51,37 @@ public abstract class AmbiguousArtifactTransformsFailureDescriber extends Abstra
         formatSortedAttributes(formatter, failure.getRequestedAttributes());
         formatter.node("Found the following transforms");
 
-        Comparator<TransformedVariant> variantComparator =
-            Comparator.<TransformedVariant, String>comparing(x -> x.getTransformChain().getDisplayName())
-                .thenComparing(x -> x.getAttributes().toString());
-        Map<ResolvedVariant, List<TransformedVariant>> variantToTransforms = failure.getTransformedVariants().stream().collect(Collectors.groupingBy(
-            TransformedVariant::getRoot,
-            () -> new TreeMap<>(Comparator.comparing(variant -> variant.asDescribable().getDisplayName())),
-            Collectors.collectingAndThen(Collectors.toList(), list -> list.stream().sorted(variantComparator).collect(Collectors.toList()))));
+        Comparator<TransformationChainData> variantDataComparator =
+            Comparator.comparing(TransformationChainData::describeTransformations)
+                .thenComparing(x -> x.getFinalAttributes().toString());
+
+        Map<SourceVariantData, List<TransformationChainData>> transformationPaths = failure.getPotentialVariants().stream()
+            .collect(Collectors.groupingBy(
+                TransformationChainData::getInitialVariant,
+                () -> new TreeMap<>(Comparator.comparing(SourceVariantData::getVariantName)),
+                Collectors.collectingAndThen(Collectors.toList(), list -> list.stream().sorted(variantDataComparator).collect(Collectors.toList()))));
 
         formatter.startChildren();
-        for (Map.Entry<ResolvedVariant, List<TransformedVariant>> entry : variantToTransforms.entrySet()) {
-            formatter.node("From '" + entry.getKey().asDescribable().getDisplayName() + "'");
-            formatter.startChildren();
-            formatter.node("With source attributes");
-            formatSortedAttributes(formatter, entry.getKey().getAttributes());
-            formatter.node("Candidate transform(s)");
-            formatter.startChildren();
-            for (TransformedVariant variant : entry.getValue()) {
-                formatter.node("Transform '" + variant.getTransformChain().getDisplayName() + "' producing attributes:");
-                formatSortedAttributes(formatter, variant.getAttributes());
-            }
+        transformationPaths.forEach((root, transformations) -> {
+            formatSourceVariant(root, formatter);
+            transformations.forEach(transformationChainData -> {
+                formatter.node("Transform '" + transformationChainData.describeTransformations() + "' producing attributes:");
+                formatSortedAttributes(formatter, transformationChainData.getFinalAttributes());
+            });
             formatter.endChildren();
             formatter.endChildren();
-        }
+        });
         formatter.endChildren();
         return formatter.toString();
+    }
+
+    private void formatSourceVariant(SourceVariantData sourceVariantData, TreeFormatter formatter) {
+        formatter.node("From '" + sourceVariantData.getVariantName() + "'");
+        formatter.startChildren();
+        formatter.node("With source attributes");
+        formatSortedAttributes(formatter, sourceVariantData.getAttributes());
+        formatter.node("Candidate transform(s)");
+        formatter.startChildren();
     }
 
     private void formatSortedAttributes(TreeFormatter formatter, AttributeContainer attributes) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/SourceVariantData.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/SourceVariantData.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.resolution.failure.transform;
+
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+
+/**
+ * A lightweight replacement for {@link org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant ResolvedVariant}
+ * that contains the data in the root variant that is used to begin an artifact transformation chain.
+ * <p>
+ * Immutable data class.  Meant to be easily serialized as part of build operation recording and tracing.
+ */
+public final class SourceVariantData {
+    private final String variantName;
+    private final ImmutableAttributes attributes;
+
+    public SourceVariantData(String variantName, ImmutableAttributes attributes) {
+        this.variantName = variantName;
+        this.attributes = attributes;
+    }
+
+    public String getVariantName() {
+        return variantName;
+    }
+
+    public ImmutableAttributes getAttributes() {
+        return attributes;
+    }
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/TransformData.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/TransformData.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.resolution.failure.transform;
+
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+
+/**
+ * A lightweight replacement for {@link org.gradle.api.internal.artifacts.transform.TransformStep TransformStep}
+ * that contains the data in each ArtifactTransform step that comprises an artifact transformation chain.
+ * <p>
+ * Immutable data class.  Meant to be easily serialized as part of build operation recording and tracing.
+ */
+public final class TransformData {
+    private final String transformName;
+    private final ImmutableAttributes fromAttributes;
+    private final ImmutableAttributes toAttributes;
+
+    public TransformData(String transformName, ImmutableAttributes fromAttributes, ImmutableAttributes toAttributes) {
+        this.transformName = transformName;
+        this.fromAttributes = fromAttributes;
+        this.toAttributes = toAttributes;
+    }
+
+    public String getTransformName() {
+        return transformName;
+    }
+
+    public ImmutableAttributes getFromAttributes() {
+        return fromAttributes;
+    }
+
+    public ImmutableAttributes getToAttributes() {
+        return toAttributes;
+    }
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/TransformData.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/TransformData.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.resolution.failure.transform;
 
+import org.gradle.api.artifacts.transform.TransformAction;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 
 /**
@@ -25,24 +26,40 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
  * Immutable data class.  Meant to be easily serialized as part of build operation recording and tracing.
  */
 public final class TransformData {
+    private final Class<? extends TransformAction<?>> transformActionClass;
     private final String transformName;
     private final ImmutableAttributes fromAttributes;
     private final ImmutableAttributes toAttributes;
 
-    public TransformData(String transformName, ImmutableAttributes fromAttributes, ImmutableAttributes toAttributes) {
+    public TransformData(Class<? extends TransformAction<?>> transformActionClass, String transformName, ImmutableAttributes fromAttributes, ImmutableAttributes toAttributes) {
+        this.transformActionClass = transformActionClass;
         this.transformName = transformName;
         this.fromAttributes = fromAttributes;
         this.toAttributes = toAttributes;
+    }
+
+    public Class<? extends TransformAction<?>> getTransformActionClass() {
+        return transformActionClass;
     }
 
     public String getTransformName() {
         return transformName;
     }
 
+    /**
+     * The set of attributes that will be modified by this Artifact Transform, with their original values.
+     *
+     * @return attributes as described
+     */
     public ImmutableAttributes getFromAttributes() {
         return fromAttributes;
     }
 
+    /**
+     * The set of attributes that will be modified by this Artifact Transform, with their resulting values.
+     *
+     * @return attributes as described
+     */
     public ImmutableAttributes getToAttributes() {
         return toAttributes;
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/TransformationChainData.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/TransformationChainData.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.resolution.failure.transform;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+
+import java.util.stream.Collectors;
+
+/**
+ * Represents a variant which is produced as the result of applying an artifact transform chain
+ * to a root producer variant.
+ * <p>
+ * Immutable data class.  Meant to be easily serialized as part of build operation recording and tracing.
+ */
+public final class TransformationChainData {
+    private final SourceVariantData startingVariant;
+    private final ImmutableList<TransformData> steps;
+
+    public TransformationChainData(SourceVariantData startingVariant, ImmutableList<TransformData> steps) {
+        this.startingVariant = startingVariant;
+        this.steps = steps;
+    }
+
+    public SourceVariantData getInitialVariant() {
+        return startingVariant;
+    }
+
+    public String describeTransformations() {
+        return steps.stream()
+            .map(TransformData::getTransformName)
+            .collect(Collectors.joining(", "));
+    }
+
+    public ImmutableAttributes getFinalAttributes() {
+        return steps.get(steps.size() - 1).getToAttributes();
+    }
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/TransformationChainData.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/TransformationChainData.java
@@ -30,12 +30,19 @@ import java.util.stream.Collectors;
 public final class TransformationChainData {
     private final SourceVariantData startingVariant;
     private final ImmutableList<TransformData> steps;
+    private final ImmutableAttributes finalAttributes;
 
-    public TransformationChainData(SourceVariantData startingVariant, ImmutableList<TransformData> steps) {
+    public TransformationChainData(SourceVariantData startingVariant, ImmutableList<TransformData> steps, ImmutableAttributes finalAttributes) {
         this.startingVariant = startingVariant;
         this.steps = steps;
+        this.finalAttributes = finalAttributes;
     }
 
+    /**
+     * The variant that was used as the starting point for this chain of transformations.
+     *
+     * @return initial variant
+     */
     public SourceVariantData getInitialVariant() {
         return startingVariant;
     }
@@ -46,7 +53,15 @@ public final class TransformationChainData {
             .collect(Collectors.joining(", "));
     }
 
+    /**
+     * The complete resulting set of attributes on the "virtual variant" created by processing the source variant
+     * completely through this transformation chain.
+     * <p>
+     * This explicitly includes attributes of the source variant that were not modified by any transformations.
+     *
+     * @return attributes as described
+     */
     public ImmutableAttributes getFinalAttributes() {
-        return steps.get(steps.size() - 1).getToAttributes();
+        return finalAttributes;
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/TransformedVariantConverter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/TransformedVariantConverter.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.resolution.failure.transform;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.Action;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
+import org.gradle.api.internal.artifacts.transform.Transform;
+import org.gradle.api.internal.artifacts.transform.TransformStep;
+import org.gradle.api.internal.artifacts.transform.TransformedVariant;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+
+import javax.inject.Inject;
+import java.util.List;
+
+/**
+ * This type is responsible for converting from heavyweight {@link TransformedVariant} instances to
+ * lightweight {@link TransformationChainData} instances.
+ * <p>
+ * See the {@link org.gradle.internal.component.resolution.failure.transform package javadoc} for why.
+ */
+public final class TransformedVariantConverter {
+    private final ImmutableAttributesFactory attributesFactory;
+
+    @Inject
+    public TransformedVariantConverter(ImmutableAttributesFactory attributesFactory) {
+        this.attributesFactory = attributesFactory;
+    }
+
+    public ImmutableList<TransformationChainData> convert(List<TransformedVariant> transformedVariants) {
+        ImmutableList.Builder<TransformationChainData> builder = ImmutableList.builder();
+        transformedVariants.forEach(transformedVariant -> builder.add(convert(transformedVariant)));
+        return builder.build();
+    }
+
+    private TransformationChainData convert(TransformedVariant transformedVariant) {
+        AttributeChangeRecordingVisitor visitor = new AttributeChangeRecordingVisitor(transformedVariant.getRoot());
+        transformedVariant.getTransformChain().visitTransformSteps(visitor);
+        return visitor.buildResultData();
+    }
+
+    private final class AttributeChangeRecordingVisitor implements Action<TransformStep> {
+        private final ImmutableList.Builder<TransformData> stepsBuilder = ImmutableList.builder();
+
+        private final SourceVariantData sourceVariant;
+        private ImmutableAttributes currentAttributes;
+
+        public AttributeChangeRecordingVisitor(ResolvedVariant root) {
+            sourceVariant = new SourceVariantData(root.asDescribable().getDisplayName(), root.getAttributes());
+            currentAttributes = sourceVariant.getAttributes();
+        }
+
+        @Override
+        public void execute(TransformStep transformStep) {
+            TransformData transformData = convert(currentAttributes, transformStep);
+            stepsBuilder.add(transformData);
+            currentAttributes = transformData.getFromAttributes();
+        }
+
+        public TransformationChainData buildResultData() {
+            return new TransformationChainData(sourceVariant, stepsBuilder.build());
+        }
+
+        private TransformData convert(ImmutableAttributes currentAttributes, TransformStep step) {
+            Transform transform = step.getTransform();
+            ImmutableAttributes resultingToAttributes = attributesFactory.join(currentAttributes, transform.getToAttributes()).asImmutable();
+            return new TransformData(transform.getDisplayName(), currentAttributes, resultingToAttributes);
+        }
+    }
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/package-info.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains types for capturing data about the chain of variant transformations that
+ * are available to satisfy an artifact selection request.
+ * <p>
+ * These types are a more lightweight representation of the data in {@link org.gradle.api.internal.artifacts.transform.TransformedVariant TransformedVariant},
+ * that will not pose problems to serialization in {@link org.gradle.internal.operations.BuildOperation BuildOperation}s and traces.  They
+ * contain all the interesting data about these transformation chains necessary to analyze a failure and describe it
+ * using a {@link org.gradle.internal.component.resolution.failure.describer.ResolutionFailureDescriber ResolutionFailureDescriber}.
+ */
+@org.gradle.api.NonNullApi
+package org.gradle.internal.component.resolution.failure.transform;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/package-info.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/package-info.java
@@ -19,9 +19,12 @@
  * are available to satisfy an artifact selection request.
  * <p>
  * These types are a more lightweight representation of the data in {@link org.gradle.api.internal.artifacts.transform.TransformedVariant TransformedVariant},
- * that will not pose problems to serialization in {@link org.gradle.internal.operations.BuildOperation BuildOperation}s and traces.  They
- * contain all the interesting data about these transformation chains necessary to analyze a failure and describe it
+ * and related types that allow us to package this data for external consumers without exposing internal dependency resolution types.  These
+ * contain all the interesting data about any transformation chains necessary to analyze a failure and describe it
  * using a {@link org.gradle.internal.component.resolution.failure.describer.ResolutionFailureDescriber ResolutionFailureDescriber}.
+ * <p>
+ * One important property of these types is that they do not pose problems to serialization in
+ * {@link org.gradle.internal.operations.BuildOperation BuildOperation}s and traces.
  */
 @org.gradle.api.NonNullApi
 package org.gradle.internal.component.resolution.failure.transform;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AmbiguousArtifactTransformsFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AmbiguousArtifactTransformsFailure.java
@@ -18,35 +18,24 @@ package org.gradle.internal.component.resolution.failure.type;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.internal.artifacts.transform.TransformedVariant;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.catalog.problems.ResolutionFailureProblemId;
 import org.gradle.internal.component.resolution.failure.interfaces.ArtifactSelectionFailure;
-
-import java.util.List;
+import org.gradle.internal.component.resolution.failure.transform.TransformationChainData;
 
 /**
  * An {@link ArtifactSelectionFailure} that represents the situation when multiple artifact transforms are
  * available that would satisfy an artifact selection request.
  */
 public final class AmbiguousArtifactTransformsFailure extends AbstractArtifactSelectionFailure {
-    /*
-     * TODO: We need to keep track of the transformed variant and transformation chains that are available
-     * to satisfy the artifact selection request somehow (so that failure describers can investigate it), but
-     * we should use a much simpler stateless data-only type (without Project and Gradle references) for this.
-     *
-     * This type causes issues with BuildOperationTrace serialization and really isn't the right place to use
-     * this type...but this is what was originally used to describe these kind of failures, so it remains for now
-     * until we have a chance to refactor this.
-     */
-    private final ImmutableList<TransformedVariant> transformedVariants;
+    private final ImmutableList<TransformationChainData> potentialVariants;
 
-    public AmbiguousArtifactTransformsFailure(ComponentIdentifier targetComponent, String targetVariant, AttributeContainerInternal requestedAttributes, List<TransformedVariant> transformedVariants) {
+    public AmbiguousArtifactTransformsFailure(ComponentIdentifier targetComponent, String targetVariant, AttributeContainerInternal requestedAttributes, ImmutableList<TransformationChainData> potentialVariants) {
         super(ResolutionFailureProblemId.AMBIGUOUS_ARTIFACT_TRANSFORM, targetComponent, targetVariant, requestedAttributes);
-        this.transformedVariants = ImmutableList.copyOf(transformedVariants);
+        this.potentialVariants = potentialVariants;
     }
 
-    public ImmutableList<TransformedVariant> getTransformedVariants() {
-        return transformedVariants;
+    public ImmutableList<TransformationChainData> getPotentialVariants() {
+        return potentialVariants;
     }
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactVariantSelectorFactoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactVariantSelectorFactoryTest.groovy
@@ -119,7 +119,7 @@ class DefaultArtifactVariantSelectorFactoryTest extends Specification {
         def variant2 = resolvedVariant()
         def set = resolvedVariantSet()
         def variants = [variant1, variant2]
-        def transformedVariants = variants.collect { transformedVariant(it, requested)}
+        def transformedVariants = variants.collect { transformedVariant(it, it.attributes, requested)}
 
         given:
         set.schema >> producerSchema
@@ -244,10 +244,17 @@ Found the following transforms:
         attributeContainer.asImmutable()
     }
 
-    TransformedVariant transformedVariant(ResolvedVariant root, AttributeContainerInternal attributes) {
-        ImmutableAttributes attrs = attributes.asImmutable()
+    TransformedVariant transformedVariant(ResolvedVariant root, AttributeContainerInternal fromAttributes, AttributeContainerInternal toAttributes) {
+        ImmutableAttributes attrs = toAttributes.asImmutable()
+        Transform transform = Mock(Transform) {
+            getDisplayName() >> ""
+            getFromAttributes() >> fromAttributes
+            getToAttributes() >> toAttributes
+        }
         TransformStep step = Mock(TransformStep) {
             getDisplayName() >> ""
+            getTransform() >> transform
+            getFromAttributes() >> fromAttributes
         }
         VariantDefinition definition = Mock(VariantDefinition) {
             getTransformChain() >> new TransformChain(null, step)

--- a/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/DependencyManagementTestUtil.groovy
+++ b/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/DependencyManagementTestUtil.groovy
@@ -28,6 +28,7 @@ import org.gradle.internal.component.external.model.ModuleComponentGraphResolveS
 import org.gradle.internal.component.external.model.PreferJavaRuntimeVariant
 import org.gradle.internal.component.model.ComponentIdGenerator
 import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler
+import org.gradle.internal.component.resolution.failure.transform.TransformedVariantConverter
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.TestUtil
 
@@ -63,6 +64,11 @@ class DependencyManagementTestUtil {
         def services = TestUtil.createTestServices {
             it.add(AttributeDescriberRegistry)
         }
-        new ResolutionFailureHandler(TestUtil.instantiatorFactory().inject(services), new DefaultProblems([new NoOpProblemEmitter()]))
+
+        return new ResolutionFailureHandler(
+            TestUtil.instantiatorFactory().inject(services),
+            new DefaultProblems([new NoOpProblemEmitter()]),
+            new TransformedVariantConverter(AttributeTestUtil.attributesFactory())
+        )
     }
 }

--- a/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/DependencyManagementTestUtil.groovy
+++ b/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/DependencyManagementTestUtil.groovy
@@ -68,7 +68,7 @@ class DependencyManagementTestUtil {
         return new ResolutionFailureHandler(
             TestUtil.instantiatorFactory().inject(services),
             new DefaultProblems([new NoOpProblemEmitter()]),
-            new TransformedVariantConverter(AttributeTestUtil.attributesFactory())
+            new TransformedVariantConverter()
         )
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactoryTest.groovy
@@ -288,4 +288,31 @@ class DefaultImmutableAttributesFactoryTest extends Specification {
         expect:
         result.findEntry(Usage.USAGE_ATTRIBUTE).get().toString() == "java-runtime"
     }
+
+    def "can join 2 attribute containers with disjoint attributes"() {
+        def attributes1 = factory.of(FOO, "foo")
+        def attributes2 = factory.concat(factory.of(BAR, "bar"), factory.of(BAZ, "baz"))
+
+        when:
+        def result = factory.join(attributes1, attributes2).asImmutable()
+
+        then:
+        result.asMap().size() == 3
+        result.findEntry(FOO).get().toString() == "foo"
+        result.findEntry(BAR).get().toString() == "bar"
+        result.findEntry(BAZ).get().toString() == "baz"
+    }
+
+    def "can join 2 attribute containers with attribute overrides"() {
+        def attributes1 = factory.of(FOO, "foo")
+        def attributes2 = factory.concat(factory.of(BAR, "bar"), factory.of(FOO, "foo2"))
+
+        when:
+        def result = factory.join(attributes1, attributes2).asImmutable()
+
+        then:
+        result.asMap().size() == 2
+        result.findEntry(FOO).get().toString() == "foo2"
+        result.findEntry(BAR).get().toString() == "bar"
+    }
 }


### PR DESCRIPTION
These types allow for restoring `BuildOperationTrace` serialization.  They prevent exposing inner dependency resolution types via failure data.
