### PR TITLE
Allow authors to disable extension registration for software types

### DIFF
--- a/platforms/core-configuration/declarative-dsl-evaluator/src/main/kotlin/org/gradle/internal/declarativedsl/evaluator/main/PrebuiltInterpretationSchemaBuilder.kt
+++ b/platforms/core-configuration/declarative-dsl-evaluator/src/main/kotlin/org/gradle/internal/declarativedsl/evaluator/main/PrebuiltInterpretationSchemaBuilder.kt
@@ -28,7 +28,7 @@ class PrebuiltInterpretationSchemaBuilder(
     private val projectSequence: InterpretationSequence
 ) : InterpretationSchemaBuilder {
     override fun getEvaluationSchemaForScript(scriptContext: DeclarativeScriptContext): InterpretationSchemaBuildingResult = when (scriptContext) {
-        DeclarativeScriptContext.ProjectScript -> InterpretationSchemaBuildingResult.InterpretationSequenceAvailable(projectSequence)
+        is DeclarativeScriptContext.ProjectScript -> InterpretationSchemaBuildingResult.InterpretationSequenceAvailable(projectSequence)
         is DeclarativeScriptContext.SettingsScript -> InterpretationSchemaBuildingResult.InterpretationSequenceAvailable(settingsSequence)
         DeclarativeScriptContext.UnknownScript -> InterpretationSchemaBuildingResult.SchemaNotBuilt
     }

--- a/platforms/core-configuration/declarative-dsl-evaluator/src/main/kotlin/org/gradle/internal/declarativedsl/evaluator/main/SimpleAnalysisEvaluator.kt
+++ b/platforms/core-configuration/declarative-dsl-evaluator/src/main/kotlin/org/gradle/internal/declarativedsl/evaluator/main/SimpleAnalysisEvaluator.kt
@@ -82,7 +82,7 @@ class SimpleAnalysisEvaluator(
 
     private
     fun scriptContextFromFileName(fileName: String) = when (File(fileName).name) {
-        "build.gradle.dcl" -> DeclarativeScriptContext.ProjectScript
+        "build.gradle.dcl" -> object : DeclarativeScriptContext.ProjectScript {}
         "settings.gradle.dcl" -> object : DeclarativeScriptContext.SettingsScript {}
         else -> DeclarativeScriptContext.UnknownScript
     }

--- a/platforms/core-configuration/declarative-dsl-evaluator/src/main/kotlin/org/gradle/internal/declarativedsl/evaluator/schema/InterpretationSchemaBuilder.kt
+++ b/platforms/core-configuration/declarative-dsl-evaluator/src/main/kotlin/org/gradle/internal/declarativedsl/evaluator/schema/InterpretationSchemaBuilder.kt
@@ -35,7 +35,7 @@ sealed interface InterpretationSchemaBuildingResult {
 sealed interface DeclarativeScriptContext {
     interface SettingsScript : DeclarativeScriptContext
 
-    object ProjectScript : DeclarativeScriptContext
+    interface ProjectScript : DeclarativeScriptContext
 
     object UnknownScript : DeclarativeScriptContext
 }

--- a/platforms/core-configuration/declarative-dsl-provider/build.gradle.kts
+++ b/platforms/core-configuration/declarative-dsl-provider/build.gradle.kts
@@ -27,12 +27,12 @@ dependencies {
     api(projects.declarativeDslEvaluator)
     api(projects.declarativeDslToolingModels)
     api(libs.kotlinStdlib)
+    api(libs.inject)
 
     implementation(projects.declarativeDslInternalUtils)
     implementation(projects.baseServices)
     implementation(projects.resources)
     implementation(projects.serviceLookup)
-    implementation(libs.inject)
     implementation(libs.guava)
     implementation(libs.kotlinReflect)
 

--- a/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/settings/SoftwareTypeDeclarationIntegrationTest.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/settings/SoftwareTypeDeclarationIntegrationTest.groovy
@@ -317,7 +317,7 @@ class SoftwareTypeDeclarationIntegrationTest extends AbstractIntegrationSpec imp
 
         then:
         failure.assertHasCause("A problem was found with the SoftwareTypeImplPlugin plugin.")
-        failure.assertHasCause("Type 'org.gradle.test.SoftwareTypeImplPlugin' property 'testSoftwareTypeExtension' has @SoftwareType annotation with 'disableExtensionRegistration' set to true, but no extension with name 'testSoftwareType' was registered.")
+        failure.assertHasCause("Type 'org.gradle.test.SoftwareTypeImplPlugin' property 'testSoftwareTypeExtension' has @SoftwareType annotation with 'disableModelManagement' set to true, but no extension with name 'testSoftwareType' was registered.")
     }
 
     def 'sensible error when software type plugin declares that it registers its own extension but registers the wrong object'() {
@@ -333,7 +333,7 @@ class SoftwareTypeDeclarationIntegrationTest extends AbstractIntegrationSpec imp
 
         then:
         failure.assertHasCause("A problem was found with the SoftwareTypeImplPlugin plugin.")
-        failure.assertHasCause("Type 'org.gradle.test.SoftwareTypeImplPlugin' property 'testSoftwareTypeExtension' has @SoftwareType annotation with 'disableExtensionRegistration' set to true, but the extension with name 'testSoftwareType' does not match the value of the property.")
+        failure.assertHasCause("Type 'org.gradle.test.SoftwareTypeImplPlugin' property 'testSoftwareTypeExtension' has @SoftwareType annotation with 'disableModelManagement' set to true, but the extension with name 'testSoftwareType' does not match the value of the property.")
     }
 
     static String getPluginsFromIncludedBuild() {

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/evaluator/DeclarativeKotlinScriptEvaluator.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/evaluator/DeclarativeKotlinScriptEvaluator.kt
@@ -20,6 +20,7 @@ import org.gradle.api.Project
 import org.gradle.api.initialization.Settings
 import org.gradle.api.internal.SettingsInternal
 import org.gradle.api.internal.initialization.ClassLoaderScope
+import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.declarative.dsl.evaluation.InterpretationSequence
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.internal.declarativedsl.defaults.softwareTypeRegistryBasedModelDefaultsRegistrar
@@ -40,6 +41,7 @@ import org.gradle.internal.declarativedsl.evaluator.schema.InterpretationSchemaB
 import org.gradle.internal.declarativedsl.evaluator.schema.DeclarativeScriptContext
 import org.gradle.internal.declarativedsl.settings.SettingsBlocksCheck
 import org.gradle.internal.declarativedsl.common.UnsupportedSyntaxFeatureCheck
+import org.gradle.plugin.software.internal.SoftwareFeatureApplicator
 import org.gradle.plugin.software.internal.SoftwareTypeRegistry
 
 
@@ -110,7 +112,7 @@ class DefaultDeclarativeKotlinScriptEvaluator(
         targetScope: ClassLoaderScope
     ): DeclarativeScriptContext = when (target) {
         is Settings -> LoadedSettingsScriptContext(target as SettingsInternal, targetScope, scriptSource)
-        is Project -> DeclarativeScriptContext.ProjectScript
+        is Project -> LoadedProjectScriptContext((target as ProjectInternal).services.get(SoftwareFeatureApplicator::class.java))
         else -> DeclarativeScriptContext.UnknownScript
     }
 }

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/evaluator/GradleProcessInterpretationSchemaBuilder.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/evaluator/GradleProcessInterpretationSchemaBuilder.kt
@@ -26,6 +26,7 @@ import org.gradle.internal.declarativedsl.evaluator.schema.InterpretationSchemaB
 import org.gradle.internal.declarativedsl.evaluator.schema.DeclarativeScriptContext
 import org.gradle.internal.declarativedsl.project.projectInterpretationSequence
 import org.gradle.internal.declarativedsl.settings.settingsInterpretationSequence
+import org.gradle.plugin.software.internal.SoftwareFeatureApplicator
 import org.gradle.plugin.software.internal.SoftwareTypeRegistry
 
 
@@ -43,11 +44,11 @@ class GradleProcessInterpretationSchemaBuilder(
                 )
             }
 
-            is DeclarativeScriptContext.ProjectScript -> InterpretationSequenceAvailable(projectInterpretationSequence)
+            is DeclarativeScriptContext.ProjectScript -> {
+                require(scriptContext is LoadedProjectScriptContext) { "A ${LoadedProjectScriptContext::class.simpleName} is needed to build the project schema" }
+                InterpretationSequenceAvailable(projectInterpretationSequence(softwareTypeRegistry, scriptContext.softwareFeatureApplicator))
+            }
         }
-
-    private
-    val projectInterpretationSequence by lazy { projectInterpretationSequence(softwareTypeRegistry) }
 }
 
 
@@ -56,3 +57,7 @@ data class LoadedSettingsScriptContext(
     val targetScope: ClassLoaderScope,
     val scriptSource: ScriptSource
 ) : DeclarativeScriptContext.SettingsScript
+
+data class LoadedProjectScriptContext(
+    val softwareFeatureApplicator: SoftwareFeatureApplicator
+) : DeclarativeScriptContext.ProjectScript

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/evaluator/defaults/DeclarativeModelDefaultsHandler.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/evaluator/defaults/DeclarativeModelDefaultsHandler.kt
@@ -38,15 +38,16 @@ import org.gradle.internal.declarativedsl.language.LanguageTreeResult
 import org.gradle.internal.declarativedsl.language.SyntheticallyProduced
 import org.gradle.internal.declarativedsl.project.projectInterpretationSequenceStep
 import org.gradle.plugin.software.internal.ModelDefaultsHandler
+import org.gradle.plugin.software.internal.SoftwareFeatureApplicator
 import org.gradle.plugin.software.internal.SoftwareTypeRegistry
 
 
 /**
  * A {@link ConventionHandler} for applying declarative conventions.
  */
-class DeclarativeModelDefaultsHandler(softwareTypeRegistry: SoftwareTypeRegistry) : ModelDefaultsHandler {
+class DeclarativeModelDefaultsHandler(softwareTypeRegistry: SoftwareTypeRegistry, softwareFeatureApplicator: SoftwareFeatureApplicator) : ModelDefaultsHandler {
     private
-    val step = projectInterpretationSequenceStep(softwareTypeRegistry)
+    val step = projectInterpretationSequenceStep(softwareTypeRegistry, softwareFeatureApplicator)
     private
     val modelDefaultsRepository = softwareTypeRegistryBasedModelDefaultsRepository(softwareTypeRegistry)
 

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/evaluator/defaults/DeclarativeModelDefaultsHandler.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/evaluator/defaults/DeclarativeModelDefaultsHandler.kt
@@ -40,18 +40,22 @@ import org.gradle.internal.declarativedsl.project.projectInterpretationSequenceS
 import org.gradle.plugin.software.internal.ModelDefaultsHandler
 import org.gradle.plugin.software.internal.SoftwareFeatureApplicator
 import org.gradle.plugin.software.internal.SoftwareTypeRegistry
+import javax.inject.Inject
 
 
 /**
  * A {@link ConventionHandler} for applying declarative conventions.
  */
-class DeclarativeModelDefaultsHandler(softwareTypeRegistry: SoftwareTypeRegistry, softwareFeatureApplicator: SoftwareFeatureApplicator) : ModelDefaultsHandler {
+abstract class DeclarativeModelDefaultsHandler @Inject constructor(softwareTypeRegistry: SoftwareTypeRegistry) : ModelDefaultsHandler {
     private
-    val step = projectInterpretationSequenceStep(softwareTypeRegistry, softwareFeatureApplicator)
+    val step = lazy { projectInterpretationSequenceStep(softwareTypeRegistry, getSoftwareFeatureApplicator()) }
     private
     val modelDefaultsRepository = softwareTypeRegistryBasedModelDefaultsRepository(softwareTypeRegistry)
 
-    override fun <T : Any> apply(target: T, softwareTypeName: String, plugin: Plugin<in T>) {
+    @Inject
+    abstract fun getSoftwareFeatureApplicator(): SoftwareFeatureApplicator
+
+    override fun <T : Any> apply(target: T, softwareTypeName: String, plugin: Plugin<*>) {
         val analysisStepRunner = ApplyDefaultsOnlyAnalysisStepRunner()
         val analysisStepContext = AnalysisStepContext(
             emptySet(),
@@ -62,7 +66,7 @@ class DeclarativeModelDefaultsHandler(softwareTypeRegistry: SoftwareTypeRegistry
             .runInterpretationSequenceStep(
                 "<none>",
                 "",
-                step,
+                step.value,
                 ConversionStepContext(target, analysisStepContext)
             )
 

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/ProjectInterpretationSequenceStep.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/ProjectInterpretationSequenceStep.kt
@@ -19,6 +19,7 @@ package org.gradle.internal.declarativedsl.project
 import org.gradle.internal.declarativedsl.evaluator.defaults.ApplyModelDefaults
 import org.gradle.internal.declarativedsl.evaluationSchema.SimpleInterpretationSequenceStepWithConversion
 import org.gradle.internal.declarativedsl.common.UnsupportedSyntaxFeatureCheck
+import org.gradle.plugin.software.internal.SoftwareFeatureApplicator
 import org.gradle.plugin.software.internal.SoftwareTypeRegistry
 
 
@@ -27,9 +28,12 @@ import org.gradle.plugin.software.internal.SoftwareTypeRegistry
  * configured in the Settings DSL.
  */
 internal
-fun projectInterpretationSequenceStep(softwareTypeRegistry: SoftwareTypeRegistry) = SimpleInterpretationSequenceStepWithConversion(
+fun projectInterpretationSequenceStep(
+    softwareTypeRegistry: SoftwareTypeRegistry,
+    softwareFeatureApplicator: SoftwareFeatureApplicator
+) = SimpleInterpretationSequenceStepWithConversion(
     "project",
     features = setOf(ApplyModelDefaults(), UnsupportedSyntaxFeatureCheck.feature),
 ) {
-    projectEvaluationSchema(softwareTypeRegistry)
+    projectEvaluationSchema(softwareTypeRegistry, softwareFeatureApplicator)
 }

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/ProjectSchema.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/ProjectSchema.kt
@@ -23,21 +23,24 @@ import org.gradle.internal.declarativedsl.evaluationSchema.DefaultInterpretation
 import org.gradle.internal.declarativedsl.evaluationSchema.buildEvaluationAndConversionSchema
 import org.gradle.internal.declarativedsl.evaluator.conversion.EvaluationAndConversionSchema
 import org.gradle.internal.declarativedsl.software.softwareTypesWithPluginApplication
+import org.gradle.plugin.software.internal.SoftwareFeatureApplicator
 import org.gradle.plugin.software.internal.SoftwareTypeRegistry
 
 
 internal
 fun projectInterpretationSequence(
-    softwareTypeRegistry: SoftwareTypeRegistry
-) = DefaultInterpretationSequence(listOf(projectInterpretationSequenceStep(softwareTypeRegistry)))
+    softwareTypeRegistry: SoftwareTypeRegistry,
+    softwareFeatureApplicator: SoftwareFeatureApplicator
+) = DefaultInterpretationSequence(listOf(projectInterpretationSequenceStep(softwareTypeRegistry, softwareFeatureApplicator)))
 
 
 fun projectEvaluationSchema(
-    softwareTypeRegistry: SoftwareTypeRegistry
+    softwareTypeRegistry: SoftwareTypeRegistry,
+    softwareFeatureApplicator: SoftwareFeatureApplicator
 ): EvaluationAndConversionSchema {
     return buildEvaluationAndConversionSchema(ProjectTopLevelReceiver::class, analyzeEverything) {
         gradleDslGeneralSchema()
         dependencyCollectors()
-        softwareTypesWithPluginApplication(ProjectTopLevelReceiver::class, softwareTypeRegistry)
+        softwareTypesWithPluginApplication(ProjectTopLevelReceiver::class, softwareTypeRegistry, softwareFeatureApplicator)
     }
 }

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/provider/DeclarativeDslServices.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/provider/DeclarativeDslServices.kt
@@ -29,6 +29,7 @@ import org.gradle.internal.service.ServiceRegistration
 import org.gradle.internal.service.ServiceRegistrationProvider
 import org.gradle.internal.service.scopes.AbstractGradleModuleServices
 import org.gradle.plugin.software.internal.ModelDefaultsHandler
+import org.gradle.plugin.software.internal.SoftwareFeatureApplicator
 import org.gradle.plugin.software.internal.SoftwareTypeRegistry
 import java.io.File
 
@@ -36,6 +37,10 @@ import java.io.File
 class DeclarativeDslServices : AbstractGradleModuleServices() {
     override fun registerBuildServices(registration: ServiceRegistration) {
         registration.addProvider(BuildServices)
+    }
+
+    override fun registerProjectServices(registration: ServiceRegistration) {
+        registration.addProvider(ProjectServices)
     }
 }
 
@@ -53,14 +58,18 @@ object BuildServices : ServiceRegistrationProvider {
         return defaultDeclarativeScriptEvaluator(schemaBuilder, softwareTypeRegistry)
     }
 
-    @Provides
-    fun createSoftwareTypeConventionHandler(
-        softwareTypeRegistry: SoftwareTypeRegistry
-    ): ModelDefaultsHandler {
-        return DeclarativeModelDefaultsHandler(softwareTypeRegistry)
-    }
-
     private
     fun BuildLayoutFactory.settingsDir(gradle: GradleInternal): File =
         getLayoutFor(BuildLayoutConfiguration(gradle.startParameter)).settingsDir
+}
+
+internal
+object ProjectServices : ServiceRegistrationProvider {
+    @Provides
+    fun createDeclarativeModelDefaultsHandler(
+        softwareTypeRegistry: SoftwareTypeRegistry,
+        softwareFeatureApplicator: SoftwareFeatureApplicator
+    ): ModelDefaultsHandler {
+        return DeclarativeModelDefaultsHandler(softwareTypeRegistry, softwareFeatureApplicator)
+    }
 }

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/provider/DeclarativeDslServices.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/provider/DeclarativeDslServices.kt
@@ -17,6 +17,7 @@
 package org.gradle.internal.declarativedsl.provider
 
 import org.gradle.api.internal.GradleInternal
+import org.gradle.api.model.ObjectFactory
 import org.gradle.initialization.layout.BuildLayoutConfiguration
 import org.gradle.initialization.layout.BuildLayoutFactory
 import org.gradle.internal.declarativedsl.evaluator.DeclarativeKotlinScriptEvaluator
@@ -29,7 +30,6 @@ import org.gradle.internal.service.ServiceRegistration
 import org.gradle.internal.service.ServiceRegistrationProvider
 import org.gradle.internal.service.scopes.AbstractGradleModuleServices
 import org.gradle.plugin.software.internal.ModelDefaultsHandler
-import org.gradle.plugin.software.internal.SoftwareFeatureApplicator
 import org.gradle.plugin.software.internal.SoftwareTypeRegistry
 import java.io.File
 
@@ -68,8 +68,8 @@ object ProjectServices : ServiceRegistrationProvider {
     @Provides
     fun createDeclarativeModelDefaultsHandler(
         softwareTypeRegistry: SoftwareTypeRegistry,
-        softwareFeatureApplicator: SoftwareFeatureApplicator
+        objectFactory: ObjectFactory
     ): ModelDefaultsHandler {
-        return DeclarativeModelDefaultsHandler(softwareTypeRegistry, softwareFeatureApplicator)
+        return objectFactory.newInstance(DeclarativeModelDefaultsHandler::class.java, softwareTypeRegistry)
     }
 }

--- a/platforms/core-configuration/declarative-dsl-provider/src/test/kotlin/org/gradle/internal/declarativedsl/software/SoftwareTypesTest.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/test/kotlin/org/gradle/internal/declarativedsl/software/SoftwareTypesTest.kt
@@ -25,6 +25,7 @@ import org.gradle.internal.declarativedsl.common.gradleDslGeneralSchema
 import org.gradle.internal.declarativedsl.evaluationSchema.buildEvaluationAndConversionSchema
 import org.gradle.internal.declarativedsl.evaluationSchema.buildEvaluationSchema
 import org.gradle.plugin.software.internal.ModelDefault
+import org.gradle.plugin.software.internal.SoftwareFeatureApplicator
 import org.gradle.plugin.software.internal.SoftwareTypeImplementation
 import org.gradle.plugin.software.internal.SoftwareTypeRegistry
 import org.junit.Assert.assertFalse
@@ -48,6 +49,8 @@ class SoftwareTypesTest {
             )
         }
 
+        val applicatorMock = mock<SoftwareFeatureApplicator>()
+
         val schemaForSettings = buildEvaluationSchema(TopLevel::class, analyzeEverything) {
             gradleDslGeneralSchema()
             softwareTypesConventions(TopLevel::class, registryMock)
@@ -55,7 +58,7 @@ class SoftwareTypesTest {
 
         val schemaForProject = buildEvaluationAndConversionSchema(TopLevel::class, analyzeEverything) {
             gradleDslGeneralSchema()
-            softwareTypesWithPluginApplication(TopLevel::class, registryMock)
+            softwareTypesWithPluginApplication(TopLevel::class, registryMock, applicatorMock)
         }
 
         listOf(schemaForSettings, schemaForProject).forEach { schema ->

--- a/platforms/core-configuration/declarative-dsl-provider/src/testFixtures/groovy/org/gradle/internal/declarativedsl/settings/SoftwareTypeFixture.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/testFixtures/groovy/org/gradle/internal/declarativedsl/settings/SoftwareTypeFixture.groovy
@@ -162,6 +162,30 @@ trait SoftwareTypeFixture {
         return pluginBuilder
     }
 
+    PluginBuilder withSoftwareTypePluginThatRegistersItsOwnExtension() {
+        return withSoftwareTypePlugins(
+            softwareTypeExtension,
+            projectPluginThatRegistersItsOwnExtension,
+            settingsPluginThatRegistersSoftwareType
+        )
+    }
+
+    PluginBuilder withSoftwareTypePluginThatFailsToRegistersItsOwnExtension() {
+        return withSoftwareTypePlugins(
+            softwareTypeExtension,
+            getProjectPluginThatRegistersItsOwnExtension(false),
+            settingsPluginThatRegistersSoftwareType
+        )
+    }
+
+    PluginBuilder withSoftwareTypePluginThatRegistersTheWrongExtension() {
+        return withSoftwareTypePlugins(
+            softwareTypeExtension,
+            getProjectPluginThatRegistersItsOwnExtension(true, "new String()"),
+            settingsPluginThatRegistersSoftwareType
+        )
+    }
+
     static String getSoftwareTypeExtension() {
         return """
             package org.gradle.test;
@@ -374,14 +398,15 @@ trait SoftwareTypeFixture {
 
             abstract public class ${softwareTypePluginClassName} implements Plugin<Project> {
 
-                @SoftwareType(${getSoftwareTypeArguments(softwareType, publicTypeClassName)})
+                @SoftwareType(${SoftwareTypeArgumentBuilder.name(softwareType)
+                                    .modelPublicType(publicTypeClassName)
+                                    .build()})
                 abstract public ${implementationTypeClassName} getTestSoftwareTypeExtension();
 
                 @Override
                 public void apply(Project target) {
                     System.out.println("Applying " + getClass().getSimpleName());
                     ${implementationTypeClassName} extension = getTestSoftwareTypeExtension();
-                    target.getExtensions().add("${softwareType}", extension);
 
                     ${conventions}
                     target.getTasks().register("print${implementationTypeClassName}Configuration", DefaultTask.class, task -> {
@@ -394,9 +419,77 @@ trait SoftwareTypeFixture {
         """
     }
 
-    private static getSoftwareTypeArguments(String name, String modelPublicType) {
-        return "name=\"${name}\"" +
-            (modelPublicType ? ", modelPublicType=${modelPublicType}.class" : "")
+    static String getProjectPluginThatRegistersItsOwnExtension(
+        boolean shouldRegisterExtension = true,
+        String extension = "extension"
+    ) {
+        String implementationTypeClassName = "TestSoftwareTypeExtension"
+        String softwareTypePluginClassName = "SoftwareTypeImplPlugin"
+        String softwareType = "testSoftwareType"
+        String conventions = testSoftwareTypeExtensionConventions
+        String extensionRegistration = shouldRegisterExtension ? """target.getExtensions().add("${softwareType}", ${extension});""" : ""
+        return """
+            package org.gradle.test;
+
+            import org.gradle.api.DefaultTask;
+            import org.gradle.api.Plugin;
+            import org.gradle.api.Project;
+            import org.gradle.api.provider.ListProperty;
+            import org.gradle.api.provider.Property;
+            import org.gradle.api.tasks.Nested;
+            import ${SoftwareType.class.name};
+            import javax.inject.Inject;
+
+            abstract public class ${softwareTypePluginClassName} implements Plugin<Project> {
+
+                @SoftwareType(${SoftwareTypeArgumentBuilder.name(softwareType)
+                                    .disableExtensionRegistration(true)
+                                    .build()})
+                abstract public ${implementationTypeClassName} getTestSoftwareTypeExtension();
+
+                @Override
+                public void apply(Project target) {
+                    System.out.println("Applying " + getClass().getSimpleName());
+                    ${implementationTypeClassName} extension = getTestSoftwareTypeExtension();
+                    ${extensionRegistration}
+
+                    ${conventions}
+                    target.getTasks().register("print${implementationTypeClassName}Configuration", DefaultTask.class, task -> {
+                        task.doLast("print restricted extension content", t -> {
+                            System.out.println(extension);
+                        });
+                    });
+                }
+            }
+        """
+    }
+
+    private static class SoftwareTypeArgumentBuilder {
+        String name
+        String modelPublicType
+        boolean disableExtensionRegistration
+
+        static SoftwareTypeArgumentBuilder name(String name) {
+            SoftwareTypeArgumentBuilder builder = new SoftwareTypeArgumentBuilder()
+            builder.name = name
+            return builder
+        }
+
+        SoftwareTypeArgumentBuilder modelPublicType(String modelPublicType) {
+            this.modelPublicType = modelPublicType
+            return this
+        }
+
+        SoftwareTypeArgumentBuilder disableExtensionRegistration(boolean disableExtensionRegistration) {
+            this.disableExtensionRegistration = disableExtensionRegistration
+            return this
+        }
+
+        String build() {
+            return "name=\"${name}\"" +
+                (modelPublicType ? ", modelPublicType=${modelPublicType}.class" : "") +
+                (disableExtensionRegistration ? ", disableExtensionRegistration=true" : "")
+        }
     }
 
     static String getTestSoftwareTypeExtensionConventions() {

--- a/platforms/core-configuration/declarative-dsl-provider/src/testFixtures/groovy/org/gradle/internal/declarativedsl/settings/SoftwareTypeFixture.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/testFixtures/groovy/org/gradle/internal/declarativedsl/settings/SoftwareTypeFixture.groovy
@@ -443,7 +443,7 @@ trait SoftwareTypeFixture {
             abstract public class ${softwareTypePluginClassName} implements Plugin<Project> {
 
                 @SoftwareType(${SoftwareTypeArgumentBuilder.name(softwareType)
-                                    .disableExtensionRegistration(true)
+                                    .disableModelManagement(true)
                                     .build()})
                 abstract public ${implementationTypeClassName} getTestSoftwareTypeExtension();
 
@@ -467,7 +467,7 @@ trait SoftwareTypeFixture {
     private static class SoftwareTypeArgumentBuilder {
         String name
         String modelPublicType
-        boolean disableExtensionRegistration
+        boolean disableModelManagement
 
         static SoftwareTypeArgumentBuilder name(String name) {
             SoftwareTypeArgumentBuilder builder = new SoftwareTypeArgumentBuilder()
@@ -480,15 +480,15 @@ trait SoftwareTypeFixture {
             return this
         }
 
-        SoftwareTypeArgumentBuilder disableExtensionRegistration(boolean disableExtensionRegistration) {
-            this.disableExtensionRegistration = disableExtensionRegistration
+        SoftwareTypeArgumentBuilder disableModelManagement(boolean disableModelManagement) {
+            this.disableModelManagement = disableModelManagement
             return this
         }
 
         String build() {
             return "name=\"${name}\"" +
                 (modelPublicType ? ", modelPublicType=${modelPublicType}.class" : "") +
-                (disableExtensionRegistration ? ", disableExtensionRegistration=true" : "")
+                (disableModelManagement ? ", disableModelManagement=true" : "")
         }
     }
 

--- a/platforms/core-configuration/declarative-dsl-tooling-builders/src/main/kotlin/org/gradle/declarative/dsl/tooling/builders/DeclarativeSchemaModelBuilder.kt
+++ b/platforms/core-configuration/declarative-dsl-tooling-builders/src/main/kotlin/org/gradle/declarative/dsl/tooling/builders/DeclarativeSchemaModelBuilder.kt
@@ -24,16 +24,19 @@ import org.gradle.internal.build.BuildState
 import org.gradle.internal.declarativedsl.evaluationSchema.DefaultInterpretationSequence
 import org.gradle.internal.declarativedsl.evaluationSchema.SimpleInterpretationSequenceStep
 import org.gradle.internal.declarativedsl.evaluator.GradleProcessInterpretationSchemaBuilder
+import org.gradle.internal.declarativedsl.evaluator.LoadedProjectScriptContext
 import org.gradle.internal.declarativedsl.evaluator.LoadedSettingsScriptContext
 import org.gradle.internal.declarativedsl.evaluator.schema.DefaultEvaluationSchema
 import org.gradle.internal.declarativedsl.evaluator.schema.InterpretationSchemaBuildingResult
-import org.gradle.internal.declarativedsl.evaluator.schema.DeclarativeScriptContext
+import org.gradle.plugin.software.internal.SoftwareFeatureApplicator
 import org.gradle.plugin.software.internal.SoftwareTypeRegistry
 import org.gradle.tooling.provider.model.internal.BuildScopeModelBuilder
 import java.io.Serializable
 
 
-class DeclarativeSchemaModelBuilder(private val softwareTypeRegistry: SoftwareTypeRegistry) : BuildScopeModelBuilder {
+class DeclarativeSchemaModelBuilder(
+    private val softwareTypeRegistry: SoftwareTypeRegistry
+) : BuildScopeModelBuilder {
 
     override fun create(target: BuildState): Any {
         // Make sure the project tree has been loaded and can be queried (but not necessarily configured)
@@ -46,7 +49,9 @@ class DeclarativeSchemaModelBuilder(private val softwareTypeRegistry: SoftwareTy
 
         val settingsSequence = schemaBuilder.getEvaluationSchemaForScript(settingsContext)
             .sequenceOrError().analysisOnly()
-        val projectSequence = schemaBuilder.getEvaluationSchemaForScript(DeclarativeScriptContext.ProjectScript)
+
+        val projectContext = LoadedProjectScriptContext(SoftwareFeatureApplicator.ANALYSIS_ONLY)
+        val projectSequence = schemaBuilder.getEvaluationSchemaForScript(projectContext)
             .sequenceOrError().analysisOnly()
 
         return DefaultDeclarativeSchemaModel(settingsSequence, projectSequence)

--- a/platforms/extensibility/plugin-use/build.gradle.kts
+++ b/platforms/extensibility/plugin-use/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     api(projects.logging)
     api(projects.messaging)
     api(projects.modelCore)
+    api(projects.problemsApi)
 
     api(libs.guava)
     api(libs.jsr305)
@@ -20,7 +21,6 @@ dependencies {
     implementation(projects.functional)
 
     implementation(projects.jvmServices)
-    implementation(projects.problemsApi)
 
     testImplementation(testFixtures(projects.resourcesHttp))
 

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/internal/PluginUseServices.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/internal/PluginUseServices.java
@@ -205,8 +205,8 @@ public class PluginUseServices extends AbstractGradleModuleServices {
     @NonNullApi
     private static class ProjectScopeServices implements ServiceRegistrationProvider {
         @Provides
-        SoftwareFeatureApplicator createSoftwareFeatureApplicator(Project project, PluginScheme pluginScheme, InternalProblems problems) {
-            return new DefaultSoftwareFeatureApplicator(project, pluginScheme.getInspectionScheme(), problems);
+        SoftwareFeatureApplicator createSoftwareFeatureApplicator(Project project, ModelDefaultsApplicator modelDefaultsApplicator, PluginScheme pluginScheme, InternalProblems problems) {
+            return new DefaultSoftwareFeatureApplicator(project, modelDefaultsApplicator, pluginScheme.getInspectionScheme(), problems);
         }
 
         @Provides

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/DefaultModelDefaultsApplicator.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/DefaultModelDefaultsApplicator.java
@@ -17,7 +17,6 @@
 package org.gradle.plugin.software.internal;
 
 import org.gradle.api.Plugin;
-import org.gradle.internal.Cast;
 
 import java.util.List;
 
@@ -25,18 +24,14 @@ import java.util.List;
  * Applies the model defaults for a given software type to a target project if the provided plugin class is a software type plugin.
  */
 public class DefaultModelDefaultsApplicator implements ModelDefaultsApplicator {
-    private final SoftwareTypeRegistry softwareTypeRegistry;
     private final List<ModelDefaultsHandler> defaultsHandlers;
 
-    public DefaultModelDefaultsApplicator(SoftwareTypeRegistry softwareTypeRegistry, List<ModelDefaultsHandler> defaultsHandlers) {
-        this.softwareTypeRegistry = softwareTypeRegistry;
+    public DefaultModelDefaultsApplicator(List<ModelDefaultsHandler> defaultsHandlers) {
         this.defaultsHandlers = defaultsHandlers;
     }
 
     @Override
-    public <T> void applyDefaultsTo(T target, Plugin<? super T> plugin) {
-        softwareTypeRegistry.implementationFor(Cast.uncheckedCast(plugin.getClass())).ifPresent(softwareTypeImplementation ->
-            defaultsHandlers.forEach(handler -> handler.apply(target, softwareTypeImplementation.getSoftwareType(), plugin))
-        );
+    public <T> void applyDefaultsTo(T target, Plugin<? super T> plugin, SoftwareTypeImplementation<?> softwareTypeImplementation) {
+        defaultsHandlers.forEach(handler -> handler.apply(target, softwareTypeImplementation.getSoftwareType(), plugin));
     }
 }

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/DefaultModelDefaultsApplicator.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/DefaultModelDefaultsApplicator.java
@@ -31,7 +31,7 @@ public class DefaultModelDefaultsApplicator implements ModelDefaultsApplicator {
     }
 
     @Override
-    public <T> void applyDefaultsTo(T target, Plugin<? super T> plugin, SoftwareTypeImplementation<?> softwareTypeImplementation) {
+    public <T> void applyDefaultsTo(T target, Plugin<?> plugin, SoftwareTypeImplementation<?> softwareTypeImplementation) {
         defaultsHandlers.forEach(handler -> handler.apply(target, softwareTypeImplementation.getSoftwareType(), plugin));
     }
 }

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/DefaultSoftwareFeatureApplicator.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/DefaultSoftwareFeatureApplicator.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugin.software.internal;
+
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.NonNullApi;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.internal.plugins.DslObject;
+import org.gradle.api.internal.plugins.software.SoftwareType;
+import org.gradle.api.internal.tasks.properties.InspectionScheme;
+import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.problems.Severity;
+import org.gradle.api.problems.internal.GradleCoreProblemGroup;
+import org.gradle.api.problems.internal.InternalProblems;
+import org.gradle.internal.Cast;
+import org.gradle.internal.exceptions.DefaultMultiCauseException;
+import org.gradle.internal.properties.PropertyValue;
+import org.gradle.internal.properties.PropertyVisitor;
+import org.gradle.internal.reflect.DefaultTypeValidationContext;
+import org.gradle.internal.reflect.validation.TypeValidationProblemRenderer;
+import org.gradle.model.internal.type.ModelType;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class DefaultSoftwareFeatureApplicator implements SoftwareFeatureApplicator {
+    private final Project project;
+    private final InspectionScheme inspectionScheme;
+    private final InternalProblems problems;
+    private final Set<ApplicationKey> applied = new HashSet<>();
+
+    public DefaultSoftwareFeatureApplicator(Project project, InspectionScheme inspectionScheme, InternalProblems problems) {
+        this.project = project;
+        this.inspectionScheme = inspectionScheme;
+        this.problems = problems;
+    }
+
+    @Override
+    public <T> T applyFeatureTo(ExtensionAware target, SoftwareTypeImplementation<T> softwareFeature) {
+        ApplicationKey key = new ApplicationKey(target, softwareFeature);
+        if (!applied.contains(key)) {
+            applyAndMaybeRegisterExtension(target, softwareFeature);
+            applied.add(key);
+        }
+        return Cast.uncheckedCast(target.getExtensions().getByName(softwareFeature.getSoftwareType()));
+    }
+
+    private <T> void applyAndMaybeRegisterExtension(ExtensionAware target, SoftwareTypeImplementation<T> softwareFeature) {
+        Plugin<Project> plugin = project.getPlugins().getPlugin(softwareFeature.getPluginClass());
+
+        DefaultTypeValidationContext typeValidationContext = DefaultTypeValidationContext.withRootType(softwareFeature.getPluginClass(), false, problems);
+        ExtensionAddingVisitor<T> extensionAddingVisitor = new ExtensionAddingVisitor<>(target, typeValidationContext);
+        inspectionScheme.getPropertyWalker().visitProperties(
+            plugin,
+            typeValidationContext,
+            extensionAddingVisitor
+        );
+
+        if (!typeValidationContext.getProblems().isEmpty()) {
+            throw new DefaultMultiCauseException(
+                String.format(typeValidationContext.getProblems().size() == 1
+                        ? "A problem was found with the %s plugin."
+                        : "Some problems were found with the %s plugin.",
+                    getPluginObjectDisplayName(plugin)),
+                typeValidationContext.getProblems().stream()
+                    .map(TypeValidationProblemRenderer::renderMinimalInformationAbout)
+                    .sorted()
+                    .map(InvalidUserDataException::new)
+                    .collect(toImmutableList())
+            );
+        }
+    }
+
+    private static String getPluginObjectDisplayName(Object parameterObject) {
+        return ModelType.of(new DslObject(parameterObject).getDeclaredType()).getDisplayName();
+    }
+
+    @NonNullApi
+    public static class ExtensionAddingVisitor<T> implements PropertyVisitor {
+        private final ExtensionAware target;
+        private final DefaultTypeValidationContext validationContext;
+
+        public ExtensionAddingVisitor(ExtensionAware target, DefaultTypeValidationContext validationContext) {
+            this.target = target;
+            this.validationContext = validationContext;
+        }
+
+        @Override
+        public void visitSoftwareTypeProperty(String propertyName, PropertyValue value, Class<?> declaredPropertyType, SoftwareType softwareType) {
+            T publicModelObject = Cast.uncheckedNonnullCast(value.call());
+            if (softwareType.disableExtensionRegistration()) {
+                Object extension = target.getExtensions().findByName(softwareType.name());
+                if (extension == null) {
+                    validationContext.visitPropertyProblem(problem ->
+                        problem
+                            .forProperty(propertyName)
+                            .id("extension-not-registered-for-software-type", "was not registered as an extension", GradleCoreProblemGroup.validation().property())
+                            .contextualLabel("has @SoftwareType annotation with 'disableExtensionRegistration' set to true, but no extension with name '" + softwareType.name() + "' was registered")
+                            .severity(Severity.ERROR)
+                            .details("When 'disableExtensionRegistration' is set, the plugin must register the '" + propertyName + "' property as an extension with the same name as the software type.")
+                            .solution("During plugin application, register the '" + propertyName + "' property as an extension with the name '" + softwareType.name() + "'.")
+                            .solution("Set 'disableExtensionRegistration' to false or remove the parameter from the @SoftwareType annotation.")
+                    );
+                } else if (extension != publicModelObject) {
+                    validationContext.visitPropertyProblem(problem ->
+                        problem
+                            .forProperty(propertyName)
+                            .id("mismatched-extension-registered-for-software-type", "does not match the extension registered as '" + softwareType.name(), GradleCoreProblemGroup.validation().property())
+                            .contextualLabel("has @SoftwareType annotation with 'disableExtensionRegistration' set to true, but the extension with name '" + softwareType.name() + "' does not match the value of the property")
+                            .severity(Severity.ERROR)
+                            .details("When 'disableExtensionRegistration' is set, the plugin must register the '" + propertyName + "' property as an extension with the same name as the software type.")
+                            .solution("During plugin application, register the '" + propertyName + "' property as an extension with the name '" + softwareType.name() + "'.")
+                    );
+                }
+            } else {
+                target.getExtensions().add(
+                    publicTypeFrom(softwareType.modelPublicType(), declaredPropertyType),
+                    softwareType.name(),
+                    publicModelObject
+                );
+            }
+        }
+
+        private Class<? super T> publicTypeFrom(Class<?> fromAnnotation, Class<?> declaredPropertyType) {
+            return Cast.uncheckedCast(fromAnnotation == Void.class ? declaredPropertyType : fromAnnotation);
+        }
+    }
+
+    private static class ApplicationKey {
+        private final Object target;
+        private final SoftwareTypeImplementation<?> softwareFeature;
+
+        public ApplicationKey(Object target, SoftwareTypeImplementation<?> softwareFeature) {
+            this.target = target;
+            this.softwareFeature = softwareFeature;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ApplicationKey that = (ApplicationKey) o;
+            return Objects.equals(target, that.target) && Objects.equals(softwareFeature, that.softwareFeature);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(target, softwareFeature);
+        }
+    }
+}

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/DefaultSoftwareFeatureApplicator.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/DefaultSoftwareFeatureApplicator.java
@@ -167,13 +167,20 @@ public class DefaultSoftwareFeatureApplicator implements SoftwareFeatureApplicat
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
+
             AppliedFeature that = (AppliedFeature) o;
-            return Objects.equals(target, that.target) && Objects.equals(softwareFeature, that.softwareFeature);
+            // We use identity comparison here because we want to ensure that the software feature is applied to
+            // each target object, even if two different target objects have equality.
+            return target == that.target && Objects.equals(softwareFeature, that.softwareFeature);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(target, softwareFeature);
+            // We use identity hashes here because we want to ensure that the software feature is applied to
+            // each target object, even if two different target objects hash equally.
+            int result = System.identityHashCode(target);
+            result = 31 * result + softwareFeature.hashCode();
+            return result;
         }
     }
 }

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/DefaultSoftwareFeatureApplicator.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/DefaultSoftwareFeatureApplicator.java
@@ -45,7 +45,7 @@ public class DefaultSoftwareFeatureApplicator implements SoftwareFeatureApplicat
     private final Project project;
     private final InspectionScheme inspectionScheme;
     private final InternalProblems problems;
-    private final Set<ApplicationKey> applied = new HashSet<>();
+    private final Set<AppliedFeature> applied = new HashSet<>();
 
     public DefaultSoftwareFeatureApplicator(Project project, InspectionScheme inspectionScheme, InternalProblems problems) {
         this.project = project;
@@ -55,10 +55,10 @@ public class DefaultSoftwareFeatureApplicator implements SoftwareFeatureApplicat
 
     @Override
     public <T> T applyFeatureTo(ExtensionAware target, SoftwareTypeImplementation<T> softwareFeature) {
-        ApplicationKey key = new ApplicationKey(target, softwareFeature);
-        if (!applied.contains(key)) {
+        AppliedFeature appliedFeature = new AppliedFeature(target, softwareFeature);
+        if (!applied.contains(appliedFeature)) {
             applyAndMaybeRegisterExtension(target, softwareFeature);
-            applied.add(key);
+            applied.add(appliedFeature);
         }
         return Cast.uncheckedCast(target.getExtensions().getByName(softwareFeature.getSoftwareType()));
     }
@@ -144,11 +144,11 @@ public class DefaultSoftwareFeatureApplicator implements SoftwareFeatureApplicat
         }
     }
 
-    private static class ApplicationKey {
+    private static class AppliedFeature {
         private final Object target;
         private final SoftwareTypeImplementation<?> softwareFeature;
 
-        public ApplicationKey(Object target, SoftwareTypeImplementation<?> softwareFeature) {
+        public AppliedFeature(Object target, SoftwareTypeImplementation<?> softwareFeature) {
             this.target = target;
             this.softwareFeature = softwareFeature;
         }
@@ -161,7 +161,7 @@ public class DefaultSoftwareFeatureApplicator implements SoftwareFeatureApplicat
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
-            ApplicationKey that = (ApplicationKey) o;
+            AppliedFeature that = (AppliedFeature) o;
             return Objects.equals(target, that.target) && Objects.equals(softwareFeature, that.softwareFeature);
         }
 

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/DefaultSoftwareFeatureApplicator.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/DefaultSoftwareFeatureApplicator.java
@@ -41,6 +41,12 @@ import java.util.Set;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
+/**
+ * Applies software features to a target object by registering the software model as an extension of the target object (unless
+ * configured otherwise) and performing validations.  Application returns the public model object of the feature.  Features
+ * are applied only once per target object and always return the same public model object for a given target/feature
+ * combination.
+ */
 public class DefaultSoftwareFeatureApplicator implements SoftwareFeatureApplicator {
     private final Project project;
     private final InspectionScheme inspectionScheme;

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/DefaultSoftwareFeatureApplicator.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/DefaultSoftwareFeatureApplicator.java
@@ -114,27 +114,27 @@ public class DefaultSoftwareFeatureApplicator implements SoftwareFeatureApplicat
         @Override
         public void visitSoftwareTypeProperty(String propertyName, PropertyValue value, Class<?> declaredPropertyType, SoftwareType softwareType) {
             T publicModelObject = Cast.uncheckedNonnullCast(value.call());
-            if (softwareType.disableExtensionRegistration()) {
+            if (softwareType.disableModelManagement()) {
                 Object extension = target.getExtensions().findByName(softwareType.name());
                 if (extension == null) {
                     validationContext.visitPropertyProblem(problem ->
                         problem
                             .forProperty(propertyName)
                             .id("extension-not-registered-for-software-type", "was not registered as an extension", GradleCoreProblemGroup.validation().property())
-                            .contextualLabel("has @SoftwareType annotation with 'disableExtensionRegistration' set to true, but no extension with name '" + softwareType.name() + "' was registered")
+                            .contextualLabel("has @SoftwareType annotation with 'disableModelManagement' set to true, but no extension with name '" + softwareType.name() + "' was registered")
                             .severity(Severity.ERROR)
-                            .details("When 'disableExtensionRegistration' is set, the plugin must register the '" + propertyName + "' property as an extension with the same name as the software type.")
+                            .details("When 'disableModelManagement' is set, the plugin must register the '" + propertyName + "' property as an extension with the same name as the software type.")
                             .solution("During plugin application, register the '" + propertyName + "' property as an extension with the name '" + softwareType.name() + "'.")
-                            .solution("Set 'disableExtensionRegistration' to false or remove the parameter from the @SoftwareType annotation.")
+                            .solution("Set 'disableModelManagement' to false or remove the parameter from the @SoftwareType annotation.")
                     );
                 } else if (extension != publicModelObject) {
                     validationContext.visitPropertyProblem(problem ->
                         problem
                             .forProperty(propertyName)
                             .id("mismatched-extension-registered-for-software-type", "does not match the extension registered as '" + softwareType.name(), GradleCoreProblemGroup.validation().property())
-                            .contextualLabel("has @SoftwareType annotation with 'disableExtensionRegistration' set to true, but the extension with name '" + softwareType.name() + "' does not match the value of the property")
+                            .contextualLabel("has @SoftwareType annotation with 'disableModelManagement' set to true, but the extension with name '" + softwareType.name() + "' does not match the value of the property")
                             .severity(Severity.ERROR)
-                            .details("When 'disableExtensionRegistration' is set, the plugin must register the '" + propertyName + "' property as an extension with the same name as the software type.")
+                            .details("When 'disableModelManagement' is set, the plugin must register the '" + propertyName + "' property as an extension with the same name as the software type.")
                             .solution("During plugin application, register the '" + propertyName + "' property as an extension with the name '" + softwareType.name() + "'.")
                     );
                 }

--- a/platforms/extensibility/plugin-use/src/test/groovy/org/gradle/plugin/software/internal/DefaultSoftwareFeatureApplicatorTest.groovy
+++ b/platforms/extensibility/plugin-use/src/test/groovy/org/gradle/plugin/software/internal/DefaultSoftwareFeatureApplicatorTest.groovy
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugin.software.internal
+
+import org.gradle.api.Plugin
+import org.gradle.api.internal.plugins.ExtensionContainerInternal
+import org.gradle.api.internal.plugins.software.SoftwareType
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.internal.tasks.properties.InspectionScheme
+import org.gradle.api.plugins.PluginContainer
+import org.gradle.api.problems.internal.AdditionalDataBuilderFactory
+import org.gradle.api.problems.internal.InternalProblems
+import org.gradle.internal.exceptions.DefaultMultiCauseException
+import org.gradle.internal.properties.PropertyValue
+import org.gradle.internal.properties.bean.PropertyWalker
+import spock.lang.Specification
+
+class DefaultSoftwareFeatureApplicatorTest extends Specification {
+    def target = Mock(ProjectInternal)
+    def inspectionScheme = Mock(InspectionScheme)
+    def problems = Mock(InternalProblems) {
+        getAdditionalDataBuilderFactory() >> new AdditionalDataBuilderFactory()
+    }
+    def applicator = new DefaultSoftwareFeatureApplicator(target, inspectionScheme, problems)
+    def plugin = Mock(Plugin)
+    def plugins = Mock(PluginContainer)
+    def propertyWalker = Mock(PropertyWalker)
+    def propertyValue = Mock(PropertyValue)
+    def softwareType = Mock(SoftwareType)
+    def extensions = Mock(ExtensionContainerInternal)
+    SoftwareTypeImplementation<Foo> softwareTypeImplementation = Mock(SoftwareTypeImplementation)
+    def foo = new Foo()
+
+    def "adds software types as extensions when software type plugin is applied"() {
+        when:
+        def returned = applicator.applyFeatureTo(target, softwareTypeImplementation)
+
+        then:
+        _ * softwareTypeImplementation.pluginClass >> plugin.class
+        1 * target.plugins >> plugins
+        1 * plugins.getPlugin(plugin.class) >> plugin
+        1 * inspectionScheme.getPropertyWalker() >> propertyWalker
+        1 * propertyWalker.visitProperties(plugin, _, _) >> { args -> args[2].visitSoftwareTypeProperty("foo", propertyValue, Foo.class, softwareType) }
+        _ * target.getExtensions() >> extensions
+        1 * softwareType.modelPublicType() >> Foo.class
+        1 * softwareType.name() >> "foo"
+        1 * propertyValue.call() >> foo
+        1 * extensions.add(Foo.class, "foo", foo)
+        _ * softwareTypeImplementation.softwareType >> "foo"
+        1 * extensions.getByName("foo") >> foo
+
+        and:
+        returned == foo
+    }
+
+    def "only adds software types as extensions once when software type plugin is applied multiple times"() {
+        when:
+        def first = applicator.applyFeatureTo(target, softwareTypeImplementation)
+
+        then:
+        _ * softwareTypeImplementation.pluginClass >> plugin.class
+        1 * target.plugins >> plugins
+        1 * plugins.getPlugin(plugin.class) >> plugin
+        1 * inspectionScheme.getPropertyWalker() >> propertyWalker
+        1 * propertyWalker.visitProperties(plugin, _, _) >> { args -> args[2].visitSoftwareTypeProperty("foo", propertyValue, Foo.class, softwareType) }
+        _ * target.getExtensions() >> extensions
+        1 * softwareType.modelPublicType() >> Foo.class
+        1 * softwareType.name() >> "foo"
+        1 * propertyValue.call() >> foo
+        1 * extensions.add(Foo.class, "foo", foo)
+        _ * softwareTypeImplementation.softwareType >> "foo"
+        1 * extensions.getByName("foo") >> foo
+
+        and:
+        first == foo
+
+        when:
+        def second = applicator.applyFeatureTo(target, softwareTypeImplementation)
+
+        then:
+        _ * target.getExtensions() >> extensions
+        _ * softwareTypeImplementation.softwareType >> "foo"
+        1 * extensions.getByName("foo") >> foo
+        0 * _
+
+        and:
+        second == first
+        second == foo
+    }
+
+    def "does not add software type as extension when registration is disabled"() {
+        def plugin = Mock(Plugin)
+
+        when:
+        def returned = applicator.applyFeatureTo(target, softwareTypeImplementation)
+
+        then:
+        1 * softwareType.disableExtensionRegistration() >> true
+        _ * extensions.findByName("foo") >> foo
+
+        and:
+        _ * softwareTypeImplementation.pluginClass >> plugin.class
+        1 * target.plugins >> plugins
+        1 * plugins.getPlugin(plugin.class) >> plugin
+        1 * inspectionScheme.getPropertyWalker() >> propertyWalker
+        1 * propertyWalker.visitProperties(plugin, _, _) >> { args -> args[2].visitSoftwareTypeProperty("foo", propertyValue, Foo.class, softwareType) }
+        1 * propertyValue.call() >> foo
+        _ * target.getExtensions() >> extensions
+        _ * softwareType.name() >> "foo"
+        0 * extensions.add(_, _, _)
+        _ * softwareTypeImplementation.softwareType >> "foo"
+        1 * extensions.getByName("foo") >> foo
+
+        and:
+        returned == foo
+    }
+
+    def "throws sensible error when registration is disabled but no extension is registered"() {
+        def plugin = Mock(Plugin)
+
+        when:
+        applicator.applyFeatureTo(target, softwareTypeImplementation)
+
+        then:
+        1 * softwareType.disableExtensionRegistration() >> true
+        1 * extensions.findByName("foo") >> null
+
+        and:
+        _ * softwareTypeImplementation.pluginClass >> plugin.class
+        1 * target.plugins >> plugins
+        1 * plugins.getPlugin(plugin.class) >> plugin
+        1 * inspectionScheme.getPropertyWalker() >> propertyWalker
+        1 * propertyWalker.visitProperties(plugin, _, _) >> { args -> args[2].visitSoftwareTypeProperty("foo", propertyValue, Foo.class, softwareType) }
+        1 * propertyValue.call() >> foo
+        _ * target.getExtensions() >> extensions
+        _ * softwareType.name() >> "foo"
+        0 * extensions.add(_, _, _)
+
+        and:
+        def e = thrown(DefaultMultiCauseException)
+        e.causes.size() == 1
+        e.causes.find { it.message.contains("property 'foo' has @SoftwareType annotation with 'disableExtensionRegistration' set to true, but no extension with name 'foo' was registered")}
+    }
+
+    def "throws sensible error when registration is disabled but extension is different than the property"() {
+        def plugin = Mock(Plugin)
+
+        when:
+        applicator.applyFeatureTo(target, softwareTypeImplementation)
+
+        then:
+        1 * softwareType.disableExtensionRegistration() >> true
+        1 * extensions.findByName("foo") >> new Foo()
+
+        and:
+        _ * softwareTypeImplementation.pluginClass >> plugin.class
+        1 * target.plugins >> plugins
+        1 * plugins.getPlugin(plugin.class) >> plugin
+        1 * inspectionScheme.getPropertyWalker() >> propertyWalker
+        1 * propertyWalker.visitProperties(plugin, _, _) >> { args -> args[2].visitSoftwareTypeProperty("foo", propertyValue, Foo.class, softwareType) }
+        1 * propertyValue.call() >> foo
+        _ * target.getExtensions() >> extensions
+        _ * softwareType.name() >> "foo"
+        0 * extensions.add(_, _, _)
+
+        and:
+        def e = thrown(DefaultMultiCauseException)
+        e.causes.size() == 1
+        e.causes.find { it.message.contains("property 'foo' has @SoftwareType annotation with 'disableExtensionRegistration' set to true, but the extension with name 'foo' does not match the value of the property")}
+    }
+
+    private static class Foo {}
+}

--- a/platforms/extensibility/plugin-use/src/test/groovy/org/gradle/plugin/software/internal/DefaultSoftwareFeatureApplicatorTest.groovy
+++ b/platforms/extensibility/plugin-use/src/test/groovy/org/gradle/plugin/software/internal/DefaultSoftwareFeatureApplicatorTest.groovy
@@ -112,7 +112,7 @@ class DefaultSoftwareFeatureApplicatorTest extends Specification {
         def returned = applicator.applyFeatureTo(target, softwareTypeImplementation)
 
         then:
-        1 * softwareType.disableExtensionRegistration() >> true
+        1 * softwareType.disableModelManagement() >> true
         _ * extensions.findByName("foo") >> foo
 
         and:
@@ -140,7 +140,7 @@ class DefaultSoftwareFeatureApplicatorTest extends Specification {
         applicator.applyFeatureTo(target, softwareTypeImplementation)
 
         then:
-        1 * softwareType.disableExtensionRegistration() >> true
+        1 * softwareType.disableModelManagement() >> true
         1 * extensions.findByName("foo") >> null
 
         and:
@@ -157,7 +157,7 @@ class DefaultSoftwareFeatureApplicatorTest extends Specification {
         and:
         def e = thrown(DefaultMultiCauseException)
         e.causes.size() == 1
-        e.causes.find { it.message.contains("property 'foo' has @SoftwareType annotation with 'disableExtensionRegistration' set to true, but no extension with name 'foo' was registered")}
+        e.causes.find { it.message.contains("property 'foo' has @SoftwareType annotation with 'disableModelManagement' set to true, but no extension with name 'foo' was registered")}
     }
 
     def "throws sensible error when registration is disabled but extension is different than the property"() {
@@ -167,7 +167,7 @@ class DefaultSoftwareFeatureApplicatorTest extends Specification {
         applicator.applyFeatureTo(target, softwareTypeImplementation)
 
         then:
-        1 * softwareType.disableExtensionRegistration() >> true
+        1 * softwareType.disableModelManagement() >> true
         1 * extensions.findByName("foo") >> new Foo()
 
         and:
@@ -184,7 +184,7 @@ class DefaultSoftwareFeatureApplicatorTest extends Specification {
         and:
         def e = thrown(DefaultMultiCauseException)
         e.causes.size() == 1
-        e.causes.find { it.message.contains("property 'foo' has @SoftwareType annotation with 'disableExtensionRegistration' set to true, but the extension with name 'foo' does not match the value of the property")}
+        e.causes.find { it.message.contains("property 'foo' has @SoftwareType annotation with 'disableModelManagement' set to true, but the extension with name 'foo' does not match the value of the property")}
     }
 
     private static class Foo {}

--- a/platforms/extensibility/plugin-use/src/test/groovy/org/gradle/plugin/software/internal/DefaultSoftwareFeatureApplicatorTest.groovy
+++ b/platforms/extensibility/plugin-use/src/test/groovy/org/gradle/plugin/software/internal/DefaultSoftwareFeatureApplicatorTest.groovy
@@ -31,11 +31,12 @@ import spock.lang.Specification
 
 class DefaultSoftwareFeatureApplicatorTest extends Specification {
     def target = Mock(ProjectInternal)
+    def modelDefaultsApplicator = Mock(ModelDefaultsApplicator)
     def inspectionScheme = Mock(InspectionScheme)
     def problems = Mock(InternalProblems) {
         getAdditionalDataBuilderFactory() >> new AdditionalDataBuilderFactory()
     }
-    def applicator = new DefaultSoftwareFeatureApplicator(target, inspectionScheme, problems)
+    def applicator = new DefaultSoftwareFeatureApplicator(target, modelDefaultsApplicator, inspectionScheme, problems)
     def plugin = Mock(Plugin)
     def plugins = Mock(PluginContainer)
     def propertyWalker = Mock(PropertyWalker)
@@ -60,6 +61,7 @@ class DefaultSoftwareFeatureApplicatorTest extends Specification {
         1 * softwareType.name() >> "foo"
         1 * propertyValue.call() >> foo
         1 * extensions.add(Foo.class, "foo", foo)
+        1 * modelDefaultsApplicator.applyDefaultsTo(target, plugin, softwareTypeImplementation)
         _ * softwareTypeImplementation.softwareType >> "foo"
         1 * extensions.getByName("foo") >> foo
 
@@ -82,6 +84,7 @@ class DefaultSoftwareFeatureApplicatorTest extends Specification {
         1 * softwareType.name() >> "foo"
         1 * propertyValue.call() >> foo
         1 * extensions.add(Foo.class, "foo", foo)
+        1 * modelDefaultsApplicator.applyDefaultsTo(target, plugin, softwareTypeImplementation)
         _ * softwareTypeImplementation.softwareType >> "foo"
         1 * extensions.getByName("foo") >> foo
 
@@ -122,6 +125,7 @@ class DefaultSoftwareFeatureApplicatorTest extends Specification {
         _ * target.getExtensions() >> extensions
         _ * softwareType.name() >> "foo"
         0 * extensions.add(_, _, _)
+        1 * modelDefaultsApplicator.applyDefaultsTo(target, plugin, softwareTypeImplementation)
         _ * softwareTypeImplementation.softwareType >> "foo"
         1 * extensions.getByName("foo") >> foo
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/plugins/software/SoftwareType.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/plugins/software/SoftwareType.java
@@ -47,4 +47,12 @@ public @interface SoftwareType {
      * @since 8.9
      */
     Class<?> modelPublicType() default Void.class;
+
+    /**
+     * By default, Gradle will automatically register an extension for the software type on the Project object.  If this is set to true, Gradle
+     * will not register the extension and the plugin will need to do so manually.
+     *
+     * @since 8.11
+     */
+    boolean disableExtensionRegistration() default false;
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/plugins/software/SoftwareType.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/plugins/software/SoftwareType.java
@@ -52,7 +52,7 @@ public @interface SoftwareType {
      * By default, Gradle will automatically register an extension for the software type on the Project object.  If this is set to true, Gradle
      * will not register the extension and the plugin will need to do so manually.
      *
-     * @since 8.11
+     * @since 8.12
      */
     boolean disableExtensionRegistration() default false;
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/plugins/software/SoftwareType.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/plugins/software/SoftwareType.java
@@ -49,10 +49,11 @@ public @interface SoftwareType {
     Class<?> modelPublicType() default Void.class;
 
     /**
-     * By default, Gradle will automatically register an extension for the software type on the Project object.  If this is set to true, Gradle
-     * will not register the extension and the plugin will need to do so manually.
+     * By default, Gradle will automatically create an instance of the public model type and register it as an extension on the Project object.
+     * If this is set to true, Gradle will not manage the public model and the plugin will need to create the instance and register it as an
+     * extension explicitly.  If this is set to true, but the plugin does not register an extension with the correct type, an error will be thrown.
      *
      * @since 8.12
      */
-    boolean disableExtensionRegistration() default false;
+    boolean disableModelManagement() default false;
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ActionBasedModelDefaultsHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ActionBasedModelDefaultsHandler.java
@@ -51,7 +51,7 @@ public class ActionBasedModelDefaultsHandler implements ModelDefaultsHandler {
     }
 
     @Override
-    public <T> void apply(T target, String softwareTypeName, Plugin<? super T> plugin) {
+    public <T> void apply(T target, String softwareTypeName, Plugin<?> plugin) {
         SoftwareTypeImplementation<?> softwareTypeImplementation = softwareTypeRegistry.getSoftwareTypeImplementations().get(softwareTypeName);
 
         DefaultTypeValidationContext typeValidationContext = DefaultTypeValidationContext.withRootType(plugin.getClass(), false, problems);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginManager.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginManager.java
@@ -196,7 +196,7 @@ public class DefaultPluginManager implements PluginManagerInternal {
             pluginContainer.pluginAdded(pluginInstance);
 
             // Apply any build-level model defaults for the target
-            target.applyModelDefaults(pluginInstance);
+            target.applySoftwareFeatures(pluginInstance);
         } else {
             target.applyRules(pluginId, pluginClass);
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PluginTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PluginTarget.java
@@ -38,5 +38,5 @@ public interface PluginTarget {
 
     void applyImperativeRulesHybrid(@Nullable String pluginId, Plugin<?> plugin, Class<?> declaringClass);
 
-    default void applyModelDefaults(Plugin<?> plugin) { }
+    default void applySoftwareFeatures(Plugin<?> plugin) { }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/SoftwareFeatureApplyingPluginTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/SoftwareFeatureApplyingPluginTarget.java
@@ -18,21 +18,28 @@ package org.gradle.api.internal.plugins;
 
 import org.gradle.api.NonNullApi;
 import org.gradle.api.Plugin;
+import org.gradle.api.Project;
 import org.gradle.configuration.ConfigurationTargetIdentifier;
 import org.gradle.internal.Cast;
 import org.gradle.plugin.software.internal.ModelDefaultsApplicator;
+import org.gradle.plugin.software.internal.SoftwareFeatureApplicator;
+import org.gradle.plugin.software.internal.SoftwareTypeRegistry;
 
 import javax.annotation.Nullable;
 
 @NonNullApi
-public class ModelDefaultsApplyingPluginTarget<T> implements PluginTarget {
+public class SoftwareFeatureApplyingPluginTarget implements PluginTarget {
     private final PluginTarget delegate;
-    private final T target;
+    private final Project target;
+    private final SoftwareTypeRegistry softwareTypeRegistry;
+    private final SoftwareFeatureApplicator softwareFeatureApplicator;
     private final ModelDefaultsApplicator modelDefaultsApplicator;
 
-    public ModelDefaultsApplyingPluginTarget(T target, PluginTarget delegate, ModelDefaultsApplicator modelDefaultsApplicator) {
+    public SoftwareFeatureApplyingPluginTarget(Project target, PluginTarget delegate, SoftwareTypeRegistry softwareTypeRegistry, SoftwareFeatureApplicator softwareFeatureApplicator, ModelDefaultsApplicator modelDefaultsApplicator) {
         this.target = target;
         this.delegate = delegate;
+        this.softwareTypeRegistry = softwareTypeRegistry;
+        this.softwareFeatureApplicator = softwareFeatureApplicator;
         this.modelDefaultsApplicator = modelDefaultsApplicator;
     }
 
@@ -57,8 +64,11 @@ public class ModelDefaultsApplyingPluginTarget<T> implements PluginTarget {
     }
 
     @Override
-    public void applyModelDefaults(Plugin<?> plugin) {
-        modelDefaultsApplicator.applyDefaultsTo(target, Cast.uncheckedNonnullCast(plugin));
+    public void applySoftwareFeatures(Plugin<?> plugin) {
+        softwareTypeRegistry.implementationFor(Cast.uncheckedCast(plugin.getClass())).ifPresent(softwareTypeImplementation -> {
+            softwareFeatureApplicator.applyFeatureTo(target, softwareTypeImplementation);
+            modelDefaultsApplicator.applyDefaultsTo(target, Cast.uncheckedCast(plugin), softwareTypeImplementation);
+        });
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/SoftwareFeatureApplyingPluginTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/SoftwareFeatureApplyingPluginTarget.java
@@ -21,7 +21,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.configuration.ConfigurationTargetIdentifier;
 import org.gradle.internal.Cast;
-import org.gradle.plugin.software.internal.ModelDefaultsApplicator;
 import org.gradle.plugin.software.internal.SoftwareFeatureApplicator;
 import org.gradle.plugin.software.internal.SoftwareTypeRegistry;
 
@@ -33,14 +32,12 @@ public class SoftwareFeatureApplyingPluginTarget implements PluginTarget {
     private final Project target;
     private final SoftwareTypeRegistry softwareTypeRegistry;
     private final SoftwareFeatureApplicator softwareFeatureApplicator;
-    private final ModelDefaultsApplicator modelDefaultsApplicator;
 
-    public SoftwareFeatureApplyingPluginTarget(Project target, PluginTarget delegate, SoftwareTypeRegistry softwareTypeRegistry, SoftwareFeatureApplicator softwareFeatureApplicator, ModelDefaultsApplicator modelDefaultsApplicator) {
+    public SoftwareFeatureApplyingPluginTarget(Project target, PluginTarget delegate, SoftwareTypeRegistry softwareTypeRegistry, SoftwareFeatureApplicator softwareFeatureApplicator) {
         this.target = target;
         this.delegate = delegate;
         this.softwareTypeRegistry = softwareTypeRegistry;
         this.softwareFeatureApplicator = softwareFeatureApplicator;
-        this.modelDefaultsApplicator = modelDefaultsApplicator;
     }
 
     @Override
@@ -67,7 +64,6 @@ public class SoftwareFeatureApplyingPluginTarget implements PluginTarget {
     public void applySoftwareFeatures(Plugin<?> plugin) {
         softwareTypeRegistry.implementationFor(Cast.uncheckedCast(plugin.getClass())).ifPresent(softwareTypeImplementation -> {
             softwareFeatureApplicator.applyFeatureTo(target, softwareTypeImplementation);
-            modelDefaultsApplicator.applyDefaultsTo(target, Cast.uncheckedCast(plugin), softwareTypeImplementation);
         });
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -40,7 +40,6 @@ import org.gradle.api.internal.file.DefaultFileSystemOperations;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.temp.TemporaryFileProvider;
-import org.gradle.api.internal.initialization.ActionBasedModelDefaultsHandler;
 import org.gradle.api.internal.initialization.BuildLogicBuildQueue;
 import org.gradle.api.internal.initialization.BuildLogicBuilder;
 import org.gradle.api.internal.initialization.DefaultBuildLogicBuilder;
@@ -77,7 +76,6 @@ import org.gradle.api.internal.tasks.TaskStatistics;
 import org.gradle.api.invocation.BuildInvocationDetails;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.problems.internal.AdditionalDataBuilderFactory;
-import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.services.internal.BuildServiceProvider;
 import org.gradle.api.services.internal.BuildServiceProviderNagger;
@@ -219,8 +217,6 @@ import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.snapshot.CaseSensitivity;
 import org.gradle.model.internal.inspect.ModelRuleSourceDetector;
 import org.gradle.plugin.management.internal.autoapply.AutoAppliedPluginHandler;
-import org.gradle.plugin.software.internal.ModelDefaultsHandler;
-import org.gradle.plugin.software.internal.PluginScheme;
 import org.gradle.plugin.software.internal.SoftwareTypeRegistry;
 import org.gradle.plugin.use.internal.PluginRequestApplicator;
 import org.gradle.process.internal.DefaultExecOperations;
@@ -800,11 +796,6 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
     @Provides
     protected SharedModelDefaults createSharedModelDefaults(Instantiator instantiator, SoftwareTypeRegistry softwareTypeRegistry) {
         return instantiator.newInstance(DefaultSharedModelDefaults.class, softwareTypeRegistry);
-    }
-
-    @Provides
-    protected ModelDefaultsHandler createActionDefaultsHandler(SoftwareTypeRegistry softwareTypeRegistry, PluginScheme pluginScheme, InternalProblems problems) {
-        return new ActionBasedModelDefaultsHandler(softwareTypeRegistry, pluginScheme.getInspectionScheme(), problems);
     }
 
     @Provides

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -32,13 +32,14 @@ import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.collections.ManagedFactories;
 import org.gradle.api.internal.file.temp.DefaultTemporaryFileProvider;
 import org.gradle.api.internal.file.temp.TemporaryFileProvider;
+import org.gradle.api.internal.initialization.ActionBasedModelDefaultsHandler;
 import org.gradle.api.internal.initialization.BuildLogicBuilder;
 import org.gradle.api.internal.initialization.DefaultScriptHandlerFactory;
 import org.gradle.api.internal.initialization.ScriptHandlerFactory;
 import org.gradle.api.internal.initialization.ScriptHandlerInternal;
 import org.gradle.api.internal.plugins.DefaultPluginManager;
 import org.gradle.api.internal.plugins.ImperativeOnlyPluginTarget;
-import org.gradle.api.internal.plugins.ModelDefaultsApplyingPluginTarget;
+import org.gradle.api.internal.plugins.SoftwareFeatureApplyingPluginTarget;
 import org.gradle.api.internal.plugins.PluginInstantiator;
 import org.gradle.api.internal.plugins.PluginManagerInternal;
 import org.gradle.api.internal.plugins.PluginRegistry;
@@ -101,7 +102,10 @@ import org.gradle.normalization.internal.DefaultRuntimeClasspathNormalization;
 import org.gradle.normalization.internal.InputNormalizationHandlerInternal;
 import org.gradle.normalization.internal.RuntimeClasspathNormalizationInternal;
 import org.gradle.plugin.software.internal.ModelDefaultsApplicator;
+import org.gradle.plugin.software.internal.ModelDefaultsHandler;
 import org.gradle.plugin.software.internal.PluginScheme;
+import org.gradle.plugin.software.internal.SoftwareFeatureApplicator;
+import org.gradle.plugin.software.internal.SoftwareTypeRegistry;
 import org.gradle.process.internal.ExecFactory;
 import org.gradle.tooling.provider.model.internal.DefaultToolingModelBuilderRegistry;
 
@@ -227,7 +231,9 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
         DomainObjectCollectionFactory domainObjectCollectionFactory,
         PluginScheme pluginScheme,
         InternalProblems problems,
-        ModelDefaultsApplicator modelDefaultsApplicator
+        ModelDefaultsApplicator modelDefaultsApplicator,
+        SoftwareTypeRegistry softwareTypeRegistry,
+        SoftwareFeatureApplicator softwareFeatureApplicator
     ) {
 
         PluginTarget ruleBasedTarget = new RuleBasedPluginTarget(
@@ -236,7 +242,7 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
             modelRuleExtractor,
             modelRuleSourceDetector
         );
-        PluginTarget pluginTarget = new ModelDefaultsApplyingPluginTarget<>(project, ruleBasedTarget, modelDefaultsApplicator);
+        PluginTarget pluginTarget = new SoftwareFeatureApplyingPluginTarget(project, ruleBasedTarget, softwareTypeRegistry, softwareFeatureApplicator, modelDefaultsApplicator);
         return instantiator.newInstance(
             DefaultPluginManager.class,
             pluginRegistry,
@@ -372,5 +378,10 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
             new org.gradle.api.internal.file.ManagedFactories.DirectoryManagedFactory(fileFactory),
             new org.gradle.api.internal.file.ManagedFactories.DirectoryPropertyManagedFactory(filePropertyFactory)
         );
+    }
+
+    @Provides
+    protected ModelDefaultsHandler createActionDefaultsHandler(SoftwareTypeRegistry softwareTypeRegistry, PluginScheme pluginScheme, InternalProblems problems) {
+        return new ActionBasedModelDefaultsHandler(softwareTypeRegistry, pluginScheme.getInspectionScheme(), problems);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -381,7 +381,7 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
     }
 
     @Provides
-    protected ModelDefaultsHandler createActionDefaultsHandler(SoftwareTypeRegistry softwareTypeRegistry, PluginScheme pluginScheme, InternalProblems problems) {
+    protected ModelDefaultsHandler createActionBasedModelDefaultsHandler(SoftwareTypeRegistry softwareTypeRegistry, PluginScheme pluginScheme, InternalProblems problems) {
         return new ActionBasedModelDefaultsHandler(softwareTypeRegistry, pluginScheme.getInspectionScheme(), problems);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -101,7 +101,6 @@ import org.gradle.normalization.internal.DefaultInputNormalizationHandler;
 import org.gradle.normalization.internal.DefaultRuntimeClasspathNormalization;
 import org.gradle.normalization.internal.InputNormalizationHandlerInternal;
 import org.gradle.normalization.internal.RuntimeClasspathNormalizationInternal;
-import org.gradle.plugin.software.internal.ModelDefaultsApplicator;
 import org.gradle.plugin.software.internal.ModelDefaultsHandler;
 import org.gradle.plugin.software.internal.PluginScheme;
 import org.gradle.plugin.software.internal.SoftwareFeatureApplicator;
@@ -231,7 +230,6 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
         DomainObjectCollectionFactory domainObjectCollectionFactory,
         PluginScheme pluginScheme,
         InternalProblems problems,
-        ModelDefaultsApplicator modelDefaultsApplicator,
         SoftwareTypeRegistry softwareTypeRegistry,
         SoftwareFeatureApplicator softwareFeatureApplicator
     ) {
@@ -242,7 +240,7 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
             modelRuleExtractor,
             modelRuleSourceDetector
         );
-        PluginTarget pluginTarget = new SoftwareFeatureApplyingPluginTarget(project, ruleBasedTarget, softwareTypeRegistry, softwareFeatureApplicator, modelDefaultsApplicator);
+        PluginTarget pluginTarget = new SoftwareFeatureApplyingPluginTarget(project, ruleBasedTarget, softwareTypeRegistry, softwareFeatureApplicator);
         return instantiator.newInstance(
             DefaultPluginManager.class,
             pluginRegistry,

--- a/subprojects/core/src/main/java/org/gradle/plugin/software/internal/ModelDefaultsApplicator.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/software/internal/ModelDefaultsApplicator.java
@@ -22,5 +22,5 @@ import org.gradle.api.Plugin;
  * Applies the model defaults for the software type declared in the given plugin to a target object.
  */
 public interface ModelDefaultsApplicator {
-    <T> void applyDefaultsTo(T target, Plugin<? super T> plugin);
+    <T> void applyDefaultsTo(T target, Plugin<? super T> plugin, SoftwareTypeImplementation<?> softwareTypeImplementation);
 }

--- a/subprojects/core/src/main/java/org/gradle/plugin/software/internal/ModelDefaultsApplicator.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/software/internal/ModelDefaultsApplicator.java
@@ -22,5 +22,5 @@ import org.gradle.api.Plugin;
  * Applies the model defaults for the software type declared in the given plugin to a target object.
  */
 public interface ModelDefaultsApplicator {
-    <T> void applyDefaultsTo(T target, Plugin<? super T> plugin, SoftwareTypeImplementation<?> softwareTypeImplementation);
+    <T> void applyDefaultsTo(T target, Plugin<?> plugin, SoftwareTypeImplementation<?> softwareTypeImplementation);
 }

--- a/subprojects/core/src/main/java/org/gradle/plugin/software/internal/ModelDefaultsHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/software/internal/ModelDefaultsHandler.java
@@ -22,5 +22,5 @@ import org.gradle.api.Plugin;
  * Applies the model defaults from a given software type to a target object.
  */
 public interface ModelDefaultsHandler {
-    <T> void apply(T target, String softwareTypeName, Plugin<? super T> plugin);
+    <T> void apply(T target, String softwareTypeName, Plugin<?> plugin);
 }

--- a/subprojects/core/src/main/java/org/gradle/plugin/software/internal/SoftwareFeatureApplicator.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/software/internal/SoftwareFeatureApplicator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugin.software.internal;
+
+import org.gradle.api.plugins.ExtensionAware;
+
+/**
+ * Encapsulates the work of applying a software feature to a target.
+ *
+ * @since 8.11
+ */
+public interface SoftwareFeatureApplicator {
+    /**
+     * Applies the given software feature to the target, registering the public model object as an extension of the target and
+     * returning it.  This method can be called multiple times, but will only apply the feature once.
+     *
+     * @param target - the receiver object to apply the feature to
+     * @param softwareFeature - the feature to apply
+     * @return the public model object for the feature
+     * @param <T> the type of the public model object for the feature
+     * @since 8.11
+     */
+    <T> T applyFeatureTo(ExtensionAware target, SoftwareTypeImplementation<T> softwareFeature);
+
+    SoftwareFeatureApplicator ANALYSIS_ONLY = new SoftwareFeatureApplicator() {
+        @Override
+        public <T> T applyFeatureTo(ExtensionAware target, SoftwareTypeImplementation<T> softwareFeature) {
+            // This should never be called if the sequence is analysis only as this is only needed during resolution
+            throw new UnsupportedOperationException();
+        }
+    };
+}

--- a/subprojects/core/src/main/java/org/gradle/plugin/software/internal/SoftwareFeatureApplicator.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/software/internal/SoftwareFeatureApplicator.java
@@ -17,12 +17,15 @@
 package org.gradle.plugin.software.internal;
 
 import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 /**
  * Encapsulates the work of applying a software feature to a target.
  *
  * @since 8.12
  */
+@ServiceScope(Scope.Project.class)
 public interface SoftwareFeatureApplicator {
     /**
      * Applies the given software feature to the target, registering the public model object as an extension of the target and

--- a/subprojects/core/src/main/java/org/gradle/plugin/software/internal/SoftwareFeatureApplicator.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/software/internal/SoftwareFeatureApplicator.java
@@ -21,7 +21,7 @@ import org.gradle.api.plugins.ExtensionAware;
 /**
  * Encapsulates the work of applying a software feature to a target.
  *
- * @since 8.11
+ * @since 8.12
  */
 public interface SoftwareFeatureApplicator {
     /**
@@ -32,7 +32,7 @@ public interface SoftwareFeatureApplicator {
      * @param softwareFeature - the feature to apply
      * @return the public model object for the feature
      * @param <T> the type of the public model object for the feature
-     * @since 8.11
+     * @since 8.12
      */
     <T> T applyFeatureTo(ExtensionAware target, SoftwareTypeImplementation<T> softwareFeature);
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginManagerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginManagerTest.groovy
@@ -278,7 +278,7 @@ class DefaultPluginManagerTest extends Specification {
         then:
         1 * target.getConfigurationTargetIdentifier()
         1 * target.applyImperativeRulesHybrid(null, { hybridClass.isInstance(it) }, hybridClass)
-        1 * target.applyModelDefaults(_)
+        1 * target.applySoftwareFeatures(_)
         0 * target._
         1 * action.execute(_)
         0 * action._
@@ -362,7 +362,7 @@ class DefaultPluginManagerTest extends Specification {
         then:
         1 * target.getConfigurationTargetIdentifier()
         1 * target.applyImperative(null, { imperativeClass.isInstance(it) })
-        1 * target.applyModelDefaults(_)
+        1 * target.applySoftwareFeatures(_)
         0 * target._
 
         and:
@@ -387,7 +387,7 @@ class DefaultPluginManagerTest extends Specification {
         then:
         1 * target.getConfigurationTargetIdentifier()
         1 * target.applyImperative(null, { imperativeClass.isInstance(it) })
-        1 * target.applyModelDefaults(_)
+        1 * target.applySoftwareFeatures(_)
         0 * target._
         1 * action.execute(_)
         0 * action._
@@ -534,7 +534,7 @@ class DefaultPluginManagerTest extends Specification {
         then:
         1 * target.getConfigurationTargetIdentifier()
         1 * target.applyImperative("bar", { imperativeClass.isInstance(it) })
-        1 * target.applyModelDefaults(_)
+        1 * target.applySoftwareFeatures(_)
         0 * target._
         1 * action.execute(_)
         0 * action._

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/SoftwareFeatureApplyingPluginTargetTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/SoftwareFeatureApplyingPluginTargetTest.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.plugins
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.plugin.software.internal.ModelDefaultsApplicator
+import org.gradle.plugin.software.internal.SoftwareFeatureApplicator
+import org.gradle.plugin.software.internal.SoftwareTypeImplementation
+import org.gradle.plugin.software.internal.SoftwareTypeRegistry
+import spock.lang.Specification
+
+class SoftwareFeatureApplyingPluginTargetTest extends Specification {
+    def target = Mock(Project)
+    def delegate = Mock(PluginTarget)
+    def softwareTypeRegistry = Mock(SoftwareTypeRegistry)
+    def softwareFeatureApplicator = Mock(SoftwareFeatureApplicator)
+    def modelDefaultsApplicator = Mock(ModelDefaultsApplicator)
+    def plugin = Mock(Plugin)
+    def softwareTypeImplementation = Mock(SoftwareTypeImplementation)
+    def pluginTarget = new SoftwareFeatureApplyingPluginTarget(target, delegate, softwareTypeRegistry, softwareFeatureApplicator, modelDefaultsApplicator)
+
+    def "applies software feature to target"() {
+        when:
+        pluginTarget.applySoftwareFeatures(plugin)
+
+        then:
+        1 * softwareTypeRegistry.implementationFor(plugin.getClass()) >> Optional.of(softwareTypeImplementation)
+        1 * softwareFeatureApplicator.applyFeatureTo(target, softwareTypeImplementation)
+        1 * modelDefaultsApplicator.applyDefaultsTo(target, plugin, softwareTypeImplementation)
+    }
+
+    def "does not apply software feature when plugin is not in registry"() {
+        when:
+        pluginTarget.applySoftwareFeatures(plugin)
+
+        then:
+        1 * softwareTypeRegistry.implementationFor(plugin.getClass()) >> Optional.empty()
+        0 * softwareFeatureApplicator.applyFeatureTo(_, _)
+        0 * modelDefaultsApplicator.applyDefaultsTo(_, _, _)
+    }
+
+    def "delegates to target for other methods"() {
+        when:
+        pluginTarget.applyImperative("com.test.plugin", plugin)
+
+        then:
+        1 * delegate.applyImperative("com.test.plugin", plugin)
+
+        when:
+        pluginTarget.applyRules("com.test.plugin", plugin.getClass())
+
+        then:
+        1 * delegate.applyRules("com.test.plugin", plugin.getClass())
+
+        when:
+        pluginTarget.applyImperativeRulesHybrid("com.test.plugin", plugin, String.class)
+
+        then:
+        1 * delegate.applyImperativeRulesHybrid("com.test.plugin", plugin, String.class)
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/SoftwareFeatureApplyingPluginTargetTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/SoftwareFeatureApplyingPluginTargetTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.internal.plugins
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.plugin.software.internal.ModelDefaultsApplicator
 import org.gradle.plugin.software.internal.SoftwareFeatureApplicator
 import org.gradle.plugin.software.internal.SoftwareTypeImplementation
 import org.gradle.plugin.software.internal.SoftwareTypeRegistry
@@ -29,10 +28,9 @@ class SoftwareFeatureApplyingPluginTargetTest extends Specification {
     def delegate = Mock(PluginTarget)
     def softwareTypeRegistry = Mock(SoftwareTypeRegistry)
     def softwareFeatureApplicator = Mock(SoftwareFeatureApplicator)
-    def modelDefaultsApplicator = Mock(ModelDefaultsApplicator)
     def plugin = Mock(Plugin)
     def softwareTypeImplementation = Mock(SoftwareTypeImplementation)
-    def pluginTarget = new SoftwareFeatureApplyingPluginTarget(target, delegate, softwareTypeRegistry, softwareFeatureApplicator, modelDefaultsApplicator)
+    def pluginTarget = new SoftwareFeatureApplyingPluginTarget(target, delegate, softwareTypeRegistry, softwareFeatureApplicator)
 
     def "applies software feature to target"() {
         when:
@@ -41,7 +39,6 @@ class SoftwareFeatureApplyingPluginTargetTest extends Specification {
         then:
         1 * softwareTypeRegistry.implementationFor(plugin.getClass()) >> Optional.of(softwareTypeImplementation)
         1 * softwareFeatureApplicator.applyFeatureTo(target, softwareTypeImplementation)
-        1 * modelDefaultsApplicator.applyDefaultsTo(target, plugin, softwareTypeImplementation)
     }
 
     def "does not apply software feature when plugin is not in registry"() {
@@ -51,7 +48,6 @@ class SoftwareFeatureApplyingPluginTargetTest extends Specification {
         then:
         1 * softwareTypeRegistry.implementationFor(plugin.getClass()) >> Optional.empty()
         0 * softwareFeatureApplicator.applyFeatureTo(_, _)
-        0 * modelDefaultsApplicator.applyDefaultsTo(_, _, _)
     }
 
     def "delegates to target for other methods"() {

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/ProjectReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/ProjectReportTaskIntegrationTest.groovy
@@ -169,9 +169,7 @@ No sub-projects
                 public abstract LibraryExtension getLibrary();
 
                 @Override
-                public void apply(Project project) {
-                    project.getExtensions().add("library", getLibrary());
-                }
+                public void apply(Project project) { }
             }
         """
         file("build-logic/src/main/java/com/example/restricted/ApplicationPlugin.java") << """
@@ -186,9 +184,7 @@ No sub-projects
                 public abstract ApplicationExtension getApplication();
 
                 @Override
-                public void apply(Project project) {
-                    project.getExtensions().add("application", getApplication());
-                }
+                public void apply(Project project) { }
             }
         """
         file("build-logic/src/main/java/com/example/restricted/UtilityPlugin.java") << """
@@ -203,9 +199,7 @@ No sub-projects
                 public abstract UtilityExtension getUtility();
 
                 @Override
-                public void apply(Project project) {
-                    project.getExtensions().add("utility", getUtility());
-                }
+                public void apply(Project project) { }
             }
         """
         file("build-logic/src/main/java/com/example/restricted/SoftwareTypeRegistrationPlugin.java") << """


### PR DESCRIPTION
In #29648, we stopped automatically registering an extension for the software type when its plugin is applied.  This was because we had cases where we wanted to allow the plugin to create the model object rather than injecting it via an abstract getter.  However, this requires plugin authors to manually register the extension.

This introduces an API parameter on `@SoftwareType` such that a plugin author can explicitly declare that they will handle extension registration.  If they declare this, we will check after plugin application to validate that the extension is registered and throw a validation error if not.  If they don't declare this, Gradle will automatically register the extension for them.

This PR also creates some infrastructure (`SoftwareFeatureApplicator`) in preparation for future work towards composable features.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
