### PR TITLE
Attributes Cleanup

### DIFF
--- a/platforms/software/dependency-management/build.gradle.kts
+++ b/platforms/software/dependency-management/build.gradle.kts
@@ -123,6 +123,7 @@ dependencies {
     integTestImplementation(libs.socksProxy) {
         because("SOCKS proxy not part of internal-integ-testing api, since it has limited usefulness, so must be explicitly depended upon")
     }
+    integTestImplementation(testFixtures(projects.core))
     integTestImplementation(testFixtures(projects.security))
     integTestImplementation(testFixtures(projects.modelCore))
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMavenImmutableAttributesFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMavenImmutableAttributesFactory.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.internal.isolation.Isolatable;
 import org.gradle.internal.snapshot.impl.CoercingStringValueSnapshot;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMavenImmutableAttributesFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMavenImmutableAttributesFactory.java
@@ -30,7 +30,6 @@ import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.internal.isolation.Isolatable;
 import org.gradle.internal.snapshot.impl.CoercingStringValueSnapshot;
 
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMavenImmutableAttributesFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMavenImmutableAttributesFactory.java
@@ -22,6 +22,7 @@ import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.DocsType;
 import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
+import org.gradle.api.internal.attributes.AbstractAttributesFactory;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributeMergingException;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -34,7 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class DefaultMavenImmutableAttributesFactory implements MavenImmutableAttributesFactory {
+public class DefaultMavenImmutableAttributesFactory extends AbstractAttributesFactory implements MavenImmutableAttributesFactory {
     private final ImmutableAttributesFactory delegate;
     private final NamedObjectInstantiator objectInstantiator;
     private final Map<List<Object>, ImmutableAttributes> concatCache = new ConcurrentHashMap<>();

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/attributes/immutable/ImmutableAttributesTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/attributes/immutable/ImmutableAttributesTest.groovy
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.attributes.immutable
+
+import org.gradle.api.attributes.Usage
+import org.gradle.api.internal.artifacts.JavaEcosystemSupport
+import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.internal.snapshot.impl.CoercingStringValueSnapshot
+import spock.lang.Specification
+
+/**
+ * Unit tests for {@link ImmutableAttributes}.
+ */
+class ImmutableAttributesTest extends Specification implements TestsImmutableAttributes {
+    def "empty set is empty"() {
+        when:
+        def attributes = ImmutableAttributes.EMPTY
+
+        then:
+        attributes.empty
+        attributes.keySet() == [] as Set
+    }
+
+    def "can lookup entries in empty set"() {
+        when:
+        def attributes = ImmutableAttributes.EMPTY
+
+        then:
+        attributes.getAttribute(FOO) == null
+        !attributes.findEntry(FOO).isPresent()
+        !attributes.findEntry("foo").isPresent()
+    }
+
+    def "immutable attribute sets throw a default error when attempting modification"() {
+        when:
+        attributes.attribute(FOO, "foo")
+
+        then:
+        UnsupportedOperationException t = thrown()
+        t.message == "Mutation of attributes is not allowed"
+
+        where:
+        attributes << [ImmutableAttributes.EMPTY, factory.of(FOO, "other"), factory.of(BAR, "other")]
+    }
+
+    def "can lookup entries in a singleton set"() {
+        when:
+        def attributes = factory.of(FOO, "foo")
+
+        then:
+        attributes.getAttribute(FOO) == 'foo'
+        attributes.findEntry(FOO).get() == "foo"
+        attributes.findEntry("foo").get() == "foo"
+
+        attributes.getAttribute(BAR) == null
+        !attributes.findEntry(BAR).isPresent()
+        !attributes.findEntry("bar").isPresent()
+    }
+
+    def "can lookup entries in a multiple value set"() {
+        when:
+        def attributes = factory.concat(factory.of(FOO, 'foo'), BAR, 'bar')
+
+        then:
+        attributes.getAttribute(FOO) == "foo"
+        attributes.findEntry(FOO).get() == "foo"
+        attributes.findEntry("foo").get() == "foo"
+
+        attributes.getAttribute(BAR) == "bar"
+        attributes.findEntry(BAR).get() == "bar"
+        attributes.findEntry("bar").get() == "bar"
+
+        attributes.getAttribute(BAZ) == null
+        !attributes.findEntry(BAZ).isPresent()
+        !attributes.findEntry("baz").isPresent()
+    }
+
+    def "order of entries is not significant in equality"() {
+        when:
+        def set1 = factory.concat(factory.of(FOO, "foo"), BAR, "bar")
+        def set2 = factory.concat(factory.of(BAR, "bar"), FOO, "foo")
+
+        then:
+        set1 == set2
+    }
+
+    def "translates deprecated usage values"() {
+        def result = factory.of(Usage.USAGE_ATTRIBUTE, instantiator.named(Usage, JavaEcosystemSupport.DEPRECATED_JAVA_API_JARS))
+
+        expect:
+        result.findEntry(Usage.USAGE_ATTRIBUTE).get().name == "java-api"
+    }
+
+    @SuppressWarnings('GroovyAssignabilityCheck')
+    def "translates deprecated usage values as Isolatable"() {
+        def result = factory.of(Usage.USAGE_ATTRIBUTE, new CoercingStringValueSnapshot(JavaEcosystemSupport.DEPRECATED_JAVA_RUNTIME_JARS, instantiator))
+
+        expect:
+        result.findEntry(Usage.USAGE_ATTRIBUTE).get().toString() == "java-runtime"
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AbstractAttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AbstractAttributesFactory.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.attributes;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import org.gradle.api.attributes.Attribute;
+import org.gradle.internal.Cast;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import com.google.common.cache.LoadingCache;
+
+/**
+ * Abstract base implementation of {@link ImmutableAttributesFactory}, that memoizes {@link #fromMap(Map)}
+ * conversions to improve performance.
+ */
+public abstract class AbstractAttributesFactory implements ImmutableAttributesFactory {
+    private final LoadingCache<Map<Attribute<?>, ?>, ImmutableAttributes> conversionCache  = CacheBuilder.newBuilder()
+        .maximumSize(1000)
+        .expireAfterWrite(Duration.ofMinutes(10))
+        .build(
+            new CacheLoader<Map<Attribute<?>, ?>, ImmutableAttributes>() {
+                @Override
+                public ImmutableAttributes load(Map<Attribute<?>, ?> attributes) {
+                    ImmutableAttributes result = ImmutableAttributes.EMPTY;
+                    for (Map.Entry<Attribute<?>, ?> entry : attributes.entrySet()) {
+                        /*
+                            The order of the concatenation arguments here is important, as we have tests like
+                            ConfigurationCacheDependencyResolutionIntegrationTest and ConfigurationCacheDependencyResolutionIntegrationTest
+                            that rely on a particular order of failures when there are multiple invalid attribute type
+                            conversions.  So even if it looks unnatural to list result second, this should remain.
+                         */
+                        result = concat(of(entry.getKey(), Cast.uncheckedNonnullCast(entry.getValue())), result);
+                    }
+                    return result;
+                }
+            });
+
+    /**
+     * Returns an attribute container that contains the values in the given map
+     * of attribute to attribute value.
+     * <p>
+     * This method is meant to be the inverse of {@link AttributeContainerInternal#asMap()}.
+     *
+     * @param attributes the attribute values the result should contain
+     * @return immutable instance containing only the specified attributes
+     */
+    @Override
+    public ImmutableAttributes fromMap(Map<Attribute<?>, ?> attributes) {
+        try {
+            return conversionCache.get(attributes);
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactory.java
@@ -73,15 +73,6 @@ public class DefaultImmutableAttributesFactory implements ImmutableAttributesFac
     }
 
     @Override
-    public ImmutableAttributes fromMap(Map<Attribute<?>, ?> attributes) {
-        ImmutableAttributes result = ImmutableAttributes.EMPTY;
-        for (Map.Entry<Attribute<?>, ?> entry : attributes.entrySet()) {
-            result = concat(result, of(entry.getKey(), Cast.uncheckedNonnullCast(entry.getValue())));
-        }
-        return result;
-    }
-
-    @Override
     public <T> ImmutableAttributes concat(ImmutableAttributes node, Attribute<T> key, @Nullable T value) {
         return concat(node, key, isolate(value));
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactory.java
@@ -77,7 +77,7 @@ public class DefaultImmutableAttributesFactory implements ImmutableAttributesFac
         return concat(node, key, isolate(value));
     }
 
-    private <T> Isolatable<T> isolate(@Nullable T value) {
+    public <T> Isolatable<T> isolate(@Nullable T value) {
         if (value instanceof String) {
             return Cast.uncheckedNonnullCast(new CoercingStringValueSnapshot((String) value, instantiator));
         } else {
@@ -121,10 +121,6 @@ public class DefaultImmutableAttributesFactory implements ImmutableAttributesFac
         });
 
         return result.get();
-    }
-
-    public ImmutableAttributes getRoot() {
-        return root;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactory.java
@@ -73,6 +73,15 @@ public class DefaultImmutableAttributesFactory implements ImmutableAttributesFac
     }
 
     @Override
+    public ImmutableAttributes fromMap(Map<Attribute<?>, ?> attributes) {
+        ImmutableAttributes result = ImmutableAttributes.EMPTY;
+        for (Map.Entry<Attribute<?>, ?> entry : attributes.entrySet()) {
+            result = concat(result, of(entry.getKey(), Cast.uncheckedNonnullCast(entry.getValue())));
+        }
+        return result;
+    }
+
+    @Override
     public <T> ImmutableAttributes concat(ImmutableAttributes node, Attribute<T> key, @Nullable T value) {
         return concat(node, key, isolate(value));
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactory.java
@@ -33,7 +33,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 @ServiceScope(Scope.BuildSession.class)
-public class DefaultImmutableAttributesFactory implements ImmutableAttributesFactory {
+public class DefaultImmutableAttributesFactory extends AbstractAttributesFactory implements ImmutableAttributesFactory {
     private final ImmutableAttributes root;
     private final Map<ImmutableAttributes, List<DefaultImmutableAttributes>> children;
     private final IsolatableFactory isolatableFactory;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/ImmutableAttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/ImmutableAttributesFactory.java
@@ -18,6 +18,8 @@ package org.gradle.api.internal.attributes;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.internal.isolation.Isolatable;
 
+import java.util.Map;
+
 public interface ImmutableAttributesFactory {
     /**
      * Returns an empty mutable attribute container.
@@ -46,6 +48,17 @@ public interface ImmutableAttributesFactory {
      * Returns an attribute container that contains the given value.
      */
     <T> ImmutableAttributes of(Attribute<T> key, T value);
+
+    /**
+     * Returns an attribute container that contains the values in the given map
+     * of attribute -> attribute value.
+     * <p>
+     * This method is meant to be the inverse of {@link AttributeContainerInternal#asMap()}.
+     *
+     * @param attributes the attribute values the result should contain
+     * @return immutable instance containing only the specified attributes
+     */
+    ImmutableAttributes fromMap(Map<Attribute<?>, ?> attributes);
 
     /**
      * Adds the given attribute to the given container. Note: the container _should not_ contain the given attribute.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/ImmutableAttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/ImmutableAttributesFactory.java
@@ -62,7 +62,13 @@ public interface ImmutableAttributesFactory {
     default ImmutableAttributes fromMap(Map<Attribute<?>, ?> attributes) {
         ImmutableAttributes result = ImmutableAttributes.EMPTY;
         for (Map.Entry<Attribute<?>, ?> entry : attributes.entrySet()) {
-            result = concat(result, of(entry.getKey(), Cast.uncheckedNonnullCast(entry.getValue())));
+            /*
+                The order of the concatenation arguments here is important, as we have tests like
+                ConfigurationCacheDependencyResolutionIntegrationTest and ConfigurationCacheDependencyResolutionIntegrationTest
+                that rely on a particular order of failures when there are multiple invalid attribute type
+                conversions.  So even if it looks unnatural to list result second, this should remain.
+             */
+            result = concat(of(entry.getKey(), Cast.uncheckedNonnullCast(entry.getValue())), result);
         }
         return result;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/ImmutableAttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/ImmutableAttributesFactory.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.attributes;
 
 import org.gradle.api.attributes.Attribute;
+import org.gradle.internal.Cast;
 import org.gradle.internal.isolation.Isolatable;
 
 import java.util.Map;
@@ -51,14 +52,20 @@ public interface ImmutableAttributesFactory {
 
     /**
      * Returns an attribute container that contains the values in the given map
-     * of attribute -> attribute value.
+     * of attribute to attribute value.
      * <p>
      * This method is meant to be the inverse of {@link AttributeContainerInternal#asMap()}.
      *
      * @param attributes the attribute values the result should contain
      * @return immutable instance containing only the specified attributes
      */
-    ImmutableAttributes fromMap(Map<Attribute<?>, ?> attributes);
+    default ImmutableAttributes fromMap(Map<Attribute<?>, ?> attributes) {
+        ImmutableAttributes result = ImmutableAttributes.EMPTY;
+        for (Map.Entry<Attribute<?>, ?> entry : attributes.entrySet()) {
+            result = concat(result, of(entry.getKey(), Cast.uncheckedNonnullCast(entry.getValue())));
+        }
+        return result;
+    }
 
     /**
      * Adds the given attribute to the given container. Note: the container _should not_ contain the given attribute.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/ImmutableAttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/ImmutableAttributesFactory.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.attributes;
 
 import org.gradle.api.attributes.Attribute;
-import org.gradle.internal.Cast;
 import org.gradle.internal.isolation.Isolatable;
 
 import java.util.Map;
@@ -59,19 +58,7 @@ public interface ImmutableAttributesFactory {
      * @param attributes the attribute values the result should contain
      * @return immutable instance containing only the specified attributes
      */
-    default ImmutableAttributes fromMap(Map<Attribute<?>, ?> attributes) {
-        ImmutableAttributes result = ImmutableAttributes.EMPTY;
-        for (Map.Entry<Attribute<?>, ?> entry : attributes.entrySet()) {
-            /*
-                The order of the concatenation arguments here is important, as we have tests like
-                ConfigurationCacheDependencyResolutionIntegrationTest and ConfigurationCacheDependencyResolutionIntegrationTest
-                that rely on a particular order of failures when there are multiple invalid attribute type
-                conversions.  So even if it looks unnatural to list result second, this should remain.
-             */
-            result = concat(of(entry.getKey(), Cast.uncheckedNonnullCast(entry.getValue())), result);
-        }
-        return result;
-    }
+    ImmutableAttributes fromMap(Map<Attribute<?>, ?> attributes);
 
     /**
      * Adds the given attribute to the given container. Note: the container _should not_ contain the given attribute.

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactoryTest.groovy
@@ -16,9 +16,9 @@
 
 package org.gradle.api.internal.attributes
 
-
 import org.gradle.api.internal.attributes.immutable.TestsImmutableAttributes
 import spock.lang.Specification
+
 /**
  * Unit tests for {@link DefaultImmutableAttributesFactory}.
  * <p>

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
@@ -224,8 +224,8 @@ class DefaultMutableAttributeContainerTest extends Specification {
         container.attributeProvider(testLazy, testProvider)
 
         then: "they are located in proper internal collections"
-        container.@state.contains(testEager)
-        !container.@state.contains(testLazy)
+        container.@attributes.containsKey(testEager)
+        !container.@attributes.containsKey(testLazy)
         container.@lazyAttributes.containsKey(testLazy)
         !container.@lazyAttributes.containsKey(testEager)
 
@@ -234,8 +234,8 @@ class DefaultMutableAttributeContainerTest extends Specification {
 
         then: "the result should not change the internals of the class"
         result == "{eager=eager value, lazy=property(java.lang.String, fixed(class java.lang.String, lazy value))}"
-        container.@state.contains(testEager)
-        !container.@state.contains(testLazy)
+        container.@attributes.containsKey(testEager)
+        !container.@attributes.containsKey(testLazy)
         container.@lazyAttributes.containsKey(testLazy)
         !container.@lazyAttributes.containsKey(testEager)
     }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/attributes/immutable/TestsImmutableAttributes.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/attributes/immutable/TestsImmutableAttributes.groovy
@@ -31,7 +31,7 @@ import org.gradle.util.TestUtil
 trait TestsImmutableAttributes {
     static final Attribute<String> FOO = Attribute.of("foo", String)
     static final Attribute<String> BAR = Attribute.of("bar", String)
-    static final Attribute<Object> OTHER_BAR = Attribute.of(BAR.name, Object.class)
+    static final Attribute<Object> OTHER_BAR = Attribute.of("bar", Object)
     static final Attribute<String> BAZ = Attribute.of("baz", String)
 
     IsolatableFactory isolatableFactory = SnapshotTestUtil.isolatableFactory()

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/attributes/immutable/TestsImmutableAttributes.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/attributes/immutable/TestsImmutableAttributes.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.attributes.immutable
+
+import org.gradle.api.attributes.Attribute
+import org.gradle.api.internal.attributes.DefaultImmutableAttributesFactory
+import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory
+import org.gradle.api.internal.model.NamedObjectInstantiator
+import org.gradle.internal.isolation.IsolatableFactory
+import org.gradle.util.SnapshotTestUtil
+import org.gradle.util.TestUtil
+
+/**
+ * Supplies some example attributes and a factory for easy testing of {@link ImmutableAttributes} and related types.
+ */
+trait TestsImmutableAttributes {
+    static final Attribute<String> FOO = Attribute.of("foo", String)
+    static final Attribute<String> BAR = Attribute.of("bar", String)
+    static final Attribute<Object> OTHER_BAR = Attribute.of(BAR.name, Object.class)
+    static final Attribute<String> BAZ = Attribute.of("baz", String)
+
+    IsolatableFactory isolatableFactory = SnapshotTestUtil.isolatableFactory()
+    NamedObjectInstantiator instantiator = TestUtil.objectInstantiator()
+
+    ImmutableAttributesFactory factory = new DefaultImmutableAttributesFactory(isolatableFactory, instantiator)
+}

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/AttributeTestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/AttributeTestUtil.groovy
@@ -25,7 +25,6 @@ import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.attributes.DefaultImmutableAttributesFactory
 import org.gradle.api.internal.attributes.ImmutableAttributes
-import org.gradle.api.internal.attributes.ImmutableAttributesFactory
 import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchema
 import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchemaFactory
 

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/AttributeTestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/AttributeTestUtil.groovy
@@ -30,7 +30,7 @@ import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchema
 import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchemaFactory
 
 class AttributeTestUtil {
-    static ImmutableAttributesFactory attributesFactory() {
+    static DefaultImmutableAttributesFactory attributesFactory() {
         return new DefaultImmutableAttributesFactory(SnapshotTestUtil.isolatableFactory(), TestUtil.objectInstantiator())
     }
 


### PR DESCRIPTION
- Mutable attributes now no longer contain an immutable instance - they function via a simple `Map` of eager attributes, which aligns with the simple map of lazy attributes
  - This makes for simpler code, especially of mutable methods which would be expected to be simple like `remove()`
  - Adds `fromMap` to factory for easy creation of immutable attributes from a mutable container
- Separate tests for `ImmutableAttributes` from tests for `DefaultImmutableAttributesFactory`
  - New `TestsImmutableAttributes` trait commonizes shared test setup 
  - Tests return the only attribute factory implementation directoy
- Remove unused public `getRoot()` method exposing the empty immutable attributes from the factory
