### PR TITLE
Annotate `FileChange.getChangeType()` as non-nullable

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/work/FileChange.java
+++ b/subprojects/core-api/src/main/java/org/gradle/work/FileChange.java
@@ -16,6 +16,7 @@
 
 package org.gradle.work;
 
+import javax.annotation.Nonnull;
 import org.gradle.api.file.FileType;
 
 import java.io.File;
@@ -35,6 +36,7 @@ public interface FileChange {
     /**
      * The type of change to the file.
      */
+    @Nonnull
     ChangeType getChangeType();
 
     /**


### PR DESCRIPTION
Fix #30669


### Context

> Why do you believe many users will benefit from this change?

see #30669

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
