### PR TITLE
Add PartOf=X,Y,Z custom value to the build

### DIFF
--- a/.teamcity/src/main/kotlin/common/BuildScanUtils.kt
+++ b/.teamcity/src/main/kotlin/common/BuildScanUtils.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import model.Stage
+import model.StageName
+import model.TestCoverage
+
+fun buildScanTagParam(tag: String) = """-Dscan.tag.$tag"""
+fun buildScanCustomValueParam(key: String, value: String) = """-Dscan.value.$key=$value"""
+
+fun TestCoverage.asBuildScanCustomValue() =
+    "${testType.name.toCapitalized()}${testJvmVersion.name.toCapitalized()}${vendor.displayName}${os.asName()}${arch.asName()}"
+
+// Generates a build scan custom value "PartOf=X,Y,Z"
+// where X, Y, Z are all the stages including current stage
+// For example, for the stage PullRequestFeedback, the custom value will be "PartOf=PullRequestFeedback,ReadyForNightly,ReadyForRelease"
+private fun Stage.getBuildScanCustomValues(): List<String> {
+    return StageName.values()
+        .slice(this.stageName.ordinal until StageName.READY_FOR_RELEASE.ordinal + 1)
+        .map { it.uuid }
+}
+
+fun Stage.getBuildScanCustomValueParam(testCoverage: TestCoverage? = null): String {
+    val customValues = if (testCoverage != null) {
+        listOf(testCoverage.asBuildScanCustomValue()) + getBuildScanCustomValues()
+    } else {
+        getBuildScanCustomValues()
+    }
+    return buildScanCustomValueParam(
+        "PartOf",
+        customValues.joinToString(",")
+    )
+}

--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -20,8 +20,6 @@ import common.KillProcessMode.KILL_ALL_GRADLE_PROCESSES
 import configurations.CompileAll
 import configurations.FunctionalTest
 import configurations.branchesFilterExcluding
-import configurations.buildScanCustomValue
-import configurations.buildScanTag
 import configurations.checkCleanDirUnixLike
 import configurations.checkCleanDirWindows
 import configurations.enablePullRequestFeature
@@ -249,7 +247,13 @@ fun Dependencies.compileAllDependency(compileAllId: String) {
     }
 }
 
-fun functionalTestExtraParameters(buildScanTag: String, os: Os, arch: Arch, testJvmVersion: String, testJvmVendor: String): String {
+fun functionalTestExtraParameters(
+    buildScanTags: List<String>,
+    os: Os,
+    arch: Arch,
+    testJvmVersion: String,
+    testJvmVendor: String
+): String {
     val buildScanValues = mapOf(
         "coverageOs" to os.name.lowercase(),
         "coverageArch" to arch.name.lowercase(),
@@ -261,8 +265,8 @@ fun functionalTestExtraParameters(buildScanTag: String, os: Os, arch: Arch, test
             "-PtestJavaVersion=$testJvmVersion",
             "-PtestJavaVendor=$testJvmVendor"
         ) +
-            listOf(buildScanTag(buildScanTag)) +
-            buildScanValues.map { buildScanCustomValue(it.key, it.value) }
+            buildScanTags.map { buildScanTagParam(it) } +
+            buildScanValues.map { buildScanCustomValueParam(it.key, it.value) }
         ).filter { it.isNotBlank() }.joinToString(separator = " ")
 }
 

--- a/.teamcity/src/main/kotlin/configurations/BuildDistributions.kt
+++ b/.teamcity/src/main/kotlin/configurations/BuildDistributions.kt
@@ -1,6 +1,8 @@
 package configurations
 
 import common.Os.LINUX
+import common.buildScanTagParam
+import common.getBuildScanCustomValueParam
 import model.CIBuildModel
 import model.Stage
 
@@ -13,9 +15,13 @@ class BuildDistributions(model: CIBuildModel, stage: Stage) : OsAwareBaseGradleB
         model,
         this,
         "packageBuild",
-        extraParameters = buildScanTag("BuildDistributions") +
-            " -PtestJavaVersion=${LINUX.buildJavaVersion.major}" +
-            " -Porg.gradle.java.installations.auto-download=false"
+        extraParameters =
+        listOf(
+            stage.getBuildScanCustomValueParam(),
+            buildScanTagParam("BuildDistributions"),
+            "-PtestJavaVersion=${LINUX.buildJavaVersion.major}",
+            "-Porg.gradle.java.installations.auto-download=false"
+        ).joinToString(" ")
     )
 
     features {

--- a/.teamcity/src/main/kotlin/configurations/CheckLinks.kt
+++ b/.teamcity/src/main/kotlin/configurations/CheckLinks.kt
@@ -1,6 +1,7 @@
 package configurations
 
 import common.Os
+import common.buildScanTagParam
 import model.CIBuildModel
 import model.Stage
 
@@ -13,6 +14,6 @@ class CheckLinks(model: CIBuildModel, stage: Stage) : OsAwareBaseGradleBuildType
         model,
         this,
         ":docs:checkLinks",
-        extraParameters = buildScanTag("CheckLinks") + " " + "-Porg.gradle.java.installations.auto-download=false"
+        extraParameters = buildScanTagParam("CheckLinks") + " " + "-Porg.gradle.java.installations.auto-download=false"
     )
 })

--- a/.teamcity/src/main/kotlin/configurations/CompileAll.kt
+++ b/.teamcity/src/main/kotlin/configurations/CompileAll.kt
@@ -1,6 +1,8 @@
 package configurations
 
 import common.Os
+import common.buildScanTagParam
+import common.getBuildScanCustomValueParam
 import model.CIBuildModel
 import model.Stage
 
@@ -17,7 +19,11 @@ class CompileAll(model: CIBuildModel, stage: Stage) : OsAwareBaseGradleBuildType
         model,
         this,
         "compileAllBuild -PignoreIncomingBuildReceipt=true -DdisableLocalCache=true",
-        extraParameters = buildScanTag("CompileAll") + " " + "-Porg.gradle.java.installations.auto-download=false"
+        extraParameters = listOf(
+            stage.getBuildScanCustomValueParam(),
+            buildScanTagParam("CompileAll"),
+            "-Porg.gradle.java.installations.auto-download=false",
+        ).joinToString(" ")
     )
 
     artifactRules = """$artifactRules

--- a/.teamcity/src/main/kotlin/configurations/DocsTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/DocsTest.kt
@@ -3,6 +3,7 @@ package configurations
 import common.JvmCategory
 import common.Os
 import common.applyDefaultSettings
+import common.buildScanTagParam
 import common.toCapitalized
 import configurations.TestSplitType.EXCLUDE
 import configurations.TestSplitType.INCLUDE
@@ -133,7 +134,7 @@ class DocsTest(
         os = os,
         arch = os.defaultArch,
         timeout = 60,
-        extraParameters = buildScanTag(docsTestType.docsTestName) +
+        extraParameters = buildScanTagParam(docsTestType.docsTestName) +
             " -PenableConfigurationCacheForDocsTests=${docsTestType.ccEnabled}" +
             " -PtestJavaVersion=${testJava.version.major}" +
             " -PtestJavaVendor=${testJava.vendor.name}" +

--- a/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
+++ b/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
@@ -5,10 +5,12 @@ import common.BuildToolBuildJvm
 import common.KillProcessMode.KILL_PROCESSES_STARTED_BY_GRADLE
 import common.Os
 import common.applyDefaultSettings
+import common.buildScanTagParam
 import common.buildToolGradleParameters
 import common.checkCleanM2AndAndroidUserHome
 import common.functionalTestExtraParameters
 import common.functionalTestParameters
+import common.getBuildScanCustomValueParam
 import common.gradleWrapper
 import common.killProcessStep
 import jetbrains.buildServer.configs.kotlin.BuildStep
@@ -47,7 +49,7 @@ class FlakyTestQuarantine(model: CIBuildModel, stage: Stage, os: Os, arch: Arch 
     }
 
     testsWithOs.forEachIndexed { index, testCoverage ->
-        val extraParameters = functionalTestExtraParameters("FlakyTestQuarantine", os, arch, testCoverage.testJvmVersion.major.toString(), testCoverage.vendor.name)
+        val extraParameters = functionalTestExtraParameters(listOf("FlakyTestQuarantine"), os, arch, testCoverage.testJvmVersion.major.toString(), testCoverage.vendor.name)
         val parameters = (
             buildToolGradleParameters(true) +
                 listOf(
@@ -60,7 +62,7 @@ class FlakyTestQuarantine(model: CIBuildModel, stage: Stage, os: Os, arch: Arch 
                 ) +
                 listOf(extraParameters) +
                 functionalTestParameters(os, arch) +
-                listOf(buildScanTag(functionalTestTag))
+                listOf(buildScanTagParam(functionalTestTag), stage.getBuildScanCustomValueParam())
             ).joinToString(separator = " ")
         steps {
             gradleWrapper {

--- a/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
@@ -3,6 +3,7 @@ package configurations
 import com.alibaba.fastjson.JSONObject
 import com.alibaba.fastjson.annotation.JSONField
 import common.functionalTestExtraParameters
+import common.getBuildScanCustomValueParam
 import jetbrains.buildServer.configs.kotlin.BuildSteps
 import jetbrains.buildServer.configs.kotlin.buildFeatures.perfmon
 import model.CIBuildModel
@@ -50,7 +51,6 @@ class FunctionalTest(
     parallelizationMethod: ParallelizationMethod = ParallelizationMethod.None,
     subprojects: List<String> = listOf(),
     extraParameters: String = "",
-    maxParallelForks: String = "%maxParallelForks%",
     extraBuildSteps: BuildSteps.() -> Unit = {},
     preBuildSteps: BuildSteps.() -> Unit = {}
 ) : OsAwareBaseGradleBuildType(os = testCoverage.os, stage = stage, init = {
@@ -60,7 +60,8 @@ class FunctionalTest(
     val testTasks = getTestTaskName(testCoverage, subprojects)
 
     val assembledExtraParameters = mutableListOf(
-        functionalTestExtraParameters(functionalTestTag, testCoverage.os, testCoverage.arch, testCoverage.testJvmVersion.major.toString(), testCoverage.vendor.name),
+        stage.getBuildScanCustomValueParam(testCoverage),
+        functionalTestExtraParameters(listOf(functionalTestTag), testCoverage.os, testCoverage.arch, testCoverage.testJvmVersion.major.toString(), testCoverage.vendor.name),
         "-PflakyTests=${determineFlakyTestStrategy(stage)}",
         extraParameters,
         parallelizationMethod.extraBuildParameters

--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -9,6 +9,7 @@ import common.KillProcessMode.KILL_PROCESSES_STARTED_BY_GRADLE
 import common.Os
 import common.VersionedSettingsBranch
 import common.applyDefaultSettings
+import common.buildScanTagParam
 import common.buildToolGradleParameters
 import common.checkCleanM2AndAndroidUserHome
 import common.cleanUpGitUntrackedFilesAndDirectories
@@ -30,6 +31,9 @@ import jetbrains.buildServer.configs.kotlin.buildFeatures.parallelTests
 import jetbrains.buildServer.configs.kotlin.buildFeatures.pullRequests
 import model.CIBuildModel
 import model.StageName
+
+const val GRADLE_RUNNER_STEP_NAME = "GRADLE_RUNNER"
+const val GRADLE_RETRY_RUNNER_STEP_NAME = "GRADLE_RETRY_RUNNER"
 
 fun checkCleanDirUnixLike(dir: String, exitOnFailure: Boolean = true) = """
     REPO=$dir
@@ -116,7 +120,7 @@ fun BaseGradleBuildType.gradleRunnerStep(
     maxParallelForks: String = "%maxParallelForks%",
     isRetry: Boolean = false,
 ) {
-    val stepName: String = if (isRetry) "GRADLE_RETRY_RUNNER" else "GRADLE_RUNNER"
+    val stepName: String = if (isRetry) GRADLE_RETRY_RUNNER_STEP_NAME else GRADLE_RUNNER_STEP_NAME
     val stepExecutionMode: ExecutionMode = if (isRetry) ExecutionMode.RUN_ONLY_ON_FAILURE else ExecutionMode.DEFAULT
     val extraBuildScanTags: List<String> = if (isRetry) listOf("RetriedBuild") else emptyList()
 
@@ -124,7 +128,7 @@ fun BaseGradleBuildType.gradleRunnerStep(
     val parameters = (
         buildToolGradleParameters(daemon, maxParallelForks = maxParallelForks) +
             listOf(extraParameters) +
-            buildScanTags.map { buildScanTag(it) } +
+            buildScanTags.map { buildScanTagParam(it) } +
             functionalTestParameters(os, arch)
         ).joinToString(separator = " ") + if (isRetry) " -PretryBuild" else ""
 
@@ -216,8 +220,6 @@ fun applyTestDefaults(
     applyDefaultDependencies(model, buildType, dependsOnQuickFeedbackLinux)
 }
 
-fun buildScanTag(tag: String) = """"-Dscan.tag.$tag""""
-fun buildScanCustomValue(key: String, value: String) = """"-Dscan.value.$key=$value""""
 fun applyDefaultDependencies(model: CIBuildModel, buildType: BuildType, dependsOnQuickFeedbackLinux: Boolean) {
     if (dependsOnQuickFeedbackLinux) {
         // wait for quick feedback phase to finish successfully

--- a/.teamcity/src/main/kotlin/configurations/Gradleception.kt
+++ b/.teamcity/src/main/kotlin/configurations/Gradleception.kt
@@ -3,10 +3,12 @@ package configurations
 import common.BuildToolBuildJvm
 import common.Jvm
 import common.Os
+import common.buildScanTagParam
 import common.buildToolGradleParameters
 import common.customGradle
 import common.dependsOn
 import common.functionalTestParameters
+import common.getBuildScanCustomValueParam
 import common.gradleWrapper
 import common.requiresNotEc2Agent
 import common.requiresNotSharedHost
@@ -82,9 +84,10 @@ class Gradleception(
      */
     val dogfoodTimestamp1 = "19800101010101+0000"
     val dogfoodTimestamp2 = "19800202020202+0000"
-    val buildScanTagForType = buildScanTag("Gradleception")
-    val buildScanTagForGroovy4 = buildScanTag("Groovy4")
-    val buildScanTags = if (bundleGroovy4) listOf(buildScanTagForType, buildScanTagForGroovy4) else listOf(buildScanTagForType)
+    val buildScanTagForType = buildScanTagParam("Gradleception")
+    val buildScanTagForGroovy4 = buildScanTagParam("Groovy4")
+    val buildScanTags =
+        if (bundleGroovy4) listOf(buildScanTagForType, buildScanTagForGroovy4) else listOf(buildScanTagForType)
     val extraSysProp = mutableListOf<String>()
     if (bundleGroovy4) {
         extraSysProp += "-DbundleGroovy4=true"
@@ -92,7 +95,10 @@ class Gradleception(
     if (buildJvm.version != BuildToolBuildJvm.version) {
         extraSysProp += "-Dorg.gradle.ignoreBuildJavaVersionCheck=true"
     }
-    val defaultParameters = (buildToolGradleParameters() + buildScanTags + extraSysProp + functionalTestParameters(Os.LINUX)).joinToString(separator = " ")
+    val defaultParameters =
+        (buildToolGradleParameters() + buildScanTags + extraSysProp + functionalTestParameters(Os.LINUX)).joinToString(
+            separator = " "
+        )
 
     params {
         // Override the default commit id so the build steps produce reproducible distribution
@@ -103,7 +109,16 @@ class Gradleception(
         model,
         this,
         ":distributions-full:install",
-        extraParameters = "-Pgradle_installPath=dogfood-first-for-hash -PignoreIncomingBuildReceipt=true -PbuildTimestamp=$dogfoodTimestamp1 $buildScanTagForType ${extraSysProp.joinToString(separator = " ")}",
+        extraParameters =
+        (
+            listOf(
+                stage.getBuildScanCustomValueParam(),
+                "-Pgradle_installPath=dogfood-first-for-hash",
+                "-PignoreIncomingBuildReceipt=true",
+                "-PbuildTimestamp=$dogfoodTimestamp1",
+                buildScanTagForType,
+            ) + extraSysProp
+            ).joinToString(" "),
         buildJvm = buildJvm,
         extraSteps = {
             script {
@@ -118,14 +133,16 @@ class Gradleception(
             gradleWrapper {
                 name = "BUILD_GRADLE_DISTRIBUTION"
                 tasks = "clean :distributions-full:install"
-                gradleParams = "-Pgradle_installPath=dogfood-first -PignoreIncomingBuildReceipt=true -PbuildTimestamp=$dogfoodTimestamp1 $defaultParameters"
+                gradleParams =
+                    "-Pgradle_installPath=dogfood-first -PignoreIncomingBuildReceipt=true -PbuildTimestamp=$dogfoodTimestamp1 $defaultParameters"
             }
 
             localGradle {
                 name = "BUILD_WITH_BUILT_GRADLE"
                 tasks = "clean :distributions-full:install"
                 gradleHome = "%teamcity.build.checkoutDir%/dogfood-first"
-                gradleParams = "-Pgradle_installPath=dogfood-second -PignoreIncomingBuildReceipt=true -PbuildTimestamp=$dogfoodTimestamp2 $defaultParameters"
+                gradleParams =
+                    "-Pgradle_installPath=dogfood-second -PignoreIncomingBuildReceipt=true -PbuildTimestamp=$dogfoodTimestamp2 $defaultParameters"
             }
 
             localGradle {

--- a/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
@@ -20,8 +20,10 @@ import common.KillProcessMode.KILL_ALL_GRADLE_PROCESSES
 import common.KillProcessMode.KILL_PROCESSES_STARTED_BY_GRADLE
 import common.Os
 import common.applyPerformanceTestSettings
+import common.buildScanTagParam
 import common.buildToolGradleParameters
 import common.checkCleanM2AndAndroidUserHome
+import common.getBuildScanCustomValueParam
 import common.gradleWrapper
 import common.individualPerformanceTestArtifactRules
 import common.killProcessStep
@@ -104,7 +106,8 @@ class PerformanceTest(
                                 arch
                             ) + "-DenableTestDistribution=%enableTestDistribution%" +
                                 buildToolGradleParameters() +
-                                buildScanTag("PerformanceTest")
+                                stage.getBuildScanCustomValueParam() +
+                                buildScanTagParam("PerformanceTest")
                             ).joinToString(separator = " ")
                     }
                 }

--- a/.teamcity/src/main/kotlin/configurations/SanityCheck.kt
+++ b/.teamcity/src/main/kotlin/configurations/SanityCheck.kt
@@ -1,6 +1,8 @@
 package configurations
 
 import common.Os
+import common.buildScanTagParam
+import common.getBuildScanCustomValueParam
 import model.CIBuildModel
 import model.Stage
 
@@ -17,7 +19,11 @@ class SanityCheck(model: CIBuildModel, stage: Stage) : OsAwareBaseGradleBuildTyp
         model,
         this,
         "sanityCheck",
-        extraParameters = "-DenableCodeQuality=true ${buildScanTag("SanityCheck")} " + "-Porg.gradle.java.installations.auto-download=false"
+        extraParameters = listOf(
+            stage.getBuildScanCustomValueParam(),
+            buildScanTagParam("SanityCheck"),
+            "-Porg.gradle.java.installations.auto-download=false"
+        ).joinToString(" ")
     )
 }) {
     companion object {

--- a/.teamcity/src/main/kotlin/configurations/SmokeIdeTests.kt
+++ b/.teamcity/src/main/kotlin/configurations/SmokeIdeTests.kt
@@ -17,6 +17,8 @@
 package configurations
 
 import common.Os
+import common.buildScanTagParam
+import common.getBuildScanCustomValueParam
 import common.requiresNotEc2Agent
 import model.CIBuildModel
 import model.Stage
@@ -39,7 +41,10 @@ class SmokeIdeTests(model: CIBuildModel, stage: Stage) : OsAwareBaseGradleBuildT
         model = model,
         buildType = this,
         gradleTasks = ":smoke-ide-test:smokeIdeTest",
-        extraParameters = buildScanTag("SmokeIdeTests"),
+        extraParameters = listOf(
+            stage.getBuildScanCustomValueParam(),
+            buildScanTagParam("SmokeIdeTests")
+        ).joinToString(" "),
     )
 }) {
     companion object {

--- a/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
+++ b/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
@@ -2,6 +2,8 @@ package configurations
 
 import common.JvmCategory
 import common.Os
+import common.buildScanTagParam
+import common.getBuildScanCustomValueParam
 import common.requiresNotEc2Agent
 import common.toCapitalized
 import model.CIBuildModel
@@ -28,8 +30,11 @@ class SmokeTests(model: CIBuildModel, stage: Stage, testJava: JvmCategory, id: S
         this,
         ":smoke-test:$task",
         timeout = 120,
-        extraParameters = buildScanTag("SmokeTests") +
-            " -PtestJavaVersion=${testJava.version.major}" +
-            " -PtestJavaVendor=${testJava.vendor.name}"
+        extraParameters = listOf(
+            stage.getBuildScanCustomValueParam(),
+            buildScanTagParam("SmokeTests"),
+            "-PtestJavaVersion=${testJava.version.major}",
+            "-PtestJavaVendor=${testJava.vendor.name}"
+        ).joinToString(" ")
     )
 })

--- a/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
+++ b/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
@@ -52,7 +52,7 @@ class RerunFlakyTest(os: Os, arch: Arch = Arch.AMD64) : BuildType({
     // Show all failed tests here, since that is what we are interested in
     failureConditions.supportTestRetry = false
 
-    val extraParameters = functionalTestExtraParameters("RerunFlakyTest", os, arch, "%$testJvmVersionParameter%", "%$testJvmVendorParameter%")
+    val extraParameters = functionalTestExtraParameters(listOf("RerunFlakyTest"), os, arch, "%$testJvmVersionParameter%", "%$testJvmVendorParameter%")
     val parameters = (
         buildToolGradleParameters(daemon) +
             listOf(extraParameters) +

--- a/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
+++ b/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
@@ -11,7 +11,6 @@ import io.mockk.mockk
 import io.mockk.slot
 import jetbrains.buildServer.configs.kotlin.BuildStep
 import jetbrains.buildServer.configs.kotlin.BuildSteps
-import jetbrains.buildServer.configs.kotlin.buildSteps.GradleBuildStep
 import model.CIBuildModel
 import model.JsonBasedGradleSubprojectProvider
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -58,6 +57,7 @@ class ApplyDefaultConfigurationTest {
     fun setUp() {
         val stepsCapturer = slot<BuildSteps.() -> Unit>()
         every { buildType.steps } returns steps
+        every { buildType.stage } returns buildModel.stages[2]
         every {
             buildType.steps(capture(stepsCapturer))
         } answers {
@@ -79,7 +79,7 @@ class ApplyDefaultConfigurationTest {
             ),
             steps.items.map(BuildStep::name)
         )
-        assertEquals(expectedRunnerParam(), getGradleStep("GRADLE_RUNNER").gradleParams)
+        assertEquals(expectedRunnerParam(), steps.getGradleStep("GRADLE_RUNNER").gradleParams)
     }
 
     @ParameterizedTest
@@ -138,14 +138,11 @@ class ApplyDefaultConfigurationTest {
 
     private
     fun verifyGradleRunnerParams(extraParameters: String, expectedDaemonParam: String, os: Os = Os.LINUX) {
-        assertEquals(BuildStep.ExecutionMode.DEFAULT, getGradleStep("GRADLE_RUNNER").executionMode)
+        assertEquals(BuildStep.ExecutionMode.DEFAULT, steps.getGradleStep("GRADLE_RUNNER").executionMode)
 
-        assertEquals(expectedRunnerParam(expectedDaemonParam, extraParameters, os), getGradleStep("GRADLE_RUNNER").gradleParams)
-        assertEquals("clean myTask", getGradleStep("GRADLE_RUNNER").tasks)
+        assertEquals(expectedRunnerParam(expectedDaemonParam, extraParameters, os), steps.getGradleStep("GRADLE_RUNNER").gradleParams)
+        assertEquals("clean myTask", steps.getGradleStep("GRADLE_RUNNER").tasks)
     }
-
-    private
-    fun getGradleStep(stepName: String) = steps.items.find { it.name == stepName }!! as GradleBuildStep
 
     private
     fun expectedRunnerParam(daemon: String = "--daemon", extraParameters: String = "", os: Os = Os.LINUX): String {
@@ -154,6 +151,6 @@ class ApplyDefaultConfigurationTest {
         val windowsPaths =
             "-Porg.gradle.java.installations.paths=%windows.java8.openjdk.64bit%,%windows.java11.openjdk.64bit%,%windows.java17.openjdk.64bit%,%windows.java21.openjdk.64bit%,%windows.java23.openjdk.64bit%"
         val expectedInstallationPaths = if (os == Os.WINDOWS) windowsPaths else linuxPaths
-        return "-Dorg.gradle.workers.max=%maxParallelForks% -PmaxParallelForks=%maxParallelForks% $pluginPortalUrlOverride -s --no-configuration-cache %additional.gradle.parameters% $daemon --continue $extraParameters \"-Dscan.tag.Check\" \"-Dscan.tag.\" -PteamCityBuildId=%teamcity.build.id% \"$expectedInstallationPaths\" -Porg.gradle.java.installations.auto-download=false -Porg.gradle.java.installations.auto-detect=false"
+        return "-Dorg.gradle.workers.max=%maxParallelForks% -PmaxParallelForks=%maxParallelForks% $pluginPortalUrlOverride -s --no-configuration-cache %additional.gradle.parameters% $daemon --continue $extraParameters -Dscan.tag.Check -Dscan.tag.PullRequestFeedback -PteamCityBuildId=%teamcity.build.id% \"$expectedInstallationPaths\" -Porg.gradle.java.installations.auto-download=false -Porg.gradle.java.installations.auto-detect=false"
     }
 }

--- a/.teamcity/src/test/kotlin/BuildScanTagUtilsTest.kt
+++ b/.teamcity/src/test/kotlin/BuildScanTagUtilsTest.kt
@@ -1,0 +1,52 @@
+import common.JvmVendor
+import common.JvmVersion
+import common.Os
+import common.VersionedSettingsBranch
+import common.asBuildScanCustomValue
+import common.getBuildScanCustomValueParam
+import jetbrains.buildServer.configs.kotlin.DslContext
+import model.CIBuildModel
+import model.JsonBasedGradleSubprojectProvider
+import model.TestCoverage
+import model.TestType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class BuildScanTagUtilsTest {
+    init {
+        DslContext.initForTest()
+    }
+
+    private val subprojectProvider = JsonBasedGradleSubprojectProvider(File("../.teamcity/subprojects.json"))
+    private val model = CIBuildModel(
+        projectId = "Check",
+        branch = VersionedSettingsBranch.fromDslContext(),
+        buildScanTags = listOf("Check"),
+        subprojects = subprojectProvider
+    )
+
+    @Test
+    fun `test stage tags`() {
+        assertEquals(
+            "-Dscan.value.PartOf=QuickFeedbackLinuxOnly,QuickFeedback,PullRequestFeedback,ReadyforNightly,ReadyforRelease",
+            model.stages[0].getBuildScanCustomValueParam()
+        )
+        assertEquals(
+            "-Dscan.value.PartOf=QuickFeedback,PullRequestFeedback,ReadyforNightly,ReadyforRelease",
+            model.stages[1].getBuildScanCustomValueParam()
+        )
+        assertEquals(
+            "-Dscan.value.PartOf=ReadyforRelease",
+            model.stages[4].getBuildScanCustomValueParam()
+        )
+    }
+
+    @Test
+    fun `test functional test project tags`() {
+        assertEquals(
+            "QuickJava23AdoptiumLinuxAmd64",
+            TestCoverage(1, TestType.quick, Os.LINUX, JvmVersion.java23, JvmVendor.openjdk).asBuildScanCustomValue()
+        )
+    }
+}

--- a/.teamcity/src/test/kotlin/BuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/BuildTypeTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import common.JvmVendor
+import common.JvmVersion
+import common.Os
+import common.VersionedSettingsBranch
+import configurations.CompileAll
+import configurations.FunctionalTest
+import configurations.GRADLE_RUNNER_STEP_NAME
+import jetbrains.buildServer.configs.kotlin.DslContext
+import model.CIBuildModel
+import model.JsonBasedGradleSubprojectProvider
+import model.TestCoverage
+import model.TestType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class BuildTypeTest {
+    init {
+        DslContext.initForTest()
+    }
+
+    private
+    val buildModel = CIBuildModel(
+        projectId = "Gradle_Check",
+        branch = VersionedSettingsBranch("master"),
+        buildScanTags = listOf("Check"),
+        subprojects = JsonBasedGradleSubprojectProvider(File("../.teamcity/subprojects.json"))
+    )
+
+    @Test
+    fun `CompileAll parameters are correct`() {
+        val gradleStep = CompileAll(buildModel, buildModel.stages[0]).steps.getGradleStep(GRADLE_RUNNER_STEP_NAME)
+        assertEquals(
+            listOf(
+                "-Dorg.gradle.workers.max=%maxParallelForks%",
+                "-PmaxParallelForks=%maxParallelForks%",
+                "-Dorg.gradle.internal.plugins.portal.url.override=%gradle.plugins.portal.url%",
+                "-s",
+                "--no-configuration-cache",
+                "%additional.gradle.parameters%",
+                "--daemon",
+                "--continue",
+                "-Dscan.value.PartOf=QuickFeedbackLinuxOnly,QuickFeedback,PullRequestFeedback,ReadyforNightly,ReadyforRelease",
+                "-Dscan.tag.CompileAll",
+                "-Porg.gradle.java.installations.auto-download=false",
+                "-Dscan.tag.Check",
+                "-PteamCityBuildId=%teamcity.build.id%",
+                "\"-Porg.gradle.java.installations.paths=%linux.java7.oracle.64bit%,%linux.java8.oracle.64bit%,%linux.java11.openjdk.64bit%,%linux.java17.openjdk.64bit%,%linux.java21.openjdk.64bit%,%linux.java23.openjdk.64bit%\"",
+                "-Porg.gradle.java.installations.auto-download=false",
+                "-Porg.gradle.java.installations.auto-detect=false"
+            ).joinToString(" "),
+            gradleStep.gradleParams
+        )
+    }
+
+    @Test
+    fun `functional test parameters are correct`() {
+        val functionalTest = FunctionalTest(
+            buildModel,
+            "TestFunctionalTest",
+            "Test Functional Test",
+            "Test Functional Test",
+            TestCoverage(4, TestType.platform, Os.WINDOWS, JvmVersion.java23, JvmVendor.openjdk),
+            buildModel.stages[2]
+        )
+        val gradleStep = functionalTest.steps.getGradleStep(GRADLE_RUNNER_STEP_NAME)
+        assertEquals(
+            listOf(
+                "-Dorg.gradle.workers.max=4",
+                "-PmaxParallelForks=4",
+                "-Dorg.gradle.internal.plugins.portal.url.override=%gradle.plugins.portal.url%",
+                "-s",
+                "--no-configuration-cache",
+                "%additional.gradle.parameters%",
+                "--daemon",
+                "--continue",
+                "-Dscan.value.PartOf=PlatformJava23AdoptiumWindowsAmd64,PullRequestFeedback,ReadyforNightly,ReadyforRelease",
+                "-PtestJavaVersion=23",
+                "-PtestJavaVendor=openjdk",
+                "-Dscan.tag.FunctionalTest",
+                "-Dscan.value.coverageOs=windows",
+                "-Dscan.value.coverageArch=amd64",
+                "-Dscan.value.coverageJvmVendor=openjdk",
+                "-Dscan.value.coverageJvmVersion=java23",
+                "-PflakyTests=exclude",
+                "-Dscan.tag.Check",
+                "-PteamCityBuildId=%teamcity.build.id%",
+                "\"-Porg.gradle.java.installations.paths=%windows.java8.openjdk.64bit%,%windows.java11.openjdk.64bit%,%windows.java17.openjdk.64bit%,%windows.java21.openjdk.64bit%,%windows.java23.openjdk.64bit%\"",
+                "-Porg.gradle.java.installations.auto-download=false",
+                "-Porg.gradle.java.installations.auto-detect=false"
+            ).joinToString(" "),
+            gradleStep.gradleParams
+        )
+    }
+}

--- a/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
@@ -91,7 +91,8 @@ class PerformanceTestBuildTypeTest {
             "%additional.gradle.parameters%",
             "--daemon",
             "--continue",
-            "\"-Dscan.tag.PerformanceTest\""
+            "-Dscan.value.PartOf=PullRequestFeedback,ReadyforNightly,ReadyforRelease",
+            "-Dscan.tag.PerformanceTest"
         )
 
         assertEquals(
@@ -156,7 +157,8 @@ class PerformanceTestBuildTypeTest {
             "%additional.gradle.parameters%",
             "--daemon",
             "--continue",
-            "\"-Dscan.tag.PerformanceTest\""
+            "-Dscan.value.PartOf=PullRequestFeedback,ReadyforNightly,ReadyforRelease",
+            "-Dscan.tag.PerformanceTest"
         )
 
         assertEquals(

--- a/.teamcity/src/test/kotlin/common.kt
+++ b/.teamcity/src/test/kotlin/common.kt
@@ -1,5 +1,7 @@
 import jetbrains.buildServer.configs.kotlin.AbsoluteId
+import jetbrains.buildServer.configs.kotlin.BuildSteps
 import jetbrains.buildServer.configs.kotlin.DslContext
+import jetbrains.buildServer.configs.kotlin.buildSteps.GradleBuildStep
 
 fun DslContext.initForTest() {
     // Set the project id here, so we can use methods on the DslContext
@@ -9,3 +11,5 @@ fun DslContext.initForTest() {
     settingsRoot.name = "GradleMaster"
     addParameters("Branch" to "master")
 }
+
+fun BuildSteps.getGradleStep(stepName: String) = items.find { it.name == stepName }!! as GradleBuildStep


### PR DESCRIPTION
As the first step to replace all TeamCity links with build scan links, we need to tag build scan with custom values so that they can be displayed as part of build chain.

For example, [this build](https://ge.gradle.org/s/krnszz7eaovzo) has custom value `PartOf=
QuickJava8AdoptiumWindowsAmd64,QuickFeedback,PullRequestFeedback,ReadyforNightly,ReadyforRelease` so we can search by:

- https://ge.gradle.org/scans?search.names=PartOf&search.timeZoneId=Asia%2FShanghai&search.values=*QuickJava8AdoptiumWindowsAmd64*
- https://ge.gradle.org/scans?search.names=PartOf&search.timeZoneId=Asia%2FShanghai&search.values=*QuickFeedback*
- ...
- https://ge.gradle.org/scans?search.names=PartOf&search.timeZoneId=Asia%2FShanghai&search.values=*ReadyforRelease*
