### PR TITLE
Revert "Remove build-logic and build-logic-commons checks from `sanityCheck` to unblock `master`"

### DIFF
--- a/build-logic/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
+++ b/build-logic/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
@@ -92,9 +92,8 @@ fun TaskContainer.registerEarlyFeedbackRootLifecycleTasks() {
         description = "Run all basic checks (without tests) - to be run locally and on CI for early feedback"
         group = "verification"
         dependsOn(
-            // TODO: fix https://github.com/gradle/gradle-private/issues/4456
-            // gradle.includedBuild("build-logic-commons").task(":check"),
-            // gradle.includedBuild("build-logic").task(":check"),
+            gradle.includedBuild("build-logic-commons").task(":check"),
+            gradle.includedBuild("build-logic").task(":check"),
             ":docs:checkstyleApi",
             ":internal-build-reports:allIncubationReportsZip",
             ":architecture-test:checkBinaryCompatibility",


### PR DESCRIPTION
Reverts gradle/gradle#30469