### PR TITLE
Move generated dependency-accessors to global cache

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DependenciesAccessorsWorkspaceProvider.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DependenciesAccessorsWorkspaceProvider.java
@@ -17,7 +17,7 @@ package org.gradle.api.internal.catalog;
 
 import org.gradle.api.internal.cache.CacheConfigurationsInternal;
 import org.gradle.cache.CacheCleanupStrategyFactory;
-import org.gradle.cache.scopes.BuildTreeScopedCacheBuilderFactory;
+import org.gradle.cache.scopes.GlobalScopedCacheBuilderFactory;
 import org.gradle.internal.execution.workspace.ImmutableWorkspaceProvider;
 import org.gradle.internal.execution.workspace.impl.CacheBasedImmutableWorkspaceProvider;
 import org.gradle.internal.file.FileAccessTimeJournal;
@@ -28,7 +28,7 @@ public class DependenciesAccessorsWorkspaceProvider implements ImmutableWorkspac
     private final CacheBasedImmutableWorkspaceProvider delegate;
 
     public DependenciesAccessorsWorkspaceProvider(
-        BuildTreeScopedCacheBuilderFactory cacheBuilderFactory,
+        GlobalScopedCacheBuilderFactory cacheBuilderFactory,
         FileAccessTimeJournal fileAccessTimeJournal,
         CacheConfigurationsInternal cacheConfigurations,
         CacheCleanupStrategyFactory cacheCleanupStrategyFactory


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/30680