### PR TITLE
Enable strict classloading (correctly this time)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.parallel=true
-org.gradle.classloaderscope.strict=true
+systemProp.org.gradle.classloaderscope.strict=true
 systemProp.gradle.publish.skip.namespace.check=true
 # Kotlin DSL settings
 org.gradle.kotlin.dsl.allWarningsAsErrors=true


### PR DESCRIPTION
To avoid any incompatibilities between CC and daemon reuse in the `gradle/gradle` build.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
