### PR TITLE
Add dependsOn to ensure task ordering in samples

### DIFF
--- a/platforms/documentation/docs/src/snippets/dependencyManagement/performingResolution-artifactResolution/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/performingResolution-artifactResolution/groovy/build.gradle
@@ -30,6 +30,9 @@ tasks.register("resolveConfiguration", ResolveFiles) {
     files.from(configurations.runtimeClasspath)
 }
 tasks.register("resolveIncomingFiles", ResolveFiles) {
+// end::implicit-file-resolution[]
+    dependsOn(tasks.named("resolveConfiguration")) // To preserve output ordering
+// tag::implicit-file-resolution[]
     files.from(configurations.runtimeClasspath.incoming.files)
 }
 // end::implicit-file-resolution[]

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/performingResolution-artifactResolution/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/performingResolution-artifactResolution/kotlin/build.gradle.kts
@@ -30,6 +30,9 @@ tasks.register<ResolveFiles>("resolveConfiguration") {
     files.from(configurations.runtimeClasspath)
 }
 tasks.register<ResolveFiles>("resolveIncomingFiles") {
+// end::implicit-file-resolution[]
+    dependsOn(tasks.named("resolveConfiguration")) // To preserve output ordering
+// tag::implicit-file-resolution[]
     files.from(configurations.runtimeClasspath.map { it.incoming.files })
 }
 // end::implicit-file-resolution[]


### PR DESCRIPTION
Builds were breaking on CI because these executed in an arbitrary order

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
