### PR TITLE
Remove unnecessary commit statuses

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/DocsTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/DocsTest.kt
@@ -96,9 +96,6 @@ class DocsTestTrigger(model: CIBuildModel, docsTestProject: DocsTestProject) : O
 
     applyDefaultSettings()
 
-    features {
-        publishBuildStatusToGithub(model)
-    }
     dependencies {
         snapshotDependencies(docsTestProject.docsTests)
     }
@@ -122,10 +119,6 @@ class DocsTest(
 
     id("${model.projectId}_${docsTestType.docsTestName}_${os.asName()}_$index")
     name = "${docsTestType.docsTestDesc} - ${testJava.version.name.toCapitalized()} ${os.asName()} ($index)"
-
-    features {
-        publishBuildStatusToGithub(model)
-    }
 
     applyTestDefaults(
         model,

--- a/.teamcity/src/main/kotlin/configurations/FunctionalTestsPass.kt
+++ b/.teamcity/src/main/kotlin/configurations/FunctionalTestsPass.kt
@@ -29,10 +29,6 @@ class FunctionalTestsPass(model: CIBuildModel, functionalTestProject: Functional
 
         applyDefaultSettings()
 
-        features {
-            publishBuildStatusToGithub(model)
-        }
-
         dependencies {
             snapshotDependencies(functionalTestProject.functionalTests)
         }

--- a/.teamcity/src/main/kotlin/configurations/Gradleception.kt
+++ b/.teamcity/src/main/kotlin/configurations/Gradleception.kt
@@ -64,10 +64,6 @@ class Gradleception(
         requiresNotSharedHost()
     }
 
-    features {
-        publishBuildStatusToGithub(model)
-    }
-
     dependencies {
         // If SanityCheck fails, Gradleception will definitely fail because the last build step is also sanityCheck
         dependsOn(RelativeId(SanityCheck.buildTypeId(model)))

--- a/.teamcity/src/main/kotlin/configurations/SmokeIdeTests.kt
+++ b/.teamcity/src/main/kotlin/configurations/SmokeIdeTests.kt
@@ -28,10 +28,6 @@ class SmokeIdeTests(model: CIBuildModel, stage: Stage) : OsAwareBaseGradleBuildT
     name = "Smoke Ide Tests"
     description = "Tests against IDE sync process"
 
-    features {
-        publishBuildStatusToGithub(model)
-    }
-
     requirements {
         // These tests are usually heavy and the build time is twice on EC2 agents
         requiresNotEc2Agent()

--- a/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
+++ b/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
@@ -14,10 +14,6 @@ class SmokeTests(model: CIBuildModel, stage: Stage, testJava: JvmCategory, id: S
     name = "Smoke Tests with 3rd Party Plugins ($task) - ${testJava.version.name.toCapitalized()} Linux"
     description = "Smoke tests against third party plugins to see if they still work with the current Gradle version"
 
-    features {
-        publishBuildStatusToGithub(model)
-    }
-
     tcParallelTests(splitNumber)
 
     requirements {


### PR DESCRIPTION
We publish too many commit statuses. This is the commit statuses we publish for a single PullRequestFeedback build (the strikethroughed ones are to be removed by this PR):

Keep:
- Build Distributions (Pull Request Feedback) - TeamCity build finished
- Compile All (Quick Feedback - Linux Only) - TeamCity build finished
- GitHub Merge Queue Check Pass (Check) - Ready to enqueue
- Pull Request Feedback (Trigger) (Check) - TeamCity build finished
- Quick Feedback (Trigger) (Check) - TeamCity build finished
- Quick Feedback - Linux Only (Trigger) (Check) - TeamCity build finished
- Sanity Check (Quick Feedback - Linux Only) - TeamCity build finished

Removing:
- ~ConfigCache Java8 Oracle Linux Amd64 (Trigger) (Pull Request Feedback) - TeamCity build finished~
- ~Docs Test - Java23 Linux (1) (Docs Test - Java23 Linux) - TeamCity build finished~
- ~Docs Test - Java23 Linux (2) (Docs Test - Java23 Linux) - TeamCity build finished~
- ~Docs Test - Java23 Linux (3) (Docs Test - Java23 Linux) - TeamCity build finished~
- ~Docs Test - Java23 Linux (4) (Docs Test - Java23 Linux) - TeamCity build finished~
- ~Docs Test - Java23 Linux (Trigger) (Pull Request Feedback) - TeamCity build finished~
- ~Docs Test - Java23 Windows (1) (Docs Test - Java23 Windows) - TeamCity build finished~
- ~Docs Test - Java23 Windows (2) (Docs Test - Java23 Windows) - TeamCity build finished~
- ~Docs Test - Java23 Windows (3) (Docs Test - Java23 Windows) - TeamCity build finished~
- ~Docs Test - Java23 Windows (4) (Docs Test - Java23 Windows) - TeamCity build finished~
- ~Docs Test - Java23 Windows (Trigger) (Pull Request Feedback) - TeamCity build finished~
- ~Docs Test With Config Cache Enabled - Java23 Linux (1) (Docs Test - Java23 Linux) - TeamCity build finished~
- ~Docs Test With Config Cache Enabled - Java23 Linux (2) (Docs Test - Java23 Linux) - TeamCity build finished~
- ~Docs Test With Config Cache Enabled - Java23 Linux (3) (Docs Test - Java23 Linux) - TeamCity build finished~
- ~Docs Test With Config Cache Enabled - Java23 Linux (4) (Docs Test - Java23 Linux) - TeamCity build finished~
- ~Gradleception - Groovy 4.x Java11 Adoptium Linux (Pull Request Feedback) - TeamCity build finished~
- ~Gradleception - Java11 Adoptium Linux (Pull Request Feedback) - TeamCity build finished~
- ~IsolatedProjects Java8 Oracle Linux Amd64 (Trigger) (Pull Request Feedback) - TeamCity build finished~
- ~Platform Java23 Adoptium Windows Amd64 (Trigger) (Pull Request Feedback) - TeamCity build finished~
- ~Platform Java8 Oracle Linux Amd64 (Trigger) (Pull Request Feedback) - TeamCity build finished~
- ~Quick Java23 Adoptium Linux Amd64 (Trigger) (Quick Feedback - Linux Only) - TeamCity build finished~
- ~Quick Java8 Adoptium Windows Amd64 (Trigger) (Quick Feedback) - TeamCity build finished~
- ~Smoke Ide Tests (Pull Request Feedback) - TeamCity build finished~
- ~Smoke Tests with 3rd Party Plugins (configCacheSantaTrackerSmokeTest) - Java17 Linux (Pull Request Feedback) TeamCity build finished~
- ~Smoke Tests with 3rd Party Plugins (configCacheSmokeTest) - Java21 Linux (Pull Request Feedback) - TeamCity build - finished~
- ~Smoke Tests with 3rd Party Plugins (configCacheSmokeTest) - Java8 Linux (Pull Request Feedback) - TeamCity build finished~
- ~Smoke Tests with 3rd Party Plugins (gradleBuildSmokeTest) - Java21 Linux (Pull Request Feedback) - TeamCity build finished~
- ~Smoke Tests with 3rd Party Plugins (santaTrackerSmokeTest) - Java17 Linux (Pull Request Feedback) - TeamCity build finished~
- ~Smoke Tests with 3rd Party Plugins (smokeTest) - Java21 Linux (Pull Request Feedback) - TeamCity build finished~