### PR TITLE
Fix build scan publish in GitHub action builds

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -68,7 +68,7 @@ jobs:
       run: ./gradlew --no-configuration-cache --init-script .github/workflows/codeql-analysis.init.gradle -DcacheNode=us -S testClasses -Dhttp.keepAlive=false
       env:
         # Set the DEVELOCITY_ACCESS_KEY so that Gradle Build Scans are generated
-        DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+        DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         # Potential stop-gap solution for ReadTimeout issues with the Gradle Build Cache
         # https://gradle.slack.com/archives/CHDLT99C6/p1636477584059200
         GRADLE_OPTS: -Dhttp.keepAlive=false

--- a/.github/workflows/contributor-pr.yml
+++ b/.github/workflows/contributor-pr.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   # Set the DEVELOCITY_ACCESS_KEY so that Gradle Build Scans are generated
-  DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
   # Enable debug for the `gradle-build-action` cache operations
   GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
 
@@ -43,7 +43,7 @@ jobs:
         with:
           script: |
             if (context.payload.pull_request && context.payload.pull_request.head.repo.fork) {
-                core.setOutput('sys-prop-args', '-DagreePublicBuildScanTermOfService=yes -DcacheNode=us')
+                core.setOutput('sys-prop-args', '-DagreePublicBuildScanTermOfService=yes -DcacheNode=us --scan')
             } else {
                 core.setOutput('sys-prop-args', '-DcacheNode=us')
             }

--- a/testing/internal-testing/src/test/groovy/org/gradle/infra/EnvironmentVariablesPropagationTest.groovy
+++ b/testing/internal-testing/src/test/groovy/org/gradle/infra/EnvironmentVariablesPropagationTest.groovy
@@ -28,6 +28,7 @@ class EnvironmentVariablesPropagationTest extends Specification {
 
         where:
         value << ['GRADLE_ENTERPRISE_ACCESS_KEY',
+                  "DEVELOCITY_ACCESS_KEY",
                   "api_key",
                   "access_key",
                   "apikey",


### PR DESCRIPTION
1. Add `--scan` to contributor GitHub action runs so that they can publish to `scans.gradle.com`.
2. Rename `GRADLE_ENTERPRISE_ACCESS_KEY` to `DEVELOCITY_ACCESS_KEY`.