### PR TITLE
Enhance configuring of target bytecode version by using --release flag more often

### DIFF
--- a/build-logic-commons/build-platform/build.gradle.kts
+++ b/build-logic-commons/build-platform/build.gradle.kts
@@ -73,7 +73,7 @@ dependencies {
             because("CVE-2022-40152 on lower versions")
         }
         api("com.beust:jcommander:1.78")
-        api("org.codehaus.groovy:$groovyVersion")
+        api("org.codehaus.groovy:groovy:$groovyVersion")
         api("org.codehaus.groovy.modules.http-builder:http-builder:0.7.2") // TODO maybe change group name when upgrading to Groovy 4
         api("org.codenarc:CodeNarc:$codenarcVersion")
         api("org.eclipse.jgit:org.eclipse.jgit:5.13.3.202401111512-r")

--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.java-shared-runtime.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.java-shared-runtime.gradle.kts
@@ -24,6 +24,9 @@ testing {
     suites {
         val test by getting(JvmTestSuite::class) {
             useSpock()
+            dependencies {
+                implementation(platform("gradlebuild:build-platform"))
+            }
         }
     }
 }

--- a/build-logic/jvm/build.gradle.kts
+++ b/build-logic/jvm/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation("org.ow2.asm:asm-commons")
     implementation("com.google.code.gson:gson")
     implementation("com.gradle:develocity-gradle-plugin")
+    implementation(kotlin("gradle-plugin"))
 
     implementation("com.thoughtworks.qdox:qdox") {
         because("ParameterNamesIndex")

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -20,6 +20,7 @@ import com.gradle.develocity.agent.gradle.test.DevelocityTestConfiguration
 import gradlebuild.basics.BuildEnvironment
 import gradlebuild.basics.FlakyTestStrategy
 import gradlebuild.basics.accessors.kotlinMainSourceSet
+import gradlebuild.basics.buildRunningOnCi
 import gradlebuild.basics.flakyTestStrategy
 import gradlebuild.basics.maxParallelForks
 import gradlebuild.basics.maxTestDistributionLocalExecutors
@@ -27,7 +28,6 @@ import gradlebuild.basics.maxTestDistributionPartitionSecond
 import gradlebuild.basics.maxTestDistributionRemoteExecutors
 import gradlebuild.basics.predictiveTestSelectionEnabled
 import gradlebuild.basics.rerunAllTests
-import gradlebuild.basics.buildRunningOnCi
 import gradlebuild.basics.testDistributionDogfoodingTag
 import gradlebuild.basics.testDistributionEnabled
 import gradlebuild.basics.testDistributionServerUrl
@@ -39,6 +39,9 @@ import gradlebuild.filterEnvironmentVariables
 import gradlebuild.jvm.argumentproviders.CiEnvironmentProvider
 import gradlebuild.jvm.extension.UnitTestAndCompileExtension
 import org.gradle.internal.os.OperatingSystem
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.jvm.JvmTargetValidationMode
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.time.Duration
 
 plugins {
@@ -48,33 +51,202 @@ plugins {
     id("gradlebuild.dependency-modules")
 }
 
-extensions.create<UnitTestAndCompileExtension>("gradlebuildJava", project, tasks)
+// Create an extension that allows projects to configure the way they are compiled and tested.
+// Particularly, we let them describe the "platform" they are targeting, like a Gradle worker, daemon, etc.
+// Furthermore, we let them describe whether they are using any "workarounds" like:
+// - Using JDK internal classes
+// - Using Java standard library APIs that were introduced after the JVM version they are targeting
+// - Using dependencies that target a higher JVM version than the project's target JVM version
+//
+// All of these workarounds should be generally avoided, but, with this data we can configure the
+// compile tasks to permit some of these requirements.
+// TODO: Rename this. It controls more than just java compilation.
+val gradlebuildJava = extensions.create<UnitTestAndCompileExtension>("gradlebuildJava").apply {
+    usesFutureStdlib.convention(targetVersion.map {
+        // Assume most of our projects targeting workers use Java standard libraries
+        // that were introduced in version later than the version they target.
+
+        // It is by chance that these future libraries are not loaded on test workers during runtime.
+        // TODO: In Gradle 9.0, tooling API and workers will target JVM 8 and we can set this value to false by default.
+        it < 8
+    })
+    usesIncompatibleDependencies.convention(targetVersion.map {
+        // Assume most of our projects targeting workers use dependencies like guava
+        // which require Java 8. (base-services for example uses guava).
+
+        // It is by chance that these incompatible dependencies are not loaded on test workers during runtime.
+        // TODO: In Gradle 9.0, tooling API and workers will target JVM 8 and we can set this value to false by default.
+        it < 8
+    })
+
+    // Assume by default, a library targets the daemon and does not reference JDK internal classes.
+    usedInDaemon()
+    usesJdkInternals.convention(false)
+}
+
+// Use the Java 11 compiler, when possible, to perform compilation.
+// This does not mean we target Java 11 bytecode. The target bytecode
+// is controlled by the `gradlebuildJava.targetVersion` property.
+configureDefaultToolchain(11)
+enforceCompatibility(gradlebuildJava)
 
 removeTeamcityTempProperty()
 addDependencies()
-configureCompile()
+configureCompileDefaults()
+addCompileAllTasks()
 configureSourcesVariant()
 configureTests()
 
 tasks.registerCITestDistributionLifecycleTasks()
 
-fun configureCompile() {
-    java.toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
-        vendor = JvmVendorSpec.ADOPTIUM
-    }
-
+fun configureCompileDefaults() {
     tasks.withType<JavaCompile>().configureEach {
-        configureCompileTask(options)
         options.compilerArgs.add("-parameters")
+        configureCompileTask(options)
     }
     tasks.withType<GroovyCompile>().configureEach {
         groovyOptions.encoding = "utf-8"
-        sourceCompatibility = "1.8"
-        targetCompatibility = "1.8"
         configureCompileTask(options)
     }
-    addCompileAllTask()
+}
+
+/**
+ * When possible, use a Java compiler with the given version when
+ * performing compilation. This does not necessarily mean we are
+ * emitting bytecode for the given version.
+ * <p>
+ * In some cases, the toolchain used here may be overridden, for
+ * example when compiling Groovy code, as it does not support
+ * the --release flag, or when targeting much older bytecode versions.
+ */
+fun configureDefaultToolchain(toolchainVersion: Int) {
+    java.toolchain {
+        languageVersion = JavaLanguageVersion.of(toolchainVersion)
+        vendor = JvmVendorSpec.ADOPTIUM
+    }
+}
+
+/**
+ * Given the user-configured values in the extension, configure the compilation tasks
+ * to enforce compatibility with the target JVM version.
+ *
+ * We try to use the toolchain configured in [configureDefaultToolchain] as much as possible,
+ * but in some cases, we need to use another toolchain.
+ *
+ * In some cases, we need to set the source and target compatibility flags instead of using
+ * the release flag. This is because the release flag limits us from using internal APIs or
+ * APIs defined by a Java version higher than the target version.
+ *
+ * Finally, Groovy does not support the release flag at all. We manually set a toolchain
+ * for Groovy to ensure it compiles against the correct classes.
+ */
+private
+fun enforceCompatibility(gradlebuildJava: UnitTestAndCompileExtension) {
+    // When using the release flag, compiled code cannot access JDK internal classes or standard library
+    // APIs defined in future versions of Java. If either of these cases are true, we do not use the
+    // release flag, but instead set the source and target compatibility flags.
+    val useRelease = this.gradlebuildJava.usesJdkInternals.zip(this.gradlebuildJava.usesFutureStdlib) { internals, futureApis -> !internals && !futureApis }
+
+    val targetVersion = gradlebuildJava.targetVersion
+    enforceJavaCompatibility(targetVersion, useRelease)
+    enforceGroovyCompatibility(targetVersion)
+    enforceKotlinCompatibility(targetVersion, useRelease)
+
+    project.afterEvaluate {
+        if (targetVersion.get() < 8) {
+            // Apply ParameterNamesIndex since 6 and 7 bytecode doesn't support -parameters
+            project.apply(plugin = "gradlebuild.api-parameter-names-index")
+        }
+
+        if (gradlebuildJava.usesIncompatibleDependencies.get()) {
+            // Some projects use dependencies that target higher JVM versions
+            // than the projects target. Disable dependency management checks
+            // that verify these dependencies have compatible java versions.
+            java.disableAutoTargetJvm()
+        }
+    }
+}
+
+fun enforceJavaCompatibility(targetVersion: Provider<Int>, useRelease: Provider<Boolean>) {
+    tasks.withType<JavaCompile>().configureEach {
+        // Set the release flag is requested.
+        // Otherwise, we set the source and target compatibility in the afterEvaluate below.
+        options.release = useRelease.flatMap { doUseRelease -> targetVersion.filter { doUseRelease } }
+
+        // If we are targeting Java < 8, we need to use a different compiler,
+        // since compilers will only cross-compile down to a certain version.
+        javaCompiler = javaToolchains.compilerFor {
+            languageVersion = targetVersion.flatMap {
+                if (it >= 8) {
+                    // The toolchain on the project is able to target JDK >= 8
+                    java.toolchain.languageVersion
+                } else {
+                    // To compile Java 6 and 7 sources, we need an older compiler
+                    // We choose 11 since it supports both of these versions.
+                    provider { JavaLanguageVersion.of(11) }
+                }
+            }
+            vendor = JvmVendorSpec.ADOPTIUM
+        }
+    }
+
+    // Need to use afterEvaluate since source/target compatibility are not lazy
+    project.afterEvaluate {
+        tasks.withType<JavaCompile>().configureEach {
+            if (!useRelease.get()) {
+                val version = targetVersion.get().toString()
+                sourceCompatibility = version
+                targetCompatibility = version
+            }
+        }
+    }
+}
+
+fun enforceGroovyCompatibility(targetVersion: Provider<Int>) {
+    tasks.withType<GroovyCompile>().configureEach {
+        // Groovy does not support the release flag. We must compile with the same
+        // JDK we are targeting in order to see the correct standard lib classes
+        // during compilation
+        javaLauncher = javaToolchains.launcherFor {
+            languageVersion = targetVersion.map {
+                // Use the target version's toolchain if it is 8 or higher.
+                // We do not expect dev machines to have Java 6 or 7 installed,
+                // so when compiling this code, we accept the risk of seeing
+                // higher standard library classes.
+                JavaLanguageVersion.of(maxOf(it, 8))
+            }
+            // TODO: Use a stable vendor. CI currently specifies different vendors for Java 8 depending on the OS
+        }
+    }
+
+    // Need to use afterEvaluate since source/target Compatibility are not lazy
+    project.afterEvaluate {
+        tasks.withType<GroovyCompile>().configureEach {
+            val version = targetVersion.get().toString()
+            sourceCompatibility = version
+            targetCompatibility = version
+        }
+    }
+}
+
+fun enforceKotlinCompatibility(targetVersion: Provider<Int>, useRelease: Provider<Boolean>) {
+    tasks.withType<KotlinCompile>().configureEach {
+        jvmTargetValidationMode.set(JvmTargetValidationMode.ERROR)
+        compilerOptions {
+            jvmTarget = targetVersion.map {
+                JvmTarget.fromTarget(if (it < 9) "1.${it}" else it.toString())
+            }
+
+            // TODO KT-49746: Use the DSL to set the release version
+            freeCompilerArgs.addAll(useRelease.zip(jvmTarget) { doUseRelease, targetVersion ->
+                if (doUseRelease) {
+                    listOf("-Xjdk-release=${targetVersion.target}")
+                } else {
+                    listOf()
+                }
+            })
+        }
+    }
 }
 
 fun configureSourcesVariant() {
@@ -111,7 +283,6 @@ fun configureSourcesVariant() {
 }
 
 fun configureCompileTask(options: CompileOptions) {
-    options.release = 8
     options.encoding = "utf-8"
     options.isIncremental = true
     options.isFork = true
@@ -149,7 +320,7 @@ fun addDependencies() {
     }
 }
 
-fun addCompileAllTask() {
+fun addCompileAllTasks() {
     tasks.register("compileAll") {
         description = "Compile all source code, including main, test, integTest, crossVersionTest, testFixtures, etc."
         val compileTasks = project.tasks.matching {
@@ -197,7 +368,7 @@ fun Test.configureJvmForTest() {
     jvmArgumentProviders.add(CiEnvironmentProvider(this))
     val launcher = project.javaToolchains.launcherFor {
         languageVersion = jvmVersionForTest()
-        vendor = project.testJavaVendor.orNull
+        vendor = project.testJavaVendor.orElse(JvmVendorSpec.ADOPTIUM)
     }
     javaLauncher = launcher
     if (jvmVersionForTest().canCompileOrRun(9)) {

--- a/build-logic/jvm/src/main/kotlin/gradlebuild/jvm/extension/UnitTestAndCompileExtension.kt
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild/jvm/extension/UnitTestAndCompileExtension.kt
@@ -16,47 +16,79 @@
 
 package gradlebuild.jvm.extension
 
-import org.gradle.api.Project
-import org.gradle.api.tasks.TaskContainer
-import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.*
 
+/**
+ * An extension intended for configuring the manner in which a project is
+ * compiled and tested.
+ */
+abstract class UnitTestAndCompileExtension {
 
-abstract class UnitTestAndCompileExtension(
-    private val project: Project,
-    private val tasks: TaskContainer,
-) {
+    /**
+     * Set this flag to true if the project compiles against JDK internal classes.
+     *
+     * This workaround should be used sparingly.
+     */
+    abstract val usesJdkInternals: Property<Boolean>
+
+    /**
+     * Set this flag to true if the project compiles against Java standard library APIs
+     * that were introduced after the [targetVersion] of the project.
+     *
+     * This workaround should be used sparingly.
+     */
+    abstract val usesFutureStdlib: Property<Boolean>
+
+    /**
+     * Set this flag to true if the project compiles against dependencies that target a
+     * higher JVM version than the [targetVersion] of the project.
+     *
+     * This workaround should be used sparingly.
+     */
+    abstract val usesIncompatibleDependencies: Property<Boolean>
+
+    /**
+     * Stores the mutable value of the target bytecode version for this project,
+     * but is protected to prevent the user from setting it directly.
+     */
+    protected abstract val targetVersionProperty: Property<Int>
+
+    /**
+     * Get the target bytecode version for this project.
+     *
+     * To configure this value, call a `usedIn*` method.
+     */
+    val targetVersion: Provider<Int>
+        get() = targetVersionProperty
 
     /**
      * Enforces **Java 6** compatibility.
      */
     fun usedInWorkers() {
-        enforceCompatibility(6)
+        targetVersionProperty = 6
     }
 
     /**
      * Enforces **Java 6** compatibility.
      */
     fun usedForStartup() {
-        enforceCompatibility(6)
+        targetVersionProperty = 6
     }
 
     /**
      * Enforces **Java 7** compatibility.
      */
     fun usedInToolingApi() {
-        enforceCompatibility(7)
+        targetVersionProperty = 7
     }
 
-    private
-    fun enforceCompatibility(majorVersion: Int) {
-        tasks.withType<JavaCompile>().configureEach {
-            options.release = null
-            options.compilerArgs.remove("-parameters")
-            sourceCompatibility = "$majorVersion"
-            targetCompatibility = "$majorVersion"
-        }
-        // Apply ParameterNamesIndex since 6 doesn't support -parameters
-        project.apply(plugin = "gradlebuild.api-parameter-names-index")
+    /**
+     * Enforces **Java 8** compatibility.
+     */
+    fun usedInDaemon() {
+        targetVersionProperty = 8
     }
+
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # 1. Reduce Xmx after https://github.com/gradle/gradle-private/issues/4168 is resolved
 # 2. Enable html problem report for this build with -Dorg.gradle.internal.problems.report.enabled=true
-org.gradle.jvmargs=-Xmx3000m -XX:MaxMetaspaceSize=768m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -Dorg.gradle.internal.problems.report.enabled=true
+org.gradle.jvmargs=-Xmx3100m -XX:MaxMetaspaceSize=768m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -Dorg.gradle.internal.problems.report.enabled=true
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true

--- a/platforms/core-configuration/bean-serialization-services/build.gradle.kts
+++ b/platforms/core-configuration/bean-serialization-services/build.gradle.kts
@@ -21,6 +21,10 @@ plugins {
 
 description = "Configuration Cache services supporting bean serialization"
 
+gradlebuildJava {
+    usesJdkInternals = true
+}
+
 dependencies {
     api(projects.graphSerialization)
     api(projects.stdlibJavaExtensions)

--- a/platforms/core-configuration/core-serialization-codecs/build.gradle.kts
+++ b/platforms/core-configuration/core-serialization-codecs/build.gradle.kts
@@ -20,6 +20,10 @@ plugins {
 
 description = "Configuration Cache serialization codecs for :core (and family) types"
 
+gradlebuildJava {
+    usesFutureStdlib = true
+}
+
 dependencies {
     api(projects.baseServices)
     api(projects.configurationCacheBase)

--- a/platforms/core-configuration/model-core/build.gradle.kts
+++ b/platforms/core-configuration/model-core/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
 
 description = "Implementation of configuration model types and annotation metadata handling (Providers, software model, conventions)"
 
+gradlebuildJava {
+    usesJdkInternals = true
+}
+
 dependencies {
     api(projects.serialization)
     api(projects.serviceLookup)
@@ -67,12 +71,6 @@ dependencies {
 
 strictCompile {
     ignoreRawTypes() // raw types used in public API
-}
-
-tasks.withType<JavaCompile>().configureEach {
-    options.release = null
-    sourceCompatibility = "8"
-    targetCompatibility = "8"
 }
 
 integTest.usesJavadocCodeSnippets = true

--- a/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/DefaultFileHasher.java
+++ b/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/DefaultFileHasher.java
@@ -15,12 +15,13 @@
  */
 package org.gradle.internal.hash;
 
+import org.gradle.api.UncheckedIOException;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
 
 public class DefaultFileHasher implements FileHasher {
     private final StreamHasher streamHasher;

--- a/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/DefaultStreamHasher.java
+++ b/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/DefaultStreamHasher.java
@@ -16,11 +16,11 @@
 package org.gradle.internal.hash;
 
 import com.google.common.io.ByteStreams;
+import org.gradle.api.UncheckedIOException;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UncheckedIOException;
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
 

--- a/platforms/core-runtime/base-services/build.gradle.kts
+++ b/platforms/core-runtime/base-services/build.gradle.kts
@@ -13,6 +13,12 @@ gradlebuildJava.usedInWorkers()
 tasks.named<JavaCompile>("compileTestJava") {
     options.release = 8
 }
+afterEvaluate {
+    tasks.named<GroovyCompile>("compileTestGroovy") {
+        sourceCompatibility = "1.8"
+        targetCompatibility = "1.8"
+    }
+}
 
 /**
  * Use Java 8 compatibility for JMH benchmarks

--- a/platforms/core-runtime/build-operations/src/testFixtures/java/org/gradle/internal/operations/TestBuildOperationRunner.java
+++ b/platforms/core-runtime/build-operations/src/testFixtures/java/org/gradle/internal/operations/TestBuildOperationRunner.java
@@ -17,8 +17,6 @@
 package org.gradle.internal.operations;
 
 import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
 
 import javax.annotation.Nullable;
@@ -137,20 +135,13 @@ public class TestBuildOperationRunner implements BuildOperationRunner {
 
         public <D, R, T extends BuildOperationType<D, R>> List<TypedRecord<D, R>> all(final Class<T> type) {
             final Class<D> detailsType = BuildOperationTypes.detailsType(type);
-            return FluentIterable.from(records)
-                .filter(new Predicate<Record>() {
-                    @Override
-                    public boolean apply(Record input) {
-                        return detailsType.isInstance(input.descriptor.getDetails());
-                    }
-                })
-                .transform(new Function<Record, TypedRecord<D, R>>() {
-                    @Override
-                    public TypedRecord<D, R> apply(Record input) {
-                        return input.asTyped(type);
-                    }
-                })
-                .toList();
+            List<TypedRecord<D, R>> results = new ArrayList<TypedRecord<D, R>>(records.size());
+            for (Record record : records) {
+                if (detailsType.isInstance(record.descriptor.getDetails())) {
+                    results.add(record.asTyped(type));
+                }
+            }
+            return results;
         }
 
         @SuppressWarnings("unused")

--- a/platforms/core-runtime/native/src/testFixtures/groovy/org/gradle/util/WindowsSymbolicLinkUtil.groovy
+++ b/platforms/core-runtime/native/src/testFixtures/groovy/org/gradle/util/WindowsSymbolicLinkUtil.groovy
@@ -16,8 +16,6 @@
 
 package org.gradle.util
 
-import com.sun.security.auth.module.NTSystem
-
 class WindowsSymbolicLinkUtil {
     static void createWindowsSymbolicLink(File link, File target) {
         def extraOptions = target.isDirectory() ? ["/d"] : []
@@ -38,6 +36,6 @@ class WindowsSymbolicLinkUtil {
     // See: https://support.microsoft.com/en-us/help/243330/well-known-security-identifiers-in-windows-operating-systems
     private static final String WELL_KNOWN_ADMINISTRATORS_GROUP_SID = "S-1-5-32-544"
     private static void assertAdministrator() {
-        assert new NTSystem().getGroupIDs().any { it == WELL_KNOWN_ADMINISTRATORS_GROUP_SID }
+        assert ["cmd.exe", "/d", "/c", "whoami", "/groups"].execute().text.contains(WELL_KNOWN_ADMINISTRATORS_GROUP_SID)
     }
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r82/FetchBuildInvocationsTasks.java
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r82/FetchBuildInvocationsTasks.java
@@ -20,17 +20,19 @@ import org.gradle.tooling.BuildAction;
 import org.gradle.tooling.BuildController;
 import org.gradle.tooling.model.Task;
 import org.gradle.tooling.model.gradle.BuildInvocations;
+import org.gradle.tooling.model.gradle.GradleBuild;
 
+import java.util.ArrayList;
 import java.util.List;
-
-import static java.util.stream.Collectors.toList;
 
 public class FetchBuildInvocationsTasks implements BuildAction<List<Task>> {
     @Override
     public List<Task> execute(BuildController controller) {
-        return controller.getBuildModel().getEditableBuilds().stream()
-            .map(build -> controller.getModel(build.getRootProject(), BuildInvocations.class))
-            .flatMap(invocations -> invocations.getTasks().stream())
-            .collect(toList());
+        List<Task> result = new ArrayList<>();
+        for (GradleBuild build : controller.getBuildModel().getEditableBuilds()) {
+            BuildInvocations invocations = controller.getModel(build.getRootProject(), BuildInvocations.class);
+            result.addAll(invocations.getTasks());
+        }
+        return result;
     }
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r82/FetchRootProjectsTasks.java
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r82/FetchRootProjectsTasks.java
@@ -20,16 +20,19 @@ import org.gradle.tooling.BuildAction;
 import org.gradle.tooling.BuildController;
 import org.gradle.tooling.model.GradleProject;
 import org.gradle.tooling.model.Task;
+import org.gradle.tooling.model.gradle.GradleBuild;
 
+import java.util.ArrayList;
 import java.util.List;
-
-import static java.util.stream.Collectors.toList;
 
 public class FetchRootProjectsTasks implements BuildAction<List<Task>> {
     @Override
     public List<Task> execute(BuildController controller) {
-        return controller.getBuildModel().getEditableBuilds().stream()
-            .flatMap(build -> controller.getModel(build.getRootProject(), GradleProject.class).getTasks().stream())
-            .collect(toList());
+        List<Task> result = new ArrayList<>();
+        for (GradleBuild build : controller.getBuildModel().getEditableBuilds()) {
+            GradleProject rootProject = controller.getModel(build.getRootProject(), GradleProject.class);
+            result.addAll(rootProject.getTasks());
+        }
+        return result;
     }
 }

--- a/platforms/jvm/java-compiler-plugin/build.gradle.kts
+++ b/platforms/jvm/java-compiler-plugin/build.gradle.kts
@@ -4,10 +4,8 @@ plugins {
 
 description = "A Java compiler plugin used by Gradle's incremental compiler"
 
-tasks.withType<JavaCompile>().configureEach {
-    options.release = null
-    sourceCompatibility = "8"
-    targetCompatibility = "8"
+gradlebuildJava {
+    usesJdkInternals = true
 }
 
 tasks.withType<Test>().configureEach {

--- a/platforms/jvm/language-java/build.gradle.kts
+++ b/platforms/jvm/language-java/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
 
 description = "Source for JavaCompile, JavaExec and Javadoc tasks, it also contains logic for incremental Java compilation"
 
+gradlebuildJava {
+    usesJdkInternals = true
+}
+
 errorprone {
     disabledChecks.addAll(
         "CheckReturnValue", // 2 occurrences
@@ -107,12 +111,6 @@ tasks.withType<Test>().configureEach {
     if (!javaVersion.isJava9Compatible) {
         classpath += javaLauncher.get().metadata.installationPath.files("lib/tools.jar")
     }
-}
-
-tasks.withType<JavaCompile>().configureEach {
-    options.release = null
-    sourceCompatibility = "8"
-    targetCompatibility = "8"
 }
 
 strictCompile {

--- a/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
+++ b/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
@@ -18,8 +18,8 @@ package org.gradle
 
 import org.apache.tools.ant.taskdefs.Expand
 import org.gradle.api.logging.configuration.WarningMode
+import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
-import org.gradle.internal.jvm.Jvm
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
@@ -65,7 +65,9 @@ class SrcDistributionIntegrationSpec extends DistributionIntegrationSpec {
             withArgument("--no-configuration-cache") // TODO:configuration-cache remove me
             withTasks(':distributions-full:binDistributionZip')
             withArgument("-D${PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY}=${gradlePluginRepositoryMirrorUrl()}")
-            withArgument("-Porg.gradle.java.installations.paths=${Jvm.current().javaHome.absolutePath}")
+            withArgument("-Porg.gradle.java.installations.auto-detect=false")
+            withArgument("-Porg.gradle.java.installations.auto-download=false")
+            withArgument("-Porg.gradle.java.installations.paths=${AvailableJavaHomes.getAvailableJvms().collect { it.javaHome.absolutePath }.join(",")}" as String)
             withEnvironmentVars([BUILD_BRANCH: System.getProperty("gradleBuildBranch"), BUILD_COMMIT_ID: System.getProperty("gradleBuildCommitId")])
             withWarningMode(WarningMode.None)
             noDeprecationChecks()


### PR DESCRIPTION
When attempting to upgrade the toolchain to Java 21, we noticed some issues with the way we were configuring java, groovy, and kotlin compilation.

1. For java, we did not use the release flag when compiling < 8, meaning projects targeting Java 6 could see java 8 APIs.
2. For groovy, we only set the source/target compatibility flags. When compiling with a newer toolchain, emitted Groovy bytecode would contain classes from newer standard libs even though the code was targeted for older bytecode versions
3. For kotlin, we did not use the release flag, meaning when we used a newer toolchain, Kotlin would emit bytecode that contained references to newer APIs that were not present on the target java version.

For most of these use cases, used the release flag more strictly (java and kotlin). Some projects actually use newer APIs even though they target older versions. For this, we added an opt-in flag called 'usesFutureStdlib' that disables the release flag.

For groovy, we are forced to use toolchains to set the proper version, as they do not support a --release flag. GROOVY-11105 tracks this feature.

Some projects also access JDK internals, which are not allowed when using the release flag. For this reason, we add a usesJdkInternals to opt out of the release flag for certain projects.

Finally, some projects use dependencies that require a java version higher than the version they are targeting. We include a usesIncompatibleDependencies for those use cases.

Each of these flags should be avoided if at all possible. Code owners of projects that use these flags should work to remove them.

Along the way, we had to make some minor adjustments to code, in order to comply with the more strict requirements given by the use of the release flag.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
