### PR TITLE
Mark flaky `NativeIdeSamplesIntegrationTest`

### DIFF
--- a/platforms/ide/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/NativeIdeSamplesIntegrationTest.groovy
+++ b/platforms/ide/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/NativeIdeSamplesIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.ide.visualstudio
 import org.gradle.ide.visualstudio.fixtures.AbstractVisualStudioIntegrationSpec
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.TestDirectoryProvider
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
@@ -55,6 +56,7 @@ class NativeIdeSamplesIntegrationTest extends AbstractVisualStudioIntegrationSpe
 
     @Requires(IntegTestPreconditions.HasMsBuild)
     @ToBeFixedForConfigurationCache
+    @Flaky(because = "https://github.com/gradle/gradle-private/issues/4488")
     def "build generated visual studio solution"() {
         useMsbuildTool()
 


### PR DESCRIPTION
It's been flaky for a while: https://ge.gradle.org/scans/tests?search.relativeStartTime=P28D&search.timeZoneId=Asia%2FShanghai&tests.container=org.gradle.ide.visualstudio.NativeIdeSamplesIntegrationTest&tests.test=build%20generated%20visual%20studio%20solution%20visual%20c%2B%2B%202019%20(16.0.0)