### PR TITLE
Updated interface FileSystemOperations and implementing class to cast…

### DIFF
--- a/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/DefaultFileSystemOperations.java
+++ b/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/file/DefaultFileSystemOperations.java
@@ -55,7 +55,7 @@ public class DefaultFileSystemOperations implements FileSystemOperations {
     }
 
     @Override
-    public WorkResult sync(Action<? super CopySpec> action) {
+    public WorkResult sync(Action<? super SyncSpec> action) {
         return fileOperations.sync(action);
     }
 


### PR DESCRIPTION
… the CopySpec to SyncSpec, because the internal implementation seems to create the correct instance. (#30704)

