### PR TITLE
Fix type used in ResolutionFailureData cross-version test

### DIFF
--- a/platforms/software/dependency-management/src/crossVersionTest/groovy/org/gradle/integtests/api/problems/internal/ResolutionFailureDataCrossVersionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/crossVersionTest/groovy/org/gradle/integtests/api/problems/internal/ResolutionFailureDataCrossVersionIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.integtests.api.problems.internal
 
-import org.gradle.api.problems.internal.GeneralData
 import org.gradle.api.problems.internal.ResolutionFailureData
 import org.gradle.integtests.fixtures.GroovyBuildScriptLanguage
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
@@ -25,7 +24,7 @@ import org.gradle.integtests.tooling.fixture.ToolingApiVersion
 import org.gradle.tooling.events.ProgressEvent
 import org.gradle.tooling.events.ProgressListener
 import org.gradle.tooling.events.problems.ProblemEvent
-import spock.lang.Ignore
+import org.gradle.tooling.events.problems.internal.GeneralData
 
 /**
  * Tests that the tooling API can receive and process a problem containing additional {@link ResolutionFailureData}
@@ -33,7 +32,6 @@ import spock.lang.Ignore
  */
 @TargetGradleVersion(">=8.11")
 @ToolingApiVersion(">=8.11")
-@Ignore("https://github.com/gradle/gradle-private/issues/4490")
 class ResolutionFailureDataCrossVersionIntegrationTest extends ToolingApiSpecification {
     def "can supply ResolutionFailureData"() {
         given:


### PR DESCRIPTION
The `org.gradle.api.problems.internal.GeneralData` type is an interface, and Groovy was generating a dynamic proxy to allow viewing the actual type, `org.gradle.tooling.events.problems.internal.GeneralData`, as an instance of it when we cast with `as`. However, when running with a different version than current as the TAPI provider, we do not put Groovy on the classpath of the tooling types, so when Groovy went to generate the proxy, it was unable to find Groovy types and failed. This fixes the problem by using the correct type so a proxy does not need to be created.

Fixes https://github.com/gradle/gradle-private/issues/4490

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
