### PR TITLE
Natively support capability selectors in failure handler

### DIFF
--- a/platforms/documentation/docs/src/snippets/java/fixtures/tests/dependencyInsight.out
+++ b/platforms/documentation/docs/src/snippets/java/fixtures/tests/dependencyInsight.out
@@ -3,7 +3,7 @@
 com.google.code.gson:gson:2.8.5 FAILED
    Failures:
       - Could not resolve com.google.code.gson:gson:2.8.5.
-          - Unable to find a variant providing the requested capability 'com.google.code.gson:gson-test-fixtures':
+          - Unable to find a variant with capabilities matching feature 'test-fixtures':
                - Variant 'compile' provides 'com.google.code.gson:gson:2.8.5'
                - Variant 'enforced-platform-compile' provides 'com.google.code.gson:gson-derived-enforced-platform:2.8.5'
                - Variant 'enforced-platform-runtime' provides 'com.google.code.gson:gson-derived-enforced-platform:2.8.5'

--- a/platforms/documentation/docs/src/snippets/java/fixtures/tests/dependencyInsight.out
+++ b/platforms/documentation/docs/src/snippets/java/fixtures/tests/dependencyInsight.out
@@ -3,7 +3,7 @@
 com.google.code.gson:gson:2.8.5 FAILED
    Failures:
       - Could not resolve com.google.code.gson:gson:2.8.5.
-          - Unable to find a variant with capabilities matching feature 'test-fixtures':
+          - Unable to find a variant with the requested capability: feature 'test-fixtures':
                - Variant 'compile' provides 'com.google.code.gson:gson:2.8.5'
                - Variant 'enforced-platform-compile' provides 'com.google.code.gson:gson-derived-enforced-platform:2.8.5'
                - Variant 'enforced-platform-runtime' provides 'com.google.code.gson:gson-derived-enforced-platform:2.8.5'

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ResolutionFailureHandlerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ResolutionFailureHandlerIntegrationTest.groovy
@@ -443,7 +443,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
 
         String basicOutput = """   Failures:
       - Could not resolve com.google.code.gson:gson:2.8.5."""
-        String fullOutput = """          - Unable to find a variant providing the requested capability 'com.google.code.gson:gson-test-fixtures':
+        String fullOutput = """          - Unable to find a variant with capabilities matching feature 'test-fixtures':
                - Variant 'compile' provides 'com.google.code.gson:gson:2.8.5'
                - Variant 'enforced-platform-compile' provides 'com.google.code.gson:gson-derived-enforced-platform:2.8.5'
                - Variant 'enforced-platform-runtime' provides 'com.google.code.gson:gson-derived-enforced-platform:2.8.5'

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ResolutionFailureHandlerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ResolutionFailureHandlerIntegrationTest.groovy
@@ -443,7 +443,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
 
         String basicOutput = """   Failures:
       - Could not resolve com.google.code.gson:gson:2.8.5."""
-        String fullOutput = """          - Unable to find a variant with capabilities matching feature 'test-fixtures':
+        String fullOutput = """          - Unable to find a variant with the requested capability: feature 'test-fixtures':
                - Variant 'compile' provides 'com.google.code.gson:gson:2.8.5'
                - Variant 'enforced-platform-compile' provides 'com.google.code.gson:gson-derived-enforced-platform:2.8.5'
                - Variant 'enforced-platform-runtime' provides 'com.google.code.gson:gson-derived-enforced-platform:2.8.5'

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantsDependencySubstitutionRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantsDependencySubstitutionRulesIntegrationTest.groovy
@@ -167,7 +167,7 @@ class VariantsDependencySubstitutionRulesIntegrationTest extends AbstractIntegra
         fails ':checkDeps'
 
         then:
-        failure.assertHasCause "Unable to find a variant providing the requested capability 'org:lib-test-fixtures':"
+        failure.assertHasCause "Unable to find a variant with capabilities matching coordinates 'org:lib-test-fixtures':"
     }
 
     def "can substitute a project dependency without capabilities with a dependency with capabilities"() {
@@ -205,7 +205,7 @@ class VariantsDependencySubstitutionRulesIntegrationTest extends AbstractIntegra
         fails ':checkDeps'
 
         then:
-        failure.assertHasCause "Unable to find a variant providing the requested capability 'org:lib-test-fixtures':"
+        failure.assertHasCause "Unable to find a variant with capabilities matching coordinates 'org:lib-test-fixtures':"
     }
 
     def "can substitute a dependency with capabilities with a dependency without capabilities"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantsDependencySubstitutionRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantsDependencySubstitutionRulesIntegrationTest.groovy
@@ -167,7 +167,7 @@ class VariantsDependencySubstitutionRulesIntegrationTest extends AbstractIntegra
         fails ':checkDeps'
 
         then:
-        failure.assertHasCause "Unable to find a variant with capabilities matching coordinates 'org:lib-test-fixtures':"
+        failure.assertHasCause "Unable to find a variant with the requested capability: coordinates 'org:lib-test-fixtures':"
     }
 
     def "can substitute a project dependency without capabilities with a dependency with capabilities"() {
@@ -205,7 +205,7 @@ class VariantsDependencySubstitutionRulesIntegrationTest extends AbstractIntegra
         fails ':checkDeps'
 
         then:
-        failure.assertHasCause "Unable to find a variant with capabilities matching coordinates 'org:lib-test-fixtures':"
+        failure.assertHasCause "Unable to find a variant with the requested capability: coordinates 'org:lib-test-fixtures':"
     }
 
     def "can substitute a dependency with capabilities with a dependency without capabilities"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
@@ -122,6 +122,44 @@ class CapabilitiesLocalComponentIntegrationTest extends AbstractIntegrationSpec 
         succeeds("resolve")
     }
 
+    def "error when multiple capability selectors do not match includes both selectors"() {
+        settingsFile << """
+            include("other")
+        """
+        file("other/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
+        """
+        buildFile << """
+            plugins {
+                id("java-library")
+            }
+
+            dependencies {
+                implementation(project(":other")) {
+                    capabilities {
+                        requireCapability("org:capability:1.0")
+                        requireFeature("foo")
+                    }
+                }
+            }
+
+            task resolve {
+                def files = configurations.runtimeClasspath.incoming.files
+                doLast {
+                    println(files*.name)
+                }
+            }
+        """
+
+        when:
+        fails("resolve")
+
+        then:
+        failure.assertHasCause("Unable to find a variant with capabilities matching [coordinates 'org:capability', feature 'foo']")
+    }
+
     @Issue("https://github.com/gradle/gradle/issues/26377")
     def "ResolvedVariantResults reported by ResolutionResult and ArtifactCollection have same capabilities when they are added to configuration in hierarchy"() {
         settingsFile << "include 'producer'"
@@ -177,6 +215,48 @@ class CapabilitiesLocalComponentIntegrationTest extends AbstractIntegrationSpec 
 
                     def expected = ["com.foo:producer:2.0", "org.bar:dependency-scope-capability:1.0", "org.bar:consumable-capability:1.0"] as Set
                     assert graphVariant.capabilities.collect { "\${it.group}:\${it.name}:\${it.version}" } as Set == expected
+                }
+            }
+        """
+
+        expect:
+        succeeds("resolve")
+    }
+
+    def "can request capability without version"() {
+        settingsFile << """
+            include("other")
+        """
+        file("other/build.gradle") << """
+            configurations {
+                consumable("apiElements") {
+                    outgoing {
+                        artifact(file("foo.txt"))
+                        capability("org:capability:1.0")
+                    }
+                    attributes {
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.LIBRARY))
+                    }
+                }
+            }
+        """
+        buildFile << """
+            plugins {
+                id("java-library")
+            }
+
+            dependencies {
+                implementation(project(":other")) {
+                    capabilities {
+                        requireCapability("org:capability")
+                    }
+                }
+            }
+
+            task resolve {
+                def files = configurations.runtimeClasspath.incoming.files
+                doLast {
+                    assert files*.name == ["foo.txt"]
                 }
             }
         """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
@@ -157,7 +157,7 @@ class CapabilitiesLocalComponentIntegrationTest extends AbstractIntegrationSpec 
         fails("resolve")
 
         then:
-        failure.assertHasCause("Unable to find a variant with capabilities matching [coordinates 'org:capability', feature 'foo']")
+        failure.assertHasCause("Unable to find a variant with the requested capabilities: [coordinates 'org:capability', feature 'foo']")
     }
 
     @Issue("https://github.com/gradle/gradle/issues/26377")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/features/FeaturesResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/features/FeaturesResolveIntegrationTest.groovy
@@ -120,7 +120,7 @@ class FeaturesResolveIntegrationTest extends AbstractModuleDependencyResolveTest
         fails 'checkDeps'
 
         then:
-        failure.assertHasCause("""Unable to find a variant with capabilities matching coordinates 'org:feature-3':
+        failure.assertHasCause("""Unable to find a variant with the requested capability: coordinates 'org:feature-3':
    - Variant 'api' provides 'org:foo:1.0'
    - Variant 'feature1' provides 'org:feature-1:1.0'
    - Variant 'feature2' provides 'org:feature-2:1.0'

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/features/FeaturesResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/features/FeaturesResolveIntegrationTest.groovy
@@ -120,7 +120,7 @@ class FeaturesResolveIntegrationTest extends AbstractModuleDependencyResolveTest
         fails 'checkDeps'
 
         then:
-        failure.assertHasCause("""Unable to find a variant providing the requested capability 'org:feature-3':
+        failure.assertHasCause("""Unable to find a variant with capabilities matching coordinates 'org:feature-3':
    - Variant 'api' provides 'org:foo:1.0'
    - Variant 'feature1' provides 'org:feature-1:1.0'
    - Variant 'feature2' provides 'org:feature-2:1.0'

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionFailureHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionFailureHandler.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.resolution.failure;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.capability.CapabilitySelector;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
@@ -145,7 +146,7 @@ public class ResolutionFailureHandler {
     ) {
         ResolutionCandidateAssessor resolutionCandidateAssessor = new ResolutionCandidateAssessor(requestedAttributes, matcher);
         List<AssessedCandidate> assessedCandidates = resolutionCandidateAssessor.assessResolvedVariantStates(matchingVariants, targetComponent.getDefaultCapability());
-        AmbiguousVariantsFailure failure = new AmbiguousVariantsFailure(targetComponent.getId(), requestedAttributes, requestedCapabilities, assessedCandidates);
+        AmbiguousVariantsFailure failure = new AmbiguousVariantsFailure(targetComponent.getId(), requestedAttributes, ImmutableSet.copyOf(requestedCapabilities), assessedCandidates);
         return describeFailure(failure);
     }
 
@@ -156,7 +157,7 @@ public class ResolutionFailureHandler {
         AttributeContainerInternal requestedAttributes
     ) {
         List<AssessedCandidate> assessedCandidates = Collections.emptyList();
-        NoCompatibleVariantsFailure failure = new NoCompatibleVariantsFailure(targetComponent.getId(), requestedAttributes, Collections.emptySet(), assessedCandidates);
+        NoCompatibleVariantsFailure failure = new NoCompatibleVariantsFailure(targetComponent.getId(), requestedAttributes, ImmutableSet.of(), assessedCandidates);
         return describeFailure(failure);
     }
 
@@ -169,7 +170,7 @@ public class ResolutionFailureHandler {
     ) {
         ResolutionCandidateAssessor resolutionCandidateAssessor = new ResolutionCandidateAssessor(requestedAttributes, matcher);
         List<AssessedCandidate> assessedCandidates = resolutionCandidateAssessor.assessGraphSelectionCandidates(candidates);
-        NoCompatibleVariantsFailure failure = new NoCompatibleVariantsFailure(targetComponent.getId(), requestedAttributes, requestedCapabilities, assessedCandidates);
+        NoCompatibleVariantsFailure failure = new NoCompatibleVariantsFailure(targetComponent.getId(), requestedAttributes, ImmutableSet.copyOf(requestedCapabilities), assessedCandidates);
         return describeFailure(failure);
     }
 
@@ -182,7 +183,7 @@ public class ResolutionFailureHandler {
     ) {
         ResolutionCandidateAssessor resolutionCandidateAssessor = new ResolutionCandidateAssessor(requestedAttributes, matcher);
         List<AssessedCandidate> assessedCandidates = resolutionCandidateAssessor.assessResolvedVariantStates(candidates, targetComponent.getDefaultCapability());
-        NoVariantsWithMatchingCapabilitiesFailure failure = new NoVariantsWithMatchingCapabilitiesFailure(targetComponent.getId(), requestedAttributes, requestedCapabilities, assessedCandidates);
+        NoVariantsWithMatchingCapabilitiesFailure failure = new NoVariantsWithMatchingCapabilitiesFailure(targetComponent.getId(), requestedAttributes, ImmutableSet.copyOf(requestedCapabilities), assessedCandidates);
         return describeFailure(failure);
     }
     // endregion Variant Selection failures

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionFailureHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionFailureHandler.java
@@ -17,12 +17,8 @@
 package org.gradle.internal.component.resolution.failure;
 
 import com.google.common.collect.ImmutableList;
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.capability.CapabilitySelector;
-import org.gradle.api.internal.artifacts.capability.FeatureCapabilitySelector;
-import org.gradle.api.internal.artifacts.capability.SpecificCapabilitySelector;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.internal.artifacts.capability.DefaultSpecificCapabilitySelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariantSet;
 import org.gradle.api.internal.artifacts.transform.AttributeMatchingArtifactVariantSelector;
@@ -31,13 +27,11 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.matching.AttributeMatcher;
-import org.gradle.api.internal.capabilities.ImmutableCapability;
 import org.gradle.api.problems.internal.AdditionalDataBuilderFactory;
 import org.gradle.api.problems.internal.DefaultResolutionFailureData;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.api.problems.internal.ResolutionFailureData;
 import org.gradle.api.problems.internal.ResolutionFailureDataSpec;
-import org.gradle.internal.component.external.model.DefaultImmutableCapability;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.model.ComponentGraphResolveMetadata;
 import org.gradle.internal.component.model.ComponentGraphResolveState;
@@ -49,8 +43,8 @@ import org.gradle.internal.component.resolution.failure.ResolutionCandidateAsses
 import org.gradle.internal.component.resolution.failure.describer.ResolutionFailureDescriber;
 import org.gradle.internal.component.resolution.failure.exception.AbstractResolutionFailureException;
 import org.gradle.internal.component.resolution.failure.interfaces.ResolutionFailure;
-import org.gradle.internal.component.resolution.failure.transform.TransformedVariantConverter;
 import org.gradle.internal.component.resolution.failure.transform.TransformationChainData;
+import org.gradle.internal.component.resolution.failure.transform.TransformedVariantConverter;
 import org.gradle.internal.component.resolution.failure.type.AmbiguousArtifactTransformsFailure;
 import org.gradle.internal.component.resolution.failure.type.AmbiguousArtifactsFailure;
 import org.gradle.internal.component.resolution.failure.type.AmbiguousVariantsFailure;
@@ -64,7 +58,6 @@ import org.gradle.internal.component.resolution.failure.type.UnknownArtifactSele
 import org.gradle.internal.instantiation.InstanceGenerator;
 
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -152,8 +145,7 @@ public class ResolutionFailureHandler {
     ) {
         ResolutionCandidateAssessor resolutionCandidateAssessor = new ResolutionCandidateAssessor(requestedAttributes, matcher);
         List<AssessedCandidate> assessedCandidates = resolutionCandidateAssessor.assessResolvedVariantStates(matchingVariants, targetComponent.getDefaultCapability());
-        ImmutableCapabilities realizedCapabilities = realizeCapabilitySelectors(targetComponent, requestedCapabilities);
-        AmbiguousVariantsFailure failure = new AmbiguousVariantsFailure(targetComponent.getId(), requestedAttributes, realizedCapabilities, assessedCandidates);
+        AmbiguousVariantsFailure failure = new AmbiguousVariantsFailure(targetComponent.getId(), requestedAttributes, requestedCapabilities, assessedCandidates);
         return describeFailure(failure);
     }
 
@@ -164,7 +156,7 @@ public class ResolutionFailureHandler {
         AttributeContainerInternal requestedAttributes
     ) {
         List<AssessedCandidate> assessedCandidates = Collections.emptyList();
-        NoCompatibleVariantsFailure failure = new NoCompatibleVariantsFailure(targetComponent.getId(), requestedAttributes, ImmutableCapabilities.EMPTY, assessedCandidates);
+        NoCompatibleVariantsFailure failure = new NoCompatibleVariantsFailure(targetComponent.getId(), requestedAttributes, Collections.emptySet(), assessedCandidates);
         return describeFailure(failure);
     }
 
@@ -177,8 +169,7 @@ public class ResolutionFailureHandler {
     ) {
         ResolutionCandidateAssessor resolutionCandidateAssessor = new ResolutionCandidateAssessor(requestedAttributes, matcher);
         List<AssessedCandidate> assessedCandidates = resolutionCandidateAssessor.assessGraphSelectionCandidates(candidates);
-        ImmutableCapabilities realizedCapabilities = realizeCapabilitySelectors(targetComponent, requestedCapabilities);
-        NoCompatibleVariantsFailure failure = new NoCompatibleVariantsFailure(targetComponent.getId(), requestedAttributes, realizedCapabilities, assessedCandidates);
+        NoCompatibleVariantsFailure failure = new NoCompatibleVariantsFailure(targetComponent.getId(), requestedAttributes, requestedCapabilities, assessedCandidates);
         return describeFailure(failure);
     }
 
@@ -191,8 +182,7 @@ public class ResolutionFailureHandler {
     ) {
         ResolutionCandidateAssessor resolutionCandidateAssessor = new ResolutionCandidateAssessor(requestedAttributes, matcher);
         List<AssessedCandidate> assessedCandidates = resolutionCandidateAssessor.assessResolvedVariantStates(candidates, targetComponent.getDefaultCapability());
-        ImmutableCapabilities realizedCapabilities = realizeCapabilitySelectors(targetComponent, requestedCapabilities);
-        NoVariantsWithMatchingCapabilitiesFailure failure = new NoVariantsWithMatchingCapabilitiesFailure(targetComponent.getId(), requestedAttributes, realizedCapabilities, assessedCandidates);
+        NoVariantsWithMatchingCapabilitiesFailure failure = new NoVariantsWithMatchingCapabilitiesFailure(targetComponent.getId(), requestedAttributes, requestedCapabilities, assessedCandidates);
         return describeFailure(failure);
     }
     // endregion Variant Selection failures
@@ -258,25 +248,6 @@ public class ResolutionFailureHandler {
         return resolvedVariantSet.getComponentIdentifier() != null ? resolvedVariantSet.getComponentIdentifier() : () -> resolvedVariantSet.asDescribable().getDisplayName();
     }
     // endregion Artifact Selection failures
-
-    private static ImmutableCapabilities realizeCapabilitySelectors(ComponentGraphResolveState targetComponent, Set<CapabilitySelector> requestedCapabilities) {
-        Set<ImmutableCapability> realized = new LinkedHashSet<>();
-        for (CapabilitySelector selector : requestedCapabilities) {
-            if (selector instanceof SpecificCapabilitySelector) {
-                DefaultSpecificCapabilitySelector specificSelector = (DefaultSpecificCapabilitySelector) selector;
-                realized.add(new DefaultImmutableCapability(specificSelector.getGroup(), specificSelector.getName(), null));
-            } else if (selector instanceof FeatureCapabilitySelector) {
-                FeatureCapabilitySelector featureSelector = (FeatureCapabilitySelector) selector;
-                ModuleVersionIdentifier moduleId = targetComponent.getMetadata().getModuleVersionId();
-                realized.add(new DefaultImmutableCapability(
-                    moduleId.getGroup(),
-                    moduleId.getName() + "-" + featureSelector.getFeatureName(),
-                    null
-                ));
-            }
-        }
-        return ImmutableCapabilities.of(realized);
-    }
 
     /**
      * Adds a {@link ResolutionFailureDescriber} for the given failure type to the custom describers

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/NoVariantsWithMatchingCapabilitiesFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/NoVariantsWithMatchingCapabilitiesFailureDescriber.java
@@ -16,12 +16,15 @@
 
 package org.gradle.internal.component.resolution.failure.describer;
 
+import org.gradle.api.artifacts.capability.CapabilitySelector;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 import org.gradle.internal.component.resolution.failure.exception.VariantSelectionByAttributesException;
 import org.gradle.internal.component.resolution.failure.formatting.CapabilitiesDescriber;
 import org.gradle.internal.component.resolution.failure.type.NoVariantsWithMatchingCapabilitiesFailure;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * A {@link ResolutionFailureDescriber} that describes a {@link NoVariantsWithMatchingCapabilitiesFailure}.
@@ -34,14 +37,24 @@ public abstract class NoVariantsWithMatchingCapabilitiesFailureDescriber extends
         return new VariantSelectionByAttributesException(message, failure, resolutions);
     }
 
-    private String buildFailureMsg(NoVariantsWithMatchingCapabilitiesFailure failure) {
-        StringBuilder sb = new StringBuilder("Unable to find a variant with capabilities matching ");
-        sb.append(CapabilitiesDescriber.describeCapabilitySelectorsWithTitle(failure.getCapabilitySelectors()));
+    private static String buildFailureMsg(NoVariantsWithMatchingCapabilitiesFailure failure) {
+        StringBuilder sb = new StringBuilder();
+
+        Set<CapabilitySelector> capabilities = failure.getCapabilitySelectors();
+        if (capabilities.size() == 1) {
+            sb.append("Unable to find a variant with the requested capability: ");
+            sb.append(capabilities.iterator().next().getDisplayName());
+        } else {
+            sb.append("Unable to find a variant with the requested capabilities: ");
+            sb.append("[").append(capabilities.stream().map(CapabilitySelector::getDisplayName).collect(Collectors.joining(", "))).append("]");
+        }
+
         sb.append(":\n");
         for (ResolutionCandidateAssessor.AssessedCandidate candidate : failure.getCandidates()) {
             sb.append("   - Variant '").append(candidate.getDisplayName()).append("' provides ");
             sb.append(CapabilitiesDescriber.describeCapabilities(candidate.getCandidateCapabilities().asSet())).append("\n");
         }
+
         return sb.toString();
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/NoVariantsWithMatchingCapabilitiesFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/NoVariantsWithMatchingCapabilitiesFailureDescriber.java
@@ -35,8 +35,8 @@ public abstract class NoVariantsWithMatchingCapabilitiesFailureDescriber extends
     }
 
     private String buildFailureMsg(NoVariantsWithMatchingCapabilitiesFailure failure) {
-        StringBuilder sb = new StringBuilder("Unable to find a variant providing the requested ");
-        sb.append(CapabilitiesDescriber.describeCapabilitiesWithTitle(failure.getRequestedCapabilities().asSet()));
+        StringBuilder sb = new StringBuilder("Unable to find a variant with capabilities matching ");
+        sb.append(CapabilitiesDescriber.describeCapabilitySelectorsWithTitle(failure.getCapabilitySelectors()));
         sb.append(":\n");
         for (ResolutionCandidateAssessor.AssessedCandidate candidate : failure.getCandidates()) {
             sb.append("   - Variant '").append(candidate.getDisplayName()).append("' provides ");

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/formatting/CapabilitiesDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/formatting/CapabilitiesDescriber.java
@@ -15,11 +15,9 @@
  */
 package org.gradle.internal.component.resolution.failure.formatting;
 
-import org.gradle.api.artifacts.capability.CapabilitySelector;
 import org.gradle.api.capabilities.Capability;
 
 import java.util.Collection;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -54,11 +52,4 @@ public final class CapabilitiesDescriber {
         return '\'' + c.getGroup() + ":" + c.getName() + '\'';
     }
 
-    public static String describeCapabilitySelectorsWithTitle(Set<CapabilitySelector> capabilities) {
-        if (capabilities.size() == 1) {
-            return capabilities.iterator().next().getDisplayName();
-        }
-
-        return "[" + capabilities.stream().map(CapabilitySelector::getDisplayName).collect(Collectors.joining(", ")) + "]";
-    }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/formatting/CapabilitiesDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/formatting/CapabilitiesDescriber.java
@@ -15,9 +15,11 @@
  */
 package org.gradle.internal.component.resolution.failure.formatting;
 
+import org.gradle.api.artifacts.capability.CapabilitySelector;
 import org.gradle.api.capabilities.Capability;
 
 import java.util.Collection;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -50,5 +52,13 @@ public final class CapabilitiesDescriber {
             return '\'' + c.getGroup() + ":" + c.getName() + ":" + c.getVersion() + '\'';
         }
         return '\'' + c.getGroup() + ":" + c.getName() + '\'';
+    }
+
+    public static String describeCapabilitySelectorsWithTitle(Set<CapabilitySelector> capabilities) {
+        if (capabilities.size() == 1) {
+            return capabilities.iterator().next().getDisplayName();
+        }
+
+        return "[" + capabilities.stream().map(CapabilitySelector::getDisplayName).collect(Collectors.joining(", ")) + "]";
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/interfaces/VariantSelectionByAttributesFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/interfaces/VariantSelectionByAttributesFailure.java
@@ -16,8 +16,10 @@
 
 package org.gradle.internal.component.resolution.failure.interfaces;
 
+import org.gradle.api.artifacts.capability.CapabilitySelector;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.internal.component.external.model.ImmutableCapabilities;
+
+import java.util.Set;
 
 /**
  * Represents a specific type of {@link VariantSelectionFailure} where the failure occurred
@@ -38,7 +40,7 @@ public interface VariantSelectionByAttributesFailure extends VariantSelectionFai
      * Gets the capabilities requested on the dependency that selected the {@link #getTargetComponent()}
      * represented by this edge in the graph.
      *
-     * @return the capabilities used to select the component in the graph failing to select a variant
+     * @return the capabilities selectors used to select a variant
      */
-    ImmutableCapabilities getRequestedCapabilities();
+    Set<CapabilitySelector> getCapabilitySelectors();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AbstractVariantSelectionByAttributesFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AbstractVariantSelectionByAttributesFailure.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.resolution.failure.type;
 
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.capability.CapabilitySelector;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
@@ -32,9 +33,9 @@ import java.util.Set;
 public abstract class AbstractVariantSelectionByAttributesFailure extends AbstractResolutionFailure implements VariantSelectionByAttributesFailure {
     private final ComponentIdentifier targetComponent;
     private final ImmutableAttributes requestedAttributes;
-    private final Set<CapabilitySelector> capabilitySelectors;
+    private final ImmutableSet<CapabilitySelector> capabilitySelectors;
 
-    public AbstractVariantSelectionByAttributesFailure(ResolutionFailureProblemId problemId, ComponentIdentifier targetComponent, AttributeContainerInternal requestedAttributes, Set<CapabilitySelector> capabilitySelectors) {
+    public AbstractVariantSelectionByAttributesFailure(ResolutionFailureProblemId problemId, ComponentIdentifier targetComponent, AttributeContainerInternal requestedAttributes, ImmutableSet<CapabilitySelector> capabilitySelectors) {
         super(problemId);
         this.targetComponent = targetComponent;
         this.requestedAttributes = requestedAttributes.asImmutable();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AbstractVariantSelectionByAttributesFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AbstractVariantSelectionByAttributesFailure.java
@@ -16,12 +16,14 @@
 
 package org.gradle.internal.component.resolution.failure.type;
 
+import org.gradle.api.artifacts.capability.CapabilitySelector;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.catalog.problems.ResolutionFailureProblemId;
-import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.resolution.failure.interfaces.VariantSelectionByAttributesFailure;
+
+import java.util.Set;
 
 /**
  * An abstract {@link VariantSelectionByAttributesFailure} that represents the situation when a variant
@@ -30,13 +32,13 @@ import org.gradle.internal.component.resolution.failure.interfaces.VariantSelect
 public abstract class AbstractVariantSelectionByAttributesFailure extends AbstractResolutionFailure implements VariantSelectionByAttributesFailure {
     private final ComponentIdentifier targetComponent;
     private final ImmutableAttributes requestedAttributes;
-    private final ImmutableCapabilities requestedCapabilities;
+    private final Set<CapabilitySelector> capabilitySelectors;
 
-    public AbstractVariantSelectionByAttributesFailure(ResolutionFailureProblemId problemId, ComponentIdentifier targetComponent, AttributeContainerInternal requestedAttributes, ImmutableCapabilities requestedCapabilities) {
+    public AbstractVariantSelectionByAttributesFailure(ResolutionFailureProblemId problemId, ComponentIdentifier targetComponent, AttributeContainerInternal requestedAttributes, Set<CapabilitySelector> capabilitySelectors) {
         super(problemId);
         this.targetComponent = targetComponent;
         this.requestedAttributes = requestedAttributes.asImmutable();
-        this.requestedCapabilities = requestedCapabilities;
+        this.capabilitySelectors = capabilitySelectors;
     }
 
     @Override
@@ -55,7 +57,7 @@ public abstract class AbstractVariantSelectionByAttributesFailure extends Abstra
     }
 
     @Override
-    public ImmutableCapabilities getRequestedCapabilities() {
-        return requestedCapabilities;
+    public Set<CapabilitySelector> getCapabilitySelectors() {
+        return capabilitySelectors;
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AmbiguousVariantsFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AmbiguousVariantsFailure.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.resolution.failure.type;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.capability.CapabilitySelector;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
@@ -25,7 +26,6 @@ import org.gradle.internal.component.resolution.failure.ResolutionCandidateAsses
 import org.gradle.internal.component.resolution.failure.interfaces.VariantSelectionByAttributesFailure;
 
 import java.util.List;
-import java.util.Set;
 
 /**
  * A specialization of {@link VariantSelectionByAttributesFailure} that represents the situation when multiple variants are
@@ -34,7 +34,7 @@ import java.util.Set;
 public final class AmbiguousVariantsFailure extends AbstractVariantSelectionByAttributesFailure {
     private final ImmutableList<ResolutionCandidateAssessor.AssessedCandidate> candidates;
 
-    public AmbiguousVariantsFailure(ComponentIdentifier targetComponent, AttributeContainerInternal requestedAttributes, Set<CapabilitySelector> capabilitySelectors, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
+    public AmbiguousVariantsFailure(ComponentIdentifier targetComponent, AttributeContainerInternal requestedAttributes, ImmutableSet<CapabilitySelector> capabilitySelectors, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
         super(ResolutionFailureProblemId.AMBIGUOUS_VARIANTS, targetComponent, requestedAttributes, capabilitySelectors);
         this.candidates = ImmutableList.copyOf(candidates);
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AmbiguousVariantsFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/AmbiguousVariantsFailure.java
@@ -17,14 +17,15 @@
 package org.gradle.internal.component.resolution.failure.type;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.artifacts.capability.CapabilitySelector;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.catalog.problems.ResolutionFailureProblemId;
-import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 import org.gradle.internal.component.resolution.failure.interfaces.VariantSelectionByAttributesFailure;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * A specialization of {@link VariantSelectionByAttributesFailure} that represents the situation when multiple variants are
@@ -33,8 +34,8 @@ import java.util.List;
 public final class AmbiguousVariantsFailure extends AbstractVariantSelectionByAttributesFailure {
     private final ImmutableList<ResolutionCandidateAssessor.AssessedCandidate> candidates;
 
-    public AmbiguousVariantsFailure(ComponentIdentifier targetComponent, AttributeContainerInternal requestedAttributes, ImmutableCapabilities requestedCapabilities, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
-        super(ResolutionFailureProblemId.AMBIGUOUS_VARIANTS, targetComponent, requestedAttributes, requestedCapabilities);
+    public AmbiguousVariantsFailure(ComponentIdentifier targetComponent, AttributeContainerInternal requestedAttributes, Set<CapabilitySelector> capabilitySelectors, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
+        super(ResolutionFailureProblemId.AMBIGUOUS_VARIANTS, targetComponent, requestedAttributes, capabilitySelectors);
         this.candidates = ImmutableList.copyOf(candidates);
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/NoCompatibleVariantsFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/NoCompatibleVariantsFailure.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.resolution.failure.type;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.capability.CapabilitySelector;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
@@ -25,7 +26,6 @@ import org.gradle.internal.component.resolution.failure.ResolutionCandidateAsses
 import org.gradle.internal.component.resolution.failure.interfaces.VariantSelectionByAttributesFailure;
 
 import java.util.List;
-import java.util.Set;
 
 /**
  * A {@link VariantSelectionByAttributesFailure} that represents the case when a variant cannot
@@ -34,7 +34,7 @@ import java.util.Set;
 public final class NoCompatibleVariantsFailure extends AbstractVariantSelectionByAttributesFailure {
     private final ImmutableList<ResolutionCandidateAssessor.AssessedCandidate> candidates;
 
-    public NoCompatibleVariantsFailure(ComponentIdentifier targetComponent, AttributeContainerInternal requestedAttributes, Set<CapabilitySelector> capabilitySelectors, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
+    public NoCompatibleVariantsFailure(ComponentIdentifier targetComponent, AttributeContainerInternal requestedAttributes, ImmutableSet<CapabilitySelector> capabilitySelectors, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
         super(ResolutionFailureProblemId.NO_COMPATIBLE_VARIANTS, targetComponent, requestedAttributes, capabilitySelectors);
         this.candidates = ImmutableList.copyOf(candidates);
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/NoCompatibleVariantsFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/NoCompatibleVariantsFailure.java
@@ -17,14 +17,15 @@
 package org.gradle.internal.component.resolution.failure.type;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.artifacts.capability.CapabilitySelector;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.catalog.problems.ResolutionFailureProblemId;
-import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 import org.gradle.internal.component.resolution.failure.interfaces.VariantSelectionByAttributesFailure;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * A {@link VariantSelectionByAttributesFailure} that represents the case when a variant cannot
@@ -33,8 +34,8 @@ import java.util.List;
 public final class NoCompatibleVariantsFailure extends AbstractVariantSelectionByAttributesFailure {
     private final ImmutableList<ResolutionCandidateAssessor.AssessedCandidate> candidates;
 
-    public NoCompatibleVariantsFailure(ComponentIdentifier targetComponent, AttributeContainerInternal requestedAttributes, ImmutableCapabilities requestedCapabilities, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
-        super(ResolutionFailureProblemId.NO_COMPATIBLE_VARIANTS, targetComponent, requestedAttributes, requestedCapabilities);
+    public NoCompatibleVariantsFailure(ComponentIdentifier targetComponent, AttributeContainerInternal requestedAttributes, Set<CapabilitySelector> capabilitySelectors, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
+        super(ResolutionFailureProblemId.NO_COMPATIBLE_VARIANTS, targetComponent, requestedAttributes, capabilitySelectors);
         this.candidates = ImmutableList.copyOf(candidates);
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/NoVariantsWithMatchingCapabilitiesFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/NoVariantsWithMatchingCapabilitiesFailure.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.resolution.failure.type;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.capability.CapabilitySelector;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
@@ -26,7 +27,6 @@ import org.gradle.internal.component.resolution.failure.ResolutionCandidateAsses
 import org.gradle.internal.component.resolution.failure.interfaces.VariantSelectionByAttributesFailure;
 
 import java.util.List;
-import java.util.Set;
 
 /**
  * A {@link VariantSelectionByAttributesFailure} that represents the situation when no variants can
@@ -35,7 +35,7 @@ import java.util.Set;
 public final class NoVariantsWithMatchingCapabilitiesFailure extends AbstractVariantSelectionByAttributesFailure {
     private final ImmutableList<AssessedCandidate> candidates;
 
-    public NoVariantsWithMatchingCapabilitiesFailure(ComponentIdentifier targetComponent, AttributeContainerInternal requestedAttributes, Set<CapabilitySelector> capabilitySelectors, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
+    public NoVariantsWithMatchingCapabilitiesFailure(ComponentIdentifier targetComponent, AttributeContainerInternal requestedAttributes, ImmutableSet<CapabilitySelector> capabilitySelectors, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
         super(ResolutionFailureProblemId.NO_VARIANTS_WITH_MATCHING_CAPABILITIES, targetComponent, requestedAttributes, capabilitySelectors);
         this.candidates = ImmutableList.copyOf(candidates);
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/NoVariantsWithMatchingCapabilitiesFailure.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/type/NoVariantsWithMatchingCapabilitiesFailure.java
@@ -17,15 +17,16 @@
 package org.gradle.internal.component.resolution.failure.type;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.artifacts.capability.CapabilitySelector;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.catalog.problems.ResolutionFailureProblemId;
-import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor;
 import org.gradle.internal.component.resolution.failure.ResolutionCandidateAssessor.AssessedCandidate;
 import org.gradle.internal.component.resolution.failure.interfaces.VariantSelectionByAttributesFailure;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * A {@link VariantSelectionByAttributesFailure} that represents the situation when no variants can
@@ -34,8 +35,8 @@ import java.util.List;
 public final class NoVariantsWithMatchingCapabilitiesFailure extends AbstractVariantSelectionByAttributesFailure {
     private final ImmutableList<AssessedCandidate> candidates;
 
-    public NoVariantsWithMatchingCapabilitiesFailure(ComponentIdentifier targetComponent, AttributeContainerInternal requestedAttributes, ImmutableCapabilities requestedCapabilities, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
-        super(ResolutionFailureProblemId.NO_VARIANTS_WITH_MATCHING_CAPABILITIES, targetComponent, requestedAttributes, requestedCapabilities);
+    public NoVariantsWithMatchingCapabilitiesFailure(ComponentIdentifier targetComponent, AttributeContainerInternal requestedAttributes, Set<CapabilitySelector> capabilitySelectors, List<ResolutionCandidateAssessor.AssessedCandidate> candidates) {
+        super(ResolutionFailureProblemId.NO_VARIANTS_WITH_MATCHING_CAPABILITIES, targetComponent, requestedAttributes, capabilitySelectors);
         this.candidates = ImmutableList.copyOf(candidates);
     }
 

--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishFeaturesJavaIntegTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishFeaturesJavaIntegTest.groovy
@@ -86,7 +86,7 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
             withoutModuleMetadata {
                 shouldFail {
                     // documents the current behavior
-                    assertHasCause("Unable to find a variant with capabilities matching coordinates 'org:optional-feature'")
+                    assertHasCause("Unable to find a variant with the requested capability: coordinates 'org:optional-feature'")
                 }
             }
         }
@@ -274,7 +274,7 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
                 withoutModuleMetadata {
                     shouldFail {
                         // documents the current behavior
-                        assertHasCause("Unable to find a variant with capabilities matching coordinates 'org:optional-feature'")
+                        assertHasCause("Unable to find a variant with the requested capability: coordinates 'org:optional-feature'")
                     }
                 }
             }
@@ -370,7 +370,7 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
             withoutModuleMetadata {
                 shouldFail {
                     // documents the current behavior
-                    assertHasCause("Unable to find a variant with capabilities matching coordinates 'org:optional-feature'")
+                    assertHasCause("Unable to find a variant with the requested capability: coordinates 'org:optional-feature'")
                 }
             }
         }
@@ -458,7 +458,7 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
             withoutModuleMetadata {
                 shouldFail {
                     // documents the current behavior
-                    assertHasCause("Unable to find a variant with capabilities matching coordinates 'org:optional-feature'")
+                    assertHasCause("Unable to find a variant with the requested capability: coordinates 'org:optional-feature'")
                 }
             }
         }

--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishFeaturesJavaIntegTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishFeaturesJavaIntegTest.groovy
@@ -86,7 +86,7 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
             withoutModuleMetadata {
                 shouldFail {
                     // documents the current behavior
-                    assertHasCause("Unable to find a variant providing the requested capability 'org:optional-feature'")
+                    assertHasCause("Unable to find a variant with capabilities matching coordinates 'org:optional-feature'")
                 }
             }
         }
@@ -274,7 +274,7 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
                 withoutModuleMetadata {
                     shouldFail {
                         // documents the current behavior
-                        assertHasCause("Unable to find a variant providing the requested capability 'org:optional-feature'")
+                        assertHasCause("Unable to find a variant with capabilities matching coordinates 'org:optional-feature'")
                     }
                 }
             }
@@ -370,7 +370,7 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
             withoutModuleMetadata {
                 shouldFail {
                     // documents the current behavior
-                    assertHasCause("Unable to find a variant providing the requested capability 'org:optional-feature'")
+                    assertHasCause("Unable to find a variant with capabilities matching coordinates 'org:optional-feature'")
                 }
             }
         }
@@ -458,7 +458,7 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
             withoutModuleMetadata {
                 shouldFail {
                     // documents the current behavior
-                    assertHasCause("Unable to find a variant providing the requested capability 'org:optional-feature'")
+                    assertHasCause("Unable to find a variant with capabilities matching coordinates 'org:optional-feature'")
                 }
             }
         }

--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishFeaturesJavaPluginIntegTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishFeaturesJavaPluginIntegTest.groovy
@@ -81,7 +81,7 @@ class MavenPublishFeaturesJavaPluginIntegTest extends AbstractMavenPublishFeatur
             withoutModuleMetadata {
                 shouldFail {
                     // documents the current behavior
-                    assertHasCause("Unable to find a variant with capabilities matching coordinates 'org.gradle.test:publishTest-feature'")
+                    assertHasCause("Unable to find a variant with the requested capability: coordinates 'org.gradle.test:publishTest-feature'")
                 }
             }
         }
@@ -156,7 +156,7 @@ class MavenPublishFeaturesJavaPluginIntegTest extends AbstractMavenPublishFeatur
             withoutModuleMetadata {
                 shouldFail {
                     // documents the current behavior
-                    assertHasCause("Unable to find a variant with capabilities matching coordinates '$group:${name}-feature'")
+                    assertHasCause("Unable to find a variant with the requested capability: coordinates '$group:${name}-feature'")
                 }
             }
         }

--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishFeaturesJavaPluginIntegTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishFeaturesJavaPluginIntegTest.groovy
@@ -81,7 +81,7 @@ class MavenPublishFeaturesJavaPluginIntegTest extends AbstractMavenPublishFeatur
             withoutModuleMetadata {
                 shouldFail {
                     // documents the current behavior
-                    assertHasCause("Unable to find a variant providing the requested capability 'org.gradle.test:publishTest-feature'")
+                    assertHasCause("Unable to find a variant with capabilities matching coordinates 'org.gradle.test:publishTest-feature'")
                 }
             }
         }
@@ -156,7 +156,7 @@ class MavenPublishFeaturesJavaPluginIntegTest extends AbstractMavenPublishFeatur
             withoutModuleMetadata {
                 shouldFail {
                     // documents the current behavior
-                    assertHasCause("Unable to find a variant providing the requested capability '$group:${name}-feature'")
+                    assertHasCause("Unable to find a variant with capabilities matching coordinates '$group:${name}-feature'")
                 }
             }
         }

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/artifacts/capability/DefaultFeatureCapabilitySelector.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/artifacts/capability/DefaultFeatureCapabilitySelector.java
@@ -42,7 +42,7 @@ public final class DefaultFeatureCapabilitySelector implements CapabilitySelecto
 
     @Override
     public String getDisplayName() {
-        return "capability selector for feature '" + featureName + "'";
+        return "feature '" + featureName + "'";
     }
 
     @Override

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/artifacts/capability/DefaultSpecificCapabilitySelector.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/artifacts/capability/DefaultSpecificCapabilitySelector.java
@@ -51,7 +51,7 @@ public final class DefaultSpecificCapabilitySelector implements CapabilitySelect
     public String getDisplayName() {
         // We intentionally do not display the version here.
         // An exact version selector does not have a version.
-        return "capability selector '" + getGroup() + ":" + getName() + "'";
+        return "coordinates '" + getGroup() + ":" + getName() + "'";
     }
 
     /**


### PR DESCRIPTION
We stopped short of fully supporting capability selectors in failure handling code when selectors were initially introduced.

This commit ensures we properly report capability selctors in failure messages

Fixes [#30549](https://github.com/gradle/gradle/issues/30549)

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
