### PR TITLE
Identity keys in DCL configuring functions and NDOCs

### DIFF
--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/analysis/DefaultAnalysisSchema.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/analysis/DefaultAnalysisSchema.kt
@@ -209,6 +209,10 @@ object ParameterSemanticsInternal {
     data class DefaultStoreValueInProperty(override val dataProperty: DataProperty) : ParameterSemantics.StoreValueInProperty
 
     @Serializable
+    @SerialName("identityKey")
+    data class DefaultIdentityKey(override val basedOnProperty: DataProperty?) : ParameterSemantics.IdentityKey
+
+    @Serializable
     @SerialName("unknown")
     data object DefaultUnknown : ParameterSemantics.Unknown {
         @Suppress("unused")

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/analysis/resolution.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/analysis/resolution.kt
@@ -1,6 +1,7 @@
 package org.gradle.internal.declarativedsl.analysis
 
 import org.gradle.declarative.dsl.evaluation.OperationGenerationId
+import org.gradle.declarative.dsl.schema.DataParameter
 import org.gradle.declarative.dsl.schema.DataProperty
 import org.gradle.declarative.dsl.schema.DataType
 import org.gradle.declarative.dsl.schema.FqName
@@ -46,6 +47,7 @@ sealed interface ErrorReason {
     data class ValReassignment(val localVal: LocalValue) : ErrorReason
     data class ExternalReassignment(val external: ObjectOrigin.External) : ErrorReason
     data class AssignmentTypeMismatch(val expected: DataType, val actual: DataType) : ErrorReason
+    data class OpaqueArgumentForIdentityParameter(val functionCall: FunctionCall, val parameter: DataParameter, val argument: ObjectOrigin) : ErrorReason
 
     // TODO: these two are never reported for now, instead it is UnresolvedFunctionCallSignature
     data object UnusedConfigureLambda : ErrorReason

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/dom/DocumentResolution.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/dom/DocumentResolution.kt
@@ -49,7 +49,6 @@ sealed interface DocumentResolution {
             data class ContainerElementResolved(
                 override val elementType: DataType,
                 override val elementFactoryFunction: SchemaMemberFunction,
-                val isKeyArguments: Boolean
             ) : SuccessfulElementResolution
         }
 

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/dom/ResolutionFailureReasons.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/dom/ResolutionFailureReasons.kt
@@ -54,6 +54,9 @@ data object UnresolvedSignature : ElementNotResolvedReason, ValueFactoryNotResol
 data object UnresolvedName : PropertyNotAssignedReason, ElementNotResolvedReason, ValueFactoryNotResolvedReason, NamedReferenceNotResolvedReason
 
 
+data object OpaqueValueInIdentityKey : ElementNotResolvedReason, ValueFactoryNotResolvedReason
+
+
 data object NotAssignable : PropertyNotAssignedReason
 
 

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/dom/operations/overlay/DocumentOverlay.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/dom/operations/overlay/DocumentOverlay.kt
@@ -267,7 +267,8 @@ class DocumentOverlayContext(
          */
         data class CanMergeBlock(
             val functionName: String,
-            val configuredTypeName: FqName
+            val configuredTypeName: FqName,
+            val identityValues: List<Any?>
         ) : MergeKey
     }
 
@@ -290,12 +291,12 @@ fun resolutionContainerMergeKeyMapper(
 ) = DocumentOverlayContext.MergeKeyMapper { node ->
     when (val nodeResolution = resolutionContainer.data(node)) {
         is ElementResolution.SuccessfulElementResolution.ContainerElementResolved ->
-            // TODO: this will need adjustment once access-and-configure semantics get replaced with ensure-exists-and-configure with literal key arguments
             DocumentOverlayContext.MergeKey.CannotMerge
 
         is ElementResolution.SuccessfulElementResolution.ConfiguringElementResolved -> {
             val name = (node as ElementNode).name
-            DocumentOverlayContext.MergeKey.CanMergeBlock(name, nodeResolution.elementType.name)
+            val identityValues = node.elementValues.map { if (it is ValueNode.LiteralValueNode) it.value else null }
+            DocumentOverlayContext.MergeKey.CanMergeBlock(name, nodeResolution.elementType.name, identityValues)
         }
 
         is PropertyResolution.PropertyAssignmentResolved ->

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/dom/resolution/DefaultDocumentResolutionContainer.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/dom/resolution/DefaultDocumentResolutionContainer.kt
@@ -50,6 +50,7 @@ import org.gradle.internal.declarativedsl.dom.ElementNotResolvedReason
 import org.gradle.internal.declarativedsl.dom.NamedReferenceNotResolvedReason
 import org.gradle.internal.declarativedsl.dom.NonEnumValueNamedReference
 import org.gradle.internal.declarativedsl.dom.NotAssignable
+import org.gradle.internal.declarativedsl.dom.OpaqueValueInIdentityKey
 import org.gradle.internal.declarativedsl.dom.PropertyNotAssignedReason
 import org.gradle.internal.declarativedsl.dom.UnresolvedBase
 import org.gradle.internal.declarativedsl.dom.UnresolvedName
@@ -216,8 +217,7 @@ class DocumentResolver(
                 is FunctionSemantics.NewObjectFunctionSemantics -> {
                     ElementResolution.SuccessfulElementResolution.ContainerElementResolved(
                         typeRefContext.resolveRef((semantics as? FunctionSemantics.ConfigureSemantics)?.configuredType ?: semantics.returnValueType),
-                        function as SchemaMemberFunction,
-                        false // TODO: produce proper key markers
+                        function as SchemaMemberFunction
                     )
                 }
 
@@ -275,6 +275,7 @@ class DocumentResolver(
             is ErrorReason.AmbiguousImport,
             ErrorReason.DanglingPureExpression,
             is ErrorReason.NonReadableProperty,
+            is ErrorReason.OpaqueArgumentForIdentityParameter,
             ErrorReason.UnitAssignment, // TODO: should we still check for this?
             ErrorReason.AccessOnCurrentReceiverOnlyViolation -> error("not expected here")
         }
@@ -294,6 +295,8 @@ class DocumentResolver(
             is ErrorReason.UnresolvedFunctionCallReceiver -> UnresolvedBase
 
             is ErrorReason.UnresolvedReference -> UnresolvedName
+
+            is ErrorReason.OpaqueArgumentForIdentityParameter -> OpaqueValueInIdentityKey
 
             is ErrorReason.ReadOnlyPropertyAssignment,
             ErrorReason.UnitAssignment,

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/DeclarativeReflectionToObjectConverter.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/DeclarativeReflectionToObjectConverter.kt
@@ -97,7 +97,7 @@ class DeclarativeReflectionToObjectConverter(
     sealed interface ObjectAccessKey {
         data class Identity(val id: OperationId) : ObjectAccessKey
         data class CustomAccessor(val owner: ObjectOrigin, val accessorId: String) : ObjectAccessKey
-        data class ConfiguringLambda(val owner: ObjectOrigin, val function: SchemaFunction) : ObjectAccessKey
+        data class ConfiguringLambda(val owner: ObjectOrigin, val function: SchemaFunction, val identityValues: List<Any?>) : ObjectAccessKey
     }
 
 
@@ -133,7 +133,12 @@ class DeclarativeReflectionToObjectConverter(
     private
     fun objectFromConfiguringLambda(
         origin: ObjectOrigin.ConfiguringLambdaReceiver
-    ): Any? = objectByIdentity(ObjectAccessKey.ConfiguringLambda(origin.receiver, origin.function)) {
+    ): Any? = objectByIdentity(
+        ObjectAccessKey.ConfiguringLambda(
+            origin.receiver,
+            origin.function,
+            identityValues = origin.parameterBindings.bindingMap.values.map { (it as? ObjectOrigin.ConstantOrigin)?.literal?.value })
+    ) {
         val function = origin.function
         val receiverInstance = getObjectByResolvedOrigin(origin.receiver)
             ?: error("tried to invoke a function $function on a null receiver ${origin.receiver}")

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/DeclarativeReflectionToObjectConverter.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/DeclarativeReflectionToObjectConverter.kt
@@ -3,6 +3,7 @@ package org.gradle.internal.declarativedsl.mappingToJvm
 import org.gradle.declarative.dsl.schema.DataBuilderFunction
 import org.gradle.declarative.dsl.schema.DataProperty
 import org.gradle.declarative.dsl.schema.ExternalObjectProviderKey
+import org.gradle.declarative.dsl.schema.ParameterSemantics
 import org.gradle.declarative.dsl.schema.SchemaFunction
 import org.gradle.internal.declarativedsl.analysis.AssignmentMethod
 import org.gradle.internal.declarativedsl.analysis.ObjectOrigin
@@ -137,7 +138,11 @@ class DeclarativeReflectionToObjectConverter(
         ObjectAccessKey.ConfiguringLambda(
             origin.receiver,
             origin.function,
-            identityValues = origin.parameterBindings.bindingMap.values.map { (it as? ObjectOrigin.ConstantOrigin)?.literal?.value })
+            identityValues = origin.parameterBindings.bindingMap.map {(parameter, value) ->
+                if (parameter.semantics is ParameterSemantics.IdentityKey) {
+                    (value as? ObjectOrigin.ConstantOrigin)?.literal?.value
+                } else null
+            })
     ) {
         val function = origin.function
         val receiverInstance = getObjectByResolvedOrigin(origin.receiver)

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/serialization/SchemaSerialization.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/serialization/SchemaSerialization.kt
@@ -119,6 +119,7 @@ object SchemaSerialization {
             }
             polymorphic(ParameterSemantics::class) {
                 subclass(ParameterSemanticsInternal.DefaultStoreValueInProperty::class)
+                subclass(ParameterSemanticsInternal.DefaultIdentityKey::class)
                 subclass(ParameterSemanticsInternal.DefaultUnknown::class)
             }
             polymorphic(SchemaFunction::class) {

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/dom/resolution/DomFunctionResolutionTest.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/dom/resolution/DomFunctionResolutionTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.declarativedsl.dom.resolution
+
+import org.gradle.declarative.dsl.model.annotations.Configuring
+import org.gradle.declarative.dsl.model.annotations.Restricted
+import org.gradle.internal.declarativedsl.analysis.tracingCodeResolver
+import org.gradle.internal.declarativedsl.dom.data.collectToMap
+import org.gradle.internal.declarativedsl.dom.fromLanguageTree.convertBlockToDocument
+import org.gradle.internal.declarativedsl.parsing.ParseTestUtil.parseAsTopLevelBlock
+import org.gradle.internal.declarativedsl.schemaBuilder.schemaFromTypes
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DomFunctionResolutionTest {
+    @Test
+    fun `using an opaque value as identity key is reported in the DOM resolution results`() {
+        val resolver = tracingCodeResolver()
+
+        val topLevelBlock = parseAsTopLevelBlock(
+            """
+            itemNamed("ok") {
+                x = 1
+            }
+            itemNamed(stringFactory()) {
+                x = 2
+            }
+            """.trimIndent()
+        )
+
+        resolver.resolve(schema, emptyList(), topLevelBlock)
+
+        val document = convertBlockToDocument(topLevelBlock)
+        val resolved = resolutionContainer(schema, resolver.trace, document)
+        val resolutions = resolved.collectToMap(document).values
+        assertEquals(
+            resolutions.map { resolutionPrettyString(it) }.joinToString("\n"),
+            """
+            ConfiguringElementResolved -> configure Item
+            LiteralValueResolved -> ok
+            PropertyAssignmentResolved -> Item.x: Int
+            LiteralValueResolved -> 1
+            ElementNotResolved(OpaqueValueInIdentityKey)
+            ValueFactoryResolved -> stringFactory(): String
+            PropertyNotAssigned(UnresolvedBase)
+            LiteralValueResolved -> 2
+            """.trimIndent()
+        )
+    }
+
+    private
+    val schema = schemaFromTypes(TopLevel::class, this::class.nestedClasses.toList())
+
+    interface TopLevel {
+        @Suppress("unused")
+        @Configuring
+        fun itemNamed(name: String, configure: Item.() -> Unit)
+
+        @Suppress("unused")
+        @Restricted
+        fun stringFactory(): String
+    }
+
+    interface Item {
+        @Suppress("unused")
+        @get:Restricted
+        var x: Int
+    }
+}

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/dom/resolution/DomResolutionTest.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/dom/resolution/DomResolutionTest.kt
@@ -14,18 +14,16 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.declarativedsl.dom
+package org.gradle.internal.declarativedsl.dom.resolution
 
-import org.gradle.declarative.dsl.schema.DataTypeRef
-import org.gradle.declarative.dsl.schema.SchemaFunction
 import org.gradle.internal.declarativedsl.analysis.tracingCodeResolver
+import org.gradle.internal.declarativedsl.dom.TestApi
 import org.gradle.internal.declarativedsl.dom.data.collectToMap
 import org.gradle.internal.declarativedsl.dom.fromLanguageTree.convertBlockToDocument
-import org.gradle.internal.declarativedsl.dom.resolution.resolutionContainer
 import org.gradle.internal.declarativedsl.parsing.ParseTestUtil.parseAsTopLevelBlock
 import org.gradle.internal.declarativedsl.schemaBuilder.schemaFromTypes
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
 
 
 class DomResolutionTest {
@@ -146,33 +144,4 @@ class DomResolutionTest {
     private
     val schema = schemaFromTypes(TestApi.TopLevelReceiver::class, TestApi::class.nestedClasses.toList())
 
-    private
-    fun resolutionPrettyString(resolution: DocumentResolution): String =
-        resolution::class.simpleName + when (resolution) {
-            is DocumentResolution.ElementResolution.SuccessfulElementResolution.ContainerElementResolved ->
-                " -> element ${functionSignatureString(resolution.elementFactoryFunction)}"
-
-            is DocumentResolution.ElementResolution.SuccessfulElementResolution.ConfiguringElementResolved ->
-                " -> configure ${resolution.elementType}"
-
-            is DocumentResolution.PropertyResolution.PropertyAssignmentResolved ->
-                " -> ${resolution.receiverType}.${resolution.property.name}: ${typeString(resolution.property.valueType)}"
-
-            is DocumentResolution.ValueNodeResolution.ValueFactoryResolution.ValueFactoryResolved ->
-                " -> ${functionSignatureString(resolution.function)}"
-
-            is DocumentResolution.ValueNodeResolution.LiteralValueResolved -> " -> ${resolution.value}"
-            is DocumentResolution.UnsuccessfulResolution -> "(${resolution.reasons.joinToString()})"
-            is DocumentResolution.ValueNodeResolution.NamedReferenceResolution.NamedReferenceResolved -> " -> ${resolution.referenceName}"
-        }
-
-    private
-    fun typeString(typeRef: DataTypeRef) = when (typeRef) {
-        is DataTypeRef.Type -> typeRef.dataType.toString()
-        is DataTypeRef.Name -> typeRef.fqName.simpleName
-    }
-
-    private
-    fun functionSignatureString(function: SchemaFunction) =
-        "${function.simpleName}(${function.parameters.joinToString { typeString(it.type) }}): ${typeString(function.returnValueType)}"
 }

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/dom/resolution/testUtils.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/dom/resolution/testUtils.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.declarativedsl.dom.resolution
+
+import org.gradle.declarative.dsl.schema.DataTypeRef
+import org.gradle.declarative.dsl.schema.SchemaFunction
+import org.gradle.internal.declarativedsl.dom.DocumentResolution
+
+internal fun resolutionPrettyString(resolution: DocumentResolution): String =
+    resolution::class.simpleName + when (resolution) {
+        is DocumentResolution.ElementResolution.SuccessfulElementResolution.ContainerElementResolved ->
+            " -> element ${functionSignatureString(resolution.elementFactoryFunction)}"
+
+        is DocumentResolution.ElementResolution.SuccessfulElementResolution.ConfiguringElementResolved ->
+            " -> configure ${resolution.elementType}"
+
+        is DocumentResolution.PropertyResolution.PropertyAssignmentResolved ->
+            " -> ${resolution.receiverType}.${resolution.property.name}: ${typeString(resolution.property.valueType)}"
+
+        is DocumentResolution.ValueNodeResolution.ValueFactoryResolution.ValueFactoryResolved ->
+            " -> ${functionSignatureString(resolution.function)}"
+
+        is DocumentResolution.ValueNodeResolution.LiteralValueResolved -> " -> ${resolution.value}"
+        is DocumentResolution.UnsuccessfulResolution -> "(${resolution.reasons.joinToString()})"
+        is DocumentResolution.ValueNodeResolution.NamedReferenceResolution.NamedReferenceResolved -> " -> ${resolution.referenceName}"
+    }
+
+private fun functionSignatureString(function: SchemaFunction) =
+    "${function.simpleName}(${function.parameters.joinToString { typeString(it.type) }}): ${typeString(function.returnValueType)}"
+
+private fun typeString(typeRef: DataTypeRef) = when (typeRef) {
+    is DataTypeRef.Type -> typeRef.dataType.toString()
+    is DataTypeRef.Name -> typeRef.fqName.simpleName
+}

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/ConfiguringFunctionWithIdentityTest.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/ConfiguringFunctionWithIdentityTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.declarativedsl.mappingToJvm
+
+import org.gradle.declarative.dsl.model.annotations.Configuring
+import org.gradle.declarative.dsl.model.annotations.Restricted
+import org.gradle.internal.declarativedsl.analysis.ResolutionResult
+import org.gradle.internal.declarativedsl.demo.resolve
+import org.gradle.internal.declarativedsl.schemaBuilder.kotlinFunctionAsConfigureLambda
+import org.gradle.internal.declarativedsl.schemaBuilder.schemaFromTypes
+import org.junit.Assert
+import org.junit.Test
+
+class ConfiguringFunctionWithIdentityTest {
+    @Test
+    fun `maps objects with different identity keys to different JVM objects, same keys to same objects`() {
+        val resolution = schema.resolve(
+            """
+            itemByName("one") {
+                x = 1
+            }
+            itemByName("one") {
+                y = 1
+            }
+            itemByName("two") {
+                x = 2
+            }
+            itemByName("two") {
+                y = 2
+            }
+            """.trimIndent()
+        )
+        Assert.assertEquals(setOf(Item("one", 1, 1), Item("two", 2, 2)), objectFrom(resolution).items.toSet())
+    }
+
+    private fun objectFrom(resolution: ResolutionResult) =
+        runtimeInstanceFromResult(schema, resolution, kotlinFunctionAsConfigureLambda, RuntimeCustomAccessors.none, ::TopLevel)
+
+    val schema = schemaFromTypes(
+        TopLevel::class,
+        this::class.nestedClasses
+    )
+
+    class TopLevel {
+        val items: MutableList<Item> = mutableListOf()
+
+        @Configuring
+        @Suppress("unused")
+        fun itemByName(name: String, configure: Item.() -> Unit) {
+            Item(name).also(items::add).also(configure)
+        }
+    }
+
+    data class Item(val name: String, @get:Restricted var x: Int = 0, @get:Restricted var y: Int = 0)
+}

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/schemaBuidler/FunctionExtractorTest.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/schemaBuidler/FunctionExtractorTest.kt
@@ -17,13 +17,17 @@
 package org.gradle.internal.declarativedsl.schemaBuidler
 
 import org.gradle.declarative.dsl.model.annotations.Adding
+import org.gradle.declarative.dsl.model.annotations.Configuring
 import org.gradle.declarative.dsl.schema.DataClass
 import org.gradle.declarative.dsl.schema.FunctionSemantics
+import org.gradle.declarative.dsl.schema.ParameterSemantics
 import org.gradle.internal.declarativedsl.schemaBuilder.schemaFromTypes
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.Test
 import org.junit.jupiter.api.assertThrows
 import org.gradle.internal.declarativedsl.assertIs
+import org.gradle.internal.declarativedsl.schemaUtils.singleFunctionNamed
+import org.gradle.internal.declarativedsl.schemaUtils.typeFor
 
 
 class FunctionExtractorTest {
@@ -51,6 +55,15 @@ class FunctionExtractorTest {
         assertIs<FunctionSemantics.AddAndConfigure>(function.semantics)
     }
 
+    @Test
+    fun `configuring functions may accept parameters recognized as identity keys`() {
+        with(schemaFromTypes(ReceiverFour::class, listOf(ReceiverFour::class))) {
+            assertIs<ParameterSemantics.IdentityKey>(
+                typeFor<ReceiverFour>().singleFunctionNamed("configuring").function.parameters.single().semantics
+            )
+        }
+    }
+
     abstract class ReceiverOne {
         @Adding
         abstract fun adding(receiver: ReceiverOne.() -> Unit): ReceiverOne
@@ -64,5 +77,10 @@ class FunctionExtractorTest {
     abstract class ReceiverThree {
         @Adding
         abstract fun adding(three: Int)
+    }
+
+    abstract class ReceiverFour {
+        @Configuring
+        abstract fun configuring(item: Int, configure: ReceiverFour.() -> Unit)
     }
 }

--- a/platforms/core-configuration/declarative-dsl-evaluator/src/main/kotlin/org/gradle/internal/declarativedsl/evaluator/EvaluationFailureMessageGenerator.kt
+++ b/platforms/core-configuration/declarative-dsl-evaluator/src/main/kotlin/org/gradle/internal/declarativedsl/evaluator/EvaluationFailureMessageGenerator.kt
@@ -122,6 +122,7 @@ object EvaluationFailureMessageGenerator {
         is ErrorReason.UnresolvedFunctionCallSignature -> "unresolved function call signature for '${errorReason.functionCall.name}'"
         ErrorReason.AccessOnCurrentReceiverOnlyViolation -> "this member can only be accessed on a current receiver"
         is ErrorReason.NonReadableProperty -> "property cannot be used as a value: '${errorReason.property.name}'"
+        is ErrorReason.OpaqueArgumentForIdentityParameter -> "opaque identity argument: ${errorReason.parameter.name} = ${errorReason.argument.originElement.sourceData.text()}"
     }
 
     private

--- a/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/settings/SoftwareTypeModelDefaultsIntegrationTest.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/settings/SoftwareTypeModelDefaultsIntegrationTest.groovy
@@ -331,6 +331,22 @@ class SoftwareTypeModelDefaultsIntegrationTest extends AbstractIntegrationSpec i
         "kotlin" | ".kts"
     }
 
+    def "can configure defaults for named domain object container elements"() {
+        given:
+        withSoftwareTypePluginWithNdoc().prepareToExecute()
+
+        file("settings.gradle.dcl") << getDeclarativeSettingsScriptThatSetsDefaultsForNdoc()
+
+        file("build.gradle.dcl") << getDeclarativeScriptThatConfiguresOnlyTestSoftwareType(fooNdocYValues())
+
+        when:
+        run(":printTestSoftwareTypeExtensionConfiguration")
+
+        then:
+        outputContains("Foo(name = one, x = 1, y = 11)")
+        outputContains("Foo(name = two, x = 2, y = 22)")
+    }
+
     @NotYetImplemented
     def "can configure build-level defaults in a settings plugin"() {
         given:
@@ -407,6 +423,19 @@ class SoftwareTypeModelDefaultsIntegrationTest extends AbstractIntegrationSpec i
         return implementation(dependencies) + "\n" + api(dependencies) + "\n" + compileOnly(dependencies) + "\n" + runtimeOnly(dependencies)
     }
 
+    static String fooNdocYValues() {
+        return """
+        foos {
+            foo("one") {
+                y = 11
+            }
+            foo("two") {
+                y = 22
+            }
+        }
+        """
+    }
+
     static String dependencies(String dependencies) {
         return """
             dependencies {
@@ -448,4 +477,20 @@ class SoftwareTypeModelDefaultsIntegrationTest extends AbstractIntegrationSpec i
             }
         """
     }
+
+    static String getDeclarativeSettingsScriptThatSetsDefaultsForNdoc(String configuration="") {
+        return getDeclarativeSettingsScriptThatSetsDefaults("" +
+            """
+            foos {
+                foo("one") {
+                    x = 1
+                }
+                foo("two") {
+                    x = 2
+                }
+            }
+            """
+        )
+    }
+
 }

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/ndoc/ContainersSchemaComponent.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/ndoc/ContainersSchemaComponent.kt
@@ -244,7 +244,11 @@ private fun elementFactoryFunction(
             DefaultDataParameter("name", DataTypeInternal.DefaultStringDataType.ref, false, ParameterSemanticsInternal.DefaultUnknown)
         ),
         false,
-        FunctionSemanticsInternal.DefaultAddAndConfigure(elementTypeRef, DefaultRequired)
+        FunctionSemanticsInternal.DefaultAccessAndConfigure(
+            ConfigureAccessorInternal.DefaultConfiguringLambdaArgument(elementTypeRef),
+            FunctionSemanticsInternal.DefaultAccessAndConfigure.DefaultReturnType.DefaultConfiguredObject,
+            DefaultRequired
+        )
     )
 }
 

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/ndoc/ContainersSchemaComponent.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/ndoc/ContainersSchemaComponent.kt
@@ -241,7 +241,7 @@ private fun elementFactoryFunction(
         receiverTypeRef,
         elementFactoryName,
         listOf(
-            DefaultDataParameter("name", DataTypeInternal.DefaultStringDataType.ref, false, ParameterSemanticsInternal.DefaultUnknown)
+            DefaultDataParameter("name", DataTypeInternal.DefaultStringDataType.ref, false, ParameterSemanticsInternal.DefaultIdentityKey(null))
         ),
         false,
         FunctionSemanticsInternal.DefaultAccessAndConfigure(

--- a/platforms/core-configuration/declarative-dsl-provider/src/testFixtures/groovy/org/gradle/internal/declarativedsl/settings/SoftwareTypeFixture.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/testFixtures/groovy/org/gradle/internal/declarativedsl/settings/SoftwareTypeFixture.groovy
@@ -41,6 +41,14 @@ trait SoftwareTypeFixture {
         )
     }
 
+    PluginBuilder withSoftwareTypePluginWithNdoc() {
+        return withSoftwareTypePlugins(
+            softwareTypeExtensionWithNdoc,
+            getProjectPluginThatProvidesSoftwareType("TestSoftwareTypeExtension", null, "SoftwareTypeImplPlugin", "testSoftwareType", ""),
+            settingsPluginThatRegistersSoftwareType
+        )
+    }
+
     PluginBuilder withSoftwareTypePluginWithMismatchedModelTypes() {
         def pluginBuilder = withSoftwareTypePlugins(
             softwareTypeExtension,
@@ -206,6 +214,55 @@ trait SoftwareTypeFixture {
             }
         """
     }
+
+    static String getSoftwareTypeExtensionWithNdoc() {
+        return """
+            package org.gradle.test;
+
+            import org.gradle.declarative.dsl.model.annotations.Restricted;
+
+            import org.gradle.api.Named;
+            import org.gradle.api.NamedDomainObjectContainer;
+            import org.gradle.api.provider.Property;
+
+            import java.util.stream.Collectors;
+
+            public abstract class TestSoftwareTypeExtension {
+                public abstract NamedDomainObjectContainer<Foo> getFoos();
+
+                public abstract static class Foo implements Named {
+                    private String name;
+
+                    public Foo(String name) {
+                        this.name = name;
+                    }
+
+                    @Override
+                    public String getName() {
+                        return name;
+                    }
+
+                    @Restricted
+                    public abstract Property<Integer> getX();
+
+                    @Restricted
+                    public abstract Property<Integer> getY();
+
+                    @Override
+                    public String toString() {
+                        return "Foo(name = " + name + ", x = " + getX().get() + ", y = " + getY().get() + ")";
+                    }
+                }
+
+                @Override
+                public String toString() {
+                    return getFoos().stream().map(Foo::toString).collect(Collectors.joining(", "));
+                }
+            }
+
+        """
+    }
+
 
     static String getPublicModelType() {
         return """

--- a/platforms/core-configuration/declarative-dsl-tooling-models/src/main/kotlin/org/gradle/declarative/dsl/schema/ParameterSemantics.kt
+++ b/platforms/core-configuration/declarative-dsl-tooling-models/src/main/kotlin/org/gradle/declarative/dsl/schema/ParameterSemantics.kt
@@ -22,11 +22,16 @@ import java.io.Serializable
 
 @ToolingModelContract(subTypes = [
     ParameterSemantics.StoreValueInProperty::class,
+    ParameterSemantics.IdentityKey::class,
     ParameterSemantics.Unknown::class
 ])
 sealed interface ParameterSemantics : Serializable {
     interface StoreValueInProperty : ParameterSemantics {
         val dataProperty: DataProperty
+    }
+
+    interface IdentityKey : ParameterSemantics {
+        val basedOnProperty : DataProperty?
     }
 
     interface Unknown : ParameterSemantics


### PR DESCRIPTION

* Introduce a new kind of parameter semantics for DCL functions, `IdentityKey`
* Let configuring functions mark their parameters with this kind of semantics, so that they can now not only be parameterless (thus configuring a predefined object), but can now configure an object based on the identity key.
* In the DOM overlay operation, combine element nodes that get resolved to "configuring" functions with identity values
* Make DCL NDOC support use configuring functions with identity keys instead of "adding" functionsπ
