### PR TITLE
Improve ambiguous Artifact Transformation chain scenario handling

### DIFF
--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/text/TreeFormatter.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/text/TreeFormatter.java
@@ -33,8 +33,21 @@ public class TreeFormatter implements DiagnosticsVisitor {
     private final AbstractStyledTextOutput original;
     private Node current;
     private Prefixer prefixer = new DefaultPrefixer();
+    private final boolean alwaysChildrenOnNewlines;
 
     public TreeFormatter() {
+        this(false);
+    }
+
+    /**
+     * By default, if a child node + the parent node have only a short amount of total text,
+     * the formatter will merge them both onto the same line.
+     * <p>
+     * If this is set to {@code true}, this behavior will be disabled.
+     *
+     * @param alwaysChildrenOnNewlines {@code true} = never merge nodes; {@code false} (default) = merge nodes with short total text
+     */
+    public TreeFormatter(boolean alwaysChildrenOnNewlines) {
         this.original = new AbstractStyledTextOutput() {
             @Override
             protected void doAppend(String text) {
@@ -42,6 +55,7 @@ public class TreeFormatter implements DiagnosticsVisitor {
             }
         };
         this.current = new Node();
+        this.alwaysChildrenOnNewlines = alwaysChildrenOnNewlines;
     }
 
     @Override
@@ -322,7 +336,7 @@ public class TreeFormatter implements DiagnosticsVisitor {
         final String text;
     }
 
-    private static class Node {
+    private class Node {
         final Node parent;
         final StringBuilder value;
         Node firstChild;
@@ -367,7 +381,9 @@ public class TreeFormatter implements DiagnosticsVisitor {
             }
             if (firstChild.nextSibling == null
                 && firstChild.firstChild == null
-                && value.length() + firstChild.value.length() < 60) {
+                && value.length() + firstChild.value.length() < 60
+                && !alwaysChildrenOnNewlines
+            ) {
                 // A single leaf node as child and total text is not too long, collapse
                 if (trailing == ':') {
                     return Separator.Empty;

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/text/TreeFormatter.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/text/TreeFormatter.java
@@ -298,7 +298,7 @@ public class TreeFormatter implements DiagnosticsVisitor {
             output.append(node.value);
         }
 
-        Separator separator = node.getFirstChildSeparator();
+        Separator separator = node.getFirstChildSeparator(alwaysChildrenOnNewlines);
 
         if (!separator.newLine) {
             output.append(separator.text);
@@ -336,7 +336,7 @@ public class TreeFormatter implements DiagnosticsVisitor {
         final String text;
     }
 
-    private class Node {
+    private static class Node {
         final Node parent;
         final StringBuilder value;
         Node firstChild;
@@ -366,7 +366,7 @@ public class TreeFormatter implements DiagnosticsVisitor {
             }
         }
 
-        Separator getFirstChildSeparator() {
+        Separator getFirstChildSeparator(boolean alwaysChildrenOnNewlines) {
             if (firstChild == null) {
                 return Separator.NewLine;
             }

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/logging/text/TreeFormatterTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/logging/text/TreeFormatterTest.groovy
@@ -135,6 +135,25 @@ class TreeFormatterTest extends Specification {
   - ${longText}""")
     }
 
+    def "formats short node with single child on separate lines when asked alwaysChildrenOnNewLines = #alwaysChildrenOnNewLines"() {
+        given:
+        formatter = new TreeFormatter(alwaysChildrenOnNewLines)
+
+        when:
+        formatter.node("introduction")
+        formatter.startChildren()
+        formatter.node("hello = world")
+        formatter.endChildren()
+
+        then:
+        formatter.toString() == toPlatformLineSeparators(expectation)
+
+        where:
+        alwaysChildrenOnNewLines    || expectation
+        true                        || "introduction:\n  - hello = world"
+        false                       || "introduction: hello = world"
+    }
+
     def "formats node with trailing '.'"() {
         when:
         formatter.node("Some things.")

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -2,7 +2,7 @@ The Gradle team is excited to announce Gradle @version@.
 
 This release features [1](), [2](), ... [n](), and more.
 
-<!-- 
+<!--
 Include only their name, impactful features should be called out separately below.
  [Some person](https://github.com/some-person)
 
@@ -21,9 +21,71 @@ Switch your build to use Gradle @version@ by updating the [Wrapper](userguide/gr
 
 See the [Gradle 8.x upgrade guide](userguide/upgrading_version_8.html#changes_@baseVersion@) to learn about deprecations, breaking changes, and other considerations when upgrading to Gradle @version@.
 
-For Java, Groovy, Kotlin, and Android compatibility, see the [full compatibility notes](userguide/compatibility.html).   
+For Java, Groovy, Kotlin, and Android compatibility, see the [full compatibility notes](userguide/compatibility.html).
 
 ## New features and usability improvements
+
+### Error and warning reporting improvements
+
+#### Ambiguous Artifact Transformation chains are detected and reported
+
+Previously, when two or more equal-length chains of <<artifact_transforms.adoc#sec,artifact transforms>> produced compatible variants to satisfy a resolution request, Gradle would arbitrarily and silently select one.
+Gradle now emits a deprecation warning for this case.
+
+This deprecation warning is the same failure message that now appears when multiple equal-length chains are available, producing incompatible variants that could each satisfy a resolution request.
+In this case, resolution fails with an ambiguity failure, and Gradle emits a message like this:
+
+```text
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+Could not determine the dependencies of task ':forceResolution'.
+> Could not resolve all dependencies for configuration ':resolveMe'.
+   > Found multiple transformation chains that produce a variant of 'root project :' with requested attributes:
+       - color 'red'
+       - matter 'liquid'
+       - shape 'round'
+     Found the following transformation chains:
+       - From configuration ':squareBlueLiquidElements':
+           - With source attributes:
+               - artifactType 'txt'
+               - color 'blue'
+               - matter 'liquid'
+               - shape 'square'
+               - texture 'smooth'
+           - Candidate transformation chains:
+               - Transformation chain: 'BrokenColorTransform' -> 'BrokenShapeTransform':
+                   - 'BrokenColorTransform':
+                       - Converts from attributes:
+                           - color 'blue'
+                           - texture 'smooth'
+                       - To attributes:
+                           - color 'red'
+                           - texture 'bumpy'
+                   - 'BrokenShapeTransform':
+                       - Converts from attributes:
+                           - shape 'square'
+                           - texture 'bumpy'
+                       - To attributes:
+                           - shape 'round'
+               - Transformation chain: 'BrokenColorTransform' -> 'BrokenShapeTransform':
+                   - 'BrokenColorTransform':
+                       - Converts from attributes:
+                           - color 'blue'
+                           - texture 'smooth'
+                       - To attributes:
+                           - color 'red'
+                           - texture 'rough'
+                   - 'BrokenShapeTransform':
+                       - Converts from attributes:
+                           - shape 'square'
+                           - texture 'rough'
+                       - To attributes:
+                           - shape 'round'
+```
+
+The formatting of this message has been improved to comprehensively display information about each complete chain of transformations that produces the candidates that would satisfy the request.
+This allows authors to better analyze and understand their builds, allowing them to remove the ambiguity.
 
 <!-- Do not add breaking changes or deprecations here! Add them to the upgrade guide instead. -->
 
@@ -78,7 +140,7 @@ Gradle provides rich APIs for plugin authors and build engineers to develop cust
 
 #### `DependencyConstraintHandler` now has `addProvider` methods
 
-The [`DependencyConstraintHandler`](javadoc/org/gradle/api/artifacts/dsl/DependencyConstraintHandler.html) now has `addProvider` methods, similar to the 
+The [`DependencyConstraintHandler`](javadoc/org/gradle/api/artifacts/dsl/DependencyConstraintHandler.html) now has `addProvider` methods, similar to the
 [`DependencyHandler`](javadoc/org/gradle/api/artifacts/dsl/DependencyHandler.html).
 
 ```kotlin

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -30,7 +30,7 @@ For Java, Groovy, Kotlin, and Android compatibility, see the [full compatibility
 #### Ambiguous Artifact Transformation chains are detected and reported
 
 Previously, when two or more equal-length chains of <<artifact_transforms.adoc#sec,artifact transforms>> produced compatible variants to satisfy a resolution request, Gradle would arbitrarily and silently select one.
-Gradle now emits a deprecation warning for this case.
+Gradle now emits a warning for this case.
 
 This deprecation warning is the same failure message that now appears when multiple equal-length chains are available, producing incompatible variants that could each satisfy a resolution request.
 In this case, resolution fails with an ambiguity failure, and Gradle emits a message like this:

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -54,7 +54,7 @@ Could not determine the dependencies of task ':forceResolution'.
                - shape 'square'
                - texture 'smooth'
            - Candidate transformation chains:
-               - Transformation chain: 'BrokenColorTransform' -> 'BrokenShapeTransform':
+               - Transformation chain: 'ColorTransform' -> 'ShapeTransform':
                    - 'BrokenColorTransform':
                        - Converts from attributes:
                            - color 'blue'
@@ -68,7 +68,7 @@ Could not determine the dependencies of task ':forceResolution'.
                            - texture 'bumpy'
                        - To attributes:
                            - shape 'round'
-               - Transformation chain: 'BrokenColorTransform' -> 'BrokenShapeTransform':
+               - Transformation chain: 'ColorTransform' -> 'ShapeTransform':
                    - 'BrokenColorTransform':
                        - Converts from attributes:
                            - color 'blue'

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/controlling-dependency-resolution/artifact_transforms.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/controlling-dependency-resolution/artifact_transforms.adoc
@@ -396,7 +396,8 @@ To register an artifact transform, you must use link:{groovyDslPath}/org.gradle.
 There are a few points to consider when using `registerTransform()`:
 
 - At least one `from` and `to` attributes are required.
-- Each `from` attribute must have a corresponding `to` attribute, and vice-versa.
+- Each `to` attribute must have a corresponding `from` attribute.
+- Additional `from` attributes can be included which do _not_ have corresponding `to` attributes.
 - The transform action itself can have configuration options. You can configure them with the `parameters {}` block.
 - You must register the transform on the project that has the configuration that will be resolved.
 - You can supply any type implementing link:{groovyDslPath}/org.gradle.api.artifacts.transform.TransformAction.html[TransformAction] to the `registerTransform()` method.

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -55,6 +55,56 @@ This is necessary because the SDK could be discovered inconsistently without thi
 
 === Deprecations
 
+[[deprecated_ambiguous_transformation_chains]]
+==== Deprecated Ambiguous Transformation Chains
+
+Previously, when at least two equal-length chains of <<artifact_transforms.adoc#sec:implementing-artifact-transforms,artifact transforms>> were available that would produce compatible variants that would each satisfy a resolution request, Gradle would arbitrarily, and silently, pick one.
+
+Now, Gradle emits a deprecation warning that explains this situation:
+
+```text
+There are multiple distinct artifact transformation chains of the same length that would satisfy this request. This behavior has been deprecated. This will fail with an error in Gradle 9.0.
+Found multiple transformation chains that produce a variant of 'root project :' with requested attributes:
+  - color 'red'
+  - texture 'smooth'
+Found the following transformation chains:
+  - From configuration ':squareBlueSmoothElements':
+      - With source attributes:
+          - artifactType 'txt'
+          - color 'blue'
+          - shape 'square'
+          - texture 'smooth'
+      - Candidate transformation chains:
+          - Transformation chain: 'BrokenColorTransform':
+              - 'BrokenColorTransform':
+                  - Converts from attributes:
+                      - color 'blue'
+                      - texture 'smooth'
+                  - To attributes:
+                      - color 'red'
+          - Transformation chain: 'BrokenColorTransform2':
+              - 'BrokenColorTransform2':
+                  - Converts from attributes:
+                      - color 'blue'
+                      - texture 'smooth'
+                  - To attributes:
+                      - color 'red'
+ Remove one or more registered transforms, or add additional attributes to them to ensure only a single valid transformation chain exists.
+
+```
+
+In such a scenario, Gradle has no way to know which of the two (or more) possible transformation chains should be used.
+Picking an arbitrary chain can lead to inefficient performance or unexpected behavior changes when seemingly unrelated parts of the build are modified.
+This is potentially a very complex situation and the message now fully explains the situation by printing all the registered transforms in order, along with their source (input) variants for each candidate chain.
+
+When encountering this type of failure, build authors should either:
+
+1. Add additional, distinguishing attributes when registering transforms present in the chain, to ensure that only a single chain will be selectable to satisfy the request
+2. Request additional attributes to disambiguate which chain is selected (if they result in non-identical final attributes)
+3. Remove unnecessary registered transforms from the build
+
+This will become an error in Gradle 9.0.
+
 [[init_must_run_alone]]
 ==== `init` must run alone
 The <<build_init_plugin.adoc#sec:build_init_tasks, `init` task>> must run by itself.

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -75,14 +75,14 @@ Found the following transformation chains:
           - shape 'square'
           - texture 'smooth'
       - Candidate transformation chains:
-          - Transformation chain: 'BrokenColorTransform':
+          - Transformation chain: 'ColorTransform':
               - 'BrokenColorTransform':
                   - Converts from attributes:
                       - color 'blue'
                       - texture 'smooth'
                   - To attributes:
                       - color 'red'
-          - Transformation chain: 'BrokenColorTransform2':
+          - Transformation chain: 'ColorTransform2':
               - 'BrokenColorTransform2':
                   - Converts from attributes:
                       - color 'blue'

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ResolutionFailureHandlerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ResolutionFailureHandlerIntegrationTest.groovy
@@ -371,24 +371,32 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        assertFullMessageCorrect("""   > Found multiple transforms that can produce a variant of root project : with requested attributes:
+        assertFullMessageCorrect("""   > Found multiple transformation chains that produce a variant of 'root project :' with requested attributes:
        - color 'red'
        - shape 'round'
-     Found the following transforms:
-       - From 'configuration ':roundBlueLiquidElements'':
+     Found the following transformation chains:
+       - From configuration ':roundBlueLiquidElements':
            - With source attributes:
                - color 'blue'
                - shape 'round'
                - state 'liquid'
-           - Candidate transform(s):
-               - Transform 'BrokenTransform' producing attributes:
-                   - color 'red'
-                   - shape 'round'
-                   - state 'gas'
-               - Transform 'BrokenTransform' producing attributes:
-                   - color 'red'
-                   - shape 'round'
-                   - state 'solid'""")
+           - Candidate transformation chains:
+               - Transformation chain: 'BrokenTransform':
+                   - 'BrokenTransform':
+                       - Converts from attributes:
+                           - color 'blue'
+                           - state 'liquid'
+                       - To attributes:
+                           - color 'red'
+                           - state 'gas'
+               - Transformation chain: 'BrokenTransform':
+                   - 'BrokenTransform':
+                       - Converts from attributes:
+                           - color 'blue'
+                           - state 'liquid'
+                       - To attributes:
+                           - color 'red'
+                           - state 'solid'""")
 
         and: "Helpful resolutions are provided"
         assertSuggestsReviewingAlgorithm()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
@@ -387,15 +387,6 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         setupExternalDependency()
 
         buildFile << """
-            allprojects {
-                dependencies {
-                    registerTransform(MakeGreen) {
-                        from.attribute(color, 'blue')
-                        to.attribute(color, 'green')
-                    }
-                }
-            }
-
             project(":consumer") {
                 dependencies {
                     implementation project(":producer")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformEdgeCasesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformEdgeCasesIntegrationTest.groovy
@@ -1,0 +1,902 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.transform
+
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.executer.ExpectedDeprecationWarning
+import org.gradle.util.GradleVersion
+import org.gradle.util.internal.ToBeImplemented
+
+/**
+ * This class tests interesting edge case scenarios involving registering Artifact Transforms.
+ * <p>
+ * These tests describe <strong>current</strong> behavior, but not necessarily <strong>desired</strong> behavior.
+ */
+class ArtifactTransformEdgeCasesIntegrationTest extends AbstractIntegrationSpec implements ArtifactTransformTestFixture {
+    def "multiple distinct transformation chains fails with a reasonable message"() {
+        file("my-initial-file.txt") << "Contents"
+
+        buildKotlinFile << """
+            val color = Attribute.of("color", String::class.java)
+            val shape = Attribute.of("shape", String::class.java)
+            val matter = Attribute.of("matter", String::class.java)
+            val texture = Attribute.of("texture", String::class.java)
+
+            configurations {
+                // Supply a square-blue-liquid variant
+                consumable("squareBlueLiquidElements") {
+                    attributes.attribute(shape, "square")
+                    attributes.attribute(color, "blue")
+                    attributes.attribute(matter, "liquid")
+                    attributes.attribute(texture, "unknown")
+
+                    outgoing {
+                        artifact(file("my-initial-file.txt"))
+                    }
+                }
+
+                dependencyScope("myDependencies")
+
+                // Initial ask is for liquid, satisfied by the square-blue-liquid variant
+                resolvable("resolveMe") {
+                    extendsFrom(configurations.getByName("myDependencies"))
+                    attributes.attribute(matter, "liquid")
+                }
+            }
+
+            abstract class BrokenTransform : TransformAction<TransformParameters.None> {
+                override fun transform(outputs: TransformOutputs) {
+                    throw AssertionError("Should not actually be selected to run")
+                }
+            }
+
+            dependencies {
+                add("myDependencies", project(":"))
+
+                // blue -> purple -> red
+                registerTransform(BrokenTransform::class.java) {
+                    from.attribute(color, "blue")
+                    from.attribute(texture, "unknown")
+                    to.attribute(color, "purple")
+                    to.attribute(texture, "rough")
+                }
+                registerTransform(BrokenTransform::class.java) {
+                    from.attribute(color, "purple")
+                    to.attribute(color, "red")
+                }
+
+                // square -> triangle -> round
+                registerTransform(BrokenTransform::class.java) {
+                    from.attribute(shape, "square")
+                    to.attribute(shape, "triangle")
+                }
+                registerTransform(BrokenTransform::class.java) {
+                    from.attribute(shape, "triangle")
+                    to.attribute(shape, "round")
+                }
+
+                // blue -> yellow -> red
+                registerTransform(BrokenTransform::class.java) {
+                    from.attribute(color, "blue")
+                    from.attribute(texture, "unknown")
+                    to.attribute(color, "yellow")
+                    to.attribute(texture, "smooth")
+                }
+                registerTransform(BrokenTransform::class.java) {
+                    from.attribute(color, "yellow")
+                    to.attribute(color, "red")
+                }
+
+                // square -> flat -> round
+                registerTransform(BrokenTransform::class.java) {
+                    from.attribute(shape, "square")
+                    to.attribute(shape, "flat")
+                }
+                registerTransform(BrokenTransform::class.java) {
+                    from.attribute(shape, "flat")
+                    to.attribute(shape, "round")
+                }
+            }
+
+            val forceResolution by tasks.registering {
+                inputs.files(configurations.getByName("resolveMe").incoming.artifactView {
+                    // After getting initial square-blue-liquid variant with liquid request, we request something red-round
+                    // There should be 2 separate transformation chains of equal length that produce this
+                    attributes.attribute(color, "red")
+                    attributes.attribute(shape, "round")
+                }.artifacts.artifactFiles)
+
+                doLast {
+                    inputs.files.files.forEach { println(it) }
+                }
+            }
+        """
+
+        expect:
+        fails "forceResolution"
+
+        failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
+        failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
+        failure.assertHasErrorOutput("""   > Found multiple transformation chains that produce a variant of 'root project :' with requested attributes:
+       - color 'red'
+       - matter 'liquid'
+       - shape 'round'
+     Found the following transformation chains:
+       - From configuration ':squareBlueLiquidElements':
+           - With source attributes:
+               - artifactType 'txt'
+               - color 'blue'
+               - matter 'liquid'
+               - shape 'square'
+               - texture 'unknown'
+           - Candidate transformation chains:
+               - Transformation chain: 'BrokenTransform' -> 'BrokenTransform' -> 'BrokenTransform' -> 'BrokenTransform':
+                   - 'BrokenTransform':
+                       - Converts from attributes:
+                           - shape 'square'
+                       - To attributes:
+                           - shape 'triangle'
+                   - 'BrokenTransform':
+                       - Converts from attributes:
+                           - shape 'triangle'
+                       - To attributes:
+                           - shape 'round'
+                   - 'BrokenTransform':
+                       - Converts from attributes:
+                           - color 'blue'
+                           - texture 'unknown'
+                       - To attributes:
+                           - color 'purple'
+                           - texture 'rough'
+                   - 'BrokenTransform':
+                       - Converts from attributes:
+                           - color 'purple'
+                       - To attributes:
+                           - color 'red'
+               - Transformation chain: 'BrokenTransform' -> 'BrokenTransform' -> 'BrokenTransform' -> 'BrokenTransform':
+                   - 'BrokenTransform':
+                       - Converts from attributes:
+                           - shape 'square'
+                       - To attributes:
+                           - shape 'flat'
+                   - 'BrokenTransform':
+                       - Converts from attributes:
+                           - shape 'flat'
+                       - To attributes:
+                           - shape 'round'
+                   - 'BrokenTransform':
+                       - Converts from attributes:
+                           - color 'blue'
+                           - texture 'unknown'
+                       - To attributes:
+                           - color 'purple'
+                           - texture 'rough'
+                   - 'BrokenTransform':
+                       - Converts from attributes:
+                           - color 'purple'
+                       - To attributes:
+                           - color 'red'
+               - Transformation chain: 'BrokenTransform' -> 'BrokenTransform' -> 'BrokenTransform' -> 'BrokenTransform':
+                   - 'BrokenTransform':
+                       - Converts from attributes:
+                           - color 'blue'
+                           - texture 'unknown'
+                       - To attributes:
+                           - color 'yellow'
+                           - texture 'smooth'
+                   - 'BrokenTransform':
+                       - Converts from attributes:
+                           - color 'yellow'
+                       - To attributes:
+                           - color 'red'
+                   - 'BrokenTransform':
+                       - Converts from attributes:
+                           - shape 'square'
+                       - To attributes:
+                           - shape 'triangle'
+                   - 'BrokenTransform':
+                       - Converts from attributes:
+                           - shape 'triangle'
+                       - To attributes:
+                           - shape 'round'
+               - Transformation chain: 'BrokenTransform' -> 'BrokenTransform' -> 'BrokenTransform' -> 'BrokenTransform':
+                   - 'BrokenTransform':
+                       - Converts from attributes:
+                           - shape 'square'
+                       - To attributes:
+                           - shape 'flat'
+                   - 'BrokenTransform':
+                       - Converts from attributes:
+                           - shape 'flat'
+                       - To attributes:
+                           - shape 'round'
+                   - 'BrokenTransform':
+                       - Converts from attributes:
+                           - color 'blue'
+                           - texture 'unknown'
+                       - To attributes:
+                           - color 'yellow'
+                           - texture 'smooth'
+                   - 'BrokenTransform':
+                       - Converts from attributes:
+                           - color 'yellow'
+                       - To attributes:
+                           - color 'red'""")
+    }
+
+    def "multiple distinct transformation chains fails with a reasonable message with different transform types and non-corresponding from-to attribute pairs"() {
+        file("my-initial-file.txt") << "Contents"
+
+        buildKotlinFile << """
+            val color = Attribute.of("color", String::class.java)
+            val shape = Attribute.of("shape", String::class.java)
+            val matter = Attribute.of("matter", String::class.java)
+            val texture = Attribute.of("texture", String::class.java)
+
+            configurations {
+                // Supply a square-blue-liquid-smooth variant
+                consumable("squareBlueLiquidSmoothElements") {
+                    attributes.attribute(shape, "square")
+                    attributes.attribute(color, "blue")
+                    attributes.attribute(matter, "liquid")
+                    attributes.attribute(texture, "smooth")
+
+                    outgoing {
+                        artifact(file("my-initial-file.txt"))
+                    }
+                }
+
+                dependencyScope("myDependencies")
+
+                // Initial ask is for liquid, satisfied by the square-blue-liquid-smooth variant
+                resolvable("resolveMe") {
+                    extendsFrom(configurations.getByName("myDependencies"))
+                    attributes.attribute(matter, "liquid")
+                }
+            }
+
+            abstract class BrokenColorTransform : TransformAction<TransformParameters.None> {
+                override fun transform(outputs: TransformOutputs) {
+                    throw AssertionError("Should not actually be selected to run")
+                }
+            }
+
+            abstract class BrokenShapeTransform : TransformAction<TransformParameters.None> {
+                override fun transform(outputs: TransformOutputs) {
+                    throw AssertionError("Should not actually be selected to run")
+                }
+            }
+
+            dependencies {
+                add("myDependencies", project(":"))
+
+                // blue/smooth -> red/bumpy
+                registerTransform(BrokenColorTransform::class.java) {
+                    from.attribute(color, "blue")
+                    from.attribute(texture, "smooth")
+                    to.attribute(color, "red")
+                    to.attribute(texture, "bumpy")
+                }
+
+                // blue/smooth -> red/rough
+                registerTransform(BrokenColorTransform::class.java) {
+                    from.attribute(color, "blue")
+                    from.attribute(texture, "smooth")
+                    to.attribute(color, "red")
+                    to.attribute(texture, "rough")
+                }
+
+                // square/rough -> round
+                registerTransform(BrokenShapeTransform::class.java) {
+                    from.attribute(shape, "square")
+                    from.attribute(texture, "rough")
+                    to.attribute(shape, "round")
+                }
+
+                // square/bumpy -> round
+                registerTransform(BrokenShapeTransform::class.java) {
+                    from.attribute(shape, "square")
+                    from.attribute(texture, "bumpy")
+                    to.attribute(shape, "round")
+                }
+            }
+
+            val forceResolution by tasks.registering {
+                inputs.files(configurations.getByName("resolveMe").incoming.artifactView {
+                    // After getting initial square-blue-liquid-smooth variant with liquid request, we request something red-round
+                    // There should be 2 separate transformation chains of equal length that produce this
+                    attributes.attribute(color, "red")
+                    attributes.attribute(shape, "round")
+                }.artifacts.artifactFiles)
+
+                doLast {
+                    inputs.files.files.forEach { println(it) }
+                }
+            }
+        """
+
+        expect:
+        fails "forceResolution"
+
+        failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
+        failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
+        failure.assertHasErrorOutput("""   > Found multiple transformation chains that produce a variant of 'root project :' with requested attributes:
+       - color 'red'
+       - matter 'liquid'
+       - shape 'round'
+     Found the following transformation chains:
+       - From configuration ':squareBlueLiquidSmoothElements':
+           - With source attributes:
+               - artifactType 'txt'
+               - color 'blue'
+               - matter 'liquid'
+               - shape 'square'
+               - texture 'smooth'
+           - Candidate transformation chains:
+               - Transformation chain: 'BrokenColorTransform' -> 'BrokenShapeTransform':
+                   - 'BrokenColorTransform':
+                       - Converts from attributes:
+                           - color 'blue'
+                           - texture 'smooth'
+                       - To attributes:
+                           - color 'red'
+                           - texture 'bumpy'
+                   - 'BrokenShapeTransform':
+                       - Converts from attributes:
+                           - shape 'square'
+                           - texture 'bumpy'
+                       - To attributes:
+                           - shape 'round'
+               - Transformation chain: 'BrokenColorTransform' -> 'BrokenShapeTransform':
+                   - 'BrokenColorTransform':
+                       - Converts from attributes:
+                           - color 'blue'
+                           - texture 'smooth'
+                       - To attributes:
+                           - color 'red'
+                           - texture 'rough'
+                   - 'BrokenShapeTransform':
+                       - Converts from attributes:
+                           - shape 'square'
+                           - texture 'rough'
+                       - To attributes:
+                           - shape 'round'""")
+    }
+
+    def "multiple identical attribute transformations of distinct types should fail"() {
+        file("my-initial-file.txt") << "Contents"
+
+        buildKotlinFile << """
+            val color = Attribute.of("color", String::class.java)
+            val shape = Attribute.of("shape", String::class.java)
+            val texture = Attribute.of("texture", String::class.java)
+
+            configurations {
+                // Supply a square-blue-smooth variant
+                consumable("squareBlueSmoothElements") {
+                    attributes.attribute(shape, "square")
+                    attributes.attribute(color, "blue")
+                    attributes.attribute(texture, "smooth")
+
+                    outgoing {
+                        artifact(file("my-initial-file.txt"))
+                    }
+                }
+
+                dependencyScope("myDependencies")
+
+                // Initial ask is for smooth, satisfied by the square-blue-smooth variant
+                resolvable("resolveMe") {
+                    extendsFrom(configurations.getByName("myDependencies"))
+                    attributes.attribute(texture, "smooth")
+                }
+            }
+
+            abstract class BrokenColorTransform : TransformAction<TransformParameters.None> {
+                override fun transform(outputs: TransformOutputs) {
+                    throw AssertionError("Should not actually be selected to run")
+                }
+            }
+
+            abstract class BrokenColorTransform2 : TransformAction<TransformParameters.None> {
+                override fun transform(outputs: TransformOutputs) {
+                    throw AssertionError("Should not actually be selected to run")
+                }
+            }
+
+            dependencies {
+                add("myDependencies", project(":"))
+
+                // blue/smooth -> red (type 1)
+                registerTransform(BrokenColorTransform::class.java) {
+                    from.attribute(color, "blue")
+                    from.attribute(texture, "smooth")
+                    to.attribute(color, "red")
+                }
+
+                // blue/smooth -> red (type 2)
+                registerTransform(BrokenColorTransform2::class.java) {
+                    from.attribute(color, "blue")
+                    from.attribute(texture, "smooth")
+                    to.attribute(color, "red")
+                }
+            }
+
+            val forceResolution by tasks.registering {
+                inputs.files(configurations.getByName("resolveMe").incoming.artifactView {
+                    // After getting initial square-blue-smooth variant with smooth request, we request something red
+                    // There should be 2 separate transformation chains of equal length that produce this
+                    attributes.attribute(color, "red")
+                }.artifacts.artifactFiles)
+
+                doLast {
+                    inputs.files.files.forEach { println(it) }
+                }
+            }
+        """
+
+        expect:
+        executer.expectDeprecationWarning(ExpectedDeprecationWarning.withMessage("There are multiple distinct artifact transformation chains of the same length that would satisfy this request. This behavior has been deprecated. This will fail with an error in Gradle 9.0. " + """
+Found multiple transformation chains that produce a variant of 'root project :' with requested attributes:
+  - color 'red'
+  - texture 'smooth'
+Found the following transformation chains:
+  - From configuration ':squareBlueSmoothElements':
+      - With source attributes:
+          - artifactType 'txt'
+          - color 'blue'
+          - shape 'square'
+          - texture 'smooth'
+      - Candidate transformation chains:
+          - Transformation chain: 'BrokenColorTransform':
+              - 'BrokenColorTransform':
+                  - Converts from attributes:
+                      - color 'blue'
+                      - texture 'smooth'
+                  - To attributes:
+                      - color 'red'
+          - Transformation chain: 'BrokenColorTransform2':
+              - 'BrokenColorTransform2':
+                  - Converts from attributes:
+                      - color 'blue'
+                      - texture 'smooth'
+                  - To attributes:
+                      - color 'red'
+ Remove one or more registered transforms, or add additional attributes to them to ensure only a single valid transformation chain exists. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#deprecated_ambiguous_transformation_chains"""))
+
+        fails "forceResolution"
+
+        // Currently, Gradle emits a deprecation warning and this only fails because the transforms throw exceptions.
+        // After Gradle 9.0, remove the deprecation expectation and this (currently passing) assertion:
+        failure.assertHasCause("Should not actually be selected to run")
+        // ...and uncomment the assertions below, which test what SHOULD happen after the deprecation is made an error in Gradle 9.0:
+/*
+        failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
+        failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
+        failure.assertHasErrorOutput("""   > Found multiple transformation chains that produce a variant of 'root project :' with requested attributes:
+  - color 'red'
+  - texture 'smooth'
+Found the following transformation chains:
+  - From configuration ':squareBlueSmoothElements':
+      - With source attributes:
+          - artifactType 'txt'
+          - color 'blue'
+          - shape 'square'
+          - texture 'smooth'
+      - Candidate transformation chains:
+          - Transformation chain: 'BrokenColorTransform':
+              - 'BrokenColorTransform':
+                  - Converts from attributes:
+                      - color 'blue'
+                      - texture 'smooth'
+                  - To attributes:
+                      - color 'red'
+          - Transformation chain: 'BrokenColorTransform2':
+              - 'BrokenColorTransform2':
+                  - Converts from attributes:
+                      - color 'blue'
+                      - texture 'smooth'
+                  - To attributes:
+                      - color 'red'""")
+*/
+    }
+
+    def "transforms from selected chains aren't instantiated and don't run if there are no artifacts on the source variant"() {
+        file("my-initial-file.txt") << "Contents"
+
+        buildKotlinFile << """
+            val color = Attribute.of("color", String::class.java)
+            val shape = Attribute.of("shape", String::class.java)
+
+            configurations {
+                // Supply a square-blue variant, without artifacts
+                consumable("squareBlueSmoothElements") {
+                    attributes.attribute(shape, "square")
+                    attributes.attribute(color, "blue")
+                }
+
+                dependencyScope("myDependencies")
+
+                // Initial ask is for square, satisfied by the square-blue variant
+                resolvable("resolveMe") {
+                    extendsFrom(configurations.getByName("myDependencies"))
+                    attributes.attribute(shape, "square")
+                }
+            }
+
+            abstract class BrokenColorTransform : TransformAction<TransformParameters.None> {
+                init {
+                    throw AssertionError("Should not ever be instantiated")
+                }
+
+                override fun transform(outputs: TransformOutputs) {
+                    throw AssertionError("Should not actually be selected to run")
+                }
+            }
+
+            dependencies {
+                add("myDependencies", project(":"))
+
+                // blue -> red
+                registerTransform(BrokenColorTransform::class.java) {
+                    from.attribute(color, "blue")
+                    to.attribute(color, "red")
+                }
+            }
+
+            val forceResolution by tasks.registering {
+                inputs.files(configurations.getByName("resolveMe").incoming.artifactView {
+                    // After getting initial square-blue variant with square request, we request something also red
+                    // A transformation must be run to produce this, but it shouldn't be created or run because there are no artifacts
+                    attributes.attribute(color, "red")
+                }.artifacts.artifactFiles)
+
+                doLast {
+                    inputs.files.files.forEach { println(it) }
+                }
+            }
+        """
+
+        expect:
+        succeeds "forceResolution"
+    }
+
+    def "if a transform removes all artifacts from a variant, leaving an empty directory, subsequent transforms in selected chain still run"() {
+        file("my-initial-file.txt") << "Contents"
+
+        buildKotlinFile << """
+            val color = Attribute.of("color", String::class.java)
+            val shape = Attribute.of("shape", String::class.java)
+            val matter = Attribute.of("matter", String::class.java)
+
+            configurations {
+                // Supply a square-blue-liquid variant, with an artifact
+                consumable("squareBlueSmoothElements") {
+                    attributes.attribute(shape, "square")
+                    attributes.attribute(color, "blue")
+                    attributes.attribute(matter, "liquid")
+
+                    outgoing {
+                        artifact(file("my-initial-file.txt"))
+                    }
+                }
+
+                dependencyScope("myDependencies")
+
+                // Initial ask is for liquid, satisfied by the square-blue-liquid variant
+                resolvable("resolveMe") {
+                    extendsFrom(configurations.getByName("myDependencies"))
+                    attributes.attribute(matter, "liquid")
+                }
+            }
+
+            abstract class ShapeTransform : TransformAction<TransformParameters.None> {
+                @get:InputArtifact
+                abstract val inputArtifact: Provider<FileSystemLocation>
+
+                override fun transform(outputs: TransformOutputs) {
+                    outputs.dir("empty")
+                }
+            }
+
+            abstract class ColorTransform : TransformAction<TransformParameters.None> {
+                @get:InputArtifact
+                abstract val inputArtifact: Provider<FileSystemLocation>
+
+                override fun transform(outputs: TransformOutputs) {
+                    assert(inputArtifact.get().getAsFile().getName() == "empty")
+                }
+            }
+
+            dependencies {
+                add("myDependencies", project(":"))
+
+                // square -> round
+                registerTransform(ShapeTransform::class.java) {
+                    from.attribute(shape, "square")
+                    to.attribute(shape, "round")
+                }
+
+                // blue/round -> red (must run second)
+                registerTransform(ColorTransform::class.java) {
+                    from.attribute(color, "blue")
+                    from.attribute(shape, "round")
+                    to.attribute(color, "red")
+                }
+            }
+
+            val forceResolution by tasks.registering {
+                inputs.files(configurations.getByName("resolveMe").incoming.artifactView {
+                    // After getting initial square-blue variant with square request, we request something red-round
+                    // A transformation chain must be run to produce this, but the first transformation should remove input artifacts, resulting in the color transform running on empty dir
+                    attributes.attribute(color, "red")
+                    attributes.attribute(shape, "round")
+                }.artifacts.artifactFiles)
+
+                doLast {
+                    inputs.files.files.forEach { println(it) }
+                }
+            }
+        """
+
+        expect:
+        succeeds "forceResolution"
+    }
+
+    @ToBeImplemented("https://github.com/gradle/gradle/issues/30784")
+    def "registering multiple transformations using the same type and from and to attributes should fail"() {
+        file("my-initial-file.txt") << "Contents"
+
+        buildKotlinFile << """
+            val color = Attribute.of("color", String::class.java)
+            val shape = Attribute.of("shape", String::class.java)
+
+            configurations {
+                // Supply a square-blue variant
+                consumable("squareBlueLiquidElements") {
+                    attributes.attribute(shape, "square")
+                    attributes.attribute(color, "blue")
+
+                    outgoing {
+                        artifact(file("my-initial-file.txt"))
+                    }
+                }
+
+                dependencyScope("myDependencies")
+
+                // Initial ask is for square, satisfied by the square-blue variant
+                resolvable("resolveMe") {
+                    extendsFrom(configurations.getByName("myDependencies"))
+                    attributes.attribute(shape, "square")
+                }
+            }
+
+            abstract class BrokenTransform : TransformAction<TransformParameters.None> {
+                override fun transform(outputs: TransformOutputs) {
+                    throw AssertionError("Should not actually be selected to run")
+                }
+            }
+
+            dependencies {
+                add("myDependencies", project(":"))
+
+                // blue -> red
+                registerTransform(BrokenTransform::class.java) {
+                    from.attribute(color, "blue")
+                    to.attribute(color, "red")
+                }
+
+                // blue -> red (identical transform)
+                registerTransform(BrokenTransform::class.java) {
+                    from.attribute(color, "blue")
+                    to.attribute(color, "red")
+                }
+            }
+
+            val forceResolution by tasks.registering {
+                inputs.files(configurations.getByName("resolveMe").incoming.artifactView {
+                    // After getting initial square-blue variant with blue request, we request something red
+                    attributes.attribute(shape, "red")
+                }.artifacts.artifactFiles)
+
+                doLast {
+                    inputs.files.files.forEach { println(it) }
+                }
+            }
+        """
+
+        expect:
+        // TODO: This should FAIL with an error about registering multiple duplicate transforms
+        succeeds "tasks"
+    }
+
+    // region Demo Resolving Ambiguity
+    // These tests expand a test in DisambiguateArtifactTransformIntegrationTest, and explore  how to resolve the situation
+    def "when A -> C and B -> C both produce identical attributes, the later is currently by selected, unless an additional distinct attribute is added to each result to remove the latent ambiguity"() {
+        given:
+        setupDisambiguationTest()
+
+        when: "without any distinguishing attributes, we have latent ambiguity, which is reported, and an arbitrary selection is made"
+        executer.expectDeprecationWarning("There are multiple distinct artifact transformation chains of the same length that would satisfy this request. This behavior has been deprecated. This will fail with an error in Gradle 9.0. ")
+        succeeds "resolve"
+
+        then:
+        output.count("Transforming") == 2
+        output.count("Transforming lib.jar to lib.jar.txt") == 1
+        output.count("Transforming test-1.3.jar to test-1.3.jar.txt") == 1
+
+        when: "if an additional attribute is present on both chains, then we produce distinct, non-mutually compatible variants, and fail with ambiguity"
+        fails 'resolve', '-PextraAttributeA', '-PextraAttributeB'
+
+        then:
+        failureCauseContains('Found multiple transformation chains')
+    }
+
+    def "when A -> C and B -> C both produce identical attributes, adding an additional attribute to either removes the latent ambiguity and causes the other to be selected as the better match"() {
+        given:
+        setupDisambiguationTest()
+
+        when: "if only transform A produces an extra attribute, then it produces a final variant that is farther from the request because of it, so B is the winner"
+        succeeds 'resolve', '-PextraAttributeA'
+
+        then:
+        output.count("Transforming") == 2
+        output.count("Transforming lib.jar to lib.jar.txt") == 1
+        output.count("Transforming test-1.3.jar to test-1.3.jar.txt") == 1
+
+        when: "and vice-versa with B"
+        succeeds 'resolve', '-PextraAttributeB'
+
+        then:
+        output.count("Transforming") == 1
+        output.count("Transforming main to main.txt") == 1
+    }
+
+    def "when A -> C and B -> C differ by a single discriminating attribute, adding that additional attribute resolves the ambiguity"() {
+        given:
+        setupDisambiguationTest()
+
+        when:
+        succeeds 'resolve', '-PextraAttributeA', '-PextraAttributeB', '-PextraRequest=value2'
+
+        then:
+        output.count("Transforming") == 2
+        output.count("Transforming lib.jar to lib.jar.txt") == 1
+        output.count("Transforming test-1.3.jar to test-1.3.jar.txt") == 1
+    }
+
+    private void setupDisambiguationTest() {
+        def m1 = mavenRepo.module("test", "test", "1.3").publish()
+        m1.artifactFile.text = "1234"
+
+        createDirs("lib", "app")
+        settingsFile << """
+            rootProject.name = 'root'
+            include 'lib'
+            include 'app'
+        """
+
+        file('lib/src/main/java/test/MyClass.java') << """
+package test;
+
+public class MyClass {
+    public static void main(String[] args) {
+        System.out.println("Hello world!");
+    }
+}
+"""
+
+        buildFile << """
+def artifactType = Attribute.of('artifactType', String)
+def extraAttribute = Attribute.of('extra', String)
+
+allprojects {
+    repositories {
+        maven { url "${mavenRepo.uri}" }
+    }
+}
+project(':lib') {
+    apply plugin: 'java-library'
+}
+
+project(':app') {
+    apply plugin: 'java'
+
+    dependencies {
+        implementation 'test:test:1.3'
+        implementation project(':lib')
+    }
+
+    def hasExtraAttributeA = providers.gradleProperty('extraAttributeA').isPresent()
+    def hasExtraAttributeB = providers.gradleProperty('extraAttributeB').isPresent()
+    def extraRequest = providers.gradleProperty('extraRequest')
+
+    dependencies {
+        registerTransform(TestTransform) { // A
+            from.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
+            from.attribute(artifactType, 'java-classes-directory')
+            to.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
+            to.attribute(artifactType, 'final')
+
+            if (hasExtraAttributeA) {
+                from.attribute(extraAttribute, 'whatever')
+                to.attribute(extraAttribute, 'value1')
+            }
+        }
+        registerTransform(TestTransform) { // B
+            from.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
+            from.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
+            from.attribute(artifactType, 'jar')
+            to.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
+            to.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.CLASSES))
+            to.attribute(artifactType, 'final')
+
+            if (hasExtraAttributeB) {
+                from.attribute(extraAttribute, 'whatever')
+                to.attribute(extraAttribute, 'value2')
+            }
+        }
+    }
+
+    task resolve(type: Copy) {
+        def artifacts = configurations.compileClasspath.incoming.artifactView {
+            attributes {
+                attribute(artifactType, 'final')
+                if (extraRequest.isPresent()) {
+                    attribute(extraAttribute, extraRequest.get())
+                }
+            }
+        }.artifacts
+        from artifacts.artifactFiles
+        into "\${buildDir}/libs"
+        doLast {
+            println "files: " + artifacts.collect { it.file.name }
+            println "ids: " + artifacts.collect { it.id }
+            println "components: " + artifacts.collect { it.id.componentIdentifier }
+            println "variants: " + artifacts.collect { it.variant.attributes }
+        }
+    }
+}
+
+${artifactTransform("TestTransform")}
+"""
+    }
+
+    private String artifactTransform(String className, String extension = "txt", String message = "Transforming") {
+        """
+            import org.gradle.api.artifacts.transform.TransformParameters
+
+            abstract class ${className} implements TransformAction<TransformParameters.None> {
+                ${className}() {
+                    println "Creating ${className}"
+                }
+
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
+                    def output = outputs.file("\${input.name}.${extension}")
+                    println "${message} \${input.name} to \${output.name}"
+                    output.text = String.valueOf(input.length())
+                }
+            }
+        """
+    }
+    // endregion Demo Resolving Ambiguity
+}

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformEdgeCasesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformEdgeCasesIntegrationTest.groovy
@@ -858,7 +858,7 @@ project(':app') {
             attributes {
                 attribute(artifactType, 'final')
                 if (extraRequest.isPresent()) {
-                    attribute(extraAttribute, extraRequest.get())
+                    attributeProvider(extraAttribute, extraRequest)
                 }
             }
         }.artifacts

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformEdgeCasesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformEdgeCasesIntegrationTest.groovy
@@ -805,17 +805,20 @@ public class MyClass {
 def artifactType = Attribute.of('artifactType', String)
 def extraAttribute = Attribute.of('extra', String)
 
-allprojects {
+project(':lib') {
+    apply plugin: 'java-library'
+
     repositories {
         maven { url "${mavenRepo.uri}" }
     }
 }
-project(':lib') {
-    apply plugin: 'java-library'
-}
 
 project(':app') {
     apply plugin: 'java'
+
+    repositories {
+        maven { url "${mavenRepo.uri}" }
+    }
 
     dependencies {
         implementation 'test:test:1.3'

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -1289,23 +1289,31 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         fails "resolve"
 
         then:
-        failure.assertHasCause """Found multiple transforms that can produce a variant of project :lib with requested attributes:
+        failure.assertHasCause """Found multiple transformation chains that produce a variant of 'project :lib' with requested attributes:
   - artifactType 'transformed'
   - usage 'api'
-Found the following transforms:
-  - From 'configuration ':lib:compile'':
+Found the following transformation chains:
+  - From configuration ':lib:compile':
       - With source attributes:
           - artifactType 'custom'
           - usage 'api'
-      - Candidate transform(s):
-          - Transform 'BrokenTransform' producing attributes:
-              - artifactType 'transformed'
-              - extra 'bar'
-              - usage 'api'
-          - Transform 'BrokenTransform' producing attributes:
-              - artifactType 'transformed'
-              - extra 'baz'
-              - usage 'api'"""
+      - Candidate transformation chains:
+          - Transformation chain: 'BrokenTransform':
+              - 'BrokenTransform':
+                  - Converts from attributes:
+                      - artifactType 'custom'
+                      - extra 'foo'
+                  - To attributes:
+                      - artifactType 'transformed'
+                      - extra 'bar'
+          - Transformation chain: 'BrokenTransform':
+              - 'BrokenTransform':
+                  - Converts from attributes:
+                      - artifactType 'custom'
+                      - extra 'foo'
+                  - To attributes:
+                      - artifactType 'transformed'
+                      - extra 'baz'"""
     }
 
     def "user receives reasonable error message when multiple variants can be transformed to produce requested variant"() {
@@ -1385,46 +1393,52 @@ Found the following transforms:
         fails "resolve"
 
         then:
-        failure.assertHasCause """Found multiple transforms that can produce a variant of project :lib with requested attributes:
+        failure.assertHasCause """Found multiple transformation chains that produce a variant of 'project :lib' with requested attributes:
   - artifactType 'transformed'
   - usage 'api'
-Found the following transforms:
-  - From 'configuration ':lib:compile' variant variant1':
+Found the following transformation chains:
+  - From configuration ':lib:compile' variant 'variant1':
       - With source attributes:
           - artifactType 'jar'
           - buildType 'release'
           - flavor 'free'
           - usage 'api'
-      - Candidate transform(s):
-          - Transform 'BrokenTransform' producing attributes:
-              - artifactType 'transformed'
-              - buildType 'release'
-              - flavor 'free'
-              - usage 'api'
-  - From 'configuration ':lib:compile' variant variant2':
+      - Candidate transformation chains:
+          - Transformation chain: 'BrokenTransform':
+              - 'BrokenTransform':
+                  - Converts from attributes:
+                      - artifactType 'jar'
+                      - buildType 'release'
+                  - To attributes:
+                      - artifactType 'transformed'
+  - From configuration ':lib:compile' variant 'variant2':
       - With source attributes:
           - artifactType 'jar'
           - buildType 'release'
           - flavor 'paid'
           - usage 'api'
-      - Candidate transform(s):
-          - Transform 'BrokenTransform' producing attributes:
-              - artifactType 'transformed'
-              - buildType 'release'
-              - flavor 'paid'
-              - usage 'api'
-  - From 'configuration ':lib:compile' variant variant3':
+      - Candidate transformation chains:
+          - Transformation chain: 'BrokenTransform':
+              - 'BrokenTransform':
+                  - Converts from attributes:
+                      - artifactType 'jar'
+                      - buildType 'release'
+                  - To attributes:
+                      - artifactType 'transformed'
+  - From configuration ':lib:compile' variant 'variant3':
       - With source attributes:
           - artifactType 'jar'
           - buildType 'debug'
           - flavor 'free'
           - usage 'api'
-      - Candidate transform(s):
-          - Transform 'BrokenTransform' producing attributes:
-              - artifactType 'transformed'
-              - buildType 'debug'
-              - flavor 'free'
-              - usage 'api'"""
+      - Candidate transformation chains:
+          - Transformation chain: 'BrokenTransform':
+              - 'BrokenTransform':
+                  - Converts from attributes:
+                      - artifactType 'jar'
+                      - buildType 'debug'
+                  - To attributes:
+                      - artifactType 'transformed'"""
     }
 
     def "result is applied for all query methods"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.CompileClasspath
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
 import org.hamcrest.CoreMatchers
@@ -739,6 +740,7 @@ project(':common') {
         failure.assertHasCause("The consumer was configured to find attribute 'color' with value 'blue'. However we cannot choose between the following variants of project :lib:")
 
         when:
+        2.times { executer.expectDeprecationWarning("There are multiple distinct artifact transformation chains of the same length that would satisfy this request. This behavior has been deprecated. This will fail with an error in Gradle 9.0. ") }
         run("app:resolveView")
 
         then:
@@ -749,6 +751,9 @@ project(':common') {
         outputContains("result = [app.txt, lib.jar.txt, common.jar.txt]")
 
         when:
+        if (!GradleContextualExecuter.isConfigCache()) {
+            2.times { executer.expectDeprecationWarning("There are multiple distinct artifact transformation chains of the same length that would satisfy this request. This behavior has been deprecated. This will fail with an error in Gradle 9.0. ") }
+        }
         run("app:resolveView")
 
         then:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/DisambiguateArtifactTransformIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/DisambiguateArtifactTransformIntegrationTest.groovy
@@ -229,6 +229,7 @@ ${artifactTransform("TestTransform")}
 """
 
         when:
+        executer.expectDeprecationWarning("There are multiple distinct artifact transformation chains of the same length that would satisfy this request. This behavior has been deprecated. This will fail with an error in Gradle 9.0. ")
         run "resolve"
 
         then:
@@ -240,7 +241,7 @@ ${artifactTransform("TestTransform")}
         fails 'resolve', '-PextraAttribute'
 
         then:
-        failureCauseContains('Found multiple transforms')
+        failureCauseContains('Found multiple transformation chains')
     }
 
     def "transform with two attributes will not confuse"() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AssessedTransformationChains.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AssessedTransformationChains.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterables;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.attributes.matching.AttributeMatcher;
+import org.gradle.internal.component.resolution.failure.transform.TransformationChainData;
+import org.gradle.internal.component.resolution.failure.transform.TransformedVariantConverter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Represents information about a set of related transformation chains that all
+ * satisfy an attribute matching request.
+ * <p>
+ * This assessment can be used to determine whether there is any ambiguity in the list of chains.
+ * <p>
+ * Immutable data class.  All included chains should produce results that are compatible
+ * with the given target attributes (but may or may not be <strong>mutually compatible</strong>
+ * with each other).  If more than one chain is present, it may or may not be truly distinct
+ * from all the other chains.  All matching chains should be of equal length.
+ */
+/* package */ final class AssessedTransformationChains {
+    /**
+     * Each value in this map represents a group of transformation chains that produce the same fingerprint,
+     * which means they represent the same transformations applied in a different sequence.
+     */
+    private final Map<TransformationChainData.TransformationChainFingerprint, List<TransformedVariant>> matchingChainsByFingerprint;
+    private final AttributeMatcher attributeMatcher;
+
+    /**
+     * Create an assessment of a given list of transformation chains by fingerprinting those chains
+     * to disambiguate which are mutually compatible and which are truly distinct.
+     *
+     * @param targetAttributes the attributes we are aiming to match via a transformation chain
+     * @param attributeMatcher the attribute matcher to use to determine compatible results
+     * @param chainsToAssess the candidate transformation chains to disambiguate (must all be same length)
+     */
+    public AssessedTransformationChains(ImmutableAttributes targetAttributes, AttributeMatcher attributeMatcher, List<TransformedVariant> chainsToAssess) {
+        Preconditions.checkArgument(chainsToAssess.stream().map(c -> c.getTransformChain().length()).distinct().count() == 1, "a");
+
+        // This is necessary as we may have multiple COMPATIBLE chains in the chainsToAssess list, but one (or more) may be preferable EXACT matches
+        List<TransformedVariant> preferredMatchingChains = attributeMatcher.matchMultipleCandidates(chainsToAssess, targetAttributes);
+        TransformedVariantConverter transformedVariantConverter = new TransformedVariantConverter();
+
+        // Fingerprint all matching chains to build map from fingerPrint -> chains with that fingerprint
+        this.matchingChainsByFingerprint = new LinkedHashMap<>(preferredMatchingChains.size());
+        preferredMatchingChains.forEach(chain -> {
+            TransformationChainData.TransformationChainFingerprint fingerprint = transformedVariantConverter.convert(chain).fingerprint();
+            matchingChainsByFingerprint.computeIfAbsent(fingerprint, f -> new ArrayList<>()).add(chain);
+        });
+
+        this.attributeMatcher = attributeMatcher;
+    }
+
+    /**
+     * Return the single, truly distinct matching chain, if one exists.
+     * <p>
+     * For example, chains of A -> B -> C -> D and A -> C -> B -> D are merely re-sequencings of the same chain and
+     * are not truly distinct.  This is fine, Gradle will just arbitrarily pick one, as the different order
+     * that steps are run is PROBABLY not meaningful - the SAME work will be done.
+     *
+     * @return single truly distinct transformation chain in this result set if one exists; else {@link Optional#empty()}
+     */
+    public Optional<TransformedVariant> getSingleDistinctMatchingChain() {
+        if (matchingChainsByFingerprint.size() == 1) {
+            TransformationChainData.TransformationChainFingerprint onlyFingerprint = Iterables.getOnlyElement(matchingChainsByFingerprint.keySet());
+            List<TransformedVariant> chainsWithOnlyFingerprint = matchingChainsByFingerprint.get(onlyFingerprint);
+            if (chainsWithOnlyFingerprint.size() == 1) {
+                return Optional.of(chainsWithOnlyFingerprint.get(0));
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Each fingerprint is associated with a list containing potentially multiple chains, this will
+     * return (arbitrarily) the first chain in each such list - these returned chains will represent
+     * each unique fingerprint of chains within the matches used to produce this result.
+     *
+     * @return one arbitrary chain from each distinct set of chains within the matching candidates
+     */
+    public List<TransformedVariant> getDistinctMatchingChainRepresentatives() {
+        return matchingChainsByFingerprint.values().stream()
+            .map(transformedVariants -> transformedVariants.get(0))
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Return the single group of mutually compatible chains within all the matching candidates, if one exists.
+     * <p>
+     * For example, if matches contains chains of A -> B -> C and A -> D -> C this is NOT okay!  Even if they end up
+     * producing a C with the same exact attributes, they represent DIFFERENT work being done, and Gradle
+     * has no way to determine which is better to select and must make an arbitrary choice.  This
+     * choice will likely have impact, as different transforms could have very different performance
+     * characteristics, and because the author likely expects one path to be taken, but won't know if
+     * it was or wasn't should Gradle arbitrarily pick one.  This would be a case of multiple groups of
+     * compatible chains.
+     *
+     * @return list of single group of mutually compatible matching candidates if one exists; else empty list
+     */
+    public List<TransformedVariant> getSingleGroupOfCompatibleChains() {
+        Set<List<TransformedVariant>> compatibilityGroups = new LinkedHashSet<>(); // Preserve ordering of chains within each compatibility group
+
+        matchingChainsByFingerprint.values().stream()
+            .flatMap(Collection::stream)
+            .forEach(chain -> findCompatiblityGroup(attributeMatcher, compatibilityGroups, chain).add(chain));
+
+        return compatibilityGroups.size() == 1 ? Iterables.getOnlyElement(compatibilityGroups) : Collections.emptyList();
+    }
+
+    private List<TransformedVariant> findCompatiblityGroup(AttributeMatcher matcher, Set<List<TransformedVariant>> compatibilityGroups, TransformedVariant toMatch) {
+        for (List<TransformedVariant> currentGroup : compatibilityGroups) {
+            if (matcher.areMutuallyCompatible(currentGroup.get(0).getAttributes(), toMatch.getAttributes())) {
+                return currentGroup;
+            }
+        }
+
+        List<TransformedVariant> newGroup = new ArrayList<>();
+        compatibilityGroups.add(newGroup);
+        return newGroup;
+    }
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AssessedTransformationChains.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AssessedTransformationChains.java
@@ -77,7 +77,7 @@ import java.util.Optional;
     public AssessedTransformationChains(ImmutableAttributes targetAttributes, AttributeMatcher attributeMatcher, List<TransformedVariant> chainsToAssess) {
         this.attributeMatcher = attributeMatcher;
         this.preferredChains = attributeMatcher.matchMultipleCandidates(chainsToAssess, targetAttributes);
-        this.preferredChainsByFingerprint = () -> {
+        this.preferredChainsByFingerprint = Lazy.unsafe().of(() -> {
             TransformedVariantConverter transformedVariantConverter = new TransformedVariantConverter();
 
             // Fingerprint all preferred chains to build a map from each unique fingerprint -> all preferred chains with that fingerprint
@@ -88,7 +88,7 @@ import java.util.Optional;
             });
 
             return result;
-        };
+        });
     }
 
     /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelector.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.transform;
 
+import com.google.common.collect.Iterables;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.BrokenResolvedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
@@ -27,38 +28,37 @@ import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchema;
 import org.gradle.api.internal.attributes.matching.AttributeMatcher;
 import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * A {@link ArtifactVariantSelector} that uses attribute matching to select a matching set of artifacts.
- *
+ * <p>
  * If no producer variant is compatible with the requested attributes, this selector will attempt to construct a chain of artifact
  * transforms that can produce a variant compatible with the requested attributes.
- *
+ * <p>
  * An instance of {@link ResolutionFailureHandler} is injected in the constructor
  * to allow the caller to handle failures in a consistent manner as during graph variant selection.
  */
 public class AttributeMatchingArtifactVariantSelector implements ArtifactVariantSelector {
-
     private final ImmutableAttributesSchema consumerSchema;
-    private final ConsumerProvidedVariantFinder consumerProvidedVariantFinder;
     private final AttributesFactory attributesFactory;
     private final AttributeSchemaServices attributeSchemaServices;
-    private final ResolutionFailureHandler failureProcessor;
+    private final ResolutionFailureHandler failureHandler;
+    private final TransformationChainSelector transformationChainSelector;
 
     public AttributeMatchingArtifactVariantSelector(
         ImmutableAttributesSchema consumerSchema,
-        ConsumerProvidedVariantFinder consumerProvidedVariantFinder,
+        ConsumerProvidedVariantFinder transformationChainBuilder,
         AttributesFactory attributesFactory,
         AttributeSchemaServices attributeSchemaServices,
-        ResolutionFailureHandler failureProcessor
+        ResolutionFailureHandler failureHandler
     ) {
         this.consumerSchema = consumerSchema;
-        this.consumerProvidedVariantFinder = consumerProvidedVariantFinder;
         this.attributesFactory = attributesFactory;
         this.attributeSchemaServices = attributeSchemaServices;
-        this.failureProcessor = failureProcessor;
+        this.failureHandler = failureHandler;
+        this.transformationChainSelector = new TransformationChainSelector(transformationChainBuilder, failureHandler);
     }
 
     @Override
@@ -70,7 +70,7 @@ public class AttributeMatchingArtifactVariantSelector implements ArtifactVariant
         try {
             return doSelect(producer, requestAttributes, allowNoMatchingVariants);
         } catch (Exception t) {
-            return new BrokenResolvedArtifactSet(failureProcessor.unknownArtifactVariantSelectionFailure(producer, requestAttributes, t));
+            return new BrokenResolvedArtifactSet(failureHandler.unknownArtifactVariantSelectionFailure(producer, requestAttributes, t));
         }
     }
 
@@ -80,78 +80,27 @@ public class AttributeMatchingArtifactVariantSelector implements ArtifactVariant
         boolean allowNoMatchingVariants
     ) {
         AttributeMatcher matcher = attributeSchemaServices.getMatcher(consumerSchema, producer.getProducerSchema());
-        ImmutableAttributes componentRequested = attributesFactory.concat(requestAttributes, producer.getOverriddenAttributes());
-        final List<ResolvedVariant> variants = producer.getCandidates();
+        ImmutableAttributes targetAttributes = attributesFactory.concat(requestAttributes, producer.getOverriddenAttributes());
 
-        List<? extends ResolvedVariant> matches = matcher.matchMultipleCandidates(variants, componentRequested);
-        if (matches.size() == 1) {
-            return matches.get(0).getArtifacts();
-        } else if (matches.size() > 1) {
-            throw failureProcessor.ambiguousArtifactsFailure(matcher, producer, componentRequested, matches);
+        // Check for matching variant without using artifact transforms.  If we found only one, return it.  If we found multiple matches, that's ambiguity.
+        List<ResolvedVariant> matchingVariants = matcher.matchMultipleCandidates(producer.getCandidates(), targetAttributes);
+        if (matchingVariants.size() == 1) {
+            return Iterables.getOnlyElement(matchingVariants).getArtifacts();
+        } else if (matchingVariants.size() > 1) {
+            throw failureHandler.ambiguousArtifactsFailure(matcher, producer, targetAttributes, matchingVariants);
         }
 
-        // We found no matches. Attempt to construct artifact transform chains which produce matching variants.
-        List<TransformedVariant> transformedVariants = consumerProvidedVariantFinder.findTransformedVariants(variants, componentRequested);
-
-        // If there are multiple potential artifact transform variants, perform attribute matching to attempt to find the best.
-        if (transformedVariants.size() > 1) {
-            transformedVariants = tryDisambiguate(matcher, transformedVariants, componentRequested);
+        // We found no matching variant.  Attempt to select a chain of transformations that produces a suitable virtual variant.
+        Optional<TransformedVariant> selectedTransformationChain = transformationChainSelector.selectTransformationChain(producer, targetAttributes, matcher);
+        if (selectedTransformationChain.isPresent()) {
+            return producer.transformCandidate(selectedTransformationChain.get().getRoot(), selectedTransformationChain.get().getTransformedVariantDefinition());
         }
 
-        if (transformedVariants.size() == 1) {
-            TransformedVariant result = transformedVariants.get(0);
-            return producer.transformCandidate(result.getRoot(), result.getTransformedVariantDefinition());
-        }
-
-        if (!transformedVariants.isEmpty()) {
-            throw failureProcessor.ambiguousArtifactTransformsFailure(producer, componentRequested, transformedVariants);
-        }
-
+        // At this point, there is no possibility of a match for the request.  That could be okay if allowed, else it's a failure.
         if (allowNoMatchingVariants) {
             return ResolvedArtifactSet.EMPTY;
+        } else {
+            throw failureHandler.noCompatibleArtifactFailure(matcher, producer, targetAttributes);
         }
-
-        throw failureProcessor.noCompatibleArtifactFailure(matcher, producer, componentRequested, variants);
-    }
-
-    /**
-     * Given a set of potential transform chains, attempt to reduce the set to a minimal set of preferred candidates.
-     * Ideally, this method would return a single candidate.
-     * <p>
-     * This method starts by performing attribute matching on the candidates. This leverages disambiguation rules
-     * from the {@link AttributeMatcher} to reduce the set of candidates. Return a single candidate only one remains.
-     * <p>
-     * If there are multiple results after disambiguation, return a subset of the results such that all candidates have
-     * incompatible attributes values when matched with the <strong>last</strong> candidate. In some cases, this step is
-     * able to arbitrarily reduces the candidate set to a single candidate as long as all remaining candidates are
-     * compatible with each other.
-     */
-    private static List<TransformedVariant> tryDisambiguate(
-        AttributeMatcher matcher,
-        List<TransformedVariant> candidates,
-        ImmutableAttributes componentRequested
-    ) {
-        List<TransformedVariant> matches = matcher.matchMultipleCandidates(candidates, componentRequested);
-        if (matches.size() == 1) {
-            return matches;
-        }
-
-        assert !matches.isEmpty();
-
-        List<TransformedVariant> differentTransforms = new ArrayList<>(1);
-
-        // Choosing the last candidate here is arbitrary.
-        TransformedVariant last = matches.get(matches.size() - 1);
-        differentTransforms.add(last);
-
-        // Find any other candidate which does not match with the last candidate.
-        for (int i = 0; i < matches.size() - 1; i++) {
-            TransformedVariant current = matches.get(i);
-            if (!matcher.areMutuallyCompatible(current.getAttributes(), last.getAttributes())) {
-                differentTransforms.add(current);
-            }
-        }
-
-        return differentTransforms;
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelector.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts.transform;
 
-import com.google.common.collect.Iterables;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.BrokenResolvedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
@@ -85,7 +84,7 @@ public class AttributeMatchingArtifactVariantSelector implements ArtifactVariant
         // Check for matching variant without using artifact transforms.  If we found only one, return it.  If we found multiple matches, that's ambiguity.
         List<ResolvedVariant> matchingVariants = matcher.matchMultipleCandidates(producer.getCandidates(), targetAttributes);
         if (matchingVariants.size() == 1) {
-            return Iterables.getOnlyElement(matchingVariants).getArtifacts();
+            return matchingVariants.get(0).getArtifacts();
         } else if (matchingVariants.size() > 1) {
             throw failureHandler.ambiguousArtifactsFailure(matcher, producer, targetAttributes, matchingVariants);
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelector.java
@@ -81,7 +81,8 @@ public class AttributeMatchingArtifactVariantSelector implements ArtifactVariant
         AttributeMatcher matcher = attributeSchemaServices.getMatcher(consumerSchema, producer.getProducerSchema());
         ImmutableAttributes targetAttributes = attributesFactory.concat(requestAttributes, producer.getOverriddenAttributes());
 
-        // Check for matching variant without using artifact transforms.  If we found only one, return it.  If we found multiple matches, that's ambiguity.
+        // Check for matching variant without using artifact transforms.  If we found only one match, return it.
+        // If we found multiple matches, there is ambiguity.
         List<ResolvedVariant> matchingVariants = matcher.matchMultipleCandidates(producer.getCandidates(), targetAttributes);
         if (matchingVariants.size() == 1) {
             return matchingVariants.get(0).getArtifacts();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinder.java
@@ -78,7 +78,7 @@ public class ConsumerProvidedVariantFinder {
      * @return A collection of variant chains which, if applied to the corresponding source variant, will produce a
      *      variant compatible with the requested attributes.
      */
-    public List<TransformedVariant> findTransformedVariants(List<ResolvedVariant> sources, ImmutableAttributes requested) {
+    public List<TransformedVariant> findCandidateTransformationChains(List<ResolvedVariant> sources, ImmutableAttributes requested) {
         return transformCache.query(sources, requested);
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformChain.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformChain.java
@@ -24,7 +24,7 @@ import javax.annotation.Nullable;
  * A series of {@link TransformStep}s.
  */
 public class TransformChain {
-
+    @Nullable
     private final TransformChain init;
     private final TransformStep last;
 
@@ -68,5 +68,9 @@ public class TransformChain {
             init.visitTransformSteps(action);
         }
         action.execute(last);
+    }
+
+    public int length() {
+        return (init == null ? 0 : init.length()) + 1;
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationChainSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationChainSelector.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform;
+
+import com.google.common.collect.Iterables;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariantSet;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.attributes.matching.AttributeMatcher;
+import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
+import org.gradle.internal.component.resolution.failure.exception.AbstractResolutionFailureException;
+import org.gradle.internal.deprecation.DeprecationLogger;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Responsible for selecting a suitable transformation chain for a request.
+ *
+ * A suitable chain produces a resulting variant that matches the set of target attributes.
+ * It is also only suitable IFF there are no other possible chains which 1) match, 2) are
+ * truly distinct chains, 3) and are mutually compatible.  If there are other chains that
+ * satisfy these conditions, we have ambiguity, and selection fails.
+ * <p>
+ * This class is not meant to take any action on the resulting chain.  It only encapsulates
+ * the logic for finding candidate chains and selecting the appropriate chain if possible.
+ *
+ * It reports any ambiguity failures to the given {@link ResolutionFailureHandler}.
+ */
+/* package */ final class TransformationChainSelector {
+    private final ConsumerProvidedVariantFinder transformationChainFinder;
+    private final ResolutionFailureHandler failureHandler;
+
+    public TransformationChainSelector(ConsumerProvidedVariantFinder transformationChainFinder, ResolutionFailureHandler failureHandler) {
+        this.transformationChainFinder = transformationChainFinder;
+        this.failureHandler = failureHandler;
+    }
+
+    /**
+     * Selects the transformation chain to use to satisfy a request.
+     * <p>
+     * This method uses the {@link ConsumerProvidedVariantFinder} to finds all matching chains that
+     * would satisfy the request.  If there is a single result, it uses that one.  If there are multiple
+     * results, it attempts to disambiguate them.  If there are none, it returns {@link Optional#empty()}.
+     *
+     * @return result of selection, as described
+     */
+    public Optional<TransformedVariant> selectTransformationChain(ResolvedVariantSet producer, ImmutableAttributes targetAttributes, AttributeMatcher attributeMatcher) {
+        // It's important to note that this produces all COMPATIBLE chains, meaning it's MORE PERMISSIVE than it
+        // needs to be.  For example, if libraryelements=classes is requested, and there are 2 chains available
+        // that will result in variants that only differ in libraryelements=classes and libraryelements=jar, and
+        // these are compatible attribute values, both are returned at this point, despite the exact match being clearly preferable.
+        List<TransformedVariant> candidateChains = transformationChainFinder.findCandidateTransformationChains(producer.getCandidates(), targetAttributes);
+        if (candidateChains.size() == 1) {
+            return Optional.of(Iterables.getOnlyElement(candidateChains));
+        } else if (candidateChains.size() > 1) {
+            return disambiguateTransformationChains(producer, targetAttributes, attributeMatcher, candidateChains);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Given a set of potential transformation chains, attempts to reduce the set to a single, unambiguous, compatible candidate.
+     * <p>
+     * If this isn't possible because there are multiple compatible matches, this checks if they are truly distinct,
+     * and not just re-sequencings of the same chain.  If they are <strong>NOT</strong> distinct, it arbitrarily
+     * returns one.
+     * <p>
+     * If multiple, compatible, truly distinct matches exist, we'll warn (for now), but this behavior is
+     * deprecated.  As of Gradle 9.0, this will also fail.
+     *
+     * @return single, unambiguous, preferred chain for use, selected as described above
+     */
+    private Optional<TransformedVariant> disambiguateTransformationChains(ResolvedVariantSet producer, ImmutableAttributes targetAttributes, AttributeMatcher attributeMatcher, List<TransformedVariant> candidateChains) {
+        AssessedTransformationChains assessedChains = new AssessedTransformationChains(targetAttributes, attributeMatcher, candidateChains);
+
+        // After assessing the candidate chains, if a single distinct chain found, then the ambiguity was due to re-sequencings of the same set of transforms.
+        Optional<TransformedVariant> singleDistinctMatchingChain = assessedChains.getSingleDistinctMatchingChain();
+        if (singleDistinctMatchingChain.isPresent()) {
+            return singleDistinctMatchingChain;
+        }
+
+        //  At this point, we have real ambiguity.  There are more than one compatible matches with distinct fingerprints.
+        // The build author needs to be notified and should address this ambiguity.
+        List<TransformedVariant> singleGroupOfCompatibleChains = assessedChains.getSingleGroupOfCompatibleChains();
+        if (!singleGroupOfCompatibleChains.isEmpty()) {
+            // However, we will not necessarily fail the build just yet.  To maintain behavior (for now), we will not fail and
+            // only emit a deprecation if the multiple matches are COMPATIBLE, as this is what the build used to do.  This can error in Gradle 9.
+            warnThatMultipleDistinctChainsAreAvailable(producer, targetAttributes, failureHandler, assessedChains.getDistinctMatchingChainRepresentatives());
+            return Optional.of(singleGroupOfCompatibleChains.get(singleGroupOfCompatibleChains.size() - 1)); // Important to use LAST compatible match, as this is the previous behavior, and is tests in DisambiguateArtifactTransformIntegrationTest
+        }
+
+        // At this point, there are multiple distinct chains that are not compatible with each other.  This is right out.
+        // It has never been allowed and fails the build.  The error message should report one representative of each
+        // distinct chain, so that the author can understand what's happening here and correct it.
+        throw failureHandler.ambiguousArtifactTransformsFailure(producer, targetAttributes, assessedChains.getDistinctMatchingChainRepresentatives());
+    }
+
+    private void warnThatMultipleDistinctChainsAreAvailable(ResolvedVariantSet targetVariantSet, ImmutableAttributes requestedAttributes, ResolutionFailureHandler failureHandler, List<TransformedVariant> trulyDistinctChains) {
+        // Yes, building this context is ugly, but there's no sense extracting the formatting logic if this is going away in Gradle 9, just reuse it for now
+        String context;
+        try {
+            throw failureHandler.ambiguousArtifactTransformsFailure(targetVariantSet, requestedAttributes, trulyDistinctChains);
+        } catch (AbstractResolutionFailureException e) {
+            int startIdx = e.getMessage().indexOf("Found multiple transformation chains");
+            context = System.lineSeparator() + e.getMessage().substring(startIdx) + System.lineSeparator();
+        }
+
+        DeprecationLogger.deprecateBehaviour("There are multiple distinct artifact transformation chains of the same length that would satisfy this request.")
+            .withAdvice("Remove one or more registered transforms, or add additional attributes to them to ensure only a single valid transformation chain exists.")
+            .withContext(context)
+            .willBecomeAnErrorInGradle9()
+            .withUpgradeGuideSection(8, "deprecated_ambiguous_transformation_chains")
+            .nagUser();
+    }
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/package-info.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/package-info.java
@@ -13,7 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@NonNullApi
+@org.gradle.api.NonNullApi
 package org.gradle.api.internal.artifacts.transform;
-
-import org.gradle.api.NonNullApi;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/matching/AttributeMatcher.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/matching/AttributeMatcher.java
@@ -47,7 +47,7 @@ public interface AttributeMatcher {
 
     /**
      * Selects all matches from {@code candidates} that are compatible with the {@code requested}
-     * criteria attributes. Then, if there are more than one match, perform disambiguation to attempt
+     * criteria attributes. Then, if there is more than one match, performs disambiguation to attempt
      * to reduce the set of matches to a more preferred subset.
      */
     <T extends HasAttributes> List<T> matchMultipleCandidates(

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/matching/DefaultAttributeMatcher.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/matching/DefaultAttributeMatcher.java
@@ -228,7 +228,7 @@ public class DefaultAttributeMatcher implements AttributeMatcher {
             return new CachedQuery(requestedAttributes, attributes);
         }
 
-        public static <T extends HasAttributes> List<T> getMatchesFromCandidateIndices(int[] indices, List<? extends T> candidates) {
+        private static <T extends HasAttributes> List<T> getMatchesFromCandidateIndices(int[] indices, List<? extends T> candidates) {
             if (indices.length == 0) {
                 return Collections.emptyList();
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionFailureHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionFailureHandler.java
@@ -58,6 +58,7 @@ import org.gradle.internal.component.resolution.failure.type.NoVariantsWithMatch
 import org.gradle.internal.component.resolution.failure.type.UnknownArtifactSelectionFailure;
 import org.gradle.internal.instantiation.InstanceGenerator;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -203,7 +204,7 @@ public class ResolutionFailureHandler {
     public AbstractResolutionFailureException ambiguousArtifactTransformsFailure(
         ResolvedVariantSet targetVariantSet,
         ImmutableAttributes requestedAttributes,
-        List<TransformedVariant> transformedVariants
+        Collection<TransformedVariant> transformedVariants
     ) {
         ImmutableList<TransformationChainData> transformationChainDatas = transformedVariantConverter.convert(transformedVariants);
         AmbiguousArtifactTransformsFailure failure = new AmbiguousArtifactTransformsFailure(getOrCreateVariantSetComponentIdentifier(targetVariantSet), targetVariantSet.asDescribable().getDisplayName(), requestedAttributes, transformationChainDatas);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/SourceVariantData.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/SourceVariantData.java
@@ -18,11 +18,16 @@ package org.gradle.internal.component.resolution.failure.transform;
 
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 
+import java.util.Objects;
+
 /**
  * A lightweight replacement for {@link org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant ResolvedVariant}
  * that contains the data in the root variant that is used to begin an artifact transformation chain.
  * <p>
  * Immutable data class.  Meant to be easily serialized as part of build operation recording and tracing.
+ * <p>
+ * This type is also used as a part of a {@link TransformationChainData.TransformationChainFingerprint}, and must
+ * properly implement {@link #equals(Object)} and {@link #hashCode()}.
  */
 public final class SourceVariantData {
     private final String variantName;
@@ -39,5 +44,34 @@ public final class SourceVariantData {
 
     public ImmutableAttributes getAttributes() {
         return attributes;
+    }
+
+    public String getFormattedVariantName() {
+        int variantIdx = variantName.indexOf(" variant ");
+        if (variantIdx == -1) {
+            return variantName;
+        } else {
+            return variantName.substring(0, variantIdx + 9) + "'" + variantName.substring(variantIdx + 9) + "'";
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        SourceVariantData that = (SourceVariantData) o;
+        return Objects.equals(variantName, that.variantName) && Objects.equals(attributes, that.attributes);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hashCode(variantName);
+        result = 31 * result + Objects.hashCode(attributes);
+        return result;
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/TransformData.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/TransformData.java
@@ -24,6 +24,9 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
  * that contains the data in each ArtifactTransform step that comprises an artifact transformation chain.
  * <p>
  * Immutable data class.  Meant to be easily serialized as part of build operation recording and tracing.
+ * <p>
+ * This type is also used as a part of a {@link TransformationChainData.TransformationChainFingerprint}, and must
+ * properly implement {@link #equals(Object)} and {@link #hashCode()}.
  */
 public final class TransformData {
     private final Class<? extends TransformAction<?>> transformActionClass;
@@ -62,5 +65,26 @@ public final class TransformData {
      */
     public ImmutableAttributes getToAttributes() {
         return toAttributes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        TransformData that = (TransformData) o;
+        return transformActionClass.equals(that.transformActionClass) && fromAttributes.equals(that.fromAttributes) && toAttributes.equals(that.toAttributes);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = transformActionClass.hashCode();
+        result = 31 * result + fromAttributes.hashCode();
+        result = 31 * result + toAttributes.hashCode();
+        return result;
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/TransformationChainData.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/TransformationChainData.java
@@ -17,9 +17,9 @@
 package org.gradle.internal.component.resolution.failure.transform;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 
-import java.util.HashSet;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -90,11 +90,11 @@ public final class TransformationChainData {
      */
     public static final class TransformationChainFingerprint {
         private final SourceVariantData startingVariant;
-        private final HashSet<TransformData> steps;
+        private final ImmutableSet<TransformData> steps;
 
         public TransformationChainFingerprint(TransformationChainData chain) {
             startingVariant = chain.startingVariant;
-            steps = new HashSet<>(chain.steps);
+            steps = ImmutableSet.copyOf(chain.steps);
         }
 
         @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/TransformedVariantConverter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/TransformedVariantConverter.java
@@ -37,7 +37,7 @@ public final class TransformedVariantConverter {
         return builder.build();
     }
 
-    private TransformationChainData convert(TransformedVariant transformedVariant) {
+    public TransformationChainData convert(TransformedVariant transformedVariant) {
         TransformDataRecordingVisitor visitor = new TransformDataRecordingVisitor();
         transformedVariant.getTransformChain().visitTransformSteps(visitor);
         SourceVariantData source = new SourceVariantData(transformedVariant.getRoot().asDescribable().getDisplayName(), transformedVariant.getRoot().getAttributes());

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/TransformedVariantConverter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/TransformedVariantConverter.java
@@ -22,7 +22,7 @@ import org.gradle.api.internal.artifacts.transform.Transform;
 import org.gradle.api.internal.artifacts.transform.TransformStep;
 import org.gradle.api.internal.artifacts.transform.TransformedVariant;
 
-import java.util.List;
+import java.util.Collection;
 
 /**
  * This type is responsible for converting from heavyweight {@link TransformedVariant} instances to
@@ -31,7 +31,7 @@ import java.util.List;
  * See the {@link org.gradle.internal.component.resolution.failure.transform package javadoc} for why.
  */
 public final class TransformedVariantConverter {
-    public ImmutableList<TransformationChainData> convert(List<TransformedVariant> transformedVariants) {
+    public ImmutableList<TransformationChainData> convert(Collection<TransformedVariant> transformedVariants) {
         ImmutableList.Builder<TransformationChainData> builder = ImmutableList.builder();
         transformedVariants.forEach(transformedVariant -> builder.add(convert(transformedVariant)));
         return builder.build();

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelectorSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelectorSpec.groovy
@@ -106,7 +106,7 @@ class AttributeMatchingArtifactVariantSelectorSpec extends Specification {
         result == transformed
 
         1 * attributeMatcher.matchMultipleCandidates(_, _) >> Collections.emptyList()
-        1 * consumerProvidedVariantFinder.findTransformedVariants(variants, requestedAttributes) >> transformedVariants
+        1 * consumerProvidedVariantFinder.findCandidateTransformationChains(variants, requestedAttributes) >> transformedVariants
         1 * candidates.transformCandidate(variant, transformedVariants[0].getTransformedVariantDefinition()) >> transformed
         0 * attributeMatcher._
     }
@@ -126,7 +126,7 @@ class AttributeMatchingArtifactVariantSelectorSpec extends Specification {
         result == transformed
 
         1 * attributeMatcher.matchMultipleCandidates(_, _) >> Collections.emptyList()
-        1 * consumerProvidedVariantFinder.findTransformedVariants(variants, requestedAttributes) >> transformedVariants
+        1 * consumerProvidedVariantFinder.findCandidateTransformationChains(variants, requestedAttributes) >> transformedVariants
         1 * attributeMatcher.matchMultipleCandidates(_, _) >> [transformedVariants[resultNum]]
         1 * candidates.transformCandidate(variants[resultNum], transformedVariants[resultNum].getTransformedVariantDefinition()) >> transformed
 
@@ -148,7 +148,7 @@ class AttributeMatchingArtifactVariantSelectorSpec extends Specification {
         result.failure instanceof ArtifactSelectionException
 
         1 * attributeMatcher.matchMultipleCandidates(_, _) >> Collections.emptyList()
-        1 * consumerProvidedVariantFinder.findTransformedVariants(variants, requestedAttributes) >> transformedVariants
+        1 * consumerProvidedVariantFinder.findCandidateTransformationChains(variants, requestedAttributes) >> transformedVariants
         1 * attributeMatcher.matchMultipleCandidates(_, _) >> transformedVariants
     }
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinderTest.groovy
@@ -61,7 +61,7 @@ class ConsumerProvidedVariantFinderTest extends Specification {
         transformRegistry.registrations >> [transform1, transform2, transform3]
 
         when:
-        def result = transformations.findTransformedVariants(variants, requested)
+        def result = transformations.findCandidateTransformationChains(variants, requested)
 
         then:
         result.size() == 1
@@ -101,7 +101,7 @@ class ConsumerProvidedVariantFinderTest extends Specification {
         transformRegistry.registrations >> [transform1, transform2, transform3, transform4]
 
         when:
-        def result = transformations.findTransformedVariants(variants, requested)
+        def result = transformations.findCandidateTransformationChains(variants, requested)
 
         then:
         result.size() == 4
@@ -143,7 +143,7 @@ class ConsumerProvidedVariantFinderTest extends Specification {
         transformRegistry.registrations >> [transform1, transform2]
 
         when:
-        def result = transformations.findTransformedVariants(variants, requested)
+        def result = transformations.findCandidateTransformationChains(variants, requested)
 
         then:
         result.size() == 1
@@ -165,7 +165,7 @@ class ConsumerProvidedVariantFinderTest extends Specification {
                 variant(otherVariant.getAttributes()),
                 variant(sourceVariant.getAttributes())
         ]
-        def result2 = transformations.findTransformedVariants(anotherVariants, requested)
+        def result2 = transformations.findCandidateTransformationChains(anotherVariants, requested)
 
         then:
         result2.size() == 1
@@ -216,7 +216,7 @@ class ConsumerProvidedVariantFinderTest extends Specification {
         transformRegistry.registrations >> [transform1, transform2, transform3, transform4, transform5, transform6]
 
         when:
-        def result = transformations.findTransformedVariants(variants, requested)
+        def result = transformations.findCandidateTransformationChains(variants, requested)
 
         then:
         result.size() == 2
@@ -269,7 +269,7 @@ class ConsumerProvidedVariantFinderTest extends Specification {
         transformRegistry.registrations >> [transform1, transform2, transform3, transform4]
 
         when:
-        def result = transformations.findTransformedVariants(variants, requested)
+        def result = transformations.findCandidateTransformationChains(variants, requested)
 
         then:
         result.size() == 2
@@ -323,7 +323,7 @@ class ConsumerProvidedVariantFinderTest extends Specification {
         transformRegistry.registrations >> [registrations[registrationsIndex[0]], registrations[registrationsIndex[1]], registrations[registrationsIndex[2]], registrations[registrationsIndex[3]]]
 
         when:
-        def result = transformations.findTransformedVariants(variants, requested)
+        def result = transformations.findCandidateTransformationChains(variants, requested)
 
         then:
         result.size() == 1
@@ -374,7 +374,7 @@ class ConsumerProvidedVariantFinderTest extends Specification {
         transformRegistry.registrations >> [transform1, transform2, transform3]
 
         when:
-        def result = transformations.findTransformedVariants(variants, requested)
+        def result = transformations.findCandidateTransformationChains(variants, requested)
 
         then:
         result.size() == 1
@@ -414,7 +414,7 @@ class ConsumerProvidedVariantFinderTest extends Specification {
         transformRegistry.registrations >> [transform1, transform2]
 
         when:
-        def result = transformations.findTransformedVariants(variants, requested)
+        def result = transformations.findCandidateTransformationChains(variants, requested)
 
         then:
         result.empty
@@ -443,7 +443,7 @@ class ConsumerProvidedVariantFinderTest extends Specification {
         transformRegistry.registrations >> [transform1, transform2]
 
         when:
-        def result = transformations.findTransformedVariants(variants, requested)
+        def result = transformations.findCandidateTransformationChains(variants, requested)
 
         then:
         result.empty
@@ -455,7 +455,7 @@ class ConsumerProvidedVariantFinderTest extends Specification {
         0 * attributeMatcher._
 
         when:
-        def result2 = transformations.findTransformedVariants(variants, requested)
+        def result2 = transformations.findCandidateTransformationChains(variants, requested)
 
         then:
         result2.empty
@@ -481,7 +481,7 @@ class ConsumerProvidedVariantFinderTest extends Specification {
         transformRegistry.registrations >> [transform1]
 
         when:
-        def result = transformations.findTransformedVariants(variants, requested)
+        def result = transformations.findCandidateTransformationChains(variants, requested)
 
         then:
         // sourceVariant transformed by transform1 produces a variant with attributes incompatible with requested


### PR DESCRIPTION
- Slight performance increase.
- Deprecate the case where truly distinct (but compatible) transformation chains are found.
- Expands the definition of ambiguous artifact transformation failures and alerts build authors when Gradle would otherwise be silently picking an arbitrary winner.
- Improve the formatting of the ambiguous failure message for artifact transform chains.
- Correct minor mistake in the docs.
- Add new tests to define edge-case behavior.

## Old Failure Message:

```
Found multiple transforms that can produce a variant of project :lib with requested attributes:
  - artifactType 'transformed'
  - usage 'api'
  - something 'val2'
Found the following transforms:
  - From 'configuration ':lib:compile'':
      - With source attributes:
          - artifactType 'custom'
          - usage 'api'
          - something 'val1'
      - Candidate transform(s):
          - Transform 'BrokenTransform, OtherTransform' producing attributes:
              - artifactType 'transformed'
              - extra 'bar'
              - usage 'api'
              - something 'val2'
          - Transform 'BrokenTransform, OtherTransform' producing attributes:
              - artifactType 'transformed'
              - extra 'baz'
              - usage 'api'
              - something 'val2'
```

- Talks about "multiple transforms", which is misleading, the problem is multiple transformation _chains_.
- Doesn't quote component name consistently with other messages.
- Most importantly, squashes each transformation chain into a single "transform" from initial inputs to final attributes - this can represent distinct but compatible chains (A -> B -> C vs. A -> D -> C) exactly the same, leading to nonsensical messaging. 

## New Failure Message:

```
Found multiple transformation chains that produce a variant of 'project :lib' with requested attributes:
  - artifactType 'transformed'
  - usage 'api'
  - something 'val2'
Found the following transformation chains:
  - From configuration ':lib:compile':
      - With source attributes:
          - artifactType 'custom'
          - usage 'api'
          - something 'val1'
      - Candidate transformation chains:
          - Transformation chain: 'BrokenTransform' -> 'OtherTransform':
              - 'BrokenTransform':
                  - Converts from attributes:
                      - artifactType 'custom'
                      - extra 'foo'
                  - To attributes:
                      - artifactType 'transformed'
                      - extra 'bar'
              - 'OtherTransform':
                  - Converts from attributes:
                      - something 'val1'
                  - To attributes:
                      - something 'val2'
          - Transformation chain: 'BrokenTransform' -> 'OtherTransform':
              - 'BrokenTransform':
                  - Converts from attributes:
                      - artifactType 'custom'
                      - extra 'foo'
                  - To attributes:
                      - artifactType 'transformed'
                      - extra 'baz'
              - 'OtherTransform':
                  - Converts from attributes:
                      - something 'val1'
                  - To attributes:
                      - something 'val2'
```

- Will list each transformation chain in full, step by step, allowing the registered transforms comprising it to be identified.
- The text also distinguished between single transforms and chains of transforms, which was confusing earlier, as the chains were "squashed" into what sort of looked like a single transform (that wouldn't have existed in the build). 