### PR TITLE
Use a non-caching non-reporting JVM metadata detector when provisioning

### DIFF
--- a/platforms/core-runtime/client-services/build.gradle.kts
+++ b/platforms/core-runtime/client-services/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
     implementation(projects.buildOperations)
     implementation(projects.buildProcessServices)
     implementation(projects.fileOperations)
+    implementation(projects.fileTemp)
     implementation(projects.instrumentationAgentServices)
     implementation(projects.loggingApi)
     implementation(projects.time)

--- a/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/toolchain/DaemonClientToolchainServices.java
+++ b/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/toolchain/DaemonClientToolchainServices.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.file.temp.GradleUserHomeTemporaryFileProvider;
 import org.gradle.cache.FileLockManager;
 import org.gradle.initialization.GradleUserHomeDirProvider;
 import org.gradle.internal.jvm.inspection.DefaultJavaInstallationRegistry;
+import org.gradle.internal.jvm.inspection.DefaultJvmMetadataDetector;
 import org.gradle.internal.jvm.inspection.JavaInstallationRegistry;
 import org.gradle.internal.jvm.inspection.JvmInstallationProblemReporter;
 import org.gradle.internal.jvm.inspection.JvmMetadataDetector;
@@ -41,6 +42,7 @@ import org.gradle.jvm.toolchain.internal.SdkmanInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.ToolchainConfiguration;
 import org.gradle.jvm.toolchain.internal.WindowsInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.install.DefaultJdkCacheDirectory;
+import org.gradle.process.internal.ExecHandleFactory;
 
 import java.util.List;
 
@@ -80,7 +82,7 @@ public class DaemonClientToolchainServices implements ServiceRegistrationProvide
     }
 
     @Provides
-    protected JdkCacheDirectory createJdkCacheDirectory(GradleUserHomeDirProvider gradleUserHomeDirProvider, FileLockManager fileLockManager, JvmMetadataDetector jvmMetadataDetector, GradleUserHomeTemporaryFileProvider gradleUserHomeTemporaryFileProvider) {
-        return new DefaultJdkCacheDirectory(gradleUserHomeDirProvider, null, fileLockManager, jvmMetadataDetector, gradleUserHomeTemporaryFileProvider);
+    protected JdkCacheDirectory createJdkCacheDirectory(GradleUserHomeDirProvider gradleUserHomeDirProvider, FileLockManager fileLockManager, ExecHandleFactory execHandleFactory, GradleUserHomeTemporaryFileProvider gradleUserHomeTemporaryFileProvider) {
+        return new DefaultJdkCacheDirectory(gradleUserHomeDirProvider, null, fileLockManager, new DefaultJvmMetadataDetector(execHandleFactory, gradleUserHomeTemporaryFileProvider), gradleUserHomeTemporaryFileProvider);
     }
 }

--- a/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/internal/install/DefaultJdkCacheDirectory.java
+++ b/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/internal/install/DefaultJdkCacheDirectory.java
@@ -41,7 +41,6 @@ import org.gradle.jvm.toolchain.internal.JvmInstallationMetadataMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -86,7 +85,15 @@ public class DefaultJdkCacheDirectory implements JdkCacheDirectory {
     // This is a prerequisite for atomic moves in most cases, which are used in the provisionFromArchive method
     private final GradleUserHomeTemporaryFileProvider temporaryFileProvider;
 
-    @Inject
+    /**
+     * Creates a new JDK cache directory manager.
+     *
+     * @param homeDirProvider provider for the Gradle user home directory information
+     * @param operations file operations
+     * @param lockManager lock manager
+     * @param detector JVM metadata detector, an instance of {@link org.gradle.internal.jvm.inspection.DefaultJvmMetadataDetector} should be passed to avoid logging of any kind
+     * @param temporaryFileProvider temporary file provider
+     */
     public DefaultJdkCacheDirectory(
         GradleUserHomeDirProvider homeDirProvider,
         FileOperations operations,

--- a/platforms/jvm/toolchains-jvm/build.gradle.kts
+++ b/platforms/jvm/toolchains-jvm/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     api(projects.native)
     api(projects.persistentCache)
     api(projects.platformBase)
+    api(projects.processServices)
     api(projects.resources)
     api(projects.toolchainsJvmShared)
 
@@ -46,6 +47,7 @@ dependencies {
     api(libs.jsr305)
 
     implementation(projects.diagnostics)
+    implementation(projects.fileTemp)
     implementation(projects.logging)
 
     implementation(libs.commonsIo)

--- a/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/internal/services/ToolchainsJvmServices.java
+++ b/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/internal/services/ToolchainsJvmServices.java
@@ -18,6 +18,7 @@ package org.gradle.jvm.internal.services;
 
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.file.FileResolver;
+import org.gradle.api.internal.file.temp.GradleUserHomeTemporaryFileProvider;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ProviderFactory;
@@ -25,6 +26,7 @@ import org.gradle.cache.FileLockManager;
 import org.gradle.initialization.GradleUserHomeDirProvider;
 import org.gradle.internal.authentication.AuthenticationSchemeRegistry;
 import org.gradle.internal.jvm.inspection.DefaultJavaInstallationRegistry;
+import org.gradle.internal.jvm.inspection.DefaultJvmMetadataDetector;
 import org.gradle.internal.jvm.inspection.JavaInstallationRegistry;
 import org.gradle.internal.jvm.inspection.JvmInstallationProblemReporter;
 import org.gradle.internal.jvm.inspection.JvmMetadataDetector;
@@ -57,6 +59,7 @@ import org.gradle.jvm.toolchain.internal.install.DefaultJavaToolchainProvisionin
 import org.gradle.jvm.toolchain.internal.install.DefaultJdkCacheDirectory;
 import org.gradle.jvm.toolchain.internal.install.SecureFileDownloader;
 import org.gradle.platform.internal.DefaultBuildPlatform;
+import org.gradle.process.internal.ExecHandleFactory;
 
 import java.util.List;
 
@@ -83,8 +86,8 @@ public class ToolchainsJvmServices extends AbstractGradleModuleServices {
         }
 
         @Provides
-        protected JdkCacheDirectory createJdkCacheDirectory(ObjectFactory objectFactory, GradleUserHomeDirProvider homeDirProvider, FileOperations operations, FileLockManager lockManager, JvmMetadataDetector detector) {
-            return objectFactory.newInstance(DefaultJdkCacheDirectory.class, homeDirProvider, operations, lockManager, detector);
+        protected JdkCacheDirectory createJdkCacheDirectory(ObjectFactory objectFactory, GradleUserHomeDirProvider homeDirProvider, FileOperations operations, FileLockManager lockManager, ExecHandleFactory execHandleFactory, GradleUserHomeTemporaryFileProvider temporaryFileProvider) {
+            return new DefaultJdkCacheDirectory(homeDirProvider, operations, lockManager, new DefaultJvmMetadataDetector(execHandleFactory, temporaryFileProvider), temporaryFileProvider);
         }
 
         @Provides


### PR DESCRIPTION
Fixes #30409

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
