### PR TITLE
Fix some tests failing on Windows with CC

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -593,7 +593,7 @@ class GradleKotlinDslIntegrationTest : AbstractKotlinIntegrationTest() {
             require(uri("settings.gradle.kts").toString().endsWith("settings.gradle.kts"), { "uri(path)" })
             require(file("settings.gradle.kts").isFile, { "file(path)" })
             require(files("settings.gradle.kts").files.isNotEmpty(), { "files(paths)" })
-            require(fileTree(".").contains(file("settings.gradle.kts")), { "fileTree(path)" })
+            require(fileTree(".") { include("*.kts") }.contains(file("settings.gradle.kts")), { "fileTree(path)" })
             require(copySpec {} != null, { "copySpec {}" })
             require(mkdir("some").isDirectory, { "mkdir(path)" })
             require(delete("some"), { "delete(path)" })

--- a/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/DefaultFileHasher.java
+++ b/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/DefaultFileHasher.java
@@ -40,6 +40,8 @@ public class DefaultFileHasher implements FileHasher {
         }
         try {
             return streamHasher.hash(inputStream);
+        } catch (IOException e) {
+            throw new UncheckedIOException(String.format("Failed to create MD5 hash for file '%s'", file), e);
         } finally {
             try {
                 inputStream.close();

--- a/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/DefaultStreamHasher.java
+++ b/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/DefaultStreamHasher.java
@@ -16,7 +16,6 @@
 package org.gradle.internal.hash;
 
 import com.google.common.io.ByteStreams;
-import org.gradle.api.UncheckedIOException;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,12 +29,8 @@ public class DefaultStreamHasher implements StreamHasher {
     private final Queue<byte[]> buffers = new ArrayBlockingQueue<byte[]>(16);
 
     @Override
-    public HashCode hash(InputStream inputStream) {
-        try {
-            return doHash(inputStream, ByteStreams.nullOutputStream());
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to create MD5 hash for file content.", e);
-        }
+    public HashCode hash(InputStream inputStream) throws IOException {
+        return doHash(inputStream, ByteStreams.nullOutputStream());
     }
 
     @Override

--- a/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/StreamHasher.java
+++ b/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/StreamHasher.java
@@ -27,7 +27,7 @@ public interface StreamHasher {
     /**
      * Returns the hash of the given input stream. The stream will not be closed by the method.
      */
-    HashCode hash(InputStream inputStream);
+    HashCode hash(InputStream inputStream) throws IOException;
 
     /**
      * Returns the hash of the given input stream while copying the data to the output stream.

--- a/platforms/core-runtime/wrapper-shared/src/integTest/groovy/org/gradle/integtests/PathTraversalCheckerIntegrationTest.groovy
+++ b/platforms/core-runtime/wrapper-shared/src/integTest/groovy/org/gradle/integtests/PathTraversalCheckerIntegrationTest.groovy
@@ -58,10 +58,10 @@ class PathTraversalCheckerIntegrationTest extends AbstractIntegrationSpec {
         executer.withStacktraceEnabled()
 
         given:
-        buildFile << '''
+        buildFile '''
             task copyEvilZip(type: Copy) {
                 from(zipTree('evil.zip'))
-                into('.')
+                into(layout.buildDirectory)
             }
         '''
 

--- a/platforms/core-runtime/wrapper-shared/src/integTest/groovy/org/gradle/integtests/TarSlipIntegrationTest.groovy
+++ b/platforms/core-runtime/wrapper-shared/src/integTest/groovy/org/gradle/integtests/TarSlipIntegrationTest.groovy
@@ -55,10 +55,10 @@ class TarSlipIntegrationTest extends AbstractIntegrationSpec {
         executer.withStacktraceEnabled()
 
         given:
-        buildFile << '''
+        buildFile '''
             task copyEvilTar(type: Copy) {
                 from(tarTree('evil.tar.bz'))
-                into('.')
+                into(layout.buildDirectory)
             }
         '''
 

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/DefaultClassSetAnalyzer.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/DefaultClassSetAnalyzer.java
@@ -31,7 +31,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 
 import static org.gradle.internal.FileUtils.hasExtension;
 
@@ -137,6 +139,8 @@ public class DefaultClassSetAnalyzer implements ClassSetAnalyzer {
             InputStream inputStream = fileDetails.open();
             try {
                 return hasher.hash(inputStream);
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed to hash " + fileDetails, e);
             } finally {
                 IoActions.closeQuietly(inputStream);
             }


### PR DESCRIPTION
Main fix is to not use root project's directory as an input to avoid hitting file locks inside `.gradle` directory, which either fail the test or make the test fail before the expected failure happens.

FileHasher is updated to provide a better error message with a file path to make debugging similar issues easier in the future.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
