### PR TITLE
Mark C++ plugins partially supported with Configuration Cache

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/core-plugins/visual_studio_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/core-plugins/visual_studio_plugin.adoc
@@ -15,8 +15,6 @@
 [[visual_studio_plugin]]
 = Visual Studio
 
-WARNING: The Visual Studio Plugin is not compatible with the <<configuration_cache.adoc#config_cache:plugins:core,configuration cache>>.
-
 The Visual Studio Plugin generate files that are used by the https://visualstudio.microsoft.com/[Visual Studio IDE], thus making it possible to open the solution into Visual Studio (`File` - `Open` - `Project/Solution...`).
 
 What exactly the `visual-studio` plugin generates depends on which other plugins are used:

--- a/platforms/documentation/docs/src/docs/userguide/native/xcode_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/native/xcode_plugin.adoc
@@ -15,8 +15,6 @@
 [[xcode_plugin]]
 = Xcode
 
-WARNING: The Xcode Plugin is not compatible with the <<configuration_cache.adoc#config_cache:plugins:core,configuration cache>>.
-
 The Xcode Plugin generate files that are used by the https://developer.apple.com/xcode/[Xcode IDE] to open Gradle projects into Xcode (`File` - `Open...`). The generated Xcode project delegates build actions to Gradle.
 
 What exactly the `xcode` plugin generates depends on which other plugins are used:

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/configuration_cache.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/configuration_cache.adoc
@@ -345,8 +345,8 @@ link:{gradle-issues}13462[[.green]#✓#]:: <<antlr_plugin.adoc#antlr_plugin,ANTL
 
 a|
 [horizontal]
-link:{gradle-issues}13484[[.green]#✓#]:: <<cpp_application_plugin.adoc#cpp_application_plugin,C++ Application>>
-link:{gradle-issues}13485[[.green]#✓#]:: <<cpp_library_plugin.adoc#cpp_library_plugin,C++ Library>>
+link:{gradle-issues}30806[[.yellow]#⚠#]:: <<cpp_application_plugin.adoc#cpp_application_plugin,C++ Application>>
+link:{gradle-issues}30806[[.yellow]#⚠#]:: <<cpp_library_plugin.adoc#cpp_library_plugin,C++ Library>>
 link:{gradle-issues}13514[[.green]#✓#]:: <<cpp_unit_test_plugin.adoc#cpp_unit_test_plugin,C++ Unit Test>>
 link:{gradle-issues}13515[[.green]#✓#]:: <<swift_application_plugin.adoc#swift_application_plugin,Swift Application>>
 link:{gradle-issues}13487[[.green]#✓#]:: <<swift_library_plugin.adoc#swift_library_plugin,Swift Library>>


### PR DESCRIPTION
Resource linking on Windows doesn't work properly yet.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
