### PR TITLE
Fix test GradleRunnerBuildFailureIntegrationTest

### DIFF
--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerBuildFailureIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerBuildFailureIntegrationTest.groovy
@@ -112,10 +112,10 @@ $t.buildResult.output"""
 
     def GradleRunner createRunner() {
         def args = ['helloWorld']
-        if(gradleVersion >= GradleVersion.version("4.5")){
+        if (gradleVersion >= GradleVersion.version("4.5")) {
             args += '--warning-mode=none'
         }
-        if(gradleVersion > GradleVersion.version("8.10")){
+        if (gradleVersion > GradleVersion.version("8.11-milestone-1")) {
             args += "--no-problems-report"
         }
         this.runner(args)


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-private/issues/4484

I previously assumed newer than 8.10 is good enough to qualify a 8.11 build, but 8.10.2 is also newer, so this broke the test.

also newer or equal than 8.11 doesn't work because 8.11 snapshots are not newer or equal 8.11.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
