### PR TITLE
Add JDK8 to promotion build

### DIFF
--- a/.teamcity/src/main/kotlin/common/Jvm.kt
+++ b/.teamcity/src/main/kotlin/common/Jvm.kt
@@ -32,3 +32,10 @@ object BuildToolBuildJvm : Jvm {
     override val vendor: JvmVendor
         get() = JvmVendor.openjdk
 }
+
+object OpenJdk8 : Jvm {
+    override val version: JvmVersion
+        get() = JvmVersion.java8
+    override val vendor: JvmVendor
+        get() = JvmVendor.openjdk
+}

--- a/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
+++ b/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
@@ -1,6 +1,7 @@
 package promotion
 
 import common.BuildToolBuildJvm
+import common.OpenJdk8
 import common.Os
 import common.VersionedSettingsBranch
 import common.cleanupRule
@@ -42,6 +43,8 @@ class PromotionProject(branch: VersionedSettingsBranch) : Project({
         password("env.DOTCOM_DEV_DOCS_AWS_SECRET_KEY", "%dotcomDevDocsAwsSecretKey%")
         password("env.ORG_GRADLE_PROJECT_sdkmanToken", "%sdkmanToken%")
         param("env.JAVA_HOME", javaHome(BuildToolBuildJvm, Os.LINUX))
+        // https://github.com/gradle/gradle-private/issues/4504
+        param("env.JDK8", javaHome(OpenJdk8, Os.LINUX))
         param("env.ORG_GRADLE_PROJECT_artifactoryUserName", "%gradle.internal.repository.build-tool.publish.username%")
         password("env.ORG_GRADLE_PROJECT_infrastructureEmailPwd", "%infrastructureEmailPwd%")
         param("env.ORG_GRADLE_PROJECT_sdkmanKey", "8ed1a771bc236c287ad93c699bfdd2d7")

--- a/build-logic/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
@@ -76,6 +76,7 @@ val propagatedEnvironmentVariables = listOf(
     "LC_ALL",
     "LC_CTYPE",
 
+    "JDK8",
     "JDK_HOME",
     "JRE_HOME",
     "CommonProgramFiles",


### PR DESCRIPTION
This is to fix https://github.com/gradle/gradle-private/issues/4504

This PR adds `JDK8` env variable into the promotion build, so that `runDistributionBuild` could read this env variable and pass it to the test JVM. Then the env variable
is recognized by `AvailableJavaHomes.EnvVariableJvmLocator` and passed to `SrcDistributionIntegrationSpec.sourceZipContents`

Example build: https://builds.gradle.org/buildConfiguration/Gradle_Master_Promotion_PublishBranchSnapshotFromQuickFeedback/89908990