### PR TITLE
Allow type inspection infrastructure to inspect non-property methods

### DIFF
--- a/platforms/core-configuration/flow-services/src/main/kotlin/org/gradle/internal/flow/services/FlowParametersInstantiator.kt
+++ b/platforms/core-configuration/flow-services/src/main/kotlin/org/gradle/internal/flow/services/FlowParametersInstantiator.kt
@@ -110,6 +110,7 @@ class FlowParametersInstantiator(
             listOf(
                 org.gradle.api.tasks.Optional::class.java
             ),
+            emptyList(),
             instantiatorFactory.decorateScheme()
         )
     }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/AbstractAnnotationHandler.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/AbstractAnnotationHandler.java
@@ -20,8 +20,25 @@ import com.google.common.collect.ImmutableSet;
 
 import java.lang.annotation.Annotation;
 
-public abstract class AbstractFunctionAnnotationHandler extends AbstractAnnotationHandler implements FunctionAnnotationHandler {
-    public AbstractFunctionAnnotationHandler(Class<? extends Annotation> annotationType, ImmutableSet<Class<? extends Annotation>> allowedModifiers) {
-        super(annotationType, allowedModifiers);
+/**
+ * Base class for annotation handlers.
+ */
+public abstract class AbstractAnnotationHandler implements AnnotationHandler {
+    protected final Class<? extends Annotation> annotationType;
+    protected final ImmutableSet<Class<? extends Annotation>> allowedModifiers;
+
+    public AbstractAnnotationHandler(Class<? extends Annotation> annotationType, ImmutableSet<Class<? extends Annotation>> allowedModifiers) {
+        this.annotationType = annotationType;
+        this.allowedModifiers = allowedModifiers;
+    }
+
+    @Override
+    public Class<? extends Annotation> getAnnotationType() {
+        return annotationType;
+    }
+
+    @Override
+    public ImmutableSet<Class<? extends Annotation>> getAllowedModifiers() {
+        return allowedModifiers;
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/AbstractFunctionAnnotationHandler.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/AbstractFunctionAnnotationHandler.java
@@ -20,6 +20,9 @@ import com.google.common.collect.ImmutableSet;
 
 import java.lang.annotation.Annotation;
 
+/**
+ * Base class for function annotation handlers.
+ */
 public abstract class AbstractFunctionAnnotationHandler extends AbstractAnnotationHandler implements FunctionAnnotationHandler {
     public AbstractFunctionAnnotationHandler(Class<? extends Annotation> annotationType, ImmutableSet<Class<? extends Annotation>> allowedModifiers) {
         super(annotationType, allowedModifiers);

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/AbstractFunctionAnnotationHandler.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/AbstractFunctionAnnotationHandler.java
@@ -20,11 +20,11 @@ import com.google.common.collect.ImmutableSet;
 
 import java.lang.annotation.Annotation;
 
-public abstract class AbstractMethodAnnotationHandler implements MethodAnnotationHandler {
+public abstract class AbstractFunctionAnnotationHandler implements FunctionAnnotationHandler {
     private final Class<? extends Annotation> annotationType;
     private final ImmutableSet<Class<? extends Annotation>> allowedModifiers;
 
-    public AbstractMethodAnnotationHandler(Class<? extends Annotation> annotationType, ImmutableSet<Class<? extends Annotation>> allowedModifiers) {
+    public AbstractFunctionAnnotationHandler(Class<? extends Annotation> annotationType, ImmutableSet<Class<? extends Annotation>> allowedModifiers) {
         this.annotationType = annotationType;
         this.allowedModifiers = allowedModifiers;
     }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/AbstractMethodAnnotationHandler.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/AbstractMethodAnnotationHandler.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.properties.annotations;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.lang.annotation.Annotation;
+
+public abstract class AbstractMethodAnnotationHandler implements MethodAnnotationHandler {
+    private final Class<? extends Annotation> annotationType;
+    private final ImmutableSet<Class<? extends Annotation>> allowedModifiers;
+
+    public AbstractMethodAnnotationHandler(Class<? extends Annotation> annotationType, ImmutableSet<Class<? extends Annotation>> allowedModifiers) {
+        this.annotationType = annotationType;
+        this.allowedModifiers = allowedModifiers;
+    }
+
+    @Override
+    public Class<? extends Annotation> getAnnotationType() {
+        return annotationType;
+    }
+
+    @Override
+    public ImmutableSet<Class<? extends Annotation>> getAllowedModifiers() {
+        return allowedModifiers;
+    }
+}

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/AnnotationHandler.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/AnnotationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,16 +20,18 @@ import com.google.common.collect.ImmutableSet;
 
 import java.lang.annotation.Annotation;
 
-public abstract class AbstractPropertyAnnotationHandler extends AbstractAnnotationHandler implements PropertyAnnotationHandler {
-    private final Kind kind;
+/**
+ * Base class for handling validation, dependency handling, and skipping for a function or property marked with
+ * a given annotation.
+ */
+public interface AnnotationHandler {
+    /**
+     * The annotation type which this handler is responsible for.
+     */
+    Class<? extends Annotation> getAnnotationType();
 
-    protected AbstractPropertyAnnotationHandler(Class<? extends Annotation> annotationType, Kind kind, ImmutableSet<Class<? extends Annotation>> allowedModifiers) {
-        super(annotationType, allowedModifiers);
-        this.kind = kind;
-    }
-
-    @Override
-    public Kind getKind() {
-        return kind;
-    }
+    /**
+     * The modifier annotations allowed for the handled function type. This set can further be restricted by the actual work type.
+     */
+    ImmutableSet<Class<? extends Annotation>> getAllowedModifiers();
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/DefaultTypeMetadataStore.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/DefaultTypeMetadataStore.java
@@ -25,6 +25,7 @@ import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.cache.internal.CrossBuildInMemoryCache;
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
 import org.gradle.internal.reflect.annotations.AnnotationCategory;
+import org.gradle.internal.reflect.annotations.MethodAnnotationMetadata;
 import org.gradle.internal.reflect.annotations.PropertyAnnotationMetadata;
 import org.gradle.internal.reflect.annotations.TypeAnnotationMetadata;
 import org.gradle.internal.reflect.annotations.TypeAnnotationMetadataStore;
@@ -32,8 +33,10 @@ import org.gradle.internal.reflect.validation.ReplayingTypeValidationContext;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
 import org.gradle.util.internal.TextUtil;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Locale;
 import java.util.Map;
@@ -50,7 +53,9 @@ import static org.gradle.internal.reflect.annotations.AnnotationCategory.TYPE;
 public class DefaultTypeMetadataStore implements TypeMetadataStore {
     private final Collection<? extends TypeAnnotationHandler> typeAnnotationHandlers;
     private final ImmutableMap<Class<? extends Annotation>, ? extends PropertyAnnotationHandler> propertyAnnotationHandlers;
+    private final ImmutableMap<Class<? extends Annotation>, ? extends MethodAnnotationHandler> methodAnnotationHandlers;
     private final ImmutableSet<Class<? extends Annotation>> allowedPropertyModifiers;
+    private final ImmutableSet<Class<? extends Annotation>> allowedMethodModifiers;
     private final CrossBuildInMemoryCache<Class<?>, TypeMetadata> cache;
     private final TypeAnnotationMetadataStore typeAnnotationMetadataStore;
     private final PropertyTypeResolver propertyTypeResolver;
@@ -61,6 +66,8 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
         Collection<? extends TypeAnnotationHandler> typeAnnotationHandlers,
         Collection<? extends PropertyAnnotationHandler> propertyAnnotationHandlers,
         Collection<Class<? extends Annotation>> allowedPropertyModifiers,
+        Collection<? extends MethodAnnotationHandler> methodAnnotationHandlers,
+        Collection<Class<? extends Annotation>> allowedMethodModifiers,
         TypeAnnotationMetadataStore typeAnnotationMetadataStore,
         PropertyTypeResolver propertyTypeResolver,
         CrossBuildInMemoryCacheFactory cacheFactory,
@@ -69,6 +76,8 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
         this.typeAnnotationHandlers = ImmutableSet.copyOf(typeAnnotationHandlers);
         this.propertyAnnotationHandlers = Maps.uniqueIndex(propertyAnnotationHandlers, PropertyAnnotationHandler::getAnnotationType);
         this.allowedPropertyModifiers = ImmutableSet.copyOf(allowedPropertyModifiers);
+        this.methodAnnotationHandlers = Maps.uniqueIndex(methodAnnotationHandlers, MethodAnnotationHandler::getAnnotationType);
+        this.allowedMethodModifiers = ImmutableSet.copyOf(allowedMethodModifiers);
         this.typeAnnotationMetadataStore = typeAnnotationMetadataStore;
         this.displayName = calculateDisplayName(propertyAnnotationHandlers);
         this.propertyTypeResolver = propertyTypeResolver;
@@ -105,6 +114,13 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
             }
         }
 
+        ImmutableSet.Builder<PropertyMetadata> effectiveProperties = getEffectiveProperties(annotationMetadata, validationContext);
+        ImmutableSet.Builder<MethodMetadata> effectiveMethods = getEffectiveMethods(annotationMetadata, validationContext);
+        return new DefaultTypeMetadata(publicType, effectiveProperties.build(), effectiveMethods.build(), validationContext, propertyAnnotationHandlers, methodAnnotationHandlers, annotationMetadata);
+    }
+
+    @Nonnull
+    private ImmutableSet.Builder<PropertyMetadata> getEffectiveProperties(TypeAnnotationMetadata annotationMetadata, ReplayingTypeValidationContext validationContext) {
         ImmutableSet.Builder<PropertyMetadata> effectiveProperties = ImmutableSet.builderWithExpectedSize(annotationMetadata.getPropertiesAnnotationMetadata().size());
         for (PropertyAnnotationMetadata propertyAnnotationMetadata : annotationMetadata.getPropertiesAnnotationMetadata()) {
             Map<AnnotationCategory, Annotation> propertyAnnotations = propertyAnnotationMetadata.getAnnotations();
@@ -169,7 +185,78 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
                 effectiveProperties.add(property);
             }
         }
-        return new DefaultTypeMetadata(publicType, effectiveProperties.build(), validationContext, propertyAnnotationHandlers, annotationMetadata);
+        return effectiveProperties;
+    }
+
+    @Nonnull
+    private ImmutableSet.Builder<MethodMetadata> getEffectiveMethods(TypeAnnotationMetadata annotationMetadata, ReplayingTypeValidationContext validationContext) {
+        ImmutableSet.Builder<MethodMetadata> effectiveMethods = ImmutableSet.builderWithExpectedSize(annotationMetadata.getMethodsAnnotationMetadata().size());
+        for (MethodAnnotationMetadata methodAnnotationMetadata : annotationMetadata.getMethodsAnnotationMetadata()) {
+            Map<AnnotationCategory, Annotation> methodAnnotations = methodAnnotationMetadata.getAnnotations();
+            Annotation methodAnnotation = methodAnnotations.get(TYPE);
+
+            if (methodAnnotation == null) {
+                continue;
+            }
+
+            Class<? extends Annotation> methodType = methodAnnotation.annotationType();
+
+            MethodAnnotationHandler annotationHandler = methodAnnotationHandlers.get(methodType);
+            if (annotationHandler == null) {
+                validationContext.visitPropertyProblem(problem ->
+                    problem
+                        .forMethod(methodAnnotationMetadata.getMethod().getName())
+                        .id(TextUtil.screamingSnakeToKebabCase(ANNOTATION_INVALID_IN_CONTEXT), "Invalid annotation in context", GradleCoreProblemGroup.validation().type())
+                        .contextualLabel(String.format("is annotated with invalid method type @%s", methodType.getSimpleName()))
+                        .documentedAt(userManual("validation_problems", ANNOTATION_INVALID_IN_CONTEXT.toLowerCase(Locale.ROOT)))
+                        .severity(ERROR)
+                        .details("The '@" + methodType.getSimpleName() + "' annotation cannot be used in this context")
+                        .solution("Remove the method")
+                        .solution("Use a different annotation, e.g one of " + toListOfAnnotations(methodAnnotationHandlers.keySet()))
+                );
+                continue;
+            }
+
+            ImmutableSet<Class<? extends Annotation>> allowedModifiersForMethodType = annotationHandler.getAllowedModifiers();
+            for (Map.Entry<AnnotationCategory, Annotation> entry : methodAnnotations.entrySet()) {
+                AnnotationCategory annotationCategory = entry.getKey();
+                if (annotationCategory == TYPE) {
+                    continue;
+                }
+                Class<? extends Annotation> annotationType = entry.getValue().annotationType();
+                if (!allowedModifiersForMethodType.contains(annotationType)) {
+                    validationContext.visitPropertyProblem(problem ->
+                        problem
+                            .forMethod(methodAnnotationMetadata.getMethod().getName())
+                            .id(TextUtil.screamingSnakeToKebabCase(INCOMPATIBLE_ANNOTATIONS), "Incompatible annotations", GradleCoreProblemGroup.validation().type())
+                            .contextualLabel("is annotated with @" + annotationType.getSimpleName() + " but that is not allowed for '" + methodType.getSimpleName() + "' methods")
+                            .documentedAt(userManual("validation_problems", INCOMPATIBLE_ANNOTATIONS.toLowerCase(Locale.ROOT)))
+                            .severity(ERROR)
+                            .details("This modifier is used in conjunction with a property of type '" + methodType.getSimpleName() + "' but this doesn't have semantics")
+                            .solution("Remove the '@" + annotationType.getSimpleName() + "' annotation"));
+                } else if (!allowedMethodModifiers.contains(annotationType)) {
+                    validationContext.visitPropertyProblem(problem ->
+                        problem
+                            .forProperty(methodAnnotationMetadata.getMethod().getName())
+                            .id(TextUtil.screamingSnakeToKebabCase(ANNOTATION_INVALID_IN_CONTEXT), "Invalid annotation in context", GradleCoreProblemGroup.validation().property())
+                            .contextualLabel(String.format("is annotated with invalid modifier @%s", annotationType.getSimpleName()))
+                            .documentedAt(userManual("validation_problems", ANNOTATION_INVALID_IN_CONTEXT.toLowerCase(Locale.ROOT)))
+                            .severity(ERROR)
+                            .details("The '@" + annotationType.getSimpleName() + "' annotation cannot be used in this context")
+                            .solution("Use a different annotation, e.g one of " + toListOfAnnotations(allowedPropertyModifiers))
+                            .solution("Remove the annotation")
+                    );
+                }
+            }
+
+            MethodMetadata method = new DefaultMethodMetadata(methodType, methodAnnotationMetadata);
+            annotationHandler.validateMethodMetadata(method, validationContext);
+
+            if (annotationHandler.isMethodRelevant()) {
+                effectiveMethods.add(method);
+            }
+        }
+        return effectiveMethods;
     }
 
     private static String toListOfAnnotations(ImmutableSet<Class<? extends Annotation>> classes) {
@@ -183,21 +270,27 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
     private static class DefaultTypeMetadata implements TypeMetadata {
         private final Class<?> type;
         private final ImmutableSet<PropertyMetadata> propertiesMetadata;
+        private final ImmutableSet<MethodMetadata> methodsMetadata;
         private final ReplayingTypeValidationContext validationProblems;
-        private final ImmutableMap<Class<? extends Annotation>, ? extends PropertyAnnotationHandler> annotationHandlers;
+        private final ImmutableMap<Class<? extends Annotation>, ? extends PropertyAnnotationHandler> propertyAnnotationHandlers;
+        private final ImmutableMap<Class<? extends Annotation>, ? extends MethodAnnotationHandler> methodAnnotationHandlers;
         private final TypeAnnotationMetadata typeAnnotationMetadata;
 
         DefaultTypeMetadata(
             Class<?> type,
             ImmutableSet<PropertyMetadata> propertiesMetadata,
+            ImmutableSet<MethodMetadata> methodsMetadata,
             ReplayingTypeValidationContext validationProblems,
-            ImmutableMap<Class<? extends Annotation>, ? extends PropertyAnnotationHandler> annotationHandlers,
+            ImmutableMap<Class<? extends Annotation>, ? extends PropertyAnnotationHandler> propertyAnnotationHandlers,
+            ImmutableMap<Class<? extends Annotation>, ? extends MethodAnnotationHandler> methodAnnotationHandlers,
             TypeAnnotationMetadata typeAnnotationMetadata
         ) {
             this.type = type;
             this.propertiesMetadata = propertiesMetadata;
+            this.methodsMetadata = methodsMetadata;
             this.validationProblems = validationProblems;
-            this.annotationHandlers = annotationHandlers;
+            this.propertyAnnotationHandlers = propertyAnnotationHandlers;
+            this.methodAnnotationHandlers = methodAnnotationHandlers;
             this.typeAnnotationMetadata = typeAnnotationMetadata;
         }
 
@@ -212,13 +305,23 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
         }
 
         @Override
+        public Set<MethodMetadata> getMethodsMetadata() {
+            return methodsMetadata;
+        }
+
+        @Override
         public boolean hasAnnotatedProperties() {
             return !propertiesMetadata.isEmpty();
         }
 
         @Override
         public PropertyAnnotationHandler getAnnotationHandlerFor(PropertyMetadata propertyMetadata) {
-            return annotationHandlers.get(propertyMetadata.getPropertyType());
+            return propertyAnnotationHandlers.get(propertyMetadata.getPropertyType());
+        }
+
+        @Override
+        public MethodAnnotationHandler getAnnotationHandlerFor(MethodMetadata methodMetadata) {
+            return methodAnnotationHandlers.get(methodMetadata.getMethodType());
         }
 
         @Override
@@ -286,6 +389,71 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
         @Override
         public String toString() {
             return String.format("@%s %s", propertyType.getSimpleName(), getPropertyName());
+        }
+    }
+
+    private static class DefaultMethodMetadata implements MethodMetadata {
+        private final Class<? extends Annotation> methodType;
+        private final MethodAnnotationMetadata annotationMetadata;
+
+        public DefaultMethodMetadata(Class<? extends Annotation> methodType, MethodAnnotationMetadata annotationMetadata) {
+            this.methodType = methodType;
+            this.annotationMetadata = annotationMetadata;
+        }
+
+        @Override
+        public String getMethodName() {
+            return annotationMetadata.getMethod().getName();
+        }
+
+        @Override
+        public Method getMethod() {
+            return annotationMetadata.getMethod();
+        }
+
+        @Override
+        public boolean isAnnotationPresent(Class<? extends Annotation> annotationType) {
+            return annotationMetadata.isAnnotationPresent(annotationType);
+        }
+
+        @Override
+        public <T extends Annotation> Optional<T> getAnnotation(Class<T> annotationType) {
+            return annotationMetadata.getAnnotation(annotationType);
+        }
+
+        @Override
+        public Optional<Annotation> getAnnotationForCategory(AnnotationCategory category) {
+            return Optional.ofNullable(annotationMetadata.getAnnotations().get(category));
+        }
+
+        @Override
+        public boolean hasAnnotationForCategory(AnnotationCategory category) {
+            return annotationMetadata.getAnnotations().get(category) != null;
+        }
+
+        @Override
+        public Class<? extends Annotation> getMethodType() {
+            return methodType;
+        }
+
+        @Override
+        public TypeToken<?> getDeclaredType() {
+            return annotationMetadata.getDeclaredType();
+        }
+
+        @Override
+        public int hashCode() {
+            return annotationMetadata.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return annotationMetadata.equals(obj);
+        }
+
+        @Override
+        public String toString() {
+            return annotationMetadata.toString();
         }
     }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/DefaultTypeMetadataStore.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/DefaultTypeMetadataStore.java
@@ -252,9 +252,7 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
             FunctionMetadata function = new DefaultFunctionMetadata(functionType, functionAnnotationMetadata);
             annotationHandler.validateFunctionMetadata(function, validationContext);
 
-            if (annotationHandler.isFunctionRelevant()) {
-                effectiveFunctions.add(function);
-            }
+            effectiveFunctions.add(function);
         }
         return effectiveFunctions;
     }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/DefaultTypeMetadataStore.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/DefaultTypeMetadataStore.java
@@ -123,7 +123,7 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
     private ImmutableSet.Builder<PropertyMetadata> getEffectiveProperties(TypeAnnotationMetadata annotationMetadata, ReplayingTypeValidationContext validationContext) {
         ImmutableSet.Builder<PropertyMetadata> effectiveProperties = ImmutableSet.builderWithExpectedSize(annotationMetadata.getPropertiesAnnotationMetadata().size());
         for (PropertyAnnotationMetadata propertyAnnotationMetadata : annotationMetadata.getPropertiesAnnotationMetadata()) {
-            Map<AnnotationCategory, Annotation> propertyAnnotations = propertyAnnotationMetadata.getAnnotations();
+            Map<AnnotationCategory, Annotation> propertyAnnotations = propertyAnnotationMetadata.getAnnotationsByCategory();
             Class<? extends Annotation> propertyType = propertyTypeResolver.resolveAnnotationType(propertyAnnotations);
             if (propertyType == null) {
                 missingPropertyAnnotationHandler.handleMissingPropertyAnnotation(validationContext, propertyAnnotationMetadata, displayName);
@@ -192,7 +192,7 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
     private ImmutableSet.Builder<FunctionMetadata> getEffectiveFunctions(TypeAnnotationMetadata annotationMetadata, ReplayingTypeValidationContext validationContext) {
         ImmutableSet.Builder<FunctionMetadata> effectiveFunctions = ImmutableSet.builderWithExpectedSize(annotationMetadata.getFunctionAnnotationMetadata().size());
         for (FunctionAnnotationMetadata functionAnnotationMetadata : annotationMetadata.getFunctionAnnotationMetadata()) {
-            Map<AnnotationCategory, Annotation> functionAnnotations = functionAnnotationMetadata.getAnnotations();
+            Map<AnnotationCategory, Annotation> functionAnnotations = functionAnnotationMetadata.getAnnotationsByCategory();
             Annotation functionAnnotation = functionAnnotations.get(TYPE);
 
             if (functionAnnotation == null) {
@@ -360,12 +360,12 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
 
         @Override
         public Optional<Annotation> getAnnotationForCategory(AnnotationCategory category) {
-            return Optional.ofNullable(annotationMetadata.getAnnotations().get(category));
+            return Optional.ofNullable(annotationMetadata.getAnnotationsByCategory().get(category));
         }
 
         @Override
         public boolean hasAnnotationForCategory(AnnotationCategory category) {
-            return annotationMetadata.getAnnotations().get(category) != null;
+            return annotationMetadata.getAnnotationsByCategory().get(category) != null;
         }
 
         @Override
@@ -375,7 +375,7 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
 
         @Override
         public TypeToken<?> getDeclaredType() {
-            return annotationMetadata.getDeclaredType();
+            return annotationMetadata.getDeclaredReturnType();
         }
 
         @Nullable
@@ -421,12 +421,12 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
 
         @Override
         public Optional<Annotation> getAnnotationForCategory(AnnotationCategory category) {
-            return Optional.ofNullable(annotationMetadata.getAnnotations().get(category));
+            return Optional.ofNullable(annotationMetadata.getAnnotationsByCategory().get(category));
         }
 
         @Override
         public boolean hasAnnotationForCategory(AnnotationCategory category) {
-            return annotationMetadata.getAnnotations().get(category) != null;
+            return annotationMetadata.getAnnotationsByCategory().get(category) != null;
         }
 
         @Override
@@ -436,7 +436,7 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
 
         @Override
         public TypeToken<?> getDeclaredType() {
-            return annotationMetadata.getDeclaredType();
+            return annotationMetadata.getDeclaredReturnType();
         }
 
         @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/DefaultTypeMetadataStore.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/DefaultTypeMetadataStore.java
@@ -114,13 +114,13 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
             }
         }
 
-        ImmutableSet.Builder<PropertyMetadata> effectiveProperties = getEffectiveProperties(annotationMetadata, validationContext);
-        ImmutableSet.Builder<FunctionMetadata> effectiveFunctions = getEffectiveFunctions(annotationMetadata, validationContext);
-        return new DefaultTypeMetadata(publicType, effectiveProperties.build(), effectiveFunctions.build(), validationContext, propertyAnnotationHandlers, functionAnnotationHandlers, annotationMetadata);
+        ImmutableSet<PropertyMetadata> effectiveProperties = getEffectiveProperties(annotationMetadata, validationContext);
+        ImmutableSet<FunctionMetadata> effectiveFunctions = getEffectiveFunctions(annotationMetadata, validationContext);
+        return new DefaultTypeMetadata(publicType, effectiveProperties, effectiveFunctions, validationContext, propertyAnnotationHandlers, functionAnnotationHandlers, annotationMetadata);
     }
 
     @Nonnull
-    private ImmutableSet.Builder<PropertyMetadata> getEffectiveProperties(TypeAnnotationMetadata annotationMetadata, ReplayingTypeValidationContext validationContext) {
+    private ImmutableSet<PropertyMetadata> getEffectiveProperties(TypeAnnotationMetadata annotationMetadata, ReplayingTypeValidationContext validationContext) {
         ImmutableSet.Builder<PropertyMetadata> effectiveProperties = ImmutableSet.builderWithExpectedSize(annotationMetadata.getPropertiesAnnotationMetadata().size());
         for (PropertyAnnotationMetadata propertyAnnotationMetadata : annotationMetadata.getPropertiesAnnotationMetadata()) {
             Map<AnnotationCategory, Annotation> propertyAnnotations = propertyAnnotationMetadata.getAnnotationsByCategory();
@@ -185,11 +185,11 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
                 effectiveProperties.add(property);
             }
         }
-        return effectiveProperties;
+        return effectiveProperties.build();
     }
 
     @Nonnull
-    private ImmutableSet.Builder<FunctionMetadata> getEffectiveFunctions(TypeAnnotationMetadata annotationMetadata, ReplayingTypeValidationContext validationContext) {
+    private ImmutableSet<FunctionMetadata> getEffectiveFunctions(TypeAnnotationMetadata annotationMetadata, ReplayingTypeValidationContext validationContext) {
         ImmutableSet.Builder<FunctionMetadata> effectiveFunctions = ImmutableSet.builderWithExpectedSize(annotationMetadata.getFunctionAnnotationMetadata().size());
         for (FunctionAnnotationMetadata functionAnnotationMetadata : annotationMetadata.getFunctionAnnotationMetadata()) {
             Map<AnnotationCategory, Annotation> functionAnnotations = functionAnnotationMetadata.getAnnotationsByCategory();
@@ -254,7 +254,7 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
 
             effectiveFunctions.add(function);
         }
-        return effectiveFunctions;
+        return effectiveFunctions.build();
     }
 
     private static String toListOfAnnotations(ImmutableSet<Class<? extends Annotation>> classes) {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/FunctionAnnotationHandler.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/FunctionAnnotationHandler.java
@@ -16,12 +16,9 @@
 
 package org.gradle.internal.properties.annotations;
 
-import com.google.common.collect.ImmutableSet;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
-
-import java.lang.annotation.Annotation;
 
 /**
  * Handles validation, dependency handling, and skipping for a function marked with a given annotation.
@@ -29,17 +26,7 @@ import java.lang.annotation.Annotation;
  * <p>Each handler must be registered as a global service.</p>
  */
 @ServiceScope(Scope.Global.class)
-public interface FunctionAnnotationHandler {
-    /**
-     * The annotation type which this handler is responsible for.
-     */
-    Class<? extends Annotation> getAnnotationType();
-
-    /**
-     * The modifier annotations allowed for the handled function type. This set can further be restricted by the actual work type.
-     */
-    ImmutableSet<Class<? extends Annotation>> getAllowedModifiers();
-
+public interface FunctionAnnotationHandler extends AnnotationHandler {
     /**
      * Visits problems associated with the given function, if any.
      */

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/FunctionAnnotationHandler.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/FunctionAnnotationHandler.java
@@ -24,32 +24,32 @@ import org.gradle.internal.service.scopes.ServiceScope;
 import java.lang.annotation.Annotation;
 
 /**
- * Handles validation, dependency handling, and skipping for a method marked with a given annotation.
+ * Handles validation, dependency handling, and skipping for a function marked with a given annotation.
  *
  * <p>Each handler must be registered as a global service.</p>
  */
 @ServiceScope(Scope.Global.class)
-public interface MethodAnnotationHandler {
+public interface FunctionAnnotationHandler {
     /**
      * The annotation type which this handler is responsible for.
      */
     Class<? extends Annotation> getAnnotationType();
 
     /**
-     * The modifier annotations allowed for the handled method type. This set can further be restricted by the actual work type.
+     * The modifier annotations allowed for the handled function type. This set can further be restricted by the actual work type.
      */
     ImmutableSet<Class<? extends Annotation>> getAllowedModifiers();
 
     /**
-     * Does this handler do something useful with the method that match it? Or can these methods be ignored?
+     * Does this handler do something useful with the functions that match it? Or can these functions be ignored?
      *
      * Should consider splitting up this type, perhaps into something that inspects the methods and produces the actual handlers and validation problems.
      */
-    boolean isMethodRelevant();
+    boolean isFunctionRelevant();
 
     /**
-     * Visits problems associated with the given method, if any.
+     * Visits problems associated with the given function, if any.
      */
-    default void validateMethodMetadata(MethodMetadata methodMetadata, TypeValidationContext validationContext) {}
+    default void validateFunctionMetadata(FunctionMetadata functionMetadata, TypeValidationContext validationContext) {}
 
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/FunctionAnnotationHandler.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/FunctionAnnotationHandler.java
@@ -41,13 +41,6 @@ public interface FunctionAnnotationHandler {
     ImmutableSet<Class<? extends Annotation>> getAllowedModifiers();
 
     /**
-     * Does this handler do something useful with the functions that match it? Or can these functions be ignored?
-     *
-     * Should consider splitting up this type, perhaps into something that inspects the methods and produces the actual handlers and validation problems.
-     */
-    boolean isFunctionRelevant();
-
-    /**
      * Visits problems associated with the given function, if any.
      */
     default void validateFunctionMetadata(FunctionMetadata functionMetadata, TypeValidationContext validationContext) {}

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/FunctionMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/FunctionMetadata.java
@@ -24,9 +24,9 @@ import java.lang.reflect.Method;
 import java.util.Optional;
 
 /**
- * Represents the metadata of a non-property method.
+ * Represents the metadata of a function (i.e. an annotated method not associated with a property).
  */
-public interface MethodMetadata {
+public interface FunctionMetadata {
     String getMethodName();
 
     Method getMethod();
@@ -39,7 +39,7 @@ public interface MethodMetadata {
 
     boolean hasAnnotationForCategory(AnnotationCategory category);
 
-    Class<? extends Annotation> getMethodType();
+    Class<? extends Annotation> getFunctionType();
 
     TypeToken<?> getDeclaredType();
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/MethodAnnotationHandler.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/MethodAnnotationHandler.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.properties.annotations;
+
+import com.google.common.collect.ImmutableSet;
+import org.gradle.internal.reflect.validation.TypeValidationContext;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * Handles validation, dependency handling, and skipping for a method marked with a given annotation.
+ *
+ * <p>Each handler must be registered as a global service.</p>
+ */
+@ServiceScope(Scope.Global.class)
+public interface MethodAnnotationHandler {
+    /**
+     * The annotation type which this handler is responsible for.
+     */
+    Class<? extends Annotation> getAnnotationType();
+
+    /**
+     * The modifier annotations allowed for the handled method type. This set can further be restricted by the actual work type.
+     */
+    ImmutableSet<Class<? extends Annotation>> getAllowedModifiers();
+
+    /**
+     * Does this handler do something useful with the method that match it? Or can these methods be ignored?
+     *
+     * Should consider splitting up this type, perhaps into something that inspects the methods and produces the actual handlers and validation problems.
+     */
+    boolean isMethodRelevant();
+
+    /**
+     * Visits problems associated with the given method, if any.
+     */
+    default void validateMethodMetadata(MethodMetadata methodMetadata, TypeValidationContext validationContext) {}
+
+}

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/MethodMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/MethodMetadata.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.properties.annotations;
+
+import com.google.common.reflect.TypeToken;
+import org.gradle.internal.reflect.annotations.AnnotationCategory;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+/**
+ * Represents the metadata of a non-property method.
+ */
+public interface MethodMetadata {
+    String getMethodName();
+
+    Method getMethod();
+
+    boolean isAnnotationPresent(Class<? extends Annotation> annotationType);
+
+    <T extends Annotation> Optional<T> getAnnotation(Class<T> annotationType);
+
+    Optional<Annotation> getAnnotationForCategory(AnnotationCategory category);
+
+    boolean hasAnnotationForCategory(AnnotationCategory category);
+
+    Class<? extends Annotation> getMethodType();
+
+    TypeToken<?> getDeclaredType();
+}

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/PropertyAnnotationHandler.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/PropertyAnnotationHandler.java
@@ -15,14 +15,11 @@
  */
 package org.gradle.internal.properties.annotations;
 
-import com.google.common.collect.ImmutableSet;
 import org.gradle.internal.properties.PropertyValue;
 import org.gradle.internal.properties.PropertyVisitor;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
-
-import java.lang.annotation.Annotation;
 
 /**
  * Handles validation, dependency handling, and skipping for a property marked with a given annotation.
@@ -30,17 +27,7 @@ import java.lang.annotation.Annotation;
  * <p>Each handler must be registered as a global service.</p>
  */
 @ServiceScope(Scope.Global.class)
-public interface PropertyAnnotationHandler {
-    /**
-     * The annotation type which this handler is responsible for.
-     */
-    Class<? extends Annotation> getAnnotationType();
-
-    /**
-     * The modifier annotations allowed for the handled property type. This set can further be restricted by the actual work type.
-     */
-    ImmutableSet<Class<? extends Annotation>> getAllowedModifiers();
-
+public interface PropertyAnnotationHandler extends AnnotationHandler {
     /**
      * Does this handler do something useful with the properties that match it? Or can these properties be ignored?
      *

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/TypeMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/TypeMetadata.java
@@ -30,9 +30,16 @@ public interface TypeMetadata {
      */
     Set<PropertyMetadata> getPropertiesMetadata();
 
+    /**
+     * Returns the set of relevant annotated methods, that is, those methods annotated with a relevant annotation.
+     */
+    Set<MethodMetadata> getMethodsMetadata();
+
     boolean hasAnnotatedProperties();
 
     PropertyAnnotationHandler getAnnotationHandlerFor(PropertyMetadata propertyMetadata);
+
+    MethodAnnotationHandler getAnnotationHandlerFor(MethodMetadata methodMetadata);
 
     TypeAnnotationMetadata getTypeAnnotationMetadata();
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/TypeMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/TypeMetadata.java
@@ -33,13 +33,13 @@ public interface TypeMetadata {
     /**
      * Returns the set of relevant annotated methods, that is, those methods annotated with a relevant annotation.
      */
-    Set<MethodMetadata> getMethodsMetadata();
+    Set<FunctionMetadata> getFunctionMetadata();
 
     boolean hasAnnotatedProperties();
 
     PropertyAnnotationHandler getAnnotationHandlerFor(PropertyMetadata propertyMetadata);
 
-    MethodAnnotationHandler getAnnotationHandlerFor(MethodMetadata methodMetadata);
+    FunctionAnnotationHandler getAnnotationHandlerFor(FunctionMetadata functionMetadata);
 
     TypeAnnotationMetadata getTypeAnnotationMetadata();
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/FunctionAnnotationMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/FunctionAnnotationMetadata.java
@@ -16,5 +16,5 @@
 
 package org.gradle.internal.reflect.annotations;
 
-public interface MethodAnnotationMetadata extends HasAnnotationMetadata, Comparable<MethodAnnotationMetadata> {
+public interface FunctionAnnotationMetadata extends HasAnnotationMetadata, Comparable<FunctionAnnotationMetadata> {
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/FunctionAnnotationMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/FunctionAnnotationMetadata.java
@@ -16,5 +16,8 @@
 
 package org.gradle.internal.reflect.annotations;
 
+/**
+ * Annotation metadata associated with functions (i.e. an annotated method not associated with a property).
+ */
 public interface FunctionAnnotationMetadata extends HasAnnotationMetadata, Comparable<FunctionAnnotationMetadata> {
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/HasAnnotationMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/HasAnnotationMetadata.java
@@ -14,15 +14,23 @@
  * limitations under the License.
  */
 
-package org.gradle.api.problems.internal;
+package org.gradle.internal.reflect.annotations;
 
-/**
- * Specifies configuration options when creating a new TypeValidationData instance.
- */
-public interface TypeValidationDataSpec extends AdditionalDataSpec {
-    TypeValidationDataSpec pluginId(String pluginId);
-    TypeValidationDataSpec propertyName(String propertyName);
-    TypeValidationDataSpec methodName(String methodName);
-    TypeValidationDataSpec parentPropertyName(String parentPropertyName);
-    TypeValidationDataSpec typeName(String typeName);
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+public interface HasAnnotationMetadata {
+    Method getMethod();
+
+    boolean isAnnotationPresent(Class<? extends Annotation> annotationType);
+
+    <T extends Annotation> Optional<T> getAnnotation(Class<T> annotationType);
+
+    ImmutableMap<AnnotationCategory, Annotation> getAnnotations();
+
+    TypeToken<?> getDeclaredType();
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/HasAnnotationMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/HasAnnotationMetadata.java
@@ -45,11 +45,11 @@ public interface HasAnnotationMetadata {
     /**
      * Returns the annotations present on this element.
      */
-    ImmutableMap<AnnotationCategory, Annotation> getAnnotations();
+    ImmutableMap<AnnotationCategory, Annotation> getAnnotationsByCategory();
 
     /**
      * Returns the declared type of this element. For a property, this is the type of the property.
      * For a function, this is the return type of the function.
      */
-    TypeToken<?> getDeclaredType();
+    TypeToken<?> getDeclaredReturnType();
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/HasAnnotationMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/HasAnnotationMetadata.java
@@ -23,14 +23,33 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Optional;
 
+/**
+ * Base interface for elements that have annotation metadata, such as properties and functions.
+ */
 public interface HasAnnotationMetadata {
+    /**
+     * The method that this metadata is associated with (if relevant).
+     */
     Method getMethod();
 
+    /**
+     * Whether the given annotation is present on this element.
+     */
     boolean isAnnotationPresent(Class<? extends Annotation> annotationType);
 
+    /**
+     * Returns the annotation of the given type that is present on this element, if any.
+     */
     <T extends Annotation> Optional<T> getAnnotation(Class<T> annotationType);
 
+    /**
+     * Returns the annotations present on this element.
+     */
     ImmutableMap<AnnotationCategory, Annotation> getAnnotations();
 
+    /**
+     * Returns the declared type of this element. For a property, this is the type of the property.
+     * For a function, this is the return type of the function.
+     */
     TypeToken<?> getDeclaredType();
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/MethodAnnotationMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/MethodAnnotationMetadata.java
@@ -14,15 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.problems.internal;
+package org.gradle.internal.reflect.annotations;
 
-/**
- * Specifies configuration options when creating a new TypeValidationData instance.
- */
-public interface TypeValidationDataSpec extends AdditionalDataSpec {
-    TypeValidationDataSpec pluginId(String pluginId);
-    TypeValidationDataSpec propertyName(String propertyName);
-    TypeValidationDataSpec methodName(String methodName);
-    TypeValidationDataSpec parentPropertyName(String parentPropertyName);
-    TypeValidationDataSpec typeName(String typeName);
+public interface MethodAnnotationMetadata extends HasAnnotationMetadata, Comparable<MethodAnnotationMetadata> {
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/PropertyAnnotationMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/PropertyAnnotationMetadata.java
@@ -16,26 +16,10 @@
 
 package org.gradle.internal.reflect.annotations;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
-
 import javax.annotation.Nullable;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.util.Optional;
 
-public interface PropertyAnnotationMetadata extends Comparable<PropertyAnnotationMetadata> {
-    Method getGetter();
-
+public interface PropertyAnnotationMetadata extends HasAnnotationMetadata, Comparable<PropertyAnnotationMetadata> {
     String getPropertyName();
-
-    boolean isAnnotationPresent(Class<? extends Annotation> annotationType);
-
-    <T extends Annotation> Optional<T> getAnnotation(Class<T> annotationType);
-
-    ImmutableMap<AnnotationCategory, Annotation> getAnnotations();
-
-    TypeToken<?> getDeclaredType();
 
     @Nullable
     Object getPropertyValue(Object object);

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/PropertyAnnotationMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/PropertyAnnotationMetadata.java
@@ -18,6 +18,9 @@ package org.gradle.internal.reflect.annotations;
 
 import javax.annotation.Nullable;
 
+/**
+ * Annotation metadata associated with properties.
+ */
 public interface PropertyAnnotationMetadata extends HasAnnotationMetadata, Comparable<PropertyAnnotationMetadata> {
     String getPropertyName();
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/TypeAnnotationMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/TypeAnnotationMetadata.java
@@ -39,6 +39,11 @@ public interface TypeAnnotationMetadata {
      */
     ImmutableSortedSet<PropertyAnnotationMetadata> getPropertiesAnnotationMetadata();
 
+    /**
+     * Information about the type and annotations of each method of the type (i.e. annotated methods that are not properties).
+     */
+    ImmutableSortedSet<MethodAnnotationMetadata> getMethodsAnnotationMetadata();
+
     void visitValidationFailures(TypeValidationContext validationContext);
 
     /**

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/TypeAnnotationMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/TypeAnnotationMetadata.java
@@ -42,7 +42,7 @@ public interface TypeAnnotationMetadata {
     /**
      * Information about the type and annotations of each method of the type (i.e. annotated methods that are not properties).
      */
-    ImmutableSortedSet<MethodAnnotationMetadata> getMethodsAnnotationMetadata();
+    ImmutableSortedSet<FunctionAnnotationMetadata> getFunctionAnnotationMetadata();
 
     void visitValidationFailures(TypeValidationContext validationContext);
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/AbstractHasAnnotationMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/AbstractHasAnnotationMetadata.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.reflect.annotations.impl;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
+import org.gradle.internal.Cast;
+import org.gradle.internal.reflect.annotations.AnnotationCategory;
+import org.gradle.internal.reflect.annotations.HasAnnotationMetadata;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+public class AbstractHasAnnotationMetadata implements HasAnnotationMetadata {
+    protected final Method method;
+    protected final TypeToken<?> declaredType;
+    protected final ImmutableMap<AnnotationCategory, Annotation> annotationsByCategory;
+    protected final ImmutableMap<Class<? extends Annotation>, Annotation> annotationsByType;
+
+    public AbstractHasAnnotationMetadata(Method method, ImmutableMap<AnnotationCategory, Annotation> annotationsByCategory) {
+        this.method = method;
+        method.setAccessible(true);
+        this.declaredType = TypeToken.of(method.getGenericReturnType());
+        this.annotationsByCategory = annotationsByCategory;
+        this.annotationsByType = collectAnnotationsByType(annotationsByCategory);
+    }
+
+    protected static ImmutableMap<Class<? extends Annotation>, Annotation> collectAnnotationsByType(ImmutableMap<AnnotationCategory, Annotation> annotations) {
+        ImmutableMap.Builder<Class<? extends Annotation>, Annotation> builder = ImmutableMap.builderWithExpectedSize(annotations.size());
+        for (Annotation value : annotations.values()) {
+            builder.put(value.annotationType(), value);
+        }
+        return builder.build();
+    }
+
+    @Override
+    public Method getMethod() {
+        return method;
+    }
+
+    @Override
+    public boolean isAnnotationPresent(Class<? extends Annotation> annotationType) {
+        return annotationsByType.containsKey(annotationType);
+    }
+
+    @Override
+    public <T extends Annotation> Optional<T> getAnnotation(Class<T> annotationType) {
+        return Optional.ofNullable(Cast.uncheckedCast(annotationsByType.get(annotationType)));
+    }
+
+    @Override
+    public ImmutableMap<AnnotationCategory, Annotation> getAnnotations() {
+        return annotationsByCategory;
+    }
+
+    @Override
+    public TypeToken<?> getDeclaredType() {
+        return declaredType;
+    }
+}

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/AbstractHasAnnotationMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/AbstractHasAnnotationMetadata.java
@@ -43,7 +43,7 @@ public abstract class AbstractHasAnnotationMetadata implements HasAnnotationMeta
         this.annotationsByType = collectAnnotationsByType(annotationsByCategory);
     }
 
-    protected static ImmutableMap<Class<? extends Annotation>, Annotation> collectAnnotationsByType(ImmutableMap<AnnotationCategory, Annotation> annotations) {
+    private static ImmutableMap<Class<? extends Annotation>, Annotation> collectAnnotationsByType(ImmutableMap<AnnotationCategory, Annotation> annotations) {
         ImmutableMap.Builder<Class<? extends Annotation>, Annotation> builder = ImmutableMap.builderWithExpectedSize(annotations.size());
         for (Annotation value : annotations.values()) {
             builder.put(value.annotationType(), value);
@@ -67,12 +67,12 @@ public abstract class AbstractHasAnnotationMetadata implements HasAnnotationMeta
     }
 
     @Override
-    public ImmutableMap<AnnotationCategory, Annotation> getAnnotations() {
+    public ImmutableMap<AnnotationCategory, Annotation> getAnnotationsByCategory() {
         return annotationsByCategory;
     }
 
     @Override
-    public TypeToken<?> getDeclaredType() {
+    public TypeToken<?> getDeclaredReturnType() {
         return declaredType;
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/AbstractHasAnnotationMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/AbstractHasAnnotationMetadata.java
@@ -26,7 +26,10 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Optional;
 
-public class AbstractHasAnnotationMetadata implements HasAnnotationMetadata {
+/**
+ * Base class for elements that have annotation metadata, such as properties and functions.
+ */
+public abstract class AbstractHasAnnotationMetadata implements HasAnnotationMetadata {
     protected final Method method;
     protected final TypeToken<?> declaredType;
     protected final ImmutableMap<AnnotationCategory, Annotation> annotationsByCategory;

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultFunctionAnnotationMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultFunctionAnnotationMetadata.java
@@ -26,6 +26,9 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
+/**
+ * Default implementation of {@link FunctionAnnotationMetadata}.
+ */
 public class DefaultFunctionAnnotationMetadata extends AbstractHasAnnotationMetadata implements FunctionAnnotationMetadata {
 
     public DefaultFunctionAnnotationMetadata(Method method, ImmutableMap<AnnotationCategory, Annotation> annotationsByCategory) {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultFunctionAnnotationMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultFunctionAnnotationMetadata.java
@@ -44,14 +44,25 @@ public class DefaultFunctionAnnotationMetadata extends AbstractHasAnnotationMeta
         return Arrays.stream(getMethod().getParameterTypes()).map(Class::getSimpleName).collect(Collectors.joining(", "));
     }
 
+    /**
+     * Compares this metadata to another metadata by comparing the method name and the parameter types.
+     */
     @Override
     public int compareTo(@Nonnull FunctionAnnotationMetadata o) {
         int result = getMethod().getName().compareTo(o.getMethod().getName());
         if (result == 0) {
+            // This is the same method name, compare the number of parameters
             if (getMethod().getParameterCount() != o.getMethod().getParameterCount()) {
                 return getMethod().getParameterCount() - o.getMethod().getParameterCount();
             } else {
-                return Arrays.equals(getMethod().getParameterTypes(), o.getMethod().getParameterTypes()) ? 0 : 1;
+                // Same method name, same number of parameters, compare the parameter types
+                for (int i = 0; i < getMethod().getParameterCount(); i++) {
+                    // If the parameters don't match, return the comparison of the first mismatched parameter type name
+                    if (getMethod().getParameterTypes()[i] != o.getMethod().getParameterTypes()[i]) {
+                        return getMethod().getParameterTypes()[i].getName().compareTo(o.getMethod().getParameterTypes()[i].getName());
+                    }
+                }
+                return 0;
             }
         } else {
             return result;

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultFunctionAnnotationMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultFunctionAnnotationMetadata.java
@@ -18,7 +18,7 @@ package org.gradle.internal.reflect.annotations.impl;
 
 import com.google.common.collect.ImmutableMap;
 import org.gradle.internal.reflect.annotations.AnnotationCategory;
-import org.gradle.internal.reflect.annotations.MethodAnnotationMetadata;
+import org.gradle.internal.reflect.annotations.FunctionAnnotationMetadata;
 
 import javax.annotation.Nonnull;
 import java.lang.annotation.Annotation;
@@ -26,9 +26,9 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-public class DefaultMethodAnnotationMetadata extends AbstractHasAnnotationMetadata implements MethodAnnotationMetadata {
+public class DefaultFunctionAnnotationMetadata extends AbstractHasAnnotationMetadata implements FunctionAnnotationMetadata {
 
-    public DefaultMethodAnnotationMetadata(Method method, ImmutableMap<AnnotationCategory, Annotation> annotationsByCategory) {
+    public DefaultFunctionAnnotationMetadata(Method method, ImmutableMap<AnnotationCategory, Annotation> annotationsByCategory) {
         super(method, annotationsByCategory);
     }
 
@@ -42,7 +42,7 @@ public class DefaultMethodAnnotationMetadata extends AbstractHasAnnotationMetada
     }
 
     @Override
-    public int compareTo(@Nonnull MethodAnnotationMetadata o) {
+    public int compareTo(@Nonnull FunctionAnnotationMetadata o) {
         int result = getMethod().getName().compareTo(o.getMethod().getName());
         if (result == 0) {
             if (getMethod().getParameterCount() != o.getMethod().getParameterCount()) {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultMethodAnnotationMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultMethodAnnotationMetadata.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.reflect.annotations.impl;
+
+import com.google.common.collect.ImmutableMap;
+import org.gradle.internal.reflect.annotations.AnnotationCategory;
+import org.gradle.internal.reflect.annotations.MethodAnnotationMetadata;
+
+import javax.annotation.Nonnull;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public class DefaultMethodAnnotationMetadata extends AbstractHasAnnotationMetadata implements MethodAnnotationMetadata {
+
+    public DefaultMethodAnnotationMetadata(Method method, ImmutableMap<AnnotationCategory, Annotation> annotationsByCategory) {
+        super(method, annotationsByCategory);
+    }
+
+    @Override
+    public String toString() {
+        return getMethod().getName() + "(" + getParameterTypeString() + ")";
+    }
+
+    private String getParameterTypeString() {
+        return Arrays.stream(getMethod().getParameterTypes()).map(Class::getSimpleName).collect(Collectors.joining(", "));
+    }
+
+    @Override
+    public int compareTo(@Nonnull MethodAnnotationMetadata o) {
+        int result = getMethod().getName().compareTo(o.getMethod().getName());
+        if (result == 0) {
+            if (getMethod().getParameterCount() != o.getMethod().getParameterCount()) {
+                return getMethod().getParameterCount() - o.getMethod().getParameterCount();
+            } else {
+                return Arrays.equals(getMethod().getParameterTypes(), o.getMethod().getParameterTypes()) ? 0 : 1;
+            }
+        } else {
+            return result;
+        }
+    }
+}

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultPropertyAnnotationMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultPropertyAnnotationMetadata.java
@@ -17,9 +17,7 @@
 package org.gradle.internal.reflect.annotations.impl;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 import org.gradle.api.GradleException;
-import org.gradle.internal.Cast;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.reflect.annotations.AnnotationCategory;
 import org.gradle.internal.reflect.annotations.PropertyAnnotationMetadata;
@@ -29,35 +27,13 @@ import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Optional;
 
-public class DefaultPropertyAnnotationMetadata implements PropertyAnnotationMetadata {
+public class DefaultPropertyAnnotationMetadata extends AbstractHasAnnotationMetadata implements PropertyAnnotationMetadata {
     private final String propertyName;
-    private final Method getter;
-    private final TypeToken<?> declaredType;
-    private final ImmutableMap<AnnotationCategory, Annotation> annotationsByCategory;
-    private final ImmutableMap<Class<? extends Annotation>, Annotation> annotationsByType;
 
     public DefaultPropertyAnnotationMetadata(String propertyName, Method getter, ImmutableMap<AnnotationCategory, Annotation> annotationsByCategory) {
+        super(getter, annotationsByCategory);
         this.propertyName = propertyName;
-        this.getter = getter;
-        getter.setAccessible(true);
-        this.declaredType = TypeToken.of(getter.getGenericReturnType());
-        this.annotationsByCategory = annotationsByCategory;
-        this.annotationsByType = collectAnnotationsByType(annotationsByCategory);
-    }
-
-    private static ImmutableMap<Class<? extends Annotation>, Annotation> collectAnnotationsByType(ImmutableMap<AnnotationCategory, Annotation> annotations) {
-        ImmutableMap.Builder<Class<? extends Annotation>, Annotation> builder = ImmutableMap.builderWithExpectedSize(annotations.size());
-        for (Annotation value : annotations.values()) {
-            builder.put(value.annotationType(), value);
-        }
-        return builder.build();
-    }
-
-    @Override
-    public Method getGetter() {
-        return getter;
     }
 
     @Override
@@ -66,44 +42,24 @@ public class DefaultPropertyAnnotationMetadata implements PropertyAnnotationMeta
     }
 
     @Override
-    public boolean isAnnotationPresent(Class<? extends Annotation> annotationType) {
-        return annotationsByType.containsKey(annotationType);
-    }
-
-    @Override
-    public <T extends Annotation> Optional<T> getAnnotation(Class<T> annotationType) {
-        return Optional.ofNullable(Cast.uncheckedCast(annotationsByType.get(annotationType)));
-    }
-
-    @Override
-    public ImmutableMap<AnnotationCategory, Annotation> getAnnotations() {
-        return annotationsByCategory;
-    }
-
-    @Override
     public int compareTo(@Nonnull PropertyAnnotationMetadata o) {
         return propertyName.compareTo(o.getPropertyName());
-    }
-
-    @Override
-    public TypeToken<?> getDeclaredType() {
-        return declaredType;
     }
 
     @Nullable
     @Override
     public Object getPropertyValue(Object object) {
         try {
-            return getter.invoke(object);
+            return getMethod().invoke(object);
         } catch (InvocationTargetException e) {
             throw UncheckedException.throwAsUncheckedException(e.getCause());
         } catch (Exception e) {
-            throw new GradleException(String.format("Could not call %s.%s() on %s", getter.getDeclaringClass().getSimpleName(), getter.getName(), object), e);
+            throw new GradleException(String.format("Could not call %s.%s() on %s", getMethod().getDeclaringClass().getSimpleName(), getMethod().getName(), object), e);
         }
     }
 
     @Override
     public String toString() {
-        return String.format("%s / %s()", propertyName, getter.getName());
+        return String.format("%s / %s()", propertyName, getMethod().getName());
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadata.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Maps;
 import org.gradle.internal.Cast;
+import org.gradle.internal.reflect.annotations.MethodAnnotationMetadata;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
 import org.gradle.internal.reflect.validation.ReplayingTypeValidationContext;
 import org.gradle.internal.reflect.annotations.PropertyAnnotationMetadata;
@@ -32,11 +33,13 @@ import java.util.Optional;
 public class DefaultTypeAnnotationMetadata implements TypeAnnotationMetadata {
     private final ImmutableBiMap<Class<? extends Annotation>, Annotation> annotations;
     private final ImmutableSortedSet<PropertyAnnotationMetadata> properties;
+    private final ImmutableSortedSet<MethodAnnotationMetadata> methods;
     private final ReplayingTypeValidationContext validationProblems;
 
-    public DefaultTypeAnnotationMetadata(Iterable<? extends Annotation> annotations, Iterable<? extends PropertyAnnotationMetadata> properties, ReplayingTypeValidationContext validationProblems) {
+    public DefaultTypeAnnotationMetadata(Iterable<? extends Annotation> annotations, Iterable<? extends PropertyAnnotationMetadata> properties, Iterable<? extends MethodAnnotationMetadata> methods, ReplayingTypeValidationContext validationProblems) {
         this.annotations = ImmutableBiMap.copyOf(Maps.uniqueIndex(annotations, Annotation::annotationType));
         this.properties = ImmutableSortedSet.copyOf(properties);
+        this.methods = ImmutableSortedSet.copyOf(methods);
         this.validationProblems = validationProblems;
     }
 
@@ -53,6 +56,11 @@ public class DefaultTypeAnnotationMetadata implements TypeAnnotationMetadata {
     @Override
     public ImmutableSortedSet<PropertyAnnotationMetadata> getPropertiesAnnotationMetadata() {
         return properties;
+    }
+
+    @Override
+    public ImmutableSortedSet<MethodAnnotationMetadata> getMethodsAnnotationMetadata() {
+        return methods;
     }
 
     @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadata.java
@@ -30,6 +30,9 @@ import org.gradle.internal.reflect.annotations.TypeAnnotationMetadata;
 import java.lang.annotation.Annotation;
 import java.util.Optional;
 
+/**
+ * Default implementation of {@link TypeAnnotationMetadata}.
+ */
 public class DefaultTypeAnnotationMetadata implements TypeAnnotationMetadata {
     private final ImmutableBiMap<Class<? extends Annotation>, Annotation> annotations;
     private final ImmutableSortedSet<PropertyAnnotationMetadata> properties;

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadata.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadata.java
@@ -21,7 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Maps;
 import org.gradle.internal.Cast;
-import org.gradle.internal.reflect.annotations.MethodAnnotationMetadata;
+import org.gradle.internal.reflect.annotations.FunctionAnnotationMetadata;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
 import org.gradle.internal.reflect.validation.ReplayingTypeValidationContext;
 import org.gradle.internal.reflect.annotations.PropertyAnnotationMetadata;
@@ -33,10 +33,10 @@ import java.util.Optional;
 public class DefaultTypeAnnotationMetadata implements TypeAnnotationMetadata {
     private final ImmutableBiMap<Class<? extends Annotation>, Annotation> annotations;
     private final ImmutableSortedSet<PropertyAnnotationMetadata> properties;
-    private final ImmutableSortedSet<MethodAnnotationMetadata> methods;
+    private final ImmutableSortedSet<FunctionAnnotationMetadata> methods;
     private final ReplayingTypeValidationContext validationProblems;
 
-    public DefaultTypeAnnotationMetadata(Iterable<? extends Annotation> annotations, Iterable<? extends PropertyAnnotationMetadata> properties, Iterable<? extends MethodAnnotationMetadata> methods, ReplayingTypeValidationContext validationProblems) {
+    public DefaultTypeAnnotationMetadata(Iterable<? extends Annotation> annotations, Iterable<? extends PropertyAnnotationMetadata> properties, Iterable<? extends FunctionAnnotationMetadata> methods, ReplayingTypeValidationContext validationProblems) {
         this.annotations = ImmutableBiMap.copyOf(Maps.uniqueIndex(annotations, Annotation::annotationType));
         this.properties = ImmutableSortedSet.copyOf(properties);
         this.methods = ImmutableSortedSet.copyOf(methods);
@@ -59,7 +59,7 @@ public class DefaultTypeAnnotationMetadata implements TypeAnnotationMetadata {
     }
 
     @Override
-    public ImmutableSortedSet<MethodAnnotationMetadata> getMethodsAnnotationMetadata() {
+    public ImmutableSortedSet<FunctionAnnotationMetadata> getFunctionAnnotationMetadata() {
         return methods;
     }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStore.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStore.java
@@ -563,13 +563,13 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
         }
 
         if (Modifier.isStatic(method.getModifiers())) {
-            validateNotAnnotatedForMethod(MethodKind.STATIC, method, annotations.keySet(), validationContext);
+            validateNotAnnotatedForStaticMethod(method, annotations.keySet(), validationContext);
             return;
         }
 
         PropertyAccessorType accessorType = PropertyAccessorType.of(method);
         if (accessorType != null) {
-            validateNotAnnotatedForMethod(MethodKind.PROPERTY, method, annotations.keySet(), validationContext);
+            validateNotAnnotatedForPropertyGetter(method, annotations.keySet(), validationContext);
             return;
         }
 
@@ -659,7 +659,7 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
 
     private static final String IGNORED_ANNOTATIONS_ON_PROPERTY = "IGNORED_ANNOTATIONS_ON_PROPERTY";
 
-    private static void validateNotAnnotatedForMethod(MethodKind methodKind, Method method, Set<Class<? extends Annotation>> annotationTypes, TypeValidationContext validationContext) {
+    private static void validateNotAnnotatedForPropertyGetter(Method method, Set<Class<? extends Annotation>> annotationTypes, TypeValidationContext validationContext) {
         if (!annotationTypes.isEmpty()) {
             validationContext.visitTypeProblem(problem ->
                 problem.withAnnotationType(method.getDeclaringClass())
@@ -667,7 +667,7 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                     .contextualLabel(
                         String.format(
                             "%s '%s()' should not be annotated with: %s",
-                            methodKind.getDisplayName(), method.getName(),
+                            MethodKind.PROPERTY.getDisplayName(), method.getName(),
                             simpleAnnotationNames(annotationTypes.stream())
                         )
                     )
@@ -676,6 +676,27 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                     .details("Non-property annotations are ignored if they are placed on a property getter")
                     .solution("Remove the annotations")
                     .solution("Rename the method")
+            );
+        }
+    }
+
+    private static void validateNotAnnotatedForStaticMethod(Method method, Set<Class<? extends Annotation>> annotationTypes, TypeValidationContext validationContext) {
+        if (!annotationTypes.isEmpty()) {
+            validationContext.visitTypeProblem(problem ->
+                problem.withAnnotationType(method.getDeclaringClass())
+                    .id(TextUtil.screamingSnakeToKebabCase(IGNORED_ANNOTATIONS_ON_PROPERTY), "Ignored annotations on property", GradleCoreProblemGroup.validation().type())
+                    .contextualLabel(
+                        String.format(
+                            "%s '%s()' should not be annotated with: %s",
+                            MethodKind.STATIC.getDisplayName(), method.getName(),
+                            simpleAnnotationNames(annotationTypes.stream())
+                        )
+                    )
+                    .documentedAt(userManual("validation_problems", IGNORED_ANNOTATIONS_ON_PROPERTY.toLowerCase(Locale.ROOT)))
+                    .severity(ERROR)
+                    .details("Non-property annotations are ignored if they are placed on a static method")
+                    .solution("Remove the annotations")
+                    .solution("Make the method non-static")
             );
         }
     }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStore.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStore.java
@@ -870,7 +870,7 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
             return annotations.stream().filter(annotation -> !ignoredMethodAnnotationsAllowedModifiers.contains(annotation.annotationType()));
         }
 
-        void handleAnnotatedIgnoredMethod(Class<? extends Annotation> ignoredMethodAnnotation) {
+        private void handleAnnotatedIgnoredMethod(Class<? extends Annotation> ignoredMethodAnnotation) {
             visitPropertyProblem(problem ->
                 problem
                     .forProperty(propertyName)

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStore.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStore.java
@@ -760,7 +760,7 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
         }
 
         public void inheritAnnotations(boolean fromInterface, HasAnnotationMetadata superProperty) {
-            superProperty.getAnnotations()
+            superProperty.getAnnotationsByCategory()
                 .forEach((fromInterface
                     ? inheritedInterfaceAnnotations
                     : inheritedSuperclassAnnotations)::put);

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStore.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStore.java
@@ -33,6 +33,8 @@ import org.gradle.cache.internal.CrossBuildInMemoryCache;
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
 import org.gradle.internal.reflect.PropertyAccessorType;
 import org.gradle.internal.reflect.annotations.AnnotationCategory;
+import org.gradle.internal.reflect.annotations.HasAnnotationMetadata;
+import org.gradle.internal.reflect.annotations.MethodAnnotationMetadata;
 import org.gradle.internal.reflect.annotations.PropertyAnnotationMetadata;
 import org.gradle.internal.reflect.annotations.TypeAnnotationMetadata;
 import org.gradle.internal.reflect.annotations.TypeAnnotationMetadataStore;
@@ -49,6 +51,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -86,6 +89,11 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
         }
 
         @Override
+        public ImmutableSortedSet<MethodAnnotationMetadata> getMethodsAnnotationMetadata() {
+            return ImmutableSortedSet.of();
+        }
+
+        @Override
         public void visitValidationFailures(TypeValidationContext validationContext) {
         }
 
@@ -98,6 +106,7 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
     private final ImmutableSet<Class<? extends Annotation>> recordedTypeAnnotations;
     private final ImmutableSet<String> ignoredPackagePrefixes;
     private final ImmutableMap<Class<? extends Annotation>, AnnotationCategory> propertyAnnotationCategories;
+    private final ImmutableMap<Class<? extends Annotation>, AnnotationCategory> methodAnnotationCategories;
     private final CrossBuildInMemoryCache<Class<?>, TypeAnnotationMetadata> cache;
     private final ImmutableSet<String> potentiallyIgnoredMethodNames;
     private final ImmutableSet<Equivalence.Wrapper<Method>> globallyIgnoredMethods;
@@ -123,6 +132,7 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
     public DefaultTypeAnnotationMetadataStore(
         Collection<Class<? extends Annotation>> recordedTypeAnnotations,
         Map<Class<? extends Annotation>, ? extends AnnotationCategory> propertyAnnotationCategories,
+        Map<Class<? extends Annotation>, ? extends AnnotationCategory> methodAnnotationCategories,
         Collection<String> ignoredPackagePrefixes,
         Collection<Class<?>> ignoredSuperTypes,
         Collection<Class<?>> ignoreMethodsFromTypes,
@@ -134,7 +144,8 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
     ) {
         this.recordedTypeAnnotations = ImmutableSet.copyOf(recordedTypeAnnotations);
         this.ignoredPackagePrefixes = collectIgnoredPackagePrefixes(ignoredPackagePrefixes);
-        this.propertyAnnotationCategories = allAnnotationCategories(propertyAnnotationCategories, ignoredMethodAnnotations);
+        this.propertyAnnotationCategories = allAnnotationCategoriesForProperties(propertyAnnotationCategories, ignoredMethodAnnotations);
+        this.methodAnnotationCategories = allAnnotationCategories(methodAnnotationCategories, Collections.emptyList());
         this.cache = initCache(ignoredSuperTypes, cacheFactory);
         this.potentiallyIgnoredMethodNames = allMethodNamesOf(ignoreMethodsFromTypes);
         this.globallyIgnoredMethods = allMethodsOf(ignoreMethodsFromTypes);
@@ -151,13 +162,22 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
         );
     }
 
-    private static ImmutableMap<Class<? extends Annotation>, AnnotationCategory> allAnnotationCategories(
+    private static ImmutableMap<Class<? extends Annotation>, AnnotationCategory> allAnnotationCategoriesForProperties(
         Map<Class<? extends Annotation>, ? extends AnnotationCategory> propertyAnnotationCategories,
         Collection<Class<? extends Annotation>> ignoredMethodAnnotations
     ) {
         ImmutableMap.Builder<Class<? extends Annotation>, AnnotationCategory> builder = ImmutableMap.builder();
-        builder.putAll(propertyAnnotationCategories);
+        builder.putAll(allAnnotationCategories(propertyAnnotationCategories, ignoredMethodAnnotations));
         builder.put(Inject.class, TYPE);
+        return builder.build();
+    }
+
+    private static ImmutableMap<Class<? extends Annotation>, AnnotationCategory> allAnnotationCategories(
+        Map<Class<? extends Annotation>, ? extends AnnotationCategory> annotationCategories,
+        Collection<Class<? extends Annotation>> ignoredMethodAnnotations
+    ) {
+        ImmutableMap.Builder<Class<? extends Annotation>, AnnotationCategory> builder = ImmutableMap.builder();
+        builder.putAll(annotationCategories);
         for (Class<? extends Annotation> ignoredMethodAnnotation : ignoredMethodAnnotations) {
             builder.put(ignoredMethodAnnotation, TYPE);
         }
@@ -217,36 +237,59 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
             }
         }
 
-        Map<String, PropertyAnnotationMetadataBuilder> methodBuilders = new HashMap<>();
+        Map<String, PropertyAnnotationMetadataBuilder> propertyMethodBuilders = new HashMap<>();
+        Map<MethodSignature, MethodAnnotationMetadataBuilder> nonPropertyMethodBuilders = new HashMap<>();
         ReplayingTypeValidationContext validationContext = new ReplayingTypeValidationContext();
 
-        inheritMethods(type, validationContext, methodBuilders);
+        inheritMethods(type, validationContext, propertyMethodBuilders);
+        inheritNonPropertyMethods(type, validationContext, nonPropertyMethodBuilders);
 
         ImmutableSortedSet<PropertyAnnotationMetadata> propertiesMetadata;
+        ImmutableSortedSet<MethodAnnotationMetadata> nonPropertyMethodsMetadata;
         if (!type.isSynthetic()) {
-            propertiesMetadata = extractPropertiesFrom(type, methodBuilders, validationContext);
+            propertiesMetadata = extractPropertiesFrom(type, propertyMethodBuilders, validationContext);
+            nonPropertyMethodsMetadata = extractMethodsFrom(type, nonPropertyMethodBuilders, validationContext);
         } else {
             ImmutableSortedSet.Builder<PropertyAnnotationMetadata> propertiesMetadataBuilder = ImmutableSortedSet.naturalOrder();
-            for (PropertyAnnotationMetadataBuilder propertyMetadataBuilder : methodBuilders.values()) {
+            for (PropertyAnnotationMetadataBuilder propertyMetadataBuilder : propertyMethodBuilders.values()) {
                 propertiesMetadataBuilder.add(propertyMetadataBuilder.build());
             }
             propertiesMetadata = propertiesMetadataBuilder.build();
+
+            ImmutableSortedSet.Builder<MethodAnnotationMetadata> methodsMetadataBuilder = ImmutableSortedSet.naturalOrder();
+            for (MethodAnnotationMetadataBuilder methodMetadataBuilder : nonPropertyMethodBuilders.values()) {
+                methodsMetadataBuilder.add(methodMetadataBuilder.build());
+            }
+            nonPropertyMethodsMetadata = methodsMetadataBuilder.build();
         }
 
-        return new DefaultTypeAnnotationMetadata(typeAnnotations.build(), propertiesMetadata, validationContext);
+        return new DefaultTypeAnnotationMetadata(typeAnnotations.build(), propertiesMetadata, nonPropertyMethodsMetadata, validationContext);
     }
 
     private void inheritMethods(Class<?> type, TypeValidationContext validationContext, Map<String, PropertyAnnotationMetadataBuilder> methodBuilders) {
         visitSuperTypes(type, (superType, metadata) -> {
             for (PropertyAnnotationMetadata property : metadata.getPropertiesAnnotationMetadata()) {
-                getOrCreateBuilder(property.getPropertyName(), property.getGetter(), validationContext, methodBuilders)
+                getOrCreatePropertyBuilder(property.getPropertyName(), property.getMethod(), validationContext, methodBuilders)
                     .inheritAnnotations(superType.isInterface(), property);
             }
         });
     }
 
-    private PropertyAnnotationMetadataBuilder getOrCreateBuilder(String propertyName, Method getter, TypeValidationContext validationContext, Map<String, PropertyAnnotationMetadataBuilder> propertyBuilders) {
+    private void inheritNonPropertyMethods(Class<?> type, TypeValidationContext validationContext, Map<MethodSignature, MethodAnnotationMetadataBuilder> methodBuilders) {
+        visitSuperTypes(type, (superType, metadata) -> {
+            for (MethodAnnotationMetadata method : metadata.getMethodsAnnotationMetadata()) {
+                getOrCreateMethodBuilder(method.getMethod(), validationContext, methodBuilders)
+                    .inheritAnnotations(superType.isInterface(), method);
+            }
+        });
+    }
+
+    private PropertyAnnotationMetadataBuilder getOrCreatePropertyBuilder(String propertyName, Method getter, TypeValidationContext validationContext, Map<String, PropertyAnnotationMetadataBuilder> propertyBuilders) {
         return propertyBuilders.computeIfAbsent(getter.getName(), methodName -> new PropertyAnnotationMetadataBuilder(propertyName, getter, validationContext));
+    }
+
+    private MethodAnnotationMetadataBuilder getOrCreateMethodBuilder(Method method, TypeValidationContext validationContext, Map<MethodSignature, MethodAnnotationMetadataBuilder> methodBuilders) {
+        return methodBuilders.computeIfAbsent(MethodSignature.of(method), methodName -> new MethodAnnotationMetadataBuilder(method, validationContext));
     }
 
     private ImmutableSortedSet<PropertyAnnotationMetadata> extractPropertiesFrom(Class<?> type, Map<String, PropertyAnnotationMetadataBuilder> methodBuilders, TypeValidationContext validationContext) {
@@ -254,12 +297,25 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
         // Make sure getters end up before the setters
         Arrays.sort(methods, comparing(Method::getName));
         for (Method method : methods) {
-            processMethodAnnotations(method, methodBuilders, validationContext);
+            processPropertyMethodAnnotations(method, methodBuilders, validationContext);
         }
 
         ImmutableList<PropertyAnnotationMetadataBuilder> propertyBuilders = convertMethodToPropertyBuilders(methodBuilders);
-        ImmutableMap<String, ImmutableMap<Class<? extends Annotation>, Annotation>> fieldAnnotationsByPropertyName = collectFieldAnnotations(type);
+        ImmutableMap<String, ImmutableMap<Class<? extends Annotation>, Annotation>> fieldAnnotationsByPropertyName = collectFieldAnnotations(type, validationContext);
         return mergePropertiesAndFieldMetadata(type, propertyBuilders, fieldAnnotationsByPropertyName, validationContext);
+    }
+
+    private ImmutableSortedSet<MethodAnnotationMetadata> extractMethodsFrom(Class<?> type, Map<MethodSignature, MethodAnnotationMetadataBuilder> methodBuilders, TypeValidationContext validationContext) {
+        Method[] methods = type.getDeclaredMethods();
+        // Make sure getters end up before the setters
+        Arrays.sort(methods, comparing(Method::getName));
+        for (Method method : methods) {
+            processNonPropertyMethodAnnotations(method, methodBuilders, validationContext);
+        }
+
+        ImmutableSortedSet.Builder<MethodAnnotationMetadata> methodsMetadataBuilder = ImmutableSortedSet.naturalOrder();
+        methodBuilders.values().forEach(metadataBuilder -> methodsMetadataBuilder.add(metadataBuilder.build()));
+        return methodsMetadataBuilder.build();
     }
 
     private static final String REDUNDANT_GETTERS = "REDUNDANT_GETTERS";
@@ -267,7 +323,7 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
     private ImmutableList<PropertyAnnotationMetadataBuilder> convertMethodToPropertyBuilders(Map<String, PropertyAnnotationMetadataBuilder> methodBuilders) {
         Map<String, PropertyAnnotationMetadataBuilder> propertyBuilders = new LinkedHashMap<>();
         List<PropertyAnnotationMetadataBuilder> metadataBuilders = Ordering.<PropertyAnnotationMetadataBuilder>from(
-                comparing(metadataBuilder -> metadataBuilder.getGetter().getName()))
+                comparing(metadataBuilder -> metadataBuilder.getMethod().getName()))
             .sortedCopy(methodBuilders.values());
         for (PropertyAnnotationMetadataBuilder metadataBuilder : metadataBuilders) {
             String propertyName = metadataBuilder.getPropertyName();
@@ -275,7 +331,7 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
             // Do we have an 'is'-getter as well as a 'get'-getter?
             if (previouslySeenBuilder != null) {
                 // It is okay to have redundant generated 'is'-getters
-                if (generatedMethodDetector.test(metadataBuilder.getter)) {
+                if (generatedMethodDetector.test(metadataBuilder.getMethod())) {
                     continue;
                 }
                 // The 'is'-getter is ignored, we can skip it in favor of the 'get'-getter
@@ -296,8 +352,8 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                         .contextualLabel(
                             String.format(
                                 "has redundant getters: '%s()' and '%s()'",
-                                previouslySeenBuilder.getter.getName(),
-                                metadataBuilder.getter.getName()
+                                previouslySeenBuilder.getMethod().getName(),
+                                metadataBuilder.getMethod().getName()
                             )
                         )
                         .documentedAt(userManual("validation_problems", REDUNDANT_GETTERS.toLowerCase(Locale.ROOT)))
@@ -311,13 +367,34 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
         return ImmutableList.copyOf(propertyBuilders.values());
     }
 
-    private ImmutableMap<String, ImmutableMap<Class<? extends Annotation>, Annotation>> collectFieldAnnotations(Class<?> type) {
+    private ImmutableMap<String, ImmutableMap<Class<? extends Annotation>, Annotation>> collectFieldAnnotations(Class<?> type, TypeValidationContext validationContext) {
         ImmutableMap.Builder<String, ImmutableMap<Class<? extends Annotation>, Annotation>> fieldAnnotationsByPropertyName = ImmutableMap.builder();
         for (Field declaredField : type.getDeclaredFields()) {
             if (declaredField.isSynthetic()) {
                 continue;
             }
-            fieldAnnotationsByPropertyName.put(declaredField.getName(), collectRelevantAnnotations(declaredField));
+            fieldAnnotationsByPropertyName.put(declaredField.getName(), collectRelevantAnnotations(declaredField, propertyAnnotationCategories));
+            ImmutableMap<Class<? extends Annotation>, Annotation> nonPropertyAnnotations = collectRelevantAnnotations(declaredField, methodAnnotationCategories);
+            if (!nonPropertyAnnotations.isEmpty()) {
+                // Non-property method annotations should not be applicable to fields and should throw a compile time error, but in the
+                // event that they are marked applicable to fields, we report them as a problem.  If we add an annotation that is somehow
+                // valid in this context, we'll need to handle it in some way to avoid the problem being generated.
+                validationContext.visitTypeProblem(problem ->
+                    problem.withAnnotationType(declaredField.getDeclaringClass())
+                        .id(TextUtil.screamingSnakeToKebabCase(IGNORED_ANNOTATIONS_ON_PROPERTY), "Ignored annotations on property", GradleCoreProblemGroup.validation().type())
+                        .contextualLabel(
+                            String.format(
+                                "field '%s()' should not be annotated with: %s",
+                                declaredField.getName(),
+                                simpleAnnotationNames(nonPropertyAnnotations.keySet().stream())
+                            )
+                        )
+                        .documentedAt(userManual("validation_problems", IGNORED_ANNOTATIONS_ON_PROPERTY.toLowerCase(Locale.ROOT)))
+                        .severity(ERROR)
+                        .details("Non-property annotations are ignored if they are placed on a field")
+                        .solution("Remove the annotations")
+                );
+            }
         }
         return fieldAnnotationsByPropertyName.build();
     }
@@ -405,7 +482,7 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
 
     private static final String PRIVATE_GETTER_MUST_NOT_BE_ANNOTATED = "PRIVATE_GETTER_MUST_NOT_BE_ANNOTATED";
 
-    private void processMethodAnnotations(Method method, Map<String, PropertyAnnotationMetadataBuilder> methodBuilders, TypeValidationContext validationContext) {
+    private void processPropertyMethodAnnotations(Method method, Map<String, PropertyAnnotationMetadataBuilder> methodBuilders, TypeValidationContext validationContext) {
         if (shouldIgnore(method)) {
             return;
         }
@@ -415,22 +492,22 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
             return;
         }
 
-        ImmutableMap<Class<? extends Annotation>, Annotation> annotations = collectRelevantAnnotations(method);
+        ImmutableMap<Class<? extends Annotation>, Annotation> annotations = collectRelevantAnnotations(method, propertyAnnotationCategories);
 
         if (Modifier.isStatic(method.getModifiers())) {
-            validateNotAnnotated(MethodKind.STATIC, method, annotations.keySet(), validationContext);
+            validateNotAnnotatedForProperty(MethodKind.STATIC, method, annotations.keySet(), validationContext);
             return;
         }
 
         PropertyAccessorType accessorType = PropertyAccessorType.of(method);
         if (accessorType == null) {
-            validateNotAnnotated(MethodKind.NON_PROPERTY, method, annotations.keySet(), validationContext);
+            validateNotAnnotatedForProperty(MethodKind.NON_PROPERTY, method, annotations.keySet(), validationContext);
             return;
         }
 
         String propertyName = accessorType.propertyNameFor(method);
         if (accessorType == PropertyAccessorType.SETTER) {
-            validateNotAnnotated(MethodKind.SETTER, method, annotations.keySet(), validationContext);
+            validateNotAnnotatedForProperty(MethodKind.SETTER, method, annotations.keySet(), validationContext);
             validateSetterForMutableType(method, accessorType, validationContext, propertyName);
             return;
         }
@@ -443,7 +520,7 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
             return;
         }
 
-        PropertyAnnotationMetadataBuilder metadataBuilder = getOrCreateBuilder(propertyName, method, validationContext, methodBuilders);
+        PropertyAnnotationMetadataBuilder metadataBuilder = getOrCreatePropertyBuilder(propertyName, method, validationContext, methodBuilders);
         metadataBuilder.overrideMethod(method);
 
         if (privateGetter) {
@@ -458,6 +535,60 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                     .details("Annotations on private getters are ignored")
                     .solution("Make the getter public")
                     .solution("Annotate the public version of the getter")
+            );
+        }
+
+        for (Annotation annotation : annotations.values()) {
+            metadataBuilder.declareAnnotation(annotation);
+        }
+    }
+
+    private static final String PRIVATE_METHOD_MUST_NOT_BE_ANNOTATED = "PRIVATE_METHOD_MUST_NOT_BE_ANNOTATED";
+
+    private void processNonPropertyMethodAnnotations(Method method, Map<MethodSignature, MethodAnnotationMetadataBuilder> methodBuilders, TypeValidationContext validationContext) {
+        if (shouldIgnore(method)) {
+            return;
+        }
+        // As an optimization first check if the method name is among the candidates before we construct an equivalence wrapper
+        if (potentiallyIgnoredMethodNames.contains(method.getName())
+            && globallyIgnoredMethods.contains(SIGNATURE_EQUIVALENCE.wrap(method))) {
+            return;
+        }
+
+        ImmutableMap<Class<? extends Annotation>, Annotation> annotations = collectRelevantAnnotations(method, methodAnnotationCategories);
+
+        // If the non-property method is not annotated, we can ignore it
+        if (annotations.isEmpty()) {
+            return;
+        }
+
+        if (Modifier.isStatic(method.getModifiers())) {
+            validateNotAnnotatedForMethod(MethodKind.STATIC, method, annotations.keySet(), validationContext);
+            return;
+        }
+
+        PropertyAccessorType accessorType = PropertyAccessorType.of(method);
+        if (accessorType != null) {
+            validateNotAnnotatedForMethod(MethodKind.PROPERTY, method, annotations.keySet(), validationContext);
+            return;
+        }
+
+        MethodAnnotationMetadataBuilder metadataBuilder = getOrCreateMethodBuilder(method, validationContext, methodBuilders);
+        metadataBuilder.overrideMethod(method);
+
+        boolean privateMethod = Modifier.isPrivate(method.getModifiers());
+        if (privateMethod) {
+            // At this point we must have annotations on this private getter
+            metadataBuilder.visitMethodProblem(problem ->
+                problem
+                    .forMethod(method.getName())
+                    .id(TextUtil.screamingSnakeToKebabCase(PRIVATE_METHOD_MUST_NOT_BE_ANNOTATED), "Private method with wrong annotation", GradleCoreProblemGroup.validation().property())
+                    .contextualLabel(String.format("is private and annotated with %s", simpleAnnotationNames(annotations.keySet().stream())))
+                    .documentedAt(userManual("validation_problems", PRIVATE_METHOD_MUST_NOT_BE_ANNOTATED.toLowerCase(Locale.ROOT)))
+                    .severity(ERROR)
+                    .details("Annotations on private methods are ignored")
+                    .solution("Make the method public")
+                    .solution("Annotate the public version of the method")
             );
         }
 
@@ -505,7 +636,7 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
 
     private static final String IGNORED_ANNOTATIONS_ON_METHOD = "IGNORED_ANNOTATIONS_ON_METHOD";
 
-    private static void validateNotAnnotated(MethodKind methodKind, Method method, Set<Class<? extends Annotation>> annotationTypes, TypeValidationContext validationContext) {
+    private static void validateNotAnnotatedForProperty(MethodKind methodKind, Method method, Set<Class<? extends Annotation>> annotationTypes, TypeValidationContext validationContext) {
         if (!annotationTypes.isEmpty()) {
             validationContext.visitTypeProblem(problem ->
                 problem.withAnnotationType(method.getDeclaringClass())
@@ -526,13 +657,36 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
         }
     }
 
+    private static final String IGNORED_ANNOTATIONS_ON_PROPERTY = "IGNORED_ANNOTATIONS_ON_PROPERTY";
+
+    private static void validateNotAnnotatedForMethod(MethodKind methodKind, Method method, Set<Class<? extends Annotation>> annotationTypes, TypeValidationContext validationContext) {
+        if (!annotationTypes.isEmpty()) {
+            validationContext.visitTypeProblem(problem ->
+                problem.withAnnotationType(method.getDeclaringClass())
+                    .id(TextUtil.screamingSnakeToKebabCase(IGNORED_ANNOTATIONS_ON_PROPERTY), "Ignored annotations on property", GradleCoreProblemGroup.validation().type())
+                    .contextualLabel(
+                        String.format(
+                            "%s '%s()' should not be annotated with: %s",
+                            methodKind.getDisplayName(), method.getName(),
+                            simpleAnnotationNames(annotationTypes.stream())
+                        )
+                    )
+                    .documentedAt(userManual("validation_problems", IGNORED_ANNOTATIONS_ON_PROPERTY.toLowerCase(Locale.ROOT)))
+                    .severity(ERROR)
+                    .details("Non-property annotations are ignored if they are placed on a property getter")
+                    .solution("Remove the annotations")
+                    .solution("Rename the method")
+            );
+        }
+    }
+
     private static String simpleAnnotationNames(Stream<Class<? extends Annotation>> annotationTypes) {
         return annotationTypes
             .map(annotationType -> "@" + annotationType.getSimpleName())
             .collect(joining(", "));
     }
 
-    private ImmutableMap<Class<? extends Annotation>, Annotation> collectRelevantAnnotations(AnnotatedElement element) {
+    private static ImmutableMap<Class<? extends Annotation>, Annotation> collectRelevantAnnotations(AnnotatedElement element, ImmutableMap<Class<? extends Annotation>, AnnotationCategory> relevantCategories) {
         Annotation[] annotations = element.getDeclaredAnnotations();
         if (annotations.length == 0) {
             return ImmutableMap.of();
@@ -540,101 +694,79 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
         ImmutableMap.Builder<Class<? extends Annotation>, Annotation> relevantAnnotations = ImmutableMap.builderWithExpectedSize(annotations.length);
         for (Annotation annotation : annotations) {
             Class<? extends Annotation> annotationType = annotation.annotationType();
-            if (propertyAnnotationCategories.containsKey(annotationType)) {
+            if (relevantCategories.containsKey(annotationType)) {
                 relevantAnnotations.put(annotationType, annotation);
             }
         }
         return relevantAnnotations.build();
     }
 
-    private class PropertyAnnotationMetadataBuilder implements Comparable<PropertyAnnotationMetadataBuilder> {
-        private final String propertyName;
-        private Method getter;
-        private final ListMultimap<AnnotationCategory, Annotation> declaredAnnotations = MultimapBuilder
+    private static abstract class HasAnnotationMetadataBuilder {
+        protected static final String IGNORED_PROPERTY_MUST_NOT_BE_ANNOTATED = "IGNORED_PROPERTY_MUST_NOT_BE_ANNOTATED";
+        protected static final String CONFLICTING_ANNOTATIONS = "CONFLICTING_ANNOTATIONS";
+        protected final ListMultimap<AnnotationCategory, Annotation> declaredAnnotations = MultimapBuilder
             .treeKeys(comparing(AnnotationCategory::getDisplayName))
             .arrayListValues()
             .build();
-        private final SetMultimap<AnnotationCategory, Annotation> inheritedInterfaceAnnotations = MultimapBuilder
+        protected final SetMultimap<AnnotationCategory, Annotation> inheritedInterfaceAnnotations = MultimapBuilder
             .treeKeys(comparing(AnnotationCategory::getDisplayName))
             .linkedHashSetValues()
             .build();
-        private final SetMultimap<AnnotationCategory, Annotation> inheritedSuperclassAnnotations = MultimapBuilder
+        protected final SetMultimap<AnnotationCategory, Annotation> inheritedSuperclassAnnotations = MultimapBuilder
             .treeKeys(comparing(AnnotationCategory::getDisplayName))
             .linkedHashSetValues()
             .build();
-        private final TypeValidationContext validationContext;
+        protected final TypeValidationContext validationContext;
+        protected Method method;
 
-        public PropertyAnnotationMetadataBuilder(String propertyName, Method getter, TypeValidationContext validationContext) {
-            this.propertyName = propertyName;
-            this.getter = getter;
+        private HasAnnotationMetadataBuilder(Method method, TypeValidationContext validationContext) {
+            overrideMethod(method);
             this.validationContext = validationContext;
         }
 
-        public String getPropertyName() {
-            return propertyName;
-        }
-
-        public Method getGetter() {
-            return getter;
+        public Method getMethod() {
+            return method;
         }
 
         public void overrideMethod(Method method) {
-            this.getter = method;
+            this.method = method;
         }
 
         public void declareAnnotation(Annotation annotation) {
-            AnnotationCategory category = propertyAnnotationCategories.get(annotation.annotationType());
+            AnnotationCategory category = geAnnotationCategories().get(annotation.annotationType());
             declaredAnnotations.put(category, annotation);
         }
 
-        public void inheritAnnotations(boolean fromInterface, PropertyAnnotationMetadata superProperty) {
+        public void inheritAnnotations(boolean fromInterface, HasAnnotationMetadata superProperty) {
             superProperty.getAnnotations()
                 .forEach((fromInterface
                     ? inheritedInterfaceAnnotations
                     : inheritedSuperclassAnnotations)::put);
         }
 
-        void visitPropertyProblem(Action<? super TypeAwareProblemBuilder> problemSpec) {
-            validationContext.visitPropertyProblem(problemSpec);
+        protected ImmutableSet<AnnotationCategory> allAnnotationCategories() {
+            return ImmutableSet.<AnnotationCategory>builder()
+                .addAll(declaredAnnotations.keySet())
+                .addAll(inheritedInterfaceAnnotations.keySet())
+                .addAll(inheritedSuperclassAnnotations.keySet())
+                .build();
         }
 
-        public PropertyAnnotationMetadata build() {
-            return new DefaultPropertyAnnotationMetadata(propertyName, getter, resolveAnnotations());
-        }
-
-        private static final String IGNORED_PROPERTY_MUST_NOT_BE_ANNOTATED = "IGNORED_PROPERTY_MUST_NOT_BE_ANNOTATED";
-
-        private ImmutableMap<AnnotationCategory, Annotation> resolveAnnotations() {
-            // If method should be ignored, then ignore all other annotations
-            List<Annotation> declaredTypes = declaredAnnotations.get(TYPE);
-            for (Annotation declaredType : declaredTypes) {
-                Class<? extends Annotation> ignoredMethodAnnotation = declaredType.annotationType();
-                if (ignoredMethodAnnotations.contains(ignoredMethodAnnotation)) {
-                    if (declaredAnnotations.size() > 1 && ignoreAnnotationDisallowedModifiers(declaredAnnotations.values()).count() > 1) {
-                        visitPropertyProblem(problem ->
-                            problem
-                                .forProperty(propertyName)
-                                .id(TextUtil.screamingSnakeToKebabCase(IGNORED_PROPERTY_MUST_NOT_BE_ANNOTATED), "Has wrong combination of annotations", GradleCoreProblemGroup.validation().property())
-                                .contextualLabel(
-                                    String.format(
-                                        "annotated with @%s should not be also annotated with %s",
-                                        ignoredMethodAnnotation.getSimpleName(),
-                                        simpleAnnotationNames(ignoreAnnotationDisallowedModifiers(declaredAnnotations.values())
-                                            .<Class<? extends Annotation>>map(Annotation::annotationType)
-                                            .filter(annotationType -> !annotationType.equals(ignoredMethodAnnotation)))
-                                    )
-                                )
-                                .documentedAt(userManual("validation_problems", IGNORED_PROPERTY_MUST_NOT_BE_ANNOTATED.toLowerCase(Locale.ROOT)))
-                                .severity(ERROR)
-                                .details("A property is ignored but also has input annotations")
-                                .solution("Remove the input annotations")
-                                .solution("Remove the @" + ignoredMethodAnnotation.getSimpleName() + " annotation")
-                        );
-                    }
-                    return ImmutableMap.of(TYPE, declaredType);
+        public boolean hasAnnotation(Class<? extends Annotation> annotationType) {
+            Iterable<Annotation> allAnnotations = Iterables.concat(
+                declaredAnnotations.values(),
+                inheritedInterfaceAnnotations.values(),
+                inheritedSuperclassAnnotations.values()
+            );
+            for (Annotation annotation : allAnnotations) {
+                if (annotation.annotationType().equals(annotationType)) {
+                    return true;
                 }
             }
+            return false;
+        }
 
+        protected ImmutableMap<AnnotationCategory, Annotation> resolveAnnotations() {
             ImmutableMap.Builder<AnnotationCategory, Annotation> builder = ImmutableMap.builder();
             for (AnnotationCategory category : allAnnotationCategories()) {
                 Annotation resolvedAnnotation;
@@ -655,58 +787,108 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
             return builder.build();
         }
 
-        private Stream<Annotation> ignoreAnnotationDisallowedModifiers(Collection<Annotation> annotations) {
-            return annotations.stream().filter(annotation -> !ignoredMethodAnnotationsAllowedModifiers.contains(annotation.annotationType()));
-        }
-
-        private ImmutableSet<AnnotationCategory> allAnnotationCategories() {
-            return ImmutableSet.<AnnotationCategory>builder()
-                .addAll(declaredAnnotations.keySet())
-                .addAll(inheritedInterfaceAnnotations.keySet())
-                .addAll(inheritedSuperclassAnnotations.keySet())
-                .build();
-        }
-
-        private static final String CONFLICTING_ANNOTATIONS = "CONFLICTING_ANNOTATIONS";
-
         private Annotation resolveAnnotation(String source, AnnotationCategory category, Collection<Annotation> annotationsForCategory) {
-            Iterator<Annotation> iDeclaredAnnotationForCategory = annotationsForCategory.iterator();
+            Iterator<Annotation> declaredAnnotationForCategoryIterator = annotationsForCategory.iterator();
             // Ignore all but the first recorded annotation
-            Annotation declaredAnnotationForCategory = iDeclaredAnnotationForCategory.next();
-            if (iDeclaredAnnotationForCategory.hasNext()) {
-                visitPropertyProblem(problem ->
-                    problem
-                        .forProperty(propertyName)
-                        .id(TextUtil.screamingSnakeToKebabCase(CONFLICTING_ANNOTATIONS), StringUtils.capitalize(category.getDisplayName()) + " has conflicting annotation", GradleCoreProblemGroup.validation().property())
-                        .contextualLabel(
-                            String.format(
-                                "has conflicting %s annotations %s: %s",
-                                category.getDisplayName(),
-                                source,
-                                simpleAnnotationNames(annotationsForCategory.stream().map(Annotation::annotationType))
-                            )
-                        )
-                        .documentedAt(userManual("validation_problems", CONFLICTING_ANNOTATIONS.toLowerCase(Locale.ROOT)))
-                        .severity(ERROR)
-                        .details("The different annotations have different semantics and Gradle cannot determine which one to pick")
-                        .solution("Choose between one of the conflicting annotations")
-                );
+            Annotation declaredAnnotationForCategory = declaredAnnotationForCategoryIterator.next();
+            if (declaredAnnotationForCategoryIterator.hasNext()) {
+                handleConflictingAnnotation(source, category, annotationsForCategory);
             }
             return declaredAnnotationForCategory;
         }
 
-        public boolean hasAnnotation(Class<? extends Annotation> annotationType) {
-            Iterable<Annotation> allAnnotations = Iterables.concat(
-                declaredAnnotations.values(),
-                inheritedInterfaceAnnotations.values(),
-                inheritedSuperclassAnnotations.values()
-            );
-            for (Annotation annotation : allAnnotations) {
-                if (annotation.annotationType().equals(annotationType)) {
-                    return true;
+        abstract protected ImmutableMap<Class<? extends Annotation>, AnnotationCategory> geAnnotationCategories();
+
+        abstract protected void handleConflictingAnnotation(String source, AnnotationCategory category, Collection<Annotation> annotationsForCategory);
+    }
+
+    private class PropertyAnnotationMetadataBuilder extends HasAnnotationMetadataBuilder implements Comparable<PropertyAnnotationMetadataBuilder> {
+        private final String propertyName;
+
+        public PropertyAnnotationMetadataBuilder(String propertyName, Method getter, TypeValidationContext validationContext) {
+            super(getter, validationContext);
+            this.propertyName = propertyName;
+        }
+
+        public String getPropertyName() {
+            return propertyName;
+        }
+
+        @Override
+        protected ImmutableMap<Class<? extends Annotation>, AnnotationCategory> geAnnotationCategories() {
+            return propertyAnnotationCategories;
+        }
+
+        public PropertyAnnotationMetadata build() {
+            return new DefaultPropertyAnnotationMetadata(propertyName, getMethod(), resolveAnnotations());
+        }
+
+        private void visitPropertyProblem(Action<? super TypeAwareProblemBuilder> problemSpec) {
+            validationContext.visitPropertyProblem(problemSpec);
+        }
+
+        @Override
+        protected ImmutableMap<AnnotationCategory, Annotation> resolveAnnotations() {
+            // If method should be ignored, then ignore all other annotations
+            List<Annotation> declaredTypes = declaredAnnotations.get(TYPE);
+            for (Annotation declaredType : declaredTypes) {
+                Class<? extends Annotation> ignoredMethodAnnotation = declaredType.annotationType();
+                if (ignoredMethodAnnotations.contains(ignoredMethodAnnotation)) {
+                    if (declaredAnnotations.values().size() > 1 && ignoreAnnotationDisallowedModifiers(declaredAnnotations.values()).count() > 1) {
+                        handleAnnotatedIgnoredMethod(ignoredMethodAnnotation);
+                    }
+                    return ImmutableMap.of(TYPE, declaredType);
                 }
             }
-            return false;
+
+            return super.resolveAnnotations();
+        }
+
+        private Stream<Annotation> ignoreAnnotationDisallowedModifiers(Collection<Annotation> annotations) {
+            return annotations.stream().filter(annotation -> !ignoredMethodAnnotationsAllowedModifiers.contains(annotation.annotationType()));
+        }
+
+        void handleAnnotatedIgnoredMethod(Class<? extends Annotation> ignoredMethodAnnotation) {
+            visitPropertyProblem(problem ->
+                problem
+                    .forProperty(propertyName)
+                    .id(TextUtil.screamingSnakeToKebabCase(IGNORED_PROPERTY_MUST_NOT_BE_ANNOTATED), "Has wrong combination of annotations", GradleCoreProblemGroup.validation().property())
+                    .contextualLabel(
+                        String.format(
+                            "annotated with @%s should not be also annotated with %s",
+                            ignoredMethodAnnotation.getSimpleName(),
+                            simpleAnnotationNames(ignoreAnnotationDisallowedModifiers(declaredAnnotations.values())
+                                .<Class<? extends Annotation>>map(Annotation::annotationType)
+                                .filter(annotationType -> !annotationType.equals(ignoredMethodAnnotation)))
+                        )
+                    )
+                    .documentedAt(userManual("validation_problems", IGNORED_PROPERTY_MUST_NOT_BE_ANNOTATED.toLowerCase(Locale.ROOT)))
+                    .severity(ERROR)
+                    .details("A property is ignored but also has input annotations")
+                    .solution("Remove the input annotations")
+                    .solution("Remove the @" + ignoredMethodAnnotation.getSimpleName() + " annotation")
+            );
+        }
+
+        @Override
+        protected void handleConflictingAnnotation(String source, AnnotationCategory category, Collection<Annotation> annotationsForCategory) {
+            visitPropertyProblem(problem ->
+                problem
+                    .forProperty(propertyName)
+                    .id(TextUtil.screamingSnakeToKebabCase(CONFLICTING_ANNOTATIONS), StringUtils.capitalize(category.getDisplayName()) + " has conflicting annotation", GradleCoreProblemGroup.validation().property())
+                    .contextualLabel(
+                        String.format(
+                            "has conflicting %s annotations %s: %s",
+                            category.getDisplayName(),
+                            source,
+                            simpleAnnotationNames(annotationsForCategory.stream().map(Annotation::annotationType))
+                        )
+                    )
+                    .documentedAt(userManual("validation_problems", CONFLICTING_ANNOTATIONS.toLowerCase(Locale.ROOT)))
+                    .severity(ERROR)
+                    .details("The different annotations have different semantics and Gradle cannot determine which one to pick")
+                    .solution("Choose between one of the conflicting annotations")
+            );
         }
 
         @Override
@@ -715,8 +897,54 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
         }
     }
 
+    private class MethodAnnotationMetadataBuilder extends HasAnnotationMetadataBuilder implements Comparable<MethodAnnotationMetadataBuilder> {
+        public MethodAnnotationMetadataBuilder(Method method, TypeValidationContext validationContext) {
+            super(method, validationContext);
+        }
+
+        @Override
+        protected ImmutableMap<Class<? extends Annotation>, AnnotationCategory> geAnnotationCategories() {
+            return methodAnnotationCategories;
+        }
+
+        public MethodAnnotationMetadata build() {
+            return new DefaultMethodAnnotationMetadata(getMethod(), resolveAnnotations());
+        }
+
+        private void visitMethodProblem(Action<? super TypeAwareProblemBuilder> problemSpec) {
+            validationContext.visitTypeProblem(problemSpec);
+        }
+
+        @Override
+        protected void handleConflictingAnnotation(String source, AnnotationCategory category, Collection<Annotation> annotationsForCategory) {
+            visitMethodProblem(problem ->
+                problem
+                    .forMethod(method.getName())
+                    .id(TextUtil.screamingSnakeToKebabCase(CONFLICTING_ANNOTATIONS), StringUtils.capitalize(category.getDisplayName()) + " has conflicting annotation", GradleCoreProblemGroup.validation().type())
+                    .contextualLabel(
+                        String.format(
+                            "has conflicting %s annotations %s: %s",
+                            category.getDisplayName(),
+                            source,
+                            simpleAnnotationNames(annotationsForCategory.stream().map(Annotation::annotationType))
+                        )
+                    )
+                    .documentedAt(userManual("validation_problems", CONFLICTING_ANNOTATIONS.toLowerCase(Locale.ROOT)))
+                    .severity(ERROR)
+                    .details("The different annotations have different semantics and Gradle cannot determine which one to pick")
+                    .solution("Choose between one of the conflicting annotations")
+            );
+        }
+
+        @Override
+        public int compareTo(MethodAnnotationMetadataBuilder o) {
+            return getMethod().getName().compareTo(o.getMethod().getName());
+        }
+    }
+
     private enum MethodKind {
         STATIC("static method"),
+        PROPERTY("property"),
         NON_PROPERTY("method"),
         SETTER("setter");
 
@@ -728,6 +956,40 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
 
         public String getDisplayName() {
             return displayName;
+        }
+    }
+
+    private static class MethodSignature {
+        private final String name;
+        private final Class<?>[] parameterTypes;
+
+        public MethodSignature(String name, Class<?>[] parameterTypes) {
+            this.name = name;
+            this.parameterTypes = parameterTypes;
+        }
+
+        public static MethodSignature of(Method method) {
+            return new MethodSignature(method.getName(), method.getParameterTypes());
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            MethodSignature that = (MethodSignature) o;
+            return name.equals(that.name) && Arrays.equals(parameterTypes, that.parameterTypes);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = name.hashCode();
+            result = 31 * result + Arrays.hashCode(parameterTypes);
+            return result;
         }
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultTypeAwareProblemBuilder.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultTypeAwareProblemBuilder.java
@@ -54,6 +54,12 @@ public class DefaultTypeAwareProblemBuilder extends DelegatingProblemBuilder imp
     }
 
     @Override
+    public TypeAwareProblemBuilder forMethod(String methodName) {
+        additionalData(TypeValidationDataSpec.class, data -> data.methodName(methodName));
+        return this;
+    }
+
+    @Override
     public TypeAwareProblemBuilder parentProperty(@Nullable String parentProperty) {
         if (parentProperty == null) {
             return this;
@@ -123,6 +129,24 @@ public class DefaultTypeAwareProblemBuilder extends DelegatingProblemBuilder imp
             builder.append(property)
                 .append("' ");
         }
+
+        Object method = additionalData.map(TypeValidationData::getMethodName).orElse(null);
+        if (method != null) {
+            if (typeRelevant) {
+                builder.append("method '");
+            } else {
+                if (pluginId.isPresent()) {
+                    builder.append("In plugin '")
+                        .append(pluginId.get())
+                        .append("' method '");
+                } else {
+                    builder.append("Method '");
+                }
+            }
+            builder.append(method)
+                .append("' ");
+        }
+
         return builder.toString();
     }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultTypeAwareProblemBuilder.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultTypeAwareProblemBuilder.java
@@ -111,43 +111,51 @@ public class DefaultTypeAwareProblemBuilder extends DelegatingProblemBuilder imp
 
         Object property = additionalData.map(TypeValidationData::getPropertyName).orElse(null);
         if (property != null) {
-            if (typeRelevant) {
-                builder.append("property '");
-            } else {
-                if (pluginId.isPresent()) {
-                    builder.append("In plugin '")
-                        .append(pluginId.get())
-                        .append("' property '");
-                } else {
-                    builder.append("Property '");
-                }
-            }
-            additionalData.map(TypeValidationData::getParentPropertyName).ifPresent(parentProperty -> {
-                builder.append(parentProperty);
-                builder.append('.');
-            });
-            builder.append(property)
-                .append("' ");
+            renderPropertyIntro(additionalData, typeRelevant, builder, pluginId, property);
         }
 
         Object method = additionalData.map(TypeValidationData::getFunctionName).orElse(null);
         if (method != null) {
-            if (typeRelevant) {
-                builder.append("method '");
-            } else {
-                if (pluginId.isPresent()) {
-                    builder.append("In plugin '")
-                        .append(pluginId.get())
-                        .append("' method '");
-                } else {
-                    builder.append("Method '");
-                }
-            }
-            builder.append(method)
-                .append("' ");
+            renderMethodIntro(typeRelevant, builder, pluginId, method);
         }
 
         return builder.toString();
+    }
+
+    private static void renderPropertyIntro(Optional<TypeValidationData> additionalData, boolean typeRelevant, StringBuilder builder, Optional<DefaultPluginId> pluginId, Object property) {
+        if (typeRelevant) {
+            builder.append("property '");
+        } else {
+            if (pluginId.isPresent()) {
+                builder.append("In plugin '")
+                    .append(pluginId.get())
+                    .append("' property '");
+            } else {
+                builder.append("Property '");
+            }
+        }
+        additionalData.map(TypeValidationData::getParentPropertyName).ifPresent(parentProperty -> {
+            builder.append(parentProperty);
+            builder.append('.');
+        });
+        builder.append(property)
+            .append("' ");
+    }
+
+    private static void renderMethodIntro(boolean typeRelevant, StringBuilder builder, Optional<DefaultPluginId> pluginId, Object method) {
+        if (typeRelevant) {
+            builder.append("method '");
+        } else {
+            if (pluginId.isPresent()) {
+                builder.append("In plugin '")
+                    .append(pluginId.get())
+                    .append("' method '");
+            } else {
+                builder.append("Method '");
+            }
+        }
+        builder.append(method)
+            .append("' ");
     }
 
     // A heuristic to determine if the type is relevant or not.

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultTypeAwareProblemBuilder.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultTypeAwareProblemBuilder.java
@@ -54,8 +54,8 @@ public class DefaultTypeAwareProblemBuilder extends DelegatingProblemBuilder imp
     }
 
     @Override
-    public TypeAwareProblemBuilder forMethod(String methodName) {
-        additionalData(TypeValidationDataSpec.class, data -> data.methodName(methodName));
+    public TypeAwareProblemBuilder forFunction(String methodName) {
+        additionalData(TypeValidationDataSpec.class, data -> data.functionName(methodName));
         return this;
     }
 
@@ -130,7 +130,7 @@ public class DefaultTypeAwareProblemBuilder extends DelegatingProblemBuilder imp
                 .append("' ");
         }
 
-        Object method = additionalData.map(TypeValidationData::getMethodName).orElse(null);
+        Object method = additionalData.map(TypeValidationData::getFunctionName).orElse(null);
         if (method != null) {
             if (typeRelevant) {
                 builder.append("method '");

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/validation/TypeAwareProblemBuilder.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/validation/TypeAwareProblemBuilder.java
@@ -27,5 +27,7 @@ public interface TypeAwareProblemBuilder extends InternalProblemSpec {
 
     TypeAwareProblemBuilder forProperty(String propertyName);
 
+    TypeAwareProblemBuilder forMethod(String methodName);
+
     TypeAwareProblemBuilder parentProperty(@Nullable String parentProperty);
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/validation/TypeAwareProblemBuilder.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/validation/TypeAwareProblemBuilder.java
@@ -27,7 +27,7 @@ public interface TypeAwareProblemBuilder extends InternalProblemSpec {
 
     TypeAwareProblemBuilder forProperty(String propertyName);
 
-    TypeAwareProblemBuilder forMethod(String methodName);
+    TypeAwareProblemBuilder forFunction(String methodName);
 
     TypeAwareProblemBuilder parentProperty(@Nullable String parentProperty);
 }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/properties/annotations/DefaultTypeMetadataStoreTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/properties/annotations/DefaultTypeMetadataStoreTest.groovy
@@ -126,7 +126,6 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
         _ * propertyAnnotationHandler.annotationType >> SearchPath
 
         def methodAnnotationHandler = Stub(FunctionAnnotationHandler)
-        _ * methodAnnotationHandler.functionRelevant >> true
         _ * methodAnnotationHandler.annotationType >> SearchMethod
 
         def metadataStore = new DefaultTypeMetadataStore([], [propertyAnnotationHandler], [], [methodAnnotationHandler], [], typeAnnotationMetadataStore, TestPropertyTypeResolver.INSTANCE, cacheFactory, MissingPropertyAnnotationHandler.DO_NOTHING)
@@ -169,7 +168,6 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
         }
 
         def methodAnnotationHandler = Stub(FunctionAnnotationHandler)
-        _ * methodAnnotationHandler.functionRelevant >> true
         _ * methodAnnotationHandler.annotationType >> SearchMethod
         _ * methodAnnotationHandler.validateFunctionMetadata(_, _) >> { FunctionMetadata metadata, TypeValidationContext context ->
             context.visitTypeProblem {
@@ -202,7 +200,7 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
         and:
         collectProblems(typeMetadata) == [
             dummyPropertyValidationProblemWithLink(null, 'searchPath', 'is broken', 'Test').trim(),
-            dummyMethodValidationProblemWithLink(null, 'doSearch', 'is broken', 'Test').trim()
+            dummyFunctionValidationProblemWithLink(null, 'doSearch', 'is broken', 'Test').trim()
         ]
     }
 
@@ -221,7 +219,6 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
             }
         }
         def methodAnnotationHandler = Stub(FunctionAnnotationHandler)
-        _ * methodAnnotationHandler.functionRelevant >> false
         _ * methodAnnotationHandler.annotationType >> SearchMethod
         _ * methodAnnotationHandler.validateFunctionMetadata(_, _) >> { FunctionMetadata metadata, TypeValidationContext context ->
             context.visitTypeProblem {
@@ -239,14 +236,12 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
         when:
         def typeMetadata = metadataStore.getTypeMetadata(TaskWithCustomAnnotation)
         def propertiesMetadata = typeMetadata.propertiesMetadata
-        def methodsMetadata = typeMetadata.functionMetadata
 
         then:
         propertiesMetadata.empty
-        methodsMetadata.empty
         collectProblems(typeMetadata) == [
             dummyPropertyValidationProblemWithLink(null, 'searchPath', 'is broken', 'Test').trim(),
-            dummyMethodValidationProblemWithLink(null, 'doSearch', 'is broken', 'Test').trim()
+            dummyFunctionValidationProblemWithLink(null, 'doSearch', 'is broken', 'Test').trim()
         ]
     }
 

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/properties/annotations/DefaultTypeMetadataStoreTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/properties/annotations/DefaultTypeMetadataStoreTest.groovy
@@ -47,9 +47,11 @@ import org.gradle.api.tasks.OutputDirectories
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.OutputFiles
+import org.gradle.api.tasks.TaskAction
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.execution.model.annotations.ModifierAnnotationCategory
 import org.gradle.internal.reflect.DefaultTypeValidationContext
+import org.gradle.internal.reflect.annotations.AnnotationCategory
 import org.gradle.internal.reflect.annotations.impl.DefaultTypeAnnotationMetadataStore
 import org.gradle.internal.reflect.validation.TypeValidationContext
 import org.gradle.internal.reflect.validation.ValidationMessageChecker
@@ -62,6 +64,7 @@ import spock.lang.Specification
 
 import javax.inject.Inject
 import java.lang.annotation.Annotation
+import java.util.stream.Collectors
 
 import static org.gradle.internal.deprecation.Documentation.userManual
 import static org.gradle.internal.execution.model.annotations.ModifierAnnotationCategory.NORMALIZATION
@@ -77,6 +80,10 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
         Console, Internal, ReplacedBy
     ]
 
+    static final PROCESSED_METHOD_TYPE_ANNOTATIONS = [
+        TaskAction
+    ]
+
     @Shared
     GroovyClassLoader groovyClassLoader
     def services = ServiceRegistryBuilder.builder().provider(new ExecutionGlobalServices()).build()
@@ -84,6 +91,7 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
     def typeAnnotationMetadataStore = new DefaultTypeAnnotationMetadataStore(
         [CustomCacheable],
         ModifierAnnotationCategory.asMap((PROCESSED_PROPERTY_TYPE_ANNOTATIONS + [SearchPath]) as Set<Class<? extends Annotation>>),
+        (PROCESSED_METHOD_TYPE_ANNOTATIONS + [SearchMethod]).stream().collect(Collectors.toMap({ it }, { AnnotationCategory.TYPE })),
         ["java", "groovy"],
         [DefaultTask],
         [Object, GroovyObject],
@@ -94,7 +102,7 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
         cacheFactory
     )
     def propertyTypeResolver = new DefaultPropertyTypeResolver()
-    def metadataStore = new DefaultTypeMetadataStore([], services.getAll(PropertyAnnotationHandler), [Classpath, CompileClasspath], typeAnnotationMetadataStore, propertyTypeResolver, cacheFactory, MissingPropertyAnnotationHandler.DO_NOTHING)
+    def metadataStore = new DefaultTypeMetadataStore([], services.getAll(PropertyAnnotationHandler), [Classpath, CompileClasspath], services.getAll(MethodAnnotationHandler), [], typeAnnotationMetadataStore, propertyTypeResolver, cacheFactory, MissingPropertyAnnotationHandler.DO_NOTHING)
 
     def setupSpec() {
         groovyClassLoader = new GroovyClassLoader(getClass().classLoader)
@@ -103,6 +111,9 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
     static class TaskWithCustomAnnotation extends DefaultTask {
         @SearchPath
         FileCollection searchPath
+
+        @SearchMethod
+        void doSearch() { }
     }
 
     @CustomCacheable
@@ -110,30 +121,43 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
     }
 
     def "can use custom annotation handler"() {
-        def annotationHandler = Stub(PropertyAnnotationHandler)
-        _ * annotationHandler.propertyRelevant >> true
-        _ * annotationHandler.annotationType >> SearchPath
+        def propertyAnnotationHandler = Stub(PropertyAnnotationHandler)
+        _ * propertyAnnotationHandler.propertyRelevant >> true
+        _ * propertyAnnotationHandler.annotationType >> SearchPath
 
-        def metadataStore = new DefaultTypeMetadataStore([], [annotationHandler], [], typeAnnotationMetadataStore, TestPropertyTypeResolver.INSTANCE, cacheFactory, MissingPropertyAnnotationHandler.DO_NOTHING)
+        def methodAnnotationHandler = Stub(MethodAnnotationHandler)
+        _ * methodAnnotationHandler.methodRelevant >> true
+        _ * methodAnnotationHandler.annotationType >> SearchMethod
+
+        def metadataStore = new DefaultTypeMetadataStore([], [propertyAnnotationHandler], [], [methodAnnotationHandler], [], typeAnnotationMetadataStore, TestPropertyTypeResolver.INSTANCE, cacheFactory, MissingPropertyAnnotationHandler.DO_NOTHING)
 
         when:
         def typeMetadata = metadataStore.getTypeMetadata(TaskWithCustomAnnotation)
         def propertiesMetadata = typeMetadata.propertiesMetadata
+        def methodsMetadata = typeMetadata.methodsMetadata
 
         then:
         propertiesMetadata.size() == 1
         def propertyMetadata = propertiesMetadata.first()
         propertyMetadata.propertyName == 'searchPath'
         propertyMetadata.propertyType == SearchPath
-        typeMetadata.getAnnotationHandlerFor(propertyMetadata) == annotationHandler
+        typeMetadata.getAnnotationHandlerFor(propertyMetadata) == propertyAnnotationHandler
+        collectProblems(typeMetadata).empty
+
+        and:
+        methodsMetadata.size() == 1
+        def methodMetadata = methodsMetadata.first()
+        methodMetadata.methodName == 'doSearch'
+        methodMetadata.methodType == SearchMethod
+        typeMetadata.getAnnotationHandlerFor(methodMetadata) == methodAnnotationHandler
         collectProblems(typeMetadata).empty
     }
 
     def "custom annotation handler can inspect for static property problems"() {
-        def annotationHandler = Stub(PropertyAnnotationHandler)
-        _ * annotationHandler.propertyRelevant >> true
-        _ * annotationHandler.annotationType >> SearchPath
-        _ * annotationHandler.validatePropertyMetadata(_, _) >> { PropertyMetadata metadata, TypeValidationContext context ->
+        def propertyAnnotationHandler = Stub(PropertyAnnotationHandler)
+        _ * propertyAnnotationHandler.propertyRelevant >> true
+        _ * propertyAnnotationHandler.annotationType >> SearchPath
+        _ * propertyAnnotationHandler.validatePropertyMetadata(_, _) >> { PropertyMetadata metadata, TypeValidationContext context ->
             context.visitPropertyProblem {
                 it
                     .forProperty(metadata.propertyName)
@@ -144,24 +168,49 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
             }
         }
 
-        def metadataStore = new DefaultTypeMetadataStore([], [annotationHandler], [], typeAnnotationMetadataStore, TestPropertyTypeResolver.INSTANCE, cacheFactory, MissingPropertyAnnotationHandler.DO_NOTHING)
+        def methodAnnotationHandler = Stub(MethodAnnotationHandler)
+        _ * methodAnnotationHandler.methodRelevant >> true
+        _ * methodAnnotationHandler.annotationType >> SearchMethod
+        _ * methodAnnotationHandler.validateMethodMetadata(_, _) >> { MethodMetadata metadata, TypeValidationContext context ->
+            context.visitTypeProblem {
+                it
+                    .forMethod(metadata.getMethodName())
+                    .id("test-problem", "is broken", GradleCoreProblemGroup.validation())
+                    .documentedAt(userManual("id", "section"))
+                    .severity(Severity.WARNING)
+                    .details("Test")
+            }
+        }
+
+        def metadataStore = new DefaultTypeMetadataStore([], [propertyAnnotationHandler], [], [methodAnnotationHandler], [], typeAnnotationMetadataStore, TestPropertyTypeResolver.INSTANCE, cacheFactory, MissingPropertyAnnotationHandler.DO_NOTHING)
 
         when:
         def typeMetadata = metadataStore.getTypeMetadata(TaskWithCustomAnnotation)
         def propertiesMetadata = typeMetadata.propertiesMetadata
+        def methodsMetadata = typeMetadata.methodsMetadata
 
         then:
         propertiesMetadata.size() == 1
         def propertyMetadata = propertiesMetadata.first()
         propertyMetadata.propertyName == 'searchPath'
-        collectProblems(typeMetadata) == [dummyValidationProblemWithLink(null, 'searchPath', 'is broken', 'Test').trim()]
+
+        and:
+        methodsMetadata.size() == 1
+        def methodMetadata = methodsMetadata.first()
+        methodMetadata.methodName == 'doSearch'
+
+        and:
+        collectProblems(typeMetadata) == [
+            dummyPropertyValidationProblemWithLink(null, 'searchPath', 'is broken', 'Test').trim(),
+            dummyMethodValidationProblemWithLink(null, 'doSearch', 'is broken', 'Test').trim()
+        ]
     }
 
     def "custom annotation that is not relevant can have validation problems"() {
-        def annotationHandler = Stub(PropertyAnnotationHandler)
-        _ * annotationHandler.propertyRelevant >> false
-        _ * annotationHandler.annotationType >> SearchPath
-        _ * annotationHandler.validatePropertyMetadata(_, _) >> { PropertyMetadata metadata, TypeValidationContext context ->
+        def propertyAnnotationHandler = Stub(PropertyAnnotationHandler)
+        _ * propertyAnnotationHandler.propertyRelevant >> false
+        _ * propertyAnnotationHandler.annotationType >> SearchPath
+        _ * propertyAnnotationHandler.validatePropertyMetadata(_, _) >> { PropertyMetadata metadata, TypeValidationContext context ->
             context.visitPropertyProblem {
                 it
                     .forProperty(metadata.propertyName)
@@ -171,16 +220,34 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
                     .details("Test")
             }
         }
+        def methodAnnotationHandler = Stub(MethodAnnotationHandler)
+        _ * methodAnnotationHandler.methodRelevant >> false
+        _ * methodAnnotationHandler.annotationType >> SearchMethod
+        _ * methodAnnotationHandler.validateMethodMetadata(_, _) >> { MethodMetadata metadata, TypeValidationContext context ->
+            context.visitTypeProblem {
+                it
+                    .forMethod(metadata.getMethodName())
+                    .id("test-problem", "is broken", GradleCoreProblemGroup.validation())
+                    .documentedAt(userManual("id", "section"))
+                    .severity(Severity.WARNING)
+                    .details("Test")
+            }
+        }
 
-        def metadataStore = new DefaultTypeMetadataStore([], [annotationHandler], [], typeAnnotationMetadataStore, TestPropertyTypeResolver.INSTANCE, cacheFactory, MissingPropertyAnnotationHandler.DO_NOTHING)
+        def metadataStore = new DefaultTypeMetadataStore([], [propertyAnnotationHandler], [], [methodAnnotationHandler], [], typeAnnotationMetadataStore, TestPropertyTypeResolver.INSTANCE, cacheFactory, MissingPropertyAnnotationHandler.DO_NOTHING)
 
         when:
         def typeMetadata = metadataStore.getTypeMetadata(TaskWithCustomAnnotation)
         def propertiesMetadata = typeMetadata.propertiesMetadata
+        def methodsMetadata = typeMetadata.methodsMetadata
 
         then:
         propertiesMetadata.empty
-        collectProblems(typeMetadata) == [dummyValidationProblemWithLink(null, 'searchPath', 'is broken', 'Test').trim()]
+        methodsMetadata.empty
+        collectProblems(typeMetadata) == [
+            dummyPropertyValidationProblemWithLink(null, 'searchPath', 'is broken', 'Test').trim(),
+            dummyMethodValidationProblemWithLink(null, 'doSearch', 'is broken', 'Test').trim()
+        ]
     }
 
     def "custom type annotation handler can inspect for static type problems"() {
@@ -197,7 +264,7 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
             }
         }
 
-        def metadataStore = new DefaultTypeMetadataStore([typeAnnotationHandler], [], [], typeAnnotationMetadataStore, TestPropertyTypeResolver.INSTANCE, cacheFactory, MissingPropertyAnnotationHandler.DO_NOTHING)
+        def metadataStore = new DefaultTypeMetadataStore([typeAnnotationHandler], [], [], [], [], typeAnnotationMetadataStore, TestPropertyTypeResolver.INSTANCE, cacheFactory, MissingPropertyAnnotationHandler.DO_NOTHING)
 
         when:
         def taskMetadata = metadataStore.getTypeMetadata(DefaultTask)
@@ -209,7 +276,7 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
         def typeMetadata = metadataStore.getTypeMetadata(TypeWithCustomAnnotation)
 
         then:
-        collectProblems(typeMetadata) == [dummyValidationProblemWithLink(TypeWithCustomAnnotation.canonicalName, null, 'type is broken', 'Test').trim()]
+        collectProblems(typeMetadata) == [dummyPropertyValidationProblemWithLink(TypeWithCustomAnnotation.canonicalName, null, 'type is broken', 'Test').trim()]
     }
 
     def "can override @#parentAnnotation.simpleName property type with @#childAnnotation.simpleName"() {
@@ -341,9 +408,13 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
 
     def "all properties on #workClass are ignored"() {
         when:
-        def typeMetadata = metadataStore.getTypeMetadata(workClass).propertiesMetadata.findAll { it.propertyType == null }
+        def typeMetadata = metadataStore.getTypeMetadata(workClass)
+        def properties = typeMetadata.propertiesMetadata.findAll { it.propertyType == null }
+        def methods = typeMetadata.methodsMetadata
+
         then:
-        typeMetadata*.propertyName.empty
+        properties*.propertyName.empty
+        methods.empty
 
         where:
         workClass << [ConventionTask.class, DefaultTask.class, AbstractTask.class, Task.class, Object.class, GroovyObject.class, IConventionAware.class, ExtensionAware.class, HasConvention.class, ScriptOrigin.class, DynamicObjectAware.class]
@@ -379,14 +450,21 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
         String oldProperty
         @Console
         boolean console
+        @TaskAction
+        void doSomething() { }
     }
 
-    def "can get annotated properties of simple task"() {
+    def "can get annotated properties and methods of simple task"() {
         when:
-        def properties = metadataStore.getTypeMetadata(SimpleTask).propertiesMetadata
+        def typeMetadata = metadataStore.getTypeMetadata(SimpleTask)
+        def properties = typeMetadata.propertiesMetadata
+        def methods = typeMetadata.methodsMetadata
 
         then:
         properties.propertyName.sort() == ["destroys", "inputDirectory", "inputFile", "inputFiles", "inputString", "outputDirectories", "outputDirectory", "outputFile", "outputFiles", "someCache"]
+
+        and:
+        methods.methodName.sort() == ["doSomething"]
     }
 
     static class TypeWithUnannotatedProperties extends DefaultTask {
@@ -398,7 +476,7 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
 
     def "warns about and ignores properties that are not annotated"() {
         when:
-        def metadataStore = new DefaultTypeMetadataStore([], services.getAll(PropertyAnnotationHandler), [Classpath, CompileClasspath], typeAnnotationMetadataStore, propertyTypeResolver, cacheFactory, MissingPropertyAnnotationHandler.MISSING_INPUT_OUTPUT_HANDLER)
+        def metadataStore = new DefaultTypeMetadataStore([], services.getAll(PropertyAnnotationHandler), [Classpath, CompileClasspath], [], [], typeAnnotationMetadataStore, propertyTypeResolver, cacheFactory, MissingPropertyAnnotationHandler.MISSING_INPUT_OUTPUT_HANDLER)
         def metadata = metadataStore.getTypeMetadata(TypeWithUnannotatedProperties)
 
         then:
@@ -407,6 +485,22 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
             missingAnnotationMessage { property('bad1').missingInputOrOutput().includeLink() },
             missingAnnotationMessage { property('bad2').missingInputOrOutput().includeLink() },
         ]
+    }
+
+    static class TypeWithUnannotatedMethods extends DefaultTask {
+        void bad1() { }
+        void bad2() { }
+        @TaskAction
+        void good() { }
+    }
+
+    def "ignores methods that are not annotated"() {
+        when:
+        def metadataStore = new DefaultTypeMetadataStore([], services.getAll(PropertyAnnotationHandler), [], services.getAll(MethodAnnotationHandler), [], typeAnnotationMetadataStore, propertyTypeResolver, cacheFactory, MissingPropertyAnnotationHandler.MISSING_INPUT_OUTPUT_HANDLER)
+        def metadata = metadataStore.getTypeMetadata(TypeWithUnannotatedMethods)
+
+        then:
+        metadata.methodsMetadata.methodName == ['good']
     }
 
     static class TypeWithNonRelevantProperties extends DefaultTask {

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/properties/annotations/SearchMethod.java
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/properties/annotations/SearchMethod.java
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-package org.gradle.api.problems.internal;
+package org.gradle.internal.properties.annotations;
 
-/**
- * Specifies configuration options when creating a new TypeValidationData instance.
- */
-public interface TypeValidationDataSpec extends AdditionalDataSpec {
-    TypeValidationDataSpec pluginId(String pluginId);
-    TypeValidationDataSpec propertyName(String propertyName);
-    TypeValidationDataSpec methodName(String methodName);
-    TypeValidationDataSpec parentPropertyName(String parentPropertyName);
-    TypeValidationDataSpec typeName(String typeName);
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@interface SearchMethod {
 }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/properties/bean/DefaultPropertyWalkerTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/properties/bean/DefaultPropertyWalkerTest.groovy
@@ -252,6 +252,7 @@ class DefaultPropertyWalkerTest extends AbstractProjectBuilderSpec {
         def typeAnnotationMetadataStore = new DefaultTypeAnnotationMetadataStore(
             [],
             ModifierAnnotationCategory.asMap(PROPERTY_TYPE_ANNOTATIONS),
+            [:],
             ["java", "groovy"],
             [],
             [Object, GroovyObject],
@@ -262,7 +263,7 @@ class DefaultPropertyWalkerTest extends AbstractProjectBuilderSpec {
             cacheFactory
         )
         def propertyHandlers = services.getAll(PropertyAnnotationHandler)
-        def typeMetadataStore = new DefaultTypeMetadataStore([], propertyHandlers, [PathSensitive], typeAnnotationMetadataStore, TestPropertyTypeResolver.INSTANCE, cacheFactory, MissingPropertyAnnotationHandler.DO_NOTHING)
+        def typeMetadataStore = new DefaultTypeMetadataStore([], propertyHandlers, [PathSensitive], [], [], typeAnnotationMetadataStore, TestPropertyTypeResolver.INSTANCE, cacheFactory, MissingPropertyAnnotationHandler.DO_NOTHING)
         new DefaultPropertyWalker(typeMetadataStore, new TestImplementationResolver(), propertyHandlers).visitProperties(task, validationContext, visitor)
     }
 }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStoreTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStoreTest.groovy
@@ -960,7 +960,7 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         assertMethods TypeWithAnnotatedGetterMethods, [:], [
             strict(fieldShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedGetterMethods.canonicalName).kind('field').method('anything').annotation('Foo').includeLink() }),
             strict(propertyShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedGetterMethods.canonicalName).kind('property').method('getSomething').annotation('Foo').includeLink() }),
-            strict(propertyShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedGetterMethods.canonicalName).kind('static method').method('getStatic').annotation('Bar').includeLink() }),
+            strict(staticMethodShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedGetterMethods.canonicalName).kind('static method').method('getStatic').annotation('Bar').includeLink() }),
             strict(propertyShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedGetterMethods.canonicalName).kind('property').method('isSomethingElse').annotation('Bar').includeLink() }),
             strict(propertyShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedGetterMethods.canonicalName).kind('property').method('setSomething').annotation('Foo').includeLink() }),
         ]

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStoreTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStoreTest.groovy
@@ -54,9 +54,22 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         }
     }
 
+    private static final BAZ = new AnnotationCategory() {
+        @Override
+        String getDisplayName() {
+            return "baz"
+        }
+
+        @Override
+        String toString() {
+            return displayName
+        }
+    }
+
     def store = new DefaultTypeAnnotationMetadataStore(
         [TestType],
         [(Large): TYPE, (Small): TYPE, (Color): COLOR],
+        [(Foo): TYPE, (Bar): TYPE, (Baz): BAZ],
         ["java", "groovy"],
         [Object],
         [Object, GroovyObject],
@@ -90,7 +103,7 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         private String getPrivateProperty() { "private" }
     }
 
-    def "finds annotated properties"() {
+    def "finds annotated properties and methods"() {
         expect:
         assertProperties TypeWithAnnotatedProperty, [
             publicProperty: [(TYPE): Large],
@@ -100,6 +113,15 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
             injectedProperty: [(TYPE): Inject],
         ], [
             strict(privateGetterAnnotatedMessage { property('privateProperty').annotation(Small.simpleName).includeLink() })
+        ]
+        and:
+        assertMethods TypeWithAnnotatedMethod, [
+            publicMethod: [(TYPE): Foo],
+            protectedMethod: [(TYPE): Foo],
+            packageMethod: [(TYPE): Bar],
+            privateMethod: [(TYPE): Bar],
+        ], [
+            strict(privateMethodAnnotatedMessage { method('privateMethod').annotation(Bar.simpleName).includeLink() })
         ]
     }
 
@@ -122,9 +144,26 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         String getInjectedProperty() { "injected" }
     }
 
-    def "ignores all properties on type #type.simpleName"() {
+    @SuppressWarnings("unused")
+    class TypeWithAnnotatedMethod {
+        @Foo
+        String publicMethod() { "public" }
+
+        @Foo
+        protected boolean protectedMethod() { true }
+
+        @Bar
+        @PackageScope
+        boolean packageMethod() { false }
+
+        @Bar
+        private String privateMethod() { "private" }
+    }
+
+    def "ignores all methods and properties on type #type.simpleName"() {
         expect:
         assertProperties type, [:]
+        assertMethods type, [:]
         where:
         type << [int, EmptyGroovyObject, int[], Object[], Nullable]
     }
@@ -214,7 +253,7 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
                     .includeLink()
             })
         ]
-        store.getTypeAnnotationMetadata(TypeWithIsAndGetProperty).propertiesAnnotationMetadata[0].getter.name == "getBool"
+        store.getTypeAnnotationMetadata(TypeWithIsAndGetProperty).propertiesAnnotationMetadata[0].method.name == "getBool"
     }
 
     @SuppressWarnings("unused")
@@ -245,7 +284,7 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         assertProperties TypeWithIgnoredIsGetterBooleanProperty, [
             bool: [(TYPE): Small],
         ]
-        store.getTypeAnnotationMetadata(TypeWithIgnoredIsGetterBooleanProperty).propertiesAnnotationMetadata[0].getter.name == "getBool"
+        store.getTypeAnnotationMetadata(TypeWithIgnoredIsGetterBooleanProperty).propertiesAnnotationMetadata[0].method.name == "getBool"
     }
 
     @SuppressWarnings("unused")
@@ -263,7 +302,7 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         assertProperties TypeWithIgnoredGetGetterBooleanProperty, [
             bool: [(TYPE): Small],
         ]
-        store.getTypeAnnotationMetadata(TypeWithIgnoredGetGetterBooleanProperty).propertiesAnnotationMetadata[0].getter.name == "isBool"
+        store.getTypeAnnotationMetadata(TypeWithIgnoredGetGetterBooleanProperty).propertiesAnnotationMetadata[0].method.name == "isBool"
     }
 
     @SuppressWarnings("unused")
@@ -328,11 +367,16 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         }
     }
 
-    def "superclass properties are present in subclass"() {
+    def "superclass properties and methods are present in subclass"() {
         expect:
         assertProperties TypeWithSuperclassProperties, [
             baseProperty: [(TYPE): Small],
             subclassProperty: [(TYPE): Large]
+        ]
+        and:
+        assertMethods TypeWithSuperclassMethods, [
+            baseMethod: [(TYPE): Foo],
+            subclassMethod: [(TYPE): Bar]
         ]
     }
 
@@ -348,11 +392,28 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         String getSubclassProperty()
     }
 
-    def "properties are inherited from implemented interface"() {
+    @SuppressWarnings("unused")
+    interface BaseTypeWithSuperClassMethods {
+        @Foo
+        String baseMethod()
+    }
+
+    @SuppressWarnings("unused")
+    interface TypeWithSuperclassMethods extends BaseTypeWithSuperClassMethods {
+        @Bar
+        String subclassMethod()
+    }
+
+    def "properties and methods are inherited from implemented interface"() {
         expect:
         assertProperties TypeWithInterfaceProperties, [
             interfaceProperty: [(TYPE): Small],
             subclassProperty: [(TYPE): Large]
+        ]
+        and:
+        assertMethods TypeWithInterfaceMethods, [
+            interfaceMethod: [(TYPE): Foo],
+            subclassMethod: [(TYPE): Bar]
         ]
     }
 
@@ -368,10 +429,26 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         abstract String getSubclassProperty()
     }
 
-    def "overridden properties inherit super-class annotations"() {
+    @SuppressWarnings("unused")
+    interface InterfaceWithMethods {
+        @Foo
+        String interfaceMethod()
+    }
+
+    @SuppressWarnings("unused")
+    abstract class TypeWithInterfaceMethods implements InterfaceWithMethods {
+        @Bar
+        abstract String subclassMethod()
+    }
+
+    def "overridden properties and methods inherit super-class annotations"() {
         expect:
         assertProperties TypeWithInheritedProperty, [
             overriddenProperty: [(COLOR): Color]
+        ]
+        and:
+        assertMethods TypeWithInheritedMethods, [
+            overriddenMethod: [(TYPE): Foo]
         ]
     }
 
@@ -387,10 +464,27 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         String getOverriddenProperty() { "test" }
     }
 
+    @SuppressWarnings("unused")
+    class BaseTypeWithInheritedMethods {
+        @Foo
+        String overriddenMethod() { "test" }
+    }
+
+    @SuppressWarnings("unused")
+    class TypeWithInheritedMethods extends BaseTypeWithInheritedMethods {
+        @Override
+        String overriddenMethod() { "test" }
+    }
+
     def "annotation defined on implemented interface takes precedence over superclass annotation"() {
         expect:
         assertProperties TypeWithInheritedPropertyFromSuperClassAndInterface, [
             overriddenProperty: [(COLOR): { it instanceof Color && it.declaredBy() == "interface" }]
+        ]
+
+        and:
+        assertMethods TypeWithInheritedMethodFromSuperClassAndInterface, [
+            overriddenMethod: [(TYPE): Foo]
         ]
     }
 
@@ -408,12 +502,32 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         String getOverriddenProperty() { "test" }
     }
 
-    def "implemented properties inherit annotation from first conflicting interface"() {
+    @SuppressWarnings("unused")
+    interface InterfaceWithInheritedMethod {
+        @Foo
+        String getOverriddenProperty()
+    }
+
+    @SuppressWarnings("unused")
+    class TypeWithInheritedMethodFromSuperClassAndInterface
+        extends BaseTypeWithInheritedMethods
+        implements InterfaceWithInheritedMethod {
+        @Override
+        String getOverriddenProperty() { "test" }
+    }
+
+    def "implemented properties and methods inherit annotation from first conflicting interface"() {
         expect:
         assertProperties TypeWithImplementedPropertyFromInterfaces, [
             overriddenProperty: [(COLOR): { it instanceof Color && it.declaredBy() == "first-interface" }]
         ], [
             strict(conflictingAnnotationsMessage { property('overriddenProperty').inConflict('Color', 'Color').includeLink().kind('color annotations inherited (from interface)') })
+        ]
+        and:
+        assertMethods TypeWithImplementedMethodFromInterfaces, [
+            overriddenMethod: [(BAZ): { it instanceof Baz && it.declaredBy() == "first-interface" }]
+        ], [
+            strict(conflictingAnnotationsMessage { method('overriddenMethod').inConflict('Baz', 'Baz').includeLink().kind('baz annotations inherited (from interface)') })
         ]
     }
 
@@ -436,10 +550,33 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         String getOverriddenProperty() { "test" }
     }
 
+    @SuppressWarnings("unused")
+    interface FirstInterfaceWithInheritedMethod {
+        @Baz(declaredBy = "first-interface")
+        String overriddenMethod()
+    }
+
+    @SuppressWarnings("unused")
+    interface SecondInterfaceWithInheritedMethod {
+        @Baz(declaredBy = "second-interface")
+        String overriddenMethod()
+    }
+
+    @SuppressWarnings("unused")
+    class TypeWithImplementedMethodFromInterfaces
+        implements FirstInterfaceWithInheritedMethod, SecondInterfaceWithInheritedMethod {
+        @Override
+        String overriddenMethod() { "test" }
+    }
+
     def "subtype can resolve conflicting annotations from implemented interfaces"() {
         expect:
         assertProperties TypeOverridingPropertyFromConflictingInterfaces, [
             overriddenProperty: [(COLOR): { it instanceof Color && it.declaredBy() == "subtype" }]
+        ]
+        and:
+        assertMethods TypeOverridingMethodFromConflictingInterfaces, [
+            overriddenMethod: [(BAZ): { it instanceof Baz && it.declaredBy() == "subtype" }]
         ]
     }
 
@@ -451,37 +588,70 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         String getOverriddenProperty() { "test" }
     }
 
+    @SuppressWarnings("unused")
+    class TypeOverridingMethodFromConflictingInterfaces
+        implements FirstInterfaceWithInheritedMethod, SecondInterfaceWithInheritedMethod {
+        @Override
+        @Baz(declaredBy = "subtype")
+        String overriddenMethod() { "test" }
+    }
+
     def "can override same annotation in subclass"() {
         expect:
-        assertProperties TypeWithOverride, [
+        assertProperties TypeWithPropertyOverride, [
             overriddenProperty: [(COLOR): { it instanceof Color && it.declaredBy() == "override" }]
+        ]
+        and:
+        assertMethods TypeWithMethodOverride, [
+            overriddenMethod: [(BAZ): { it instanceof Baz && it.declaredBy() == "override" }]
         ]
     }
 
-    def "property getter is from overriding class"() {
+    def "property getter or method is from overriding class"() {
         when:
-        def metadata = store.getTypeAnnotationMetadata(TypeWithOverride)
+        def propertyMetadata = store.getTypeAnnotationMetadata(TypeWithPropertyOverride)
         then:
-        metadata.propertiesAnnotationMetadata[0].getter.declaringClass == TypeWithOverride
+        propertyMetadata.propertiesAnnotationMetadata[0].method.declaringClass == TypeWithPropertyOverride
+        when:
+        def methodMetadata = store.getTypeAnnotationMetadata(TypeWithMethodOverride)
+        then:
+        methodMetadata.methodsAnnotationMetadata[0].method.declaringClass == TypeWithMethodOverride
     }
 
     @SuppressWarnings("unused")
-    interface BaseTypeWithOverride {
+    interface BaseTypeWithPropertyOverride {
         @Color(declaredBy = "base")
         String getOverriddenProperty()
     }
 
     @SuppressWarnings("unused")
-    interface TypeWithOverride extends BaseTypeWithOverride {
+    interface TypeWithPropertyOverride extends BaseTypeWithPropertyOverride {
         @Override
         @Color(declaredBy = "override")
         String getOverriddenProperty()
+    }
+
+    @SuppressWarnings("unused")
+    interface BaseTypeWithMethodOverride {
+        @Baz(declaredBy = "base")
+        String overriddenMethod()
+    }
+
+    @SuppressWarnings("unused")
+    interface TypeWithMethodOverride extends BaseTypeWithMethodOverride {
+        @Override
+        @Baz(declaredBy = "override")
+        String overriddenMethod()
     }
 
     def "can override annotation with different annotation in same category in subclass"() {
         expect:
         assertProperties CanOverrideOverrideCategoryClass, [
             overriddenProperty: [(TYPE): Small, (COLOR): Color]
+        ]
+        and:
+        assertMethods CanOverrideOverrideMethodCategoryClass, [
+            overriddenMethod: [(TYPE): Bar, (BAZ): Baz]
         ]
     }
 
@@ -501,6 +671,24 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         @Override
         @Small
         String getOverriddenProperty()
+    }
+
+    @SuppressWarnings("unused")
+    interface CanOverrideMethodCategoryBaseClass {
+        @Foo
+        String overriddenMethod()
+    }
+
+    interface CanOverrideMethodCategoryIntermediateClass extends CanOverrideMethodCategoryBaseClass {
+        @Override
+        @Baz
+        String overriddenMethod()
+    }
+
+    interface CanOverrideOverrideMethodCategoryClass extends CanOverrideMethodCategoryIntermediateClass {
+        @Override
+        @Bar
+        String overriddenMethod()
     }
 
     def "can ignore supertype property"() {
@@ -543,7 +731,7 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         String getPropertyIgnoredInBase()
     }
 
-    def "warns about conflicting property types being specified, chooses first declaration"() {
+    def "warns about conflicting property or method types being specified, chooses first declaration"() {
         expect:
         assertProperties TypeWithPropertiesWithMultipleAnnotationsOfSameCategory, [
             largeThenSmall: [(TYPE): Large],
@@ -551,6 +739,14 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         ], [
             strict(conflictingAnnotationsMessage { property('largeThenSmall').inConflict('Large', 'Small').includeLink() }),
             strict(conflictingAnnotationsMessage { property('smallThenLarge').inConflict('Small', 'Large').includeLink() })
+        ]
+        and:
+        assertMethods TypeWithMethodsWithMultipleAnnotationsOfSameCategory, [
+            largeThenSmall: [(TYPE): Foo],
+            smallThenLarge: [(TYPE): Bar]
+        ], [
+            strict(conflictingAnnotationsMessage { method('largeThenSmall').inConflict('Foo', 'Bar').includeLink() }),
+            strict(conflictingAnnotationsMessage { method('smallThenLarge').inConflict('Bar', 'Foo').includeLink() })
         ]
     }
 
@@ -563,6 +759,17 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         @Small
         @Large
         String getSmallThenLarge()
+    }
+
+    @SuppressWarnings("unused")
+    interface TypeWithMethodsWithMultipleAnnotationsOfSameCategory {
+        @Foo
+        @Bar
+        String largeThenSmall()
+
+        @Bar
+        @Foo
+        String smallThenLarge()
     }
 
     def "warns about both method and field having the same annotation, prefers method annotation"() {
@@ -640,12 +847,18 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         }
     }
 
-    def "warns about annotations on private properties"() {
+    def "warns about annotations on private properties or methods"() {
         expect:
         assertProperties WithAnnotationsOnPrivateProperty, [
             privateInput: [(TYPE): Large]
         ], [
             strict(privateGetterAnnotatedMessage { property('privateInput').annotation(Large.simpleName).includeLink() })
+        ]
+        and:
+        assertMethods WithAnnotationsOnPrivateMethod, [
+            privateMethod: [(TYPE): Foo]
+        ], [
+            strict(privateMethodAnnotatedMessage { method('privateMethod').annotation(Foo.simpleName).includeLink() })
         ]
     }
 
@@ -657,6 +870,18 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         }
 
         private String getNotAnInput() {
+            'Not an input'
+        }
+    }
+
+    @SuppressWarnings("unused")
+    class WithAnnotationsOnPrivateMethod {
+        @Foo
+        private String privateMethod() {
+            'Input'
+        }
+
+        private String anotherMethod() {
             'Not an input'
         }
     }
@@ -705,7 +930,7 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
     @Irrelevant
     interface TypeWithAnnotations {}
 
-    def "warns about annotations on non-getter methods"() {
+    def "warns about property annotations on non-property methods"() {
         expect:
         assertProperties TypeWithAnnotatedNonGetterMethods, [:], [
             strict(methodShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedNonGetterMethods.canonicalName).kind('method').method('doSomething').annotation('Large').includeLink() }),
@@ -730,6 +955,34 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         void setSomething(String something) {}
     }
 
+    def "warns about non-property annotations on fields or property methods"() {
+        expect:
+        assertMethods TypeWithAnnotatedGetterMethods, [:], [
+            strict(fieldShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedGetterMethods.canonicalName).kind('field').method('anything').annotation('Foo').includeLink() }),
+            strict(propertyShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedGetterMethods.canonicalName).kind('property').method('getSomething').annotation('Foo').includeLink() }),
+            strict(propertyShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedGetterMethods.canonicalName).kind('static method').method('getStatic').annotation('Bar').includeLink() }),
+            strict(propertyShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedGetterMethods.canonicalName).kind('property').method('isSomethingElse').annotation('Bar').includeLink() }),
+            strict(propertyShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedGetterMethods.canonicalName).kind('property').method('setSomething').annotation('Foo').includeLink() }),
+        ]
+    }
+
+    @SuppressWarnings("GroovyUnusedDeclaration")
+    private static class TypeWithAnnotatedGetterMethods {
+        @Foo
+        String anything
+
+        @Foo
+        String getSomething() {}
+
+        @Bar
+        static String getStatic() { "static" }
+
+        @Bar
+        boolean isSomethingElse() {}
+
+        @Foo
+        void setSomething(String something) {}
+    }
 
     def "ignores validation of generated Groovy methods"() {
         expect:
@@ -746,6 +999,8 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
     def "does not detect methods on type from ignored package"() {
         expect:
         assertProperties ArrayList, [:]
+        and:
+        assertMethods ArrayList, [:]
     }
 
     void assertProperties(Class<?> type, Map<String, Map<AnnotationCategory, ?>> expectedProperties, List<String> expectedErrors = []) {
@@ -763,6 +1018,41 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
 
             actualCategories.forEach { category ->
                 def actualAnnotation = actualProperty.annotations[category]
+                def expectedAnnotation = expectedAnnotations[category]
+                if (expectedAnnotation instanceof Class) {
+                    assert actualAnnotation.annotationType() == expectedAnnotation
+                } else if (expectedAnnotation instanceof Closure) {
+                    assert expectedAnnotation.call(actualAnnotation)
+                } else {
+                    throw new IllegalArgumentException("Unknown expectation $expectedAnnotation")
+                }
+            }
+        }
+
+        def validationContext = DefaultTypeValidationContext.withoutRootType(false, Stub(InternalProblems.class))
+        metadata.visitValidationFailures(validationContext)
+        List<String> actualErrors = validationContext.problems
+            .collect({ (normaliseLineSeparators(TypeValidationProblemRenderer.renderMinimalInformationAbout(it)) + (it.definition.severity == Severity.ERROR ? " [STRICT]" : "") as String) })
+        actualErrors.sort()
+        expectedErrors.sort()
+        assert actualErrors == expectedErrors
+    }
+
+    void assertMethods(Class<?> type, Map<String, Map<AnnotationCategory, ?>> expectedMethods, List<String> expectedErrors = []) {
+        def metadata = store.getTypeAnnotationMetadata(type)
+        def actualMethodNames = metadata.methodsAnnotationMetadata*.method.name.sort()
+        def expectedMethodNames = expectedMethods.keySet().sort()
+        assert actualMethodNames == expectedMethodNames
+
+        metadata.methodsAnnotationMetadata.forEach { actualMethod ->
+            def expectedAnnotations = expectedMethods[actualMethod.method.name]
+
+            def actualCategories = actualMethod.annotations.keySet().sort()
+            def expectedCategories = expectedAnnotations.keySet().sort()
+            assert actualCategories == expectedCategories
+
+            actualCategories.forEach { category ->
+                def actualAnnotation = actualMethod.annotations[category]
                 def expectedAnnotation = expectedAnnotations[category]
                 if (expectedAnnotation instanceof Class) {
                     assert actualAnnotation.annotationType() == expectedAnnotation
@@ -823,4 +1113,20 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
 @Retention(RetentionPolicy.RUNTIME)
 @Target([ElementType.METHOD, ElementType.FIELD])
 @interface Ignored2 {
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target([ElementType.METHOD, ElementType.FIELD])
+@interface Foo {
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target([ElementType.METHOD])
+@interface Bar {
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target([ElementType.METHOD])
+@interface Baz {
+    String declaredBy() default ""
 }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStoreTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStoreTest.groovy
@@ -103,7 +103,7 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         private String getPrivateProperty() { "private" }
     }
 
-    def "finds annotated properties and methods"() {
+    def "finds annotated properties and functions"() {
         expect:
         assertProperties TypeWithAnnotatedProperty, [
             publicProperty: [(TYPE): Large],
@@ -115,13 +115,13 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
             strict(privateGetterAnnotatedMessage { property('privateProperty').annotation(Small.simpleName).includeLink() })
         ]
         and:
-        assertMethods TypeWithAnnotatedMethod, [
+        assertFunctions TypeWithAnnotatedFunction, [
             publicMethod: [(TYPE): Foo],
             protectedMethod: [(TYPE): Foo],
             packageMethod: [(TYPE): Bar],
             privateMethod: [(TYPE): Bar],
         ], [
-            strict(privateMethodAnnotatedMessage { method('privateMethod').annotation(Bar.simpleName).includeLink() })
+            strict(privateFunctionAnnotatedMessage { method('privateMethod').annotation(Bar.simpleName).includeLink() })
         ]
     }
 
@@ -145,7 +145,7 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
     }
 
     @SuppressWarnings("unused")
-    class TypeWithAnnotatedMethod {
+    class TypeWithAnnotatedFunction {
         @Foo
         String publicMethod() { "public" }
 
@@ -160,10 +160,10 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         private String privateMethod() { "private" }
     }
 
-    def "ignores all methods and properties on type #type.simpleName"() {
+    def "ignores all functions and properties on type #type.simpleName"() {
         expect:
         assertProperties type, [:]
-        assertMethods type, [:]
+        assertFunctions type, [:]
         where:
         type << [int, EmptyGroovyObject, int[], Object[], Nullable]
     }
@@ -367,14 +367,14 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         }
     }
 
-    def "superclass properties and methods are present in subclass"() {
+    def "superclass properties and functions are present in subclass"() {
         expect:
         assertProperties TypeWithSuperclassProperties, [
             baseProperty: [(TYPE): Small],
             subclassProperty: [(TYPE): Large]
         ]
         and:
-        assertMethods TypeWithSuperclassMethods, [
+        assertFunctions TypeWithSuperclassFunctions, [
             baseMethod: [(TYPE): Foo],
             subclassMethod: [(TYPE): Bar]
         ]
@@ -393,25 +393,25 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
     }
 
     @SuppressWarnings("unused")
-    interface BaseTypeWithSuperClassMethods {
+    interface BaseTypeWithSuperClassFunctions {
         @Foo
         String baseMethod()
     }
 
     @SuppressWarnings("unused")
-    interface TypeWithSuperclassMethods extends BaseTypeWithSuperClassMethods {
+    interface TypeWithSuperclassFunctions extends BaseTypeWithSuperClassFunctions {
         @Bar
         String subclassMethod()
     }
 
-    def "properties and methods are inherited from implemented interface"() {
+    def "properties and functions are inherited from implemented interface"() {
         expect:
         assertProperties TypeWithInterfaceProperties, [
             interfaceProperty: [(TYPE): Small],
             subclassProperty: [(TYPE): Large]
         ]
         and:
-        assertMethods TypeWithInterfaceMethods, [
+        assertFunctions TypeWithInterfaceFunctions, [
             interfaceMethod: [(TYPE): Foo],
             subclassMethod: [(TYPE): Bar]
         ]
@@ -430,24 +430,24 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
     }
 
     @SuppressWarnings("unused")
-    interface InterfaceWithMethods {
+    interface InterfaceWithFunctions {
         @Foo
         String interfaceMethod()
     }
 
     @SuppressWarnings("unused")
-    abstract class TypeWithInterfaceMethods implements InterfaceWithMethods {
+    abstract class TypeWithInterfaceFunctions implements InterfaceWithFunctions {
         @Bar
         abstract String subclassMethod()
     }
 
-    def "overridden properties and methods inherit super-class annotations"() {
+    def "overridden properties and functions inherit super-class annotations"() {
         expect:
         assertProperties TypeWithInheritedProperty, [
             overriddenProperty: [(COLOR): Color]
         ]
         and:
-        assertMethods TypeWithInheritedMethods, [
+        assertFunctions TypeWithInheritedFunctions, [
             overriddenMethod: [(TYPE): Foo]
         ]
     }
@@ -465,13 +465,13 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
     }
 
     @SuppressWarnings("unused")
-    class BaseTypeWithInheritedMethods {
+    class BaseTypeWithInheritedFunctions {
         @Foo
         String overriddenMethod() { "test" }
     }
 
     @SuppressWarnings("unused")
-    class TypeWithInheritedMethods extends BaseTypeWithInheritedMethods {
+    class TypeWithInheritedFunctions extends BaseTypeWithInheritedFunctions {
         @Override
         String overriddenMethod() { "test" }
     }
@@ -483,7 +483,7 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         ]
 
         and:
-        assertMethods TypeWithInheritedMethodFromSuperClassAndInterface, [
+        assertFunctions TypeWithInheritedFunctionFromSuperClassAndInterface, [
             overriddenMethod: [(TYPE): Foo]
         ]
     }
@@ -503,20 +503,20 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
     }
 
     @SuppressWarnings("unused")
-    interface InterfaceWithInheritedMethod {
+    interface InterfaceWithInheritedFunction {
         @Foo
         String getOverriddenProperty()
     }
 
     @SuppressWarnings("unused")
-    class TypeWithInheritedMethodFromSuperClassAndInterface
-        extends BaseTypeWithInheritedMethods
-        implements InterfaceWithInheritedMethod {
+    class TypeWithInheritedFunctionFromSuperClassAndInterface
+        extends BaseTypeWithInheritedFunctions
+        implements InterfaceWithInheritedFunction {
         @Override
         String getOverriddenProperty() { "test" }
     }
 
-    def "implemented properties and methods inherit annotation from first conflicting interface"() {
+    def "implemented properties and functions inherit annotation from first conflicting interface"() {
         expect:
         assertProperties TypeWithImplementedPropertyFromInterfaces, [
             overriddenProperty: [(COLOR): { it instanceof Color && it.declaredBy() == "first-interface" }]
@@ -524,7 +524,7 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
             strict(conflictingAnnotationsMessage { property('overriddenProperty').inConflict('Color', 'Color').includeLink().kind('color annotations inherited (from interface)') })
         ]
         and:
-        assertMethods TypeWithImplementedMethodFromInterfaces, [
+        assertFunctions TypeWithImplementedFunctionFromInterfaces, [
             overriddenMethod: [(BAZ): { it instanceof Baz && it.declaredBy() == "first-interface" }]
         ], [
             strict(conflictingAnnotationsMessage { method('overriddenMethod').inConflict('Baz', 'Baz').includeLink().kind('baz annotations inherited (from interface)') })
@@ -551,20 +551,20 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
     }
 
     @SuppressWarnings("unused")
-    interface FirstInterfaceWithInheritedMethod {
+    interface FirstInterfaceWithInheritedFunction {
         @Baz(declaredBy = "first-interface")
         String overriddenMethod()
     }
 
     @SuppressWarnings("unused")
-    interface SecondInterfaceWithInheritedMethod {
+    interface SecondInterfaceWithInheritedFunction {
         @Baz(declaredBy = "second-interface")
         String overriddenMethod()
     }
 
     @SuppressWarnings("unused")
-    class TypeWithImplementedMethodFromInterfaces
-        implements FirstInterfaceWithInheritedMethod, SecondInterfaceWithInheritedMethod {
+    class TypeWithImplementedFunctionFromInterfaces
+        implements FirstInterfaceWithInheritedFunction, SecondInterfaceWithInheritedFunction {
         @Override
         String overriddenMethod() { "test" }
     }
@@ -575,7 +575,7 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
             overriddenProperty: [(COLOR): { it instanceof Color && it.declaredBy() == "subtype" }]
         ]
         and:
-        assertMethods TypeOverridingMethodFromConflictingInterfaces, [
+        assertFunctions TypeOverridingFunctionFromConflictingInterfaces, [
             overriddenMethod: [(BAZ): { it instanceof Baz && it.declaredBy() == "subtype" }]
         ]
     }
@@ -589,8 +589,8 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
     }
 
     @SuppressWarnings("unused")
-    class TypeOverridingMethodFromConflictingInterfaces
-        implements FirstInterfaceWithInheritedMethod, SecondInterfaceWithInheritedMethod {
+    class TypeOverridingFunctionFromConflictingInterfaces
+        implements FirstInterfaceWithInheritedFunction, SecondInterfaceWithInheritedFunction {
         @Override
         @Baz(declaredBy = "subtype")
         String overriddenMethod() { "test" }
@@ -602,20 +602,20 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
             overriddenProperty: [(COLOR): { it instanceof Color && it.declaredBy() == "override" }]
         ]
         and:
-        assertMethods TypeWithMethodOverride, [
+        assertFunctions TypeWithFunctionOverride, [
             overriddenMethod: [(BAZ): { it instanceof Baz && it.declaredBy() == "override" }]
         ]
     }
 
-    def "property getter or method is from overriding class"() {
+    def "property getter or function is from overriding class"() {
         when:
         def propertyMetadata = store.getTypeAnnotationMetadata(TypeWithPropertyOverride)
         then:
         propertyMetadata.propertiesAnnotationMetadata[0].method.declaringClass == TypeWithPropertyOverride
         when:
-        def methodMetadata = store.getTypeAnnotationMetadata(TypeWithMethodOverride)
+        def functionMetadata = store.getTypeAnnotationMetadata(TypeWithFunctionOverride)
         then:
-        methodMetadata.methodsAnnotationMetadata[0].method.declaringClass == TypeWithMethodOverride
+        functionMetadata.functionAnnotationMetadata[0].method.declaringClass == TypeWithFunctionOverride
     }
 
     @SuppressWarnings("unused")
@@ -632,13 +632,13 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
     }
 
     @SuppressWarnings("unused")
-    interface BaseTypeWithMethodOverride {
+    interface BaseTypeWithFunctionOverride {
         @Baz(declaredBy = "base")
         String overriddenMethod()
     }
 
     @SuppressWarnings("unused")
-    interface TypeWithMethodOverride extends BaseTypeWithMethodOverride {
+    interface TypeWithFunctionOverride extends BaseTypeWithFunctionOverride {
         @Override
         @Baz(declaredBy = "override")
         String overriddenMethod()
@@ -646,46 +646,46 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
 
     def "can override annotation with different annotation in same category in subclass"() {
         expect:
-        assertProperties CanOverrideOverrideCategoryClass, [
+        assertProperties CanOverrideOverridePropertyCategoryClass, [
             overriddenProperty: [(TYPE): Small, (COLOR): Color]
         ]
         and:
-        assertMethods CanOverrideOverrideMethodCategoryClass, [
+        assertFunctions CanOverrideOverrideFunctionCategoryClass, [
             overriddenMethod: [(TYPE): Bar, (BAZ): Baz]
         ]
     }
 
     @SuppressWarnings("unused")
-    interface CanOverrideCategoryBaseClass {
+    interface CanOverridePropertyCategoryBaseClass {
         @Large
         String getOverriddenProperty()
     }
 
-    interface CanOverrideCategoryIntermediateClass extends CanOverrideCategoryBaseClass {
+    interface CanOverridePropertyCategoryIntermediateClass extends CanOverridePropertyCategoryBaseClass {
         @Override
         @Color
         String getOverriddenProperty()
     }
 
-    interface CanOverrideOverrideCategoryClass extends CanOverrideCategoryIntermediateClass {
+    interface CanOverrideOverridePropertyCategoryClass extends CanOverridePropertyCategoryIntermediateClass {
         @Override
         @Small
         String getOverriddenProperty()
     }
 
     @SuppressWarnings("unused")
-    interface CanOverrideMethodCategoryBaseClass {
+    interface CanOverrideFunctionCategoryBaseClass {
         @Foo
         String overriddenMethod()
     }
 
-    interface CanOverrideMethodCategoryIntermediateClass extends CanOverrideMethodCategoryBaseClass {
+    interface CanOverrideFunctionCategoryIntermediateClass extends CanOverrideFunctionCategoryBaseClass {
         @Override
         @Baz
         String overriddenMethod()
     }
 
-    interface CanOverrideOverrideMethodCategoryClass extends CanOverrideMethodCategoryIntermediateClass {
+    interface CanOverrideOverrideFunctionCategoryClass extends CanOverrideFunctionCategoryIntermediateClass {
         @Override
         @Bar
         String overriddenMethod()
@@ -731,7 +731,7 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         String getPropertyIgnoredInBase()
     }
 
-    def "warns about conflicting property or method types being specified, chooses first declaration"() {
+    def "warns about conflicting property or function types being specified, chooses first declaration"() {
         expect:
         assertProperties TypeWithPropertiesWithMultipleAnnotationsOfSameCategory, [
             largeThenSmall: [(TYPE): Large],
@@ -741,7 +741,7 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
             strict(conflictingAnnotationsMessage { property('smallThenLarge').inConflict('Small', 'Large').includeLink() })
         ]
         and:
-        assertMethods TypeWithMethodsWithMultipleAnnotationsOfSameCategory, [
+        assertFunctions TypeWithFunctionsWithMultipleAnnotationsOfSameCategory, [
             largeThenSmall: [(TYPE): Foo],
             smallThenLarge: [(TYPE): Bar]
         ], [
@@ -762,7 +762,7 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
     }
 
     @SuppressWarnings("unused")
-    interface TypeWithMethodsWithMultipleAnnotationsOfSameCategory {
+    interface TypeWithFunctionsWithMultipleAnnotationsOfSameCategory {
         @Foo
         @Bar
         String largeThenSmall()
@@ -847,7 +847,7 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         }
     }
 
-    def "warns about annotations on private properties or methods"() {
+    def "warns about annotations on private properties or functions"() {
         expect:
         assertProperties WithAnnotationsOnPrivateProperty, [
             privateInput: [(TYPE): Large]
@@ -855,10 +855,10 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
             strict(privateGetterAnnotatedMessage { property('privateInput').annotation(Large.simpleName).includeLink() })
         ]
         and:
-        assertMethods WithAnnotationsOnPrivateMethod, [
+        assertFunctions WithAnnotationsOnPrivateFunction, [
             privateMethod: [(TYPE): Foo]
         ], [
-            strict(privateMethodAnnotatedMessage { method('privateMethod').annotation(Foo.simpleName).includeLink() })
+            strict(privateFunctionAnnotatedMessage { method('privateMethod').annotation(Foo.simpleName).includeLink() })
         ]
     }
 
@@ -875,7 +875,7 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
     }
 
     @SuppressWarnings("unused")
-    class WithAnnotationsOnPrivateMethod {
+    class WithAnnotationsOnPrivateFunction {
         @Foo
         private String privateMethod() {
             'Input'
@@ -930,10 +930,10 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
     @Irrelevant
     interface TypeWithAnnotations {}
 
-    def "warns about property annotations on non-property methods"() {
+    def "warns about property annotations on function methods"() {
         expect:
         assertProperties TypeWithAnnotatedNonGetterMethods, [:], [
-            strict(methodShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedNonGetterMethods.canonicalName).kind('method').method('doSomething').annotation('Large').includeLink() }),
+            strict(methodShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedNonGetterMethods.canonicalName).kind('function').method('doSomething').annotation('Large').includeLink() }),
             strict(methodShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedNonGetterMethods.canonicalName).kind('setter').method('setSomething').annotation('Large').includeLink() }),
             strict(methodShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedNonGetterMethods.canonicalName).kind('static method').method('doStatic').annotation('Large').includeLink() }),
             strict(methodShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedNonGetterMethods.canonicalName).kind('static method').method('getStatic').annotation('Small').includeLink() }),
@@ -955,12 +955,12 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         void setSomething(String something) {}
     }
 
-    def "warns about non-property annotations on fields or property methods"() {
+    def "warns about function annotations on fields or property methods"() {
         expect:
-        assertMethods TypeWithAnnotatedGetterMethods, [:], [
+        assertFunctions TypeWithAnnotatedGetterMethods, [:], [
             strict(fieldShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedGetterMethods.canonicalName).kind('field').method('anything').annotation('Foo').includeLink() }),
             strict(propertyShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedGetterMethods.canonicalName).kind('property').method('getSomething').annotation('Foo').includeLink() }),
-            strict(staticMethodShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedGetterMethods.canonicalName).kind('static method').method('getStatic').annotation('Bar').includeLink() }),
+            strict(staticPropertyMethodShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedGetterMethods.canonicalName).kind('static method').method('getStatic').annotation('Bar').includeLink() }),
             strict(propertyShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedGetterMethods.canonicalName).kind('property').method('isSomethingElse').annotation('Bar').includeLink() }),
             strict(propertyShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedGetterMethods.canonicalName).kind('property').method('setSomething').annotation('Foo').includeLink() }),
         ]
@@ -1000,7 +1000,7 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         expect:
         assertProperties ArrayList, [:]
         and:
-        assertMethods ArrayList, [:]
+        assertFunctions ArrayList, [:]
     }
 
     void assertProperties(Class<?> type, Map<String, Map<AnnotationCategory, ?>> expectedProperties, List<String> expectedErrors = []) {
@@ -1038,14 +1038,14 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         assert actualErrors == expectedErrors
     }
 
-    void assertMethods(Class<?> type, Map<String, Map<AnnotationCategory, ?>> expectedMethods, List<String> expectedErrors = []) {
+    void assertFunctions(Class<?> type, Map<String, Map<AnnotationCategory, ?>> expectedFunctions, List<String> expectedErrors = []) {
         def metadata = store.getTypeAnnotationMetadata(type)
-        def actualMethodNames = metadata.methodsAnnotationMetadata*.method.name.sort()
-        def expectedMethodNames = expectedMethods.keySet().sort()
+        def actualMethodNames = metadata.functionAnnotationMetadata*.method.name.sort()
+        def expectedMethodNames = expectedFunctions.keySet().sort()
         assert actualMethodNames == expectedMethodNames
 
-        metadata.methodsAnnotationMetadata.forEach { actualMethod ->
-            def expectedAnnotations = expectedMethods[actualMethod.method.name]
+        metadata.functionAnnotationMetadata.forEach { actualMethod ->
+            def expectedAnnotations = expectedFunctions[actualMethod.method.name]
 
             def actualCategories = actualMethod.annotations.keySet().sort()
             def expectedCategories = expectedAnnotations.keySet().sort()

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStoreTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStoreTest.groovy
@@ -1012,12 +1012,12 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         metadata.propertiesAnnotationMetadata.forEach { actualProperty ->
             def expectedAnnotations = expectedProperties[actualProperty.propertyName]
 
-            def actualCategories = actualProperty.annotations.keySet().sort()
+            def actualCategories = actualProperty.annotationsByCategory.keySet().sort()
             def expectedCategories = expectedAnnotations.keySet().sort()
             assert actualCategories == expectedCategories
 
             actualCategories.forEach { category ->
-                def actualAnnotation = actualProperty.annotations[category]
+                def actualAnnotation = actualProperty.annotationsByCategory[category]
                 def expectedAnnotation = expectedAnnotations[category]
                 if (expectedAnnotation instanceof Class) {
                     assert actualAnnotation.annotationType() == expectedAnnotation
@@ -1047,12 +1047,12 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         metadata.functionAnnotationMetadata.forEach { actualMethod ->
             def expectedAnnotations = expectedFunctions[actualMethod.method.name]
 
-            def actualCategories = actualMethod.annotations.keySet().sort()
+            def actualCategories = actualMethod.annotationsByCategory.keySet().sort()
             def expectedCategories = expectedAnnotations.keySet().sort()
             assert actualCategories == expectedCategories
 
             actualCategories.forEach { category ->
-                def actualAnnotation = actualMethod.annotations[category]
+                def actualAnnotation = actualMethod.annotationsByCategory[category]
                 def expectedAnnotation = expectedAnnotations[category]
                 if (expectedAnnotation instanceof Class) {
                     assert actualAnnotation.annotationType() == expectedAnnotation

--- a/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/annotations/TestAnnotationHandlingSupport.groovy
+++ b/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/annotations/TestAnnotationHandlingSupport.groovy
@@ -54,6 +54,7 @@ trait TestAnnotationHandlingSupport {
     TypeAnnotationMetadataStore typeAnnotationMetadataStore = new DefaultTypeAnnotationMetadataStore(
         [ThisIsAThing],
         [(TestNested): TYPE, (Long): TYPE, (Short): TYPE, (Tint): Modifiers.COLOR],
+        [:],
         ["java", "groovy"],
         [Object],
         [Object, GroovyObject],
@@ -72,6 +73,8 @@ trait TestAnnotationHandlingSupport {
             new SimplePropertyAnnotationHandler(Short, INPUT, [Tint]),
         ],
         [ItDepends, Tint],
+        [],
+        [],
         typeAnnotationMetadataStore,
         { annotations -> annotations.get(TYPE)?.annotationType() },
         TestCrossBuildInMemoryCacheFactory.instance(),

--- a/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
+++ b/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
@@ -48,6 +48,15 @@ trait ValidationMessageChecker {
             .render()
     }
 
+    String cannotUseStaticMethod(@DelegatesTo(value = SimpleMessage, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
+        def config = display(SimpleMessage, 'ignored_annotations_on_property', spec)
+        config.description("should not be annotated with: @TaskAction")
+            .reason("Non-property annotations are ignored if they are placed on a static method")
+            .solution("Remove the annotations")
+            .solution("Make the method non-static")
+            .render()
+    }
+
     String missingNonConfigurableValueMessage(@DelegatesTo(value = SimpleMessage, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
         def config = display(SimpleMessage, 'value_not_set', spec)
         config.description("doesn't have a configured value")
@@ -81,6 +90,19 @@ trait ValidationMessageChecker {
             .reason("Non-property annotations are ignored if they are placed on a property getter")
             .solution("Remove the annotations")
             .solution("Rename the method")
+    }
+
+    String staticMethodShouldNotBeAnnotatedMessage(@DelegatesTo(value = ShouldNotBeAnnotated, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
+        ShouldNotBeAnnotated config = staticMethodShouldNotBeAnnotatedConfig(spec)
+        config.render()
+    }
+
+    ShouldNotBeAnnotated staticMethodShouldNotBeAnnotatedConfig(@DelegatesTo(value = ShouldNotBeAnnotated, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
+        def config = display(ShouldNotBeAnnotated, 'ignored_annotations_on_property', spec)
+        config.description("$config.kind '$config.name()' should not be annotated with: @$config.annotation")
+            .reason("Non-property annotations are ignored if they are placed on a static method")
+            .solution("Remove the annotations")
+            .solution("Make the method non-static")
     }
 
     String fieldShouldNotBeAnnotatedMessage(@DelegatesTo(value = ShouldNotBeAnnotated, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {

--- a/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
+++ b/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
@@ -57,17 +57,42 @@ trait ValidationMessageChecker {
             .render()
     }
 
-    String methodShouldNotBeAnnotatedMessage(@DelegatesTo(value = MethodShouldNotBeAnnotated, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
-        MethodShouldNotBeAnnotated config = methodShouldNotBeAnnotatedConfig(spec)
+    String methodShouldNotBeAnnotatedMessage(@DelegatesTo(value = ShouldNotBeAnnotated, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
+        ShouldNotBeAnnotated config = methodShouldNotBeAnnotatedConfig(spec)
         config.render()
     }
 
-    MethodShouldNotBeAnnotated methodShouldNotBeAnnotatedConfig(@DelegatesTo(value = MethodShouldNotBeAnnotated, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
-        def config = display(MethodShouldNotBeAnnotated, 'ignored_annotations_on_method', spec)
-        config.description("$config.kind '$config.method()' should not be annotated with: @$config.annotation")
+    ShouldNotBeAnnotated methodShouldNotBeAnnotatedConfig(@DelegatesTo(value = ShouldNotBeAnnotated, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
+        def config = display(ShouldNotBeAnnotated, 'ignored_annotations_on_method', spec)
+        config.description("$config.kind '$config.name()' should not be annotated with: @$config.annotation")
             .reason("Input/Output annotations are ignored if they are placed on something else than a getter")
             .solution("Remove the annotations")
             .solution("Rename the method")
+    }
+
+    String propertyShouldNotBeAnnotatedMessage(@DelegatesTo(value = ShouldNotBeAnnotated, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
+        ShouldNotBeAnnotated config = propertyShouldNotBeAnnotatedConfig(spec)
+        config.render()
+    }
+
+    ShouldNotBeAnnotated propertyShouldNotBeAnnotatedConfig(@DelegatesTo(value = ShouldNotBeAnnotated, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
+        def config = display(ShouldNotBeAnnotated, 'ignored_annotations_on_property', spec)
+        config.description("$config.kind '$config.name()' should not be annotated with: @$config.annotation")
+            .reason("Non-property annotations are ignored if they are placed on a property getter")
+            .solution("Remove the annotations")
+            .solution("Rename the method")
+    }
+
+    String fieldShouldNotBeAnnotatedMessage(@DelegatesTo(value = ShouldNotBeAnnotated, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
+        ShouldNotBeAnnotated config = fieldShouldNotBeAnnotatedConfig(spec)
+        config.render()
+    }
+
+    ShouldNotBeAnnotated fieldShouldNotBeAnnotatedConfig(@DelegatesTo(value = ShouldNotBeAnnotated, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
+        def config = display(ShouldNotBeAnnotated, 'ignored_annotations_on_property', spec)
+        config.description("$config.kind '$config.name()' should not be annotated with: @$config.annotation")
+            .reason("Non-property annotations are ignored if they are placed on a field")
+            .solution("Remove the annotations")
     }
 
     String privateGetterAnnotatedMessage(@DelegatesTo(value = AnnotationContext, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
@@ -81,6 +106,19 @@ trait ValidationMessageChecker {
             .reason("Annotations on private getters are ignored")
             .solution("Make the getter public")
             .solution("Annotate the public version of the getter")
+    }
+
+    String privateMethodAnnotatedMessage(@DelegatesTo(value = AnnotationContext, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
+        AnnotationContext config = privateMethodAnnotatedConfig(spec)
+        config.render()
+    }
+
+    AnnotationContext privateMethodAnnotatedConfig(Closure<?> spec) {
+        def config = display(AnnotationContext, 'private_method_must_not_be_annotated', spec)
+        config.description("is private and annotated with @${config.annotation}")
+            .reason("Annotations on private methods are ignored")
+            .solution("Make the method public")
+            .solution("Annotate the public version of the method")
     }
 
     String ignoredAnnotatedPropertyMessage(@DelegatesTo(value = IgnoredAnnotationPropertyMessage, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
@@ -354,9 +392,20 @@ trait ValidationMessageChecker {
         }.render()
     }
 
-    String dummyValidationProblemWithLink(String onType = 'InvalidTask', String onProperty = 'dummy', String desc = 'test problem', String testReason = 'this is a test.') {
+    String dummyPropertyValidationProblemWithLink(String onType = 'InvalidTask', String onProperty = 'dummy', String desc = 'test problem', String testReason = 'this is a test.') {
         display(SimpleMessage, 'dummy') {
             type(onType).property(onProperty)
+            description(desc)
+            reason(testReason)
+            includeLink()
+            documentationId("id")
+            documentationSection("section")
+        }.render()
+    }
+
+    String dummyMethodValidationProblemWithLink(String onType = 'InvalidTask', String onMethod = 'dummy', String desc = 'test problem', String testReason = 'this is a test.') {
+        display(SimpleMessage, 'dummy') {
+            type(onType).method(onMethod)
             description(desc)
             reason(testReason)
             includeLink()
@@ -767,27 +816,27 @@ trait ValidationMessageChecker {
         }
     }
 
-    static class MethodShouldNotBeAnnotated extends ValidationMessageDisplayConfiguration<MethodShouldNotBeAnnotated> {
+    static class ShouldNotBeAnnotated extends ValidationMessageDisplayConfiguration<ShouldNotBeAnnotated> {
         String annotation
         String kind
-        String method
+        String name
 
-        MethodShouldNotBeAnnotated(ValidationMessageChecker checker) {
+        ShouldNotBeAnnotated(ValidationMessageChecker checker) {
             super(checker)
         }
 
-        MethodShouldNotBeAnnotated kind(String kind) {
+        ShouldNotBeAnnotated kind(String kind) {
             this.kind = kind
             this
         }
 
-        MethodShouldNotBeAnnotated annotation(String name) {
+        ShouldNotBeAnnotated annotation(String name) {
             annotation = name
             this
         }
 
-        MethodShouldNotBeAnnotated method(String name) {
-            method = name
+        ShouldNotBeAnnotated method(String name) {
+            this.name = name
             this
         }
     }

--- a/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
+++ b/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
@@ -429,7 +429,7 @@ trait ValidationMessageChecker {
         }.render()
     }
 
-    String dummyMethodValidationProblemWithLink(String onType = 'InvalidTask', String onMethod = 'dummy', String desc = 'test problem', String testReason = 'this is a test.') {
+    String dummyFunctionValidationProblemWithLink(String onType = 'InvalidTask', String onMethod = 'dummy', String desc = 'test problem', String testReason = 'this is a test.') {
         display(SimpleMessage, 'dummy') {
             type(onType).method(onMethod)
             description(desc)

--- a/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
+++ b/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
@@ -48,15 +48,6 @@ trait ValidationMessageChecker {
             .render()
     }
 
-    String cannotUseStaticMethod(@DelegatesTo(value = SimpleMessage, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
-        def config = display(SimpleMessage, 'ignored_annotations_on_property', spec)
-        config.description("should not be annotated with: @TaskAction")
-            .reason("Non-property annotations are ignored if they are placed on a static method")
-            .solution("Remove the annotations")
-            .solution("Make the method non-static")
-            .render()
-    }
-
     String missingNonConfigurableValueMessage(@DelegatesTo(value = SimpleMessage, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
         def config = display(SimpleMessage, 'value_not_set', spec)
         config.description("doesn't have a configured value")
@@ -87,20 +78,33 @@ trait ValidationMessageChecker {
     ShouldNotBeAnnotated propertyShouldNotBeAnnotatedConfig(@DelegatesTo(value = ShouldNotBeAnnotated, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
         def config = display(ShouldNotBeAnnotated, 'ignored_annotations_on_property', spec)
         config.description("$config.kind '$config.name()' should not be annotated with: @$config.annotation")
-            .reason("Non-property annotations are ignored if they are placed on a property getter")
+            .reason("Function annotations are ignored if they are placed on a property getter")
             .solution("Remove the annotations")
             .solution("Rename the method")
     }
 
-    String staticMethodShouldNotBeAnnotatedMessage(@DelegatesTo(value = ShouldNotBeAnnotated, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
-        ShouldNotBeAnnotated config = staticMethodShouldNotBeAnnotatedConfig(spec)
+    String staticPropertyMethodShouldNotBeAnnotatedMessage(@DelegatesTo(value = ShouldNotBeAnnotated, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
+        ShouldNotBeAnnotated config = staticPropertyMethodShouldNotBeAnnotatedConfig(spec)
         config.render()
     }
 
-    ShouldNotBeAnnotated staticMethodShouldNotBeAnnotatedConfig(@DelegatesTo(value = ShouldNotBeAnnotated, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
+    ShouldNotBeAnnotated staticPropertyMethodShouldNotBeAnnotatedConfig(@DelegatesTo(value = ShouldNotBeAnnotated, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
         def config = display(ShouldNotBeAnnotated, 'ignored_annotations_on_property', spec)
         config.description("$config.kind '$config.name()' should not be annotated with: @$config.annotation")
-            .reason("Non-property annotations are ignored if they are placed on a static method")
+            .reason("Function annotations are ignored if they are placed on a static method")
+            .solution("Remove the annotations")
+            .solution("Make the method non-static")
+    }
+
+    String staticFunctionMethodShouldNotBeAnnotatedMessage(@DelegatesTo(value = ShouldNotBeAnnotated, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
+        ShouldNotBeAnnotated config = staticFunctionMethodShouldNotBeAnnotatedConfig(spec)
+        config.render()
+    }
+
+    ShouldNotBeAnnotated staticFunctionMethodShouldNotBeAnnotatedConfig(@DelegatesTo(value = ShouldNotBeAnnotated, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
+        def config = display(ShouldNotBeAnnotated, 'ignored_annotations_on_property', spec)
+        config.description("$config.kind '$config.name()' should not be annotated with: @$config.annotation")
+            .reason("Function annotations are ignored if they are placed on a static method")
             .solution("Remove the annotations")
             .solution("Make the method non-static")
     }
@@ -113,7 +117,7 @@ trait ValidationMessageChecker {
     ShouldNotBeAnnotated fieldShouldNotBeAnnotatedConfig(@DelegatesTo(value = ShouldNotBeAnnotated, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
         def config = display(ShouldNotBeAnnotated, 'ignored_annotations_on_property', spec)
         config.description("$config.kind '$config.name()' should not be annotated with: @$config.annotation")
-            .reason("Non-property annotations are ignored if they are placed on a field")
+            .reason("Function annotations are ignored if they are placed on a field")
             .solution("Remove the annotations")
     }
 
@@ -130,7 +134,7 @@ trait ValidationMessageChecker {
             .solution("Annotate the public version of the getter")
     }
 
-    String privateMethodAnnotatedMessage(@DelegatesTo(value = AnnotationContext, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
+    String privateFunctionAnnotatedMessage(@DelegatesTo(value = AnnotationContext, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
         AnnotationContext config = privateMethodAnnotatedConfig(spec)
         config.render()
     }
@@ -860,6 +864,16 @@ trait ValidationMessageChecker {
         ShouldNotBeAnnotated method(String name) {
             this.name = name
             this
+        }
+
+        @Override
+        String getPropertyIntro() {
+            kind ? "${kind} ${super.getPropertyIntro()}" : super.getPropertyIntro()
+        }
+
+        @Override
+        String getFunctionIntro() {
+            kind ? "${kind} ${super.getFunctionIntro()}" : super.getFunctionIntro()
         }
     }
 

--- a/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageDisplayConfiguration.groovy
+++ b/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageDisplayConfiguration.groovy
@@ -33,6 +33,7 @@ class ValidationMessageDisplayConfiguration<T extends ValidationMessageDisplayCo
 
     String typeName
     String property
+    String method
     String propertyType
     String section
     String documentationId = "validation_problems"
@@ -60,6 +61,11 @@ class ValidationMessageDisplayConfiguration<T extends ValidationMessageDisplayCo
 
     T property(String name) {
         property = name
+        this
+    }
+
+    T method(String name) {
+        method = name
         this
     }
 
@@ -97,23 +103,31 @@ class ValidationMessageDisplayConfiguration<T extends ValidationMessageDisplayCo
         "property"
     }
 
+    String getMethodIntro() {
+        "method"
+    }
+
     private String getIntro() {
         if (!hasIntro) {
             return ''
         }
-        String intro = typeName ? getTypeIntro() : getPropertyDescription()
+        String intro = typeName ? getTypeIntro() : getPropertyDescription().capitalize()
         if (pluginId) {
             return "In plugin '${pluginId}' ${intro.uncapitalize()}"
         }
         return intro
     }
 
+    private String getMethodDescription() {
+        method ? "${methodIntro} '${method}' " : ""
+    }
+
     private String getPropertyDescription() {
-        property ? "${propertyIntro.capitalize()} '${property}' " : ""
+        property ? "${propertyIntro} '${property}' " : methodDescription
     }
 
     private String getTypeIntro() {
-        "Type '$typeName' ${property ? "${propertyIntro} '${property}' " : ''}"
+        "Type '$typeName' ${propertyDescription}"
     }
 
     private String getOutro() {

--- a/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageDisplayConfiguration.groovy
+++ b/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageDisplayConfiguration.groovy
@@ -35,6 +35,7 @@ class ValidationMessageDisplayConfiguration<T extends ValidationMessageDisplayCo
     String property
     String method
     String propertyType
+    String kind
     String section
     String documentationId = "validation_problems"
     boolean includeLink = false
@@ -99,19 +100,24 @@ class ValidationMessageDisplayConfiguration<T extends ValidationMessageDisplayCo
         this
     }
 
+    T kind(String kind) {
+        this.kind = kind
+        this
+    }
+
     String getPropertyIntro() {
-        "property"
+        kind ? "${kind} property" : "property"
     }
 
     String getMethodIntro() {
-        "method"
+        kind ? "${kind} method" : "method"
     }
 
     private String getIntro() {
         if (!hasIntro) {
             return ''
         }
-        String intro = typeName ? getTypeIntro() : getPropertyDescription().capitalize()
+        String intro = typeName ? getTypeIntro() : getPropertyOrMethodDescription().capitalize()
         if (pluginId) {
             return "In plugin '${pluginId}' ${intro.uncapitalize()}"
         }
@@ -122,12 +128,12 @@ class ValidationMessageDisplayConfiguration<T extends ValidationMessageDisplayCo
         method ? "${methodIntro} '${method}' " : ""
     }
 
-    private String getPropertyDescription() {
+    private String getPropertyOrMethodDescription() {
         property ? "${propertyIntro} '${property}' " : methodDescription
     }
 
     private String getTypeIntro() {
-        "Type '$typeName' ${propertyDescription}"
+        "Type '$typeName' ${propertyOrMethodDescription}"
     }
 
     private String getOutro() {

--- a/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageDisplayConfiguration.groovy
+++ b/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageDisplayConfiguration.groovy
@@ -33,9 +33,9 @@ class ValidationMessageDisplayConfiguration<T extends ValidationMessageDisplayCo
 
     String typeName
     String property
+    String function
     String method
     String propertyType
-    String kind
     String section
     String documentationId = "validation_problems"
     boolean includeLink = false
@@ -61,12 +61,17 @@ class ValidationMessageDisplayConfiguration<T extends ValidationMessageDisplayCo
     }
 
     T property(String name) {
-        property = name
+        this.property = name
+        this
+    }
+
+    T function(String name) {
+        this.function = name
         this
     }
 
     T method(String name) {
-        method = name
+        this.method = name
         this
     }
 
@@ -100,24 +105,23 @@ class ValidationMessageDisplayConfiguration<T extends ValidationMessageDisplayCo
         this
     }
 
-    T kind(String kind) {
-        this.kind = kind
-        this
+    String getPropertyIntro() {
+        "property"
     }
 
-    String getPropertyIntro() {
-        kind ? "${kind} property" : "property"
+    String getFunctionIntro() {
+        "function"
     }
 
     String getMethodIntro() {
-        kind ? "${kind} method" : "method"
+        "method"
     }
 
     private String getIntro() {
         if (!hasIntro) {
             return ''
         }
-        String intro = typeName ? getTypeIntro() : getPropertyOrMethodDescription().capitalize()
+        String intro = typeName ? getTypeIntro() : getPropertyOrFunctionDescription().capitalize()
         if (pluginId) {
             return "In plugin '${pluginId}' ${intro.uncapitalize()}"
         }
@@ -128,12 +132,16 @@ class ValidationMessageDisplayConfiguration<T extends ValidationMessageDisplayCo
         method ? "${methodIntro} '${method}' " : ""
     }
 
-    private String getPropertyOrMethodDescription() {
-        property ? "${propertyIntro} '${property}' " : methodDescription
+    private String getFunctionDescription() {
+        function ? "${functionIntro} '${function}' " : methodDescription
+    }
+
+    private String getPropertyOrFunctionDescription() {
+        property ? "${propertyIntro} '${property}' " : functionDescription
     }
 
     private String getTypeIntro() {
-        "Type '$typeName' ${propertyOrMethodDescription}"
+        "Type '$typeName' ${propertyOrFunctionDescription}"
     }
 
     private String getOutro() {

--- a/platforms/core-execution/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/platforms/core-execution/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -567,7 +567,7 @@ class IncrementalExecutionIntegrationTest extends Specification implements Valid
         then:
         def ex = thrown WorkValidationException
         WorkValidationExceptionChecker.check(ex) {
-            hasProblem dummyValidationProblemWithLink('java.lang.Object', null, 'Validation error', 'Test').trim()
+            hasProblem dummyPropertyValidationProblemWithLink('java.lang.Object', null, 'Validation error', 'Test').trim()
         }
     }
 

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/TaskActionAnnotationHandler.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/TaskActionAnnotationHandler.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.execution.model.annotations;
+
+import com.google.common.collect.ImmutableSet;
+import org.gradle.api.problems.Severity;
+import org.gradle.api.problems.internal.GradleCoreProblemGroup;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.internal.properties.annotations.AbstractMethodAnnotationHandler;
+import org.gradle.internal.properties.annotations.MethodMetadata;
+import org.gradle.internal.reflect.validation.TypeValidationContext;
+import org.gradle.util.internal.TextUtil;
+import org.gradle.work.InputChanges;
+
+import java.lang.reflect.Method;
+import java.util.Locale;
+
+import static org.gradle.internal.deprecation.Documentation.userManual;
+
+public class TaskActionAnnotationHandler extends AbstractMethodAnnotationHandler {
+    static final String TASKACTION_MUST_HAVE_ZERO_OR_ONE_PARAMETER = "TASKACTION_MUST_HAVE_ZERO_OR_ONE_PARAMETER";
+
+    public TaskActionAnnotationHandler() {
+        super(TaskAction.class, ImmutableSet.of());
+    }
+
+    @Override
+    public boolean isMethodRelevant() {
+        return true;
+    }
+
+    @Override
+    public void validateMethodMetadata(MethodMetadata methodMetadata, TypeValidationContext validationContext) {
+        Method method = methodMetadata.getMethod();
+        final Class<?>[] parameterTypes = method.getParameterTypes();
+        if (parameterTypes.length > 1) {
+            validationContext.visitTypeProblem(problem ->
+                problem
+                    .forMethod(methodMetadata.getMethodName())
+                    .id(TextUtil.screamingSnakeToKebabCase(TASKACTION_MUST_HAVE_ZERO_OR_ONE_PARAMETER), "Method has @TaskAction with too many parameters", GradleCoreProblemGroup.validation().type())
+                    .contextualLabel(String.format("Method '%s' has @TaskAction annotation with too many method parameters", methodMetadata.getMethodName()))
+                    .documentedAt(userManual("validation_problems", TASKACTION_MUST_HAVE_ZERO_OR_ONE_PARAMETER.toLowerCase(Locale.ROOT)))
+                    .severity(Severity.ERROR)
+                    .details(String.format("A method annotated with @TaskAction must have zero or one parameter of type '%s'", InputChanges.class.getName()))
+                    .solution(String.format("Change the method signature of '%s' to have zero parameters", methodMetadata.getMethodName()))
+                    .solution(String.format("Change the method signature of '%s' to have one parameter of type '%s'", methodMetadata.getMethodName(), InputChanges.class.getName()))
+                    .solution(String.format("Remove the @TaskAction annotation from method '%s'", methodMetadata.getMethodName()))
+            );
+        } else if (parameterTypes.length == 1 && parameterTypes[0] != InputChanges.class) {
+            validationContext.visitTypeProblem(problem ->
+                problem
+                    .forMethod(methodMetadata.getMethodName())
+                    .id(TextUtil.screamingSnakeToKebabCase(TASKACTION_MUST_HAVE_ZERO_OR_ONE_PARAMETER), "Method has @TaskAction with invalid parameter type", GradleCoreProblemGroup.validation().type())
+                    .contextualLabel(String.format("Method '%s' has @TaskAction annotation with invalid method parameter type", methodMetadata.getMethodName()))
+                    .documentedAt(userManual("validation_problems", TASKACTION_MUST_HAVE_ZERO_OR_ONE_PARAMETER.toLowerCase(Locale.ROOT)))
+                    .severity(Severity.ERROR)
+                    .details(String.format("A method annotated with @TaskAction must have zero or one parameter of type '%s'", InputChanges.class.getName()))
+                    .solution(String.format("Change the method signature of '%s' to have zero parameters", methodMetadata.getMethodName()))
+                    .solution(String.format("Change the method signature of '%s' to have one parameter of type '%s'", methodMetadata.getMethodName(), InputChanges.class.getName()))
+                    .solution(String.format("Remove the @TaskAction annotation from method '%s'", methodMetadata.getMethodName()))
+            );
+        }
+    }
+}

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/TaskActionAnnotationHandler.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/TaskActionAnnotationHandler.java
@@ -17,23 +17,10 @@
 package org.gradle.internal.execution.model.annotations;
 
 import com.google.common.collect.ImmutableSet;
-import org.gradle.api.problems.Severity;
-import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.properties.annotations.AbstractMethodAnnotationHandler;
-import org.gradle.internal.properties.annotations.MethodMetadata;
-import org.gradle.internal.reflect.validation.TypeValidationContext;
-import org.gradle.util.internal.TextUtil;
-import org.gradle.work.InputChanges;
-
-import java.lang.reflect.Method;
-import java.util.Locale;
-
-import static org.gradle.internal.deprecation.Documentation.userManual;
 
 public class TaskActionAnnotationHandler extends AbstractMethodAnnotationHandler {
-    static final String TASKACTION_MUST_HAVE_ZERO_OR_ONE_PARAMETER = "TASKACTION_MUST_HAVE_ZERO_OR_ONE_PARAMETER";
-
     public TaskActionAnnotationHandler() {
         super(TaskAction.class, ImmutableSet.of());
     }
@@ -41,38 +28,5 @@ public class TaskActionAnnotationHandler extends AbstractMethodAnnotationHandler
     @Override
     public boolean isMethodRelevant() {
         return true;
-    }
-
-    @Override
-    public void validateMethodMetadata(MethodMetadata methodMetadata, TypeValidationContext validationContext) {
-        Method method = methodMetadata.getMethod();
-        final Class<?>[] parameterTypes = method.getParameterTypes();
-        if (parameterTypes.length > 1) {
-            validationContext.visitTypeProblem(problem ->
-                problem
-                    .forMethod(methodMetadata.getMethodName())
-                    .id(TextUtil.screamingSnakeToKebabCase(TASKACTION_MUST_HAVE_ZERO_OR_ONE_PARAMETER), "Method has @TaskAction with too many parameters", GradleCoreProblemGroup.validation().type())
-                    .contextualLabel(String.format("Method '%s' has @TaskAction annotation with too many method parameters", methodMetadata.getMethodName()))
-                    .documentedAt(userManual("validation_problems", TASKACTION_MUST_HAVE_ZERO_OR_ONE_PARAMETER.toLowerCase(Locale.ROOT)))
-                    .severity(Severity.ERROR)
-                    .details(String.format("A method annotated with @TaskAction must have zero or one parameter of type '%s'", InputChanges.class.getName()))
-                    .solution(String.format("Change the method signature of '%s' to have zero parameters", methodMetadata.getMethodName()))
-                    .solution(String.format("Change the method signature of '%s' to have one parameter of type '%s'", methodMetadata.getMethodName(), InputChanges.class.getName()))
-                    .solution(String.format("Remove the @TaskAction annotation from method '%s'", methodMetadata.getMethodName()))
-            );
-        } else if (parameterTypes.length == 1 && parameterTypes[0] != InputChanges.class) {
-            validationContext.visitTypeProblem(problem ->
-                problem
-                    .forMethod(methodMetadata.getMethodName())
-                    .id(TextUtil.screamingSnakeToKebabCase(TASKACTION_MUST_HAVE_ZERO_OR_ONE_PARAMETER), "Method has @TaskAction with invalid parameter type", GradleCoreProblemGroup.validation().type())
-                    .contextualLabel(String.format("Method '%s' has @TaskAction annotation with invalid method parameter type", methodMetadata.getMethodName()))
-                    .documentedAt(userManual("validation_problems", TASKACTION_MUST_HAVE_ZERO_OR_ONE_PARAMETER.toLowerCase(Locale.ROOT)))
-                    .severity(Severity.ERROR)
-                    .details(String.format("A method annotated with @TaskAction must have zero or one parameter of type '%s'", InputChanges.class.getName()))
-                    .solution(String.format("Change the method signature of '%s' to have zero parameters", methodMetadata.getMethodName()))
-                    .solution(String.format("Change the method signature of '%s' to have one parameter of type '%s'", methodMetadata.getMethodName(), InputChanges.class.getName()))
-                    .solution(String.format("Remove the @TaskAction annotation from method '%s'", methodMetadata.getMethodName()))
-            );
-        }
     }
 }

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/TaskActionAnnotationHandler.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/TaskActionAnnotationHandler.java
@@ -24,9 +24,4 @@ public class TaskActionAnnotationHandler extends AbstractFunctionAnnotationHandl
     public TaskActionAnnotationHandler() {
         super(TaskAction.class, ImmutableSet.of());
     }
-
-    @Override
-    public boolean isFunctionRelevant() {
-        return true;
-    }
 }

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/TaskActionAnnotationHandler.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/TaskActionAnnotationHandler.java
@@ -20,6 +20,9 @@ import com.google.common.collect.ImmutableSet;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.properties.annotations.AbstractFunctionAnnotationHandler;
 
+/**
+ * Handles the {@link TaskAction} annotation.
+ */
 public class TaskActionAnnotationHandler extends AbstractFunctionAnnotationHandler {
     public TaskActionAnnotationHandler() {
         super(TaskAction.class, ImmutableSet.of());

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/TaskActionAnnotationHandler.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/TaskActionAnnotationHandler.java
@@ -18,15 +18,15 @@ package org.gradle.internal.execution.model.annotations;
 
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.internal.properties.annotations.AbstractMethodAnnotationHandler;
+import org.gradle.internal.properties.annotations.AbstractFunctionAnnotationHandler;
 
-public class TaskActionAnnotationHandler extends AbstractMethodAnnotationHandler {
+public class TaskActionAnnotationHandler extends AbstractFunctionAnnotationHandler {
     public TaskActionAnnotationHandler() {
         super(TaskAction.class, ImmutableSet.of());
     }
 
     @Override
-    public boolean isMethodRelevant() {
+    public boolean isFunctionRelevant() {
         return true;
     }
 }

--- a/platforms/core-execution/execution/src/test/groovy/org/gradle/internal/execution/steps/ValidateStepTest.groovy
+++ b/platforms/core-execution/execution/src/test/groovy/org/gradle/internal/execution/steps/ValidateStepTest.groovy
@@ -70,7 +70,7 @@ class ValidateStepTest extends StepSpec<BeforeExecutionContext> implements Valid
         then:
         def ex = thrown(WorkValidationException)
         WorkValidationExceptionChecker.check(ex) {
-            def validationProblem = dummyValidationProblemWithLink('java.lang.Object', null, 'Validation error', 'Test').trim()
+            def validationProblem = dummyPropertyValidationProblemWithLink('java.lang.Object', null, 'Validation error', 'Test').trim()
             hasMessage """A problem was found with the configuration of job ':test' (type 'ValidateStepTest.JobType').
   - ${validationProblem}"""
         }
@@ -96,8 +96,8 @@ class ValidateStepTest extends StepSpec<BeforeExecutionContext> implements Valid
         then:
         def ex = thrown WorkValidationException
         WorkValidationExceptionChecker.check(ex) {
-            def validationProblem1 = dummyValidationProblemWithLink('java.lang.Object', null, 'Validation error #1', 'Test')
-            def validationProblem2 = dummyValidationProblemWithLink('java.lang.Object', null, 'Validation error #2', 'Test')
+            def validationProblem1 = dummyPropertyValidationProblemWithLink('java.lang.Object', null, 'Validation error #1', 'Test')
+            def validationProblem2 = dummyPropertyValidationProblemWithLink('java.lang.Object', null, 'Validation error #2', 'Test')
             hasMessage """Some problems were found with the configuration of job ':test' (types ${quotedOxfordListOf(of('ValidateStepTest.JobType', 'ValidateStepTest.SecondaryJobType'), 'and')}).
   - ${validationProblem1.trim()}
   - ${validationProblem2.trim()}"""
@@ -157,10 +157,10 @@ class ValidateStepTest extends StepSpec<BeforeExecutionContext> implements Valid
     }
 
     def "reports deprecation warning even when there's also an error"() {
-        String expectedWarning = convertToSingleLine(dummyValidationProblemWithLink('java.lang.Object', null, 'Validation problem', 'Test').trim())
+        String expectedWarning = convertToSingleLine(dummyPropertyValidationProblemWithLink('java.lang.Object', null, 'Validation problem', 'Test').trim())
         // errors are reindented but not warnings
         expectReindentedValidationMessage()
-        String expectedError = dummyValidationProblemWithLink('java.lang.Object', null, 'Validation problem', 'Test')
+        String expectedError = dummyPropertyValidationProblemWithLink('java.lang.Object', null, 'Validation problem', 'Test')
 
         when:
         step.execute(work, context)

--- a/platforms/documentation/docs/src/docs/userguide/troubleshooting/validation_problems.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/troubleshooting/validation_problems.adoc
@@ -105,6 +105,17 @@ This causes Gradle to ignore the annotations, so they are typically not used in 
 
 To fix this problem, you must remove the annotation, create a getter for the property you want to use and annotate the getter instead.
 
+[[ignored_annotations_on_property]]
+== Invalid annotation on property or field
+
+This error indicates that an annotation intended for a non-property method has been unexpectedly placed on a field or a property method.
+Only input and output annotations like `@InputFiles` or `@OutputDirectory` should be placed on a field or a "property" method.
+A property is defined by having a getter.
+
+This causes Gradle to ignore the annotations, so they are typically not recognized when Gradle is inspecting the class for important annotations.
+
+To fix this problem, you must remove the annotation, or change the method to match the requirements of the annotation.
+
 [[mutable_type_with_setter]]
 == Mutable type with setter
 
@@ -167,6 +178,15 @@ Gradle doesn't consider private getters as inputs for up-to-date checking, which
 It is important to fix because you might think that you have declared an input when it's not the case.
 
 To fix this, either make the getter public, or annotate an existing getter instead, or create a new annotated getter.
+
+[[private_method_must_not_be_annotated]]
+== Annotations on private methods
+
+This error indicates that you have annotated a _private_ method with an annotation that Gradle expects to query for.
+Gradle won't be able to call the private method, which means that your annotations are effectively ignored.
+It is important to fix because you might think that you have declared an annotated method which can't be used.
+
+To fix this, either make the method public, or annotate another new or existing public method instead.
 
 [[ignored_property_must_not_be_annotated]]
 == Annotations on ignored properties
@@ -425,3 +445,4 @@ Nested types are expected to either declare some annotated properties (which the
 Types of the Java SE API, types of the Kotlin stdlib, and Groovy's GString are not supported, because they meet neither of those requirements.
 
 To fix this problem, declare a nested type, e.g. `Provider<T>`, `Iterable<T>`, or `<MapProperty<K, V>>`, where `T` and `V` have some annotated properties or some behaviour that requires capturing the type as input.
+

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/AbstractPluginValidationIntegrationSpec.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/AbstractPluginValidationIntegrationSpec.groovy
@@ -704,15 +704,15 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
         """
         expect:
         assertValidationFailsWith([
-            error(methodShouldNotBeAnnotatedConfig { type('MyTask').kind('method').method('notAGetter').annotation('Input') }, 'validation_problems', 'ignored_annotations_on_method'),
-            error(methodShouldNotBeAnnotatedConfig { type('MyTask.Options').kind('method').method('notANestedGetter').annotation('Input') }, 'validation_problems', 'ignored_annotations_on_method'),
+                error(methodShouldNotBeAnnotatedConfig { type('MyTask').kind('function').method('notAGetter').annotation('Input') }, 'validation_problems', 'ignored_annotations_on_method'),
+                error(methodShouldNotBeAnnotatedConfig { type('MyTask.Options').kind('function').method('notANestedGetter').annotation('Input') }, 'validation_problems', 'ignored_annotations_on_method'),
         ])
 
         and:
         if (isProblemsApiCheckEnabled()) {
             verifyAll(receivedProblem(0)) {
                 fqid == 'validation:type-validation:ignored-annotations-on-method'
-                contextualLabel == 'Type \'MyTask\' method \'notAGetter()\' should not be annotated with: @Input'
+                contextualLabel == 'Type \'MyTask\' function \'notAGetter()\' should not be annotated with: @Input'
                 details == 'Input/Output annotations are ignored if they are placed on something else than a getter'
                 solutions == [
                     'Remove the annotations',
@@ -722,7 +722,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
             }
             verifyAll(receivedProblem(1)) {
                 fqid == 'validation:type-validation:ignored-annotations-on-method'
-                contextualLabel == 'Type \'MyTask.Options\' method \'notANestedGetter()\' should not be annotated with: @Input'
+                contextualLabel == 'Type \'MyTask.Options\' function \'notANestedGetter()\' should not be annotated with: @Input'
                 details == 'Input/Output annotations are ignored if they are placed on something else than a getter'
                 solutions == [
                     'Remove the annotations',
@@ -782,11 +782,11 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
 
         expect:
         assertValidationFailsWith([
-            error(missingAnnotationConfig { type('MyTask').property('readWrite').missingInputOrOutput() }, 'validation_problems', 'missing_annotation'),
-            error(methodShouldNotBeAnnotatedConfig { type('MyTask').kind('setter').method('setReadWrite').annotation('Input') }, 'validation_problems', 'ignored_annotations_on_method'),
-            error(methodShouldNotBeAnnotatedConfig { type('MyTask').kind('setter').method('setWriteOnly').annotation('Input') }, 'validation_problems', 'ignored_annotations_on_method'),
-            error(methodShouldNotBeAnnotatedConfig { type('MyTask.Options').kind('setter').method('setReadWrite').annotation('Input') }, 'validation_problems', 'ignored_annotations_on_method'),
-            error(methodShouldNotBeAnnotatedConfig { type('MyTask.Options').kind('setter').method('setWriteOnly').annotation('Input') }, 'validation_problems', 'ignored_annotations_on_method'),
+                error(missingAnnotationConfig { type('MyTask').property('readWrite').missingInputOrOutput() }, 'validation_problems', 'missing_annotation'),
+                error(methodShouldNotBeAnnotatedConfig { type('MyTask').kind('setter').method('setReadWrite').annotation('Input') }, 'validation_problems', 'ignored_annotations_on_method'),
+                error(methodShouldNotBeAnnotatedConfig { type('MyTask').kind('setter').method('setWriteOnly').annotation('Input') }, 'validation_problems', 'ignored_annotations_on_method'),
+                error(methodShouldNotBeAnnotatedConfig { type('MyTask.Options').kind('setter').method('setReadWrite').annotation('Input') }, 'validation_problems', 'ignored_annotations_on_method'),
+                error(methodShouldNotBeAnnotatedConfig { type('MyTask.Options').kind('setter').method('setWriteOnly').annotation('Input') }, 'validation_problems', 'ignored_annotations_on_method'),
         ])
 
         and:

--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerialization.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerialization.java
@@ -607,6 +607,7 @@ public class ValidationProblemSerialization {
         public static final String FEATURE_USAGE = "featureUsage";
         public static final String PLUGIN_ID = "pluginId";
         public static final String PROPERTY_NAME = "propertyName";
+        public static final String METHOD_NAME = "methodName";
         public static final String PARENT_PROPERTY_NAME = "parentPropertyName";
         public static final String TYPE_NAME = "typeName";
         public static final String GENERAL_DATA_DATA = "data";
@@ -626,6 +627,7 @@ public class ValidationProblemSerialization {
                 TypeValidationData typeValidationData = (TypeValidationData) value;
                 out.name(PLUGIN_ID).value(typeValidationData.getPluginId());
                 out.name(PROPERTY_NAME).value(typeValidationData.getPropertyName());
+                out.name(METHOD_NAME).value(typeValidationData.getMethodName());
                 out.name(PARENT_PROPERTY_NAME).value(typeValidationData.getParentPropertyName());
                 out.name(TYPE_NAME).value(typeValidationData.getTypeName());
             } else if (value instanceof GeneralData) {
@@ -655,6 +657,7 @@ public class ValidationProblemSerialization {
                 String featureUsage = null;
                 String pluginId = null;
                 String propertyName = null;
+                String methodName = null;
                 String parentPropertyName = null;
                 String typeName = null;
                 String name;
@@ -678,6 +681,10 @@ public class ValidationProblemSerialization {
                         }
                         case PROPERTY_NAME: {
                             propertyName = in.nextString();
+                            break;
+                        }
+                        case METHOD_NAME: {
+                            methodName = in.nextString();
                             break;
                         }
                         case PARENT_PROPERTY_NAME: {
@@ -713,13 +720,13 @@ public class ValidationProblemSerialization {
                 if (type == null) {
                     throw new JsonParseException("type must not be null");
                 }
-                return createAdditionalData(type, featureUsage, pluginId, propertyName, parentPropertyName, typeName, generalData, propertyTrace);
+                return createAdditionalData(type, featureUsage, pluginId, propertyName, methodName, parentPropertyName, typeName, generalData, propertyTrace);
             } finally {
                 in.endObject();
             }
         }
 
-        private static @Nonnull AdditionalData createAdditionalData(String type, String featureUsage, String pluginId, String propertyName, String parentPropertyName, String typeName, Map<String, String> generalData, String propertyTrace) {
+        private static @Nonnull AdditionalData createAdditionalData(String type, String featureUsage, String pluginId, String propertyName, String methodName, String parentPropertyName, String typeName, Map<String, String> generalData, String propertyTrace) {
             switch (type) {
                 case DEPRECATION_DATA:
                     return new DefaultDeprecationData(DeprecationData.Type.valueOf(featureUsage));
@@ -727,6 +734,7 @@ public class ValidationProblemSerialization {
                     return new DefaultTypeValidationData(
                         pluginId,
                         propertyName,
+                        methodName,
                         parentPropertyName,
                         typeName
                     );

--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerialization.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerialization.java
@@ -607,7 +607,7 @@ public class ValidationProblemSerialization {
         public static final String FEATURE_USAGE = "featureUsage";
         public static final String PLUGIN_ID = "pluginId";
         public static final String PROPERTY_NAME = "propertyName";
-        public static final String METHOD_NAME = "methodName";
+        public static final String FUNCTION_NAME = "functionName";
         public static final String PARENT_PROPERTY_NAME = "parentPropertyName";
         public static final String TYPE_NAME = "typeName";
         public static final String GENERAL_DATA_DATA = "data";
@@ -627,7 +627,7 @@ public class ValidationProblemSerialization {
                 TypeValidationData typeValidationData = (TypeValidationData) value;
                 out.name(PLUGIN_ID).value(typeValidationData.getPluginId());
                 out.name(PROPERTY_NAME).value(typeValidationData.getPropertyName());
-                out.name(METHOD_NAME).value(typeValidationData.getMethodName());
+                out.name(FUNCTION_NAME).value(typeValidationData.getFunctionName());
                 out.name(PARENT_PROPERTY_NAME).value(typeValidationData.getParentPropertyName());
                 out.name(TYPE_NAME).value(typeValidationData.getTypeName());
             } else if (value instanceof GeneralData) {
@@ -657,7 +657,7 @@ public class ValidationProblemSerialization {
                 String featureUsage = null;
                 String pluginId = null;
                 String propertyName = null;
-                String methodName = null;
+                String functionName = null;
                 String parentPropertyName = null;
                 String typeName = null;
                 String name;
@@ -683,8 +683,8 @@ public class ValidationProblemSerialization {
                             propertyName = in.nextString();
                             break;
                         }
-                        case METHOD_NAME: {
-                            methodName = in.nextString();
+                        case FUNCTION_NAME: {
+                            functionName = in.nextString();
                             break;
                         }
                         case PARENT_PROPERTY_NAME: {
@@ -720,7 +720,7 @@ public class ValidationProblemSerialization {
                 if (type == null) {
                     throw new JsonParseException("type must not be null");
                 }
-                return createAdditionalData(type, featureUsage, pluginId, propertyName, methodName, parentPropertyName, typeName, generalData, propertyTrace);
+                return createAdditionalData(type, featureUsage, pluginId, propertyName, functionName, parentPropertyName, typeName, generalData, propertyTrace);
             } finally {
                 in.endObject();
             }

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/internal/PluginUseServices.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/internal/PluginUseServices.java
@@ -152,6 +152,7 @@ public class PluginUseServices extends AbstractGradleModuleServices {
             InspectionScheme inspectionScheme = inspectionSchemeFactory.inspectionScheme(
                 allPropertyTypes.build(),
                 Collections.emptySet(),
+                Collections.emptyList(),
                 instantiationScheme,
                 MissingPropertyAnnotationHandler.DO_NOTHING
             );

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultTypeValidationData.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultTypeValidationData.java
@@ -23,12 +23,14 @@ public class DefaultTypeValidationData implements TypeValidationData, Serializab
 
     private final String pluginId;
     private final String propertyName;
+    private final String methodName;
     private final String parentPropertyName;
     private final String typeName;
 
-    public DefaultTypeValidationData(String pluginId, String propertyName, String parentPropertyName, String typeName) {
+    public DefaultTypeValidationData(String pluginId, String propertyName, String methodName, String parentPropertyName, String typeName) {
         this.pluginId = pluginId;
         this.propertyName = propertyName;
+        this.methodName = methodName;
         this.parentPropertyName = parentPropertyName;
         this.typeName = typeName;
     }
@@ -41,6 +43,11 @@ public class DefaultTypeValidationData implements TypeValidationData, Serializab
     @Override
     public String getPropertyName() {
         return propertyName;
+    }
+
+    @Override
+    public String getMethodName() {
+        return methodName;
     }
 
     @Override
@@ -64,6 +71,7 @@ public class DefaultTypeValidationData implements TypeValidationData, Serializab
 
         private String pluginId;
         private String propertyName;
+        private String methodName;
         private String parentPropertyName;
         private String typeName;
 
@@ -73,13 +81,14 @@ public class DefaultTypeValidationData implements TypeValidationData, Serializab
         public DefaultTypeValidationDataBuilder(TypeValidationData from) {
             this.pluginId = from.getPluginId();
             this.propertyName = from.getPropertyName();
+            this.methodName = from.getMethodName();
             this.parentPropertyName = from.getParentPropertyName();
             this.typeName = from.getTypeName();
         }
 
         @Override
         public DefaultTypeValidationData build() {
-            return new DefaultTypeValidationData(pluginId, propertyName, parentPropertyName, typeName);
+            return new DefaultTypeValidationData(pluginId, propertyName, methodName, parentPropertyName, typeName);
         }
 
         @Override
@@ -91,6 +100,12 @@ public class DefaultTypeValidationData implements TypeValidationData, Serializab
         @Override
         public TypeValidationDataSpec propertyName(String propertyName) {
             this.propertyName = propertyName;
+            return this;
+        }
+
+        @Override
+        public TypeValidationDataSpec methodName(String methodName) {
+            this.methodName = methodName;
             return this;
         }
 

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultTypeValidationData.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultTypeValidationData.java
@@ -23,14 +23,14 @@ public class DefaultTypeValidationData implements TypeValidationData, Serializab
 
     private final String pluginId;
     private final String propertyName;
-    private final String methodName;
+    private final String functionName;
     private final String parentPropertyName;
     private final String typeName;
 
-    public DefaultTypeValidationData(String pluginId, String propertyName, String methodName, String parentPropertyName, String typeName) {
+    public DefaultTypeValidationData(String pluginId, String propertyName, String functionName, String parentPropertyName, String typeName) {
         this.pluginId = pluginId;
         this.propertyName = propertyName;
-        this.methodName = methodName;
+        this.functionName = functionName;
         this.parentPropertyName = parentPropertyName;
         this.typeName = typeName;
     }
@@ -46,8 +46,8 @@ public class DefaultTypeValidationData implements TypeValidationData, Serializab
     }
 
     @Override
-    public String getMethodName() {
-        return methodName;
+    public String getFunctionName() {
+        return functionName;
     }
 
     @Override
@@ -71,7 +71,7 @@ public class DefaultTypeValidationData implements TypeValidationData, Serializab
 
         private String pluginId;
         private String propertyName;
-        private String methodName;
+        private String functionName;
         private String parentPropertyName;
         private String typeName;
 
@@ -81,14 +81,14 @@ public class DefaultTypeValidationData implements TypeValidationData, Serializab
         public DefaultTypeValidationDataBuilder(TypeValidationData from) {
             this.pluginId = from.getPluginId();
             this.propertyName = from.getPropertyName();
-            this.methodName = from.getMethodName();
+            this.functionName = from.getFunctionName();
             this.parentPropertyName = from.getParentPropertyName();
             this.typeName = from.getTypeName();
         }
 
         @Override
         public DefaultTypeValidationData build() {
-            return new DefaultTypeValidationData(pluginId, propertyName, methodName, parentPropertyName, typeName);
+            return new DefaultTypeValidationData(pluginId, propertyName, functionName, parentPropertyName, typeName);
         }
 
         @Override
@@ -104,8 +104,8 @@ public class DefaultTypeValidationData implements TypeValidationData, Serializab
         }
 
         @Override
-        public TypeValidationDataSpec methodName(String methodName) {
-            this.methodName = methodName;
+        public TypeValidationDataSpec functionName(String functionName) {
+            this.functionName = functionName;
             return this;
         }
 

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/TypeValidationData.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/TypeValidationData.java
@@ -22,6 +22,7 @@ package org.gradle.api.problems.internal;
 public interface TypeValidationData extends AdditionalData {
     String getPluginId();
     String getPropertyName();
+    String getMethodName();
     String getParentPropertyName();
     String getTypeName();
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/TypeValidationData.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/TypeValidationData.java
@@ -22,7 +22,7 @@ package org.gradle.api.problems.internal;
 public interface TypeValidationData extends AdditionalData {
     String getPluginId();
     String getPropertyName();
-    String getMethodName();
+    String getFunctionName();
     String getParentPropertyName();
     String getTypeName();
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/TypeValidationDataSpec.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/TypeValidationDataSpec.java
@@ -22,7 +22,7 @@ package org.gradle.api.problems.internal;
 public interface TypeValidationDataSpec extends AdditionalDataSpec {
     TypeValidationDataSpec pluginId(String pluginId);
     TypeValidationDataSpec propertyName(String propertyName);
-    TypeValidationDataSpec methodName(String methodName);
+    TypeValidationDataSpec functionName(String methodName);
     TypeValidationDataSpec parentPropertyName(String parentPropertyName);
     TypeValidationDataSpec typeName(String typeName);
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
@@ -142,6 +142,7 @@ class DependencyManagementGlobalScopeServices implements ServiceRegistrationProv
                 IgnoreEmptyDirectories.class,
                 NormalizeLineEndings.class
             ),
+            ImmutableSet.of(),
             instantiationScheme
         );
         return new TransformParameterScheme(instantiationScheme, inspectionScheme);
@@ -167,6 +168,7 @@ class DependencyManagementGlobalScopeServices implements ServiceRegistrationProv
                 IgnoreEmptyDirectories.class,
                 NormalizeLineEndings.class
             ),
+            ImmutableSet.of(),
             instantiationScheme
         );
         return new TransformActionScheme(instantiationScheme, inspectionScheme);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/DefaultTaskClassInfoStore.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/DefaultTaskClassInfoStore.java
@@ -33,7 +33,6 @@ import org.gradle.internal.reflect.Instantiator;
 import org.gradle.work.InputChanges;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -73,11 +72,6 @@ public class DefaultTaskClassInfoStore implements TaskClassInfoStore {
 
             // TODO These validations should be done as validation in TaskActionAnnotationHandler and surfaced as problems
             Class<?> declaringClass = methodMetadata.getMethod().getDeclaringClass();
-            if (Modifier.isStatic(methodMetadata.getMethod().getModifiers())) {
-                throw new GradleException(String.format("Cannot use @TaskAction annotation on static method %s.%s().",
-                    declaringClass.getSimpleName(), methodMetadata.getMethodName()));
-            }
-
             final Class<?>[] parameterTypes = methodMetadata.getMethod().getParameterTypes();
             if (parameterTypes.length > 1) {
                 throw new GradleException(String.format(

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/DefaultTaskClassInfoStore.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/DefaultTaskClassInfoStore.java
@@ -26,10 +26,12 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.UntrackedTask;
 import org.gradle.cache.internal.CrossBuildInMemoryCache;
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
+import org.gradle.internal.properties.annotations.MethodMetadata;
+import org.gradle.internal.properties.annotations.TypeMetadata;
+import org.gradle.internal.properties.annotations.TypeMetadataStore;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.work.InputChanges;
 
-import javax.annotation.Nullable;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.HashMap;
@@ -39,9 +41,11 @@ import java.util.Optional;
 @NonNullApi
 public class DefaultTaskClassInfoStore implements TaskClassInfoStore {
     private final CrossBuildInMemoryCache<Class<?>, TaskClassInfo> classInfos;
+    private final TypeMetadataStore typeMetadataStore;
 
-    public DefaultTaskClassInfoStore(CrossBuildInMemoryCacheFactory cacheFactory) {
+    public DefaultTaskClassInfoStore(CrossBuildInMemoryCacheFactory cacheFactory, TypeMetadataStore typeMetadataStore) {
         this.classInfos = cacheFactory.newClassCache();
+        this.typeMetadataStore = typeMetadataStore;
     }
 
     @Override
@@ -49,87 +53,58 @@ public class DefaultTaskClassInfoStore implements TaskClassInfoStore {
         return classInfos.get(type, aClass -> createTaskClassInfo(aClass.asSubclass(Task.class)));
     }
 
-    private static TaskClassInfo createTaskClassInfo(Class<? extends Task> type) {
-        boolean cacheable = type.isAnnotationPresent(CacheableTask.class);
-        Optional<String> reasonNotToTrackState = Optional.ofNullable(type.getAnnotation(UntrackedTask.class))
+    private TaskClassInfo createTaskClassInfo(Class<? extends Task> type) {
+        TypeMetadata typeMetadata = typeMetadataStore.getTypeMetadata(type);
+        boolean cacheable = typeMetadata.getTypeAnnotationMetadata().isAnnotationPresent(CacheableTask.class);
+        Optional<String> reasonNotToTrackState = typeMetadata.getTypeAnnotationMetadata().getAnnotation(UntrackedTask.class)
             .map(UntrackedTask::because);
-        Map<String, Class<?>> processedMethods = new HashMap<>();
+
+        Map<String, MethodMetadata> methods = new HashMap<>();
+
         ImmutableList.Builder<TaskActionFactory> taskActionFactoriesBuilder = ImmutableList.builder();
-        IncrementalTaskActionFactory foundIncrementalTaskActionFactory = null;
-        for (Class current = type; current != null; current = current.getSuperclass()) {
-            for (Method method : current.getDeclaredMethods()) {
-                TaskActionFactory taskActionFactory = createTaskAction(type, method);
-                if (taskActionFactory == null) {
-                    continue;
-                }
-                Class<?> declaringClass = method.getDeclaringClass();
-                Class<?> previousDeclaringClass = processedMethods.put(method.getName(), declaringClass);
-                if (taskActionFactory instanceof IncrementalTaskActionFactory
-                    && foundIncrementalTaskActionFactory != null
-                    && method.getName().equals(foundIncrementalTaskActionFactory.getMethod().getName())
-                ) {
-                    // If both task actions are of the same type (InputChanges), we keep foundIncrementalTaskActionFactory.
-                    if (taskActionFactory.getClass() == foundIncrementalTaskActionFactory.getClass()) {
-                        continue;
-                    }
-                }
-                if (previousDeclaringClass == declaringClass) {
-                    throw new GradleException(String.format(
-                        "Cannot use @TaskAction annotation on multiple overloads of method %s.%s()",
-                        declaringClass.getSimpleName(), method.getName()
-                    ));
-                } else if (previousDeclaringClass != null) {
-                    continue;
-                }
-                if (taskActionFactory instanceof IncrementalTaskActionFactory) {
-                    if (foundIncrementalTaskActionFactory != null) {
-                        throw new GradleException(String.format("Cannot have multiple @TaskAction methods accepting an %s parameter.", InputChanges.class.getSimpleName()));
-                    }
-                    foundIncrementalTaskActionFactory = (IncrementalTaskActionFactory) taskActionFactory;
-                    continue;
-                }
-                taskActionFactoriesBuilder.add(taskActionFactory);
-            }
-        }
-        if (foundIncrementalTaskActionFactory != null) {
-            taskActionFactoriesBuilder.add(foundIncrementalTaskActionFactory);
-        }
-
-        return new TaskClassInfo(taskActionFactoriesBuilder.build(), cacheable, reasonNotToTrackState);
-    }
-
-    @Nullable
-    private static TaskActionFactory createTaskAction(Class<? extends Task> taskType, final Method method) {
-        if (method.getAnnotation(TaskAction.class) == null) {
-            return null;
-        }
-        Class<?> declaringClass = method.getDeclaringClass();
-        if (Modifier.isStatic(method.getModifiers())) {
-            throw new GradleException(String.format("Cannot use @TaskAction annotation on static method %s.%s().",
-                declaringClass.getSimpleName(), method.getName()));
-        }
-        final Class<?>[] parameterTypes = method.getParameterTypes();
-        if (parameterTypes.length > 1) {
-            throw new GradleException(String.format(
-                "Cannot use @TaskAction annotation on method %s.%s() as this method takes multiple parameters.",
-                declaringClass.getSimpleName(), method.getName()));
-        }
-
-        TaskActionFactory taskActionFactory;
-        if (parameterTypes.length == 1) {
-            Class<?> parameterType = parameterTypes[0];
-            if (parameterType.equals(InputChanges.class)) {
-                taskActionFactory = new IncrementalTaskActionFactory(taskType, method);
-            } else {
+        typeMetadata.getMethodsMetadata().stream().filter(methodMetadata -> methodMetadata.getAnnotation(TaskAction.class).isPresent()).forEach(methodMetadata -> {
+            MethodMetadata alreadySeen = methods.put(methodMetadata.getMethodName(), methodMetadata);
+            if (alreadySeen != null) {
                 throw new GradleException(String.format(
-                    "Cannot use @TaskAction annotation on method %s.%s() because %s is not a valid parameter to an action method.",
-                    declaringClass.getSimpleName(), method.getName(), parameterType));
+                    "Cannot use @TaskAction annotation on multiple overloads of method %s.%s()",
+                    typeMetadata.getType().getSimpleName(), methodMetadata.getMethod().getName()
+                ));
             }
-        } else {
-            taskActionFactory = new StandardTaskActionFactory(taskType, method);
+
+            // TODO These validations should be done as validation in TaskActionAnnotationHandler and surfaced as problems
+            Class<?> declaringClass = methodMetadata.getMethod().getDeclaringClass();
+            if (Modifier.isStatic(methodMetadata.getMethod().getModifiers())) {
+                throw new GradleException(String.format("Cannot use @TaskAction annotation on static method %s.%s().",
+                    declaringClass.getSimpleName(), methodMetadata.getMethodName()));
+            }
+
+            final Class<?>[] parameterTypes = methodMetadata.getMethod().getParameterTypes();
+            if (parameterTypes.length > 1) {
+                throw new GradleException(String.format(
+                    "Cannot use @TaskAction annotation on method %s.%s() as this method takes multiple parameters.",
+                    declaringClass.getSimpleName(), methodMetadata.getMethodName()));
+            }
+
+            TaskActionFactory taskActionFactory;
+            if (methodMetadata.getMethod().getParameterTypes().length == 1) {
+                Class<?> parameterType = parameterTypes[0];
+                if (!parameterType.equals(InputChanges.class)) {
+                    throw new GradleException(String.format(
+                        "Cannot use @TaskAction annotation on method %s.%s() because %s is not a valid parameter to an action method.",
+                        declaringClass.getSimpleName(), methodMetadata.getMethodName(), parameterType));
+                }
+                taskActionFactory = new IncrementalTaskActionFactory(type, methodMetadata.getMethod());
+            } else {
+                taskActionFactory = new StandardTaskActionFactory(type, methodMetadata.getMethod());
+            }
+            taskActionFactoriesBuilder.add(taskActionFactory);
+        });
+
+        if (methods.values().stream().filter(methodMetadata -> methodMetadata.getMethod().getParameterTypes().length > 0).count() > 1) {
+            throw new GradleException(String.format("Cannot have multiple @TaskAction methods accepting an %s parameter.", InputChanges.class.getSimpleName()));
         }
 
-        return taskActionFactory;
+        return new TaskClassInfo(taskActionFactoriesBuilder.build(), cacheable, reasonNotToTrackState, typeMetadata);
     }
 
     private static class StandardTaskActionFactory implements TaskActionFactory {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskClassInfo.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskClassInfo.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.project.taskfactory;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.internal.properties.annotations.TypeMetadata;
 
 import java.util.Optional;
 
@@ -24,11 +25,13 @@ public class TaskClassInfo {
     private final ImmutableList<TaskActionFactory> taskActionFactories;
     private final boolean cacheable;
     private final Optional<String> reasonNotToTrackState;
+    private final TypeMetadata typeMetadata;
 
-    public TaskClassInfo(ImmutableList<TaskActionFactory> taskActionFactories, boolean cacheable, Optional<String> reasonNotToTrackState) {
+    public TaskClassInfo(ImmutableList<TaskActionFactory> taskActionFactories, boolean cacheable, Optional<String> reasonNotToTrackState, TypeMetadata typeMetadata) {
         this.taskActionFactories = taskActionFactories;
         this.cacheable = cacheable;
         this.reasonNotToTrackState = reasonNotToTrackState;
+        this.typeMetadata = typeMetadata;
     }
 
     public ImmutableList<TaskActionFactory> getTaskActionFactories() {
@@ -41,5 +44,9 @@ public class TaskClassInfo {
 
     public Optional<String> getReasonNotToTrackState() {
         return reasonNotToTrackState;
+    }
+
+    public TypeMetadata getTypeMetadata() {
+        return typeMetadata;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/InspectionSchemeFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/InspectionSchemeFactory.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
 import org.gradle.internal.instantiation.InstantiationScheme;
 import org.gradle.internal.properties.annotations.DefaultTypeMetadataStore;
+import org.gradle.internal.properties.annotations.MethodAnnotationHandler;
 import org.gradle.internal.properties.annotations.NoOpPropertyAnnotationHandler;
 import org.gradle.internal.properties.annotations.PropertyAnnotationHandler;
 import org.gradle.internal.properties.annotations.MissingPropertyAnnotationHandler;
@@ -40,6 +41,7 @@ import java.util.Map;
 @ServiceScope(Scope.Global.class)
 public class InspectionSchemeFactory {
     private final Map<Class<? extends Annotation>, PropertyAnnotationHandler> allKnownPropertyHandlers;
+    private final Map<Class<? extends Annotation>, MethodAnnotationHandler> allKnownMethodHandlers;
     private final ImmutableList<TypeAnnotationHandler> allKnownTypeHandlers;
     private final TypeAnnotationMetadataStore typeAnnotationMetadataStore;
     private final CrossBuildInMemoryCacheFactory cacheFactory;
@@ -47,15 +49,21 @@ public class InspectionSchemeFactory {
     public InspectionSchemeFactory(
         List<? extends TypeAnnotationHandler> allKnownTypeHandlers,
         List<? extends PropertyAnnotationHandler> allKnownPropertyHandlers,
+        List<? extends MethodAnnotationHandler> allKnownMethodHandlers,
         TypeAnnotationMetadataStore typeAnnotationMetadataStore,
         CrossBuildInMemoryCacheFactory cacheFactory
     ) {
-        ImmutableMap.Builder<Class<? extends Annotation>, PropertyAnnotationHandler> builder = ImmutableMap.builder();
+        ImmutableMap.Builder<Class<? extends Annotation>, PropertyAnnotationHandler> propertyHandlerBuilder = ImmutableMap.builder();
         for (PropertyAnnotationHandler handler : allKnownPropertyHandlers) {
-            builder.put(handler.getAnnotationType(), handler);
+            propertyHandlerBuilder.put(handler.getAnnotationType(), handler);
+        }
+        ImmutableMap.Builder<Class<? extends Annotation>, MethodAnnotationHandler> methodHandlerBuilder = ImmutableMap.builder();
+        for (MethodAnnotationHandler handler : allKnownMethodHandlers) {
+            methodHandlerBuilder.put(handler.getAnnotationType(), handler);
         }
         this.allKnownTypeHandlers = ImmutableList.copyOf(allKnownTypeHandlers);
-        this.allKnownPropertyHandlers = builder.build();
+        this.allKnownPropertyHandlers = propertyHandlerBuilder.build();
+        this.allKnownMethodHandlers = methodHandlerBuilder.build();
         this.typeAnnotationMetadataStore = typeAnnotationMetadataStore;
         this.cacheFactory = cacheFactory;
     }
@@ -65,38 +73,46 @@ public class InspectionSchemeFactory {
      * Creates a new {@link InspectionScheme} with the given annotations enabled and using the given instantiation scheme.  Assumes missing annotations
      * should be handled as missing inputs or outputs.
      */
-    public InspectionScheme inspectionScheme(Collection<Class<? extends Annotation>> annotations, Collection<Class<? extends Annotation>> propertyModifiers, InstantiationScheme instantiationScheme) {
-        return inspectionScheme(annotations, propertyModifiers, instantiationScheme, MissingPropertyAnnotationHandler.MISSING_INPUT_OUTPUT_HANDLER);
+    public InspectionScheme inspectionScheme(Collection<Class<? extends Annotation>> annotations, Collection<Class<? extends Annotation>> propertyModifiers, Collection<Class<? extends Annotation>> methodModifiers, InstantiationScheme instantiationScheme) {
+        return inspectionScheme(annotations, propertyModifiers, methodModifiers, instantiationScheme, MissingPropertyAnnotationHandler.MISSING_INPUT_OUTPUT_HANDLER);
     }
 
     /**
      * Creates a new {@link InspectionScheme} with the given annotations enabled and using the given instantiation scheme.  Uses the provided missing
      * annotation handler to determine how to handle missing annotations.
      */
-    public InspectionScheme inspectionScheme(Collection<Class<? extends Annotation>> annotations, Collection<Class<? extends Annotation>> propertyModifiers, InstantiationScheme instantiationScheme, MissingPropertyAnnotationHandler missingAnnotationProblemHandler) {
+    public InspectionScheme inspectionScheme(Collection<Class<? extends Annotation>> annotations, Collection<Class<? extends Annotation>> propertyModifiers, Collection<Class<? extends Annotation>> methodModifiers, InstantiationScheme instantiationScheme, MissingPropertyAnnotationHandler missingAnnotationProblemHandler) {
         ImmutableList.Builder<PropertyAnnotationHandler> propertyHandlers = ImmutableList.builderWithExpectedSize(annotations.size());
+        ImmutableList.Builder<MethodAnnotationHandler> methodHandlers = ImmutableList.builderWithExpectedSize(annotations.size());
         for (Class<? extends Annotation> annotation : annotations) {
             PropertyAnnotationHandler propertyHandler = allKnownPropertyHandlers.get(annotation);
-            if (propertyHandler == null) {
-                throw new IllegalArgumentException(String.format("@%s is not a registered property type annotation.", annotation.getSimpleName()));
+            MethodAnnotationHandler methodHandler = allKnownMethodHandlers.get(annotation);
+            if (propertyHandler == null && methodHandler == null) {
+                throw new IllegalArgumentException(String.format("@%s is not a registered property or method type annotation.", annotation.getSimpleName()));
             }
-            propertyHandlers.add(propertyHandler);
+            if (propertyHandler != null) {
+                propertyHandlers.add(propertyHandler);
+            }
+            if (methodHandler != null) {
+                methodHandlers.add(methodHandler);
+            }
         }
+
         for (Class<? extends Annotation> annotation : instantiationScheme.getInjectionAnnotations()) {
             if (!annotations.contains(annotation)) {
                 propertyHandlers.add(new NoOpPropertyAnnotationHandler(annotation));
             }
         }
-        return new InspectionSchemeImpl(allKnownTypeHandlers, propertyHandlers.build(), propertyModifiers, typeAnnotationMetadataStore, cacheFactory, missingAnnotationProblemHandler);
+        return new InspectionSchemeImpl(allKnownTypeHandlers, propertyHandlers.build(), propertyModifiers, methodHandlers.build(), methodModifiers, typeAnnotationMetadataStore, cacheFactory, missingAnnotationProblemHandler);
     }
 
     private static class InspectionSchemeImpl implements InspectionScheme {
         private final DefaultPropertyWalker propertyWalker;
         private final DefaultTypeMetadataStore metadataStore;
 
-        public InspectionSchemeImpl(List<TypeAnnotationHandler> typeHandlers, List<PropertyAnnotationHandler> propertyHandlers, Collection<Class<? extends Annotation>> propertyModifiers, TypeAnnotationMetadataStore typeAnnotationMetadataStore, CrossBuildInMemoryCacheFactory cacheFactory, MissingPropertyAnnotationHandler missingAnnotationProblemHandler) {
+        public InspectionSchemeImpl(List<TypeAnnotationHandler> typeHandlers, List<PropertyAnnotationHandler> propertyHandlers, Collection<Class<? extends Annotation>> propertyModifiers, List<MethodAnnotationHandler> methodHandlers, Collection<Class<? extends Annotation>> methodModifiers, TypeAnnotationMetadataStore typeAnnotationMetadataStore, CrossBuildInMemoryCacheFactory cacheFactory, MissingPropertyAnnotationHandler missingAnnotationProblemHandler) {
             DefaultPropertyTypeResolver propertyTypeResolver = new DefaultPropertyTypeResolver();
-            metadataStore = new DefaultTypeMetadataStore(typeHandlers, propertyHandlers, propertyModifiers, typeAnnotationMetadataStore, propertyTypeResolver, cacheFactory, missingAnnotationProblemHandler);
+            metadataStore = new DefaultTypeMetadataStore(typeHandlers, propertyHandlers, propertyModifiers, methodHandlers, methodModifiers, typeAnnotationMetadataStore, propertyTypeResolver, cacheFactory, missingAnnotationProblemHandler);
             propertyWalker = new DefaultPropertyWalker(metadataStore, new ScriptSourceAwareImplementationResolver(), propertyHandlers);
         }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -480,11 +480,12 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
     }
 
     @Provides
-    protected ITaskFactory createITaskFactory(Instantiator instantiator, TaskClassInfoStore taskClassInfoStore) {
+    protected ITaskFactory createITaskFactory(Instantiator instantiator, TaskClassInfoStore taskClassInfoStore, InternalProblems problems) {
         return new AnnotationProcessingTaskFactory(
             instantiator,
             taskClassInfoStore,
-            new TaskFactory());
+            new TaskFactory()
+        );
     }
 
     @Provides

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -480,7 +480,7 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
     }
 
     @Provides
-    protected ITaskFactory createITaskFactory(Instantiator instantiator, TaskClassInfoStore taskClassInfoStore, InternalProblems problems) {
+    protected ITaskFactory createITaskFactory(Instantiator instantiator, TaskClassInfoStore taskClassInfoStore) {
         return new AnnotationProcessingTaskFactory(
             instantiator,
             taskClassInfoStore,

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
@@ -64,6 +64,7 @@ import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.OutputFiles;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.SkipWhenEmpty;
+import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.UntrackedTask;
 import org.gradle.api.tasks.options.OptionValues;
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
@@ -80,11 +81,13 @@ import org.gradle.internal.execution.model.annotations.InputFilesPropertyAnnotat
 import org.gradle.internal.execution.model.annotations.InputPropertyAnnotationHandler;
 import org.gradle.internal.execution.model.annotations.ModifierAnnotationCategory;
 import org.gradle.internal.execution.model.annotations.ServiceReferencePropertyAnnotationHandler;
+import org.gradle.internal.execution.model.annotations.TaskActionAnnotationHandler;
 import org.gradle.internal.instantiation.InstantiationScheme;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.instrumentation.api.annotations.ReplacesEagerProperty;
 import org.gradle.internal.operations.BuildOperationAncestryTracker;
 import org.gradle.internal.operations.BuildOperationListenerManager;
+import org.gradle.internal.properties.annotations.MethodAnnotationHandler;
 import org.gradle.internal.properties.annotations.NestedBeanAnnotationHandler;
 import org.gradle.internal.properties.annotations.NoOpPropertyAnnotationHandler;
 import org.gradle.internal.properties.annotations.PropertyAnnotationHandler;
@@ -103,6 +106,7 @@ import org.gradle.work.NormalizeLineEndings;
 import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.gradle.internal.execution.model.annotations.ModifierAnnotationCategory.OPTIONAL;
 import static org.gradle.internal.execution.model.annotations.ModifierAnnotationCategory.REPLACES_EAGER_PROPERTY;
@@ -127,6 +131,10 @@ public class ExecutionGlobalServices implements ServiceRegistrationProvider {
         OutputFiles.class,
         ServiceReference.class,
         SoftwareType.class
+    );
+
+    public static final ImmutableSet<Class<? extends Annotation>> METHOD_TYPE_ANNOTATIONS = ImmutableSet.of(
+        TaskAction.class
     );
 
     @VisibleForTesting
@@ -164,6 +172,7 @@ public class ExecutionGlobalServices implements ServiceRegistrationProvider {
                 RegistersSoftwareTypes.class
             ),
             ModifierAnnotationCategory.asMap(builder.build()),
+            METHOD_TYPE_ANNOTATIONS.stream().collect(Collectors.toMap(annotation -> annotation, annotation -> ModifierAnnotationCategory.TYPE)),
             ImmutableSet.of(
                 "java",
                 "groovy",
@@ -197,10 +206,11 @@ public class ExecutionGlobalServices implements ServiceRegistrationProvider {
     InspectionSchemeFactory createInspectionSchemeFactory(
         List<TypeAnnotationHandler> typeHandlers,
         List<PropertyAnnotationHandler> propertyHandlers,
+        List<MethodAnnotationHandler> methodHandlers,
         TypeAnnotationMetadataStore typeAnnotationMetadataStore,
         CrossBuildInMemoryCacheFactory cacheFactory
     ) {
-        return new InspectionSchemeFactory(typeHandlers, propertyHandlers, typeAnnotationMetadataStore, cacheFactory);
+        return new InspectionSchemeFactory(typeHandlers, propertyHandlers, methodHandlers, typeAnnotationMetadataStore, cacheFactory);
     }
 
     @Provides
@@ -239,6 +249,7 @@ public class ExecutionGlobalServices implements ServiceRegistrationProvider {
                 NormalizeLineEndings.class,
                 ReplacesEagerProperty.class
             ),
+            ImmutableSet.of(),
             instantiationScheme);
         return new TaskScheme(instantiationScheme, inspectionScheme);
     }
@@ -370,5 +381,10 @@ public class ExecutionGlobalServices implements ServiceRegistrationProvider {
     @Provides
     ImmutableWorkspaceMetadataStore createImmutableWorkspaceMetadataStore() {
         return new DefaultImmutableWorkspaceMetadataStore();
+    }
+
+    @Provides
+    MethodAnnotationHandler createTaskActionHandler() {
+        return new TaskActionAnnotationHandler();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
@@ -162,7 +162,7 @@ public class ExecutionGlobalServices implements ServiceRegistrationProvider {
     TypeAnnotationMetadataStore createAnnotationMetadataStore(CrossBuildInMemoryCacheFactory cacheFactory, AnnotationHandlerRegistar annotationRegistry) {
         ImmutableSet.Builder<Class<? extends Annotation>> builder = ImmutableSet.builder();
         builder.addAll(PROPERTY_TYPE_ANNOTATIONS);
-        annotationRegistry.registerPropertyTypeAnnotations(builder);
+        annotationRegistry.registerAnnotationTypes(builder);
         return new DefaultTypeAnnotationMetadataStore(
             ImmutableSet.of(
                 CacheableTask.class,
@@ -216,8 +216,8 @@ public class ExecutionGlobalServices implements ServiceRegistrationProvider {
     @Provides
     TaskScheme createTaskScheme(InspectionSchemeFactory inspectionSchemeFactory, InstantiatorFactory instantiatorFactory, AnnotationHandlerRegistar annotationRegistry) {
         InstantiationScheme instantiationScheme = instantiatorFactory.decorateScheme();
-        ImmutableSet.Builder<Class<? extends Annotation>> allPropertyTypes = ImmutableSet.builder();
-        allPropertyTypes.addAll(ImmutableSet.of(
+        ImmutableSet.Builder<Class<? extends Annotation>> allAnnotationTypes = ImmutableSet.builder();
+        allAnnotationTypes.addAll(ImmutableSet.of(
             Input.class,
             InputFile.class,
             InputFiles.class,
@@ -233,11 +233,12 @@ public class ExecutionGlobalServices implements ServiceRegistrationProvider {
             ReplacedBy.class,
             Internal.class,
             ServiceReference.class,
-            OptionValues.class
+            OptionValues.class,
+            TaskAction.class
         ));
-        annotationRegistry.registerPropertyTypeAnnotations(allPropertyTypes);
+        annotationRegistry.registerAnnotationTypes(allAnnotationTypes);
         InspectionScheme inspectionScheme = inspectionSchemeFactory.inspectionScheme(
-            allPropertyTypes.build(),
+            allAnnotationTypes.build(),
             ImmutableSet.of(
                 Classpath.class,
                 CompileClasspath.class,
@@ -260,8 +261,8 @@ public class ExecutionGlobalServices implements ServiceRegistrationProvider {
     }
 
     @Provides
-    TaskClassInfoStore createTaskClassInfoStore(CrossBuildInMemoryCacheFactory cacheFactory) {
-        return new DefaultTaskClassInfoStore(cacheFactory);
+    TaskClassInfoStore createTaskClassInfoStore(CrossBuildInMemoryCacheFactory cacheFactory, TaskScheme taskScheme) {
+        return new DefaultTaskClassInfoStore(cacheFactory, taskScheme.getMetadataStore());
     }
 
     @Provides
@@ -375,7 +376,7 @@ public class ExecutionGlobalServices implements ServiceRegistrationProvider {
 
     @ServiceScope(Scope.Global.class)
     interface AnnotationHandlerRegistar {
-        void registerPropertyTypeAnnotations(ImmutableSet.Builder<Class<? extends Annotation>> builder);
+        void registerAnnotationTypes(ImmutableSet.Builder<Class<? extends Annotation>> builder);
     }
 
     @Provides

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
@@ -87,7 +87,7 @@ import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.instrumentation.api.annotations.ReplacesEagerProperty;
 import org.gradle.internal.operations.BuildOperationAncestryTracker;
 import org.gradle.internal.operations.BuildOperationListenerManager;
-import org.gradle.internal.properties.annotations.MethodAnnotationHandler;
+import org.gradle.internal.properties.annotations.FunctionAnnotationHandler;
 import org.gradle.internal.properties.annotations.NestedBeanAnnotationHandler;
 import org.gradle.internal.properties.annotations.NoOpPropertyAnnotationHandler;
 import org.gradle.internal.properties.annotations.PropertyAnnotationHandler;
@@ -133,7 +133,7 @@ public class ExecutionGlobalServices implements ServiceRegistrationProvider {
         SoftwareType.class
     );
 
-    public static final ImmutableSet<Class<? extends Annotation>> METHOD_TYPE_ANNOTATIONS = ImmutableSet.of(
+    public static final ImmutableSet<Class<? extends Annotation>> FUNCTION_TYPE_ANNOTATIONS = ImmutableSet.of(
         TaskAction.class
     );
 
@@ -172,7 +172,7 @@ public class ExecutionGlobalServices implements ServiceRegistrationProvider {
                 RegistersSoftwareTypes.class
             ),
             ModifierAnnotationCategory.asMap(builder.build()),
-            METHOD_TYPE_ANNOTATIONS.stream().collect(Collectors.toMap(annotation -> annotation, annotation -> ModifierAnnotationCategory.TYPE)),
+            FUNCTION_TYPE_ANNOTATIONS.stream().collect(Collectors.toMap(annotation -> annotation, annotation -> ModifierAnnotationCategory.TYPE)),
             ImmutableSet.of(
                 "java",
                 "groovy",
@@ -206,11 +206,11 @@ public class ExecutionGlobalServices implements ServiceRegistrationProvider {
     InspectionSchemeFactory createInspectionSchemeFactory(
         List<TypeAnnotationHandler> typeHandlers,
         List<PropertyAnnotationHandler> propertyHandlers,
-        List<MethodAnnotationHandler> methodHandlers,
+        List<FunctionAnnotationHandler> functionHandlers,
         TypeAnnotationMetadataStore typeAnnotationMetadataStore,
         CrossBuildInMemoryCacheFactory cacheFactory
     ) {
-        return new InspectionSchemeFactory(typeHandlers, propertyHandlers, methodHandlers, typeAnnotationMetadataStore, cacheFactory);
+        return new InspectionSchemeFactory(typeHandlers, propertyHandlers, functionHandlers, typeAnnotationMetadataStore, cacheFactory);
     }
 
     @Provides
@@ -385,7 +385,7 @@ public class ExecutionGlobalServices implements ServiceRegistrationProvider {
     }
 
     @Provides
-    MethodAnnotationHandler createTaskActionHandler() {
+    FunctionAnnotationHandler createTaskActionHandler() {
         return new TaskActionAnnotationHandler();
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
@@ -224,11 +224,25 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec imp
 
         where:
         type                                  | failureMessage
-//        TaskWithStaticMethod                  | "Cannot use @TaskAction annotation on static method TaskWithStaticMethod.doStuff()."
         TaskWithMultiParamAction              | "Cannot use @TaskAction annotation on method TaskWithMultiParamAction.doStuff() as this method takes multiple parameters."
         TaskWithSingleParamAction             | "Cannot use @TaskAction annotation on method TaskWithSingleParamAction.doStuff() because int is not a valid parameter to an action method."
         TaskWithOverloadedInputChangesActions | "Cannot use @TaskAction annotation on multiple overloads of method TaskWithOverloadedInputChangesActions.doStuff()"
         TaskWithMultipleInputChangesActions   | "Cannot have multiple @TaskAction methods accepting an InputChanges parameter."
+    }
+
+    def "validation fails for task with static task action method"() {
+        when:
+        def task = expectTaskCreated(TaskWithStaticMethod)
+        execute(task)
+
+        then:
+        def e = thrown WorkValidationException
+        def expectedMessage = cannotUseStaticMethod {
+            method('staticAction()')
+                .kind("static")
+                .includeLink()
+        }
+        validateException(task, e, expectedMessage)
     }
 
     def "works for #type.simpleName"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
@@ -35,11 +35,13 @@ import org.gradle.internal.execution.WorkValidationException
 import org.gradle.internal.execution.WorkValidationExceptionChecker
 import org.gradle.internal.execution.model.annotations.ModifierAnnotationCategory
 import org.gradle.internal.properties.annotations.DefaultTypeMetadataStore
+import org.gradle.internal.properties.annotations.MethodAnnotationHandler
 import org.gradle.internal.properties.annotations.MissingPropertyAnnotationHandler
 import org.gradle.internal.properties.annotations.PropertyAnnotationHandler
 import org.gradle.internal.properties.annotations.TestPropertyTypeResolver
 import org.gradle.internal.properties.bean.DefaultPropertyWalker
 import org.gradle.internal.reflect.DirectInstantiator
+import org.gradle.internal.reflect.annotations.AnnotationCategory
 import org.gradle.internal.reflect.annotations.impl.DefaultTypeAnnotationMetadataStore
 import org.gradle.internal.reflect.validation.ValidationMessageChecker
 import org.gradle.internal.service.ServiceRegistryBuilder
@@ -98,16 +100,17 @@ import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTa
 import static org.gradle.internal.service.scopes.ExecutionGlobalServices.IGNORED_METHOD_ANNOTATIONS
 import static org.gradle.internal.service.scopes.ExecutionGlobalServices.IGNORED_METHOD_ANNOTATIONS_ALLOWED_MODIFIERS
 import static org.gradle.internal.service.scopes.ExecutionGlobalServices.PROPERTY_TYPE_ANNOTATIONS
+import static org.gradle.internal.service.scopes.ExecutionGlobalServices.METHOD_TYPE_ANNOTATIONS
 
 class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec implements ValidationMessageChecker {
     private AnnotationProcessingTaskFactory factory
     private ITaskFactory delegate
     def services = ServiceRegistryBuilder.builder().provider(new ExecutionGlobalServices()).build()
-    def taskClassInfoStore = new DefaultTaskClassInfoStore(new TestCrossBuildInMemoryCacheFactory())
     def cacheFactory = new TestCrossBuildInMemoryCacheFactory()
     def typeAnnotationMetadataStore = new DefaultTypeAnnotationMetadataStore(
         [],
         ModifierAnnotationCategory.asMap(PROPERTY_TYPE_ANNOTATIONS),
+        METHOD_TYPE_ANNOTATIONS.collectEntries { [it, AnnotationCategory.TYPE] },
         ["java", "groovy"],
         [],
         [Object, GroovyObject],
@@ -118,7 +121,9 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec imp
         cacheFactory
     )
     def propertyHandlers = services.getAll(PropertyAnnotationHandler)
-    def typeMetadataStore = new DefaultTypeMetadataStore([], propertyHandlers, [Optional, SkipWhenEmpty], typeAnnotationMetadataStore, TestPropertyTypeResolver.INSTANCE, cacheFactory, MissingPropertyAnnotationHandler.DO_NOTHING)
+    def methodHandlers = services.getAll(MethodAnnotationHandler)
+    def typeMetadataStore = new DefaultTypeMetadataStore([], propertyHandlers, [Optional, SkipWhenEmpty], methodHandlers, [], typeAnnotationMetadataStore, TestPropertyTypeResolver.INSTANCE, cacheFactory, MissingPropertyAnnotationHandler.DO_NOTHING)
+    def taskClassInfoStore = new DefaultTaskClassInfoStore(new TestCrossBuildInMemoryCacheFactory(), typeMetadataStore)
     def propertyWalker = new DefaultPropertyWalker(typeMetadataStore, new TestImplementationResolver(), propertyHandlers)
 
     @SuppressWarnings("GroovyUnusedDeclaration")
@@ -219,7 +224,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec imp
 
         where:
         type                                  | failureMessage
-        TaskWithStaticMethod                  | "Cannot use @TaskAction annotation on static method TaskWithStaticMethod.doStuff()."
+//        TaskWithStaticMethod                  | "Cannot use @TaskAction annotation on static method TaskWithStaticMethod.doStuff()."
         TaskWithMultiParamAction              | "Cannot use @TaskAction annotation on method TaskWithMultiParamAction.doStuff() as this method takes multiple parameters."
         TaskWithSingleParamAction             | "Cannot use @TaskAction annotation on method TaskWithSingleParamAction.doStuff() because int is not a valid parameter to an action method."
         TaskWithOverloadedInputChangesActions | "Cannot use @TaskAction annotation on multiple overloads of method TaskWithOverloadedInputChangesActions.doStuff()"

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTasks.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTasks.java
@@ -100,7 +100,11 @@ public class AnnotationProcessingTasks {
 
     public static class TaskWithStaticMethod extends DefaultTask {
         @TaskAction
-        public static void doStuff() {
+        public static void staticAction() {
+        }
+
+        @TaskAction
+        public void goodAction() {
         }
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/DefaultTaskClassInfoStoreTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/DefaultTaskClassInfoStoreTest.groovy
@@ -18,16 +18,30 @@ package org.gradle.api.internal.project.taskfactory
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.UntrackedTask
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
+import org.gradle.internal.properties.annotations.TypeMetadata
+import org.gradle.internal.properties.annotations.TypeMetadataStore
+import org.gradle.internal.reflect.annotations.TypeAnnotationMetadata
 import spock.lang.Specification
 
 class DefaultTaskClassInfoStoreTest extends Specification {
-    def taskClassInfoStore = new DefaultTaskClassInfoStore(new TestCrossBuildInMemoryCacheFactory())
+    def typeMetadataStore = Mock(TypeMetadataStore)
+    def taskClassInfoStore = new DefaultTaskClassInfoStore(new TestCrossBuildInMemoryCacheFactory(), typeMetadataStore)
+    def typeMetadata = Mock(TypeMetadata)
+    def typeAnnotationMetadata = Mock(TypeAnnotationMetadata)
 
     @CacheableTask
     private static class MyCacheableTask extends DefaultTask {}
 
     def "cacheable tasks are detected"() {
+        given:
+        1 * typeMetadataStore.getTypeMetadata(MyCacheableTask) >> typeMetadata
+        _ * typeMetadata.getTypeAnnotationMetadata() >> typeAnnotationMetadata
+        1 * typeAnnotationMetadata.isAnnotationPresent(CacheableTask) >> true
+        1 * typeAnnotationMetadata.getAnnotation(UntrackedTask) >> Optional.empty()
+        1 * typeMetadata.getMethodsMetadata() >> []
+
         expect:
         taskClassInfoStore.getTaskClassInfo(MyCacheableTask).cacheable
     }
@@ -35,6 +49,13 @@ class DefaultTaskClassInfoStoreTest extends Specification {
     private static class MyNonCacheableTask extends MyCacheableTask {}
 
     def "cacheability is not inherited"() {
+        given:
+        1 * typeMetadataStore.getTypeMetadata(MyNonCacheableTask) >> typeMetadata
+        _ * typeMetadata.getTypeAnnotationMetadata() >> typeAnnotationMetadata
+        1 * typeAnnotationMetadata.isAnnotationPresent(CacheableTask) >> false
+        1 * typeAnnotationMetadata.getAnnotation(UntrackedTask) >> Optional.empty()
+        1 * typeMetadata.getMethodsMetadata() >> []
+
         expect:
         !taskClassInfoStore.getTaskClassInfo(MyNonCacheableTask).cacheable
     }
@@ -50,6 +71,13 @@ class DefaultTaskClassInfoStoreTest extends Specification {
     }
 
     def "class infos are cached"() {
+        given:
+        1 * typeMetadataStore.getTypeMetadata(NonAnnotatedTask) >> typeMetadata
+        _ * typeMetadata.getTypeAnnotationMetadata() >> typeAnnotationMetadata
+        1 * typeAnnotationMetadata.isAnnotationPresent(CacheableTask) >> false
+        1 * typeAnnotationMetadata.getAnnotation(UntrackedTask) >> Optional.empty()
+        1 * typeMetadata.getMethodsMetadata() >> []
+
         def info = taskClassInfoStore.getTaskClassInfo(NonAnnotatedTask)
         expect:
         info.is(taskClassInfoStore.getTaskClassInfo(NonAnnotatedTask))

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/DefaultTaskClassInfoStoreTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/DefaultTaskClassInfoStoreTest.groovy
@@ -40,7 +40,7 @@ class DefaultTaskClassInfoStoreTest extends Specification {
         _ * typeMetadata.getTypeAnnotationMetadata() >> typeAnnotationMetadata
         1 * typeAnnotationMetadata.isAnnotationPresent(CacheableTask) >> true
         1 * typeAnnotationMetadata.getAnnotation(UntrackedTask) >> Optional.empty()
-        1 * typeMetadata.getMethodsMetadata() >> []
+        1 * typeMetadata.getFunctionMetadata() >> []
 
         expect:
         taskClassInfoStore.getTaskClassInfo(MyCacheableTask).cacheable
@@ -54,7 +54,7 @@ class DefaultTaskClassInfoStoreTest extends Specification {
         _ * typeMetadata.getTypeAnnotationMetadata() >> typeAnnotationMetadata
         1 * typeAnnotationMetadata.isAnnotationPresent(CacheableTask) >> false
         1 * typeAnnotationMetadata.getAnnotation(UntrackedTask) >> Optional.empty()
-        1 * typeMetadata.getMethodsMetadata() >> []
+        1 * typeMetadata.getFunctionMetadata() >> []
 
         expect:
         !taskClassInfoStore.getTaskClassInfo(MyNonCacheableTask).cacheable
@@ -76,7 +76,7 @@ class DefaultTaskClassInfoStoreTest extends Specification {
         _ * typeMetadata.getTypeAnnotationMetadata() >> typeAnnotationMetadata
         1 * typeAnnotationMetadata.isAnnotationPresent(CacheableTask) >> false
         1 * typeAnnotationMetadata.getAnnotation(UntrackedTask) >> Optional.empty()
-        1 * typeMetadata.getMethodsMetadata() >> []
+        1 * typeMetadata.getFunctionMetadata() >> []
 
         def info = taskClassInfoStore.getTaskClassInfo(NonAnnotatedTask)
         expect:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/AbstractTaskInputsAndOutputsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/AbstractTaskInputsAndOutputsTest.groovy
@@ -52,6 +52,7 @@ abstract class AbstractTaskInputsAndOutputsTest extends AbstractProjectBuilderSp
     def typeAnnotationMetadataStore = new DefaultTypeAnnotationMetadataStore(
         [],
         [:],
+        [:],
         ["java", "groovy"],
         [],
         [Object, GroovyObject],
@@ -62,7 +63,7 @@ abstract class AbstractTaskInputsAndOutputsTest extends AbstractProjectBuilderSp
         cacheFactory
     )
     def propertyHandlers = [new NoOpPropertyAnnotationHandler(Internal)]
-    def typeMetadataStore = new DefaultTypeMetadataStore([], propertyHandlers, [], typeAnnotationMetadataStore, TestPropertyTypeResolver.INSTANCE, cacheFactory, MissingPropertyAnnotationHandler.MISSING_INPUT_OUTPUT_HANDLER)
+    def typeMetadataStore = new DefaultTypeMetadataStore([], propertyHandlers, [], [], [], typeAnnotationMetadataStore, TestPropertyTypeResolver.INSTANCE, cacheFactory, MissingPropertyAnnotationHandler.MISSING_INPUT_OUTPUT_HANDLER)
     def walker = new DefaultPropertyWalker(typeMetadataStore, new TestImplementationResolver(), propertyHandlers)
 
     TaskInternal task

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/InspectionSchemeFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/InspectionSchemeFactoryTest.groovy
@@ -39,6 +39,7 @@ class InspectionSchemeFactoryTest extends Specification {
     def typeAnnotationMetadataStore = new DefaultTypeAnnotationMetadataStore(
         [],
         [(Thing1): TYPE, (Thing2): TYPE],
+        [:],
         ["java", "groovy"],
         [],
         [Object, GroovyObject],
@@ -48,12 +49,12 @@ class InspectionSchemeFactoryTest extends Specification {
         { false },
         cacheFactory
     )
-    def factory = new InspectionSchemeFactory([], [handler1, handler2], typeAnnotationMetadataStore, cacheFactory)
+    def factory = new InspectionSchemeFactory([], [handler1, handler2], [], typeAnnotationMetadataStore, cacheFactory)
 
     def "creates inspection scheme that understands given property annotations and injection annotations"() {
         def instantiationScheme = Stub(InstantiationScheme)
         instantiationScheme.injectionAnnotations >> [Inject]
-        def scheme = factory.inspectionScheme([Thing1, Thing2], [], instantiationScheme)
+        def scheme = factory.inspectionScheme([Thing1, Thing2], [], [], instantiationScheme)
 
         when:
         def metadata = scheme.metadataStore.getTypeMetadata(AnnotatedBean)
@@ -79,7 +80,7 @@ class InspectionSchemeFactoryTest extends Specification {
     def "annotation can be used for property annotation and injection annotations"() {
         def instantiationScheme = Stub(InstantiationScheme)
         instantiationScheme.injectionAnnotations >> [Thing2, Inject]
-        def scheme = factory.inspectionScheme([Thing1, Thing2], [], instantiationScheme)
+        def scheme = factory.inspectionScheme([Thing1, Thing2], [], [], instantiationScheme)
 
         when:
         def metadata = scheme.metadataStore.getTypeMetadata(AnnotatedBean)

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NodePluginsSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NodePluginsSmokeTest.groovy
@@ -38,9 +38,9 @@ class NodePluginsSmokeTest extends AbstractPluginValidatingSmokeTest implements 
             if (testedPluginId == 'com.moowork.node') {
                 onPlugin('com.moowork.node') {
                     failsWith([
-                        (missingAnnotationMessage { type('com.moowork.gradle.node.npm.NpmSetupTask').property('args').missingInputOrOutput().includeLink() }): ERROR,
-                        (methodShouldNotBeAnnotatedMessage {type('com.moowork.gradle.node.npm.NpmSetupTask').kind('setter').method('setArgs').annotation('Internal').includeLink()}): ERROR,
-                        (missingAnnotationMessage { type('com.moowork.gradle.node.yarn.YarnSetupTask').property('args').missingInputOrOutput().includeLink() }): ERROR,
+                            (missingAnnotationMessage { type('com.moowork.gradle.node.npm.NpmSetupTask').property('args').missingInputOrOutput().includeLink() }): ERROR,
+                            (methodShouldNotBeAnnotatedMessage {type('com.moowork.gradle.node.npm.NpmSetupTask').kind('setter').method('setArgs').annotation('Internal').includeLink()}): ERROR,
+                            (missingAnnotationMessage { type('com.moowork.gradle.node.yarn.YarnSetupTask').property('args').missingInputOrOutput().includeLink() }): ERROR,
                     ])
                 }
             } else {


### PR DESCRIPTION
This allows the type inspection infrastructure to also capture data about (and validate) annotated non-property methods in types.  One example of such a method is one annotated with `@TaskAction`.  We'll also use this for querying annotated methods in plugin classes for the software feature composability work.

As part of this, we replace the custom type inspection in `DefaultTaskClassInfoStore` with a query to the type inspection infrastructure instead.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
