### PR TITLE
Fix CC compatibility of Resource compilation on Windows

### DIFF
--- a/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/internal/DefaultStaticLibraryBinarySpec.java
+++ b/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/internal/DefaultStaticLibraryBinarySpec.java
@@ -16,6 +16,7 @@
 
 package org.gradle.nativeplatform.internal;
 
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.nativeplatform.StaticLibraryBinary;
@@ -58,7 +59,10 @@ public class DefaultStaticLibraryBinarySpec extends AbstractNativeLibraryBinaryS
 
     @Override
     public FileCollection getLinkFiles() {
-        return getFileCollectionFactory().create(new StaticLibraryLinkOutputs());
+        ConfigurableFileCollection result = getFileCollectionFactory().configurableFiles("Link files for " + getDisplayName());
+        result.from(getFileCollectionFactory().create(new StaticLibraryLinkOutputs()));
+        additionalLinkFiles.forEach(result::from);
+        return result;
     }
 
     @Override
@@ -90,12 +94,12 @@ public class DefaultStaticLibraryBinarySpec extends AbstractNativeLibraryBinaryS
     private class StaticLibraryLinkOutputs extends LibraryOutputs {
         @Override
         public String getDisplayName() {
-            return "Link files for " + DefaultStaticLibraryBinarySpec.this.getDisplayName();
+            return "Static library file for " + DefaultStaticLibraryBinarySpec.this.getDisplayName();
         }
 
         @Override
         protected boolean hasOutputs() {
-            return hasSources() || !additionalLinkFiles.isEmpty();
+            return hasSources();
         }
 
         @Override
@@ -103,9 +107,6 @@ public class DefaultStaticLibraryBinarySpec extends AbstractNativeLibraryBinaryS
             Set<File> allFiles = new LinkedHashSet<File>();
             if (hasSources()) {
                 allFiles.add(getStaticLibraryFile());
-            }
-            for (FileCollection resourceSet : additionalLinkFiles) {
-                allFiles.addAll(resourceSet.getFiles());
             }
             return allFiles;
         }

--- a/platforms/native/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/DefaultStaticLibraryBinarySpecTest.groovy
+++ b/platforms/native/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/DefaultStaticLibraryBinarySpecTest.groovy
@@ -17,9 +17,9 @@
 package org.gradle.nativeplatform.internal
 
 import org.gradle.api.Task
-import org.gradle.api.file.FileCollection
 import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.internal.CollectionCallbackActionDecorator
+import org.gradle.api.internal.file.TestFiles
 import org.gradle.language.nativeplatform.HeaderExportingSourceSet
 import org.gradle.nativeplatform.BuildType
 import org.gradle.nativeplatform.NativeLibrarySpec
@@ -108,9 +108,8 @@ class DefaultStaticLibraryBinarySpecTest extends Specification {
         binary.staticLibraryFile = outputFile
         def linkFile1 = Mock(File)
         def linkFile2 = Mock(File)
-        def additionalLinkFiles = Stub(FileCollection) {
-            getFiles() >> [linkFile1, linkFile2]
-        }
+        def additionalLinkFiles = TestFiles.fileCollectionFactory().fixed(linkFile1, linkFile2)
+
         binary.additionalLinkFiles(additionalLinkFiles)
 
         and:


### PR DESCRIPTION
By preserving file collection structure for link files

The resource compiler adds a complex output file collection as an extra link files source, that can only be evaluated once the resources have been built. Stuffing everything into StaticLibraryLinkOutputs hides this complexity inside an opaque FileCollection. The configuration cache cannot rediscover the structure and ends up resolving the collection at store time, effectively ignoring the extra files.

This commit changes the file collection implementation so CC can store the resource compilations output structure properly, in a lazy manner.

Fixes #30717

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
