### PR TITLE
Let `BeanStateReader` handle generated types transparently

### DIFF
--- a/platforms/core-configuration/bean-serialization-services/build.gradle.kts
+++ b/platforms/core-configuration/bean-serialization-services/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
 
     api(libs.kotlinStdlib)
 
-    implementation(projects.baseAsm)
+    implementation(projects.baseServices)
     implementation(projects.configurationProblemsBase)
     implementation(projects.core)
     implementation(projects.coreApi)

--- a/platforms/core-configuration/bean-serialization-services/src/main/kotlin/org/gradle/internal/serialize/beans/services/BeanPropertyWriter.kt
+++ b/platforms/core-configuration/bean-serialization-services/src/main/kotlin/org/gradle/internal/serialize/beans/services/BeanPropertyWriter.kt
@@ -24,7 +24,7 @@ import org.gradle.internal.serialize.graph.BeanStateWriter
 import org.gradle.internal.serialize.graph.WriteContext
 import org.gradle.internal.serialize.graph.reportUnsupportedFieldType
 import org.gradle.internal.serialize.graph.withDebugFrame
-import org.gradle.internal.serialize.graph.writeNextProperty
+import org.gradle.internal.serialize.graph.writePropertyValue
 import java.lang.reflect.Field
 
 
@@ -51,7 +51,7 @@ class BeanPropertyWriter(
                 reportUnsupportedFieldType(it, "serialize", fieldName, fieldValue)
             }
             withDebugFrame({ field.debugFrameName() }) {
-                writeNextProperty(fieldName, fieldValue, PropertyKind.Field)
+                writePropertyValue(PropertyKind.Field, fieldName, fieldValue)
             }
         }
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
@@ -38,6 +38,7 @@ import org.gradle.internal.cc.impl.serialize.ParallelStringDecoder
 import org.gradle.internal.cc.impl.serialize.ParallelStringEncoder
 import org.gradle.internal.encryption.EncryptionService
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.Encoder
@@ -92,7 +93,8 @@ class DefaultConfigurationCacheIO internal constructor(
     private val beanStateWriterLookup: BeanStateWriterLookup,
     private val eventEmitter: BuildOperationProgressEventEmitter,
     private val classLoaderScopeRegistryListener: ConfigurationCacheClassLoaderScopeRegistryListener,
-    private val classLoaderScopeRegistry: ClassLoaderScopeRegistry
+    private val classLoaderScopeRegistry: ClassLoaderScopeRegistry,
+    private val instantiatorFactory: InstantiatorFactory
 ) : ConfigurationCacheBuildTreeIO, ConfigurationCacheIncludedBuildIO {
 
     private
@@ -487,7 +489,10 @@ class DefaultConfigurationCacheIO internal constructor(
 
     private
     fun classDecoder() =
-        DefaultClassDecoder(classLoaderScopeRegistry.coreAndPluginsScope)
+        DefaultClassDecoder(
+            classLoaderScopeRegistry.coreAndPluginsScope,
+            instantiatorFactory.decorateScheme().deserializationInstantiator()
+        )
 
     /**
      * Provides R/W isolate contexts based on some other context.

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/DefaultClassDecoder.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/DefaultClassDecoder.kt
@@ -20,6 +20,7 @@ import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.initialization.ClassLoaderScopeOrigin
 import org.gradle.internal.Describables
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.instantiation.DeserializationInstantiator
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.graph.ClassDecoder
 import org.gradle.internal.serialize.graph.ReadIdentities
@@ -27,7 +28,8 @@ import org.gradle.internal.serialize.graph.ReadIdentities
 
 internal
 class DefaultClassDecoder(
-    private val defaultClassLoaderScope: ClassLoaderScope
+    private val defaultClassLoaderScope: ClassLoaderScope,
+    private val instantiator: DeserializationInstantiator
 ) : ClassDecoder {
 
     private
@@ -42,11 +44,13 @@ class DefaultClassDecoder(
         if (type != null) {
             return type as Class<*>
         }
+        val isGenerated = readBoolean()
         val name = readString()
         val classLoader = decodeClassLoader()
         val newType = classForName(name, classLoader ?: gradleRuntimeClassLoader)
-        classes.putInstance(id, newType)
-        return newType
+        val actualType = if (isGenerated) instantiator.getDeserializedType(newType) else newType
+        classes.putInstance(id, actualType)
+        return actualType
     }
 
     override fun Decoder.decodeClassLoader(): ClassLoader? =

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/DefaultClassDecoder.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/DefaultClassDecoder.kt
@@ -48,7 +48,7 @@ class DefaultClassDecoder(
         val name = readString()
         val classLoader = decodeClassLoader()
         val newType = classForName(name, classLoader ?: gradleRuntimeClassLoader)
-        val actualType = if (isGenerated) instantiator.getDeserializedType(newType) else newType
+        val actualType = if (isGenerated) instantiator.getGeneratedType(newType) else newType
         classes.putInstance(id, actualType)
         return actualType
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/DefaultClassEncoder.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/DefaultClassEncoder.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.cc.impl.serialize
 
+import org.gradle.api.internal.GeneratedSubclasses
 import org.gradle.initialization.ClassLoaderScopeOrigin
 import org.gradle.internal.cc.base.exceptions.ConfigurationCacheError
 import org.gradle.internal.classpath.ClassPath
@@ -76,9 +77,12 @@ class DefaultClassEncoder(
         } else {
             val newId = classes.putInstance(type)
             writeSmallInt(newId)
-            val className = type.name
+            // TODO:configuration-cache - should collect the details of the decoration (eg enabled annotations, etc), and also carry this information with the serialized class reference
+            val originalType = GeneratedSubclasses.unpack(type)
+            writeBoolean(originalType !== type)
+            val className = originalType.name
             writeString(className)
-            val classLoader = type.classLoader
+            val classLoader = originalType.classLoader
             if (!writeClassLoaderScopeOf(classLoader) && classLoader != null) {
                 // Ensure class can be found in the Gradle runtime classloader since its original classloader could not be encoded.
                 ensureClassCanBeFoundInGradleRuntimeClassLoader(className, classLoader)

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialization/codecs/AbstractUserTypeCodecTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialization/codecs/AbstractUserTypeCodecTest.kt
@@ -150,7 +150,7 @@ abstract class AbstractUserTypeCodecTest {
             beanStateReaderLookup = beanStateReaderLookupForTesting(),
             logger = mock(),
             problemsListener = mock(),
-            classDecoder = DefaultClassDecoder(mock())
+            classDecoder = DefaultClassDecoder(mock(), mock())
         )
 
     private

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/JavaRecordCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/JavaRecordCodec.kt
@@ -27,7 +27,7 @@ import org.gradle.internal.serialize.graph.logPropertyProblem
 import org.gradle.internal.serialize.graph.readPropertyValue
 import org.gradle.internal.serialize.graph.reportUnsupportedFieldType
 import org.gradle.internal.serialize.graph.withDebugFrame
-import org.gradle.internal.serialize.graph.writeNextProperty
+import org.gradle.internal.serialize.graph.writePropertyValue
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier.isStatic
 
@@ -92,7 +92,7 @@ object JavaRecordEncoding : Encoding {
                 reportUnsupportedFieldType(it, "serialize", fieldName, fieldValue)
             }
             withDebugFrame({ "${clazz.typeName}.$fieldName" }) {
-                writeNextProperty(fieldName, fieldValue, PropertyKind.Field)
+                writePropertyValue(PropertyKind.Field, fieldName, fieldValue)
             }
         }
     }

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/TaskNodeCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/TaskNodeCodec.kt
@@ -59,7 +59,7 @@ import org.gradle.internal.serialize.graph.withIsolate
 import org.gradle.internal.serialize.graph.withPropertyTrace
 import org.gradle.internal.serialize.graph.writeCollection
 import org.gradle.internal.serialize.graph.writeEnum
-import org.gradle.internal.serialize.graph.writeNextProperty
+import org.gradle.internal.serialize.graph.writePropertyValue
 import org.gradle.util.internal.DeferredUtil
 
 
@@ -275,7 +275,7 @@ suspend fun WriteContext.writeRegisteredPropertiesOf(task: Task) {
 
     suspend fun writeProperty(propertyName: String, propertyValue: Any?, kind: PropertyKind) {
         writeString(propertyName)
-        writeNextProperty(propertyName, propertyValue, kind)
+        writePropertyValue(kind, propertyName, propertyValue)
     }
 
     suspend fun writeInputProperty(propertyName: String, propertyValue: Any?) =

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/jos/JavaObjectSerializationCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/jos/JavaObjectSerializationCodec.kt
@@ -242,7 +242,7 @@ inline fun ReadContext.decodingBeanWithId(id: Int, decode: (Any, Class<*>, BeanS
     val beanType = readClass()
     return withBeanTrace(beanType) {
         val beanStateReader = beanStateReaderFor(beanType)
-        beanStateReader.run { newBeanWithId(false, id) }.also { bean ->
+        beanStateReader.run { newBeanWithId(id) }.also { bean ->
             decode(bean, beanType, beanStateReader)
         }
     }

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/BeanPropertyExtensions.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/BeanPropertyExtensions.kt
@@ -28,7 +28,7 @@ import java.lang.reflect.InvocationTargetException
  *
  * A property can only be written when there's a suitable [Codec] for its [value].
  */
-suspend fun WriteContext.writeNextProperty(name: String, value: Any?, kind: PropertyKind) {
+suspend fun WriteContext.writePropertyValue(kind: PropertyKind, name: String, value: Any?) {
     withPropertyTrace(kind, name) {
         try {
             write(value)
@@ -51,7 +51,7 @@ suspend fun WriteContext.writeNextProperty(name: String, value: Any?, kind: Prop
 
 
 /**
- * Reads a sequence of properties written with [writingProperties].
+ * Reads a bean property written with [writePropertyValue].
  */
 @Suppress("ThrowsCount")
 suspend fun ReadContext.readPropertyValue(kind: PropertyKind, name: String, action: (Any?) -> Unit) {

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
@@ -344,7 +344,7 @@ suspend fun ReadContext.decodeBean(): Any {
     val beanType = readClass()
     return withBeanTrace(beanType) {
         beanStateReaderFor(beanType).run {
-            newBean(false).also {
+            newBean().also {
                 readStateOf(it)
             }
         }
@@ -359,12 +359,12 @@ interface BeanStateWriter {
 
 interface BeanStateReader {
 
-    fun ReadContext.newBeanWithId(generated: Boolean, id: Int) =
-        newBean(generated).also {
+    fun ReadContext.newBeanWithId(id: Int) =
+        newBean().also {
             isolate.identities.putInstance(id, it)
         }
 
-    fun ReadContext.newBean(generated: Boolean): Any
+    fun ReadContext.newBean(): Any
 
     suspend fun ReadContext.readStateOf(bean: Any)
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/DeserializationInstantiator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/DeserializationInstantiator.java
@@ -23,7 +23,7 @@ import org.gradle.api.reflect.ObjectInstantiationException;
  */
 public interface DeserializationInstantiator {
     /**
-     * Creates an instance of the given type without invoking its constructor. Invokes the constructor of the given base class.
+     * Creates an instance of the {@link #getGeneratedType(Class) generated subtype} of type without invoking its constructor. Invokes the constructor of the given base class.
      *
      * @throws ObjectInstantiationException On failure to create the new instance.
      */
@@ -32,5 +32,5 @@ public interface DeserializationInstantiator {
     /**
      * Returns the generated type for the given implementation type.
      */
-    <T> Class<? extends T> getDeserializedType(Class<T> implType);
+    <T> Class<? extends T> getGeneratedType(Class<T> implType);
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/DeserializationInstantiator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/DeserializationInstantiator.java
@@ -28,4 +28,9 @@ public interface DeserializationInstantiator {
      * @throws ObjectInstantiationException On failure to create the new instance.
      */
     <T> T newInstance(Class<T> implType, Class<? super T> baseClass) throws ObjectInstantiationException;
+
+    /**
+     * Returns the generated type for the given implementation type.
+     */
+    <T> Class<? extends T> getDeserializedType(Class<T> implType);
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -179,7 +179,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
         return roleHandler;
     }
 
-    private <T> TypeToken<Provider<T>> providerOf(Class<T> providerType) {
+    private static <T> TypeToken<Provider<T>> providerOf(Class<T> providerType) {
         return new TypeToken<Provider<T>>() {
         }.where(new TypeParameter<T>() {
         }, providerType);
@@ -370,10 +370,8 @@ abstract class AbstractClassGenerator implements ClassGenerator {
             return false;
         }
         // Ignore irrelevant synthetic metaClass field injected by the Groovy compiler
-        if (instanceFields.size() == 1 && isSyntheticMetaClassField(instanceFields.get(0))) {
-            return false;
-        }
-        return true;
+        return instanceFields.size() != 1
+            || !isSyntheticMetaClassField(instanceFields.get(0));
     }
 
     private boolean isSyntheticMetaClassField(Field field) {
@@ -783,7 +781,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
     }
 
     private static class ClassGenerationHandler {
-         // used in subclasses
+        // used in subclasses
         void startType(Class<?> type) {
         }
 
@@ -1000,9 +998,8 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                     hasExtensionAwareImplementation = true;
                     return true;
                 }
-                if (property.getName().equals("conventionMapping") || property.getName().equals("convention")) {
-                    return true;
-                }
+                return property.getName().equals("conventionMapping")
+                    || property.getName().equals("convention");
             }
 
             return false;

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -92,6 +92,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.Optional.ofNullable;
+import static org.gradle.api.internal.GeneratedSubclasses.isGeneratedType;
 
 /**
  * Generates a subclass of the target class to mix-in some DSL behaviour.
@@ -186,6 +187,10 @@ abstract class AbstractClassGenerator implements ClassGenerator {
 
     @Override
     public <T> GeneratedClass<? extends T> generate(Class<T> type) {
+        if (isGeneratedType(type)) {
+            throw new IllegalArgumentException(String.format("'%s' is already generated.", type));
+        }
+
         GeneratedClassImpl generatedClass = generatedClasses.getIfPresent(type);
         if (generatedClass == null) {
             // It is possible that multiple threads will execute this branch concurrently, when the type is missing. However, the contract for `get()` below will ensure that

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -92,7 +92,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.Optional.ofNullable;
-import static org.gradle.api.internal.GeneratedSubclasses.isGeneratedType;
+import static org.gradle.api.internal.GeneratedSubclasses.unpack;
 
 /**
  * Generates a subclass of the target class to mix-in some DSL behaviour.
@@ -187,19 +187,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
 
     @Override
     public <T> GeneratedClass<? extends T> generate(Class<T> type) {
-        if (isGeneratedType(type)) {
-            throw new IllegalArgumentException(String.format("'%s' is already generated.", type));
-        }
-
-        GeneratedClassImpl generatedClass = generatedClasses.getIfPresent(type);
-        if (generatedClass == null) {
-            // It is possible that multiple threads will execute this branch concurrently, when the type is missing. However, the contract for `get()` below will ensure that
-            // only one thread will actually generate the implementation class
-            generatedClass = generatedClasses.get(type, generator);
-            // Also use the generated class for itself
-            generatedClasses.put(generatedClass.generatedClass, generatedClass);
-        }
-        return Cast.uncheckedNonnullCast(generatedClass);
+        return Cast.uncheckedNonnullCast(generatedClasses.get(unpack(type), generator));
     }
 
     private GeneratedClassImpl generateUnderLock(Class<?> type) {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/DefaultInstantiationScheme.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/DefaultInstantiationScheme.java
@@ -90,7 +90,7 @@ class DefaultInstantiationScheme implements InstantiationScheme {
         }
 
         @Override
-        public <T> Class<? extends T> getDeserializedType(Class<T> implType) {
+        public <T> Class<? extends T> getGeneratedType(Class<T> implType) {
             return classGenerator.generate(implType).getGeneratedClass();
         }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/DefaultInstantiationScheme.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/DefaultInstantiationScheme.java
@@ -23,6 +23,7 @@ import org.gradle.internal.instantiation.DeserializationInstantiator;
 import org.gradle.internal.instantiation.InstanceFactory;
 import org.gradle.internal.instantiation.InstanceGenerator;
 import org.gradle.internal.instantiation.InstantiationScheme;
+import org.gradle.internal.instantiation.generator.ClassGenerator.SerializationConstructor;
 import org.gradle.internal.service.ServiceLookup;
 
 import java.lang.annotation.Annotation;
@@ -33,7 +34,7 @@ class DefaultInstantiationScheme implements InstantiationScheme {
     private final DependencyInjectingInstantiator instantiator;
     private final ConstructorSelector constructorSelector;
     private final Set<Class<? extends Annotation>> injectionAnnotations;
-    private final CrossBuildInMemoryCache<Class<?>, ClassGenerator.SerializationConstructor<?>> deserializationConstructorCache;
+    private final CrossBuildInMemoryCache<Class<?>, SerializationConstructor<?>> deserializationConstructorCache;
     private final DeserializationInstantiator deserializationInstantiator;
     private final ClassGenerator classGenerator;
 
@@ -41,7 +42,7 @@ class DefaultInstantiationScheme implements InstantiationScheme {
         this(constructorSelector, classGenerator, defaultServices, injectionAnnotations, cacheFactory.newClassCache());
     }
 
-    private DefaultInstantiationScheme(ConstructorSelector constructorSelector, ClassGenerator classGenerator, ServiceLookup defaultServices, Set<Class<? extends Annotation>> injectionAnnotations, CrossBuildInMemoryCache<Class<?>, ClassGenerator.SerializationConstructor<?>> deserializationConstructorCache) {
+    private DefaultInstantiationScheme(ConstructorSelector constructorSelector, ClassGenerator classGenerator, ServiceLookup defaultServices, Set<Class<? extends Annotation>> injectionAnnotations, CrossBuildInMemoryCache<Class<?>, SerializationConstructor<?>> deserializationConstructorCache) {
         this.classGenerator = classGenerator;
         this.instantiator = new DependencyInjectingInstantiator(constructorSelector, defaultServices);
         this.constructorSelector = constructorSelector;
@@ -79,9 +80,9 @@ class DefaultInstantiationScheme implements InstantiationScheme {
         private final ClassGenerator classGenerator;
         private final ServiceLookup services;
         private final InstanceGenerator nestedGenerator;
-        private final CrossBuildInMemoryCache<Class<?>, ClassGenerator.SerializationConstructor<?>> constructorCache;
+        private final CrossBuildInMemoryCache<Class<?>, SerializationConstructor<?>> constructorCache;
 
-        public DefaultDeserializationInstantiator(ClassGenerator classGenerator, ServiceLookup services, InstanceGenerator nestedGenerator, CrossBuildInMemoryCache<Class<?>, ClassGenerator.SerializationConstructor<?>> constructorCache) {
+        public DefaultDeserializationInstantiator(ClassGenerator classGenerator, ServiceLookup services, InstanceGenerator nestedGenerator, CrossBuildInMemoryCache<Class<?>, SerializationConstructor<?>> constructorCache) {
             this.classGenerator = classGenerator;
             this.services = services;
             this.nestedGenerator = nestedGenerator;
@@ -97,13 +98,20 @@ class DefaultInstantiationScheme implements InstantiationScheme {
         public <T> T newInstance(Class<T> implType, Class<? super T> baseClass) {
             // TODO - The baseClass can be inferred from the implType, so attach the serialization constructor onto the GeneratedClass rather than parameterizing and caching here
             try {
-                ClassGenerator.SerializationConstructor<?> constructor = constructorCache.get(implType, () -> classGenerator.generate(implType).getSerializationConstructor(baseClass));
+                SerializationConstructor<?> constructor = serializationConstructorFor(implType, baseClass);
                 return implType.cast(constructor.newInstance(services, nestedGenerator));
             } catch (InvocationTargetException e) {
                 throw new ObjectInstantiationException(implType, e.getCause());
             } catch (Exception e) {
                 throw new ObjectInstantiationException(implType, e);
             }
+        }
+
+        private <T> SerializationConstructor<?> serializationConstructorFor(Class<T> implType, Class<? super T> baseClass) {
+            return constructorCache.get(
+                implType,
+                () -> classGenerator.generate(implType).getSerializationConstructor(baseClass)
+            );
         }
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/DefaultInstantiationScheme.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/DefaultInstantiationScheme.java
@@ -89,6 +89,11 @@ class DefaultInstantiationScheme implements InstantiationScheme {
         }
 
         @Override
+        public <T> Class<? extends T> getDeserializedType(Class<T> implType) {
+            return classGenerator.generate(implType).getGeneratedClass();
+        }
+
+        @Override
         public <T> T newInstance(Class<T> implType, Class<? super T> baseClass) {
             // TODO - The baseClass can be inferred from the implType, so attach the serialization constructor onto the GeneratedClass rather than parameterizing and caching here
             try {

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/api/internal/GeneratedSubclasses.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/api/internal/GeneratedSubclasses.java
@@ -24,14 +24,22 @@ public class GeneratedSubclasses {
     }
 
     public static Class<?> unpack(Class<?> type) {
-        if (GeneratedSubclass.class.isAssignableFrom(type)) {
-            try {
-                return (Class<?>) type.getMethod("generatedFrom").invoke(null);
-            } catch (Exception e) {
-                throw UncheckedException.throwAsUncheckedException(e);
-            }
+        if (isGeneratedType(type)) {
+            return unpackOrFail(type);
         }
         return type;
+    }
+
+    public static boolean isGeneratedType(Class<?> type) {
+        return GeneratedSubclass.class.isAssignableFrom(type);
+    }
+
+    public static Class<?> unpackOrFail(Class<?> type) {
+        try {
+            return (Class<?>) type.getMethod("generatedFrom").invoke(null);
+        } catch (Exception e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
     }
 
     public static Class<?> unpackType(Object object) {

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
@@ -17,9 +17,9 @@
 package org.gradle.cache.internal;
 
 import org.gradle.cache.ManualEvictionInMemoryCache;
-import org.gradle.internal.session.BuildSessionLifecycleListener;
 import org.gradle.internal.classloader.VisitableURLClassLoader;
 import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.session.BuildSessionLifecycleListener;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -147,6 +147,7 @@ public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemory
         }
 
         // Caller must be holding lock
+        @Nullable
         private V getIfPresentWithoutLock(K key) {
             V v = valuesForThisSession.get(key);
             if (v != null) {

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractTaskTest.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractTaskTest.groovy
@@ -122,7 +122,7 @@ abstract class AbstractTaskTest extends AbstractProjectBuilderSpec {
 
         when:
         getTask().getActions().add(Actions.doNothing())
-        getTask().getActions().set(0, { task -> throw new RuntimeException()} as Action)
+        getTask().getActions().set(0, { task -> throw new RuntimeException() } as Action)
 
         then:
         getTask().getActions().size() == 1


### PR DESCRIPTION
So generated classes can be encoded transparently.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
