### PR TITLE
Add try-resolution when Java compilation is failing

### DIFF
--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CompilationFailedException.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CompilationFailedException.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 
 public class CompilationFailedException extends RuntimeException implements CompilationFailedIndicator, ProblemAwareFailure, ResolutionProvider {
 
-    public static final String RESOLUTION_MESSAGE = "Check you code and dependencies to fix the compilation error(s)";
+    public static final String RESOLUTION_MESSAGE = "Check your code and dependencies to fix the compilation error(s)";
     public static final String COMPILATION_FAILED_DETAILS_ABOVE = "Compilation failed; see the compiler error output for details.";
     public static final String COMPILATION_FAILED_DETAILS_BELOW = "Compilation failed; see the compiler output below.";
 

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CompilationFailedException.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CompilationFailedException.java
@@ -15,9 +15,11 @@
  */
 package org.gradle.api.internal.tasks.compile;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.problems.internal.Problem;
 import org.gradle.api.problems.internal.ProblemAwareFailure;
 import org.gradle.internal.exceptions.CompilationFailedIndicator;
+import org.gradle.internal.exceptions.ResolutionProvider;
 import org.gradle.problems.internal.rendering.ProblemRenderer;
 
 import javax.annotation.Nullable;
@@ -27,8 +29,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-public class CompilationFailedException extends RuntimeException implements CompilationFailedIndicator, ProblemAwareFailure {
+public class CompilationFailedException extends RuntimeException implements CompilationFailedIndicator, ProblemAwareFailure, ResolutionProvider {
 
+    public static final String RESOLUTION_MESSAGE = "Check you code and dependencies to fix the compilation error(s)";
     public static final String COMPILATION_FAILED_DETAILS_ABOVE = "Compilation failed; see the compiler error output for details.";
     public static final String COMPILATION_FAILED_DETAILS_BELOW = "Compilation failed; see the compiler output below.";
 
@@ -78,5 +81,10 @@ public class CompilationFailedException extends RuntimeException implements Comp
     @Override
     public Collection<Problem> getProblems() {
         return reportedProblems;
+    }
+
+    @Override
+    public List<String> getResolutions() {
+        return ImmutableList.of(RESOLUTION_MESSAGE);
     }
 }

--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/integtests/JavaProjectIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/integtests/JavaProjectIntegrationTest.groovy
@@ -15,6 +15,8 @@
  */
 
 package org.gradle.integtests
+
+import org.gradle.api.internal.tasks.compile.CompilationFailedException
 import org.gradle.integtests.fixtures.AbstractIntegrationTest
 import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.integtests.fixtures.executer.ExecutionFailure
@@ -34,7 +36,8 @@ class JavaProjectIntegrationTest extends AbstractIntegrationTest {
         ExecutionFailure failure = executer.withTasks("build").runWithFailure()
 
         failure.assertHasDescription("Execution failed for task ':compileJava'.")
-        failure.assertHasCause("Compilation failed; see the compiler output below.")
+        failure.assertHasCause(CompilationFailedException.COMPILATION_FAILED_DETAILS_BELOW)
+        failure.assertHasResolution(CompilationFailedException.RESOLUTION_MESSAGE)
     }
 
     @Test
@@ -47,7 +50,8 @@ class JavaProjectIntegrationTest extends AbstractIntegrationTest {
         ExecutionFailure failure = executer.withTasks("build").runWithFailure()
 
         failure.assertHasDescription("Execution failed for task ':compileTestJava'.")
-        failure.assertHasCause("Compilation failed; see the compiler output below.")
+        failure.assertHasCause(CompilationFailedException.COMPILATION_FAILED_DETAILS_BELOW)
+        failure.assertHasResolution(CompilationFailedException.RESOLUTION_MESSAGE)
     }
 
     @Test

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -27,7 +27,6 @@ import org.gradle.api.logging.configuration.ShowStacktrace;
 import org.gradle.execution.MultipleBuildFailures;
 import org.gradle.initialization.BuildClientMetaData;
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
-import org.gradle.internal.exceptions.CompilationFailedIndicator;
 import org.gradle.internal.exceptions.ContextAwareException;
 import org.gradle.internal.exceptions.ExceptionContextVisitor;
 import org.gradle.internal.exceptions.FailureResolutionAware;
@@ -318,15 +317,9 @@ public class BuildExceptionReporter implements Action<Throwable> {
             );
         }
 
-        boolean hasCompileError = hasNonGradleSpecificCauseInAncestry &&
-            hasCauseAncestry(details.failure, CompilationFailedIndicator.class);
         LogLevel logLevel = loggingConfiguration.getLogLevel();
         boolean isLessThanInfo = logLevel.ordinal() > INFO.ordinal();
-        if (hasCompileError && isLessThanInfo) {
-            context.appendResolution(output ->
-                runWithOption(output, INFO_LONG_OPTION, " option to get more log output.")
-            );
-        } else if (logLevel != DEBUG && !hasNonGradleSpecificCauseInAncestry) {
+        if (logLevel != DEBUG && !hasNonGradleSpecificCauseInAncestry) {
             context.appendResolution(output -> {
                 output.text("Run with ");
                 if (isLessThanInfo) {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.api.tasks.TaskExecutionException
 import org.gradle.execution.MultipleBuildFailures
 import org.gradle.initialization.BuildClientMetaData
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager
+import org.gradle.internal.exceptions.CompilationFailedIndicator
 import org.gradle.internal.exceptions.ContextAwareException
 import org.gradle.internal.exceptions.DefaultMultiCauseException
 import org.gradle.internal.exceptions.FailureResolutionAware
@@ -55,8 +56,7 @@ class BuildExceptionReporterTest extends Specification {
     static final String LOCATION = "<location>"
     static final String STACKTRACE = "{info}> {normal}Run with {userinput}--stacktrace{normal} option to get the stack trace."
     static final String INFO_OR_DEBUG = "{info}> {normal}Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output."
-    static final String INFO = "{info}> {normal}Run with {userinput}--info{normal} option to get more log output."
-    static final String SCAN = "{info}> {normal}Run with {userinput}--scan{normal} to get full insights."
+    static final String TRY_SCAN = "{info}> {normal}Run with {userinput}--scan{normal} to get full insights."
     static final String GET_HELP = "{info}> {normal}Get more help at {userinput}https://help.gradle.org{normal}."
 
 
@@ -85,7 +85,7 @@ $MESSAGE
 * Try:
 $STACKTRACE
 $INFO_OR_DEBUG
-$SCAN
+$TRY_SCAN
 $GET_HELP
 """
     }
@@ -158,7 +158,7 @@ org.gradle.api.GradleException (no error message)
 * Try:
 $STACKTRACE
 $INFO_OR_DEBUG
-$SCAN
+$TRY_SCAN
 $GET_HELP
 """
     }
@@ -181,7 +181,7 @@ $MESSAGE
 * Try:
 $STACKTRACE
 $INFO_OR_DEBUG
-$SCAN
+$TRY_SCAN
 $GET_HELP
 """
     }
@@ -204,7 +204,7 @@ java.io.IOException
 * Try:
 $STACKTRACE
 $INFO_OR_DEBUG
-$SCAN
+$TRY_SCAN
 $GET_HELP
 """
     }
@@ -228,7 +228,7 @@ $MESSAGE
 * Try:
 $STACKTRACE
 $INFO_OR_DEBUG
-$SCAN
+$TRY_SCAN
 $GET_HELP
 """
     }
@@ -257,7 +257,7 @@ $MESSAGE
 * Try:
 $STACKTRACE
 $INFO_OR_DEBUG
-$SCAN
+$TRY_SCAN
 $GET_HELP
 """
     }
@@ -280,7 +280,7 @@ $MESSAGE
 * Try:
 $STACKTRACE
 $INFO_OR_DEBUG
-$SCAN
+$TRY_SCAN
 $GET_HELP
 """
     }
@@ -304,7 +304,7 @@ $MESSAGE
 
 * Try:
 $INFO_OR_DEBUG
-$SCAN
+$TRY_SCAN
 $GET_HELP
 
 * Exception is:
@@ -336,7 +336,7 @@ Execution failed for null.
 {info}> {normal}org.gradle.internal.buildevents.TestNonGradleCauseException (no error message)
 
 * Try:
-$SCAN
+$TRY_SCAN
 ==============================================================================
 
 {failure}2: {normal}{failure}Task failed with an exception.{normal}
@@ -349,8 +349,7 @@ Execution failed for null.
 {info}> {normal}org.gradle.internal.buildevents.TestCompilationFailureException (no error message)
 
 * Try:
-$INFO
-$SCAN
+$TRY_SCAN
 ==============================================================================
 
 {failure}3: {normal}{failure}Task failed with an exception.{normal}
@@ -361,7 +360,7 @@ $SCAN
 * Try:
 $STACKTRACE
 $INFO_OR_DEBUG
-$SCAN
+$TRY_SCAN
 $GET_HELP
 ==============================================================================
 """;
@@ -382,7 +381,7 @@ $MESSAGE
 
 * Try:
 $INFO_OR_DEBUG
-$SCAN
+$TRY_SCAN
 $GET_HELP
 
 * Exception is:
@@ -406,7 +405,7 @@ $MESSAGE
 
 * Try:
 $INFO_OR_DEBUG
-$SCAN
+$TRY_SCAN
 $GET_HELP
 
 * Exception is:
@@ -437,7 +436,7 @@ $MESSAGE
 {info}> {normal}resolution 2.
 $STACKTRACE
 $INFO_OR_DEBUG
-$SCAN
+$TRY_SCAN
 $GET_HELP
 """
     }
@@ -491,7 +490,7 @@ Could not resolve all task dependencies for org:example:1.0.
 * Try:
 $STACKTRACE
 $INFO_OR_DEBUG
-$SCAN
+$TRY_SCAN
 $GET_HELP
 """
     }
@@ -521,7 +520,7 @@ Could not resolve all task dependencies for org:example:1.0.
 * Try:
 $STACKTRACE
 $INFO_OR_DEBUG
-$SCAN
+$TRY_SCAN
 $GET_HELP
 """
     }
@@ -553,7 +552,7 @@ Could not resolve all task dependencies for org:example:1.0.
 * Try:
 $STACKTRACE
 $INFO_OR_DEBUG
-$SCAN
+$TRY_SCAN
 $GET_HELP
 """
     }
@@ -592,7 +591,7 @@ Could not resolve all task dependencies for org:example:1.0.
 * Try:
 $STACKTRACE
 $INFO_OR_DEBUG
-$SCAN
+$TRY_SCAN
 $GET_HELP
 """
     }
@@ -609,7 +608,7 @@ $GET_HELP
         }
     }
 
-    class TestProblemAwareFailure extends Throwable implements ProblemAwareFailure {
+    class TestProblemAwareFailure extends Throwable implements CompilationFailedIndicator, ProblemAwareFailure {
         List<Problem> problems
 
         TestProblemAwareFailure(Problem... problems) {


### PR DESCRIPTION
This PR tunes the `Try:` segment after a Java compilation fails; it doesn't makes sense to execute the build with `--info` or `--debug` this case, as all the information is available in the log.

### Example output with this PR.

```
> Task :compileJava
> Task :processResources NO-SOURCE
> Task :classes
> Task :jar
> Task :assemble

> Task :compileTestJava FAILED
/Users/bhegyi/Developer/Coding/gradles/gradle-feature-2/platforms/jvm/plugins-java/build/tmp/teŝt files/JavaProject.Test/testCompila.uild/zqhpt/src/test/java/org/gradle/broken.java:1: error: reached end of file while parsing
broken
^
1 error
[Incubating] Problems report is available at: file:///Users/bhegyi/Developer/Coding/gradles/gradle-feature-2/platforms/jvm/plugins-java/build/tmp/te%C5%9Dt%20files/JavaProject.Test/testCompila.uild/zqhpt/build/reports/problems/problems-report.html

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileTestJava'.
> Compilation failed; see the compiler output below.
  /Users/bhegyi/Developer/Coding/gradles/gradle-feature-2/platforms/jvm/plugins-java/build/tmp/teŝt files/JavaProject.Test/testCompila.uild/zqhpt/src/test/java/org/gradle/broken.java:1: error: reached end of file while parsing
  broken
  ^
  1 error

* Try:
> Check you code and dependencies to fix the compilation error(s)
> Run with --scan to get full insights.
```

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
