### PR TITLE
Fix Exec tasks not inheriting environment variables with CC (PAPI style)

### DIFF
--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/sources/process/ProviderCompatibleExecSpecTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/sources/process/ProviderCompatibleExecSpecTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.provider.sources.process
 
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.process.internal.DefaultExecSpec
+import org.gradle.util.TestUtil
 
 class ProviderCompatibleExecSpecTest extends ProviderCompatibleBaseExecSpecTestBase {
     def "spec sets commandLine on parameters"() {
@@ -35,6 +36,6 @@ class ProviderCompatibleExecSpecTest extends ProviderCompatibleBaseExecSpecTestB
 
     @Override
     protected ProviderCompatibleExecSpec createSpecUnderTest() {
-        return new ProviderCompatibleExecSpec(new DefaultExecSpec(TestFiles.pathToFileResolver(tmpDir.testDirectory)))
+        return new ProviderCompatibleExecSpec(new DefaultExecSpec(TestUtil.objectFactory(), TestFiles.pathToFileResolver(tmpDir.testDirectory)))
     }
 }

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/jvm/Jvm.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/jvm/Jvm.java
@@ -368,9 +368,9 @@ public class Jvm implements JavaInfo {
         return Optional.absent();
     }
 
-    public static Map<String, ?> getInheritableEnvironmentVariables(Map<String, ?> envVars) {
-        Map<String, Object> vars = new HashMap<String, Object>();
-        for (Map.Entry<String, ?> entry : envVars.entrySet()) {
+    public static Map<String, String> getInheritableEnvironmentVariables(Map<String, String> envVars) {
+        Map<String, String> vars = new HashMap<String, String>();
+        for (Map.Entry<String, String> entry : envVars.entrySet()) {
             // The following are known variables that can change between builds and should not be inherited
             if (APP_NAME_REGEX.matcher(entry.getKey()).matches()
                 || JAVA_MAIN_CLASS_REGEX.matcher(entry.getKey()).matches()

--- a/platforms/jvm/jvm-services/src/integTest/groovy/org/gradle/internal/jvm/inspection/DefaultJvmMetadataDetectorIntegrationTest.groovy
+++ b/platforms/jvm/jvm-services/src/integTest/groovy/org/gradle/internal/jvm/inspection/DefaultJvmMetadataDetectorIntegrationTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.jvm.toolchain.internal.InstallationLocation
 import org.gradle.process.internal.DefaultExecHandleBuilder
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
+import org.gradle.util.TestUtil
 
 import java.util.concurrent.Executors
 
@@ -34,7 +35,7 @@ class DefaultJvmMetadataDetectorIntegrationTest extends AbstractIntegrationSpec 
     def "works on real installation"() {
         when:
         def detector = new DefaultJvmMetadataDetector(
-                () -> new DefaultExecHandleBuilder(TestFiles.pathToFileResolver(), Executors.newCachedThreadPool()),
+                () -> new DefaultExecHandleBuilder(TestUtil.objectFactory(), TestFiles.pathToFileResolver(), Executors.newCachedThreadPool()),
                 TestFiles.tmpDirTemporaryFileProvider(new File(SystemProperties.getInstance().getJavaIoTmpDir()))
         )
         Jvm jvm = AvailableJavaHomes.differentJdk //the detector has special handling for the current JVM

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
@@ -400,6 +400,7 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/30790")
+    @ToBeFixedForConfigurationCache(because = "https://github.com/gradle/gradle/issues/30790")
     def "#task task inherits environment variables of build process"() {
         given:
         def shellScript = ShellScript.builder()

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.TestResources
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.process.ShellScript
@@ -400,7 +399,6 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/30790")
-    @ToBeFixedForConfigurationCache(because = "https://github.com/gradle/gradle/issues/30790")
     def "#task task inherits environment variables of build process"() {
         given:
         def shellScript = ShellScript.builder()
@@ -440,7 +438,6 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/30790")
-    @ToBeFixedForConfigurationCache(because = "https://github.com/gradle/gradle/issues/30790")
     def "#task task can add to inherited environment variables"() {
         given:
         def shellScript = ShellScript.builder()

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/provider/views/MapPropertyMapView.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/provider/views/MapPropertyMapView.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.provider.views;
 
+import com.google.common.collect.ImmutableMap;
 import org.gradle.api.provider.MapProperty;
 
 import javax.annotation.Nullable;
@@ -71,7 +72,10 @@ public class MapPropertyMapView<K, V> extends AbstractMap<K, V> {
 
     @Override
     public void putAll(Map<? extends K, ? extends V> m) {
-        delegate.putAll(m);
+        // Map.putAll only copies the values from the argument.
+        // MapProperty.putAll captures the argument reference, so we need a defensive copy to get the old behavior.
+        // ImmutableMap is null-hostile, but so is the MapProperty.
+        delegate.putAll(ImmutableMap.copyOf(m));
     }
 
     @Override

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/provider/views/NullReplacingMapView.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/provider/views/NullReplacingMapView.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.views;
+
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ForwardingMap;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Maps;
+
+import javax.annotation.Nullable;
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * An adapter for a {@code Map<K, Object>} instance that doesn't permit {@code null} values.
+ *
+ * @param <K> the type of key
+ */
+public class NullReplacingMapView<K> extends ForwardingMap<K, Object> {
+    private static class NullSentinel {
+        private static final NullSentinel INSTANCE = new NullSentinel();
+    }
+
+    private static Object toDelegate(@Nullable Object value) {
+        return value == null ? NullSentinel.INSTANCE : value;
+    }
+
+    private static @Nullable Object fromDelegate(@Nullable Object value) {
+        return value == NullSentinel.INSTANCE ? null : value;
+    }
+
+    private final Map<K, Object> delegate;
+
+    public NullReplacingMapView(Map<K, Object> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    protected Map<K, Object> delegate() {
+        return delegate;
+    }
+
+    @Override
+    @Nullable
+    public Object get(@Nullable Object key) {
+        return fromDelegate(delegate.get(key));
+    }
+
+    @Override
+    @Nullable
+    public Object getOrDefault(Object key, Object defaultValue) {
+        Object delegateValue = delegate.get(key);
+        if (delegateValue == null) {
+            return defaultValue;
+        }
+        return fromDelegate(delegateValue);
+    }
+
+    @Nullable
+    @Override
+    public Object remove(@Nullable Object key) {
+        return fromDelegate(delegate.remove(toDelegate(key)));
+    }
+
+    @Override
+    public boolean containsValue(@Nullable Object value) {
+        return delegate.containsValue(toDelegate(value));
+    }
+
+    @Override
+    public Collection<Object> values() {
+        return Collections2.transform(delegate.values(), NullReplacingMapView::fromDelegate);
+    }
+
+    @Override
+    @Nullable
+    public Object put(K key, @Nullable Object value) {
+        return fromDelegate(delegate.put(key, toDelegate(value)));
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ?> map) {
+        delegate.putAll(Maps.transformValues(map, NullReplacingMapView::toDelegate));
+    }
+
+    @Override
+    public Set<Map.Entry<K, Object>> entrySet() {
+        return new EntrySet();
+    }
+
+    private class EntrySet extends AbstractSet<Map.Entry<K, Object>> {
+        @Override
+        public Iterator<Map.Entry<K, Object>> iterator() {
+            return Iterators.transform(delegate.entrySet().iterator(), Entry::new);
+        }
+
+        @Override
+        public int size() {
+            return NullReplacingMapView.this.size();
+        }
+    }
+
+    private static class Entry<K> implements Map.Entry<K, Object> {
+        private final Map.Entry<K, Object> delegateEntry;
+
+        private Entry(Map.Entry<K, Object> delegateEntry) {
+            this.delegateEntry = delegateEntry;
+        }
+
+        @Override
+        public K getKey() {
+            return delegateEntry.getKey();
+        }
+
+        @Override
+        @Nullable
+        public Object getValue() {
+            return fromDelegate(delegateEntry.getValue());
+        }
+
+        @Override
+        @Nullable
+        public Object setValue(@Nullable Object value) {
+            return fromDelegate(delegateEntry.setValue(toDelegate(value)));
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o instanceof Map.Entry<?, ?>) {
+                Map.Entry<?, ?> entry = (Map.Entry<?, ?>) o;
+                return Objects.equals(getKey(), entry.getKey()) && Objects.equals(getValue(), entry.getValue());
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return delegateEntry.hashCode();
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/process/internal/AbstractExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/AbstractExecHandleBuilder.java
@@ -16,6 +16,7 @@
 package org.gradle.process.internal;
 
 import org.apache.commons.lang.StringUtils;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.process.BaseExecSpec;
@@ -44,8 +45,8 @@ public abstract class AbstractExecHandleBuilder extends DefaultProcessForkOption
     protected boolean daemon;
     private final Executor executor;
 
-    AbstractExecHandleBuilder(PathToFileResolver fileResolver, Executor executor, BuildCancellationToken buildCancellationToken) {
-        super(fileResolver);
+    AbstractExecHandleBuilder(ObjectFactory objectFactory, PathToFileResolver fileResolver, Executor executor, BuildCancellationToken buildCancellationToken) {
+        super(objectFactory, fileResolver);
         this.buildCancellationToken = buildCancellationToken;
         this.executor = executor;
         streamsSpec.setStandardOutput(SafeStreams.systemOut());

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecAction.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecAction.java
@@ -16,6 +16,7 @@
 
 package org.gradle.process.internal;
 
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.process.ExecResult;
@@ -26,8 +27,8 @@ import java.util.concurrent.Executor;
  * Use {@link ExecActionFactory} (for core code) or {@link org.gradle.process.ExecOperations} (for plugin code) instead.
  */
 public class DefaultExecAction extends DefaultExecHandleBuilder implements ExecAction {
-    public DefaultExecAction(PathToFileResolver fileResolver, Executor executor, BuildCancellationToken buildCancellationToken) {
-        super(fileResolver, executor, buildCancellationToken);
+    public DefaultExecAction(ObjectFactory objectFactory, PathToFileResolver fileResolver, Executor executor, BuildCancellationToken buildCancellationToken) {
+        super(objectFactory, fileResolver, executor, buildCancellationToken);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
@@ -140,7 +140,7 @@ public abstract class DefaultExecActionFactory implements ExecFactory {
 
     @Override
     public ExecAction newExecAction() {
-        return new DefaultExecAction(fileResolver, executor, buildCancellationToken);
+        return new DefaultExecAction(objectFactory, fileResolver, executor, buildCancellationToken);
     }
 
     @Override
@@ -150,7 +150,7 @@ public abstract class DefaultExecActionFactory implements ExecFactory {
 
     @Override
     public JavaForkOptionsInternal newJavaForkOptions() {
-        final DefaultJavaForkOptions forkOptions = objectFactory.newInstance(DefaultJavaForkOptions.class, fileResolver, fileCollectionFactory, new DefaultJavaDebugOptions(objectFactory));
+        final DefaultJavaForkOptions forkOptions = objectFactory.newInstance(DefaultJavaForkOptions.class, objectFactory, fileResolver, fileCollectionFactory, new DefaultJavaDebugOptions(objectFactory));
         if (forkOptions.getExecutable() == null) {
             forkOptions.setExecutable(Jvm.current().getJavaExecutable());
         }
@@ -164,7 +164,7 @@ public abstract class DefaultExecActionFactory implements ExecFactory {
         // NOTE: We do not want/need a decorated version of JavaForkOptions or JavaDebugOptions because
         // these immutable instances are held across builds and will retain classloaders/services in the decorated object
         DefaultFileCollectionFactory fileCollectionFactory = new DefaultFileCollectionFactory(fileResolver, DefaultTaskDependencyFactory.withNoAssociatedProject(), new DefaultDirectoryFileTreeFactory(), nonCachingPatternSetFactory, PropertyHost.NO_OP, FileSystems.getDefault());
-        JavaForkOptionsInternal copy = objectFactory.newInstance(DefaultJavaForkOptions.class, fileResolver, fileCollectionFactory, new DefaultJavaDebugOptions(objectFactory));
+        JavaForkOptionsInternal copy = objectFactory.newInstance(DefaultJavaForkOptions.class, objectFactory, fileResolver, fileCollectionFactory, new DefaultJavaDebugOptions(objectFactory));
         options.copyTo(copy);
         return new ImmutableJavaForkOptions(copy);
     }
@@ -180,7 +180,7 @@ public abstract class DefaultExecActionFactory implements ExecFactory {
 
     @Override
     public ExecHandleBuilder newExec() {
-        return new DefaultExecHandleBuilder(fileResolver, executor, buildCancellationToken);
+        return new DefaultExecHandleBuilder(objectFactory, fileResolver, executor, buildCancellationToken);
     }
 
     @Override
@@ -336,7 +336,7 @@ public abstract class DefaultExecActionFactory implements ExecFactory {
 
         @Override
         public ExecAction newDecoratedExecAction() {
-            DefaultExecAction execAction = instantiator.newInstance(DefaultExecAction.class, fileResolver, executor, buildCancellationToken);
+            DefaultExecAction execAction = instantiator.newInstance(DefaultExecAction.class, objectFactory, fileResolver, executor, buildCancellationToken);
             ExecHandleListener listener = getExecHandleListener();
             if (listener != null) {
                 execAction.listener(listener);
@@ -369,7 +369,7 @@ public abstract class DefaultExecActionFactory implements ExecFactory {
         @Override
         public JavaForkOptionsInternal newDecoratedJavaForkOptions() {
             JavaDebugOptions javaDebugOptions = objectFactory.newInstance(DefaultJavaDebugOptions.class, objectFactory);
-            final DefaultJavaForkOptions forkOptions = instantiator.newInstance(DefaultJavaForkOptions.class, fileResolver, fileCollectionFactory, javaDebugOptions);
+            final DefaultJavaForkOptions forkOptions = instantiator.newInstance(DefaultJavaForkOptions.class, objectFactory, fileResolver, fileCollectionFactory, javaDebugOptions);
             forkOptions.setExecutable(Jvm.current().getJavaExecutable());
             return forkOptions;
         }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandleBuilder.java
@@ -16,6 +16,7 @@
 
 package org.gradle.process.internal;
 
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.initialization.DefaultBuildCancellationToken;
 import org.gradle.internal.file.PathToFileResolver;
@@ -33,12 +34,12 @@ public class DefaultExecHandleBuilder extends AbstractExecHandleBuilder implemen
 
     private final ProcessArgumentsSpec argumentsSpec = new ProcessArgumentsSpec(this);
 
-    public DefaultExecHandleBuilder(PathToFileResolver fileResolver, Executor executor) {
-        this(fileResolver, executor, new DefaultBuildCancellationToken());
+    public DefaultExecHandleBuilder(ObjectFactory objectFactory, PathToFileResolver fileResolver, Executor executor) {
+        this(objectFactory, fileResolver, executor, new DefaultBuildCancellationToken());
     }
 
-    public DefaultExecHandleBuilder(PathToFileResolver fileResolver, Executor executor, BuildCancellationToken buildCancellationToken) {
-        super(fileResolver, executor, buildCancellationToken);
+    public DefaultExecHandleBuilder(ObjectFactory objectFactory, PathToFileResolver fileResolver, Executor executor, BuildCancellationToken buildCancellationToken) {
+        super(objectFactory, fileResolver, executor, buildCancellationToken);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecSpec.java
@@ -16,6 +16,7 @@
 
 package org.gradle.process.internal;
 
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.process.BaseExecSpec;
 import org.gradle.process.CommandLineArgumentProvider;
@@ -34,8 +35,8 @@ public class DefaultExecSpec extends DefaultProcessForkOptions implements ExecSp
     private final ProcessArgumentsSpec argumentsSpec = new ProcessArgumentsSpec(this);
 
     @Inject
-    public DefaultExecSpec(PathToFileResolver resolver) {
-        super(resolver);
+    public DefaultExecSpec(ObjectFactory objectFactory, PathToFileResolver resolver) {
+        super(objectFactory, resolver);
     }
 
     public void copyTo(ExecSpec targetSpec) {

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaExecSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaExecSpec.java
@@ -57,7 +57,7 @@ public class DefaultJavaExecSpec extends DefaultJavaForkOptions implements JavaE
         PathToFileResolver resolver,
         FileCollectionFactory fileCollectionFactory
     ) {
-        super(resolver, fileCollectionFactory, objectFactory.newInstance(DefaultJavaDebugOptions.class));
+        super(objectFactory, resolver, fileCollectionFactory, objectFactory.newInstance(DefaultJavaDebugOptions.class));
         this.jvmArguments = objectFactory.listProperty(String.class);
         this.mainClass = objectFactory.property(String.class);
         this.mainModule = objectFactory.property(String.class);

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
@@ -19,6 +19,7 @@ package org.gradle.process.internal;
 import org.gradle.api.Action;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.internal.lambdas.SerializableLambdas;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.jvm.Jvm;
@@ -38,7 +39,7 @@ public class DefaultJavaForkOptions extends DefaultProcessForkOptions implements
 
     @Inject
     public DefaultJavaForkOptions(ObjectFactory objectFactory, PathToFileResolver resolver, FileCollectionFactory fileCollectionFactory, JavaDebugOptions debugOptions) {
-        super(objectFactory, resolver);
+        super(objectFactory, resolver, CURRENT_ENVIRONMENT.map(SerializableLambdas.transformer(Jvm::getInheritableEnvironmentVariables)));
         options = new JvmOptions(fileCollectionFactory, debugOptions);
     }
 
@@ -202,12 +203,6 @@ public class DefaultJavaForkOptions extends DefaultProcessForkOptions implements
     @Override
     public void debugOptions(Action<JavaDebugOptions> action) {
         action.execute(options.getDebugOptions());
-    }
-
-    @Override
-    protected Map<String, ?> getInheritableEnvironment() {
-        // Filter out any environment variables that should not be inherited.
-        return Jvm.getInheritableEnvironmentVariables(super.getInheritableEnvironment());
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
@@ -19,6 +19,7 @@ package org.gradle.process.internal;
 import org.gradle.api.Action;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.process.CommandLineArgumentProvider;
@@ -36,8 +37,8 @@ public class DefaultJavaForkOptions extends DefaultProcessForkOptions implements
     private List<CommandLineArgumentProvider> jvmArgumentProviders;
 
     @Inject
-    public DefaultJavaForkOptions(PathToFileResolver resolver, FileCollectionFactory fileCollectionFactory, JavaDebugOptions debugOptions) {
-        super(resolver);
+    public DefaultJavaForkOptions(ObjectFactory objectFactory, PathToFileResolver resolver, FileCollectionFactory fileCollectionFactory, JavaDebugOptions debugOptions) {
+        super(objectFactory, resolver);
         options = new JvmOptions(fileCollectionFactory, debugOptions);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
@@ -80,7 +80,7 @@ public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements 
         @Nullable JavaModuleDetector javaModuleDetector,
         JavaForkOptionsInternal javaOptions
     ) {
-        super(fileResolver, executor, buildCancellationToken);
+        super(objectFactory, fileResolver, executor, buildCancellationToken);
         this.fileCollectionFactory = fileCollectionFactory;
         this.temporaryFileProvider = temporaryFileProvider;
         this.javaModuleDetector = javaModuleDetector;

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.process.JavaForkOptions
 import org.gradle.process.internal.DefaultJavaDebugOptions
 import org.gradle.process.internal.DefaultJavaForkOptions
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.TestUtil
 import org.gradle.util.UsesNativeServices
 import org.junit.Rule
 import spock.lang.Specification
@@ -43,8 +44,12 @@ class DefaultJavaForkOptionsTest extends Specification {
     private final fileCollectionFactory = TestFiles.fileCollectionFactory(tmpDir.testDirectory)
     private DefaultJavaForkOptions options
 
+    private DefaultJavaForkOptions createJavaForkOptions() {
+        new DefaultJavaForkOptions(TestUtil.objectFactory(), resolver, fileCollectionFactory, new DefaultJavaDebugOptions())
+    }
+
     def setup() {
-        options = new DefaultJavaForkOptions(resolver, fileCollectionFactory, new DefaultJavaDebugOptions())
+        options = createJavaForkOptions()
     }
 
     def "provides correct default values"() {
@@ -330,7 +335,6 @@ class DefaultJavaForkOptionsTest extends Specification {
         def files = ['file1.jar', 'file2.jar'].collect { new File(it).canonicalFile }
 
         when:
-        options = new DefaultJavaForkOptions(resolver, fileCollectionFactory, new DefaultJavaDebugOptions())
         options.bootstrapClasspath(files[0])
         options.bootstrapClasspath(files[1])
 
@@ -341,7 +345,6 @@ class DefaultJavaForkOptionsTest extends Specification {
     def "allJvmArgs includes bootstrapClasspath"() {
         when:
         def files = ['file1.jar', 'file2.jar'].collect { new File(it).canonicalFile }
-        options = new DefaultJavaForkOptions(resolver, fileCollectionFactory, new DefaultJavaDebugOptions())
         options.bootstrapClasspath(files)
 
         then:
@@ -352,7 +355,6 @@ class DefaultJavaForkOptionsTest extends Specification {
         def files = ['file1.jar', 'file2.jar'].collect { new File(it).canonicalFile }
 
         when:
-        options = new DefaultJavaForkOptions(resolver, fileCollectionFactory, new DefaultJavaDebugOptions())
         options.bootstrapClasspath(files[0])
         options.allJvmArgs = ['-Xbootclasspath:' + files[1]]
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultProcessForkOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultProcessForkOptionsTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.util
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.process.ProcessForkOptions
 import org.gradle.process.internal.DefaultProcessForkOptions
+import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 class DefaultProcessForkOptionsTest extends Specification {
@@ -25,7 +26,7 @@ class DefaultProcessForkOptionsTest extends Specification {
     def resolver = Mock(FileResolver.class) {
         resolve(".") >> baseDir
     }
-    def options = new DefaultProcessForkOptions(resolver)
+    def options = new DefaultProcessForkOptions(TestUtil.objectFactory(), resolver)
 
     def defaultValues() {
         expect:

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/DefaultExecHandleBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/DefaultExecHandleBuilderTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.process.internal
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.process.internal.streams.EmptyStdInStreamsHandler
 import org.gradle.process.internal.streams.ForwardStdinStreamsHandler
+import org.gradle.util.TestUtil
 import org.gradle.util.UsesNativeServices
 import spock.lang.Specification
 
@@ -26,7 +27,7 @@ import java.util.concurrent.Executor
 
 @UsesNativeServices
 class DefaultExecHandleBuilderTest extends Specification {
-    private final DefaultExecHandleBuilder builder = new DefaultExecHandleBuilder(TestFiles.pathToFileResolver(), Mock(Executor))
+    private final DefaultExecHandleBuilder builder = new DefaultExecHandleBuilder(TestUtil.objectFactory(), TestFiles.pathToFileResolver(), Mock(Executor))
 
     def defaultsToEmptyStandardInput() {
         expect:

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/DefaultExecHandleSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/DefaultExecHandleSpec.groovy
@@ -23,6 +23,7 @@ import org.gradle.internal.jvm.Jvm
 import org.gradle.process.ExecResult
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.TestUtil
 import org.gradle.util.internal.GUtil
 import org.gradle.util.UsesNativeServices
 import org.junit.Rule
@@ -448,7 +449,7 @@ class DefaultExecHandleSpec extends ConcurrentSpec {
     }
 
     private DefaultExecHandleBuilder handle() {
-        new DefaultExecHandleBuilder(TestFiles.pathToFileResolver(), executor, buildCancellationToken)
+        new DefaultExecHandleBuilder(TestUtil.objectFactory(), TestFiles.pathToFileResolver(), executor, buildCancellationToken)
             .executable(Jvm.current().getJavaExecutable().getAbsolutePath())
             .setTimeout(20000) //sanity timeout
             .workingDir(tmpDir.getTestDirectory())

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/process/TestJavaMain2.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/process/TestJavaMain2.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.process;
+
+import java.io.File;
+import java.net.URISyntaxException;
+
+/**
+ * An executable Java class that can be used standalone to verify javaexec routines.
+ * It just runs its arguments as a command, so it can be used to bridge {@link JavaExecSpec} and {@link ShellScript}.
+ */
+public class TestJavaMain2 {
+    // TODO(mlopatkin) Consider replacing TestJavaMain with this class + ShellScript
+    public static String getClassLocation() {
+        try {
+            return new File(TestJavaMain.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getAbsolutePath();
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        Process p = new ProcessBuilder(args)
+            .inheritIO()
+            .directory(null)
+            .start();
+        System.exit(p.waitFor());
+    }
+}

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
@@ -30,6 +30,7 @@ import org.gradle.test.fixtures.file.TestDirectoryProvider;
 import org.gradle.test.fixtures.file.TestFile;
 import org.gradle.testfixtures.internal.NativeServicesTestFixture;
 import org.gradle.util.GradleVersion;
+import org.gradle.util.TestUtil;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -195,7 +196,7 @@ public class NoDaemonGradleExecuter extends AbstractGradleExecuter {
                 }
 
                 NativeServicesTestFixture.initialize();
-                DefaultExecHandleBuilder builder = new DefaultExecHandleBuilder(TestFiles.pathToFileResolver(), Executors.newCachedThreadPool()) {
+                DefaultExecHandleBuilder builder = new DefaultExecHandleBuilder(TestUtil.objectFactory(), TestFiles.pathToFileResolver(), Executors.newCachedThreadPool()) {
                     @Override
                     public File getWorkingDir() {
                         // Override this, so that the working directory is not canonicalised. Some int tests require that


### PR DESCRIPTION
Fixes #30790.

The original issue is simple: with CC we serialize the state of an exec/javaexec task, that includes `DefaultProcessForkOptions` (directly or as a subclass). A first modification of the environment variables causes `DPFO` to take a snapshot of the current environment variables of the build process, apply the modification to the snapshot and store the combined result. CC happily serializes the snapshot, so the cached runs no longer inherit the variables from the build process.

This PR takes the Provider API future into account, and thus uses MapProperty with an initial value of a changing provider that supplies the current environment vars. This way incremental mutations are stored on top of the snapshot, so the CC can do the right thing and reapply them upon restoring the value. The public interface stays the same, though.

Another notable change is the nullable value support for the MapProperty when it is adapted to a `Map` implemented by a replacing adapter that stores a sentinel value.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
