### PR TITLE
Bump conventions plugin to 0.10.2

### DIFF
--- a/build-logic-settings/settings.gradle.kts
+++ b/build-logic-settings/settings.gradle.kts
@@ -23,7 +23,7 @@ dependencyResolutionManagement {
 
 plugins {
     id("com.gradle.develocity").version("3.18.1") // Run `java build-logic-settings/UpdateDevelocityPluginVersion.java <new-version>` to update
-    id("io.github.gradle.gradle-enterprise-conventions-plugin").version("0.10.1")
+    id("io.github.gradle.gradle-enterprise-conventions-plugin").version("0.10.2")
     id("org.gradle.toolchains.foojay-resolver-convention").version("0.8.0")
 }
 

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -871,9 +871,9 @@
             <pgp value="7186BBF993566D8C2F4F7ED7D945E643368FEF62"/>
          </artifact>
       </component>
-      <component group="io.github.gradle" name="gradle-enterprise-conventions-plugin" version="0.10.1">
-         <artifact name="gradle-enterprise-conventions-plugin-0.10.1.jar">
-            <sha256 value="69487b9158b5ec4620a9adbd5cc63fdfd1b00ce482bfa595f0340594ae10e388" origin="Verified" reason="Artifact is not signed"/>
+      <component group="io.github.gradle" name="gradle-enterprise-conventions-plugin" version="0.10.2">
+         <artifact name="gradle-enterprise-conventions-plugin-0.10.2.jar">
+            <sha256 value="48d4b3bb8337998f191f2d2a5d7afbdeaed39dd248c7c2d2ab2fcdde76b365e9" origin="Verified" reason="Artifact is not signed"/>
          </artifact>
       </component>
       <component group="io.github.java-diff-utils" name="java-diff-utils" version="4.12">

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,7 +29,7 @@ pluginManagement {
 plugins {
     id("gradlebuild.build-environment")
     id("com.gradle.develocity").version("3.18.1") // Run `java build-logic-settings/UpdateDevelocityPluginVersion.java <new-version>` to update
-    id("io.github.gradle.gradle-enterprise-conventions-plugin").version("0.10.1")
+    id("io.github.gradle.gradle-enterprise-conventions-plugin").version("0.10.2")
     id("org.gradle.toolchains.foojay-resolver-convention").version ("0.8.0")
 }
 


### PR DESCRIPTION
To fix https://github.com/gradle/gradle-private/issues/4499
