### PR TITLE
Fix flaky `ConfigurationCacheTaskExecutionIntegrationTest`

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheTaskExecutionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheTaskExecutionIntegrationTest.groovy
@@ -312,7 +312,9 @@ class ConfigurationCacheTaskExecutionIntegrationTest extends AbstractConfigurati
 
             abstract class TaskReader extends DefaultTask {
                 @InputFile abstract RegularFileProperty getFile()
-                @TaskAction def action() {}
+                @TaskAction def action() {
+                    assert(file.get().asFile.text == "foo")
+                }
             }
 
             abstract class TaskWriter extends DefaultTask {
@@ -335,12 +337,9 @@ class ConfigurationCacheTaskExecutionIntegrationTest extends AbstractConfigurati
             }
         '''
 
-        when:
+        expect:
         2.times {
             configurationCacheRun 'clean', 'a'
         }
-
-        then:
-        file('build/output.txt').text == 'foo'
     }
 }


### PR DESCRIPTION
Move assertion to task since the constraint is mainly about `:clean` not running between `TaskReader` and `TaskWriter`. It could still run as the last task and delete the file before the original assertion in the test.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
