### PR TITLE
Reduce lock contention in shared caches

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/immutable/ImmutableAttributesSchemaFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/immutable/ImmutableAttributesSchemaFactory.java
@@ -108,7 +108,16 @@ public class ImmutableAttributesSchemaFactory {
      * @return The merged schema.
      */
     public ImmutableAttributesSchema concat(ImmutableAttributesSchema consumer, ImmutableAttributesSchema producer) {
-        return mergedSchemas.computeIfAbsent(new SchemaPair(consumer, producer), pair ->
+        SchemaPair key = new SchemaPair(consumer, producer);
+
+        // First attempt to fetch the value from the map without locking
+        ImmutableAttributesSchema merged = mergedSchemas.get(key);
+        if (merged != null) {
+            return merged;
+        }
+
+        // If it is not found, compute the value atomically
+        return mergedSchemas.computeIfAbsent(key, pair ->
             create(
                 mergeStrategies(consumer, producer),
                 mergePrecedence(consumer.precedence, producer.precedence)

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesFactory.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.attributes;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
@@ -26,16 +27,14 @@ import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.snapshot.impl.CoercingStringValueSnapshot;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicReference;
 
 @ServiceScope(Scope.BuildSession.class)
 public class DefaultAttributesFactory extends AbstractAttributesFactory {
     private final ImmutableAttributes root;
-    private final Map<ImmutableAttributes, List<DefaultImmutableAttributesContainer>> children;
+    private final Map<ImmutableAttributes, ImmutableList<DefaultImmutableAttributesContainer>> children;
     private final IsolatableFactory isolatableFactory;
     private final UsageCompatibilityHandler usageCompatibilityHandler;
     private final NamedObjectInstantiator instantiator;
@@ -96,31 +95,58 @@ public class DefaultAttributesFactory extends AbstractAttributesFactory {
 
     ImmutableAttributes doConcatIsolatable(ImmutableAttributes node, Attribute<?> key, Isolatable<?> value) {
 
-        // We use an atomic reference to capture the result, as we cannot return it from
-        // `compute`, which handles locking and concurrent access to the node child cache.
-        AtomicReference<ImmutableAttributes> result = new AtomicReference<>();
+        // Try to retrieve a cached value without locking
+        ImmutableList<DefaultImmutableAttributesContainer> cachedChildren = children.get(node);
+        if (cachedChildren != null) {
+            DefaultImmutableAttributesContainer child = findChild(cachedChildren, key, value);
+            if (child != null) {
+                return child;
+            }
+        }
 
-        children.compute(node, (k, nodeChildren) -> {
+        // If we didn't find a cached value, we need to lock and update the cache
+        cachedChildren = children.compute(node, (k, nodeChildren) -> {
             if (nodeChildren != null) {
-                // Find if someone already tried to concat this value to this node
-                for (DefaultImmutableAttributesContainer child : nodeChildren) {
-                    if (child.attribute.equals(key) && child.value.equals(value)) {
-                        result.set(child);
-                        return nodeChildren;
-                    }
+                // Check if the value is already present again, now that we have the lock.
+                DefaultImmutableAttributesContainer child = findChild(nodeChildren, key, value);
+                if (child != null) {
+                    // Somebody updated the cache before we could. Return the cache unchanged.
+                    return nodeChildren;
                 }
             } else {
-                nodeChildren = new ArrayList<>();
+                nodeChildren = ImmutableList.of();
             }
 
-            // Nobody has tried to concat this value yet
+            // Nobody has tried to concat this value yet.
+            // Calculate it and add it to the children.
             DefaultImmutableAttributesContainer child = new DefaultImmutableAttributesContainer((DefaultImmutableAttributesContainer) node, key, value);
-            nodeChildren.add(child);
-            result.set(child);
-            return nodeChildren;
+            return concatChild(nodeChildren, child);
         });
 
-        return result.get();
+        return Objects.requireNonNull(findChild(cachedChildren, key, value));
+    }
+
+    private static @Nullable DefaultImmutableAttributesContainer findChild(
+        ImmutableList<DefaultImmutableAttributesContainer> nodeChildren,
+        Attribute<?> key,
+        Isolatable<?> value
+    ) {
+        for (DefaultImmutableAttributesContainer child : nodeChildren) {
+            if (child.attribute.equals(key) && child.value.equals(value)) {
+                return child;
+            }
+        }
+        return null;
+    }
+
+    private static ImmutableList<DefaultImmutableAttributesContainer> concatChild(
+        ImmutableList<DefaultImmutableAttributesContainer> nodeChildren,
+        DefaultImmutableAttributesContainer child
+    ) {
+        return ImmutableList.<DefaultImmutableAttributesContainer>builderWithExpectedSize(nodeChildren.size() + 1)
+            .addAll(nodeChildren)
+            .add(child)
+            .build();
     }
 
     @Override


### PR DESCRIPTION
There are a number of caches that are shared across the build tree / build session. These caches are accessed by many threads at once across the build, especially if we are doing a lot of dependency resolution.
We previously relied on compute and computeIfAbsent only, however these methods rely on locking for atomicity.

Testing on large builds have shown this leads to lock contention and affects performance. We update the usages of these caches to insteaed first call 'get' on the caches to check for the value, and only if not present do we use compute and computeIfAbsent.

'get' generally should not perform any locking, unlock computeX, so in most cases after the value has been calculated for a given key, we should be able to avoid lock contention on these caches.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
