### PR TITLE
Deprecation warning for task.getProject() should not be conditional on STABLE_CONFIGURATION_CACHE

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -61,5 +61,5 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="11" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="17" project-jdk-type="JavaSDK" />
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -61,5 +61,5 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="17" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="11" project-jdk-type="JavaSDK" />
 </project>

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DeprecatedFeaturesListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DeprecatedFeaturesListener.kt
@@ -66,7 +66,7 @@ class DeprecatedFeaturesListener(
     }
 
     override fun onProjectAccess(invocationDescription: String, task: TaskInternal, runningTask: TaskInternal?) {
-        if (shouldNagFor(task, runningTask)) {
+        if (shouldNagFor(task, runningTask, ignoreStable = true)) {
             nagUserAbout("Invocation of $invocationDescription at execution time", 7, "task_project")
         }
     }
@@ -98,13 +98,13 @@ class DeprecatedFeaturesListener(
     }
 
     private
-    fun shouldNagFor(task: TaskInternal, runningTask: TaskInternal?) =
-        shouldNag() && shouldReportInContext(task, runningTask)
+    fun shouldNagFor(task: TaskInternal, runningTask: TaskInternal?, ignoreStable: Boolean = false) =
+        shouldNag(ignoreStable) && shouldReportInContext(task, runningTask)
 
     private
-    fun shouldNag(): Boolean =
+    fun shouldNag(ignoreStable: Boolean = false): Boolean =
         // TODO:configuration-cache - this listener shouldn't be registered when cc is enabled
-        !buildModelParameters.isConfigurationCache && featureFlags.isEnabled(STABLE_CONFIGURATION_CACHE)
+        !buildModelParameters.isConfigurationCache && (ignoreStable || featureFlags.isEnabled(STABLE_CONFIGURATION_CACHE))
 
     private
     fun shouldNagAbout(listener: Any): Boolean = shouldNag() && !isSupportedListener(listener)

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/ModelMapIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/ModelMapIntegrationTest.groovy
@@ -18,13 +18,14 @@ package org.gradle.model
 
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.language.base.FunctionalSourceSet
 import org.gradle.platform.base.ComponentSpec
 import spock.lang.Issue
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class ModelMapIntegrationTest extends AbstractIntegrationSpec {
+class ModelMapIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
     def "provides basic meta-data for map"() {
         when:
         buildFile '''
@@ -117,6 +118,7 @@ class ModelMapIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        expectTaskGetProjectDeprecations()
         fails "components"
         failure.assertHasCause("Cannot create an instance of type 'NonRegisteredComponent' as this type is not known. Known types: ${ComponentSpec.name}, SampleComponent.")
     }
@@ -142,6 +144,7 @@ class ModelMapIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        expectTaskGetProjectDeprecations()
         fails "model"
         failure.assertHasCause("Cannot create an instance of type 'NonRegisteredComponent' as this type is not known. Known types: ${ComponentSpec.name}, SampleComponent.")
     }
@@ -170,6 +173,7 @@ class ModelMapIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        expectTaskGetProjectDeprecations()
         fails "model"
         failure.assertHasCause("Cannot create an instance of type 'NonRegisteredComponent' as this type is not known. Known types: SampleComponent.")
     }
@@ -196,6 +200,7 @@ class ModelMapIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        expectTaskGetProjectDeprecations()
         fails "components"
         failure.assertHasCause("Cannot create an instance of type 'NonRegisteredComponent' as this type is not known. Known types: SampleComponent.")
     }
@@ -221,6 +226,7 @@ class ModelMapIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        expectTaskGetProjectDeprecations()
         fails "components"
         failure.assertHasCause("Cannot create 'components.other' with type 'SampleComponent' as this is not a subtype of 'Sample2Component'.")
     }
@@ -247,6 +253,7 @@ class ModelMapIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        expectTaskGetProjectDeprecations()
         succeeds "components"
     }
 
@@ -267,6 +274,7 @@ class ModelMapIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        expectTaskGetProjectDeprecations()
         fails "model"
         failureHasCause "Cannot create 'things.bad' with type '$FunctionalSourceSet.name' as this is not a subtype of 'Thing'."
     }
@@ -322,6 +330,7 @@ class ModelMapIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
         ModelReportOutput.from(output).hasNodeStructure {
             things {
@@ -350,6 +359,7 @@ class ModelMapIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        expectTaskGetProjectDeprecations()
         fails "model"
         failureHasCause "Exception thrown while executing model rule: things { ... } @ build.gradle line 12, column 17"
         failureHasCause "Cannot create 'things.thing' with type 'UnknownThing' as this is not a subtype of 'Thing'."

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/ModelMapIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/ModelMapIntegrationTest.groovy
@@ -18,14 +18,14 @@ package org.gradle.model
 
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.language.base.FunctionalSourceSet
 import org.gradle.platform.base.ComponentSpec
 import spock.lang.Issue
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class ModelMapIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class ModelMapIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
     def "provides basic meta-data for map"() {
         when:
         buildFile '''

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/RuleSourceAppliedByRuleMethodIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/RuleSourceAppliedByRuleMethodIntegrationTest.groovy
@@ -17,11 +17,12 @@
 package org.gradle.model
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.language.base.LanguageSourceSet
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class RuleSourceAppliedByRuleMethodIntegrationTest extends AbstractIntegrationSpec {
+class RuleSourceAppliedByRuleMethodIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
     def "@Rule method can apply rules to a particular target"() {
         buildFile << '''
             @Managed
@@ -422,6 +423,7 @@ class RuleSourceAppliedByRuleMethodIntegrationTest extends AbstractIntegrationSp
         '''
 
         expect:
+        expectTaskGetProjectDeprecations()
         fails("model")
         failure.assertHasCause("Exception thrown while executing model rule: MyPlugin#rules")
         failure.assertHasCause("broken")
@@ -456,6 +458,7 @@ class RuleSourceAppliedByRuleMethodIntegrationTest extends AbstractIntegrationSp
         '''
 
         expect:
+        expectTaskGetProjectDeprecations()
         fails 'model'
         failure.assertHasCause("Exception thrown while executing model rule: CalculateName#defaultName")
         failure.assertHasCause("broken")
@@ -489,6 +492,7 @@ class RuleSourceAppliedByRuleMethodIntegrationTest extends AbstractIntegrationSp
         '''
 
         expect:
+        expectTaskGetProjectDeprecations()
         fails 'model'
         failure.assertHasCause("Exception thrown while executing model rule: MyPlugin#rules")
         failure.assertHasCause("broken")
@@ -511,6 +515,7 @@ class RuleSourceAppliedByRuleMethodIntegrationTest extends AbstractIntegrationSp
 
         expect:
         succeeds("tasks")
+        expectTaskGetProjectDeprecations()
         fails("model")
     }
 
@@ -550,6 +555,7 @@ class RuleSourceAppliedByRuleMethodIntegrationTest extends AbstractIntegrationSp
         '''
 
         expect:
+        expectTaskGetProjectDeprecations()
         fails("model")
         failure.assertHasCause("Exception thrown while executing model rule: MyPlugin#rules")
         failure.assertHasCause('''Type BrokenRuleSource is not a valid rule source:
@@ -578,6 +584,7 @@ class RuleSourceAppliedByRuleMethodIntegrationTest extends AbstractIntegrationSp
         '''
 
         expect:
+        expectTaskGetProjectDeprecations()
         fails "model"
         failure.assertHasCause('''The following model rules could not be applied due to unbound inputs and/or subjects:
 

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/RuleSourceAppliedByRuleMethodIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/RuleSourceAppliedByRuleMethodIntegrationTest.groovy
@@ -17,12 +17,12 @@
 package org.gradle.model
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.language.base.LanguageSourceSet
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class RuleSourceAppliedByRuleMethodIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class RuleSourceAppliedByRuleMethodIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
     def "@Rule method can apply rules to a particular target"() {
         buildFile << '''
             @Managed

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/InvalidManagedModelRuleIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/InvalidManagedModelRuleIntegrationTest.groovy
@@ -17,10 +17,11 @@
 package org.gradle.model.managed
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class InvalidManagedModelRuleIntegrationTest extends AbstractIntegrationSpec {
+class InvalidManagedModelRuleIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
 
     def "provides a useful error message when setting an incompatible type on a managed instance in Groovy"() {
         when:
@@ -194,6 +195,7 @@ class InvalidManagedModelRuleIntegrationTest extends AbstractIntegrationSpec {
         '''
 
         then:
+        expectTaskGetProjectDeprecations()
         fails "model"
 
         and:

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/InvalidManagedModelRuleIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/InvalidManagedModelRuleIntegrationTest.groovy
@@ -17,11 +17,11 @@
 package org.gradle.model.managed
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class InvalidManagedModelRuleIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class InvalidManagedModelRuleIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
 
     def "provides a useful error message when setting an incompatible type on a managed instance in Groovy"() {
         when:

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedModelGroovyScalarConfigurationIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedModelGroovyScalarConfigurationIntegrationTest.groovy
@@ -17,12 +17,13 @@
 package org.gradle.model.managed
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 import static org.hamcrest.CoreMatchers.containsString
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class ManagedModelGroovyScalarConfigurationIntegrationTest extends AbstractIntegrationSpec {
+class ManagedModelGroovyScalarConfigurationIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
 
     private static final String CLASSES = '''
         enum Thing {
@@ -495,6 +496,7 @@ The following types/formats are supported:
         '''
 
         then:
+        expectTaskGetProjectDeprecations(5)
         succeeds 'printResolvedValues'
 
         and:
@@ -531,6 +533,7 @@ The following types/formats are supported:
         '''
 
         then:
+        expectTaskGetProjectDeprecations()
         fails 'model'
 
         and:
@@ -546,6 +549,7 @@ The following types/formats are supported:
         '''
 
         then:
+        expectTaskGetProjectDeprecations()
         fails 'model'
 
         and:
@@ -605,6 +609,7 @@ The following types/formats are supported:
         file('p2/build.gradle') << model
 
         then:
+        expectTaskGetProjectDeprecations(3)
         succeeds ':p1:printResolvedValues', ':p2:printResolvedValues'
 
         and:

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedModelGroovyScalarConfigurationIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedModelGroovyScalarConfigurationIntegrationTest.groovy
@@ -17,13 +17,13 @@
 package org.gradle.model.managed
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 import static org.hamcrest.CoreMatchers.containsString
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class ManagedModelGroovyScalarConfigurationIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class ManagedModelGroovyScalarConfigurationIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
 
     private static final String CLASSES = '''
         enum Thing {

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedScalarCollectionsIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedScalarCollectionsIntegrationTest.groovy
@@ -17,10 +17,11 @@
 package org.gradle.model.managed
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class ManagedScalarCollectionsIntegrationTest extends AbstractIntegrationSpec {
+class ManagedScalarCollectionsIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
 
     private final static List<String> MANAGED_SCALAR_COLLECTION_TYPES = ['List', 'Set']
 
@@ -358,6 +359,7 @@ class ManagedScalarCollectionsIntegrationTest extends AbstractIntegrationSpec {
         """
 
         then:
+        expectTaskGetProjectDeprecations()
         fails 'model'
 
         and:
@@ -389,6 +391,7 @@ A valid scalar collection takes the form of List<T> or Set<T> where 'T' is one o
         """
 
         then:
+        expectTaskGetProjectDeprecations()
         fails 'model'
 
         and:

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedScalarCollectionsIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedScalarCollectionsIntegrationTest.groovy
@@ -17,11 +17,11 @@
 package org.gradle.model.managed
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class ManagedScalarCollectionsIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class ManagedScalarCollectionsIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
 
     private final static List<String> MANAGED_SCALAR_COLLECTION_TYPES = ['List', 'Set']
 

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ScalarTypesInManagedModelIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ScalarTypesInManagedModelIntegrationTest.groovy
@@ -18,10 +18,11 @@ package org.gradle.model.managed
 
 import org.gradle.api.artifacts.Configuration
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
+class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
 
     def "values of primitive types and boxed primitive types are widened as usual when using groovy"() {
         when:
@@ -390,6 +391,7 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
         '''
 
         then:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
     }
 

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ScalarTypesInManagedModelIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ScalarTypesInManagedModelIntegrationTest.groovy
@@ -18,11 +18,11 @@ package org.gradle.model.managed
 
 import org.gradle.api.artifacts.Configuration
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
 
     def "values of primitive types and boxed primitive types are widened as usual when using groovy"() {
         when:

--- a/platforms/core-configuration/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ManagedTypeDslIntegrationTest.groovy
+++ b/platforms/core-configuration/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ManagedTypeDslIntegrationTest.groovy
@@ -17,10 +17,11 @@
 package org.gradle.model.dsl
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class ManagedTypeDslIntegrationTest extends AbstractIntegrationSpec {
+class ManagedTypeDslIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
 
     def "can configure a child of a managed type using a nested closure syntax"() {
         buildFile << '''
@@ -118,6 +119,7 @@ model {
 '''
 
         when:
+        expectTaskGetProjectDeprecations()
         fails "model"
 
         then:
@@ -144,6 +146,7 @@ model {
 '''
 
         when:
+        expectTaskGetProjectDeprecations()
         fails "model"
 
         then:
@@ -171,6 +174,7 @@ model {
 '''
 
         when:
+        expectTaskGetProjectDeprecations()
         fails "model"
 
         then:
@@ -197,6 +201,7 @@ model {
 '''
 
         when:
+        expectTaskGetProjectDeprecations()
         fails "model"
 
         then:

--- a/platforms/core-configuration/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ManagedTypeDslIntegrationTest.groovy
+++ b/platforms/core-configuration/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ManagedTypeDslIntegrationTest.groovy
@@ -17,11 +17,11 @@
 package org.gradle.model.dsl
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class ManagedTypeDslIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class ManagedTypeDslIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
 
     def "can configure a child of a managed type using a nested closure syntax"() {
         buildFile << '''

--- a/platforms/core-configuration/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ModelDslIntegrationTest.groovy
+++ b/platforms/core-configuration/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ModelDslIntegrationTest.groovy
@@ -247,8 +247,9 @@ class ModelDslIntegrationTest extends AbstractIntegrationSpec {
             model {
               tasks {
                 create("printStrings") {
+                  def projectName = it.project.name
                   doLast {
-                    println it.project.name + ": " + $.strings
+                    println projectName + ": " + $.strings
                   }
                 }
               }

--- a/platforms/core-configuration/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ModelMapDslIntegrationTest.groovy
+++ b/platforms/core-configuration/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ModelMapDslIntegrationTest.groovy
@@ -17,12 +17,13 @@
 package org.gradle.model.dsl
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class ModelMapDslIntegrationTest extends AbstractIntegrationSpec {
+class ModelMapDslIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
     def setup() {
         buildFile << '''
 @Managed
@@ -256,6 +257,7 @@ model {
 }
 '''
         expect:
+        expectTaskGetProjectDeprecations()
         fails "model"
         failure.assertHasLineNumber(18)
         failure.assertHasCause('Exception thrown while executing model rule: create(main) { ... } @ build.gradle line 17, column 9')
@@ -292,6 +294,7 @@ model {
 }
 '''
         expect:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
     }
 
@@ -310,6 +313,7 @@ model {
 }
 '''
         expect:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
     }
 
@@ -392,6 +396,7 @@ model {
 '''
 
         expect:
+        expectTaskGetProjectDeprecations()
         fails 'model'
         failure.assertHasCause('Exception thrown while executing model rule: main(Thing) { ... } @ build.gradle line 17, column 9')
         failure.assertHasCause('No such property: unknown for class: Thing')
@@ -410,6 +415,7 @@ model {
 '''
 
         expect:
+        expectTaskGetProjectDeprecations()
         fails 'model'
         failure.assertHasCause('Exception thrown while executing model rule: main { ... } @ build.gradle line 17, column 9')
         failure.assertHasCause('No such property: unknown for class: Thing')
@@ -428,6 +434,7 @@ model {
 '''
 
         expect:
+        expectTaskGetProjectDeprecations()
         fails 'model'
         failure.assertHasCause('Exception thrown while executing model rule: all { ... } @ build.gradle line 17, column 9')
         failure.assertHasCause('No such property: unknown for class: Thing')
@@ -446,6 +453,7 @@ model {
 '''
 
         expect:
+        expectTaskGetProjectDeprecations()
         fails 'model'
         failure.assertHasCause('Exception thrown while executing model rule: withType(Thing) { ... } @ build.gradle line 17, column 9')
         failure.assertHasCause('No such property: unknown for class: Thing')
@@ -464,6 +472,7 @@ model {
 '''
 
         expect:
+        expectTaskGetProjectDeprecations()
         fails 'model'
         failure.assertHasCause('Exception thrown while executing model rule: beforeEach(Thing) { ... } @ build.gradle line 17, column 9')
         failure.assertHasCause('No such property: unknown for class: Thing')
@@ -482,6 +491,7 @@ model {
 '''
 
         expect:
+        expectTaskGetProjectDeprecations()
         fails 'model'
         failure.assertHasCause('Exception thrown while executing model rule: afterEach(Thing) { ... } @ build.gradle line 17, column 9')
         failure.assertHasCause('No such property: unknown for class: Thing')

--- a/platforms/core-configuration/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ModelMapDslIntegrationTest.groovy
+++ b/platforms/core-configuration/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ModelMapDslIntegrationTest.groovy
@@ -17,13 +17,13 @@
 package org.gradle.model.dsl
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class ModelMapDslIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class ModelMapDslIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
     def setup() {
         buildFile << '''
 @Managed

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/configuration_cache.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/configuration_cache.adoc
@@ -258,7 +258,6 @@ When enabled, tasks using a <<build_services#build_services, shared build servic
 In addition, when the configuration cache is not enabled but the feature flag is present, deprecations for the following <<config_cache:requirements, configuration cache requirements>> are also enabled:
 
 * <<config_cache:requirements:build_listeners, Registering build listeners>>
-* <<config_cache:requirements:use_project_during_execution, Using the `Project` object at execution time>>
 * <<config_cache:requirements:task_extensions, Using task extensions and conventions at execution time>>
 
 It is recommended to enable it as soon as possible in order to be ready for when we remove the flag and make the linked features the default.

--- a/platforms/documentation/docs/src/snippets/customModel/internalViews/tests/softwareModelExtend-iv-model.sample.conf
+++ b/platforms/documentation/docs/src/snippets/customModel/internalViews/tests/softwareModelExtend-iv-model.sample.conf
@@ -3,5 +3,7 @@
 # end::cli[]
 executable: gradle
 args: model
-flags: --quiet
+# Ignore Task.project deprecations in deprecated model task
+# https://github.com/gradle/gradle/issues/30860
+flags: "--quiet --warning-mode=none"
 expected-output-file: softwareModelExtend-iv-model.out

--- a/platforms/documentation/docs/src/snippets/customModel/languageType/tests/softwareModelExtend-components.sample.conf
+++ b/platforms/documentation/docs/src/snippets/customModel/languageType/tests/softwareModelExtend-components.sample.conf
@@ -3,5 +3,7 @@
 # end::cli[]
 executable: gradle
 args: components
-flags: --quiet
+# Ignore Task.project deprecations in deprecated components task
+# https://github.com/gradle/gradle/issues/30860
+flags: "--quiet --warning-mode=none"
 expected-output-file: softwareModelExtend-components.out

--- a/platforms/documentation/docs/src/snippets/modelRules/basicRuleSourcePlugin/tests/basicRuleSourcePlugin-model-task.sample.conf
+++ b/platforms/documentation/docs/src/snippets/modelRules/basicRuleSourcePlugin/tests/basicRuleSourcePlugin-model-task.sample.conf
@@ -5,3 +5,6 @@ executable: gradle
 args: model
 expected-output-file: basicRuleSourcePlugin-model-task.out
 allow-additional-output: true
+# Ignore Task.project deprecations in deprecated model task
+# https://github.com/gradle/gradle/issues/30860
+flags: "--warning-mode=none"

--- a/platforms/documentation/docs/src/snippets/native-binaries/cpp/tests/nativeComponentReport.sample.conf
+++ b/platforms/documentation/docs/src/snippets/native-binaries/cpp/tests/nativeComponentReport.sample.conf
@@ -4,3 +4,7 @@
 executable: gradle
 args: components
 expected-output-file: nativeComponentReport.out
+# Ignore Task.project deprecations in deprecated components task
+# https://github.com/gradle/gradle/issues/30860
+flags: "--warning-mode=none"
+

--- a/platforms/documentation/docs/src/snippets/native-binaries/cunit/tests/assembleDependentComponentsReport.sample.conf
+++ b/platforms/documentation/docs/src/snippets/native-binaries/cunit/tests/assembleDependentComponentsReport.sample.conf
@@ -4,3 +4,6 @@
 executable: gradle
 args: "dependentComponents --component=operators"
 expected-output-file: assembleDependentComponentsReport.out
+# Ignore Task.project deprecations in deprecated dependentComponents task
+# https://github.com/gradle/gradle/issues/30860
+flags: "--warning-mode=none"

--- a/platforms/documentation/docs/src/snippets/native-binaries/cunit/tests/buildDependentComponentsReport.sample.conf
+++ b/platforms/documentation/docs/src/snippets/native-binaries/cunit/tests/buildDependentComponentsReport.sample.conf
@@ -4,3 +4,6 @@
 executable: gradle
 args: "dependentComponents --test-suites --component=operators"
 expected-output-file: buildDependentComponentsReport.out
+# Ignore Task.project deprecations in deprecated dependentComponents task
+# https://github.com/gradle/gradle/issues/30860
+flags: "--warning-mode=none"

--- a/platforms/documentation/docs/src/snippets/native-binaries/cunit/tests/dependentComponentsReport.sample.conf
+++ b/platforms/documentation/docs/src/snippets/native-binaries/cunit/tests/dependentComponentsReport.sample.conf
@@ -4,3 +4,6 @@
 executable: gradle
 args: dependentComponents
 expected-output-file: dependentComponentsReport.out
+# Ignore Task.project deprecations in deprecated dependentComponents task
+# https://github.com/gradle/gradle/issues/30860
+flags: "--warning-mode=none"

--- a/platforms/documentation/docs/src/snippets/native-binaries/cunit/tests/dependentComponentsReportAll.sample.conf
+++ b/platforms/documentation/docs/src/snippets/native-binaries/cunit/tests/dependentComponentsReportAll.sample.conf
@@ -4,3 +4,6 @@
 executable: gradle
 args: dependentComponents --all
 expected-output-file: dependentComponentsReportAll.out
+# Ignore Task.project deprecations in deprecated dependentComponents task
+# https://github.com/gradle/gradle/issues/30860
+flags: "--warning-mode=none"

--- a/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy
+++ b/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy
@@ -22,6 +22,7 @@ import org.custommonkey.xmlunit.Diff
 import org.custommonkey.xmlunit.ElementNameAndAttributeQualifier
 import org.custommonkey.xmlunit.XMLAssert
 import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.plugins.ide.AbstractIdeIntegrationTest
@@ -32,7 +33,7 @@ import org.junit.Test
 
 import java.util.regex.Pattern
 
-class IdeaIntegrationTest extends AbstractIdeIntegrationTest {
+class IdeaIntegrationTest extends AbstractIdeIntegrationTest implements CommonDeprecations {
     @Rule
     public final TestResources testResources = new TestResources(testDirectoryProvider)
 
@@ -74,7 +75,7 @@ class IdeaIntegrationTest extends AbstractIdeIntegrationTest {
         assertHasExpectedContents('root.iml')
         assertHasExpectedContents('api/api.iml')
         assertHasExpectedContents('webservice/webservice.iml')
-
+        expectTaskGetProjectDeprecations(3)
         executer.withTasks('cleanIdea').run()
     }
 

--- a/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy
+++ b/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy
@@ -22,7 +22,7 @@ import org.custommonkey.xmlunit.Diff
 import org.custommonkey.xmlunit.ElementNameAndAttributeQualifier
 import org.custommonkey.xmlunit.XMLAssert
 import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.plugins.ide.AbstractIdeIntegrationTest
@@ -33,7 +33,7 @@ import org.junit.Test
 
 import java.util.regex.Pattern
 
-class IdeaIntegrationTest extends AbstractIdeIntegrationTest implements CommonDeprecations {
+class IdeaIntegrationTest extends AbstractIdeIntegrationTest implements StableConfigurationCacheDeprecations {
     @Rule
     public final TestResources testResources = new TestResources(testDirectoryProvider)
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r112/BuildInvocationsCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r112/BuildInvocationsCrossVersionSpec.groovy
@@ -38,34 +38,39 @@ class BuildInvocationsCrossVersionSpec extends ToolingApiSpecification {
 
         file("b/build.gradle") << '''
             task t3 {
+                def projectName = project.name
                 doLast {
-                    println "t3 in $project.name"
+                    println "t3 in $projectName"
                 }
             }
             task t2 {
+                def projectName = project.name
                 doLast {
-                    println "t2 in $project.name"
+                    println "t2 in $projectName"
                 }
             }
         '''
 
         file("b/c/build.gradle") << '''
             task t1 {
+                def projectName = project.name
                 doLast {
-                    println "t1 in $project.name"
+                    println "t1 in $projectName"
                 }
             }
             task t2 {
+                def projectName = project.name
                 doLast {
-                    println "t2 in $project.name"
+                    println "t2 in $projectName"
                 }
             }
         '''
 
         buildFile << '''
             task t1 {
+                def projectName = project.name
                 doLast {
-                    println "t1 in $project.name"
+                    println "t1 in $projectName"
                 }
             }
         '''

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecWithExecutableJarIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecWithExecutableJarIntegrationTest.groovy
@@ -94,6 +94,9 @@ class JavaExecWithExecutableJarIntegrationTest extends AbstractIntegrationSpec {
                 "This is scheduled to be removed in Gradle 9.0. " +
                 "Use ExecOperations.javaexec(Action) or ProviderFactory.javaexec(Action) instead. " +
                 "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_project_exec")
+            executer.expectDocumentedDeprecationWarning("Invocation of Task.project at execution time has been deprecated. "+
+                "This will fail with an error in Gradle 9.0. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_project")
         }
         succeeds taskName
 
@@ -117,6 +120,9 @@ class JavaExecWithExecutableJarIntegrationTest extends AbstractIntegrationSpec {
                 "This is scheduled to be removed in Gradle 9.0. " +
                 "Use ExecOperations.javaexec(Action) or ProviderFactory.javaexec(Action) instead. " +
                 "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_project_exec")
+            executer.expectDocumentedDeprecationWarning("Invocation of Task.project at execution time has been deprecated. "+
+                "This will fail with an error in Gradle 9.0. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_project")
         }
         fails taskName
 

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecWithLongCommandLineIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecWithLongCommandLineIntegrationTest.groovy
@@ -95,6 +95,9 @@ class JavaExecWithLongCommandLineIntegrationTest extends AbstractIntegrationSpec
                 "This is scheduled to be removed in Gradle 9.0. " +
                 "Use ExecOperations.javaexec(Action) or ProviderFactory.javaexec(Action) instead. " +
                 "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_project_exec")
+            executer.expectDocumentedDeprecationWarning("Invocation of Task.project at execution time has been deprecated. "+
+                "This will fail with an error in Gradle 9.0. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_project")
         }
         fails taskName
 
@@ -121,6 +124,9 @@ class JavaExecWithLongCommandLineIntegrationTest extends AbstractIntegrationSpec
                 "This is scheduled to be removed in Gradle 9.0. " +
                 "Use ExecOperations.javaexec(Action) or ProviderFactory.javaexec(Action) instead. " +
                 "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_project_exec")
+            executer.expectDocumentedDeprecationWarning("Invocation of Task.project at execution time has been deprecated. "+
+                "This will fail with an error in Gradle 9.0. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_project")
         }
         fails taskName
 
@@ -149,6 +155,9 @@ class JavaExecWithLongCommandLineIntegrationTest extends AbstractIntegrationSpec
                 "This is scheduled to be removed in Gradle 9.0. " +
                 "Use ExecOperations.javaexec(Action) or ProviderFactory.javaexec(Action) instead. " +
                 "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_project_exec")
+            executer.expectDocumentedDeprecationWarning("Invocation of Task.project at execution time has been deprecated. "+
+                "This will fail with an error in Gradle 9.0. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_project")
         }
         fails taskName
 
@@ -182,6 +191,9 @@ class JavaExecWithLongCommandLineIntegrationTest extends AbstractIntegrationSpec
                 "This is scheduled to be removed in Gradle 9.0. " +
                 "Use ExecOperations.javaexec(Action) or ProviderFactory.javaexec(Action) instead. " +
                 "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_project_exec")
+            executer.expectDocumentedDeprecationWarning("Invocation of Task.project at execution time has been deprecated. "+
+                "This will fail with an error in Gradle 9.0. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_project")
         }
         succeeds taskName, "-i"
 

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
@@ -84,6 +84,7 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
         expect:
         if (task == 'javaexecProjectMethod') {
             expectExecMethodDeprecation("The Project.javaexec(Closure) method", "ExecOperations.javaexec(Action) or ProviderFactory.javaexec(Action)")
+            expectTaskProjectDeprecation()
         }
         succeeds task
 
@@ -142,6 +143,7 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
         expect:
         if (task == 'execProjectMethod') {
             expectExecMethodDeprecation("The Project.exec(Closure) method", "ExecOperations.exec(Action) or ProviderFactory.exec(Action)")
+            expectTaskProjectDeprecation()
         }
         succeeds task
 
@@ -385,8 +387,10 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
         expect:
         if (task == 'execProjectMethod') {
             expectExecMethodDeprecation("The Project.exec(Closure) method", "ExecOperations.exec(Action) or ProviderFactory.exec(Action)")
+            expectTaskProjectDeprecation()
         } else if (task == 'javaexecProjectMethod') {
             expectExecMethodDeprecation("The Project.javaexec(Closure) method", "ExecOperations.javaexec(Action) or ProviderFactory.javaexec(Action)")
+            expectTaskProjectDeprecation()
         }
         succeeds task
 
@@ -411,6 +415,9 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         expectExecMethodDeprecation(expectedDeprecatedMethod, replacements)
+        if (method.startsWith("project.")) {
+            expectTaskProjectDeprecation()
+        }
         succeeds("run")
 
         then:
@@ -519,6 +526,9 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         expectExecMethodDeprecation(expectedDeprecatedMethod, replacements)
+        if (method.startsWith("project.")) {
+            expectTaskProjectDeprecation()
+        }
         succeeds("run")
 
         then:
@@ -643,6 +653,7 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         expectExecMethodDeprecation(expectedDeprecatedMethod, replacements)
+        expectTaskProjectDeprecation()
         succeeds("run")
 
         then:
@@ -722,5 +733,11 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
             "This is scheduled to be removed in Gradle 9.0. " +
             "Use $replacements instead. " +
             "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_project_exec")
+    }
+
+    private void expectTaskProjectDeprecation() {
+        executer.expectDocumentedDeprecationWarning("Invocation of Task.project at execution time has been deprecated. "+
+            "This will fail with an error in Gradle 9.0. " +
+            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_project")
     }
 }

--- a/platforms/jvm/plugins-application/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
+++ b/platforms/jvm/plugins-application/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
@@ -26,13 +26,14 @@ import org.gradle.test.preconditions.UnitTestPreconditions
 import spock.lang.Issue
 
 class ApplicationPluginIntegrationTest extends WellBehavedPluginTest {
-    @Override
-    String getMainTask() {
-        return "installDist"
-    }
 
     def setup() {
         createSampleProjectSetup()
+    }
+
+    @Override
+    String getMainTask() {
+        return "installDist"
     }
 
     def "can generate start scripts with minimal user configuration"() {

--- a/platforms/jvm/plugins-application/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
+++ b/platforms/jvm/plugins-application/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
@@ -26,14 +26,13 @@ import org.gradle.test.preconditions.UnitTestPreconditions
 import spock.lang.Issue
 
 class ApplicationPluginIntegrationTest extends WellBehavedPluginTest {
-
-    def setup() {
-        createSampleProjectSetup()
-    }
-
     @Override
     String getMainTask() {
         return "installDist"
+    }
+
+    def setup() {
+        createSampleProjectSetup()
     }
 
     def "can generate start scripts with minimal user configuration"() {

--- a/platforms/jvm/plugins-groovy/src/crossVersionTest/groovy/org/gradle/integtests/StaticGroovyTaskSubclassingBinaryCompatibilityCrossVersionSpec.groovy
+++ b/platforms/jvm/plugins-groovy/src/crossVersionTest/groovy/org/gradle/integtests/StaticGroovyTaskSubclassingBinaryCompatibilityCrossVersionSpec.groovy
@@ -61,10 +61,14 @@ class StaticGroovyTaskSubclassingBinaryCompatibilityCrossVersionSpec extends Cro
             import org.gradle.api.tasks.TaskAction
 
             @CompileStatic
-            class SubclassTask extends DefaultTask {
-                @TaskAction
-                void doGet() {
+            abstract class SubclassTask extends DefaultTask {
+                SubclassTask() {
+                    // access at configuration time to be CC-compatible
                     project.file("file.txt")
+                }
+                @TaskAction
+                void doIt() {
+                    println("Done")
                 }
             }
         """

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerCppBuildExportIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerCppBuildExportIntegrationTest.groovy
@@ -16,12 +16,10 @@
 
 package org.gradle.swiftpm
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibraries
 import org.gradle.nativeplatform.fixtures.app.CppLib
 
 class SwiftPackageManagerCppBuildExportIntegrationTest extends AbstractSwiftPackageManagerExportIntegrationTest {
-    @ToBeFixedForConfigurationCache(because = "Task.getProject() during execution")
     def "produces manifest for single project C++ library that defines only the production targets"() {
         given:
         buildFile << """
@@ -68,7 +66,6 @@ let package = Package(
         swiftPmBuildSucceeds()
     }
 
-    @ToBeFixedForConfigurationCache(because = "Task.getProject() during execution")
     def "produces manifest for multi project C++ build"() {
         given:
         createDirs("lib1", "lib2")
@@ -150,7 +147,6 @@ let package = Package(
         swiftPmBuildSucceeds()
     }
 
-    @ToBeFixedForConfigurationCache(because = "Task.getProject() during execution")
     def "produces manifest for C++ library with shared and static linkage"() {
         given:
         buildFile << """
@@ -197,7 +193,6 @@ let package = Package(
         swiftPmBuildSucceeds()
     }
 
-    @ToBeFixedForConfigurationCache(because = "Task.getProject() during execution")
     def "honors customization of component basename"() {
         given:
         createDirs("lib1", "lib2")

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerExportIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerExportIntegrationTest.groovy
@@ -16,12 +16,10 @@
 
 package org.gradle.swiftpm
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.util.internal.VersionNumber
 
 class SwiftPackageManagerExportIntegrationTest extends AbstractSwiftPackageManagerExportIntegrationTest {
 
-    @ToBeFixedForConfigurationCache(because = "Task.getProject() during execution")
     def "produces manifest for build with no native components"() {
         given:
         createDirs("lib1", "lib2")
@@ -59,7 +57,6 @@ let package = Package(
         }
     }
 
-    @ToBeFixedForConfigurationCache(because = "Task.getProject() during execution")
     def "can configure the location of the generated manifest file"() {
         given:
         buildFile << """
@@ -78,7 +75,6 @@ let package = Package(
         file("Package.swift").assertDoesNotExist()
     }
 
-    @ToBeFixedForConfigurationCache(because = "Task.getProject() during execution")
     def "can exclude certain products from the generated file"() {
         given:
         createDirs("lib1", "lib2", "app")

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerIncrementalExportIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerIncrementalExportIntegrationTest.groovy
@@ -107,7 +107,6 @@ class SwiftPackageManagerIncrementalExportIntegrationTest extends AbstractSwiftP
         result.assertTaskSkipped(":generateSwiftPmManifest")
     }
 
-    @ToBeFixedForConfigurationCache
     def "regenerates manifest when Swift components added or removed"() {
         given:
         swiftBuild()
@@ -218,7 +217,6 @@ class SwiftPackageManagerIncrementalExportIntegrationTest extends AbstractSwiftP
         result.assertTaskSkipped(":generateSwiftPmManifest")
     }
 
-    @ToBeFixedForConfigurationCache
     def "ignores irrelevant changes to Swift source"() {
         given:
         swiftBuild()
@@ -238,7 +236,6 @@ class SwiftPackageManagerIncrementalExportIntegrationTest extends AbstractSwiftP
         result.assertTaskSkipped(":generateSwiftPmManifest")
     }
 
-    @ToBeFixedForConfigurationCache
     def "ignores irrelevant changes to Swift build"() {
         given:
         swiftBuild()
@@ -302,7 +299,6 @@ class SwiftPackageManagerIncrementalExportIntegrationTest extends AbstractSwiftP
         !file("Package.swift").text.contains('main.cpp')
     }
 
-    @ToBeFixedForConfigurationCache
     def "regenerates manifest when C++ components added or removed"() {
         given:
         swiftBuild()
@@ -351,7 +347,6 @@ class SwiftPackageManagerIncrementalExportIntegrationTest extends AbstractSwiftP
         result.assertTaskSkipped(":generateSwiftPmManifest")
     }
 
-    @ToBeFixedForConfigurationCache
     def "ignores irrelevant changes to C++ source"() {
         given:
         cppBuild()
@@ -374,7 +369,6 @@ class SwiftPackageManagerIncrementalExportIntegrationTest extends AbstractSwiftP
         result.assertTaskSkipped(":generateSwiftPmManifest")
     }
 
-    @ToBeFixedForConfigurationCache
     def "ignores irrelevant changes to C++ build"() {
         given:
         cppBuild()

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerSwiftBuildExportIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerSwiftBuildExportIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.swiftpm
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.SwiftAppWithLibraries
@@ -24,7 +23,6 @@ import org.gradle.nativeplatform.fixtures.app.SwiftLib
 
 class SwiftPackageManagerSwiftBuildExportIntegrationTest extends AbstractSwiftPackageManagerExportIntegrationTest {
 
-    @ToBeFixedForConfigurationCache(because = "Task.getProject() during execution")
     def "produces manifest for single project Swift library that defines only the production targets"() {
         given:
         buildFile << """
@@ -69,7 +67,6 @@ let package = Package(
         swiftPmBuildSucceeds()
     }
 
-    @ToBeFixedForConfigurationCache(because = "Task.getProject() during execution")
     def "produces manifest for multi-project Swift build"() {
         given:
         createDirs("hello", "log")
@@ -147,7 +144,6 @@ let package = Package(
         swiftPmBuildSucceeds()
     }
 
-    @ToBeFixedForConfigurationCache(because = "Task.getProject() during execution")
     def "produces manifest for Swift library with shared and static linkage"() {
         given:
         buildFile << """
@@ -196,7 +192,6 @@ let package = Package(
 
     // See https://github.com/gradle/gradle-native/issues/1007
     @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_4_OR_OLDER)
-    @ToBeFixedForConfigurationCache(because = "Task.getProject() during execution")
     def "produces manifest for Swift component with declared Swift language version"() {
         given:
         buildFile << """
@@ -241,7 +236,6 @@ let package = Package(
         swiftPmBuildSucceeds()
     }
 
-    @ToBeFixedForConfigurationCache(because = "Task.getProject() during execution")
     def "honors customizations to Swift module name"() {
         given:
         createDirs("lib1", "lib2")

--- a/platforms/native/language-native/src/main/java/org/gradle/swiftpm/tasks/GenerateSwiftPackageManagerManifest.java
+++ b/platforms/native/language-native/src/main/java/org/gradle/swiftpm/tasks/GenerateSwiftPackageManagerManifest.java
@@ -53,8 +53,10 @@ import java.util.TreeSet;
 public abstract class GenerateSwiftPackageManagerManifest extends DefaultTask {
     private final RegularFileProperty manifestFile;
     private final Property<Package> packageProperty;
+    private final String projectName;
 
     public GenerateSwiftPackageManagerManifest() {
+        projectName = getProject().getName();
         ObjectFactory objectFactory = getProject().getObjects();
         manifestFile = objectFactory.fileProperty();
         packageProperty = objectFactory.property(Package.class);
@@ -86,7 +88,7 @@ public abstract class GenerateSwiftPackageManagerManifest extends DefaultTask {
                 writer.println("import PackageDescription");
                 writer.println();
                 writer.println("let package = Package(");
-                writer.println("    name: \"" + getProject().getName() + "\",");
+                writer.println("    name: \"" + projectName + "\",");
                 writer.println("    products: [");
                 for (AbstractProduct product : srcPackage.getProducts()) {
                     if (product.isExecutable()) {

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeBinariesIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeBinariesIntegrationTest.groovy
@@ -362,6 +362,7 @@ int main (int argc, char *argv[]) {
             }
 """
         when:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
 
         then:

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeDependentComponentsReportIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeDependentComponentsReportIntegrationTest.groovy
@@ -17,11 +17,12 @@
 package org.gradle.nativeplatform
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
 
-class NativeDependentComponentsReportIntegrationTest extends AbstractIntegrationSpec {
+class NativeDependentComponentsReportIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
 
     def setup() {
         settingsFile << "rootProject.name = 'test'"
@@ -33,6 +34,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
         when:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations()
         run "dependentComponents"
 
         then:
@@ -47,6 +49,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
         when:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations()
         run 'dependentComponents', '--component', component
 
         then:
@@ -65,6 +68,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
         when:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations()
         fails 'dependentComponents', '--component', 'unknown'
 
         then:
@@ -77,6 +81,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
         when:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations()
         fails 'dependentComponents', '--test-suites', '--component', 'unknown', '--component', 'anonymous', '--component', 'whatever', '--component', 'lib', '--component', 'main', '--component', 'libTest'
 
         then:
@@ -89,6 +94,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
         when:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations()
         run 'dependentComponents', '--component', 'lib', '--component', 'main'
 
         then:
@@ -115,6 +121,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
         }
 
         when:
+        expectTaskGetProjectDeprecations()
         run 'dependentComponents'
 
         then:
@@ -149,6 +156,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
         '''.stripIndent()
 
         when:
+        expectTaskGetProjectDeprecations()
         run 'dependentComponents', option
 
         then:
@@ -193,6 +201,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
         when:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations()
         run 'dependentComponents'
 
         then:
@@ -207,6 +216,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
         when:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations()
         run 'libraries:dependentComponents', '--component', 'foo'
 
         then:
@@ -280,6 +290,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
         expect:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations()
         succeeds 'dependentComponents'
     }
 
@@ -289,6 +300,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
         when:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations()
         run 'dependentComponents'
 
         then:
@@ -303,6 +315,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
         buildFile simpleBuildWithTestSuites()
 
         when:
+        expectTaskGetProjectDeprecations()
         run 'dependentComponents', option
 
         then:
@@ -358,6 +371,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
         when:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations()
         fails 'dependentComponents'
 
         then:
@@ -393,6 +407,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
         when:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations()
         fails 'dependentComponents'
 
         then:
@@ -428,6 +443,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
         when:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations()
         fails 'api:dependentComponents'
 
         then:
@@ -467,6 +483,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
         when:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations()
         succeeds("dependentComponents")
 
         then:
@@ -500,6 +517,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
         when:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations()
         run 'dependentComponents'
 
         then:
@@ -513,6 +531,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
         when:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations()
         run 'dependentComponents', option
 
         then:
@@ -766,4 +785,5 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
             }
         '''.stripIndent()
     }
+
 }

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeDependentComponentsReportIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeDependentComponentsReportIntegrationTest.groovy
@@ -17,12 +17,12 @@
 package org.gradle.nativeplatform
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
 
-class NativeDependentComponentsReportIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class NativeDependentComponentsReportIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
 
     def setup() {
         settingsFile << "rootProject.name = 'test'"

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/PlatformNativeComponentReportIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/PlatformNativeComponentReportIntegrationTest.groovy
@@ -49,6 +49,7 @@ model {
 """
         when:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations(1)
         succeeds "components"
 
         then:
@@ -109,6 +110,7 @@ model {
 """
         when:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations(1)
         succeeds "components"
 
         then:
@@ -201,6 +203,7 @@ model {
 """
         when:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations(1)
         succeeds "components"
 
         then:

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/platform/BinaryNativePlatformIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/platform/BinaryNativePlatformIntegrationTest.groovy
@@ -411,6 +411,7 @@ model {
             }
         '''
         then:
+        expectTaskGetProjectDeprecations()
         succeeds 'components'
 
     }

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/sourceset/GeneratedSourcesIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/sourceset/GeneratedSourcesIntegrationTest.groovy
@@ -87,6 +87,7 @@ model {
 """
 
         then:
+        expectTaskGetProjectDeprecations()
         executableBuilt(app)
     }
 
@@ -121,6 +122,7 @@ model {
 """
 
         then:
+        expectTaskGetProjectDeprecations()
         executableBuilt(app)
     }
 
@@ -151,6 +153,7 @@ model {
 """
 
         then:
+        expectTaskGetProjectDeprecations()
         executableBuilt(app)
     }
 
@@ -185,6 +188,7 @@ model {
 """
 
         then:
+        expectTaskGetProjectDeprecations()
         executableBuilt(app)
     }
 
@@ -223,6 +227,7 @@ model {
 """
 
         then:
+        expectTaskGetProjectDeprecations()
         executableBuilt(app)
     }
 
@@ -255,6 +260,7 @@ model {
 """
 
         then:
+        expectTaskGetProjectDeprecations()
         executableBuilt(app)
     }
 
@@ -291,6 +297,7 @@ model {
 """
 
         then:
+        expectTaskGetProjectDeprecations()
         executableBuilt(app)
     }
 
@@ -326,6 +333,7 @@ model {
 """
 
         then:
+        expectTaskGetProjectDeprecations()
         executableBuilt(app)
     }
 
@@ -387,6 +395,7 @@ model {
 """
 
         then:
+        expectTaskGetProjectDeprecations()
         executableBuilt(app)
     }
 
@@ -421,6 +430,7 @@ lateConfiguredGenerator {
 """
 
         then:
+        expectTaskGetProjectDeprecations()
         executableBuilt(app)
     }
 
@@ -448,6 +458,7 @@ model {
 """
 
         when:
+        expectTaskGetProjectDeprecations()
         succeeds "visualStudio"
 
         then:

--- a/platforms/native/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
+++ b/platforms/native/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
@@ -18,6 +18,7 @@ package org.gradle.nativeplatform.fixtures
 
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.SourceFile
 import org.gradle.integtests.fixtures.compatibility.MultiVersionTestCategory
 import org.gradle.internal.os.OperatingSystem
@@ -31,7 +32,7 @@ import org.gradle.test.fixtures.file.TestFile
  */
 @NativeToolchainTest
 @MultiVersionTestCategory
-abstract class AbstractInstalledToolChainIntegrationSpec extends AbstractIntegrationSpec implements HostPlatform {
+abstract class AbstractInstalledToolChainIntegrationSpec extends AbstractIntegrationSpec implements HostPlatform, CommonDeprecations {
     static AvailableToolChains.InstalledToolChain toolChain
     File initScript
 

--- a/platforms/native/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
+++ b/platforms/native/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
@@ -18,7 +18,7 @@ package org.gradle.nativeplatform.fixtures
 
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.SourceFile
 import org.gradle.integtests.fixtures.compatibility.MultiVersionTestCategory
 import org.gradle.internal.os.OperatingSystem
@@ -32,7 +32,7 @@ import org.gradle.test.fixtures.file.TestFile
  */
 @NativeToolchainTest
 @MultiVersionTestCategory
-abstract class AbstractInstalledToolChainIntegrationSpec extends AbstractIntegrationSpec implements HostPlatform, CommonDeprecations {
+abstract class AbstractInstalledToolChainIntegrationSpec extends AbstractIntegrationSpec implements HostPlatform, StableConfigurationCacheDeprecations {
     static AvailableToolChains.InstalledToolChain toolChain
     File initScript
 

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cunit/CUnitComponentReportIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cunit/CUnitComponentReportIntegrationTest.groovy
@@ -74,6 +74,7 @@ model {
 """
         when:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations()
         succeeds "components"
 
         then:

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cunit/CUnitIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cunit/CUnitIntegrationTest.groovy
@@ -197,6 +197,7 @@ model {
 }
 """
         when:
+        expectTaskGetProjectDeprecations()
         run "model"
 
         then:

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cunit/CUnitSamplesIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cunit/CUnitSamplesIntegrationTest.groovy
@@ -45,6 +45,7 @@ class CUnitSamplesIntegrationTest extends AbstractInstalledToolChainIntegrationS
         sample cunit
 
         when:
+        expectTaskGetProjectDeprecations()
         succeeds "components"
 
         then:

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/googletest/TestingNativeComponentReportIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/googletest/TestingNativeComponentReportIntegrationTest.groovy
@@ -46,6 +46,7 @@ model {
 """
         when:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations()
         succeeds "components"
 
         then:

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/plugins/TestSuiteDefinitionIntegrationSpec.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/plugins/TestSuiteDefinitionIntegrationSpec.groovy
@@ -18,10 +18,11 @@ package org.gradle.nativeplatform.test.plugins
 
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class TestSuiteDefinitionIntegrationSpec extends AbstractIntegrationSpec {
+class TestSuiteDefinitionIntegrationSpec extends AbstractIntegrationSpec implements CommonDeprecations {
     def setup() {
         buildFile << """
 interface CustomTestSuite extends TestSuiteSpec {
@@ -86,6 +87,7 @@ model {
 """
 
         when:
+        expectTaskGetProjectDeprecations()
         run "model"
 
         then:
@@ -133,6 +135,7 @@ model {
 """
 
         when:
+        expectTaskGetProjectDeprecations()
         run "model"
 
         then:
@@ -191,6 +194,7 @@ model {
 """
 
         when:
+        expectTaskGetProjectDeprecations()
         run "model"
 
         then:

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/plugins/TestSuiteDefinitionIntegrationSpec.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/plugins/TestSuiteDefinitionIntegrationSpec.groovy
@@ -18,11 +18,11 @@ package org.gradle.nativeplatform.test.plugins
 
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class TestSuiteDefinitionIntegrationSpec extends AbstractIntegrationSpec implements CommonDeprecations {
+class TestSuiteDefinitionIntegrationSpec extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
     def setup() {
         buildFile << """
 interface CustomTestSuite extends TestSuiteSpec {

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/plugins/TestSuiteModelIntegrationSpec.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/plugins/TestSuiteModelIntegrationSpec.groovy
@@ -18,10 +18,11 @@ package org.gradle.nativeplatform.test.plugins
 
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class TestSuiteModelIntegrationSpec extends AbstractIntegrationSpec {
+class TestSuiteModelIntegrationSpec extends AbstractIntegrationSpec implements CommonDeprecations {
 
     def "setup"() {
         buildFile """
@@ -104,6 +105,7 @@ class TestSuiteModelIntegrationSpec extends AbstractIntegrationSpec {
 
     def "test suite sources and binaries containers are visible in model report"() {
         when:
+        expectTaskGetProjectDeprecations()
         run "model"
 
         then:
@@ -166,6 +168,7 @@ class TestSuiteModelIntegrationSpec extends AbstractIntegrationSpec {
         """
 
         when:
+        expectTaskGetProjectDeprecations()
         run "model"
 
         then:
@@ -259,6 +262,7 @@ class TestSuiteModelIntegrationSpec extends AbstractIntegrationSpec {
         '''
 
         when:
+        expectTaskGetProjectDeprecations()
         run "model"
 
         then:

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/plugins/TestSuiteModelIntegrationSpec.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/plugins/TestSuiteModelIntegrationSpec.groovy
@@ -18,11 +18,11 @@ package org.gradle.nativeplatform.test.plugins
 
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class TestSuiteModelIntegrationSpec extends AbstractIntegrationSpec implements CommonDeprecations {
+class TestSuiteModelIntegrationSpec extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
 
     def "setup"() {
         buildFile """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyHandlerExtensionAwareDSLSpec.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyHandlerExtensionAwareDSLSpec.groovy
@@ -17,9 +17,10 @@
 package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 
-class DependencyHandlerExtensionAwareDSLSpec extends AbstractIntegrationSpec {
+class DependencyHandlerExtensionAwareDSLSpec extends AbstractIntegrationSpec implements CommonDeprecations {
     @ToBeFixedForConfigurationCache(because = "task uses DependencyHandler API")
     def "can type-safely use DependencyHandler ExtensionAware with the Groovy DSL"() {
         buildFile << """
@@ -57,6 +58,7 @@ class DependencyHandlerExtensionAwareDSLSpec extends AbstractIntegrationSpec {
             }
         """
         expect:
+        expectTaskGetProjectDeprecations()
         succeeds("assertValue")
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyHandlerExtensionAwareDSLSpec.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyHandlerExtensionAwareDSLSpec.groovy
@@ -17,10 +17,10 @@
 package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 
-class DependencyHandlerExtensionAwareDSLSpec extends AbstractIntegrationSpec implements CommonDeprecations {
+class DependencyHandlerExtensionAwareDSLSpec extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
     @ToBeFixedForConfigurationCache(because = "task uses DependencyHandler API")
     def "can type-safely use DependencyHandler ExtensionAware with the Groovy DSL"() {
         buildFile << """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.integtests.resolve
 
 import groovy.test.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.integtests.fixtures.extensions.FluidDependenciesResolveTest
@@ -24,7 +25,7 @@ import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import spock.lang.Issue
 
 @FluidDependenciesResolveTest
-class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec {
+class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
     private ResolveTestFixture resolve = new ResolveTestFixture(buildFile, "compile")
 
     def setup() {
@@ -623,6 +624,7 @@ project('c') {
 """
 
         when:
+        expectTaskGetProjectDeprecations(3)
         fails("impl:check")
 
         then:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -17,7 +17,7 @@ package org.gradle.integtests.resolve
 
 import groovy.test.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.integtests.fixtures.extensions.FluidDependenciesResolveTest
@@ -25,7 +25,7 @@ import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import spock.lang.Issue
 
 @FluidDependenciesResolveTest
-class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
     private ResolveTestFixture resolve = new ResolveTestFixture(buildFile, "compile")
 
     def setup() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsafeConfigurationResolutionDeprecationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsafeConfigurationResolutionDeprecationIntegrationTest.groovy
@@ -17,10 +17,10 @@
 package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.spockframework.lang.Wildcard
 
 class UnsafeConfigurationResolutionDeprecationIntegrationTest extends AbstractDependencyResolutionTest {
-    @ToBeFixedForConfigurationCache(because = "Task.getProject() during execution")
     def "configuration in another project produces deprecation warning when resolved"() {
         mavenRepo.module("test", "test-jar", "1.0").publish()
 
@@ -32,8 +32,11 @@ class UnsafeConfigurationResolutionDeprecationIntegrationTest extends AbstractDe
 
         buildFile << """
             task resolve {
+                def otherProjectConfiguration = provider {
+                    project(':bar').configurations.bar
+                }
                 doLast {
-                    println project(':bar').configurations.bar.files
+                    println otherProjectConfiguration.get().files
                 }
             }
 
@@ -58,7 +61,25 @@ class UnsafeConfigurationResolutionDeprecationIntegrationTest extends AbstractDe
         succeeds(":resolve")
     }
 
-    @ToBeFixedForConfigurationCache(because = "uses Configuration API at runtime")
+    private String declareRunInAnotherThread() {
+        """
+        def runInAnotherThread = { toRun ->
+            def failure = null
+            def result = null
+            def thread = new Thread({
+                try {
+                    result = toRun.call()
+                } catch (Throwable t) {
+                    failure = t
+                }
+            })
+            thread.start()
+            thread.join()
+            return failure ?: result
+        }
+        """
+    }
+
     def "exception when non-gradle thread resolves dependency graph"() {
         mavenRepo.module("test", "test-jar", "1.0").publish()
 
@@ -79,19 +100,18 @@ class UnsafeConfigurationResolutionDeprecationIntegrationTest extends AbstractDe
                 bar "test:test-jar:1.0"
             }
 
+            ${declareRunInAnotherThread()}
+
             task resolve {
+                def failure = provider {
+                    runInAnotherThread.call {
+                        configurations.bar.${expression}
+                    }
+                }
                 doFirst {
-                    def failure = null
-                    def thread = new Thread({
-                        try {
-                            file('bar') << configurations.bar.${expression}
-                        } catch(Throwable t) {
-                            failure = t
-                        }
-                    })
-                    thread.start()
-                    thread.join()
-                    throw failure
+                    assert failure.isPresent()
+                    assert (failure.get() instanceof Throwable)
+                    throw failure.get()
                 }
             }
         """
@@ -129,7 +149,6 @@ class UnsafeConfigurationResolutionDeprecationIntegrationTest extends AbstractDe
         ]
     }
 
-    @ToBeFixedForConfigurationCache(because = "uses Configuration API at runtime")
     def "no exception when non-gradle thread iterates over dependency artifacts that were declared as task inputs"() {
         mavenRepo.module("test", "test-jar", "1.0").publish()
 
@@ -150,22 +169,16 @@ class UnsafeConfigurationResolutionDeprecationIntegrationTest extends AbstractDe
                 bar "test:test-jar:1.0"
             }
 
+            ${declareRunInAnotherThread()}
+
             task resolve {
                 def configuration = configurations.bar
                 inputs.files(configuration)
+                def layout = project.layout
+                def traversal = provider { configuration.${expression} }
                 doFirst {
-                    def failure = null
-                    def thread = new Thread({
-                        try {
-                            file('bar') << configuration.${expression}
-                        } catch(Throwable t) {
-                            failure = t
-                        }
-                    })
-                    thread.start()
-                    thread.join()
-                    if (failure != null) {
-                        throw failure
+                    runInAnotherThread.call {
+                        layout.projectDirectory.file('bar').asFile << traversal.get()
                     }
                 }
             }
@@ -180,27 +193,37 @@ class UnsafeConfigurationResolutionDeprecationIntegrationTest extends AbstractDe
             executer.expectDocumentedDeprecationWarning("The ResolvedConfiguration.getFiles() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration#getFiles instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_legacy_configuration_get_files")
         }
 
+        def shouldSucceed = ccMessage instanceof Wildcard || !GradleContextualExecuter.isConfigCache()
+        if (shouldSucceed) {
+            run(":resolve")
+        } else {
+            fails(":resolve")
+        }
+
         then:
-        succeeds(":resolve")
+        if (shouldSucceed) {
+            result.assertTaskExecuted(":resolve")
+        } else {
+            result.assertHasErrorOutput(ccMessage as String)
+        }
 
         where:
-        expression << [
-            "files",
-            "incoming.resolutionResult.root",
-            "incoming.resolutionResult.rootComponent.get()",
-            "incoming.artifacts.artifactFiles.files",
-            "incoming.artifacts.artifacts",
-            "incoming.artifactView { }.files.files",
-            "incoming.artifactView { }.artifacts.artifacts",
-            "incoming.artifactView { }.artifacts.resolvedArtifacts.get()",
-            "incoming.artifactView { }.artifacts.failures",
-            "incoming.artifactView { }.artifacts.artifactFiles.files",
-            "resolve()",
-            "files { true }",
-            "fileCollection { true }.files",
-            "resolvedConfiguration.files",
-            "resolvedConfiguration.resolvedArtifacts"
-        ]
+        expression                                                      | ccMessage
+        "files"                                                         | _
+        "incoming.resolutionResult.root"                                | _
+        "incoming.resolutionResult.rootComponent.get()"                 | _
+        "incoming.artifacts.artifactFiles.files"                        | _
+        "incoming.artifacts.artifacts"                                  | "org.gradle.api.artifacts.result.ArtifactResult"
+        "incoming.artifactView { }.files.files"                         | _
+        "incoming.artifactView { }.artifacts.artifacts"                 | "org.gradle.api.artifacts.result.ArtifactResult"
+        "incoming.artifactView { }.artifacts.resolvedArtifacts.get()"   | "org.gradle.api.artifacts.result.ArtifactResult"
+        "incoming.artifactView { }.artifacts.failures"                  | _
+        "incoming.artifactView { }.artifacts.artifactFiles.files"       | _
+        "resolve()"                                                     | _
+        "files { true }"                                                | _
+        "fileCollection { true }.files"                                 | _
+        "resolvedConfiguration.files"                                   | _
+        "resolvedConfiguration.resolvedArtifacts"                       | "org.gradle.api.artifacts.ResolvedArtifact"
     }
 
     def "no exception when non-gradle thread iterates over dependency artifacts that were previously iterated"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
@@ -17,7 +17,6 @@ package org.gradle.integtests.resolve.maven
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import org.gradle.test.fixtures.maven.MavenModule
 import org.gradle.test.fixtures.maven.MavenRepository
@@ -386,7 +385,6 @@ task retrieve(type: Sync) {
     }
 
     @Issue("gradle/gradle#3019")
-    @ToBeFixedForConfigurationCache
     def "should honour changing module cache expiry for subsequent snapshot resolutions in the same build"() {
         given:
         buildFile << """
@@ -402,13 +400,16 @@ dependencies {
 }
 
 task resolveStaleThenFresh {
+    def fs = services.get(FileSystemOperations)
+    def stale = configurations.stale
+    def fresh = configurations.fresh
     doFirst {
-        project.sync {
-            from configurations.stale
+        fs.sync {
+            from stale
             into 'stale'
         }
-        project.sync {
-            from configurations.fresh
+        fs.sync {
+            from fresh
             into 'fresh'
         }
     }

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/AbstractComponentModelIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/AbstractComponentModelIntegrationTest.groovy
@@ -17,8 +17,9 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 
-abstract class AbstractComponentModelIntegrationTest extends AbstractIntegrationSpec {
+abstract class AbstractComponentModelIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
     /**
      * Registers CustomComponent type
      */

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/AbstractComponentModelIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/AbstractComponentModelIntegrationTest.groovy
@@ -17,9 +17,9 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 
-abstract class AbstractComponentModelIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+abstract class AbstractComponentModelIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
     /**
      * Registers CustomComponent type
      */

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/BaseModelIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/BaseModelIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.language.base
 
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.platform.base.ApplicationSpec
 import org.gradle.platform.base.ComponentSpec
@@ -25,7 +26,14 @@ import org.gradle.platform.base.GeneralComponentSpec
 import org.gradle.platform.base.LibrarySpec
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class BaseModelIntegrationTest extends AbstractIntegrationSpec {
+class BaseModelIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+
+    @Override
+    protected void setupExecuter() {
+        super.setupExecuter()
+        expectTaskGetProjectDeprecations()
+    }
+
     def "empty containers are visible in model report"() {
         buildFile << """
 apply plugin: 'component-model-base'

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/BaseModelIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/BaseModelIntegrationTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.language.base
 
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.platform.base.ApplicationSpec
 import org.gradle.platform.base.ComponentSpec
@@ -26,7 +26,7 @@ import org.gradle.platform.base.GeneralComponentSpec
 import org.gradle.platform.base.LibrarySpec
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class BaseModelIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class BaseModelIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
 
     @Override
     protected void setupExecuter() {

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentBinariesIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentBinariesIntegrationTest.groovy
@@ -17,10 +17,11 @@
 package org.gradle.language.base
 
 import org.gradle.api.reporting.model.ModelReportOutput
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class ComponentBinariesIntegrationTest extends AbstractComponentModelIntegrationTest {
+class ComponentBinariesIntegrationTest extends AbstractComponentModelIntegrationTest implements CommonDeprecations {
     def setup() {
         withCustomComponentType()
         withCustomBinaryType()
@@ -42,6 +43,7 @@ model {
 
     def "binaries of a component are visible in the top level binaries container"() {
         when:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
 
         then:
@@ -86,6 +88,7 @@ model {
         """
 
         when:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
 
         then:

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentBinariesIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentBinariesIntegrationTest.groovy
@@ -17,11 +17,11 @@
 package org.gradle.language.base
 
 import org.gradle.api.reporting.model.ModelReportOutput
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class ComponentBinariesIntegrationTest extends AbstractComponentModelIntegrationTest implements CommonDeprecations {
+class ComponentBinariesIntegrationTest extends AbstractComponentModelIntegrationTest implements StableConfigurationCacheDeprecations {
     def setup() {
         withCustomComponentType()
         withCustomBinaryType()

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentBinarySourcesIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentBinarySourcesIntegrationTest.groovy
@@ -18,10 +18,11 @@ package org.gradle.language.base
 
 import groovy.test.NotYetImplemented
 import org.gradle.api.reporting.model.ModelReportOutput
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class ComponentBinarySourcesIntegrationTest extends AbstractComponentModelIntegrationTest {
+class ComponentBinarySourcesIntegrationTest extends AbstractComponentModelIntegrationTest implements CommonDeprecations {
     def setup() {
         withCustomComponentType()
         withCustomBinaryType()
@@ -202,6 +203,7 @@ model {
             }
         """
         when:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
 
         then:

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentBinarySourcesIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentBinarySourcesIntegrationTest.groovy
@@ -18,11 +18,11 @@ package org.gradle.language.base
 
 import groovy.test.NotYetImplemented
 import org.gradle.api.reporting.model.ModelReportOutput
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class ComponentBinarySourcesIntegrationTest extends AbstractComponentModelIntegrationTest implements CommonDeprecations {
+class ComponentBinarySourcesIntegrationTest extends AbstractComponentModelIntegrationTest implements StableConfigurationCacheDeprecations {
     def setup() {
         withCustomComponentType()
         withCustomBinaryType()

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentModelIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentModelIntegrationTest.groovy
@@ -122,6 +122,7 @@ model {
 
     def "component sources and binaries containers are visible in model report"() {
         when:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
 
         then:
@@ -147,6 +148,7 @@ model {
         apply plugin: SomeComponentPlugin
         """
         then:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
 
         and:
@@ -183,6 +185,7 @@ model {
         apply plugin: SomeComponentPlugin
         """
         then:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
 
         and:
@@ -248,6 +251,7 @@ afterEach CustomComponent 'newComponent'"""
         apply plugin: SomeComponentPlugin
         """
         then:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
 
         and:
@@ -274,6 +278,7 @@ afterEach CustomComponent 'newComponent'"""
         }
         """
         then:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
 
         and:
@@ -303,6 +308,7 @@ afterEach CustomComponent 'newComponent'"""
         }
         """
         then:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
 
         and:
@@ -371,6 +377,7 @@ afterEach CustomComponent 'newComponent'"""
         }
         """
         then:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
 
         and:
@@ -496,6 +503,7 @@ afterEach CustomComponent 'newComponent'"""
         withBinaries()
 
         when:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
 
         then:
@@ -667,6 +675,7 @@ afterEach CustomComponent 'newComponent'"""
         """
 
         expect:
+        expectTaskGetProjectDeprecations()
         succeeds "components"
     }
 
@@ -702,6 +711,7 @@ afterEach CustomComponent 'newComponent'"""
             apply plugin: MyPlugin
         """
         expect:
+        expectTaskGetProjectDeprecations()
         succeeds "components"
     }
 }

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentModelReportIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentModelReportIntegrationTest.groovy
@@ -17,10 +17,11 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class ComponentModelReportIntegrationTest extends AbstractIntegrationSpec {
+class ComponentModelReportIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
 
     def "model report for unmanaged software components shows them all"() {
         given:
@@ -30,6 +31,7 @@ class ComponentModelReportIntegrationTest extends AbstractIntegrationSpec {
         """.stripIndent()
 
         when:
+        expectTaskGetProjectDeprecations()
         succeeds 'model'
 
         then:
@@ -96,6 +98,7 @@ class ComponentModelReportIntegrationTest extends AbstractIntegrationSpec {
         """.stripIndent()
 
         when:
+        expectTaskGetProjectDeprecations()
         succeeds 'model'
 
         then:
@@ -176,6 +179,7 @@ class ComponentModelReportIntegrationTest extends AbstractIntegrationSpec {
         """.stripIndent()
 
         when:
+        expectTaskGetProjectDeprecations()
         succeeds 'components'
 
         then:

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentModelReportIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentModelReportIntegrationTest.groovy
@@ -17,11 +17,11 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class ComponentModelReportIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class ComponentModelReportIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
 
     def "model report for unmanaged software components shows them all"() {
         given:

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentSourcesIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentSourcesIntegrationTest.groovy
@@ -96,6 +96,7 @@ class ComponentSourcesIntegrationTest extends AbstractComponentModelIntegrationT
             }
         """
         when:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
 
         then:

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomBinaryIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomBinaryIntegrationTest.groovy
@@ -17,10 +17,11 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class CustomBinaryIntegrationTest extends AbstractIntegrationSpec {
+class CustomBinaryIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
     def "setup"() {
         buildFile << """
 @Managed interface SampleBinary extends BinarySpec {
@@ -314,10 +315,10 @@ model {
         buildWithCustomBinaryPlugin()
         when:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations()
         succeeds "components"
         then:
-        output.contains """> Task :components
-
+        output.contains """
 ------------------------------------------------------------
 Root project 'custom-binary'
 ------------------------------------------------------------

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomBinaryIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomBinaryIntegrationTest.groovy
@@ -17,11 +17,11 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class CustomBinaryIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class CustomBinaryIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
     def "setup"() {
         buildFile << """
 @Managed interface SampleBinary extends BinarySpec {

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomBinaryTasksIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomBinaryTasksIntegrationTest.groovy
@@ -18,10 +18,11 @@ package org.gradle.language.base
 
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class CustomBinaryTasksIntegrationTest extends AbstractIntegrationSpec {
+class CustomBinaryTasksIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
 
     def "setup"() {
         buildFile << """
@@ -89,6 +90,7 @@ class CustomBinaryTasksIntegrationTest extends AbstractIntegrationSpec {
 '''
 
         when:
+        expectTaskGetProjectDeprecations()
         run "model"
 
         then:

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomBinaryTasksIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomBinaryTasksIntegrationTest.groovy
@@ -18,11 +18,11 @@ package org.gradle.language.base
 
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class CustomBinaryTasksIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class CustomBinaryTasksIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
 
     def "setup"() {
         buildFile << """

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentBinariesIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentBinariesIntegrationTest.groovy
@@ -18,10 +18,11 @@ package org.gradle.language.base
 
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class CustomComponentBinariesIntegrationTest extends AbstractIntegrationSpec {
+class CustomComponentBinariesIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
 
     def "setup"() {
         buildFile << """
@@ -67,6 +68,7 @@ class CustomComponentBinariesIntegrationTest extends AbstractIntegrationSpec {
         buildFile << withSimpleComponentBinaries()
 
         then:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
 
         and:
@@ -129,6 +131,7 @@ class CustomComponentBinariesIntegrationTest extends AbstractIntegrationSpec {
         given:
         buildFile << withSimpleComponentBinaries()
         when:
+        expectTaskGetProjectDeprecations()
         succeeds "components"
         then:
         output.contains("""
@@ -239,6 +242,7 @@ Binaries
         }"""
 
         when:
+        expectTaskGetProjectDeprecations()
         succeeds "components"
         then:
         output.contains("""
@@ -322,6 +326,7 @@ model {
 """
 
         when:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
 
         then:
@@ -360,6 +365,7 @@ model {
         """
 
         when:
+        expectTaskGetProjectDeprecations()
         succeeds "components"
 
         then:

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentBinariesIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentBinariesIntegrationTest.groovy
@@ -18,11 +18,11 @@ package org.gradle.language.base
 
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class CustomComponentBinariesIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class CustomComponentBinariesIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
 
     def "setup"() {
         buildFile << """

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentBinariesWithComponentReferenceIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentBinariesWithComponentReferenceIntegrationTest.groovy
@@ -17,11 +17,12 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import spock.lang.Issue
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class CustomComponentBinariesWithComponentReferenceIntegrationTest extends AbstractIntegrationSpec {
+class CustomComponentBinariesWithComponentReferenceIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
 
     @Issue("https://issues.gradle.org/browse/GRADLE-3422")
     def "@ComponentBinaries rule is not applied to component reference field of managed binary"() {
@@ -57,6 +58,7 @@ class CustomComponentBinariesWithComponentReferenceIntegrationTest extends Abstr
         """
 
         expect:
+        expectTaskGetProjectDeprecations()
         succeeds "components"
     }
 }

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentBinariesWithComponentReferenceIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentBinariesWithComponentReferenceIntegrationTest.groovy
@@ -17,12 +17,12 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import spock.lang.Issue
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class CustomComponentBinariesWithComponentReferenceIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class CustomComponentBinariesWithComponentReferenceIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
 
     @Issue("https://issues.gradle.org/browse/GRADLE-3422")
     def "@ComponentBinaries rule is not applied to component reference field of managed binary"() {

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.language.base
 
 import groovy.test.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.platform.base.ApplicationSpec
 import org.gradle.platform.base.ComponentSpec
@@ -26,7 +27,7 @@ import org.gradle.platform.base.LibrarySpec
 import org.gradle.platform.base.SourceComponentSpec
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class CustomComponentIntegrationTest extends AbstractIntegrationSpec {
+class CustomComponentIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
     def "can declare custom managed #componentSpecType"() {
         buildFile << """
             @Managed
@@ -109,6 +110,7 @@ class CustomComponentIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
     }
 
@@ -270,6 +272,7 @@ class CustomComponentIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
     }
 
@@ -563,6 +566,7 @@ class CustomComponentIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        expectTaskGetProjectDeprecations()
         fails "components"
         failure.assertHasCause("Exception thrown while executing model rule: Broken#broken")
         failure.assertHasCause("broken")
@@ -584,6 +588,7 @@ class CustomComponentIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        expectTaskGetProjectDeprecations()
         fails "components"
         failure.assertHasCause("Exception thrown while executing model rule: Broken#broken(TypeBuilder<BrokenComponentSpec>)")
         failure.assertHasCause("Broken#broken(TypeBuilder<BrokenComponentSpec>) is not a valid component model rule method.")
@@ -672,6 +677,7 @@ model {
         """
 
         expect:
+        expectTaskGetProjectDeprecations()
         succeeds "components"
     }
 }

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentIntegrationTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.language.base
 
 import groovy.test.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.platform.base.ApplicationSpec
 import org.gradle.platform.base.ComponentSpec
@@ -27,7 +27,7 @@ import org.gradle.platform.base.LibrarySpec
 import org.gradle.platform.base.SourceComponentSpec
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class CustomComponentIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class CustomComponentIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
     def "can declare custom managed #componentSpecType"() {
         buildFile << """
             @Managed

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentPluginIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentPluginIntegrationTest.groovy
@@ -17,10 +17,11 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class CustomComponentPluginIntegrationTest extends AbstractIntegrationSpec {
+class CustomComponentPluginIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
     def "setup"() {
         buildFile << """
 @Managed
@@ -54,6 +55,7 @@ model {
 }
 '''
         then:
+        expectTaskGetProjectDeprecations()
         succeeds "checkModel"
     }
 
@@ -153,11 +155,11 @@ model {
 
         when:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations()
         succeeds "components"
 
         then:
-        output.contains """> Task :components
-
+        output.contains """
 ------------------------------------------------------------
 Root project 'custom-component'
 ------------------------------------------------------------
@@ -211,6 +213,7 @@ BUILD SUCCESSFUL"""
 '''
 
         then:
+        expectTaskGetProjectDeprecations()
         succeeds "checkModel"
     }
 
@@ -266,6 +269,7 @@ BUILD SUCCESSFUL"""
 '''
 
         then:
+        expectTaskGetProjectDeprecations(2)
         succeeds "checkModel"
     }
 
@@ -318,6 +322,7 @@ BUILD SUCCESSFUL"""
 """
 
         when:
+        expectTaskGetProjectDeprecations()
         fails "model"
 
         then:

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentPluginIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentPluginIntegrationTest.groovy
@@ -17,11 +17,11 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class CustomComponentPluginIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class CustomComponentPluginIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
     def "setup"() {
         buildFile << """
 @Managed

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomManagedBinaryIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomManagedBinaryIntegrationTest.groovy
@@ -17,10 +17,11 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class CustomManagedBinaryIntegrationTest extends AbstractIntegrationSpec {
+class CustomManagedBinaryIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
     def "setup"() {
         buildFile << """
 @Managed
@@ -101,10 +102,10 @@ model {
         buildWithCustomBinaryPlugin()
         when:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations()
         succeeds "components"
         then:
-        output.contains """> Task :components
-
+        output.contains """
 ------------------------------------------------------------
 Root project 'custom-binary'
 ------------------------------------------------------------

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomManagedBinaryIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/CustomManagedBinaryIntegrationTest.groovy
@@ -17,11 +17,11 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class CustomManagedBinaryIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class CustomManagedBinaryIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
     def "setup"() {
         buildFile << """
 @Managed

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/FunctionalSourceSetIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/FunctionalSourceSetIntegrationTest.groovy
@@ -19,12 +19,13 @@ package org.gradle.language.base
 import groovy.test.NotYetImplemented
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 import static org.gradle.util.internal.TextUtil.normaliseFileSeparators
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class FunctionalSourceSetIntegrationTest extends AbstractIntegrationSpec {
+class FunctionalSourceSetIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
 
     def "can create a top level functional source set with a rule"() {
         buildFile """
@@ -94,6 +95,7 @@ class FunctionalSourceSetIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
     }
 
@@ -111,6 +113,7 @@ class FunctionalSourceSetIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
 
         then:
@@ -146,6 +149,7 @@ class FunctionalSourceSetIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
         def buildType = ModelReportOutput.from(output).modelNode.buildType
 
@@ -178,6 +182,7 @@ class FunctionalSourceSetIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
         def buildType = ModelReportOutput.from(output).modelNode.buildType
 
@@ -210,6 +215,7 @@ class FunctionalSourceSetIntegrationTest extends AbstractIntegrationSpec {
         apply plugin: Rules
         """
         expect:
+        expectTaskGetProjectDeprecations()
         succeeds ("model", "printSourceDirs")
         normaliseFileSeparators(output).contains("source dirs: [${normaliseFileSeparators(testDirectory.path)}/src/main/myJavaSourceSet]")
     }
@@ -231,6 +237,7 @@ class FunctionalSourceSetIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
+        expectTaskGetProjectDeprecations()
         succeeds ("model", "printSourceDirs")
 
         then:

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/FunctionalSourceSetIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/FunctionalSourceSetIntegrationTest.groovy
@@ -19,13 +19,13 @@ package org.gradle.language.base
 import groovy.test.NotYetImplemented
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 import static org.gradle.util.internal.TextUtil.normaliseFileSeparators
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class FunctionalSourceSetIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class FunctionalSourceSetIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
 
     def "can create a top level functional source set with a rule"() {
         buildFile """

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/InternalViewsSampleIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/InternalViewsSampleIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.language.base
 
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.test.precondition.Requires
@@ -26,7 +27,7 @@ import org.junit.Rule
 
 @Requires(UnitTestPreconditions.Online)
 @UnsupportedWithConfigurationCache(because = "software model")
-class InternalViewsSampleIntegrationTest extends AbstractIntegrationSpec {
+class InternalViewsSampleIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
     @Rule
     Sample internalViewsSample = new Sample(temporaryFolder, "customModel/internalViews/groovy")
 
@@ -35,6 +36,7 @@ class InternalViewsSampleIntegrationTest extends AbstractIntegrationSpec {
         given:
         sample internalViewsSample
         when:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
         then:
         println output

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/InternalViewsSampleIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/InternalViewsSampleIntegrationTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.language.base
 
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.test.precondition.Requires
@@ -27,7 +27,7 @@ import org.junit.Rule
 
 @Requires(UnitTestPreconditions.Online)
 @UnsupportedWithConfigurationCache(because = "software model")
-class InternalViewsSampleIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class InternalViewsSampleIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
     @Rule
     Sample internalViewsSample = new Sample(temporaryFolder, "customModel/internalViews/groovy")
 

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageSourceSetIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageSourceSetIntegrationTest.groovy
@@ -18,12 +18,13 @@ package org.gradle.language.base
 
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 import static org.gradle.util.internal.TextUtil.normaliseFileSeparators
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class LanguageSourceSetIntegrationTest extends AbstractIntegrationSpec {
+class LanguageSourceSetIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
 
     def "can not create a top level LSS for using an implementation class"() {
         buildFile.text = """
@@ -60,6 +61,7 @@ class LanguageSourceSetIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        expectTaskGetProjectDeprecations()
         succeeds("model", "printSourceDirs")
         normaliseFileSeparators(output).contains("${normaliseFileSeparators(testDirectory.path)}/src/main/lss")
     }
@@ -74,6 +76,7 @@ class LanguageSourceSetIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
 
         then:
@@ -105,6 +108,7 @@ class LanguageSourceSetIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
         def buildType = ModelReportOutput.from(output).modelNode.buildType
 
@@ -142,6 +146,7 @@ class LanguageSourceSetIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        expectTaskGetProjectDeprecations()
         succeeds "model"
         def buildType = ModelReportOutput.from(output).modelNode.buildType
 

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageSourceSetIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageSourceSetIntegrationTest.groovy
@@ -18,13 +18,13 @@ package org.gradle.language.base
 
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 import static org.gradle.util.internal.TextUtil.normaliseFileSeparators
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class LanguageSourceSetIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class LanguageSourceSetIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
 
     def "can not create a top level LSS for using an implementation class"() {
         buildFile.text = """

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageTypeIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageTypeIntegrationTest.groovy
@@ -17,10 +17,11 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class LanguageTypeIntegrationTest extends AbstractIntegrationSpec {
+class LanguageTypeIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
 
     def setup() {
         buildFile << """
@@ -66,6 +67,7 @@ class LanguageTypeIntegrationTest extends AbstractIntegrationSpec {
         }
 """
         then:
+        expectTaskGetProjectDeprecations()
         succeeds "components"
         and:
         output.contains """

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageTypeIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageTypeIntegrationTest.groovy
@@ -17,11 +17,11 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class LanguageTypeIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class LanguageTypeIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
 
     def setup() {
         buildFile << """

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageTypeSampleIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageTypeSampleIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.test.precondition.Requires
@@ -25,7 +26,7 @@ import org.junit.Rule
 
 @Requires(UnitTestPreconditions.Online)
 @UnsupportedWithConfigurationCache(because = "software model")
-class LanguageTypeSampleIntegrationTest extends AbstractIntegrationSpec {
+class LanguageTypeSampleIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
     @Rule
     Sample languageTypeSample = new Sample(temporaryFolder, "customModel/languageType/groovy")
 
@@ -39,6 +40,7 @@ class LanguageTypeSampleIntegrationTest extends AbstractIntegrationSpec {
         sample languageTypeSample
 
         when:
+        expectTaskGetProjectDeprecations()
         succeeds "components"
 
         then:

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageTypeSampleIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageTypeSampleIntegrationTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.test.precondition.Requires
@@ -26,7 +26,7 @@ import org.junit.Rule
 
 @Requires(UnitTestPreconditions.Online)
 @UnsupportedWithConfigurationCache(because = "software model")
-class LanguageTypeSampleIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class LanguageTypeSampleIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
     @Rule
     Sample languageTypeSample = new Sample(temporaryFolder, "customModel/languageType/groovy")
 

--- a/platforms/software/reporting/src/integTest/groovy/org/gradle/api/reporting/plugins/BuildDashboardPluginIntegrationTest.groovy
+++ b/platforms/software/reporting/src/integTest/groovy/org/gradle/api/reporting/plugins/BuildDashboardPluginIntegrationTest.groovy
@@ -31,6 +31,7 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
 
     def setup() {
         writeBuildFile()
+        expectTaskProjectDeprecation = true
     }
 
     private void goodCode(TestFile root = testDirectory) {
@@ -122,6 +123,7 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
     @ToBeFixedForConfigurationCache(because = ":buildDashboard")
     void 'build dashboard for a project with no other reports lists just the dashboard'() {
         when:
+        expectTaskProjectDeprecation()
         run('buildDashboard')
 
         then:
@@ -137,6 +139,7 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
         goodTests()
 
         when:
+        expectTaskProjectDeprecation()
         run('check', 'buildDashboard')
 
         then:
@@ -153,6 +156,7 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
         goodTests()
 
         when:
+        expectTaskProjectDeprecation()
         run('buildDashboard')
 
         then:
@@ -170,6 +174,7 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
         goodTests()
 
         when:
+        expectTaskProjectDeprecation()
         run('buildDashboard', 'check')
 
         then:
@@ -186,6 +191,7 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
         goodTests()
 
         when:
+        expectTaskProjectDeprecation()
         run('test')
 
         then:
@@ -202,6 +208,7 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
         badTests()
 
         when:
+        expectTaskProjectDeprecation()
         runAndFail('check')
 
         then:
@@ -262,6 +269,7 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
         goodCode()
 
         expect:
+        expectTaskProjectDeprecation()
         run('buildDashboard')
         executedAndNotSkipped(':buildDashboard')
 
@@ -272,6 +280,7 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
         buildDashboardFile.delete()
 
         then:
+        expectTaskProjectDeprecation()
         run('buildDashboard')
         executedAndNotSkipped(':buildDashboard')
     }
@@ -284,6 +293,7 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
         withCodenarc()
 
         when:
+        expectTaskProjectDeprecation()
         run('check')
         executedAndNotSkipped(':buildDashboard')
 
@@ -300,6 +310,7 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
         """
 
         and:
+        expectTaskProjectDeprecation()
         run('check')
         executedAndNotSkipped(':buildDashboard')
 
@@ -317,6 +328,7 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
         goodTests()
 
         when:
+        expectTaskProjectDeprecation()
         run('buildDashboard')
         executedAndNotSkipped(':buildDashboard')
 
@@ -328,6 +340,7 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
         hasUnavailableReport(':test', 'junitXml')
 
         when:
+        expectTaskProjectDeprecation()
         run('test')
         executedAndNotSkipped(':buildDashboard')
 
@@ -347,6 +360,7 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
         setupSubproject()
 
         when:
+        expectTaskProjectDeprecation()
         run('buildDashboard', 'check')
 
         then:
@@ -368,6 +382,7 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
         """
 
         when:
+        expectTaskProjectDeprecation()
         run("test", "jacocoTestReport")
 
         then:
@@ -386,6 +401,7 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
         withCodenarc()
 
         when:
+        expectTaskProjectDeprecation()
         run("check")
 
         then:

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/ParallelSourceDependencyIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/ParallelSourceDependencyIntegrationTest.groovy
@@ -75,8 +75,9 @@ class ParallelSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         """
         buildFile << """
             subprojects {
+                def projectName = project.name
                 tasks.resolve.doFirst {
-                    ${httpServer.callFromBuildUsingExpression("project.name")}
+                    ${httpServer.callFromBuildUsingExpression("projectName")}
                 }
             }
         """

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/DynamicObjectIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/DynamicObjectIntegrationTest.groovy
@@ -72,6 +72,7 @@ class DynamicObjectIntegrationTest extends AbstractIntegrationSpec {
         )
 
         expectConventionTypeDeprecationWarnings()
+        expectTaskProjectDeprecation()
 
         expect:
         succeeds("testTask")
@@ -109,6 +110,7 @@ class DynamicObjectIntegrationTest extends AbstractIntegrationSpec {
         )
 
         expectConventionTypeDeprecationWarnings()
+        expectTaskProjectDeprecation()
 
         expect:
         succeeds("testTask")
@@ -445,6 +447,7 @@ assert 'overridden value' == global
         '''
 
         expect:
+        expectTaskProjectDeprecation(3)
         succeeds("test")
     }
 
@@ -1045,12 +1048,12 @@ task print(type: MyTask) {
         succeeds()
     }
 
-    @ToBeFixedForConfigurationCache(because = "Task.getProject() during execution")
     def findPropertyShouldReturnValueIfFound() {
         buildFile """
             task run {
+                def property = project.findProperty('foundProperty')
                 doLast {
-                    assert project.findProperty('foundProperty') == 'foundValue'
+                    assert property == 'foundValue'
                 }
             }
         """
@@ -1060,12 +1063,12 @@ task print(type: MyTask) {
         succeeds("run")
     }
 
-    @ToBeFixedForConfigurationCache(because = "Task.getProject() during execution")
     def findPropertyShouldReturnNullIfNotFound() {
         buildFile """
             task run {
+                def property = project.findProperty('notFoundProperty')
                 doLast {
-                    assert project.findProperty('notFoundProperty') == null
+                    assert property == null
                 }
             }
         """
@@ -1082,6 +1085,14 @@ task print(type: MyTask) {
                     "Consult the upgrading guide for further information: " +
                     "https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_access_to_conventions"
             )
+        }
+    }
+
+    private void expectTaskProjectDeprecation(int repeated = 1) {
+        repeated.times {
+            executer.expectDocumentedDeprecationWarning("Invocation of Task.project at execution time has been deprecated. "+
+                "This will fail with an error in Gradle 9.0. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_project")
         }
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/taskfactory/TaskPropertyNamingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/taskfactory/TaskPropertyNamingIntegrationTest.groovy
@@ -406,12 +406,14 @@ class TaskPropertyNamingIntegrationTest extends AbstractIntegrationSpec {
 
             import javax.annotation.Nullable
 
-            class PrintInputsAndOutputs extends DefaultTask {
+            abstract class PrintInputsAndOutputs extends DefaultTask {
+                @Inject
+                abstract PropertyWalker getPropertyWalker()
                 @Internal
                 Task task
                 @TaskAction
                 void printInputsAndOutputs() {
-                    TaskPropertyUtils.visitProperties(project.services.get(PropertyWalker), task, new PropertyVisitor() {
+                    TaskPropertyUtils.visitProperties(propertyWalker, task, new PropertyVisitor() {
                         @Override
                         void visitInputProperty(String propertyName, PropertyValue value, boolean optional) {
                             println "Input property '\${propertyName}'"

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/console/AbstractExecOutputIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/console/AbstractExecOutputIntegrationTest.groovy
@@ -50,6 +50,9 @@ abstract class AbstractExecOutputIntegrationTest extends AbstractConsoleGroupedT
                 "This is scheduled to be removed in Gradle 9.0. " +
                 "Use ExecOperations.javaexec(Action) or ProviderFactory.javaexec(Action) instead. " +
                 "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_project_exec")
+            executer.expectDocumentedDeprecationWarning("Invocation of Task.project at execution time has been deprecated. "+
+                "This will fail with an error in Gradle 9.0. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_project")
         }
         executer.withConsole(consoleType)
         succeeds("run")
@@ -135,6 +138,9 @@ abstract class AbstractExecOutputIntegrationTest extends AbstractConsoleGroupedT
                 "This is scheduled to be removed in Gradle 9.0. " +
                 "Use ExecOperations.exec(Action) or ProviderFactory.exec(Action) instead. " +
                 "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_project_exec")
+            executer.expectDocumentedDeprecationWarning("Invocation of Task.project at execution time has been deprecated. "+
+                "This will fail with an error in Gradle 9.0. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_project")
         }
         succeeds("run")
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/RuleTaskCreationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/RuleTaskCreationIntegrationTest.groovy
@@ -18,11 +18,12 @@ package org.gradle.execution.taskgraph
 
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.model.internal.core.ModelPath
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class RuleTaskCreationIntegrationTest extends AbstractIntegrationSpec implements WithRuleBasedTasks {
+class RuleTaskCreationIntegrationTest extends AbstractIntegrationSpec implements WithRuleBasedTasks, CommonDeprecations {
     def setup() {
         buildFile << ruleBasedTasks()
     }
@@ -613,6 +614,7 @@ apply type: MyPlugin
 """
 
         when:
+        expectTaskGetProjectDeprecations()
         succeeds("model")
 
         then:

--- a/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/RuleTaskCreationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/RuleTaskCreationIntegrationTest.groovy
@@ -18,12 +18,12 @@ package org.gradle.execution.taskgraph
 
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.model.internal.core.ModelPath
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class RuleTaskCreationIntegrationTest extends AbstractIntegrationSpec implements WithRuleBasedTasks, CommonDeprecations {
+class RuleTaskCreationIntegrationTest extends AbstractIntegrationSpec implements WithRuleBasedTasks, StableConfigurationCacheDeprecations {
     def setup() {
         buildFile << ruleBasedTasks()
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/normalization/ConfigureRuntimeClasspathNormalizationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/normalization/ConfigureRuntimeClasspathNormalizationIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.normalization
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
@@ -28,7 +29,7 @@ import spock.lang.Issue
 import java.util.jar.Attributes
 import java.util.jar.Manifest
 
-class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractIntegrationSpec {
+class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
     def "can ignore files on runtime classpath in #tree (using runtime API: #api)"() {
         def project = new ProjectWithRuntimeClasspathNormalization(api).withFilesIgnored()
 
@@ -222,6 +223,7 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         """.stripIndent()
 
         when:
+        expectTaskGetProjectDeprecations()
         fails 'configureNormalization'
 
         then:

--- a/subprojects/core/src/integTest/groovy/org/gradle/normalization/ConfigureRuntimeClasspathNormalizationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/normalization/ConfigureRuntimeClasspathNormalizationIntegrationTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.normalization
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
@@ -29,7 +29,7 @@ import spock.lang.Issue
 import java.util.jar.Attributes
 import java.util.jar.Manifest
 
-class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
     def "can ignore files on runtime classpath in #tree (using runtime API: #api)"() {
         def project = new ProjectWithRuntimeClasspathNormalization(api).withFilesIgnored()
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/tooling/provider/model/CustomToolingModelIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/tooling/provider/model/CustomToolingModelIntegrationTest.groovy
@@ -90,6 +90,9 @@ class CustomToolingModelIntegrationTest extends AbstractIntegrationSpec implemen
         """
 
         when:
+        executer.expectDocumentedDeprecationWarning("Invocation of Task.project at execution time has been deprecated. "+
+            "This will fail with an error in Gradle 9.0. " +
+            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_project")
         run("model1", "model2", "--parallel")
 
         then:

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/components/DiagnosticsComponentReportIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/components/DiagnosticsComponentReportIntegrationTest.groovy
@@ -26,6 +26,7 @@ class DiagnosticsComponentReportIntegrationTest extends AbstractNativeComponentR
     def "informs the user when project has no components defined"() {
         when:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations()
         succeeds "components"
 
         then:
@@ -55,6 +56,7 @@ model {
 """
         when:
         executer.withArgument("--no-problems-report")
+        expectTaskGetProjectDeprecations()
         succeeds "components"
 
         then:

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/dependents/DependentComponentsReportIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/dependents/DependentComponentsReportIntegrationTest.groovy
@@ -17,8 +17,9 @@
 package org.gradle.api.reporting.dependents
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 
-class DependentComponentsReportIntegrationTest extends AbstractIntegrationSpec {
+class DependentComponentsReportIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
 
     def setup() {
         settingsFile << "rootProject.name = 'test'"
@@ -41,6 +42,7 @@ class DependentComponentsReportIntegrationTest extends AbstractIntegrationSpec {
         buildFile
 
         when:
+        expectTaskGetProjectDeprecations()
         run "dependentComponents"
 
         then:

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/dependents/DependentComponentsReportIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/dependents/DependentComponentsReportIntegrationTest.groovy
@@ -17,9 +17,9 @@
 package org.gradle.api.reporting.dependents
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 
-class DependentComponentsReportIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class DependentComponentsReportIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
 
     def setup() {
         settingsFile << "rootProject.name = 'test'"

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/DetailedModelReportIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/DetailedModelReportIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.reporting.model
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.junit.Rule
@@ -24,10 +25,15 @@ import org.junit.Rule
 import static org.gradle.util.internal.TextUtil.normaliseFileSeparators
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class DetailedModelReportIntegrationTest extends AbstractIntegrationSpec {
+class DetailedModelReportIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
 
     @Rule
     public final HttpServer server = new HttpServer()
+
+    @Override
+    def setup() {
+        expectTaskGetProjectDeprecations()
+    }
 
     def "includes a relative path to the build script"() {
         given:

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/DetailedModelReportIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/DetailedModelReportIntegrationTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.api.reporting.model
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.junit.Rule
@@ -25,7 +25,7 @@ import org.junit.Rule
 import static org.gradle.util.internal.TextUtil.normaliseFileSeparators
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class DetailedModelReportIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class DetailedModelReportIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
 
     @Rule
     public final HttpServer server = new HttpServer()

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportIntegrationTest.groovy
@@ -17,10 +17,17 @@
 package org.gradle.api.reporting.model
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class ModelReportIntegrationTest extends AbstractIntegrationSpec {
+class ModelReportIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+
+    @Override
+    protected void setupExecuter() {
+        super.setupExecuter()
+        expectTaskGetProjectDeprecations()
+    }
 
     def "displays basic structure of an empty project"() {
         given:

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportIntegrationTest.groovy
@@ -17,11 +17,11 @@
 package org.gradle.api.reporting.model
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class ModelReportIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class ModelReportIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
 
     @Override
     protected void setupExecuter() {

--- a/subprojects/diagnostics/src/testFixtures/groovy/org/gradle/api/reporting/components/AbstractComponentReportIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/testFixtures/groovy/org/gradle/api/reporting/components/AbstractComponentReportIntegrationTest.groovy
@@ -17,10 +17,11 @@ package org.gradle.api.reporting.components
 
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.internal.InternalTransformer
 import org.gradle.nativeplatform.fixtures.AvailableToolChains
 
-abstract class AbstractComponentReportIntegrationTest extends AbstractIntegrationSpec {
+abstract class AbstractComponentReportIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
     InternalTransformer<String, String> formatter = new ComponentReportOutputFormatter()
     JavaVersion currentJvm = JavaVersion.current()
     String currentJavaName = "java" + currentJvm.majorVersion
@@ -33,12 +34,14 @@ abstract class AbstractComponentReportIntegrationTest extends AbstractIntegratio
 
     boolean outputMatches(String expectedOutput) {
         def actualOutput = result.groupedOutput.task(":components").output
-        assert removeDownloadMessageAndEmptyLines(actualOutput) == expected(expectedOutput)
+        assert removeIrrelevantOutput(actualOutput) == expected(expectedOutput)
         return true
     }
 
-    String removeDownloadMessageAndEmptyLines(String output) {
-        return output.readLines().findAll { !it.isEmpty() && !(it ==~ /^Download http.*$/) }.join('\n')
+    String removeIrrelevantOutput(String output) {
+        return output.readLines().findAll {
+            !it.isEmpty() && !(it ==~ /^Download http.*$/) && !(it ==~ /.*has been deprecated.*$/)
+        }.join('\n')
     }
 
     String expected(String normalised) {

--- a/subprojects/diagnostics/src/testFixtures/groovy/org/gradle/api/reporting/components/AbstractComponentReportIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/testFixtures/groovy/org/gradle/api/reporting/components/AbstractComponentReportIntegrationTest.groovy
@@ -17,11 +17,11 @@ package org.gradle.api.reporting.components
 
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.internal.InternalTransformer
 import org.gradle.nativeplatform.fixtures.AvailableToolChains
 
-abstract class AbstractComponentReportIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+abstract class AbstractComponentReportIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
     InternalTransformer<String, String> formatter = new ComponentReportOutputFormatter()
     JavaVersion currentJvm = JavaVersion.current()
     String currentJavaName = "java" + currentJvm.majorVersion

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/ClosureScopeIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/ClosureScopeIntegrationTest.groovy
@@ -17,10 +17,11 @@
 package org.gradle.integtests
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 
 
-class ClosureScopeIntegrationTest extends AbstractIntegrationSpec {
+class ClosureScopeIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
 
     @ToBeFixedForConfigurationCache(because = "Task.getProject() during execution")
     def "check scope when closure in ext"() {
@@ -48,6 +49,7 @@ rootProject.name = "rootProject"
 include 'sampleSub'
 """
         when:
+        expectTaskGetProjectDeprecations()
         succeeds(":sampleSub:someTask")
 
         then:

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/ClosureScopeIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/ClosureScopeIntegrationTest.groovy
@@ -17,11 +17,11 @@
 package org.gradle.integtests
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 
 
-class ClosureScopeIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class ClosureScopeIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
 
     @ToBeFixedForConfigurationCache(because = "Task.getProject() during execution")
     def "check scope when closure in ext"() {

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -17,12 +17,13 @@ package org.gradle.integtests
 
 import groovy.test.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 import spock.lang.Issue
 
-class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
+class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
 
     def 'copies files and removes extra files from destDir'() {
         given:
@@ -396,6 +397,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
         '''.stripIndent()
 
         when:
+        expectTaskGetProjectDeprecations()
         run 'syncIt'
 
         then:
@@ -431,6 +433,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
         '''.stripIndent()
 
         expect:
+        expectTaskGetProjectDeprecations()
         fails 'syncIt'
 
         cleanup:
@@ -570,6 +573,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
         '''.stripIndent()
 
         when:
+        expectTaskGetProjectDeprecations()
         run 'syncIt'
 
         then:
@@ -610,6 +614,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
         '''.stripIndent()
 
         when:
+        expectTaskGetProjectDeprecations()
         run 'syncIt'
 
         then:
@@ -657,6 +662,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
         '''.stripIndent()
 
         when:
+        expectTaskGetProjectDeprecations()
         run 'syncIt'
 
         then:

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -17,13 +17,13 @@ package org.gradle.integtests
 
 import groovy.test.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 import spock.lang.Issue
 
-class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements CommonDeprecations {
+class SyncTaskIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
 
     def 'copies files and removes extra files from destDir'() {
         given:

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskActionIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskActionIntegrationTest.groovy
@@ -22,10 +22,12 @@ import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 class TaskActionIntegrationTest extends AbstractIntegrationSpec {
     @UnsupportedWithConfigurationCache(because = "tests unsupported behaviour")
-    def "nags when task action uses Task.project and feature preview is enabled"() {
-        settingsFile """
-            enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
-        """
+    def "nags when task action uses Task.project"() {
+        if (featureFlag) {
+            settingsFile """
+                enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
+            """
+        }
         buildFile """
             task broken {
                 doLast {
@@ -40,6 +42,9 @@ class TaskActionIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         noExceptionThrown()
+
+        where:
+        featureFlag << [true, false]
     }
 
     @UnsupportedWithConfigurationCache(because = "tests unsupported behaviour")

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.integtests
 import org.gradle.api.attributes.Usage
 import org.gradle.api.tasks.TasksWithInputsAndOutputs
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.CommonDeprecations
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import spock.lang.Issue
@@ -28,7 +29,15 @@ import static org.gradle.integtests.fixtures.executer.TaskOrderSpecs.any
 import static org.gradle.integtests.fixtures.executer.TaskOrderSpecs.exact
 import static org.hamcrest.CoreMatchers.startsWith
 
-class TaskExecutionIntegrationTest extends AbstractIntegrationSpec implements TasksWithInputsAndOutputs {
+class TaskExecutionIntegrationTest extends AbstractIntegrationSpec implements TasksWithInputsAndOutputs, CommonDeprecations {
+
+    int expectedTaskGetProjectDeprecationCount = 0
+
+    @Override
+    protected void setupExecuter() {
+        super.setupExecuter()
+        expectTaskGetProjectDeprecations(expectedTaskGetProjectDeprecationCount)
+    }
 
     @UnsupportedWithConfigurationCache
     def taskCanAccessTaskGraph() {
@@ -105,7 +114,9 @@ class TaskExecutionIntegrationTest extends AbstractIntegrationSpec implements Ta
         """
         expect:
         2.times {
+            expectedTaskGetProjectDeprecationCount = 2
             run("a", "b").assertTasksExecuted(":a", ":b")
+            expectedTaskGetProjectDeprecationCount = 1
             run("a", "a").assertTasksExecuted(":a")
             run("c", "a").assertTasksExecuted(":a", ":c")
             run("c", "e").assertTasksExecuted(":a", ":c", ":d", ":e")

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.integtests
 import org.gradle.api.attributes.Usage
 import org.gradle.api.tasks.TasksWithInputsAndOutputs
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.CommonDeprecations
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import spock.lang.Issue
@@ -29,7 +29,7 @@ import static org.gradle.integtests.fixtures.executer.TaskOrderSpecs.any
 import static org.gradle.integtests.fixtures.executer.TaskOrderSpecs.exact
 import static org.hamcrest.CoreMatchers.startsWith
 
-class TaskExecutionIntegrationTest extends AbstractIntegrationSpec implements TasksWithInputsAndOutputs, CommonDeprecations {
+class TaskExecutionIntegrationTest extends AbstractIntegrationSpec implements TasksWithInputsAndOutputs, StableConfigurationCacheDeprecations {
 
     int expectedTaskGetProjectDeprecationCount = 0
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -72,7 +72,7 @@ import static org.gradle.util.Matchers.matchesRegexp
 @CleanupTestDirectory
 @SuppressWarnings("IntegrationTestFixtures")
 @IntegrationTestTimeout(DEFAULT_TIMEOUT_SECONDS)
-abstract class AbstractIntegrationSpec extends Specification implements LanguageSpecificTestFileFixture {
+abstract class AbstractIntegrationSpec extends Specification implements LanguageSpecificTestFileFixture, HasGradleExecutor {
 
     @Rule
     public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
@@ -87,7 +87,7 @@ abstract class AbstractIntegrationSpec extends Specification implements Language
     private boolean enableProblemsApiCheck = false
     private BuildOperationsFixture buildOperationsFixture = null
 
-    GradleExecuter getExecuter() {
+    public GradleExecuter getExecuter() {
         if (executor == null) {
             executor = createExecuter()
         }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -90,11 +90,20 @@ abstract class AbstractIntegrationSpec extends Specification implements Language
     GradleExecuter getExecuter() {
         if (executor == null) {
             executor = createExecuter()
-            if (ignoreCleanupAssertions) {
-                executor.ignoreCleanupAssertions()
-            }
         }
         return executor
+    }
+
+    /**
+     * Applies configuration that needs to be applied
+     * every time an executer runs.
+     *
+     * May be overwritten. In most cases, the overrides should ensure to invoke the base implementation.
+     */
+    protected void setupExecuter() {
+        if (ignoreCleanupAssertions) {
+            executor.ignoreCleanupAssertions()
+        }
     }
 
     BuildTestFixture buildTestFixture = new BuildTestFixture(temporaryFolder)
@@ -446,6 +455,7 @@ tmpdir is currently ${System.getProperty("java.io.tmpdir")}""")
     }
 
     protected ExecutionResult succeeds(String... tasks) {
+        setupExecuter()
         resetProblemApiCheck()
 
         result = executer.withTasks(*tasks).run()
@@ -494,6 +504,7 @@ tmpdir is currently ${System.getProperty("java.io.tmpdir")}""")
     }
 
     protected ExecutionFailure fails(List<String> tasks) {
+        setupExecuter()
         resetProblemApiCheck()
 
         failure = executer.withTasks(tasks).runWithFailure()

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -87,7 +87,7 @@ abstract class AbstractIntegrationSpec extends Specification implements Language
     private boolean enableProblemsApiCheck = false
     private BuildOperationsFixture buildOperationsFixture = null
 
-    public GradleExecuter getExecuter() {
+    GradleExecuter getExecuter() {
         if (executor == null) {
             executor = createExecuter()
         }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationTest.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationTest.java
@@ -40,7 +40,7 @@ import java.util.List;
 
 @IntegrationTest
 @Category(IntegrationTest.class)
-public abstract class AbstractIntegrationTest {
+public abstract class AbstractIntegrationTest implements HasGradleExecutor {
 
     @Rule
     public final PreconditionVerifier preconditionVerifier = new PreconditionVerifier();
@@ -83,7 +83,8 @@ public abstract class AbstractIntegrationTest {
         return distribution;
     }
 
-    protected GradleExecuter getExecuter() {
+    @Override
+    public GradleExecuter getExecuter() {
         return executer;
     }
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/CommonDeprecations.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/CommonDeprecations.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures
+
+import groovy.transform.SelfType
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+
+/**
+ * Apply this trait to tests that may need to expect common deprecations.
+ */
+@SelfType(AbstractIntegrationSpec)
+trait CommonDeprecations {
+    void expectTaskGetProjectDeprecations(int count = 1) {
+        if (GradleContextualExecuter.notConfigCache) {
+            count.times {
+                executer.expectDocumentedDeprecationWarning("Invocation of Task.project at execution time has been deprecated. " +
+                    "This will fail with an error in Gradle 9.0. " +
+                    "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_project")
+            }
+        }
+    }
+}

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/CommonDeprecations.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/CommonDeprecations.groovy
@@ -22,7 +22,7 @@ import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 /**
  * Apply this trait to tests that may need to expect common deprecations.
  */
-@SelfType(AbstractIntegrationSpec)
+@SelfType(HasGradleExecutor)
 trait CommonDeprecations {
     void expectTaskGetProjectDeprecations(int count = 1) {
         if (GradleContextualExecuter.notConfigCache) {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/HasGradleExecutor.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/HasGradleExecutor.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures
+
+import org.gradle.integtests.fixtures.executer.GradleExecuter
+
+interface HasGradleExecutor {
+    GradleExecuter getExecuter()
+}

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/StableConfigurationCacheDeprecations.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/StableConfigurationCacheDeprecations.groovy
@@ -20,10 +20,11 @@ import groovy.transform.SelfType
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 
 /**
- * Apply this trait to tests that may need to expect common deprecations.
+ * Apply this trait to tests that may need to expect common deprecations,
+ * typically those that used to be behind the STABLE_CONFIGURATION_CACHE feature flag.
  */
 @SelfType(HasGradleExecutor)
-trait CommonDeprecations {
+trait StableConfigurationCacheDeprecations {
     void expectTaskGetProjectDeprecations(int count = 1) {
         if (GradleContextualExecuter.notConfigCache) {
             count.times {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/WellBehavedPluginTest.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/WellBehavedPluginTest.groovy
@@ -24,6 +24,8 @@ import java.util.regex.Pattern
 
 abstract class WellBehavedPluginTest extends AbstractIntegrationSpec {
 
+    boolean expectTaskProjectDeprecation
+
     String getPluginName() {
         def matcher = Pattern.compile("(\\w+)Plugin(GoodBehaviour)?(Integ(ration)?)?Test").matcher(getClass().simpleName)
         if (matcher.matches()) {
@@ -53,6 +55,7 @@ abstract class WellBehavedPluginTest extends AbstractIntegrationSpec {
         applyPluginUnqualified()
 
         expect:
+        expectTaskProjectDeprecationIfNeeded()
         succeeds mainTask
     }
 
@@ -81,6 +84,7 @@ abstract class WellBehavedPluginTest extends AbstractIntegrationSpec {
         applyPlugin()
 
         expect:
+        expectTaskProjectDeprecationIfNeeded()
         succeeds mainTask
     }
 
@@ -154,5 +158,17 @@ abstract class WellBehavedPluginTest extends AbstractIntegrationSpec {
 
         then:
         assert output.count("configuring :") == 0
+    }
+
+    void expectTaskProjectDeprecationIfNeeded() {
+        if (expectTaskProjectDeprecation) {
+            expectTaskProjectDeprecation()
+        }
+    }
+
+    void expectTaskProjectDeprecation() {
+        executer.expectDocumentedDeprecationWarning("Invocation of Task.project at execution time has been deprecated. "+
+            "This will fail with an error in Gradle 9.0. " +
+            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_project")
     }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AsciidoctorPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AsciidoctorPluginSmokeTest.groovy
@@ -121,6 +121,13 @@ class AsciidoctorPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
                     "Use ExecOperations.javaexec(Action) or ProviderFactory.javaexec(Action) instead. " +
                     "Consult the upgrading guide for further information: ${BASE_URL}/userguide/upgrading_version_8.html#deprecated_project_exec"
             )
+
+            runner.expectLegacyDeprecationWarningIf(
+                versionNumber.major < 4,
+                "Invocation of Task.project at execution time has been deprecated. " +
+                    "This will fail with an error in Gradle 9.0. " +
+                    "Consult the upgrading guide for further information: ${BASE_URL}/userguide/upgrading_version_7.html#task_project"
+            )
         }
     }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BNDSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BNDSmokeTest.groovy
@@ -17,10 +17,13 @@
 package org.gradle.smoketests
 
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.archive.JarTestFixture
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 import spock.lang.Issue
+
+import static org.gradle.api.internal.DocumentationRegistry.BASE_URL
 
 /**
  * Smoke tests for <a href="https://github.com/bndtools/bnd/blob/master/gradle-plugins/README.md">the BND plugin</a>.
@@ -407,7 +410,13 @@ Bundle-Activator: com.example.Activator
 """
 
         expect:
-        def result = runner(":run").build()
+        def result = runner(":run")
+            .expectDeprecationWarningIf(GradleContextualExecuter.notConfigCache,
+                "Invocation of Task.project at execution time has been deprecated. "+
+                "This will fail with an error in Gradle 9.0. " +
+                "Consult the upgrading guide for further information: $BASE_URL/userguide/upgrading_version_7.html#task_project",
+                "https://github.com/bndtools/bnd/issues/6346"
+            ).build()
 
         assert result.getOutput().contains("Example project ran.")
     }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleVersionsPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleVersionsPluginSmokeTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.smoketests
 
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.util.GradleVersion
 import org.gradle.util.internal.VersionNumber
 import org.junit.Assume
@@ -60,6 +61,15 @@ class GradleVersionsPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
         runner.expectDeprecationWarning(
             "The LenientConfiguration.getFirstLevelModuleDependencies(Spec) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getFirstLevelModuleDependencies() instead. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods",
             "https://github.com/ben-manes/gradle-versions-plugin/pull/856"
+        )
+
+        // with CC, these are reported as config cache problems only
+        runner.expectDeprecationWarningIf(
+            GradleContextualExecuter.isNotConfigCache(),
+            "Invocation of Task.project at execution time has been deprecated. " +
+                "This will fail with an error in Gradle 9.0. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_7.html#task_project",
+            "https://github.com/ben-manes/gradle-versions-plugin/issues/910"
         )
 
         def result = runner.build()

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GrettySmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GrettySmokeTest.groovy
@@ -78,6 +78,12 @@ class GrettySmokeTest extends AbstractPluginValidatingSmokeTest {
                     "Consult the upgrading guide for further information: ${BASE_URL}/userguide/upgrading_version_8.html#deprecated_project_exec",
                 "https://github.com/gretty-gradle-plugin/gretty/issues/312"
             )
+            .expectDeprecationWarning(
+                "Invocation of Task.project at execution time has been deprecated. " +
+                    "This will fail with an error in Gradle 9.0. " +
+                    "Consult the upgrading guide for further information: ${BASE_URL}/userguide/upgrading_version_7.html#task_project",
+                "https://github.com/gretty-gradle-plugin/gretty/issues/313"
+            )
             .build()
 
         then:

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinMultiplatformPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinMultiplatformPluginSmokeTest.groovy
@@ -17,7 +17,9 @@
 package org.gradle.smoketests
 
 import org.gradle.api.JavaVersion
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.versions.KotlinGradlePluginVersions
+import org.gradle.util.GradleVersion
 import org.gradle.util.internal.VersionNumber
 import spock.lang.Issue
 
@@ -61,6 +63,11 @@ class KotlinMultiplatformPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
                 kotlinVersionNumber >= VersionNumber.parse('1.9.22') && kotlinVersionNumber.baseVersion < KotlinGradlePluginVersions.KOTLIN_2_0_20,
                 "Internal API BuildOperationExecutor.getCurrentOperation() has been deprecated. This is scheduled to be removed in Gradle 9.0.",
                 "https://youtrack.jetbrains.com/issue/KT-67110"
+            )
+            .expectDeprecationWarningIf(
+                GradleContextualExecuter.notConfigCache,
+                "Invocation of Task.project at execution time has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_7.html#task_project",
+                "https://youtrack.jetbrains.com/issue/KT-58374"
             )
             .build()
 

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NebulaPluginsSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NebulaPluginsSmokeTest.groovy
@@ -17,10 +17,13 @@
 package org.gradle.smoketests
 
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.reflect.validation.ValidationMessageChecker
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 import spock.lang.Issue
+
+import static org.gradle.api.internal.DocumentationRegistry.BASE_URL
 
 class NebulaPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implements ValidationMessageChecker {
 
@@ -98,7 +101,9 @@ class NebulaPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implement
         """.stripIndent()
 
         when:
-        def result = runner('autoLintGradle').build()
+        def result = runner('autoLintGradle').deprecations(NebulaPluginDeprecations) {
+            expectNebulaLintPluginDeprecations()
+        }.build()
 
         then:
         int numOfRepoBlockLines = 14 + mavenCentralRepository().readLines().size()
@@ -109,7 +114,9 @@ class NebulaPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implement
         buildFile.text.contains("testImplementation('junit:junit:4.7')")
 
         when:
-        result = runner('fixGradleLint').build()
+        result = runner('fixGradleLint').deprecations(NebulaPluginDeprecations) {
+            expectNebulaLintPluginDeprecations()
+        }.build()
 
         then:
         result.output.contains("""fixed          dependency-parentheses             parentheses are unnecessary for dependencies
@@ -128,7 +135,9 @@ testImplementation('junit:junit:4.7')""")
         """.stripIndent()
 
         then:
-        runner('buildEnvironment', 'generateLock').build()
+        runner('buildEnvironment', 'generateLock').deprecations(NebulaPluginDeprecations) {
+            expectNebulaDependencyLockPluginDeprecations()
+        }.build()
 
         where:
         nebulaDepLockVersion << TestedVersions.nebulaDependencyLock.versions
@@ -191,7 +200,9 @@ testImplementation('junit:junit:4.7')""")
 
         then:
         runner('dependencies').build()
-        runner('generateLock').build()
+        runner('generateLock').deprecations(NebulaPluginDeprecations) {
+            expectNebulaDependencyLockPluginDeprecations()
+        }.build()
         runner('resolve').build()
 
         where:
@@ -244,5 +255,32 @@ testImplementation('junit:junit:4.7')""")
             'com.netflix.nebula.dependency-lock': TestedVersions.nebulaDependencyLock,
             'com.netflix.nebula.resolution-rules': Versions.of(TestedVersions.nebulaResolutionRules)
         ]
+    }
+}
+
+class NebulaPluginDeprecations extends BaseDeprecations {
+
+    NebulaPluginDeprecations(SmokeTestGradleRunner runner) {
+        super(runner)
+    }
+
+    void expectNebulaDependencyLockPluginDeprecations() {
+        // with CC, these are reported as config cache problems only
+        runner.expectDeprecationWarningIf(GradleContextualExecuter.notConfigCache,
+            "Invocation of Task.project at execution time has been deprecated. "+
+            "This will fail with an error in Gradle 9.0. " +
+            "Consult the upgrading guide for further information: $BASE_URL/userguide/upgrading_version_7.html#task_project",
+            "https://github.com/nebula-plugins/gradle-dependency-lock-plugin/issues/273"
+        )
+    }
+
+    void expectNebulaLintPluginDeprecations() {
+        // with CC, these are reported as config cache problems only
+        runner.expectDeprecationWarningIf(GradleContextualExecuter.notConfigCache,
+            "Invocation of Task.project at execution time has been deprecated. "+
+            "This will fail with an error in Gradle 9.0. " +
+            "Consult the upgrading guide for further information: $BASE_URL/userguide/upgrading_version_7.html#task_project",
+            "https://github.com/nebula-plugins/gradle-lint-plugin/issues/412"
+        )
     }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NebulaPluginsSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NebulaPluginsSmokeTest.groovy
@@ -256,31 +256,33 @@ testImplementation('junit:junit:4.7')""")
             'com.netflix.nebula.resolution-rules': Versions.of(TestedVersions.nebulaResolutionRules)
         ]
     }
+
+    private static class NebulaPluginDeprecations extends BaseDeprecations {
+
+        NebulaPluginDeprecations(SmokeTestGradleRunner runner) {
+            super(runner)
+        }
+
+        void expectNebulaDependencyLockPluginDeprecations() {
+            // with CC, these are reported as config cache problems only
+            runner.expectDeprecationWarningIf(GradleContextualExecuter.notConfigCache,
+                "Invocation of Task.project at execution time has been deprecated. "+
+                    "This will fail with an error in Gradle 9.0. " +
+                    "Consult the upgrading guide for further information: $BASE_URL/userguide/upgrading_version_7.html#task_project",
+                "https://github.com/nebula-plugins/gradle-dependency-lock-plugin/issues/273"
+            )
+        }
+
+        void expectNebulaLintPluginDeprecations() {
+            // with CC, these are reported as config cache problems only
+            runner.expectDeprecationWarningIf(GradleContextualExecuter.notConfigCache,
+                "Invocation of Task.project at execution time has been deprecated. "+
+                    "This will fail with an error in Gradle 9.0. " +
+                    "Consult the upgrading guide for further information: $BASE_URL/userguide/upgrading_version_7.html#task_project",
+                "https://github.com/nebula-plugins/gradle-lint-plugin/issues/412"
+            )
+        }
+    }
 }
 
-class NebulaPluginDeprecations extends BaseDeprecations {
 
-    NebulaPluginDeprecations(SmokeTestGradleRunner runner) {
-        super(runner)
-    }
-
-    void expectNebulaDependencyLockPluginDeprecations() {
-        // with CC, these are reported as config cache problems only
-        runner.expectDeprecationWarningIf(GradleContextualExecuter.notConfigCache,
-            "Invocation of Task.project at execution time has been deprecated. "+
-            "This will fail with an error in Gradle 9.0. " +
-            "Consult the upgrading guide for further information: $BASE_URL/userguide/upgrading_version_7.html#task_project",
-            "https://github.com/nebula-plugins/gradle-dependency-lock-plugin/issues/273"
-        )
-    }
-
-    void expectNebulaLintPluginDeprecations() {
-        // with CC, these are reported as config cache problems only
-        runner.expectDeprecationWarningIf(GradleContextualExecuter.notConfigCache,
-            "Invocation of Task.project at execution time has been deprecated. "+
-            "This will fail with an error in Gradle 9.0. " +
-            "Consult the upgrading guide for further information: $BASE_URL/userguide/upgrading_version_7.html#task_project",
-            "https://github.com/nebula-plugins/gradle-lint-plugin/issues/412"
-        )
-    }
-}


### PR DESCRIPTION
Fixes: #30860

* changed `platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DeprecatedFeaturesListener.kt` so Task.project deprecations are no longer behind `STABLE_CONFIGURATION_CACHE`
* introduced `testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/CommonDeprecations.groovy` trait to be applied to tests that may need to expect the deprecation
* updated `platforms/documentation/docs/src/docs/userguide/optimizing-performance/configuration_cache.adoc` so the deprecation is no longer linked to the feature flag
* changed `platforms/native/language-native/src/main/java/org/gradle/swiftpm/tasks/GenerateSwiftPackageManagerManifest.java` so it no longer accesses `Task.project` at execution time (all it needeed was the project name), and updated corresponding tests to remove `@ToBeFixedForCC`) 
* changed dozens of tests to expect the new deprecation
* in some cases, fixed the tests themselves (example: `platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsafeConfigurationResolutionDeprecationIntegrationTest.groovy`)

To be done:
* address doc snippet tests

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
