### PR TITLE
Clean up shared object encoder/decoder support

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeIO.kt
@@ -24,15 +24,9 @@ import org.gradle.internal.cc.impl.cacheentry.ModelKey
 import org.gradle.internal.cc.impl.serialize.Codecs
 import org.gradle.internal.serialize.graph.CloseableReadContext
 import org.gradle.internal.serialize.graph.CloseableWriteContext
-import org.gradle.internal.serialize.graph.SharedObjectDecoder
-import org.gradle.internal.serialize.graph.SharedObjectEncoder
-import org.gradle.internal.serialize.graph.InlineSharedObjectDecoder
-import org.gradle.internal.serialize.graph.InlineSharedObjectEncoder
-import org.gradle.internal.serialize.graph.InlineStringDecoder
-import org.gradle.internal.serialize.graph.InlineStringEncoder
 import org.gradle.internal.serialize.graph.MutableReadContext
-import org.gradle.internal.serialize.graph.StringDecoder
-import org.gradle.internal.serialize.graph.StringEncoder
+import org.gradle.internal.serialize.graph.SpecialDecoders
+import org.gradle.internal.serialize.graph.SpecialEncoders
 import org.gradle.internal.serialize.graph.WriteContext
 import org.gradle.util.Path
 import java.io.InputStream
@@ -75,24 +69,21 @@ interface ConfigurationCacheBuildTreeIO : ConfigurationCacheOperationIO {
         stateType: StateType,
         outputStream: () -> OutputStream,
         profile: () -> String,
-        stringEncoder: StringEncoder = InlineStringEncoder,
-        sharedObjectEncoder: SharedObjectEncoder = InlineSharedObjectEncoder,
+        specialEncoders: SpecialEncoders = SpecialEncoders(),
     ): Pair<CloseableWriteContext, Codecs>
 
     fun <R> withReadContextFor(
         stateFile: ConfigurationCacheStateFile,
-        stringDecoder: StringDecoder = InlineStringDecoder,
-        sharedObjectDecoder: SharedObjectDecoder = InlineSharedObjectDecoder,
+        specialDecoders: SpecialDecoders = SpecialDecoders(),
         readOperation: suspend MutableReadContext.(Codecs) -> R
     ): R =
-        withReadContextFor(stateFile.stateFile.name, stateFile.stateType, stateFile::inputStream, stringDecoder, sharedObjectDecoder, readOperation)
+        withReadContextFor(stateFile.stateFile.name, stateFile.stateType, stateFile::inputStream, specialDecoders, readOperation)
 
     fun <R> withReadContextFor(
         name: String,
         stateType: StateType,
         inputStream: () -> InputStream,
-        stringDecoder: StringDecoder = InlineStringDecoder,
-        sharedObjectDecoder: SharedObjectDecoder = InlineSharedObjectDecoder,
+        specialDecoders: SpecialDecoders = SpecialDecoders(),
         readOperation: suspend MutableReadContext.(Codecs) -> R
     ): R
 
@@ -105,19 +96,17 @@ interface ConfigurationCacheBuildTreeIO : ConfigurationCacheOperationIO {
     fun <R> withWriteContextFor(
         stateFile: ConfigurationCacheStateFile,
         profile: () -> String,
-        stringEncoder: StringEncoder,
-        sharedObjectEncoder: SharedObjectEncoder,
+        specialEncoders: SpecialEncoders,
         writeOperation: suspend WriteContext.(Codecs) -> R
     ): R =
-        withWriteContextFor(stateFile.stateFile.name, stateFile.stateType, stateFile::outputStream, profile, stringEncoder, sharedObjectEncoder, writeOperation)
+        withWriteContextFor(stateFile.stateFile.name, stateFile.stateType, stateFile::outputStream, profile, specialEncoders, writeOperation)
 
     fun <R> withWriteContextFor(
         name: String,
         stateType: StateType,
         outputStream: () -> OutputStream,
         profile: () -> String,
-        stringEncoder: StringEncoder,
-        sharedObjectEncoder: SharedObjectEncoder,
+        specialEncoders: SpecialEncoders,
         writeOperation: suspend WriteContext.(Codecs) -> R
     ): R
 }

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/ProviderCodecs.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/ProviderCodecs.kt
@@ -55,8 +55,10 @@ import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext
 import org.gradle.internal.serialize.graph.codecs.BeanCodec
 import org.gradle.internal.serialize.graph.codecs.Bindings
+import org.gradle.internal.serialize.graph.decodeBean
 import org.gradle.internal.serialize.graph.decodePreservingIdentity
 import org.gradle.internal.serialize.graph.decodePreservingSharedIdentity
+import org.gradle.internal.serialize.graph.encodeBean
 import org.gradle.internal.serialize.graph.encodePreservingIdentityOf
 import org.gradle.internal.serialize.graph.encodePreservingSharedIdentityOf
 import org.gradle.internal.serialize.graph.logPropertyProblem
@@ -265,16 +267,12 @@ class BuildServiceProviderCodec(
 object BuildServiceParameterCodec : Codec<BuildServiceParameters> {
     override suspend fun WriteContext.encode(value: BuildServiceParameters) =
         writeSharedObject(value) {
-            BeanCodec.run {
-                encode(value)
-            }
+            encodeBean(value)
         }
 
     override suspend fun ReadContext.decode(): BuildServiceParameters =
         readSharedObject {
-            BeanCodec.run {
-                decode()
-            }
+            decodeBean()
         }.uncheckedCast()
 }
 

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
@@ -41,6 +41,18 @@ interface BeanStateReaderLookup {
 }
 
 
+data class SpecialEncoders(
+    val stringEncoder: StringEncoder = InlineStringEncoder,
+    val sharedObjectEncoder: SharedObjectEncoder = InlineSharedObjectEncoder
+)
+
+
+data class SpecialDecoders(
+    val stringDecoder: StringDecoder = InlineStringDecoder,
+    val sharedObjectDecoder: SharedObjectDecoder = InlineSharedObjectDecoder
+)
+
+
 class DefaultWriteContext(
     name: String? = null,
 
@@ -61,11 +73,13 @@ class DefaultWriteContext(
     private
     val classEncoder: ClassEncoder,
 
-    val stringEncoder: StringEncoder = InlineStringEncoder,
-
-    val sharedObjectEncoder: SharedObjectEncoder = InlineSharedObjectEncoder
+    specialEncoders: SpecialEncoders = SpecialEncoders()
 
 ) : AbstractIsolateContext<WriteIsolate>(codec, problemsListener, name), CloseableWriteContext, Encoder by encoder {
+
+    val stringEncoder = specialEncoders.stringEncoder
+
+    val sharedObjectEncoder = specialEncoders.sharedObjectEncoder
 
     override val sharedIdentities = WriteIdentities()
 
@@ -223,13 +237,14 @@ class DefaultReadContext(
     private
     val classDecoder: ClassDecoder,
 
-    val stringDecoder: StringDecoder = InlineStringDecoder,
-
-    val sharedObjectDecoder: SharedObjectDecoder = InlineSharedObjectDecoder
-
+    specialDecoders: SpecialDecoders = SpecialDecoders()
 ) : AbstractIsolateContext<ReadIsolate>(codec, problemsListener, name), CloseableReadContext, Decoder by decoder {
 
     override val sharedIdentities = ReadIdentities()
+
+    val stringDecoder = specialDecoders.stringDecoder
+
+    val sharedObjectDecoder = specialDecoders.sharedObjectDecoder
 
     private
     var singletonProperty: Any? = null


### PR DESCRIPTION
Issue: #30855 

* introduces a parameters object for special encoders (covering string and shared objects for now)
* leverages `encode/decodeBean`, which now work properly with decorated objects, thanks to #30845


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
