### PR TITLE
Forbid cycles for included plugin builds in IP mode

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsCompositeBuildIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsCompositeBuildIntegrationTest.groovy
@@ -16,6 +16,10 @@
 
 package org.gradle.internal.cc.impl.isolated
 
+import org.gradle.test.fixtures.file.TestFile
+
+import java.util.function.Consumer
+
 class IsolatedProjectsCompositeBuildIntegrationTest extends AbstractIsolatedProjectsIntegrationTest {
     def "can build libraries composed from multiple builds"() {
         settingsFile << """
@@ -46,5 +50,123 @@ class IsolatedProjectsCompositeBuildIntegrationTest extends AbstractIsolatedProj
 
         then:
         fixture.assertStateLoaded()
+    }
+
+    def "cycles for plugin builds are prohibited"() {
+        given:
+        includePluginBuild(settingsFile, "plugins-a")
+        includedBuild("plugins-a") { layout ->
+            includePluginBuild(layout.settingsScript, "../plugins-b")
+        }
+        includedBuild("plugins-b") { layout ->
+            includePluginBuild(layout.settingsScript, "../plugins-c")
+        }
+        includedBuild("plugins-c") { layout ->
+            includePluginBuild(layout.settingsScript, "../plugins-a")
+        }
+
+        when:
+        isolatedProjectsFails("help")
+
+        then:
+        failureDescriptionContains("Cycle detected in the included builds definition: :plugins-c -> :plugins-a -> :plugins-b -> :plugins-c")
+    }
+
+    def "transitive cycles for plugin builds are prohibited"() {
+        given:
+        includePluginBuild(settingsFile, "plugins-a")
+        includedBuild("plugins-a") { layout ->
+            includeLibraryBuild(layout.settingsScript, "../library-b")
+        }
+        includedBuild("library-b") { layout ->
+            includeLibraryBuild(layout.settingsScript, "../library-c")
+        }
+        includedBuild("library-c") { layout ->
+            includePluginBuild(layout.settingsScript, "../plugins-a")
+        }
+
+        when:
+        isolatedProjectsFails("help")
+
+        then:
+        failureDescriptionContains("Cycle detected in the included builds definition: :library-c -> :plugins-a -> :library-b -> :library-c")
+    }
+
+    def "introduced-by-settings-plugin cycles for plugins builds are prohibited"() {
+        given:
+        includedBuild("settings-plugins") { layout ->
+            layout.buildScript << """
+                plugins {
+                    id("groovy-gradle-plugin")
+                }
+            """
+            layout.srcMainGroovy.file("my-plugin.settings.gradle") << """
+                pluginManagement {
+                    includeBuild("../build-logic")
+                }
+            """
+        }
+        includedBuild("build-logic") { layout ->
+            includePluginBuild(layout.settingsScript, "../settings-plugins")
+            layout.settingsScript << """
+                plugins {
+                    id("my-plugin")
+                }
+            """
+        }
+        includePluginBuild(settingsFile, "build-logic")
+
+        when:
+        isolatedProjectsFails("help")
+
+        then:
+        failureDescriptionContains("Cycle detected in the included builds definition: :build-logic -> :build-logic")
+    }
+
+    def "cycles for library builds are allowed"() {
+        given:
+        includeLibraryBuild(settingsFile, "library-a")
+        includedBuild("library-a") { layout ->
+            includeLibraryBuild(layout.settingsScript, "../library-b")
+        }
+        includedBuild("library-b") { layout ->
+            includeLibraryBuild(layout.settingsScript, "../library-c")
+        }
+        includedBuild("library-c") { layout ->
+            includeLibraryBuild(layout.settingsScript, "../library-a")
+        }
+
+        expect:
+        isolatedProjectsRun("help")
+    }
+
+    private def includedBuild(String root, Consumer<BuildLayout> configure) {
+        configure(new BuildLayout(file("$root/settings.gradle"), file("$root/build.gradle"), file("$root/src/main/groovy")))
+    }
+
+    private static def includeLibraryBuild(TestFile settingsFile, String build) {
+        settingsFile << """
+            includeBuild("$build")
+       """
+    }
+
+    private static def includePluginBuild(TestFile settingsFile, String build) {
+        settingsFile << """
+            pluginManagement {
+                includeBuild("$build")
+            }
+        """
+    }
+
+    private class BuildLayout {
+        TestFile settingsScript
+        TestFile buildScript
+        TestFile srcMainGroovy
+
+        BuildLayout(TestFile settingsScript, TestFile buildScript, TestFile srcMainGroovy) {
+            this.settingsScript = settingsScript
+            this.buildScript = buildScript
+            this.srcMainGroovy = srcMainGroovy
+        }
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsCompositeBuildIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsCompositeBuildIntegrationTest.groovy
@@ -69,7 +69,7 @@ class IsolatedProjectsCompositeBuildIntegrationTest extends AbstractIsolatedProj
         isolatedProjectsFails("help")
 
         then:
-        failureDescriptionContains("Cycle detected in the included builds definition: :plugins-c -> :plugins-a -> :plugins-b -> :plugins-c")
+        failureDescriptionContains("A cycle has been detected in the definition of plugin builds: :plugins-c -> :plugins-a -> :plugins-b -> :plugins-c. This is not supported with Isolated Projects. Please update your build definition to remove one of the edges.")
     }
 
     def "transitive cycles for plugin builds are prohibited"() {
@@ -89,7 +89,7 @@ class IsolatedProjectsCompositeBuildIntegrationTest extends AbstractIsolatedProj
         isolatedProjectsFails("help")
 
         then:
-        failureDescriptionContains("Cycle detected in the included builds definition: :library-c -> :plugins-a -> :library-b -> :library-c")
+        failureDescriptionContains("A cycle has been detected in the definition of plugin builds: :library-c -> :plugins-a -> :library-b -> :library-c. This is not supported with Isolated Projects. Please update your build definition to remove one of the edges.")
     }
 
     def "introduced-by-settings-plugin cycles for plugins builds are prohibited"() {
@@ -120,7 +120,7 @@ class IsolatedProjectsCompositeBuildIntegrationTest extends AbstractIsolatedProj
         isolatedProjectsFails("help")
 
         then:
-        failureDescriptionContains("Cycle detected in the included builds definition: :build-logic -> :build-logic")
+        failureDescriptionContains("A cycle has been detected in the definition of plugin builds: :build-logic -> :build-logic. This is not supported with Isolated Projects. Please update your build definition to remove one of the edges.")
     }
 
     def "cycles for library builds are allowed"() {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsCompositeBuildIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsCompositeBuildIntegrationTest.groovy
@@ -77,7 +77,7 @@ class IsolatedProjectsCompositeBuildIntegrationTest extends AbstractIsolatedProj
         isolatedProjectsFails("help")
 
         then:
-        failureDescriptionContains("A cycle has been detected in the definition of plugin builds: :plugins-c -> :plugins-a -> :plugins-b -> :plugins-c.")
+        failureDescriptionContains("A cycle has been detected in the definition of plugin builds: :plugins-a -> :plugins-b -> :plugins-c -> :plugins-a.")
     }
 
     def "transitive cycles(start is a plugin) for plugin builds are prohibited"() {
@@ -103,7 +103,7 @@ class IsolatedProjectsCompositeBuildIntegrationTest extends AbstractIsolatedProj
         isolatedProjectsFails("help")
 
         then:
-        failureDescriptionContains("A cycle has been detected in the definition of plugin builds: :library-c -> :plugins-a -> :library-b -> :library-c.")
+        failureDescriptionContains("A cycle has been detected in the definition of plugin builds: :plugins-a -> :library-b -> :library-c -> :plugins-a.")
     }
 
     def "transitive cycles(start is a library) for plugin builds are prohibited"() {
@@ -120,16 +120,20 @@ class IsolatedProjectsCompositeBuildIntegrationTest extends AbstractIsolatedProj
         }
 
         includedBuild("plugins-a") {
-            includeLibraryBuild(settingsScript, "../library-a")
+            includeLibraryBuild(settingsScript, "../library-c")
             applyPlugins(buildScript, ["groovy-gradle-plugin"])
             srcMainGroovy.file("plugin-a.gradle") << ""
+        }
+
+        includedBuild("library-c") {
+            includeLibraryBuild(settingsScript, "../library-b")
         }
 
         when:
         isolatedProjectsFails("help")
 
         then:
-        failureDescriptionContains("A cycle has been detected in the definition of plugin builds: :plugins-a -> :library-a -> :library-b -> :plugins-a.")
+        failureDescriptionContains("A cycle has been detected in the definition of plugin builds: :plugins-a -> :library-c -> :library-b -> :plugins-a.")
     }
 
     def "introduced-by-settings-plugin cycles for plugins builds are prohibited"() {

--- a/subprojects/composite-builds/build.gradle.kts
+++ b/subprojects/composite-builds/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     implementation(projects.daemonServices)
     implementation(projects.logging)
     implementation(projects.serviceLookup)
+    implementation(projects.functional)
 
     implementation(libs.slf4jApi)
     implementation(libs.guava)

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
@@ -78,7 +78,7 @@ public class CompositeBuildServices extends AbstractGradleModuleServices {
         ) {
             if (buildModelParameters.isIsolatedProjects()) {
                 // IP mode prohibits cycles in included plugin builds graph
-                return new CycleDetectingIncludedBuildRegistry(includedBuildFactory, listenerManager, buildStateFactory);
+                return new AcyclicIncludedBuildRegistry(includedBuildFactory, listenerManager, buildStateFactory);
             } else {
                 return new DefaultIncludedBuildRegistry(includedBuildFactory, listenerManager, buildStateFactory);
             }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
@@ -23,7 +23,11 @@ import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.api.internal.composite.CompositeBuildContext;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.composite.internal.plugins.CompositeBuildPluginResolverContributor;
+import org.gradle.internal.build.BuildStateRegistry;
+import org.gradle.internal.build.IncludedBuildFactory;
+import org.gradle.internal.buildtree.BuildModelParameters;
 import org.gradle.internal.buildtree.GlobalDependencySubstitutionRegistry;
+import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.Provides;
 import org.gradle.internal.service.ServiceRegistration;
@@ -63,7 +67,21 @@ public class CompositeBuildServices extends AbstractGradleModuleServices {
             serviceRegistration.add(BuildStateFactory.class);
             serviceRegistration.add(DefaultIncludedBuildFactory.class);
             serviceRegistration.add(DefaultIncludedBuildTaskGraph.class);
-            serviceRegistration.add(DefaultIncludedBuildRegistry.class);
+        }
+
+        @Provides
+        public BuildStateRegistry createBuildStateRegistry(
+            BuildModelParameters buildModelParameters,
+            IncludedBuildFactory includedBuildFactory,
+            ListenerManager listenerManager,
+            BuildStateFactory buildStateFactory
+        ) {
+            if (buildModelParameters.isIsolatedProjects()) {
+                // IP mode prohibits cycles in included plugin builds graph
+                return new CycleDetectingIncludedBuildRegistry(includedBuildFactory, listenerManager, buildStateFactory);
+            } else {
+                return new DefaultIncludedBuildRegistry(includedBuildFactory, listenerManager, buildStateFactory);
+            }
         }
 
         @Provides

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CycleDetectingIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CycleDetectingIncludedBuildRegistry.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.composite.internal;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.internal.BuildDefinition;
+import org.gradle.internal.build.BuildState;
+import org.gradle.internal.build.IncludedBuildFactory;
+import org.gradle.internal.build.IncludedBuildState;
+import org.gradle.internal.event.ListenerManager;
+
+import java.util.Optional;
+
+public class CycleDetectingIncludedBuildRegistry extends DefaultIncludedBuildRegistry {
+
+    private final DynamicGraphCycleDetector<BuildState> cycleDetector = new DynamicGraphCycleDetector<>();
+
+    public CycleDetectingIncludedBuildRegistry(
+        IncludedBuildFactory includedBuildFactory,
+        ListenerManager listenerManager,
+        BuildStateFactory buildStateFactory
+    ) {
+        super(includedBuildFactory, listenerManager, buildStateFactory);
+    }
+
+    @Override
+    public IncludedBuildState addIncludedBuild(BuildDefinition buildDefinition, BuildState referrer) {
+        IncludedBuildState includedBuild = super.addIncludedBuild(buildDefinition, referrer);
+        Optional<DynamicGraphCycleDetector.Cycle<BuildState>> cycle = cycleDetector.addEdge(referrer, includedBuild);
+        // If the included build was initially registered as a plugin build, any subsequent library registration
+        // resulting of that build will still be considered a plugin build, and vice versa.
+        // This is why we rely on the upcoming build definition, which reflects the actual user intention.
+        if (buildDefinition.isPluginBuild()) {
+            cycle.ifPresent(CycleDetectingIncludedBuildRegistry::reportCycle);
+        }
+        return includedBuild;
+    }
+
+    private static void reportCycle(DynamicGraphCycleDetector.Cycle<BuildState> cycle) {
+        String path = cycle.format(buildState -> buildState.getIdentityPath().getPath());
+        throw new GradleException("Cycle detected in the included builds definition: " + path);
+    }
+}

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CycleDetectingIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CycleDetectingIncludedBuildRegistry.java
@@ -52,6 +52,6 @@ public class CycleDetectingIncludedBuildRegistry extends DefaultIncludedBuildReg
 
     private static void reportCycle(DynamicGraphCycleDetector.Cycle<BuildState> cycle) {
         String path = cycle.format(buildState -> buildState.getIdentityPath().getPath());
-        throw new GradleException("Cycle detected in the included builds definition: " + path);
+        throw new GradleException(String.format("A cycle has been detected in the definition of plugin builds: %s. This is not supported with Isolated Projects. Please update your build definition to remove one of the edges.", path));
     }
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
@@ -109,7 +109,7 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
     }
 
     @Override
-    public IncludedBuildState addIncludedBuild(BuildDefinition buildDefinition) {
+    public IncludedBuildState addIncludedBuild(BuildDefinition buildDefinition, BuildState referrer) {
         return registerBuild(buildDefinition, false, null);
     }
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DynamicGraphCycleDetector.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DynamicGraphCycleDetector.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.composite.internal;
+
+import org.gradle.internal.collect.PersistentList;
+
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * A directed graph implementation that dynamically detects and prevents cycles as edges are added.
+ *
+ * <p>This class allows the construction of a directed graph where nodes are added along with their dependencies
+ * (represented as directed edges). As each edge is added, the graph checks if introducing the edge would result
+ * in a cycle. If a cycle is detected, the edge is not added, and an {@link Optional} containing the cycle
+ * (represented as a {@link Cycle}) is returned.</p>
+ *
+ * <p>This class is useful in scenarios where dynamically managing dependencies between entities is required,
+ * and introducing cycles in the dependency graph must be avoided.</p>
+ *
+ * <p>The graph is represented internally as a {@link Map}, where each node is mapped to a set of its referrers
+ * (i.e., nodes that point to it). Cycle detection uses a depth-first search (DFS) approach to trace paths
+ * between nodes when new edges are added.</p>
+ *
+ * @param <T> the type of nodes in the graph
+ * */
+class DynamicGraphCycleDetector<T> {
+
+    public static class Cycle<T> {
+
+        private final PersistentList<T> path;
+
+        public Cycle(PersistentList<T> path) {
+            this.path = path;
+        }
+
+        public String format(Function<T, String> toString) {
+            StringBuilder builder = new StringBuilder();
+            for (T segment : path) {
+                if (builder.length() > 0) {
+                    builder.append(" -> ");
+                }
+                builder.append(toString.apply(segment));
+            }
+            return builder.toString();
+        }
+
+        public Cycle<T> plus(T from) {
+            return new Cycle<>(path.plus(from));
+        }
+    }
+
+    private final Map<T, Set<T>> graph = new HashMap<>();
+
+    public synchronized Optional<Cycle<T>> addEdge(T from, T to) {
+        if (from.equals(to)) {
+            return Optional.of(new Cycle<>(PersistentList.of(from, to)));
+        }
+        Optional<Cycle<T>> cycle = findCycle(from, to);
+        if (cycle.isPresent()) {
+            return cycle.map(it -> it.plus(from));
+        }
+        referrersOf(to).add(from);
+        return Optional.empty();
+    }
+
+    @Nonnull
+    private Optional<Cycle<T>> findCycle(T from, T to) {
+        return findCycle(from, to, PersistentList.of(from));
+    }
+
+    @Nonnull
+    private Optional<Cycle<T>> findCycle(T from, T to, PersistentList<T> path) {
+        Set<T> referrers = referrersOf(from);
+        if (referrers.contains(to)) {
+            return Optional.of(new Cycle<>(path.plus(to)));
+        }
+        for (T referrer : referrers) {
+            Optional<Cycle<T>> cycle = findCycle(referrer, to, path.plus(referrer));
+            if (cycle.isPresent()) {
+                return cycle;
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private Set<T> referrersOf(T from) {
+        return graph.computeIfAbsent(from, k -> new LinkedHashSet<>());
+    }
+}

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DynamicGraphCycleDetector.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DynamicGraphCycleDetector.java
@@ -42,7 +42,7 @@ import java.util.function.Function;
  * between nodes when new edges are added.</p>
  *
  * @param <T> the type of nodes in the graph
- * */
+ */
 class DynamicGraphCycleDetector<T> {
 
     public static class Cycle<T> {
@@ -77,7 +77,7 @@ class DynamicGraphCycleDetector<T> {
         }
         Optional<Cycle<T>> cycle = findCycle(from, to);
         if (cycle.isPresent()) {
-            return cycle.map(it -> it.plus(from));
+            return cycle;
         }
         referrersOf(to).add(from);
         return Optional.empty();
@@ -85,12 +85,15 @@ class DynamicGraphCycleDetector<T> {
 
     @Nonnull
     private Optional<Cycle<T>> findCycle(T from, T to) {
-        return findCycle(from, to, PersistentList.of(from));
+        return findCycle(from, to, PersistentList.of(from)).map(it -> it.plus(from));
     }
 
     @Nonnull
     private Optional<Cycle<T>> findCycle(T from, T to, PersistentList<T> path) {
-        Set<T> referrers = referrersOf(from);
+        Set<T> referrers = graph.get(from);
+        if (referrers == null) {
+            return Optional.empty();
+        }
         if (referrers.contains(to)) {
             return Optional.of(new Cycle<>(path.plus(to)));
         }

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildRegistryTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildRegistryTest.groovy
@@ -134,7 +134,7 @@ class DefaultIncludedBuildRegistryTest extends Specification {
         includedBuildFactory.createBuild(buildIdentifier, buildDefinition, false, _ as BuildState) >> includedBuild
 
         when:
-        def result = registry.addIncludedBuild(buildDefinition)
+        def result = registry.addIncludedBuild(buildDefinition, Stub(BuildState))
         then:
         1 * buildAddedListener.buildAdded(includedBuild)
         0 * _
@@ -156,8 +156,8 @@ class DefaultIncludedBuildRegistryTest extends Specification {
         given:
         registry.attachRootBuild(rootBuild())
 
-        registry.addIncludedBuild(buildDefinition1)
-        registry.addIncludedBuild(buildDefinition2)
+        registry.addIncludedBuild(buildDefinition1, Stub(BuildState))
+        registry.addIncludedBuild(buildDefinition2, Stub(BuildState))
 
         expect:
         registry.includedBuilds as List == [includedBuild1, includedBuild2]
@@ -178,9 +178,9 @@ class DefaultIncludedBuildRegistryTest extends Specification {
         registry.attachRootBuild(rootBuild())
 
         expect:
-        registry.addIncludedBuild(buildDefinition1)
-        registry.addIncludedBuild(buildDefinition2)
-        registry.addIncludedBuild(buildDefinition3)
+        registry.addIncludedBuild(buildDefinition1, Stub(BuildState))
+        registry.addIncludedBuild(buildDefinition2, Stub(BuildState))
+        registry.addIncludedBuild(buildDefinition3, Stub(BuildState))
 
         registry.includedBuilds as List == [includedBuild1, includedBuild2, includedBuild3]
 
@@ -195,10 +195,10 @@ class DefaultIncludedBuildRegistryTest extends Specification {
 
         given:
         registry.attachRootBuild(rootBuild())
-        registry.addIncludedBuild(buildDefinition1)
+        registry.addIncludedBuild(buildDefinition1, Stub(BuildState))
 
         expect:
-        registry.addIncludedBuild(buildDefinition2) is includedBuild
+        registry.addIncludedBuild(buildDefinition2, Stub(BuildState)) is includedBuild
     }
 
     def "can add an implicit included build"() {
@@ -266,7 +266,7 @@ class DefaultIncludedBuildRegistryTest extends Specification {
         def parentDefinition = build(parentDir, "parent")
         def parent = expectIncludedBuildAdded("parent", parentDefinition)
 
-        registry.addIncludedBuild(parentDefinition)
+        registry.addIncludedBuild(parentDefinition, Stub(BuildState))
 
         expect:
         def nestedBuild1 = registry.getBuildSrcNestedBuild(rootBuild)

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DynamicGraphCycleDetectorTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DynamicGraphCycleDetectorTest.groovy
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.composite.internal
+
+import spock.lang.Specification
+
+class DynamicGraphCycleDetectorTest extends Specification {
+
+    def 'can detect immediate cycles'() {
+        given:
+        def graph = new DynamicGraphCycleDetector<String>()
+
+        when:
+        def result = graph.addEdge("A", "A")
+
+        then:
+        result.present
+
+        and:
+        result.get().format({ ":$it".toString() }) == ":A -> :A"
+    }
+
+    def 'can detect direct cycles'() {
+        given:
+        def graph = new DynamicGraphCycleDetector<String>()
+
+        when:
+        def result1 = graph.addEdge("A", "B")
+
+        then:
+        result1.empty
+
+        then:
+        def result2 = graph.addEdge("B", "A")
+
+        then:
+        result2.present
+
+        and:
+        result2.get().format({ ":$it".toString() }) == ":B -> :A -> :B"
+    }
+
+    def 'can detect indirect cycles'() {
+        given:
+        def graph = new DynamicGraphCycleDetector<String>()
+
+        when:
+        graph.addEdge("A", "B")
+        graph.addEdge("B", "C")
+
+        then:
+        def result = graph.addEdge("C", "A")
+        result.present
+
+        and:
+        result.get().format({ ":$it".toString() }) == ":C -> :A -> :B -> :C"
+    }
+
+    def 'can detect long indirect cycles'() {
+        given:
+        def graph = new DynamicGraphCycleDetector<String>()
+
+        when:
+        graph.addEdge("A", "B")
+        graph.addEdge("B", "C")
+        graph.addEdge("C", "D")
+
+        then:
+        def result = graph.addEdge("D", "A")
+        result.present
+
+        and:
+        result.get().format({ ":$it".toString() }) == ":D -> :A -> :B -> :C -> :D"
+    }
+}

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DynamicGraphCycleDetectorTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DynamicGraphCycleDetectorTest.groovy
@@ -42,7 +42,7 @@ class DynamicGraphCycleDetectorTest extends Specification {
         def result1 = graph.addEdge("A", "B")
 
         then:
-        result1.empty
+        !result1.present
 
         then:
         def result2 = graph.addEdge("B", "A")

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
@@ -81,7 +81,7 @@ public interface BuildStateRegistry {
     /**
      * Creates an included build. An included build is-a nested build whose projects and outputs are treated as part of the composite build.
      */
-    IncludedBuildState addIncludedBuild(BuildDefinition buildDefinition);
+    IncludedBuildState addIncludedBuild(BuildDefinition buildDefinition, BuildState referrer);
 
     /**
      * Creates an included build. An included build is-a nested build whose projects and outputs are treated as part of the composite build.

--- a/subprojects/core/src/main/java/org/gradle/internal/composite/DefaultBuildIncluder.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/composite/DefaultBuildIncluder.java
@@ -59,7 +59,7 @@ public class DefaultBuildIncluder implements BuildIncluder {
             return rootBuild;
         } else {
             BuildDefinition buildDefinition = toBuildDefinition(includedBuildSpec, gradle);
-            IncludedBuildState build = buildRegistry.addIncludedBuild(buildDefinition);
+            IncludedBuildState build = buildRegistry.addIncludedBuild(buildDefinition, gradle.getOwner());
             coordinator.prepareForInclusion(build, buildDefinition.isPluginBuild());
             return build;
         }
@@ -73,7 +73,7 @@ public class DefaultBuildIncluder implements BuildIncluder {
     @Override
     public Collection<IncludedBuildState> getRegisteredPluginBuilds() {
         return pluginBuildDefinitions.stream().map(buildDefinition -> {
-            IncludedBuildState build = buildRegistry.addIncludedBuild(buildDefinition);
+            IncludedBuildState build = buildRegistry.addIncludedBuild(buildDefinition, gradle.getOwner());
             coordinator.prepareForInclusion(build, true);
             return build;
         }).collect(Collectors.toList());


### PR DESCRIPTION
Fixes [#30902](https://github.com/gradle/gradle/issues/30902)
Part of [#30402](https://github.com/gradle/gradle/issues/30402)

In vintage, cycles are allowed in included builds definition, since configuration is sequential. For parallel configuration in IP mode we want to avoid cycles in included plugin builds definition, since those may lead to deadlocks. 