### PR TITLE
Fix `buildCommitDistribution` if mirroring info is missing

### DIFF
--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
@@ -171,7 +171,13 @@ abstract class BuildCommitDistribution @Inject internal constructor(
             "--no-configuration-cache",
             "--init-script",
             mirrorInitScript.absolutePath,
-            "-D${PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY}=${System.getProperty(PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY)}",
+        )
+
+        System.getProperty(PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY)?.let {
+            buildCommands.add("-D${PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY}=$it")
+        }
+
+        buildCommands += listOf(
             "clean",
             "-Dscan.tag.BuildCommitDistribution",
             ":distributions-full:binDistributionZip",

--- a/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
+++ b/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import org.gradle.api.internal.artifacts.BaseRepositoryFactory.PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY
 import org.gradle.api.internal.GradleInternal
 import org.gradle.build.event.BuildEventsListenerRegistry
 import org.gradle.internal.nativeintegration.network.HostnameLookup


### PR DESCRIPTION
Fixes a potential `null` repo URL introduced in https://github.com/gradle/gradle/pull/30104 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
