### PR TITLE
Remove unnecessary @Restricted annotations on Settings APIs

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/ProjectDescriptor.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/ProjectDescriptor.java
@@ -45,7 +45,6 @@ public interface ProjectDescriptor {
      *
      * @param name The new name for the project. Should not be null
      */
-    @Restricted
     void setName(String name);
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
@@ -342,7 +342,6 @@ public interface Settings extends PluginAware, ExtensionAware {
      *
      * @since 3.5
      */
-    @Restricted
     PluginManagementSpec getPluginManagement();
 
     /**
@@ -383,7 +382,6 @@ public interface Settings extends PluginAware, ExtensionAware {
      *
      * @since 6.8
      */
-    @Restricted
     DependencyResolutionManagement getDependencyResolutionManagement();
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/resolve/DependencyResolutionManagement.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/resolve/DependencyResolutionManagement.java
@@ -44,7 +44,6 @@ public interface DependencyResolutionManagement {
      * Returns the shared repository handler
      */
     @Incubating
-    @Restricted
     RepositoryHandler getRepositories();
 
     @Incubating

--- a/subprojects/core-api/src/main/java/org/gradle/plugin/management/PluginManagementSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/plugin/management/PluginManagementSpec.java
@@ -21,7 +21,6 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.initialization.ConfigurableIncludedPluginBuild;
 import org.gradle.declarative.dsl.model.annotations.Adding;
 import org.gradle.declarative.dsl.model.annotations.Configuring;
-import org.gradle.declarative.dsl.model.annotations.Restricted;
 import org.gradle.internal.HasInternalProtocol;
 import org.gradle.plugin.use.PluginDependenciesSpec;
 
@@ -42,7 +41,6 @@ public interface PluginManagementSpec {
     /**
      * The plugin repositories to use.
      */
-    @Restricted
     RepositoryHandler getRepositories();
 
     /**


### PR DESCRIPTION
Remove `@Restricted` annotations from properties in the settings model that are not meant to be used in DCL.

Remove unnecessary `@Restricted` annotation from the setter where there is also an annotated getter.