### PR TITLE
Use contextual exception for non declarable error

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/InvalidConfigurationResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/InvalidConfigurationResolutionIntegrationTest.groovy
@@ -75,6 +75,24 @@ class InvalidConfigurationResolutionIntegrationTest extends AbstractIntegrationS
         failure.hasErrorOutput("Dependencies can not be declared against the `compile` configuration.")
     }
 
+    def "failures adding dependencies to resolvable configurations emitted from configure closure are reported"() {
+        given:
+        buildFile << """
+            configurations.resolvable('foo') {
+                dependencies.add(project.dependencies.create('com.example:foo:4.2'))
+            }
+
+            // Realize the configuration
+            configurations.foo
+        """
+
+        when:
+        fails("help")
+
+        then:
+        failure.hasErrorOutput("Dependencies can not be declared against the `foo` configuration.")
+    }
+
     def "fail if a dependency constraint is declared on a configuration which can not be declared against"() {
         given:
         buildFile << """

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencySet.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencySet.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts;
 import org.gradle.api.Action;
 import org.gradle.api.Describable;
 import org.gradle.api.DomainObjectSet;
-import org.gradle.api.GradleException;
+import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.DependencySet;
@@ -70,7 +70,7 @@ public class DefaultDependencySet extends DelegatingDomainObjectSet<Dependency> 
 
     private void assertConfigurationIsDeclarable() {
         if (!clientConfiguration.isCanBeDeclared()) {
-            throw new GradleException("Dependencies can not be declared against the `" + clientConfiguration.getName() + "` configuration.");
+            throw new InvalidUserCodeException("Dependencies can not be declared against the `" + clientConfiguration.getName() + "` configuration.");
         }
     }
 


### PR DESCRIPTION
We use an exception annotated with @Contextual so that the error appears in the console.

This brings up a bigger question whether this annotation is worth having or not, or if we should just print all exceptions to the console. I can see there being many exceptions that are being hidden because of this annotation and the logic behind it

Fixes #27029

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
