### PR TITLE
Reapply "When running performance tests, no daemon should mean "cold daemon"

### DIFF
--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleBuildExperimentRunner.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleBuildExperimentRunner.java
@@ -181,7 +181,7 @@ public class GradleBuildExperimentRunner extends AbstractBuildExperimentRunner {
         } else {
             invoker = invocationSpec.isUseDaemon()
                 ? GradleBuildInvoker.Cli
-                : GradleBuildInvoker.CliNoDaemon;
+                : GradleBuildInvoker.Cli.withColdDaemon();
         }
 
         boolean measureGarbageCollection = experiment.isMeasureGarbageCollection()
@@ -238,7 +238,7 @@ public class GradleBuildExperimentRunner extends AbstractBuildExperimentRunner {
             invocationSettings.getWarmUpCount(),
             invocationSettings.getBuildCount(),
             invocationSettings.getOutputDir(),
-            ImmutableList.of(),
+            actualJvmArgs,
             invocationSettings.getMeasuredBuildOperations()
         );
     }


### PR DESCRIPTION
This reverts commit 382086706bfe11f39df4911c04351c1a1701985d.

Necessary to test if #30850 works reliably.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
