### PR TITLE
Fix Javadoc `{@link }`

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/CompatibilityRuleChain.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/CompatibilityRuleChain.java
@@ -58,7 +58,7 @@ public interface CompatibilityRuleChain<T> {
      * Compatibility doesn't mean equality. Typically two different Java platforms can be
      * compatible, without being equal.</p>
      *
-     * <p>A rule <i>can</i> express an opinion by calling the @{link {@link CompatibilityCheckDetails#compatible()}}
+     * <p>A rule <i>can</i> express an opinion by calling the {@link CompatibilityCheckDetails#compatible()}
      * method to tell that two attributes are compatible, or it <i>can</i> call {@link CompatibilityCheckDetails#incompatible()}
      * to say that they are not compatible. It is not mandatory for a rule to express an opinion.</p>
      *

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/DisambiguationRuleChain.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/DisambiguationRuleChain.java
@@ -41,7 +41,7 @@ public interface DisambiguationRuleChain<T> {
      * <p>Adds an arbitrary disambiguation rule to the chain.</p>
      * <p>A disambiguation rule can select the best match from a list of candidates.</p>
      *
-     * <p>A rule <i>can</i> express an preference by calling the @{link {@link MultipleCandidatesDetails#closestMatch(Object)}
+     * <p>A rule <i>can</i> express an preference by calling the {@link MultipleCandidatesDetails#closestMatch(Object)}
      * method to tell that a candidate is the best one.</p>
      *
      * <p>It is not mandatory for a rule to choose, and it is not an error to select multiple candidates.</p>


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
