### PR TITLE
Upgrade develocity maven extension for .teamcity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,7 +106,7 @@ atlassian-ide-plugin.xml
 .gradletasknamecache
 
 # Added GE support maven support to the maven build in .teamcity, per the GE docs, this dir is NOT to be committed
-.teamcity/.mvn/.gradle-enterprise/
+.teamcity/.mvn/.develocity/
 /discoclient.properties
 
 # Ignore local configuration files for asdf, allowing the JDK to be configured for project (https://asdf-vm.com)

--- a/.teamcity/.mvn/develocity.xml
+++ b/.teamcity/.mvn/develocity.xml
@@ -1,5 +1,3 @@
-
-
 <!--
   ~ Copyright 2022 the original author or authors.
   ~
@@ -16,17 +14,13 @@
   ~ limitations under the License.
   -->
 
-<gradleEnterprise
-        xmlns="https://www.gradle.com/gradle-enterprise-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://www.gradle.com/gradle-enterprise-maven https://www.gradle.com/schema/gradle-enterprise-maven.xsd">
+<develocity>
     <server>
         <url>https://develocity.grdev.net</url>
     </server>
-
     <buildScan>
-        <publish>ALWAYS</publish>
-        <termsOfService>
-            <url>https://gradle.com/terms-of-service</url>
-        </termsOfService>
+        <publishing>
+            <onlyIf>true</onlyIf>
+        </publishing>
     </buildScan>
-</gradleEnterprise>
+</develocity>

--- a/.teamcity/.mvn/extensions.xml
+++ b/.teamcity/.mvn/extensions.xml
@@ -16,9 +16,9 @@
   -->
 
 <extensions>
-    <extension>
-        <groupId>com.gradle</groupId>
-        <artifactId>gradle-enterprise-maven-extension</artifactId>
-        <version>1.14.4</version>
-    </extension>
+  <extension>
+    <groupId>com.gradle</groupId>
+    <artifactId>develocity-maven-extension</artifactId>
+    <version>1.22.2</version>
+  </extension>
 </extensions>

--- a/.teamcity/src/main/kotlin/configurations/CheckTeamCityKotlinDSL.kt
+++ b/.teamcity/src/main/kotlin/configurations/CheckTeamCityKotlinDSL.kt
@@ -21,7 +21,7 @@ class CheckTeamCityKotlinDSL(model: CIBuildModel, stage: Stage) : OsAwareBaseGra
             }
             script {
                 name = "CLEAN_M2"
-                scriptContent = checkCleanDirUnixLike("%teamcity.agent.jvm.user.home%/.m2/.gradle-enterprise", exitOnFailure = false)
+                scriptContent = checkCleanDirUnixLike("%teamcity.agent.jvm.user.home%/.m2/.develocity", exitOnFailure = false)
             }
         }
     }


### PR DESCRIPTION
This PR upgrades develocity maven plugin to recent version. 

Also, because TeamCity check is part of Gradle build, we use `ge.gradle.org` for build scan publication.

Example: https://ge.gradle.org/s/6iclitzxen2m4