### PR TITLE
Stop triggering merge queue check builds on experimental branch

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/GitHubMergeQueueCheckPass.kt
+++ b/.teamcity/src/main/kotlin/configurations/GitHubMergeQueueCheckPass.kt
@@ -28,12 +28,14 @@ class GitHubMergeQueueCheckPass(model: CIBuildModel) : BaseGradleBuildType(init 
         publishBuildStatusToGithub(model)
     }
 
-    triggers.vcs {
-        quietPeriodMode = VcsTrigger.QuietPeriodMode.DO_NOT_USE
-        branchFilter = """
+    if (!VersionedSettingsBranch.fromDslContext().isExperimental) {
+        triggers.vcs {
+            quietPeriodMode = VcsTrigger.QuietPeriodMode.DO_NOT_USE
+            branchFilter = """
 +:gh-readonly-queue/${model.branch.branchName}/*
 +:${model.branch.branchName}
 """
+        }
     }
 
     dependencies {


### PR DESCRIPTION
Every push on `experimental` branch will trigger a MergeQueueCheck build, which is very expensive.