### PR TITLE
Make ScopedFingerprintWriter properly reenterable

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ScopedFingerprintWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ScopedFingerprintWriter.kt
@@ -21,38 +21,82 @@ import org.gradle.internal.serialize.graph.CloseableWriteContext
 import org.gradle.internal.serialize.graph.runWriteOperation
 import org.gradle.internal.serialize.graph.withPropertyTrace
 import java.io.Closeable
+import java.util.ArrayDeque
+import java.util.Queue
 
 
-internal
-class ScopedFingerprintWriter<T>(
+internal class ScopedFingerprintWriter<T>(
     private val writeContext: CloseableWriteContext
 ) : Closeable {
+    private class PendingWrite<out T>(val value: T, val trace: PropertyTrace?)
+
+    private val pendingWrites: Queue<PendingWrite<T>> = ArrayDeque()
+
+    private var isWriting = false
+
     override fun close() {
         // we synchronize access to all resources used by callbacks
         // in case there was still an event being dispatched at closing time.
         synchronized(writeContext) {
-            unsafeWrite(null)
+            require(!isWriting && pendingWrites.isEmpty()) {
+                "Incomplete write detected"
+            }
+
+            writeValue(null)
             writeContext.close()
         }
     }
 
     fun write(value: T, trace: PropertyTrace? = null) {
         synchronized(writeContext) {
-            withPropertyTrace(trace) {
-                unsafeWrite(value)
+            if (isWriting) {
+                // This re-entrance can only happen on the same thread that does the enclosing write because of the synchronized block.
+
+                // Writing a value may cause another value to be written, e.g. when `provider {}` used as a ValueSource parameter reads an environment variable.
+                // These are valid configuration inputs, but we cannot write them immediately, or we will break the layout of the outer value.
+                // For example, we might be writing value source parameters bean, and we get to serialize `provider { System.getenv(...) }`.
+                // CC writes only the value of the provider, so it computes it. That triggers another call to this method for the environment variable input.
+                // If we write the input synchronously, it will take the position intended for the provider's value, and the decoder won't be able to
+                // reconstruct the provider.
+                postponeWrite(value, trace)
+                return
+            }
+
+            isWriting = true
+            try {
+                doWrite(value, trace)
+                // Now write all inputs discovered while writing the first one or any of the consequent ones.
+                drainPendingWrites()
+            } finally {
+                isWriting = false
             }
         }
     }
 
-    private
-    fun unsafeWrite(value: T?) {
+    private fun postponeWrite(value: T, trace: PropertyTrace?) {
+        pendingWrites.add(PendingWrite(value, trace))
+    }
+
+    private fun drainPendingWrites() {
+        while (!pendingWrites.isEmpty()) {
+            val nextWrite = pendingWrites.remove()
+            doWrite(nextWrite.value, nextWrite.trace)
+        }
+    }
+
+    private fun doWrite(value: T, trace: PropertyTrace?) {
+        withPropertyTrace(trace) {
+            writeValue(value)
+        }
+    }
+
+    private fun writeValue(value: T?) {
         writeContext.runWriteOperation {
             write(value)
         }
     }
 
-    private
-    inline fun withPropertyTrace(trace: PropertyTrace?, block: ScopedFingerprintWriter<T>.() -> Unit) {
+    private inline fun withPropertyTrace(trace: PropertyTrace?, block: ScopedFingerprintWriter<T>.() -> Unit) {
         if (trace != null) {
             writeContext.withPropertyTrace(trace) { block() }
         } else {


### PR DESCRIPTION

It is possible that writing a CC input into the fingerprint triggers another input to be written. Writing synchronously is incorrect because it breaks the layout of the enclosing input and causes a deserialization error.

This commit collects all nested writes (which happen on the same thread) and writes them after completing the enclosing one, so the layout of the fingerprint file - a sequence of inputs - is preserved.

Fixes #30925