### PR TITLE
Clean up in ExpectingFailureRuleStatement

### DIFF
--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ExpectingFailureRuleStatement.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ExpectingFailureRuleStatement.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.fixtures
 
+import org.gradle.test.fixtures.file.AbstractTestDirectoryProvider
 import org.junit.runners.model.Statement
 
 class ExpectingFailureRuleStatement extends Statement {
@@ -39,6 +40,9 @@ class ExpectingFailureRuleStatement extends Statement {
         } catch (Throwable ex) {
             System.err.println("Failed with $feature as expected:")
             ex.printStackTrace()
+            if (next instanceof AbstractTestDirectoryProvider.TestDirectoryCleaningStatement) {
+                next.cleanup()
+            }
         }
     }
 }

--- a/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/AbstractTestDirectoryProvider.java
+++ b/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/AbstractTestDirectoryProvider.java
@@ -86,7 +86,7 @@ public abstract class AbstractTestDirectoryProvider implements TestRule, TestDir
         return new TestDirectoryCleaningStatement(base, description);
     }
 
-    private class TestDirectoryCleaningStatement extends Statement {
+    public class TestDirectoryCleaningStatement extends Statement {
         private final Statement base;
         private final Description description;
 
@@ -95,13 +95,9 @@ public abstract class AbstractTestDirectoryProvider implements TestRule, TestDir
             this.description = description;
         }
 
-        @Override
-        public void evaluate() throws Throwable {
-            // implicitly don't clean up if this throws
-            base.evaluate();
-
+        public void cleanup() {
             try {
-                cleanup();
+                AbstractTestDirectoryProvider.this.cleanup();
             } catch (Exception e) {
                 if (suppressCleanupErrors()) {
                     System.err.println(cleanupErrorMessage());
@@ -110,6 +106,15 @@ public abstract class AbstractTestDirectoryProvider implements TestRule, TestDir
                     throw new GradleException(cleanupErrorMessage(), e);
                 }
             }
+        }
+
+        @Override
+        public void evaluate() throws Throwable {
+            // implicitly don't clean up if this throws exceptions
+            // so that we can inspect the test directory
+            base.evaluate();
+
+            cleanup();
         }
 
         private boolean suppressCleanupErrors() {


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-private/issues/4442

In the past,

- If the test succeeds, we clean up the test directory in `AbstractTestDirectoryProvider.TestDirectoryCleaningStatement.cleanup()`, then check all test directories are cleaned up in `TestFilesCleanupService.verifyTestFilesCleanup`.
- If the test fails, we don't clean up the test directory so that they can be collected as TeamCity artifacts for troubleshooting.

This works well until `ExpectingFailureRuleStatement`, which flip the success status: it wraps an instance of `AbstractTestDirectoryProvider.TestDirectoryCleaningStatement` - when `TestDirectoryCleaningStatement.evaluate()` throws exceptions, the test directory is not cleaned up, but the test status is changed to "successful". Later, `TestFilesCleanupService.verifyTestFilesCleanup` will complain like [this](https://ge.gradle.org/s/p5wxp5gls4vgg/failure#1).

It could be reproduced locally with `CI=1 ./gradlew plugins-java:iPIT --tests 'JavaProjectIntegrationTest.can recursively*' --no-configuration-cache`.

This PR fixes it by calling `AbstractTestDirectoryProvider.TestDirectoryCleaningStatement.cleanup()` after the inside call fails.