### PR TITLE
Leniently finalize upgraded properties only on implicitFinalizeValue()

### DIFF
--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -141,7 +141,11 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
 
     @Override
     public void implicitFinalizeValue() {
-        if (!valueState.isUpgradedPropertyValue()) {
+        if (valueState.isUpgradedPropertyValue()) {
+            // Upgraded properties should not be finalized to simplify migration.
+            // This behaviour should be removed with Gradle 10.
+            valueState.warnOnUpgradedPropertyValueChanges();
+        } else {
             // Property prevents reads *and* mutations,
             // however CFCs only want automatic finalization on query,
             // so we do not #disallowChanges().

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyLifecycleIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyLifecycleIntegrationTest.groovy
@@ -209,20 +209,17 @@ class PropertyLifecycleIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        if (expectDeprecationWarning) {
-            executer.expectDeprecationWarningWithPattern("Changing property value of task ':thing' property 'prop' at execution time. This behavior has been deprecated.*")
-        }
         succeeds("thing")
         outputContains("value: value 3")
 
         where:
-        annotation      | expectDeprecationWarning
-        "@Internal"     | false
-        "@Console"      | false
-        "@OptionValues" | false
-        "@ReplacedBy"   | false
-        "@Destroys"     | true
-        "@LocalState"   | true
+        annotation      | _
+        "@Internal"     | _
+        "@Console"      | _
+        "@OptionValues" | _
+        "@ReplacedBy"   | _
+        "@Destroys"     | _
+        "@LocalState"   | _
     }
 
     def "@ReplacesEagerProperty works with annotation @Nested"() {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -241,7 +241,11 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
 
     @Override
     public void implicitFinalizeValue() {
-        if (!state.isUpgradedPropertyValue()) {
+        if (state.isUpgradedPropertyValue()) {
+            // Upgraded properties should not be finalized to simplify migration.
+            // This behaviour should be removed with Gradle 10.
+            state.warnOnUpgradedPropertyValueChanges();
+        } else {
             state.disallowChangesAndFinalizeOnNextGet();
         }
     }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueState.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueState.java
@@ -170,6 +170,8 @@ public abstract class ValueState<S> {
 
     public abstract boolean isUpgradedPropertyValue();
 
+    public abstract void warnOnUpgradedPropertyValueChanges();
+
     private static class NonFinalizedValue<S> extends ValueState<S> {
         private final PropertyHost host;
         private final Function<S, S> copier;
@@ -178,6 +180,7 @@ public abstract class ValueState<S> {
         private boolean disallowChanges;
         private boolean disallowUnsafeRead;
         private boolean isUpgradedPropertyValue;
+        private boolean warnOnUpgradedPropertyChanges;
         private S convention;
 
         public NonFinalizedValue(PropertyHost host, Function<S, S> copier) {
@@ -225,7 +228,7 @@ public abstract class ValueState<S> {
         public void beforeMutate(Describable displayName) {
             if (disallowChanges) {
                 throw new IllegalStateException(String.format("The value for %s cannot be changed any further.", displayName.getDisplayName()));
-            } else if (isUpgradedPropertyValue()) {
+            } else if (warnOnUpgradedPropertyChanges) {
                 String shownDisplayName = displayName.getDisplayName();
                 DeprecationLogger.deprecateBehaviour("Changing property value of " + shownDisplayName + " at execution time.")
                     .startingWithGradle9("changing property value of " + shownDisplayName + " at execution time is deprecated and will fail in Gradle 10")
@@ -292,6 +295,11 @@ public abstract class ValueState<S> {
         @Override
         public boolean isUpgradedPropertyValue() {
             return isUpgradedPropertyValue;
+        }
+
+        @Override
+        public void warnOnUpgradedPropertyValueChanges() {
+            warnOnUpgradedPropertyChanges = true;
         }
 
         @Override
@@ -449,6 +457,11 @@ public abstract class ValueState<S> {
         @Override
         public boolean isUpgradedPropertyValue() {
             return false;
+        }
+
+        @Override
+        public void warnOnUpgradedPropertyValueChanges() {
+            // No special behaviour is needed for already finalized values, so let's ignore
         }
 
         @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/bean/DefaultPropertyWalker.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/bean/DefaultPropertyWalker.java
@@ -116,8 +116,6 @@ public class DefaultPropertyWalker implements PropertyWalker {
             this.cachedInvoker = Suppliers.memoize(() -> {
                 Object value = DeprecationLogger.whileDisabled(supplier::get);
                 if (isUpgradedProperty && isConfigurable()) {
-                    // Upgraded properties should not be finalized to simplify migration.
-                    // This behaviour should be removed with Gradle 10.
                     ((HasConfigurableValueInternal) value).markAsUpgradedProperty();
                 }
                 return value;


### PR DESCRIPTION
Since otherwise it's possible deprecation warning is called even before implicit finalization.

Or if property is not implicitly finalized at all.