### PR TITLE
Fix CC input detection deadlock

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -75,6 +75,7 @@ import org.gradle.internal.resource.local.FileResourceListener
 import org.gradle.internal.scripts.ScriptExecutionListener
 import org.gradle.internal.scripts.ScriptFileResolvedListener
 import org.gradle.internal.serialize.graph.CloseableWriteContext
+import org.gradle.internal.service.scopes.ParallelListener
 import org.gradle.tooling.provider.model.internal.ToolingModelProjectDependencyListener
 import org.gradle.util.Path
 import java.io.File
@@ -83,6 +84,7 @@ import java.util.EnumSet
 import java.util.concurrent.ConcurrentHashMap
 
 
+@ParallelListener
 internal
 class ConfigurationCacheFingerprintWriter(
     private val host: Host,


### PR DESCRIPTION
Normally, the ListenerManager holds a per-instance lock when dispatching an event, so the listener implementation doesn't have to be thread-safe. It also holds a per-listener interface lock for some internal reasons.
This, and the fact that the ConfigurationCacheFingerprintWriter can emit events while processing events lead to deadlocks when two threads were dispatching different kind of events to the writer.

This commit marks ConfigurationCacheFingerprintWriter as capable of receiving events concurrently, thus eliminating the instance lock and the potential for a deadlock.

The per-listener interface locks can in theory produce a deadlock too, but in practice we can only aim for the second lock when processing a ValueListener, so the potential for deadlocks is much lower and can be addressed separately.

Fixes #30905.