### PR TITLE
Relax CODEOWNERS architecture council notifications

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,14 +37,14 @@ testing/performance/                    @gradle/bt-support
 testing/smoke-test/                     @gradle/bt-support
 testing/soak/                           @gradle/bt-support
 
-# These files change frequently, and changes to them don't need to automatically alert the architecture council
-testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json     @gradle/bt-unassigned-maintainers
-testing/architecture-test/src/changes/archunit-store/internal-api-nullability.txt           @gradle/bt-unassigned-maintainers
-
 # Cross-cutting architecture checks and decisions
 .github/CODEOWNERS                          @gradle/bt-architecture-council
 architecture/                               @gradle/bt-architecture-council
 testing/architecture-test                   @gradle/bt-architecture-council
+
+# These files change frequently, and changes to them don't need to automatically alert the architecture council
+testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json     @gradle/bt-unassigned-maintainers
+testing/architecture-test/src/changes/archunit-store/internal-api-nullability.txt           @gradle/bt-unassigned-maintainers
 
 # Core automation platform (core/configuration)
 platforms/core-configuration/               @gradle/bt-configuration
@@ -71,20 +71,20 @@ platforms/core-configuration/declarative-dsl-internal-utils/        @gradle/bt-d
 
 # Core automation platform (core/runtime)
 platforms/core-runtime/                                     @gradle/bt-core-runtime-maintainers
-platforms/core-runtime/build-operations/                    @gradle/bt-core-runtime-maintainers @gradle/bt-execution @gradle/bt-dv-build-cache
+platforms/core-runtime/build-operations/                    @gradle/bt-core-runtime-maintainers @gradle/bt-execution @gradle/dv-integrations-team
 platforms/core-runtime/functional/                          @gradle/bt-core-runtime-maintainers @gradle/bt-execution @bamboo
-platforms/core-runtime/files/                               @gradle/bt-core-runtime-maintainers @gradle/bt-execution @gradle/bt-dv-build-cache
+platforms/core-runtime/files/                               @gradle/bt-core-runtime-maintainers @gradle/bt-execution @gradle/dv-integrations-team
 platforms/core-runtime/service-*/                           @gradle/bt-core-runtime-maintainers @alllex
 
 # Core automation platform (core/execution)
 platforms/core-execution/                                   @gradle/bt-execution
-platforms/core-execution/build-cache/                       @gradle/bt-execution @gradle/bt-dv-build-cache
-platforms/core-execution/build-cache-base/                  @gradle/bt-execution @gradle/bt-dv-build-cache
-platforms/core-execution/build-cache-http/                  @gradle/bt-execution @gradle/bt-dv-build-cache
-platforms/core-execution/build-cache-packaging/             @gradle/bt-execution @gradle/bt-dv-build-cache
-platforms/core-execution/build-cache-spi/                   @gradle/bt-execution @gradle/bt-dv-build-cache
-platforms/core-execution/hashing/                           @gradle/bt-execution @gradle/bt-dv-build-cache
-platforms/core-execution/snapshots/                         @gradle/bt-execution @gradle/bt-dv-build-cache
+platforms/core-execution/build-cache/                       @gradle/bt-execution @gradle/dv-integrations-team
+platforms/core-execution/build-cache-base/                  @gradle/bt-execution @gradle/dv-integrations-team
+platforms/core-execution/build-cache-http/                  @gradle/bt-execution @gradle/dv-integrations-team
+platforms/core-execution/build-cache-packaging/             @gradle/bt-execution @gradle/dv-integrations-team
+platforms/core-execution/build-cache-spi/                   @gradle/bt-execution @gradle/dv-integrations-team
+platforms/core-execution/hashing/                           @gradle/bt-execution @gradle/dv-integrations-team
+platforms/core-execution/snapshots/                         @gradle/bt-execution @gradle/dv-integrations-team
 
 # Develocity integration
 platforms/enterprise/                                   @gradle/bt-build-scan @gradle/dv-build-insights-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,6 +37,10 @@ testing/performance/                    @gradle/bt-support
 testing/smoke-test/                     @gradle/bt-support
 testing/soak/                           @gradle/bt-support
 
+# These files change frequently, and changes to them don't need to automatically alert the architecture council
+testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json     @gradle/bt-unassigned-maintainers
+testing/architecture-test/src/changes/archunit-store/internal-api-nullability.txt           @gradle/bt-unassigned-maintainers
+
 # Cross-cutting architecture checks and decisions
 .github/CODEOWNERS                          @gradle/bt-architecture-council
 architecture/                               @gradle/bt-architecture-council
@@ -107,10 +111,6 @@ platforms/extensibility/        @gradle/bt-extensibility-maintainers
 
 # Native
 platforms/native/                   @gradle/bt-native-maintainers
-
-# gitStream files
-.cm/                                @tresat
-.github/workflows/gitstream.yml     @tresat
 
 # IDE Experience team
 platforms/ide/                    @gradle/bt-ide-experience


### PR DESCRIPTION
- Architecture Council doesn't need to be notified on every nullability change, or deprecation/addition to the public API.
- Remove no longer used file specs.