### PR TITLE
When running gradle init, only use empty settings

### DIFF
--- a/platforms/core-runtime/logging/src/testFixtures/groovy/org/gradle/internal/logging/ToStringLogger.groovy
+++ b/platforms/core-runtime/logging/src/testFixtures/groovy/org/gradle/internal/logging/ToStringLogger.groovy
@@ -20,10 +20,11 @@ import groovy.transform.CompileStatic
 import org.gradle.internal.logging.slf4j.OutputEventListenerBackedLogger
 import org.gradle.internal.logging.slf4j.OutputEventListenerBackedLoggerContext
 import org.gradle.internal.time.MockClock
+import org.slf4j.helpers.FormattingTuple
+import org.slf4j.helpers.MessageFormatter
 
 @CompileStatic
 class ToStringLogger extends OutputEventListenerBackedLogger {
-
     private final StringBuilder log = new StringBuilder()
 
     ToStringLogger() {
@@ -36,13 +37,43 @@ class ToStringLogger extends OutputEventListenerBackedLogger {
     }
 
     @Override
+    void lifecycle(String format, Object... args) {
+        FormattingTuple tuple = MessageFormatter.arrayFormat(format, args)
+        log(tuple.getMessage())
+    }
+
+    @Override
     void debug(String message) {
         log(message)
     }
 
     @Override
+    void debug(String format, Object args) {
+        FormattingTuple tuple = MessageFormatter.format(format, args)
+        log(tuple.getMessage())
+    }
+
+    @Override
+    void debug(String format, Object... args) {
+        FormattingTuple tuple = MessageFormatter.arrayFormat(format, args)
+        log(tuple.getMessage())
+    }
+
+    @Override
     void warn(String message) {
         log(message)
+    }
+
+    @Override
+    void warn(String format, Object args) {
+        FormattingTuple tuple = MessageFormatter.format(format, args)
+        log(tuple.getMessage())
+    }
+
+    @Override
+    void warn(String format, Object... args) {
+        FormattingTuple tuple = MessageFormatter.arrayFormat(format, args)
+        log(tuple.getMessage())
     }
 
     private void log(String message) {

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -47,7 +47,7 @@ The embedded Kotlin has been updated from 2.0.20 to link:https://github.com/JetB
 === Deprecations
 
 [[init_must_run_alone]]
-==== Init must run alone
+==== `init` must run alone
 The <<build_init_plugin.adoc#sec:build_init_tasks, `init` task>> must run by itself.
 It cannot be combined with other tasks in a single Gradle invocation.
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -48,7 +48,7 @@ The embedded Kotlin has been updated from 2.0.20 to link:https://github.com/JetB
 
 [[init_must_run_alone]]
 ==== Init must run alone
-The <<build_init_plugin.adoc#build_init_tasks, `init` task>> must run by itself.
+The <<build_init_plugin.adoc#sec:build_init_tasks, `init` task>> must run by itself.
 It cannot be combined with other tasks in a single Gradle invocation.
 
 For instance, this is *not* allowed:

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -51,12 +51,14 @@ The embedded Kotlin has been updated from 2.0.20 to link:https://github.com/JetB
 The <<build_init_plugin.adoc#sec:build_init_tasks, `init` task>> must run by itself.
 It cannot be combined with other tasks in a single Gradle invocation.
 
-For instance, this is *not* allowed:
-```
-> gradlew init tasks
-```
-
 Running `init` in the same invocation as other tasks will become an error in Gradle 9.0.
+
+For instance, this wil *not* be allowed:
+
+[source]
+----
+> gradlew init tasks
+----
 
 [[changes_8.11]]
 == Upgrading from 8.10 and earlier

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -44,6 +44,20 @@ The previous step will help you identify potential problems by issuing deprecati
 
 The embedded Kotlin has been updated from 2.0.20 to link:https://github.com/JetBrains/kotlin/releases/tag/v2.0.21[Kotlin 2.0.21].
 
+=== Deprecations
+
+[[init_must_run_alone]]
+==== Init must run alone
+The <<build_init_plugin.adoc#build_init_tasks, `init` task>> must run by itself.
+It cannot be combined with other tasks in a single Gradle invocation.
+
+For instance, this is *not* allowed:
+```
+> gradlew init tasks
+```
+
+Running `init` in the same invocation as other tasks will become an error in Gradle 9.0.
+
 [[changes_8.11]]
 == Upgrading from 8.10 and earlier
 

--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
@@ -417,7 +417,7 @@ Description""") // include the next header to make sure all options are listed
 
         then:
         fails "init"
-        failure.assertHasCause("Aborting build initialization due to existing files in the project directory: '$targetDir'")
+        failure.assertHasCause("Aborting build initialization due to existing files in the project directory: '${targetDir.path}'")
         targetDir.assertHasDescendants("build.gradle")
     }
 

--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
@@ -417,21 +417,8 @@ Description""") // include the next header to make sure all options are listed
 
         then:
         fails "init"
-        failure.assertHasDescription("Task 'init' not found in project ':some-thing'.")
+        failure.assertHasCause("Aborting build initialization due to existing files in the project directory: '$targetDir'")
         targetDir.assertHasDescendants("build.gradle")
-    }
-
-    def "fails when initializing in a project directory of another build that does not contain a build script"() {
-        when:
-        containerDir.file("settings.gradle") << """
-            rootProject.name = 'root'
-            include('${targetDir.name}')
-        """
-
-        then:
-        fails "init"
-        failure.assertHasDescription("Task 'init' not found in project ':some-thing'.")
-        targetDir.listFiles().size() == 0 // Is still empty
     }
 
     def "can create build in user home directory"() {

--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
@@ -33,6 +33,21 @@ class BuildInitPluginIntegrationTest extends AbstractInitIntegrationSpec {
     @Override
     String subprojectName() { 'app' }
 
+    def "init must be only task requested #args = #allowed"() {
+        expect:
+        if (!allowed) {
+            executer.expectDocumentedDeprecationWarning("Executing other tasks along with the 'init' task has been deprecated. This will fail with an error in Gradle 9.0. The init task should be run by itself. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#init_must_run_alone")
+        }
+        succeeds(args)
+
+        where:
+        allowed | args
+        false   | ["init", "tasks"]
+        false   | ["help", "init"]
+        true    | ["init", "--type", "java-application"]
+        true    | ["help", "--task", "init"]
+    }
+
     def "init shows up on tasks overview "() {
         given:
         targetDir.file("settings.gradle").touch()

--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
@@ -33,19 +33,29 @@ class BuildInitPluginIntegrationTest extends AbstractInitIntegrationSpec {
     @Override
     String subprojectName() { 'app' }
 
-    def "init must be only task requested #args = #allowed"() {
+    @SuppressWarnings('GroovyAssignabilityCheck')
+    def "init must be only task requested #args"() {
         expect:
-        if (!allowed) {
-            executer.expectDocumentedDeprecationWarning("Executing other tasks along with the 'init' task has been deprecated. This will fail with an error in Gradle 9.0. The init task should be run by itself. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#init_must_run_alone")
-        }
+        executer.expectDocumentedDeprecationWarning("Executing other tasks along with the 'init' task has been deprecated. This will fail with an error in Gradle 9.0. The init task should be run by itself. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#init_must_run_alone")
         succeeds(args)
 
         where:
-        allowed | args
-        false   | ["init", "tasks"]
-        false   | ["help", "init"]
-        true    | ["init", "--type", "java-application"]
-        true    | ["help", "--task", "init"]
+        args << [
+            ["init", "tasks"],
+            ["help", "init"]
+        ]
+    }
+
+    @SuppressWarnings('GroovyAssignabilityCheck')
+    def "init can be run with arguments #args"() {
+        expect:
+        succeeds(args)
+
+        where:
+        args << [
+            ["init", "--type", "java-application"],
+            ["help", "--task", "init"]
+        ]
     }
 
     def "init shows up on tasks overview "() {

--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
@@ -431,6 +431,43 @@ Description""") // include the next header to make sure all options are listed
         targetDir.assertContainsDescendants("build.gradle")
     }
 
+    def "fails when initializing in a directory that contains a working settings file"() {
+        when:
+        targetDir.file("settings.gradle") << """
+            // empty
+        """
+
+        then:
+        fails "init"
+        failure.assertHasCause("Aborting build initialization due to existing files in the project directory: '${targetDir.path}'")
+        targetDir.assertContainsDescendants("settings.gradle")
+    }
+
+    def "fails when initializing in a directory that contains an invalid settings file"() {
+        when:
+        targetDir.file("settings.gradle") << """
+            nonsense
+        """
+
+        then:
+        fails "init"
+        failure.assertHasCause("Aborting build initialization due to existing files in the project directory: '${targetDir.path}'")
+        targetDir.assertContainsDescendants("settings.gradle")
+    }
+
+    def "fails when initializing plus help in a directory that contains a working settings file"() {
+        when:
+        targetDir.file("settings.gradle") << """
+            // empty
+        """
+
+        then:
+        executer.expectDocumentedDeprecationWarning("Executing other tasks along with the 'init' task has been deprecated. This will fail with an error in Gradle 9.0. The init task should be run by itself. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#init_must_run_alone")
+        fails "init", "help"
+        failure.assertHasCause("Aborting build initialization due to existing files in the project directory: '${targetDir.path}'")
+        targetDir.assertContainsDescendants("settings.gradle")
+    }
+
     def "can create build in user home directory"() {
         when:
         useTestDirectoryThatIsNotEmbeddedInAnotherBuild()

--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
@@ -418,7 +418,7 @@ Description""") // include the next header to make sure all options are listed
         then:
         fails "init"
         failure.assertHasCause("Aborting build initialization due to existing files in the project directory: '${targetDir.path}'")
-        targetDir.assertHasDescendants("build.gradle")
+        targetDir.assertContainsDescendants("build.gradle")
     }
 
     def "can create build in user home directory"() {

--- a/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/action/InitBuiltInCommand.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/action/InitBuiltInCommand.java
@@ -36,7 +36,7 @@ public class InitBuiltInCommand implements BuiltInCommand {
     }
 
     @Override
-    public boolean needsBuildDefinition() {
-        return false;
+    public boolean requireEmptyBuildDefinition() {
+        return true;
     }
 }

--- a/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/action/InitBuiltInCommand.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/action/InitBuiltInCommand.java
@@ -20,11 +20,21 @@ import org.gradle.configuration.project.BuiltInCommand;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
+import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 
+// TODO: Consider moving the InitBuiltInCommand (and help) to core, as they are not Software Platform-specific
 @ServiceScope(Scope.Global.class)
 public class InitBuiltInCommand implements BuiltInCommand {
+    public static final String NAME = "init";
+
+    @Override
+    @Nonnull
+    public String getDisplayName() {
+        return NAME;
+    }
+
     @Override
     public List<String> asDefaultTask() {
         return Collections.emptyList();
@@ -32,11 +42,16 @@ public class InitBuiltInCommand implements BuiltInCommand {
 
     @Override
     public boolean commandLineMatches(List<String> taskNames) {
-        return taskNames.size() > 0 && taskNames.get(0).equals("init");
+        return !taskNames.isEmpty() && taskNames.stream().anyMatch(taskName -> taskName.equals(NAME));
     }
 
     @Override
     public boolean requireEmptyBuildDefinition() {
+        return true;
+    }
+
+    @Override
+    public boolean isExclusive() {
         return true;
     }
 }

--- a/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/action/InitBuiltInCommand.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/action/InitBuiltInCommand.java
@@ -34,4 +34,9 @@ public class InitBuiltInCommand implements BuiltInCommand {
     public boolean commandLineMatches(List<String> taskNames) {
         return taskNames.size() > 0 && taskNames.get(0).equals("init");
     }
+
+    @Override
+    public boolean needsBuildDefinition() {
+        return false;
+    }
 }

--- a/subprojects/core/build.gradle.kts
+++ b/subprojects/core/build.gradle.kts
@@ -167,6 +167,7 @@ dependencies {
     // TODO investigate why we depend on SSHD as a platform for internal-integ-testing
     runtimeOnly(libs.antJunit)
 
+    testImplementation(projects.buildInit)
     testImplementation(projects.platformJvm)
     testImplementation(projects.platformNative)
     testImplementation(projects.testingBase)

--- a/subprojects/core/src/main/java/org/gradle/configuration/project/BuiltInCommand.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/project/BuiltInCommand.java
@@ -16,6 +16,7 @@
 
 package org.gradle.configuration.project;
 
+import org.gradle.StartParameter;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -39,7 +40,23 @@ public interface BuiltInCommand {
      */
     boolean commandLineMatches(List<String> taskNames);
 
-    default boolean needsBuildDefinition() {
-        return true;
+    /**
+     * Determines whether this command should always be run using an empty build definition.
+     * <p>
+     * In other words, should this command avoid loading Settings and just use an empty Settings definition?
+     *
+     * @return {@code true} if this command should always skip loading the build definition; {@code false} otherwise
+     */
+    default boolean requireEmptyBuildDefinition() {
+        return false;
+    }
+
+    /**
+     * Was this command specified as a task to be run in the Gradle invocation?
+     *
+     * {@code true} if so; {@code false} otherwise
+     */
+    default boolean wasInvoked(StartParameter startParameter) {
+        return commandLineMatches(startParameter.getTaskNames());
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/configuration/project/BuiltInCommand.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/project/BuiltInCommand.java
@@ -17,6 +17,7 @@
 package org.gradle.configuration.project;
 
 import org.gradle.StartParameter;
+import org.gradle.api.Describable;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -29,7 +30,7 @@ import java.util.List;
  * A built-in command can be invoked from any directory, and does not require a Gradle build definition to be present.
  */
 @ServiceScope(Scope.Global.class)
-public interface BuiltInCommand {
+public interface BuiltInCommand extends Describable {
     /**
      * Returns the list of task paths that should be used when none are specified by the user. Returns an empty list if this command should not be used as a default.
      */
@@ -48,6 +49,15 @@ public interface BuiltInCommand {
      * @return {@code true} if this command should always skip loading the build definition; {@code false} otherwise
      */
     default boolean requireEmptyBuildDefinition() {
+        return false;
+    }
+
+    /**
+     * Determines whether this command should always be run alone, without any other tasks present in the Gradle invocation.
+     *
+     * @return {@code true} if this command should always be run alone; {@code false} otherwise
+     */
+    default boolean isExclusive() {
         return false;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/configuration/project/BuiltInCommand.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/project/BuiltInCommand.java
@@ -38,4 +38,8 @@ public interface BuiltInCommand {
      * Does the given list of task paths reference this command?
      */
     boolean commandLineMatches(List<String> taskNames);
+
+    default boolean needsBuildDefinition() {
+        return true;
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/TaskNameResolvingBuildTaskScheduler.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/TaskNameResolvingBuildTaskScheduler.java
@@ -68,13 +68,16 @@ public class TaskNameResolvingBuildTaskScheduler implements BuildTaskScheduler {
      * @param plan execution plan containing requested tasks to validate
      */
     private void validateCompatibleTasksRequested(ExecutionPlan plan) {
-        Set<Task> requestedTasks = plan.getContents().getRequestedTasks();
-        if (requestedTasks.size() > 1 && requestedTasks.stream().anyMatch(t -> t.getName().equals("init"))) { // TODO: Consider moving the InitBuiltInCommand (and help) to core, as they are not Software Platform-specific
-            DeprecationLogger.deprecateAction("Executing other tasks along with the 'init' task")
-                .withAdvice("The init task should be run by itself.")
-                .willBecomeAnErrorInGradle9()
-                .withUpgradeGuideSection(8, "init_must_run_alone")
-                .nagUser();
+        //noinspection ConstantValue support mocking in tests
+        if (null != plan.getContents()) {
+            Set<Task> requestedTasks = plan.getContents().getRequestedTasks();
+            if (requestedTasks.size() > 1 && requestedTasks.stream().anyMatch(t -> t.getName().equals("init"))) { // TODO: Consider moving the InitBuiltInCommand (and help) to core, as they are not Software Platform-specific
+                DeprecationLogger.deprecateAction("Executing other tasks along with the 'init' task")
+                    .withAdvice("The init task should be run by itself.")
+                    .willBecomeAnErrorInGradle9()
+                    .withUpgradeGuideSection(8, "init_must_run_alone")
+                    .nagUser();
+            }
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
@@ -16,6 +16,7 @@
 
 package org.gradle.initialization;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.gradle.StartParameter;
 import org.gradle.api.GradleException;
 import org.gradle.api.initialization.ProjectDescriptor;
@@ -23,6 +24,8 @@ import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.configuration.project.BuiltInCommand;
 import org.gradle.initialization.buildsrc.BuildSrcDetector;
 import org.gradle.initialization.layout.BuildLayout;
@@ -35,52 +38,57 @@ import java.io.File;
 import java.util.List;
 
 /**
- * Handles locating and processing setting.gradle files.  Also deals with the buildSrc module, since that modules is
+ * Handles locating and processing setting.gradle files.  Also deals with the buildSrc module, since that module is
  * found after settings is located, but needs to be built before settings is processed.
  */
 public class DefaultSettingsLoader implements SettingsLoader {
     public static final String BUILD_SRC_PROJECT_PATH = ":" + SettingsInternal.BUILD_SRC;
+
     private final SettingsProcessor settingsProcessor;
     private final BuildLayoutFactory buildLayoutFactory;
     private final List<BuiltInCommand> builtInCommands;
+    private final Logger logger;
 
     public DefaultSettingsLoader(
         SettingsProcessor settingsProcessor,
         BuildLayoutFactory buildLayoutFactory,
         List<BuiltInCommand> builtInCommands
     ) {
+        this(settingsProcessor, buildLayoutFactory, builtInCommands, Logging.getLogger(DefaultSettingsLoader.class));
+    }
+
+    @VisibleForTesting
+    /* package */ DefaultSettingsLoader(
+        SettingsProcessor settingsProcessor,
+        BuildLayoutFactory buildLayoutFactory,
+        List<BuiltInCommand> builtInCommands,
+        Logger logger
+    ) {
         this.settingsProcessor = settingsProcessor;
         this.buildLayoutFactory = buildLayoutFactory;
         this.builtInCommands = builtInCommands;
+        this.logger = logger;
     }
 
     @Override
     public SettingsState findAndLoadSettings(GradleInternal gradle) {
         StartParameter startParameter = gradle.getStartParameter();
-
         SettingsLocation settingsLocation = buildLayoutFactory.getLayoutFor(new BuildLayoutConfiguration(startParameter));
 
-
-        // Allow a built-in command to run in a directory not contained in the settings file (but don't use the settings from that file)
-        boolean emptyBuildDefinition = false;
-        for (BuiltInCommand command : builtInCommands) {
-            if (!command.needsBuildDefinition() && command.commandLineMatches(startParameter.getTaskNames())) {
-                // Allow built-in command to run in a directory not contained in the settings file (but don't use the settings from that file)
-                emptyBuildDefinition = true;
-            }
-        }
-
         SettingsState state;
-        if (emptyBuildDefinition) {
+        if (shouldSkipLoadingBuildDefinition(startParameter)) {
+            logger.debug("Skipping loading of build definition for build: '{}'", gradle.getIdentityPath());
             state = createEmptySettings(gradle, startParameter, gradle.getClassLoaderScope());
             ProjectSpec spec = ProjectSpecs.forStartParameter(startParameter, state.getSettings());
             setDefaultProject(spec, state.getSettings());
         } else {
+            logger.debug("Loading build definition for build: '{}'", gradle.getIdentityPath());
             state = findSettingsAndLoadIfAppropriate(gradle, startParameter, settingsLocation, gradle.getClassLoaderScope());
             SettingsInternal settings = state.getSettings();
             ProjectSpec spec = ProjectSpecs.forStartParameter(startParameter, settings);
             if (useEmptySettings(spec, settings, startParameter)) {
                 // Discard the loaded settings and replace with an empty one
+                logger.debug("Discarding loaded settings and replacing with empty settings for build: '{}'", gradle.getIdentityPath());
                 state.close();
                 state = createEmptySettings(gradle, startParameter, gradle.getClassLoaderScope());
             }
@@ -88,6 +96,21 @@ public class DefaultSettingsLoader implements SettingsLoader {
         }
 
         return state;
+    }
+
+    /**
+     * Checks whether the Gradle invocation contains a built-in command that runs in a directory not contained in the settings file,
+     * and shouldn't require loading the settings - it should use a new, empty Settings instance.
+     *
+     * return {@code true} if so; {@code false} otherwise
+     */
+    private boolean shouldSkipLoadingBuildDefinition(StartParameter startParameter) {
+        for (BuiltInCommand command : builtInCommands) {
+            if (command.requireEmptyBuildDefinition() && command.wasInvoked(startParameter)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean useEmptySettings(ProjectSpec spec, SettingsInternal loadedSettings, StartParameter startParameter) {
@@ -105,7 +128,7 @@ public class DefaultSettingsLoader implements SettingsLoader {
 
         // Allow a built-in command to run in a directory not contained in the settings file (but don't use the settings from that file)
         for (BuiltInCommand command : builtInCommands) {
-            if (command.commandLineMatches(startParameter.getTaskNames())) {
+            if (command.wasInvoked(startParameter)) {
                 // Allow built-in command to run in a directory not contained in the settings file (but don't use the settings from that file)
                 return true;
             }
@@ -122,6 +145,7 @@ public class DefaultSettingsLoader implements SettingsLoader {
 
     @SuppressWarnings("deprecation") // StartParameter.setSettingsFile() and StartParameter.getBuildFile()
     private SettingsState createEmptySettings(GradleInternal gradle, StartParameter startParameter, ClassLoaderScope classLoaderScope) {
+        logger.debug("Creating empty settings for build: '{}'", gradle.getIdentityPath());
         StartParameterInternal noSearchParameter = (StartParameterInternal) startParameter.newInstance();
         DeprecationLogger.whileDisabled(() ->
             noSearchParameter.setSettingsFile(null)

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
@@ -76,25 +76,25 @@ public class DefaultSettingsLoader implements SettingsLoader {
         SettingsLocation settingsLocation = buildLayoutFactory.getLayoutFor(new BuildLayoutConfiguration(startParameter));
 
         SettingsState state;
+        ProjectSpec spec;
         if (shouldSkipLoadingBuildDefinition(startParameter)) {
             logger.debug("Skipping loading of build definition for build: '{}'", gradle.getIdentityPath());
             state = createEmptySettings(gradle, startParameter, gradle.getClassLoaderScope());
-            ProjectSpec spec = ProjectSpecs.forStartParameter(startParameter, state.getSettings());
-            setDefaultProject(spec, state.getSettings());
+            spec = ProjectSpecs.forStartParameter(startParameter, state.getSettings());
         } else {
             logger.debug("Loading build definition for build: '{}'", gradle.getIdentityPath());
             state = findSettingsAndLoadIfAppropriate(gradle, startParameter, settingsLocation, gradle.getClassLoaderScope());
             SettingsInternal settings = state.getSettings();
-            ProjectSpec spec = ProjectSpecs.forStartParameter(startParameter, settings);
+            spec = ProjectSpecs.forStartParameter(startParameter, settings);
             if (useEmptySettings(spec, settings, startParameter)) {
                 // Discard the loaded settings and replace with an empty one
                 logger.debug("Discarding loaded settings and replacing with empty settings for build: '{}'", gradle.getIdentityPath());
                 state.close();
-                state = createEmptySettings(gradle, startParameter, gradle.getClassLoaderScope());
+                state = createEmptySettings(gradle, startParameter, settings.getClassLoaderScope());
             }
-            setDefaultProject(spec, state.getSettings());
         }
 
+        setDefaultProject(spec, state.getSettings());
         return state;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -100,7 +100,7 @@ public class GradleScopeServices implements ServiceRegistrationProvider {
 
     @Provides
     BuildTaskScheduler createBuildTaskScheduler(CommandLineTaskParser commandLineTaskParser, ProjectConfigurer projectConfigurer, BuildTaskSelector.BuildSpecificSelector selector, List<BuiltInCommand> builtInCommands) {
-        return new DefaultTasksBuildTaskScheduler(projectConfigurer, builtInCommands, new TaskNameResolvingBuildTaskScheduler(commandLineTaskParser, selector));
+        return new DefaultTasksBuildTaskScheduler(projectConfigurer, builtInCommands, new TaskNameResolvingBuildTaskScheduler(commandLineTaskParser, selector, builtInCommands));
     }
 
     @Provides

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/NewDefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/NewDefaultProjectTest.groovy
@@ -33,7 +33,7 @@ class NewDefaultProjectTest extends AbstractProjectBuilderSpec {
 
         then:
         rootTasks.size() == 2
-        rootTasks[project]*.path as Set == [":bar", ":buildEnvironment", ":components", ":dependencies", ":dependencyInsight", ":dependentComponents", ":foo", ":help", ":javaToolchains", ":model", ":outgoingVariants", ":projects", ":properties", ":resolvableConfigurations", ":tasks", ":foo"] as Set
+        rootTasks[project]*.path as Set == [":bar", ":buildEnvironment", ":components", ":dependencies", ":dependencyInsight", ":dependentComponents", ":foo", ":help", ":init", ":javaToolchains", ":model", ":outgoingVariants", ":projects", ":properties", ":resolvableConfigurations", ":tasks", ":wrapper", ":foo"] as Set
         rootTasks[a]*.path as Set == [":a:bar", ":a:buildEnvironment", ":a:components", ":a:dependencies", ":a:dependencyInsight", ":a:dependentComponents", ":a:foo", ":a:help", ":a:javaToolchains", ":a:model", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
 
         aTasks.size() == 1
@@ -51,7 +51,7 @@ class NewDefaultProjectTest extends AbstractProjectBuilderSpec {
 
         then:
         rootTasks.size() == 1
-        rootTasks[project]*.path as Set == [":bar", ":buildEnvironment", ":components", ":dependencies", ":dependencyInsight", ":dependentComponents", ":foo", ":help", ":javaToolchains", ":model", ":outgoingVariants", ":projects", ":properties", ":resolvableConfigurations", ":tasks", ":foo"] as Set
+        rootTasks[project]*.path as Set == [":bar", ":buildEnvironment", ":components", ":dependencies", ":dependencyInsight", ":dependentComponents", ":foo", ":help", ":init", ":javaToolchains", ":model", ":outgoingVariants", ":projects", ":properties", ":resolvableConfigurations", ":tasks", ":wrapper", ":foo"] as Set
 
         aTasks.size() == 1
         aTasks[a]*.path as Set == [":a:bar", ":a:buildEnvironment", ":a:components", ":a:dependencies", ":a:dependencyInsight", ":a:dependentComponents", ":a:foo", ":a:help", ":a:javaToolchains", ":a:model", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set

--- a/subprojects/core/src/test/groovy/org/gradle/execution/TaskNameResolvingBuildTaskSchedulerSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/TaskNameResolvingBuildTaskSchedulerSpec.groovy
@@ -37,7 +37,7 @@ class TaskNameResolvingBuildTaskSchedulerSpec extends Specification {
         executionPlan = Mock(ExecutionPlan)
         parser = Mock(CommandLineTaskParser)
         selector = Mock(EntryTaskSelector)
-        action = new TaskNameResolvingBuildTaskScheduler(parser, Stub(BuildTaskSelector.BuildSpecificSelector))
+        action = new TaskNameResolvingBuildTaskScheduler(parser, Stub(BuildTaskSelector.BuildSpecificSelector), [])
     }
 
     def "empty task parameters are no-op action"() {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/TaskNameResolvingBuildTaskSchedulerSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/TaskNameResolvingBuildTaskSchedulerSpec.groovy
@@ -51,6 +51,7 @@ class TaskNameResolvingBuildTaskSchedulerSpec extends Specification {
         action.scheduleRequestedTasks(gradle, null, executionPlan)
 
         then:
+        1 * executionPlan.getContents()
         0 * executionPlan._
     }
 
@@ -96,6 +97,7 @@ class TaskNameResolvingBuildTaskSchedulerSpec extends Specification {
 
         then:
         1 * selector.applyTasksTo(_, executionPlan)
+        1 * executionPlan.getContents()
         0 * executionPlan._
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultSettingsLoaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultSettingsLoaderTest.groovy
@@ -35,6 +35,7 @@ import spock.lang.Specification
 class DefaultSettingsLoaderTest extends Specification {
     private projectRootDir = FileUtils.canonicalize(new File("someDir"))
     private mockBuildLayout = new BuildLayout(null, projectRootDir, null, Stub(ScriptFileResolver))
+    @SuppressWarnings('GroovyAssignabilityCheck')
     private mockBuildLayoutFactory = Mock(BuildLayoutFactory) {
         getLayoutFor(_) >> mockBuildLayout
     }
@@ -47,9 +48,6 @@ class DefaultSettingsLoaderTest extends Specification {
         getAllProjects() >> Collections.singleton(mockProjectDescriptor)
     }
     private startParameterInternal = new StartParameterInternal()
-    {
-        startParameterInternal.setCurrentDir( projectRootDir )
-    }
     private mockClassLoaderScope = Mock(ClassLoaderScope)
     private mockServiceRegistry = Mock(ServiceRegistry)
     private mockGradle = Mock(GradleInternal) {
@@ -61,6 +59,7 @@ class DefaultSettingsLoaderTest extends Specification {
     private mockSettingsProcessor = Mock(SettingsProcessor) {
         // When we process, we're interested in retaining the start parameter in
         // the resulting state, so we can test it, so create a new mock and configure it
+        //noinspection GroovyAssignabilityCheck
         process(mockGradle, mockBuildLayout, mockClassLoaderScope, _) >> { gradle, settingsLocation, clasLoaderScope, startParameter ->
             def mockResultSettingsScript = Mock(ScriptSource) {
                 getDisplayName() >> "foo"
@@ -77,6 +76,10 @@ class DefaultSettingsLoaderTest extends Specification {
             }
             return mockResultState
         }
+    }
+
+    void setup() {
+        startParameterInternal.setCurrentDir( projectRootDir )
     }
 
     private logger = new ToStringLogger()

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultSettingsLoaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultSettingsLoaderTest.groovy
@@ -15,61 +15,121 @@
  */
 package org.gradle.initialization
 
-
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.SettingsInternal
 import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.project.ProjectRegistry
-import org.gradle.configuration.project.BuiltInCommand
+import org.gradle.api.plugins.internal.HelpBuiltInCommand
+import org.gradle.buildinit.plugins.internal.action.InitBuiltInCommand
 import org.gradle.groovy.scripts.ScriptSource
-import org.gradle.initialization.layout.BuildLayoutFactory
 import org.gradle.initialization.layout.BuildLayout
+import org.gradle.initialization.layout.BuildLayoutFactory
 import org.gradle.internal.FileUtils
+import org.gradle.internal.logging.ToStringLogger
 import org.gradle.internal.scripts.ScriptFileResolver
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.util.Path
 import spock.lang.Specification
 
 class DefaultSettingsLoaderTest extends Specification {
+    private projectRootDir = FileUtils.canonicalize(new File("someDir"))
+    private mockBuildLayout = new BuildLayout(null, projectRootDir, null, Stub(ScriptFileResolver))
+    private mockBuildLayoutFactory = Mock(BuildLayoutFactory) {
+        getLayoutFor(_) >> mockBuildLayout
+    }
+    private mockProjectDescriptor = Mock(DefaultProjectDescriptor) {
+        getPath() >> ":"
+        getProjectDir() >> mockBuildLayout.settingsDir
+        getBuildFile() >> new File(mockBuildLayout.settingsDir, "build.gradle")
+    }
+    private mockProjectRegistry = Mock(ProjectRegistry) {
+        getAllProjects() >> Collections.singleton(mockProjectDescriptor)
+    }
+    private startParameterInternal = new StartParameterInternal()
+    {
+        startParameterInternal.setCurrentDir( projectRootDir )
+    }
+    private mockClassLoaderScope = Mock(ClassLoaderScope)
+    private mockServiceRegistry = Mock(ServiceRegistry)
+    private mockGradle = Mock(GradleInternal) {
+        getStartParameter() >> startParameterInternal
+        getServices() >> mockServiceRegistry
+        getIdentityPath() >> Path.ROOT
+        getClassLoaderScope() >> mockClassLoaderScope
+    }
+    private mockSettingsProcessor = Mock(SettingsProcessor) {
+        // When we process, we're interested in retaining the start parameter in
+        // the resulting state, so we can test it, so create a new mock and configure it
+        process(mockGradle, mockBuildLayout, mockClassLoaderScope, _) >> { gradle, settingsLocation, clasLoaderScope, startParameter ->
+            def mockResultSettingsScript = Mock(ScriptSource) {
+                getDisplayName() >> "foo"
+            }
 
-    def gradle = Mock(GradleInternal)
-    def settings = Mock(SettingsInternal)
-    def state = Mock(SettingsState)
-    def buildLayout = new BuildLayout(null, FileUtils.canonicalize(new File("someDir")), null, Stub(ScriptFileResolver))
-    def buildLayoutFactory = Mock(BuildLayoutFactory)
-    def settingsScript = Mock(ScriptSource)
-    def startParameter = new StartParameterInternal()
-    def classLoaderScope = Mock(ClassLoaderScope)
-    def settingsProcessor = Mock(SettingsProcessor)
-    def buildInCommand = Mock(BuiltInCommand)
-    def settingsHandler = new DefaultSettingsLoader(settingsProcessor, buildLayoutFactory, [buildInCommand])
+            def mockResultSettings = Mock(SettingsInternal) {
+                getProjectRegistry() >> mockProjectRegistry
+                getSettingsScript() >> mockResultSettingsScript
+                getStartParameter() >> startParameter
+            }
 
-    void findAndLoadSettingsWithExistingSettings() {
-        when:
-        def projectRegistry = Mock(ProjectRegistry)
-        def projectDescriptor = Mock(DefaultProjectDescriptor) {
-            getPath() >> ":"
+            def mockResultState = Mock(SettingsState) {
+                getSettings() >> mockResultSettings
+            }
+            return mockResultState
         }
-        def services = Mock(ServiceRegistry)
-        startParameter.setCurrentDir(buildLayout.settingsDir)
-
-        settings.getProjectRegistry() >> projectRegistry
-        projectRegistry.getAllProjects() >> Collections.singleton(projectDescriptor)
-        projectDescriptor.getProjectDir() >> buildLayout.settingsDir
-        projectDescriptor.getBuildFile() >> new File(buildLayout.settingsDir, "build.gradle")
-        gradle.getStartParameter() >> startParameter
-        gradle.getServices() >> services
-        gradle.getIdentityPath() >> Path.ROOT
-        buildLayoutFactory.getLayoutFor(_) >> buildLayout
-        gradle.getClassLoaderScope() >> classLoaderScope
-        1 * settingsProcessor.process(gradle, buildLayout, classLoaderScope, startParameter) >> state
-        _ * state.settings >> settings
-        1 * settings.settingsScript >> settingsScript
-        1 * settingsScript.displayName >> "foo"
-
-        then:
-        settingsHandler.findAndLoadSettings(gradle) == state
     }
 
+    private logger = new ToStringLogger()
+    private builtInCommands = [new InitBuiltInCommand(), new HelpBuiltInCommand()]
+    private DefaultSettingsLoader settingsLoader = new DefaultSettingsLoader(mockSettingsProcessor, mockBuildLayoutFactory, builtInCommands, logger)
+
+    def "running default task loads settings"() {
+        when:
+        def resultState = settingsLoader.findAndLoadSettings(mockGradle)
+
+        then:
+        resultState != null
+
+        and:
+        logger.toString().contains("Loading build definition for build: ':'")
+    }
+
+    def "running init uses new empty settings"() {
+        given:
+        startParameterInternal.setCurrentDir(mockBuildLayout.settingsDir)
+        startParameterInternal.setTaskNames(["init"])
+
+        when:
+        def resultState = settingsLoader.findAndLoadSettings(mockGradle)
+
+        then:
+        resultState != null
+
+        and:
+        def resultStartParam = ((StartParameterInternal) resultState.getSettings().getStartParameter())
+        resultStartParam.isUseEmptySettings()
+
+        and:
+        logger.toString().contains("Skipping loading of build definition for build: ':'")
+        !logger.toString().contains("Discarding loaded settings and replacing with empty settings for build: ':'")
+    }
+
+    def "running help only loads settings once"() {
+        given:
+        startParameterInternal.setTaskNames(["help"])
+
+        when:
+        def resultState = settingsLoader.findAndLoadSettings(mockGradle)
+
+        then:
+        resultState != null
+
+        and:
+        def resultStartParam = ((StartParameterInternal) resultState.getSettings().getStartParameter())
+        !resultStartParam.isUseEmptySettings()
+
+        and:
+        logger.toString().contains("Loading build definition for build: ':'")
+        !logger.toString().contains("Discarding loaded settings and replacing with empty settings for build: ':'")
+    }
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/plugins/internal/HelpBuiltInCommand.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/plugins/internal/HelpBuiltInCommand.java
@@ -21,11 +21,18 @@ import org.gradle.configuration.project.BuiltInCommand;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
+import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 
 @ServiceScope(Scope.Global.class)
 public class HelpBuiltInCommand implements BuiltInCommand {
+    @Override
+    @Nonnull
+    public String getDisplayName() {
+        return ProjectInternal.HELP_TASK;
+    }
+
     @Override
     public List<String> asDefaultTask() {
         return Collections.singletonList(ProjectInternal.HELP_TASK);
@@ -33,6 +40,6 @@ public class HelpBuiltInCommand implements BuiltInCommand {
 
     @Override
     public boolean commandLineMatches(List<String> taskNames) {
-        return taskNames.isEmpty() || taskNames.get(0).equals(ProjectInternal.HELP_TASK) || taskNames.get(0).equals(":" + ProjectInternal.HELP_TASK);
+        return taskNames.isEmpty() || taskNames.stream().anyMatch(taskName -> taskName.equals(ProjectInternal.HELP_TASK) || taskName.equals(":" + ProjectInternal.HELP_TASK));
     }
 }


### PR DESCRIPTION
Adjusts the settings loader behavior to only load settings once.  This supports `Plugin<Setting>`s configuring services during application, and ensures they are only configured once, which was a latent issue in the previous scheme.

This alsos validate that init task is the only task being run, deprecate the case when it is run with other tasks in the same invocation.

Finally, this adjust some tests, which seemed to have some latent issues due to the previous settings loading duplication.