### PR TITLE
Introduce ProjectDependency.getPath

### DIFF
--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -238,7 +238,7 @@ dependencies {
 }
 ```
 
-#### Introduced Isolated Projects safe project path accessor on `ProjectDependency`
+#### Introduced project path accessor on `ProjectDependency`
 This release introduces `ProjectDependency#getPath()` for accessing the identity of the target of a project dependency.
 
 <a name="native-toolchains"></a>

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -238,6 +238,9 @@ dependencies {
 }
 ```
 
+#### Introduced Isolated Projects safe project path accessor on `ProjectDependency`
+This release introduces `ProjectDependency#getPath()` for accessing the identity of the target of a project dependency.
+
 <a name="native-toolchains"></a>
 ### Native toolchains support
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -163,19 +163,27 @@ The link:{javadocPath}/org/gradle/api/artifacts/ProjectDependency.html#getDepend
 
 Accessing the mutable project instance of other projects should be avoided.
 
-In many cases, details about a project dependency are exposed by a link:{javadocPath}/org/gradle/api/artifacts/result/DependencyResult.html[DependencyResult], which can be obtained via a link:{javadocPath}/org/gradle/api/artifacts/result/ResolutionResult.html[ResolutionResult].
+To discover details about all projects that were included in a resolution, inspect the full link:{javadocPath}/org/gradle/api/artifacts/result/ResolutionResult.html[ResolutionResult].
+Project dependencies are exposed in the link:{javadocPath}/org/gradle/api/artifacts/result/DependencyResult.html[DependencyResult].
 See the user guide section on <<programmatic_dependency_resolution#sec:graph_resolution,programmatic dependency resolution>> for more details on this API.
+This is the only reliable way to find all projects that are used in a resolution.
+Inspecting only the declared `ProjectDependency`s may miss transitive or substituted project dependencies.
 
-In other cases, where only the identity of the target project is necessary, use the new Isolated Projects safe project path method: link:{javadocPath}/org/gradle/api/artifacts/ProjectDependency.html#getPath()[`ProjectDependency#getPath()`]
+To get the identity of the target project, use the new Isolated Projects safe project path method: link:{javadocPath}/org/gradle/api/artifacts/ProjectDependency.html#getPath()[`ProjectDependency#getPath()`].
 
-If accessing the target project is absolutely necessary, consider this direct replacement:
-Note, this approach will not fetch project instances from a different build.
+To access or configure the target project, consider this direct replacement:
 [source,kotlin]
 ----
 val projectDependency: ProjectDependency = getSomeProjectDependency()
-val deprecated = projectDependency.dependencyProject
-val replacement = project.project(projectDependency.path)
+
+// Old way:
+val someProject = projectDependency.dependencyProject
+
+// New way:
+val someProject = project.project(projectDependency.path)
 ----
+
+This approach will not fetch project instances from different builds.
 
 [[deprecate_legacy_configuration_get_files]]
 ==== Deprecated `ResolvedConfiguration.getFiles()` and `LenientConfiguration.getFiles()`

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -163,6 +163,20 @@ The link:{javadocPath}/org/gradle/api/artifacts/ProjectDependency.html#getDepend
 
 Accessing the mutable project instance of other projects should be avoided.
 
+In many cases, details about a project dependency are exposed by a link:{javadocPath}/org/gradle/api/artifacts/result/DependencyResult.html[DependencyResult], which can be obtained via a link:{javadocPath}/org/gradle/api/artifacts/result/ResolutionResult.html[ResolutionResult].
+See the user guide section on <<programmatic_dependency_resolution#sec:graph_resolution,programmatic dependency resolution>> for more details on this API.
+
+In other cases, where only the identity of the target project is necessary, use the new Isolated Projects safe project path method: link:{javadocPath}/org/gradle/api/artifacts/ProjectDependency.html#getPath()[`ProjectDependency#getPath()`]
+
+If accessing the target project is absolutely necessary, consider this direct replacement:
+Note, this approach will not fetch project instances from a different build.
+[source,kotlin]
+----
+val projectDependency: ProjectDependency = getSomeProjectDependency()
+val deprecated = projectDependency.dependencyProject
+val replacement = project.project(projectDependency.path)
+----
+
 [[deprecate_legacy_configuration_get_files]]
 ==== Deprecated `ResolvedConfiguration.getFiles()` and `LenientConfiguration.getFiles()`
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyNotationIntegrationSpec.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyNotationIntegrationSpec.groovy
@@ -83,6 +83,7 @@ task checkDeps {
         succeeds 'checkDeps'
     }
 
+    @ToBeFixedForConfigurationCache(because = "Task uses the Configuration API")
     def "understands project notations"() {
         when:
         createDirs("otherProject")
@@ -106,16 +107,14 @@ dependencies {
 }
 
 task checkDeps {
-    def rootOne = configurations.conf.incoming.resolutionResult.rootComponent
-    def rootTwo = configurations.confTwo.incoming.resolutionResult.rootComponent
     doLast {
-        def depsOne = rootOne.get().dependencies*.requested
-        assert depsOne.size() == 1
-        assert depsOne.find { it.projectPath == ':otherProject' }
+        def deps = configurations.conf.incoming.dependencies
+        assert deps.size() == 1
+        assert deps.find { it.path == ':otherProject' && it.targetConfiguration == null }
 
-        def depsTwo = rootTwo.get().dependencies*.requested
-        assert depsTwo.size() == 1
-        assert depsTwo.find { it.projectPath == ':otherProject' }
+        deps = configurations.confTwo.incoming.dependencies
+        assert deps.size() == 1
+        assert deps.find { it.path == ':otherProject' && it.targetConfiguration == 'otherConf' }
     }
 }
 """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FilteredConfigurationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FilteredConfigurationIntegrationTest.groovy
@@ -70,7 +70,7 @@ task verify {
     doLast {
         println "file-dependencies: " + configurations.compile.files { it instanceof FileCollectionDependency }.collect { it.name }
         println "external-dependencies: " + configurations.compile.files { it instanceof ExternalDependency }.collect { it.name }
-        println "child1-dependencies: " + configurations.compile.files { it instanceof ProjectDependency && it.dependencyProject.name == 'child1' }.collect { it.name }
+        println "child1-dependencies: " + configurations.compile.files { it instanceof ProjectDependency && it.path == ':child1' }.collect { it.name }
 
         assert configurations.compile.resolvedConfiguration.files == configurations.compile.files
         assert configurations.compile.resolvedConfiguration.lenientConfiguration.files == configurations.compile.files
@@ -84,7 +84,6 @@ task verify {
         executer.expectDocumentedDeprecationWarning("The Configuration.files(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
         executer.expectDocumentedDeprecationWarning("The ResolvedConfiguration.getFiles() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration#getFiles instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_legacy_configuration_get_files")
         executer.expectDocumentedDeprecationWarning("The LenientConfiguration.getFiles() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use a lenient ArtifactView instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_legacy_configuration_get_files")
-        executer.expectDocumentedDeprecationWarning("The ProjectDependency.getDependencyProject() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_get_dependency_project")
         run "verify"
 
         then:
@@ -135,7 +134,7 @@ project(':child1') {
 task verify {
     doLast {
         println "external-dependencies: " + configurations.compile.files { it instanceof ExternalDependency }.collect { it.name }
-        println "child1-dependencies: " + configurations.compile.files { it instanceof ProjectDependency && it.dependencyProject.name == 'child1' }.collect { it.name }
+        println "child1-dependencies: " + configurations.compile.files { it instanceof ProjectDependency && it.path == ':child1' }.collect { it.name }
 
         assert configurations.compile.resolvedConfiguration.files == configurations.compile.files
         assert configurations.compile.resolvedConfiguration.lenientConfiguration.files == configurations.compile.files
@@ -148,7 +147,6 @@ task verify {
         executer.expectDocumentedDeprecationWarning("The Configuration.files(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
         executer.expectDocumentedDeprecationWarning("The ResolvedConfiguration.getFiles() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration#getFiles instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_legacy_configuration_get_files")
         executer.expectDocumentedDeprecationWarning("The LenientConfiguration.getFiles() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use a lenient ArtifactView instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_legacy_configuration_get_files")
-        executer.expectDocumentedDeprecationWarning("The ProjectDependency.getDependencyProject() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_get_dependency_project")
         run "verify"
 
         then:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/typesafe/TypeSafeProjectAccessorsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/typesafe/TypeSafeProjectAccessorsIntegrationTest.groovy
@@ -18,11 +18,8 @@ package org.gradle.integtests.resolve.typesafe
 
 import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 
 class TypeSafeProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAccessorsIntegrationTest {
-    def resolve = new ResolveTestFixture(buildFile)
-
     def setup() {
         settingsFile << """
             rootProject.name = 'typesafe-project-accessors'
@@ -31,33 +28,24 @@ class TypeSafeProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAcc
 
     def "generates type-safe project accessors for multi-project build"() {
         given:
-        includeProjects("one", "one:other", "two", "two:other")
+        createDirs("one", "one/other", "two", "two/other")
+        settingsFile << """
+            include 'one'
+            include 'one:other'
+            include 'two:other'
+        """
 
         buildFile << """
-            plugins {
-                id("java-library")
-            }
-
-            dependencies {
-                implementation(projects.one)
-                implementation(projects.one.other)
-                implementation(projects.two.other)
-            }
+            assert project(":one").path == projects.one.path
+            assert project(":one:other").path == projects.one.other.path
+            assert project(":two:other").path == projects.two.other.path
         """
-        resolve.prepare("runtimeClasspath")
 
         when:
-        succeeds(":checkDeps")
+        run 'help'
 
         then:
         outputContains 'Type-safe project accessors is an incubating feature.'
-        resolve.expectGraph {
-            root(":", ":typesafe-project-accessors:unspecified") {
-                project(":one", "typesafe-project-accessors:one:1.0")
-                project(":one:other", "typesafe-project-accessors.one:other:1.0")
-                project(":two:other", "typesafe-project-accessors.two:other:1.0")
-            }
-        }
     }
 
     def "fails if a project doesn't follow convention"() {
@@ -99,119 +87,64 @@ class TypeSafeProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAcc
 
     def "can configure the project extension name"() {
         given:
-        includeProjects("one", "one:other", "two", "two:other")
+        createDirs("one", "one/other", "two", "two/other")
         settingsFile << """
+            include 'one'
+            include 'one:other'
+            include 'two:other'
+
             dependencyResolutionManagement {
                 defaultProjectsExtensionName.set("ts")
             }
         """
 
         buildFile << """
-            plugins {
-                id("java-library")
-            }
-
-            dependencies {
-                implementation(ts.one)
-                implementation(ts.one.other)
-                implementation(ts.two.other)
-            }
+            assert project(":one").path == ts.one.path
+            assert project(":one:other").path == ts.one.other.path
+            assert project(":two:other").path == ts.two.other.path
         """
-        resolve.prepare("runtimeClasspath")
 
         when:
-        succeeds(":checkDeps")
+        run 'help'
 
         then:
         outputContains 'Type-safe project accessors is an incubating feature.'
-        resolve.expectGraph {
-            root(":", ":typesafe-project-accessors:unspecified") {
-                project(":one", "typesafe-project-accessors:one:1.0")
-                project(":one:other", "typesafe-project-accessors.one:other:1.0")
-                project(":two:other", "typesafe-project-accessors.two:other:1.0")
-            }
-        }
     }
 
     def "can refer to the root project via its name"() {
         given:
         buildFile << """
-            plugins {
-                id("java-library")
-            }
-
-            sourceSets {
-                foo
-            }
-
-            java {
-                registerFeature('foo') {
-                    usingSourceSet(sourceSets.foo)
-                }
-            }
-
-            dependencies {
-                implementation(projects.typesafeProjectAccessors) {
-                    capabilities {
-                        it.requireFeature("foo")
-                    }
-                }
-            }
+            assert project(":").path == projects.typesafeProjectAccessors.path
         """
-        resolve.prepare("runtimeClasspath")
 
         when:
-        succeeds(':checkDeps')
+        run 'help'
 
         then:
         outputContains 'Type-safe project accessors is an incubating feature.'
-        resolve.expectGraph {
-            root(":", ":typesafe-project-accessors:unspecified") {
-                project(":", ":typesafe-project-accessors:unspecified") {
-                    artifact(name: 'typesafe-project-accessors-foo', fileName: 'typesafe-project-accessors-foo.jar')
-                }
-            }
-        }
     }
 
     def "can use the #notation notation on type-safe accessor"() {
         given:
+        createDirs("other")
         settingsFile << """
             include 'other'
         """
-        file("other/build.gradle") << """
-            plugins {
-                id("java-platform")
-                id("java-test-fixtures")
-            }
-        """
 
         buildFile << """
-            plugins {
-                id("java-library")
+            configurations {
+                implementation
             }
             dependencies {
                 implementation($notation(projects.other))
             }
         """
-        resolve.prepare("runtimeClasspath")
 
         when:
-        succeeds(':checkDeps')
+        run 'help'
 
         then:
         outputDoesNotContain('it was probably created by a plugin using internal APIs')
-        resolve.expectGraph {
-            root(":", ":typesafe-project-accessors:unspecified") {
-                project(":other", "typesafe-project-accessors:other:unspecified") {
-                    if (notation == "platform") {
-                        noArtifacts()
-                    } else {
-                        artifact(name: 'other-test-fixtures', fileName: 'other-test-fixtures.jar')
-                    }
-                }
-            }
-        }
 
         where:
         notation << [ 'platform', 'testFixtures']
@@ -220,59 +153,31 @@ class TypeSafeProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAcc
     def "buildSrc project accessors are independent from the main build accessors"() {
         given:
         file("buildSrc/build.gradle") << """
-            plugins {
-                id("java-library")
-            }
-
-            dependencies {
-                implementation(projects.one)
-                implementation(projects.two)
-            }
+            assert project(":one").path == projects.one.path
+            assert project(":two").path == projects.two.path
         """
-        ["one", "two"].each {
-            file("buildSrc/settings.gradle") << """
-                include '$it'
-            """
-            file("buildSrc/$it/build.gradle") << """
-                plugins {
-                    id("java-library")
-                }
-                version = "1.0"
-            """
-        }
+        createDirs("buildSrc/one", "buildSrc/two")
+        file("buildSrc/settings.gradle") << """
+            include 'one'
+            include 'two'
+        """
         FeaturePreviewsFixture.enableTypeSafeProjectAccessors(file("buildSrc/settings.gradle"))
-        def resolveBuildSrc = new ResolveTestFixture(file("buildSrc/build.gradle"))
-        resolveBuildSrc.prepare("runtimeClasspath")
-
-        includeProjects("three", "four")
-        buildFile << """
-            plugins {
-                id("java-library")
-            }
-
-            dependencies {
-                implementation(projects.three)
-                implementation(projects.four)
-            }
+        createDirs("one", "two")
+        settingsFile << """
+            include 'one'
+            include 'two'
         """
-        resolve.prepare("runtimeClasspath")
+
+        buildFile << """
+            assert project(":one").path == projects.one.path
+            assert project(":two").path == projects.two.path
+        """
 
         when:
-        succeeds(":buildSrc:checkDeps")
-        succeeds(":checkDeps")
+        run 'help'
 
         then:
         outputContains 'Type-safe project accessors is an incubating feature.'
-
-        // We cannot verify resolveBuildSrc since it has a ton of extra things on the
-        // classpath by default
-
-        resolve.expectGraph {
-            root(":", ":typesafe-project-accessors:unspecified") {
-                project(":three", "typesafe-project-accessors:three:1.0")
-                project(":four", "typesafe-project-accessors:four:1.0")
-            }
-        }
     }
 
     def "warns if root project name not explicitly set"() {
@@ -285,13 +190,7 @@ class TypeSafeProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAcc
             include 'one'
         """
         file("project/build.gradle") << """
-            plugins {
-                id("java-library")
-            }
-
-            dependencies {
-                implementation(projects.one)
-            }
+            assert project(":one").path == projects.one.path
         """
         FeaturePreviewsFixture.enableTypeSafeProjectAccessors(file("project/settings.gradle"))
 
@@ -316,16 +215,13 @@ class TypeSafeProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAcc
 
     def "does not warn if root project name explicitly set"() {
         given:
-        includeProjects("one")
+        createDirs("one")
+        settingsFile << """
+            include 'one'
+        """
 
         buildFile << """
-            plugins {
-                id("java-library")
-            }
-
-            dependencies {
-                implementation(projects.one)
-            }
+            assert project(":one").path == projects.one.path
         """
 
         //run once
@@ -340,23 +236,4 @@ class TypeSafeProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAcc
         then:
         outputDoesNotContain 'Project accessors enabled, but root project name not explicitly set'
     }
-
-    def includeProjects(String... names) {
-        names.each {
-            includeProject(it)
-        }
-    }
-
-    def includeProject(String name) {
-        settingsFile << """
-            include '$name'
-        """
-        file("${name.replace(':', '/')}/build.gradle") << """
-            plugins {
-                id("java-library")
-            }
-            version = "1.0"
-        """
-    }
-
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/typesafe/TypeSafeRootProjectAccessorsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/typesafe/TypeSafeRootProjectAccessorsIntegrationTest.groovy
@@ -16,52 +16,26 @@
 
 package org.gradle.integtests.resolve.typesafe
 
-import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
-
 class TypeSafeRootProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAccessorsIntegrationTest {
-    def "generates type-safe accessors for a root project with name = #name)"() {
+    def "generates type-safe accessors for a root project with name = #root)"() {
         given:
         settingsFile << """
-            rootProject.name = '$name'
+            rootProject.name = '$root'
         """
         buildFile << """
-            plugins {
-                id("java-library")
-            }
-            sourceSets {
-                foo
-            }
-            java {
-                registerFeature("foo") {
-                    usingSourceSet(sourceSets.foo)
-                }
-            }
-
-            dependencies {
-                implementation(projects.${accessor}) {
-                    capabilities {
-                        it.requireFeature("foo")
-                    }
-                }
-            }
+            def projectDependency = projects.${accessor}
+            assert projectDependency instanceof ProjectDependency
+            println("Dependency path: \\"\${projectDependency.path}\\"")
         """
-        def resolve = new ResolveTestFixture(buildFile)
-        resolve.prepare("runtimeClasspath")
 
         when:
-        succeeds(":checkDeps")
+        succeeds 'help'
 
         then:
-        resolve.expectGraph {
-            root(":", ":${name}:unspecified") {
-                project(":", ":${name}:unspecified") {
-                    artifact(name: "${name}-foo", fileName: "${name}-foo.jar")
-                }
-            }
-        }
+        outputContains 'Dependency path: ":"'
 
         where:
-        name         | accessor
+        root         | accessor
         'test'       | 'test'
         'root'       | 'root'
         'snake_case' | 'snakeCase'

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/typesafe/TypeSafeRootProjectAccessorsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/typesafe/TypeSafeRootProjectAccessorsIntegrationTest.groovy
@@ -25,7 +25,7 @@ class TypeSafeRootProjectAccessorsIntegrationTest extends AbstractTypeSafeProjec
         buildFile << """
             def projectDependency = projects.${accessor}
             assert projectDependency instanceof ProjectDependency
-            println("Dependency path: \\"\${projectDependency.path}\\"")
+            println('Dependency path: "' + projectDependency.path + '"')
         """
 
         when:

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -69,6 +69,11 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
     }
 
     @Override
+    public String getPath() {
+        return dependencyProject.getPath();
+    }
+
+    @Override
     @Deprecated
     public Project getDependencyProject() {
         DeprecationLogger.deprecateMethod(ProjectDependency.class, "getDependencyProject()")

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DelegatingProjectDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DelegatingProjectDependency.java
@@ -67,6 +67,11 @@ public class DelegatingProjectDependency implements ProjectDependencyInternal {
     }
 
     @Override
+    public String getPath() {
+        return delegate.getPath();
+    }
+
+    @Override
     @Deprecated
     public Project getDependencyProject() {
         return delegate.getDependencyProject();

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ProjectDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ProjectDependency.java
@@ -40,6 +40,9 @@ public interface ProjectDependency extends ModuleDependency, SelfResolvingDepend
 
     /**
      * Returns the project associated with this project dependency.
+     *
+     * @deprecated This method will be removed in Gradle 9.0. Accessing the mutable
+     * state of other projects should be avoided.
      */
     @Deprecated
     Project getDependencyProject();

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ProjectDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ProjectDependency.java
@@ -28,11 +28,18 @@ import java.util.Set;
 @HasInternalProtocol
 @SuppressWarnings("deprecation") // Because of SelfResolvingDependency
 public interface ProjectDependency extends ModuleDependency, SelfResolvingDependency {
+
+    /**
+     * Get the path to the project that this dependency refers to relative to its owning build.
+     *
+     * @see Project#getPath()
+     *
+     * @since 8.11
+     */
+    String getPath();
+
     /**
      * Returns the project associated with this project dependency.
-     *
-     * @deprecated This method will be removed in Gradle 9.0. Accessing the mutable
-     * state of other projects should be avoided.
      */
     @Deprecated
     Project getDependencyProject();

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
@@ -38,7 +38,7 @@ class DefaultProjectDependencyTest extends AbstractProjectBuilderSpec {
         project.group = "org.gradle"
     }
 
-    def "exposes identity"() {
+    def "exposes local project path"() {
         expect:
         projectDependency.path == project.path
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
@@ -38,6 +38,11 @@ class DefaultProjectDependencyTest extends AbstractProjectBuilderSpec {
         project.group = "org.gradle"
     }
 
+    def "exposes identity"() {
+        expect:
+        projectDependency.path == project.path
+    }
+
     void "provides dependency information"() {
         expect:
         projectDependency.transitive

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -1,6 +1,14 @@
 {
     "acceptedApiChanges": [
         {
+            "type": "org.gradle.api.artifacts.ProjectDependency",
+            "member": "Method org.gradle.api.artifacts.ProjectDependency.getPath()",
+            "acceptation": "No need to incubate",
+            "changes": [
+                "Method added to interface"
+            ]
+        },
+        {
             "type": "org.gradle.api.tasks.compile.CompileOptions",
             "member": "Method org.gradle.api.tasks.compile.CompileOptions.debugOptions(org.gradle.api.Action)",
             "acceptation": "No need to incubate",

--- a/testing/architecture-test/src/changes/archunit-store/public-api-mutable-properties.txt
+++ b/testing/architecture-test/src/changes/archunit-store/public-api-mutable-properties.txt
@@ -76,6 +76,7 @@ Method <org.gradle.api.artifacts.ModuleDependency.isTransitive()> does not have 
 Method <org.gradle.api.artifacts.MutableVersionConstraint.getBranch()> does not have raw return type (java.lang.String) assignable to any of [Property, MapProperty, ListProperty, SetProperty] in (MutableVersionConstraint.java:0)
 Method <org.gradle.api.artifacts.ProjectDependency.getBuildDependencies()> does not have raw return type (org.gradle.api.tasks.TaskDependency) assignable to any of [Provider] in (ProjectDependency.java:0)
 Method <org.gradle.api.artifacts.ProjectDependency.getDependencyProject()> does not have raw return type (org.gradle.api.Project) assignable to any of [Provider] in (ProjectDependency.java:0)
+Method <org.gradle.api.artifacts.ProjectDependency.getPath()> does not have raw return type (java.lang.String) assignable to any of [Provider] in (ProjectDependency.java:0)
 Method <org.gradle.api.artifacts.ResolutionStrategy.getCapabilitiesResolution()> does not have raw return type (org.gradle.api.artifacts.CapabilitiesResolution) assignable to any of [Provider] in (ResolutionStrategy.java:0)
 Method <org.gradle.api.artifacts.ResolutionStrategy.getComponentSelection()> does not have raw return type (org.gradle.api.artifacts.ComponentSelectionRules) assignable to any of [Provider] in (ResolutionStrategy.java:0)
 Method <org.gradle.api.artifacts.ResolutionStrategy.getDependencySubstitution()> does not have raw return type (org.gradle.api.artifacts.DependencySubstitutions) assignable to any of [Provider] in (ResolutionStrategy.java:0)


### PR DESCRIPTION
This reverts commit 61c3d081e28442f62ae399b459bb5199cdd4a9a1, plus introduces some additional updates to the upgrade guide. All test changes in this PR are reverts of code changes that were necessary to migrate away from dependencyProject.path


Fixes https://github.com/gradle/gradle/issues/30992

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
