### PR TITLE
Fix wrong channel passed to performance tests

### DIFF
--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
@@ -316,7 +316,7 @@ abstract class PerformanceTest extends DistributionTest {
             addSystemPropertyIfExist(result, "org.gradle.performance.execution.warmups", warmups)
             addSystemPropertyIfExist(result, "org.gradle.performance.execution.runs", runs)
             addSystemPropertyIfExist(result, "org.gradle.performance.regression.checks", checks)
-            addSystemPropertyIfExist(result, "org.gradle.performance.execution.channel", channel)
+            addSystemPropertyIfExist(result, "org.gradle.performance.execution.channel", channel.get())
             addSystemPropertyIfExist(result, "org.gradle.performance.debugArtifactsDirectory", getDebugArtifactsDirectory())
             addSystemPropertyIfExist(result, "gradleBuildBranch", branchName)
 


### PR DESCRIPTION
We made some changes to `channel` in
https://github.com/gradle/gradle/pull/30473
but mistakenly stored the following into DB:

```
+---------------------------------------------------------------------------------------------+
| channel                                                                                     |
+---------------------------------------------------------------------------------------------+
| task ':performance:largeEmptyMultiProjectDeclarativeDslPerformanceTest' property 'channel'   |
| task ':performance:largeEmptyMultiProjectDeclarativeDslPerformanceTest' property 'channel'   |
| task ':performance:largeEmptyMultiProjectDeclarativeDslPerformanceTest' property 'channel'   |
| commits-master                                                                              |
| commits-master                                                                              |
| commits-master                                                                              |
+---------------------------------------------------------------------------------------------+
```
