### PR TITLE
Make PatternMatchers globally shared

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/Codecs.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/Codecs.kt
@@ -85,6 +85,7 @@ import org.gradle.internal.serialize.codecs.core.MapEntrySnapshotCodec
 import org.gradle.internal.serialize.codecs.core.MapPropertyCodec
 import org.gradle.internal.serialize.codecs.core.NullValueSnapshotCodec
 import org.gradle.internal.serialize.codecs.core.OrdinalNodeCodec
+import org.gradle.internal.serialize.codecs.core.PatternMatcherCodec
 import org.gradle.internal.serialize.codecs.core.PatternSetCodec
 import org.gradle.internal.serialize.codecs.core.PropertyCodec
 import org.gradle.internal.serialize.codecs.core.ProviderCodec
@@ -234,6 +235,8 @@ class Codecs(
 
             bind(DefaultCopySpecCodec(patternSetFactory, fileCollectionFactory, objectFactory, instantiator, fileSystemOperations))
             bind(DestinationRootCopySpecCodec(fileResolver))
+
+            bind(PatternMatcherCodec)
 
             bind(TaskReferenceCodec)
 

--- a/platforms/core-configuration/core-serialization-codecs/build.gradle.kts
+++ b/platforms/core-configuration/core-serialization-codecs/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     api(projects.dependencyManagement)
     api(projects.fileCollections)
     api(projects.fileOperations)
+    api(projects.files)
     api(projects.flowServices)
     api(projects.graphSerialization)
     api(projects.stdlibJavaExtensions)

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/PatternMatcherCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/PatternMatcherCodec.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.serialize.codecs.core
+
+import org.gradle.api.internal.file.pattern.PatternMatcher
+import org.gradle.internal.extensions.stdlib.uncheckedCast
+import org.gradle.internal.serialize.graph.Codec
+import org.gradle.internal.serialize.graph.ReadContext
+import org.gradle.internal.serialize.graph.WriteContext
+import org.gradle.internal.serialize.graph.decodeBean
+import org.gradle.internal.serialize.graph.encodeBean
+
+object PatternMatcherCodec: Codec<PatternMatcher> {
+    override suspend fun WriteContext.encode(value: PatternMatcher) =
+        writeSharedObject(value) {
+            encodeBean(value)
+        }
+
+    override suspend fun ReadContext.decode(): PatternMatcher =
+        readSharedObject {
+            decodeBean()
+        }.uncheckedCast()
+}


### PR DESCRIPTION
`PatternMatcher` subclasses lead to a lot of state duplication with parallel CC. Stats for perf-android-large-build:

<img width="1726" alt="Screenshot 2024-10-23 at 16 20 36" src="https://github.com/user-attachments/assets/d3c0f686-c3c7-4527-a78d-f99db9def1e6">


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
