### PR TITLE
Remove build insights team from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -83,9 +83,9 @@ platforms/core-execution/hashing/                           @gradle/bt-execution
 platforms/core-execution/snapshots/                         @gradle/bt-execution @gradle/bt-dv-build-cache
 
 # Develocity integration
-platforms/enterprise/                                   @gradle/bt-build-scan @gradle/dv-build-insights-team
-platforms/enterprise/enterprise/                        @gradle/bt-build-scan @gradle/dv-testing-team @gradle/dv-build-insights-team @ldaley
-platforms/enterprise/enterprise-logging/                @gradle/bt-build-scan @gradle/dv-build-insights-team @gradle/dv-testing-team
+platforms/enterprise/                                   @gradle/bt-build-scan
+platforms/enterprise/enterprise/                        @gradle/bt-build-scan @gradle/dv-testing-team @ldaley
+platforms/enterprise/enterprise-logging/                @gradle/bt-build-scan @gradle/dv-testing-team
 platforms/enterprise/enterprise-operations/             @gradle/bt-build-scan
 platforms/enterprise/enterprise-plugin-performance/     @gradle/bt-build-scan
 


### PR DESCRIPTION
They are no longer responsible for that area of the code.