### PR TITLE
Remove unneeded version header for BC. 

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
@@ -613,7 +613,7 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
             }
             // Then write the ascii armored keyring
             try (FileOutputStream fos = new FileOutputStream(ascii, true);
-                 ArmoredOutputStream out = new ArmoredOutputStream(fos)) {
+                 ArmoredOutputStream out = ArmoredOutputStream.builder().build(fos)) {
                 keyRing.encode(out, true);
             }
             hasKey = true;


### PR DESCRIPTION
Fixes #31035

Related:
* https://github.com/bcgit/bc-java/commit/78176695b2a54fdb71b4536fbb7224efebafdfaa#diff-4897a7adf1d26af421064ab25a2c996e65337fb5bc4513a0115c5e33224c377cR62

The output no longer contains header [because](https://github.com/bcgit/bc-java/blob/dfc559ee9aa5886aa4b877957e06b6fae12b9fa6/pg/src/main/java/org/bouncycastle/bcpg/ArmoredOutputStream.java#L557):
```
* Note: Adding version headers to ASCII armored output is discouraged to minimize metadata.
```

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
