### PR TITLE
Clean up mock clocks in tests

### DIFF
--- a/platforms/core-runtime/build-operations/build.gradle.kts
+++ b/platforms/core-runtime/build-operations/build.gradle.kts
@@ -15,7 +15,10 @@ dependencies {
     implementation(libs.slf4jApi)
 
     testFixturesImplementation(libs.guava)
+
+    testImplementation(testFixtures(projects.time))
 }
+
 tasks.isolatedProjectsIntegTest {
     enabled = false
 }

--- a/platforms/core-runtime/build-operations/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationRunnerTest.groovy
+++ b/platforms/core-runtime/build-operations/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationRunnerTest.groovy
@@ -16,7 +16,8 @@
 
 package org.gradle.internal.operations
 
-import org.gradle.internal.time.Clock
+
+import org.gradle.internal.time.FixedClock
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 
 import javax.annotation.Nullable
@@ -27,12 +28,12 @@ import static org.gradle.internal.operations.DefaultBuildOperationRunner.Readabl
 
 class DefaultBuildOperationRunnerTest extends ConcurrentSpec {
 
-    def timeProvider = Mock(Clock)
+    def clock = FixedClock.createAt(123L)
     def listener = Mock(BuildOperationExecutionListener)
     def currentBuildOperationRef = CurrentBuildOperationRef.instance()
     def operationRunner = new DefaultBuildOperationRunner(
         currentBuildOperationRef,
-        timeProvider, new DefaultBuildOperationIdFactory(), { listener })
+        clock, new DefaultBuildOperationIdFactory(), { listener })
 
     def setup() {
         currentBuildOperationRef.clear()
@@ -52,7 +53,6 @@ class DefaultBuildOperationRunnerTest extends ConcurrentSpec {
 
         then:
         1 * buildOperation.description() >> operationDetailsBuilder
-        1 * timeProvider.currentTime >> 123L
         1 * listener.start(_, _) >> { BuildOperationDescriptor descriptor, BuildOperationState operationState ->
             descriptorUnderTest = descriptor
             operationStateUnderTest = operationState
@@ -101,7 +101,6 @@ class DefaultBuildOperationRunnerTest extends ConcurrentSpec {
         def contextUnderTest = operationRunner.start(operationDetailsBuilder)
 
         then:
-        1 * timeProvider.currentTime >> 123L
         1 * listener.start(_, _) >> { BuildOperationDescriptor descriptor, BuildOperationState operationState ->
             descriptorUnderTest = descriptor
             operationStateUnderTest = operationState
@@ -153,7 +152,6 @@ class DefaultBuildOperationRunnerTest extends ConcurrentSpec {
 
         then:
         1 * buildOperation.description() >> operationDetailsBuilder
-        1 * timeProvider.currentTime >> 123L
         1 * listener.start(_, _) >> { BuildOperationDescriptor descriptor, BuildOperationState operationState ->
             descriptorUnderTest = descriptor
             operationStateUnderTest = operationState
@@ -198,7 +196,6 @@ class DefaultBuildOperationRunnerTest extends ConcurrentSpec {
         def contextUnderTest = operationRunner.start(operationDetailsBuilder)
 
         then:
-        1 * timeProvider.currentTime >> 123L
         1 * listener.start(_, _) >> { BuildOperationDescriptor descriptor, BuildOperationState operationState ->
             descriptorUnderTest = descriptor
             operationStateUnderTest = operationState

--- a/platforms/core-runtime/daemon-services/build.gradle.kts
+++ b/platforms/core-runtime/daemon-services/build.gradle.kts
@@ -35,6 +35,8 @@ dependencies {
     implementation(projects.functional)
     implementation(projects.loggingApi)
     implementation(projects.modelCore)
+
+    testImplementation(testFixtures(projects.time))
 }
 tasks.isolatedProjectsIntegTest {
     enabled = false

--- a/platforms/core-runtime/daemon-services/src/test/groovy/org/gradle/api/internal/tasks/userinput/DefaultUserInputHandlerTest.groovy
+++ b/platforms/core-runtime/daemon-services/src/test/groovy/org/gradle/api/internal/tasks/userinput/DefaultUserInputHandlerTest.groovy
@@ -24,7 +24,7 @@ import org.gradle.internal.logging.events.TextQuestionPromptEvent
 import org.gradle.internal.logging.events.UserInputRequestEvent
 import org.gradle.internal.logging.events.UserInputResumeEvent
 import org.gradle.internal.logging.events.YesNoQuestionPromptEvent
-import org.gradle.internal.time.Clock
+import org.gradle.internal.time.FixedClock
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -35,7 +35,7 @@ class DefaultUserInputHandlerTest extends Specification {
     private static final String TEXT = 'Accept license?'
     def outputEventBroadcaster = Mock(OutputEventListener)
     def userInputReader = Mock(UserInputReader)
-    def clock = Mock(Clock)
+    def clock = FixedClock.create()
     @Subject
     def userInputHandler = new DefaultUserInputHandler(outputEventBroadcaster, clock, userInputReader)
 

--- a/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/daemon/server/DaemonExpirationStrategyTest.groovy
+++ b/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/daemon/server/DaemonExpirationStrategyTest.groovy
@@ -17,12 +17,12 @@
 package org.gradle.launcher.daemon.server
 
 import org.gradle.internal.remote.Address
+import org.gradle.internal.time.MockClock
 import org.gradle.launcher.daemon.context.DaemonContext
 import org.gradle.launcher.daemon.registry.DaemonInfo
 import org.gradle.launcher.daemon.registry.DaemonRegistry
 import org.gradle.launcher.daemon.registry.EmbeddedDaemonRegistry
 import org.gradle.launcher.daemon.server.api.DaemonState
-import org.gradle.internal.time.MockClock
 import spock.lang.Specification
 
 import static org.gradle.launcher.daemon.server.api.DaemonState.Busy
@@ -43,7 +43,7 @@ abstract class DaemonExpirationStrategyTest extends Specification {
         DaemonContext context = Mock(DaemonContext) {
             _ * getUid() >> uid
         }
-        DaemonInfo info = new DaemonInfo(daemonAddress, context, "password".bytes, Busy, new MockClock(lastIdleTime))
+        DaemonInfo info = new DaemonInfo(daemonAddress, context, "password".bytes, Busy, MockClock.createAutoIncrementingAt(lastIdleTime))
         info.setState(state)
         registry.store(info)
         return info

--- a/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/daemon/server/health/gc/GarbageCollectionCheckTest.groovy
+++ b/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/daemon/server/health/gc/GarbageCollectionCheckTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.launcher.daemon.server.health.gc
 
-import org.gradle.internal.time.Clock
+import org.gradle.internal.time.FixedClock
 import spock.lang.Specification
 
 import java.lang.management.GarbageCollectorMXBean
@@ -27,7 +27,7 @@ class GarbageCollectionCheckTest extends Specification {
     def "throwables are not propagated out of the run method"() {
         given:
         def check = new GarbageCollectionCheck(
-            Mock(Clock),
+            FixedClock.create(),
             Mock(GarbageCollectorMXBean),
             ManagementFactory.memoryPoolMXBeans.find { it.type == MemoryType.HEAP }.name,
             Mock(SlidingWindow),

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/deprecation/LoggingDeprecatedFeatureHandlerTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/deprecation/LoggingDeprecatedFeatureHandlerTest.groovy
@@ -32,6 +32,7 @@ import org.gradle.internal.operations.DefaultBuildOperationRef
 import org.gradle.internal.operations.OperationIdentifier
 import org.gradle.internal.operations.OperationProgressEvent
 import org.gradle.internal.time.Clock
+import org.gradle.internal.time.FixedClock
 import org.gradle.problems.Location
 import org.gradle.problems.ProblemDiagnostics
 import org.gradle.problems.buildtree.ProblemDiagnosticsFactory
@@ -54,11 +55,11 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
     final diagnosticsFactory = Stub(ProblemDiagnosticsFactory)
 
     final handler = new LoggingDeprecatedFeatureHandler()
-    final Clock clock = Mock(Clock)
+    final Clock clock = FixedClock.create()
     final BuildOperationListener buildOperationListener = Mock()
     final CurrentBuildOperationRef currentBuildOperationRef = new CurrentBuildOperationRef()
     final BuildOperationProgressEventEmitter progressBroadcaster = new DefaultBuildOperationProgressEventEmitter(
-        clock::getCurrentTime, currentBuildOperationRef, buildOperationListener)
+        clock, currentBuildOperationRef, buildOperationListener)
 
     def setup() {
         _ * diagnosticsFactory.newStream() >> problemStream

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/logging/console/ThrottlingOutputEventListenerTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/logging/console/ThrottlingOutputEventListenerTest.groovy
@@ -20,14 +20,14 @@ import org.gradle.internal.logging.events.EndOutputEvent
 import org.gradle.internal.logging.events.FlushOutputEvent
 import org.gradle.internal.logging.events.OutputEventListener
 import org.gradle.internal.logging.events.UpdateNowEvent
-import org.gradle.internal.time.Clock
+import org.gradle.internal.time.FixedClock
 import org.gradle.internal.time.MockClock
 import org.gradle.util.internal.MockExecutor
 import spock.lang.Subject
 
 class ThrottlingOutputEventListenerTest extends OutputSpecification {
     def listener = Mock(OutputEventListener)
-    def clock = new MockClock()
+    def clock = MockClock.create()
     def executor = new MockExecutor()
 
     @Subject renderer = new ThrottlingOutputEventListener(listener, 100, executor, clock)
@@ -160,7 +160,7 @@ class ThrottlingOutputEventListenerTest extends OutputSpecification {
     def "throwables are not propagated out of the run method of the output loop"() {
         given:
         def executor = new MockExecutor()
-        new ThrottlingOutputEventListener(listener, 100, executor, Mock(Clock))
+        new ThrottlingOutputEventListener(listener, 100, executor, FixedClock.create())
         def checks = executor.shutdownNow()
 
         when:

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/logging/progress/DefaultProgressLoggerFactoryTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/logging/progress/DefaultProgressLoggerFactoryTest.groovy
@@ -20,16 +20,19 @@ import org.gradle.internal.logging.events.ProgressEvent
 import org.gradle.internal.logging.events.ProgressStartEvent
 import org.gradle.internal.operations.DefaultBuildOperationIdFactory
 import org.gradle.internal.operations.OperationIdentifier
-import org.gradle.internal.time.Clock
+import org.gradle.internal.time.MockClock
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 
 class DefaultProgressLoggerFactoryTest extends ConcurrentSpec {
     def progressListener = Mock(ProgressListener)
-    def timeProvider = Mock(Clock)
+    def timeProvider = MockClock.create()
     def buildOperationIdFactory = new DefaultBuildOperationIdFactory()
     def factory = new DefaultProgressLoggerFactory(progressListener, timeProvider, buildOperationIdFactory)
 
     def progressLoggerBroadcastsEvents() {
+        given:
+        timeProvider.withStartTime(100L)
+
         when:
         def logger = factory.newOperation('logger')
         logger.description = 'description'
@@ -37,7 +40,6 @@ class DefaultProgressLoggerFactoryTest extends ConcurrentSpec {
 
         then:
         logger != null
-        1 * timeProvider.getCurrentTime() >> 100L
         1 * progressListener.started(!null) >> { ProgressStartEvent event ->
             assert event.timestamp == 100L
             assert event.category == 'logger'
@@ -55,10 +57,11 @@ class DefaultProgressLoggerFactoryTest extends ConcurrentSpec {
         }
 
         when:
+        timeProvider.increment(200L)
+
         logger.completed('completed', false)
 
         then:
-        1 * timeProvider.getCurrentTime() >> 300L
         1 * progressListener.completed(!null) >> { ProgressCompleteEvent event ->
             assert event.timestamp == 300L
             assert event.status == 'completed'

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/logging/slf4j/OutputEventListenerBackedLoggerTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/logging/slf4j/OutputEventListenerBackedLoggerTest.groovy
@@ -25,10 +25,9 @@ import org.gradle.internal.operations.CurrentBuildOperationRef
 import org.gradle.internal.operations.DefaultBuildOperationRef
 import org.gradle.internal.operations.OperationIdentifier
 import org.gradle.internal.time.Clock
+import org.gradle.internal.time.FixedClock
 import org.slf4j.Marker
 import spock.lang.Specification
-
-import java.util.concurrent.TimeUnit
 
 import static org.gradle.api.logging.LogLevel.DEBUG
 import static org.gradle.api.logging.LogLevel.ERROR
@@ -41,14 +40,9 @@ import static org.slf4j.Logger.ROOT_LOGGER_NAME
 class OutputEventListenerBackedLoggerTest extends Specification {
 
     final List<LogEvent> events = []
-    final long now = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS)
-    final Clock timeProvider = new Clock() {
-        @Override
-        long getCurrentTime() {
-            return now
-        }
+    final long now = 100L
+    final Clock timeProvider = FixedClock.createAt(now)
 
-    }
     final OutputEventListenerBackedLoggerContext context = new OutputEventListenerBackedLoggerContext(timeProvider)
     private final CurrentBuildOperationRef currentBuildOperationRef = CurrentBuildOperationRef.instance()
 

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/logging/source/PrintStreamLoggingSystemTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/logging/source/PrintStreamLoggingSystemTest.groovy
@@ -24,16 +24,18 @@ import org.gradle.internal.operations.CurrentBuildOperationRef
 import org.gradle.internal.operations.DefaultBuildOperationRef
 import org.gradle.internal.operations.OperationIdentifier
 import org.gradle.internal.time.Clock
+import org.gradle.internal.time.FixedClock
 import org.gradle.util.internal.TextUtil
 import spock.lang.Specification
 
 class PrintStreamLoggingSystemTest extends Specification {
+    private static final long NOW = 1200L
 
     private final OutputStream original = new ByteArrayOutputStream()
     private final PrintStream originalStream = new PrintStream(original)
     private PrintStream stream = originalStream
     private final OutputEventListener listener = Mock()
-    private final Clock timeProvider = { 1200L } as Clock
+    private final Clock timeProvider = FixedClock.createAt(NOW)
     private final PrintStreamLoggingSystem loggingSystem = new PrintStreamLoggingSystem(listener, 'category', timeProvider) {
         protected PrintStream get() {
             stream
@@ -108,7 +110,7 @@ class PrintStreamLoggingSystemTest extends Specification {
         1 * listener.onOutput({
             it instanceof StyledTextOutputEvent &&
                 it.category == 'category' &&
-                it.timestamp == 1200 &&
+                it.timestamp == NOW &&
                 it.spans[0].text == withEOL('info') &&
                 it.buildOperationId.id == 42L
         })

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/logging/text/LoggingBackedStyledTextOutputTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/logging/text/LoggingBackedStyledTextOutputTest.groovy
@@ -23,13 +23,17 @@ import org.gradle.internal.operations.CurrentBuildOperationRef
 import org.gradle.internal.operations.DefaultBuildOperationRef
 import org.gradle.internal.operations.OperationIdentifier
 import org.gradle.internal.time.Clock
+import org.gradle.internal.time.FixedClock
 
-import static org.gradle.internal.logging.text.StyledTextOutput.Style.*
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.Header
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.Normal
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.UserInput
 
 class LoggingBackedStyledTextOutputTest extends OutputSpecification {
+    private static final long NOW = 1200L
 
     private final OutputEventListener listener = Mock()
-    private final Clock timeProvider = { 1200L } as Clock
+    private final Clock timeProvider = FixedClock.createAt(NOW)
     private final LoggingBackedStyledTextOutput output = new LoggingBackedStyledTextOutput(listener, 'category', LogLevel.INFO, timeProvider)
     private final CurrentBuildOperationRef currentBuildOperationRef = CurrentBuildOperationRef.instance()
 
@@ -58,7 +62,7 @@ class LoggingBackedStyledTextOutputTest extends OutputSpecification {
             assert event.spans[0].style == Normal
             assert event.category == 'category'
             assert event.logLevel == LogLevel.INFO
-            assert event.timestamp == 1200
+            assert event.timestamp == NOW
             assert event.spans[0].text == toNative('message\n')
             assert event.buildOperationId.id == 42L
         }

--- a/platforms/core-runtime/logging/src/testFixtures/groovy/org/gradle/internal/logging/ToStringLogger.groovy
+++ b/platforms/core-runtime/logging/src/testFixtures/groovy/org/gradle/internal/logging/ToStringLogger.groovy
@@ -19,7 +19,7 @@ package org.gradle.internal.logging
 import groovy.transform.CompileStatic
 import org.gradle.internal.logging.slf4j.OutputEventListenerBackedLogger
 import org.gradle.internal.logging.slf4j.OutputEventListenerBackedLoggerContext
-import org.gradle.internal.time.MockClock
+import org.gradle.internal.time.FixedClock
 import org.slf4j.helpers.FormattingTuple
 import org.slf4j.helpers.MessageFormatter
 
@@ -28,7 +28,7 @@ class ToStringLogger extends OutputEventListenerBackedLogger {
     private final StringBuilder log = new StringBuilder()
 
     ToStringLogger() {
-        super("ToStringLogger", new OutputEventListenerBackedLoggerContext(new MockClock()), new MockClock())
+        super("ToStringLogger", new OutputEventListenerBackedLoggerContext(FixedClock.create()), FixedClock.create())
     }
 
     @Override

--- a/platforms/core-runtime/time/src/testFixtures/java/org/gradle/internal/time/FixedClock.java
+++ b/platforms/core-runtime/time/src/testFixtures/java/org/gradle/internal/time/FixedClock.java
@@ -16,20 +16,37 @@
 
 package org.gradle.internal.time;
 
-
+/**
+ * A clock that always returns the same time.
+ */
 public class FixedClock implements Clock {
-    long current;
+    private final long current;
 
-    public FixedClock() {
-        this(System.currentTimeMillis());
-    }
-
-    public FixedClock(long startTime) {
+    private FixedClock(long startTime) {
         current = startTime;
     }
 
     @Override
     public long getCurrentTime() {
         return current;
+    }
+
+    /**
+     * Creates a clock that always returns 0 as the current time.
+     *
+     * @return the clock
+     */
+    public static Clock create() {
+        return new FixedClock(0L);
+    }
+
+    /**
+     * Creates a clock that always returns {@code startTime} as the current time.
+     *
+     * @param startTime start time in milliseconds since epoch
+     * @return the clock
+     */
+    public static Clock createAt(long startTime) {
+        return new FixedClock(startTime);
     }
 }

--- a/platforms/ide/tooling-api/build.gradle.kts
+++ b/platforms/ide/tooling-api/build.gradle.kts
@@ -80,6 +80,7 @@ dependencies {
     testImplementation(testFixtures(projects.logging))
     testImplementation(testFixtures(projects.dependencyManagement))
     testImplementation(testFixtures(projects.ide))
+    testImplementation(testFixtures(projects.time))
     testImplementation(testFixtures(projects.workers))
 
     integTestNormalizedDistribution(projects.distributionsFull) {

--- a/platforms/ide/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/SynchronizedLoggingTest.groovy
+++ b/platforms/ide/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/SynchronizedLoggingTest.groovy
@@ -17,13 +17,13 @@
 package org.gradle.tooling.internal.consumer
 
 import org.gradle.internal.operations.BuildOperationIdFactory
-import org.gradle.internal.time.Clock
+import org.gradle.internal.time.FixedClock
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 
 import java.util.concurrent.CopyOnWriteArraySet
 
-public class SynchronizedLoggingTest extends ConcurrentSpec {
-    def logging = new SynchronizedLogging(Stub(Clock), Stub(BuildOperationIdFactory))
+class SynchronizedLoggingTest extends ConcurrentSpec {
+    def logging = new SynchronizedLogging(FixedClock.create(), Stub(BuildOperationIdFactory))
 
     def "initialises on first usage"() {
         expect:

--- a/platforms/jvm/testing-jvm-infrastructure/build.gradle.kts
+++ b/platforms/jvm/testing-jvm-infrastructure/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
 
     testImplementation(testFixtures(projects.core))
     testImplementation(testFixtures(projects.messaging))
+    testImplementation(testFixtures(projects.time))
     testImplementation(libs.assertj) {
         because("We test assertion errors coming from AssertJ")
     }

--- a/platforms/jvm/testing-jvm-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/TestClassExecutionEventGeneratorTest.groovy
+++ b/platforms/jvm/testing-jvm-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/TestClassExecutionEventGeneratorTest.groovy
@@ -22,18 +22,19 @@ import org.gradle.api.internal.tasks.testing.TestResultProcessor
 import org.gradle.api.tasks.testing.TestFailure
 import org.gradle.internal.id.IdGenerator
 import org.gradle.internal.time.Clock
+import org.gradle.internal.time.MockClock
 import spock.lang.Specification
 
 class TestClassExecutionEventGeneratorTest extends Specification {
     final TestResultProcessor target = Mock()
     final IdGenerator<Object> idGenerator = Mock()
-    final Clock timeProvider = Mock()
+    final Clock timeProvider = MockClock.create()
     final TestClassExecutionEventGenerator processor = new TestClassExecutionEventGenerator(target, idGenerator, timeProvider)
 
     def "fires event on test class start"() {
         given:
         idGenerator.generateId() >> 1
-        timeProvider.currentTime >> 1200
+        timeProvider.increment(1200)
 
         when:
         processor.testClassStarted("some-test")
@@ -46,12 +47,13 @@ class TestClassExecutionEventGeneratorTest extends Specification {
     def "fires event on test class finish"() {
         given:
         idGenerator.generateId() >> 1
-        timeProvider.currentTime >>> [1200, 1300]
+        timeProvider.increment(1200)
 
         and:
         processor.testClassStarted("some-test")
 
         when:
+        timeProvider.increment(100)
         processor.testClassFinished(null)
 
         then:

--- a/platforms/jvm/testing-jvm-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGTestResultProcessorAdapterTest.groovy
+++ b/platforms/jvm/testing-jvm-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGTestResultProcessorAdapterTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.api.internal.tasks.testing.testng
 import org.gradle.api.internal.tasks.testing.TestCompleteEvent
 import org.gradle.api.internal.tasks.testing.TestResultProcessor
 import org.gradle.internal.id.IdGenerator
-import org.gradle.internal.time.Clock
+import org.gradle.internal.time.FixedClock
 import org.testng.ITestClass
 import spock.lang.Issue
 import spock.lang.Specification
@@ -36,7 +36,7 @@ class TestNGTestResultProcessorAdapterTest extends Specification {
 
     @Subject
     private TestNGTestResultProcessorAdapter resultProcessorAdapter = new TestNGTestResultProcessorAdapter(
-        resultProcessor, idGenerator, Mock(Clock))
+        resultProcessor, idGenerator, FixedClock.create())
 
     @Issue("https://github.com/gradle/gradle/issues/3545")
     def "runs onAfterClass hook only once per test class"() {

--- a/platforms/jvm/testing-jvm/build.gradle.kts
+++ b/platforms/jvm/testing-jvm/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
 
     testImplementation(testFixtures(projects.core))
     testImplementation(testFixtures(projects.modelCore))
+    testImplementation(testFixtures(projects.time))
 
     integTestImplementation(testFixtures(projects.testingBase))
     integTestImplementation(testFixtures(projects.languageGroovy))

--- a/platforms/jvm/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGTestFrameworkTest.groovy
+++ b/platforms/jvm/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGTestFrameworkTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.testng.TestNGOptions
 import org.gradle.internal.actor.ActorFactory
 import org.gradle.internal.id.IdGenerator
-import org.gradle.internal.time.Clock
+import org.gradle.internal.time.FixedClock
 import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.util.TestUtil
 import spock.lang.Shared
@@ -42,7 +42,7 @@ public class TestNGTestFrameworkTest extends Specification {
     void "creates test class processor"() {
         when:
         def framework = createFramework()
-        def processor = framework.getProcessorFactory().create(Mock(IdGenerator), Mock(ActorFactory), Mock(Clock))
+        def processor = framework.getProcessorFactory().create(Mock(IdGenerator), Mock(ActorFactory), FixedClock.create())
 
         then:
         processor instanceof TestNGTestClassProcessor

--- a/platforms/native/platform-native/build.gradle.kts
+++ b/platforms/native/platform-native/build.gradle.kts
@@ -76,6 +76,7 @@ dependencies {
     testImplementation(testFixtures(projects.diagnostics))
     testImplementation(testFixtures(projects.baseServices))
     testImplementation(testFixtures(projects.snapshots))
+    testImplementation(testFixtures(projects.time))
 
     testRuntimeOnly(projects.distributionsCore) {
         because("ProjectBuilder tests load services from a Gradle distribution.")

--- a/platforms/native/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/NativeCompilerTest.groovy
+++ b/platforms/native/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/NativeCompilerTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.internal.operations.BuildOperationProgressEventListenerAdapter
 import org.gradle.internal.operations.logging.BuildOperationLogger
 import org.gradle.internal.progress.NoOpProgressLoggerFactory
 import org.gradle.internal.time.Clock
+import org.gradle.internal.time.FixedClock
 import org.gradle.internal.work.DefaultWorkerLimits
 import org.gradle.internal.work.WorkerLeaseService
 import org.gradle.nativeplatform.internal.CompilerOutputFileNamingSchemeFactory
@@ -58,7 +59,7 @@ abstract class NativeCompilerTest extends Specification {
     WorkerLeaseService workerLeaseService = new TestWorkerLeaseService()
 
     protected final BuildOperationListener buildOperationListener = Mock(BuildOperationListener)
-    protected final Clock timeProvider = Mock(Clock)
+    protected final Clock timeProvider = FixedClock.create()
     protected BuildOperationExecutor buildOperationExecutor = BuildOperationExecutorSupport.builder(new DefaultWorkerLimits(DefaultParallelismConfiguration.getDefaultMaxWorkerCount()))
         .withWorkerLeaseService(workerLeaseService)
         .withTimeSupplier(timeProvider)
@@ -167,7 +168,6 @@ abstract class NativeCompilerTest extends Specification {
         sourceFiles.each { sourceFile ->
             1 * commandLineTool.execute(_, _)
         }
-        4 * timeProvider.getCurrentTime()
         2 * buildOperationListener.started(_, _)
         2 * buildOperationListener.finished(_, _)
         0 * _

--- a/platforms/software/testing-base-infrastructure/build.gradle.kts
+++ b/platforms/software/testing-base-infrastructure/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     testImplementation(libs.commonsIo)
     testImplementation(testFixtures(projects.time))
     testImplementation(testFixtures(projects.serialization))
+    testImplementation(testFixtures(projects.time))
 
     integTestDistributionRuntimeOnly(projects.distributionsCore)
 }

--- a/platforms/software/testing-base-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/SuiteTestClassProcessorTest.groovy
+++ b/platforms/software/testing-base-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/SuiteTestClassProcessorTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.testing
 
 import org.gradle.api.internal.tasks.testing.results.AttachParentTestResultProcessor
 import org.gradle.internal.time.Clock
+import org.gradle.internal.time.FixedClock
 import spock.lang.Specification
 
 class SuiteTestClassProcessorTest extends Specification {
@@ -25,7 +26,7 @@ class SuiteTestClassProcessorTest extends Specification {
     private final TestClassProcessor targetProcessor = Mock()
     private final TestDescriptorInternal suiteDescriptor = Mock()
     private final TestClassRunInfo testClass = Mock()
-    private final Clock timeProvider = Mock()
+    private final Clock timeProvider = FixedClock.create()
     private final SuiteTestClassProcessor processor = new SuiteTestClassProcessor(suiteDescriptor, targetProcessor, timeProvider)
 
     def setup() {

--- a/platforms/software/testing-base/build.gradle.kts
+++ b/platforms/software/testing-base/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     testImplementation(testFixtures(projects.messaging))
     testImplementation(testFixtures(projects.platformBase))
     testImplementation(testFixtures(projects.serialization))
+    testImplementation(testFixtures(projects.time))
 
     testImplementation(libs.commonsIo)
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
@@ -26,7 +26,7 @@ import spock.lang.Specification
 import java.util.concurrent.TimeUnit
 
 class DefaultCacheConfigurationsTest extends Specification {
-    def clock = new FixedClock()
+    def clock = FixedClock.create()
     def cacheConfigurations = TestUtil.objectFactory().newInstance(DefaultCacheConfigurations.class, Mock(LegacyCacheCleanupEnablement), clock)
 
     def "timestamp supplier uses last configured retention value"() {

--- a/subprojects/core/src/test/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheEntryRetentionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheEntryRetentionTest.groovy
@@ -31,7 +31,7 @@ import java.time.ZonedDateTime
 import java.util.concurrent.TimeUnit
 
 class DirectoryBuildCacheEntryRetentionTest extends Specification {
-    def clock = new FixedClock()
+    def clock = FixedClock.create()
     def directoryBuildCache = Mock(DirectoryBuildCache)
     def cacheConfigurations = TestUtil.objectFactory().newInstance(DefaultCacheConfigurations.class, Mock(LegacyCacheCleanupEnablement), clock)
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildResultLoggerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildResultLoggerTest.groovy
@@ -23,25 +23,31 @@ import org.gradle.internal.logging.format.DurationFormatter
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import org.gradle.internal.logging.text.TestStyledTextOutputFactory
 import org.gradle.internal.time.Clock
+import org.gradle.internal.time.FixedClock
 import spock.lang.Specification
 import spock.lang.Subject
 
+import java.util.concurrent.TimeUnit
+
 @Subject(BuildResultLogger)
 class BuildResultLoggerTest extends Specification {
+    private static final long BUILD_START_MS = 0L
+    private static final long BUILD_DURATION_MS = TimeUnit.SECONDS.toMillis(10)
+
+    private BuildStartedTime buildStartedTime = BuildStartedTime.startingAt(BUILD_START_MS)
+    private Clock clock = FixedClock.createAt(BUILD_START_MS + BUILD_DURATION_MS)
+
     private StyledTextOutputFactory textOutputFactory = new TestStyledTextOutputFactory()
-    private BuildStartedTime buildStartedTime = BuildStartedTime.startingAt(0)
-    private Clock clock = Mock(Clock)
     private DurationFormatter durationFormatter = Mock(DurationFormatter)
     def workValidationWarningReporter = Stub(WorkValidationWarningReporter)
     private BuildResultLogger subject = new BuildResultLogger(textOutputFactory, buildStartedTime, clock, durationFormatter, workValidationWarningReporter)
 
     def "logs build success with total time"() {
         when:
-        1 * clock.currentTime >> 10
         subject.buildFinished(new BuildResult("Action", null, null));
 
         then:
-        1 * durationFormatter.format(10L) >> { "10s" }
+        1 * durationFormatter.format(BUILD_DURATION_MS) >> { "10s" }
         textOutputFactory.category == BuildResultLogger.canonicalName
         textOutputFactory.logLevel == LogLevel.LIFECYCLE
         textOutputFactory.output == """
@@ -51,11 +57,10 @@ class BuildResultLoggerTest extends Specification {
 
     def "logs build failure with total time"() {
         when:
-        1 * clock.currentTime >> 10
         subject.buildFinished(new BuildResult("Action", null, new RuntimeException()));
 
         then:
-        1 * durationFormatter.format(10L) >> { "10s" }
+        1 * durationFormatter.format(BUILD_DURATION_MS) >> { "10s" }
         textOutputFactory.category == BuildResultLogger.canonicalName
         textOutputFactory.logLevel == LogLevel.ERROR
         textOutputFactory.output == """


### PR DESCRIPTION
When Clock gets more methods, mocking it properly becomes non-trivial and tightens the coupling between the test and the implementation being tested.
