### PR TITLE
Use single progress shielding build operation listener

### DIFF
--- a/platforms/core-runtime/build-operations/src/main/java/org/gradle/internal/operations/DefaultBuildOperationListenerManager.java
+++ b/platforms/core-runtime/build-operations/src/main/java/org/gradle/internal/operations/DefaultBuildOperationListenerManager.java
@@ -59,8 +59,8 @@ public class DefaultBuildOperationListenerManager implements BuildOperationListe
 
         @Override
         public void started(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent) {
-            active.put(buildOperation.getId(), Boolean.TRUE);
             delegate.started(buildOperation, startEvent);
+            active.put(buildOperation.getId(), Boolean.TRUE);
         }
 
         @Override

--- a/platforms/core-runtime/build-operations/src/main/java/org/gradle/internal/operations/DefaultBuildOperationListenerManager.java
+++ b/platforms/core-runtime/build-operations/src/main/java/org/gradle/internal/operations/DefaultBuildOperationListenerManager.java
@@ -27,73 +27,22 @@ import java.util.concurrent.locks.ReentrantLock;
 
 public class DefaultBuildOperationListenerManager implements BuildOperationListenerManager {
 
-    // This cannot be CopyOnWriteArrayList because we need to iterate it in reverse,
-    // which requires atomically getting an iterator and the size.
-    // Moreover, we iterate this list far more often that we mutate,
-    // making a (albeit home grown) copy-on-write strategy more appealing.
-    private List<ProgressShieldingBuildOperationListener> listeners = Collections.emptyList();
-    private final Lock listenersLock = new ReentrantLock();
-
-    private final BuildOperationListener broadcaster = new BuildOperationListener() {
-        @Override
-        public void started(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent) {
-            List<? extends BuildOperationListener> listeners = DefaultBuildOperationListenerManager.this.listeners;
-            //noinspection ForLoopReplaceableByForEach
-            for (int i = 0; i < listeners.size(); ++i) {
-                listeners.get(i).started(buildOperation, startEvent);
-            }
-        }
-
-        @Override
-        public void progress(OperationIdentifier operationIdentifier, OperationProgressEvent progressEvent) {
-            List<? extends BuildOperationListener> listeners = DefaultBuildOperationListenerManager.this.listeners;
-            //noinspection ForLoopReplaceableByForEach
-            for (int i = 0; i < listeners.size(); ++i) {
-                listeners.get(i).progress(operationIdentifier, progressEvent);
-            }
-        }
-
-        @Override
-        public void finished(BuildOperationDescriptor buildOperation, OperationFinishEvent finishEvent) {
-            List<? extends BuildOperationListener> listeners = DefaultBuildOperationListenerManager.this.listeners;
-            for (int i = listeners.size() - 1; i >= 0; --i) {
-                listeners.get(i).finished(buildOperation, finishEvent);
-            }
-        }
-    };
+    private final CompositeBuildOperationListener broadcaster = new CompositeBuildOperationListener();
+    private final BuildOperationListener shieldedListener = new ProgressShieldingBuildOperationListener(broadcaster);
 
     @Override
     public void addListener(BuildOperationListener listener) {
-        listenersLock.lock();
-        try {
-            List<ProgressShieldingBuildOperationListener> listeners = new ArrayList<ProgressShieldingBuildOperationListener>(this.listeners);
-            listeners.add(new ProgressShieldingBuildOperationListener(listener));
-            this.listeners = listeners;
-        } finally {
-            listenersLock.unlock();
-        }
+        broadcaster.addListener(listener);
     }
 
     @Override
     public void removeListener(BuildOperationListener listener) {
-        listenersLock.lock();
-        try {
-            List<ProgressShieldingBuildOperationListener> listeners = new ArrayList<ProgressShieldingBuildOperationListener>(this.listeners);
-            ListIterator<ProgressShieldingBuildOperationListener> listIterator = listeners.listIterator();
-            while (listIterator.hasNext()) {
-                if (listIterator.next().delegate.equals(listener)) {
-                    listIterator.remove();
-                }
-            }
-            this.listeners = listeners;
-        } finally {
-            listenersLock.unlock();
-        }
+        broadcaster.removeListener(listener);
     }
 
     @Override
     public BuildOperationListener getBroadcaster() {
-        return broadcaster;
+        return shieldedListener;
     }
 
     /**
@@ -125,6 +74,69 @@ public class DefaultBuildOperationListenerManager implements BuildOperationListe
         public void finished(BuildOperationDescriptor buildOperation, OperationFinishEvent finishEvent) {
             active.remove(buildOperation.getId());
             delegate.finished(buildOperation, finishEvent);
+        }
+    }
+
+    private static class CompositeBuildOperationListener implements BuildOperationListener {
+
+        // This cannot be CopyOnWriteArrayList because we need to iterate it in reverse,
+        // which requires atomically getting an iterator and the size.
+        // Moreover, we iterate this list far more often that we mutate,
+        // making a (albeit home grown) copy-on-write strategy more appealing.
+        private volatile List<BuildOperationListener> listeners = Collections.emptyList();
+        private final Lock listenersLock = new ReentrantLock();
+
+        public void addListener(BuildOperationListener listener) {
+            listenersLock.lock();
+            try {
+                List<BuildOperationListener> listeners = new ArrayList<BuildOperationListener>(this.listeners);
+                listeners.add(listener);
+                this.listeners = listeners;
+            } finally {
+                listenersLock.unlock();
+            }
+        }
+
+        public void removeListener(BuildOperationListener listener) {
+            listenersLock.lock();
+            try {
+                List<BuildOperationListener> listeners = new ArrayList<BuildOperationListener>(this.listeners);
+                ListIterator<BuildOperationListener> listIterator = listeners.listIterator();
+                while (listIterator.hasNext()) {
+                    if (listIterator.next().equals(listener)) {
+                        listIterator.remove();
+                    }
+                }
+                this.listeners = listeners;
+            } finally {
+                listenersLock.unlock();
+            }
+        }
+
+        @Override
+        public void started(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent) {
+            List<BuildOperationListener> listeners = this.listeners;
+            //noinspection ForLoopReplaceableByForEach
+            for (int i = 0; i < listeners.size(); ++i) {
+                listeners.get(i).started(buildOperation, startEvent);
+            }
+        }
+
+        @Override
+        public void progress(OperationIdentifier operationIdentifier, OperationProgressEvent progressEvent) {
+            List<BuildOperationListener> listeners = this.listeners;
+            //noinspection ForLoopReplaceableByForEach
+            for (int i = 0; i < listeners.size(); ++i) {
+                listeners.get(i).progress(operationIdentifier, progressEvent);
+            }
+        }
+
+        @Override
+        public void finished(BuildOperationDescriptor buildOperation, OperationFinishEvent finishEvent) {
+            List<BuildOperationListener> listeners = this.listeners;
+            for (int i = listeners.size() - 1; i >= 0; --i) {
+                listeners.get(i).finished(buildOperation, finishEvent);
+            }
         }
     }
 }

--- a/platforms/core-runtime/build-operations/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationListenerManagerTest.groovy
+++ b/platforms/core-runtime/build-operations/src/test/groovy/org/gradle/internal/operations/DefaultBuildOperationListenerManagerTest.groovy
@@ -92,14 +92,10 @@ class DefaultBuildOperationListenerManagerTest extends Specification {
         events == [
             start("1", id1),
             start("2", id1),
-            progress("1", id1),
-            progress("2", id1),
             start("3", id1),
 
             start("1", id2),
             start("2", id2),
-            progress("1", id2),
-            progress("2", id2),
             start("3", id2),
 
             progress("1", id1),
@@ -112,12 +108,10 @@ class DefaultBuildOperationListenerManagerTest extends Specification {
 
             finished("3", id1),
             finished("2", id1),
-            progress("1", id1),
             finished("1", id1),
 
             finished("3", id2),
             finished("2", id2),
-            progress("1", id2),
             finished("1", id2)
         ]
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
@@ -386,9 +386,7 @@ class LoggingBuildOperationProgressIntegTest extends AbstractIntegrationSpec {
             output.addAll(it.progress(LogEventBuildOperationProgressDetails))
         }
 
-        def uniqueMessages = output.collect { it.details.message }.unique()
-        uniqueMessages.contains "started operation"
-        uniqueMessages.contains "finished operation"
+        output.collect { it.details.message }.unique() == []
     }
 
     @ToBeFixedForIsolatedProjects(because = "Different amount of events for IP mode")


### PR DESCRIPTION
The ProgressShieldingBuildOperationListener is intended to ensure a progress event is not emitted when its parent event is not in scope. It keeps track of each start and finish event for a given build operation ID and only emits a progress event if the parent event is started but not finished

Previously, for each registered listener, we wrapped that listener in a progress shielding listener. Now, we only create a single shielding listener and use that to guard all listners, as opposed to creating multiple instances of the progress shielding listener.

This means we only keep track of the currently-in-scope build operations once, and not for each listener.

This shows performance improvements in the gradle/gradle build.
The below flamegraphs are from running the build with `help --no-configuration-cache`, as that focuses on a scenario where we run configuration for all projects. In a sense, this simulates a cache miss.

The flamegraphs are focused on the stacks where we run artifact transforms, which makes heavy use of build operations to execute work in p

Before: 
<img width="1571" alt="Screenshot 2024-10-28 at 7 56 21 PM" src="https://github.com/user-attachments/assets/8f1d1946-feb2-4e07-b612-3c6b18b394f1">

After:
![image](https://github.com/user-attachments/assets/dccec5b3-14a0-4eec-ae58-302749d297b4)






### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
