### PR TITLE
Add gradle-profiler output files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,7 @@ atlassian-ide-plugin.xml
 
 # Ignore local configuration files for asdf, allowing the JDK to be configured for project (https://asdf-vm.com)
 .tool-versions
+
+# gradle-profiler
+gradle-user-home
+profile-out*


### PR DESCRIPTION
Gradle profiler uses a separate gradle user home and outputs reports. Ignore these in git.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
