### PR TITLE
Upgrade tested AspectJ plugin version to 8.10.2

### DIFF
--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -132,7 +132,7 @@ abstract class AbstractSmokeTest extends Specification {
         static testRetryPlugin = "1.5.10"
 
         // https://plugins.gradle.org/plugin/io.freefair.aspectj
-        static aspectj = "8.6"
+        static aspectj = "8.10.2"
 
         // https://plugins.gradle.org/plugin/de.undercouch.download
         static undercouchDownload = Versions.of("5.6.0")


### PR DESCRIPTION
Since it contains a fix for Provider API migration branch.

See https://github.com/freefair/gradle-plugins/pull/1197