### PR TITLE
Enable improved CC hit rates when switching branches back and forth

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheBuildOperationsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheBuildOperationsIntegrationTest.groovy
@@ -172,11 +172,8 @@ class ConfigurationCacheBuildOperationsIntegrationTest extends AbstractConfigura
         workGraphStoredAndLoaded()
 
         and:
-        def cacheDirs = subDirsOf(file('lib/.gradle/configuration-cache'))
-        cacheDirs.size() == 2 // key dir, entry dir
-
-        def keyDir = cacheDirs.find { dir -> dir.listFiles().any { file -> file.name == "candidates.bin" } }
-        def entryDir = cacheDirs.find { it != keyDir }
+        def cacheDir = file('lib/.gradle/configuration-cache')
+        def entryDir = single(subDirsOf(cacheDir).findAll { containsFileNamed("entry.bin", it) })
         def entryFiles = entryDir.listFiles().toList()
             .findAll { it.name !in ['entry.bin', 'buildfingerprint.bin', 'projectfingerprint.bin'] } // TODO: include fingerprints as well
 
@@ -780,8 +777,12 @@ class ConfigurationCacheBuildOperationsIntegrationTest extends AbstractConfigura
 
     private static <T> T single(List<T> list) {
         list.with {
-            assert size() == 1
+            assert size() == 1, "Expecting a singleton list, got $list"
             get(0)
         }
+    }
+
+    private static boolean containsFileNamed(String name, TestFile dir) {
+        dir.listFiles().any { file -> file.name == name }
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheBuildOperationsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheBuildOperationsIntegrationTest.groovy
@@ -172,8 +172,11 @@ class ConfigurationCacheBuildOperationsIntegrationTest extends AbstractConfigura
         workGraphStoredAndLoaded()
 
         and:
-        def cacheDir = file('lib/.gradle/configuration-cache')
-        def entryDir = single(subDirsOf(cacheDir))
+        def cacheDirs = subDirsOf(file('lib/.gradle/configuration-cache'))
+        cacheDirs.size() == 2 // key dir, entry dir
+
+        def keyDir = cacheDirs.find { dir -> dir.listFiles().any { file -> file.name == "candidates.bin" } }
+        def entryDir = cacheDirs.find { it != keyDir }
         def entryFiles = entryDir.listFiles().toList()
             .findAll { it.name !in ['entry.bin', 'buildfingerprint.bin', 'projectfingerprint.bin'] } // TODO: include fingerprints as well
 

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheCompositeBuildsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheCompositeBuildsIntegrationTest.groovy
@@ -64,7 +64,7 @@ class ConfigurationCacheCompositeBuildsIntegrationTest extends AbstractConfigura
         def confCacheDir = file("./app/.gradle/configuration-cache")
         confCacheDir.isDirectory()
         def confCacheFiles = confCacheDir.allDescendants().findAll { it != 'configuration-cache.lock' && it != 'gc.properties' }
-        confCacheFiles.size() == 12 // header, 2 * fingerprint, build strings file, root build state file, root build shared objects file, included build state file, included build shared objects file, 2 * project state file, 2 * owner-less node state files
+        confCacheFiles.size() == 13 // header, candidates file, 2 * fingerprint, build strings file, root build state file, root build shared objects file, included build state file, included build shared objects file, 2 * project state file, 2 * owner-less node state files
         if (!OperatingSystem.current().isWindows()) {
             confCacheFiles.forEach {
                 assert confCacheDir.file(it).mode == 384

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheDependencyResolutionFeaturesIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheDependencyResolutionFeaturesIntegrationTest.groovy
@@ -781,7 +781,7 @@ class ConfigurationCacheDependencyResolutionFeaturesIntegrationTest extends Abst
         verificationFile.replace('<sha256 value="12345"', "<sha256 value=\"$checkSum\"")
         configurationCacheRun("resolve1")
 
-        then:
+        then: // store failures don't invalidate existing cache entries
         configurationCache.assertStateLoaded()
 
         when:

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheDependencyResolutionFeaturesIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheDependencyResolutionFeaturesIntegrationTest.groovy
@@ -782,7 +782,7 @@ class ConfigurationCacheDependencyResolutionFeaturesIntegrationTest extends Abst
         configurationCacheRun("resolve1")
 
         then:
-        configurationCache.assertStateStored()
+        configurationCache.assertStateLoaded()
 
         when:
         configurationCacheRun("resolve1")

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheIntegrationTest.groovy
@@ -24,6 +24,50 @@ import spock.lang.Issue
 
 class ConfigurationCacheIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
 
+    def "humble beginnings"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+
+        and:
+        settingsFile ''
+
+        when:
+        configurationCacheRun 'help'
+
+        then:
+        configurationCache.assertStateStored()
+
+        when:
+        settingsFile '// a change'
+
+        and:
+        configurationCacheRun 'help'
+
+        then:
+        configurationCache.assertStateStored()
+
+        when: 'switching back to original settings file'
+        settingsFile.text = ''
+
+        and:
+        configurationCacheRun 'help'
+
+        then:
+        configurationCache.assertStateLoaded()
+
+        when: 'switching back to 2nd settings file'
+        settingsFile.text = '// a change'
+
+        and:
+        configurationCacheRun 'help'
+
+        then:
+        configurationCache.assertStateLoaded()
+        file('.gradle/configuration-cache').traverse {
+            println testDirectory.relativePath(it)
+        }
+    }
+
     def "configuration cache is out of incubation"() {
         given:
         settingsFile << ""

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheIntegrationTest.groovy
@@ -24,51 +24,6 @@ import spock.lang.Issue
 
 class ConfigurationCacheIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
 
-    def "humble beginnings"() {
-        given:
-        def configurationCache = newConfigurationCacheFixture()
-        file("gradle.properties") << "org.gradle.configuration-cache.entries-per-key=2"
-
-        and:
-        settingsFile ''
-
-        when:
-        configurationCacheRun 'help'
-
-        then:
-        configurationCache.assertStateStored()
-
-        when:
-        settingsFile '// a change'
-
-        and:
-        configurationCacheRun 'help'
-
-        then:
-        configurationCache.assertStateStored()
-
-        when: 'switching back to original settings file'
-        settingsFile.text = ''
-
-        and:
-        configurationCacheRun 'help'
-
-        then:
-        configurationCache.assertStateLoaded()
-
-        when: 'switching back to 2nd settings file'
-        settingsFile.text = '// a change'
-
-        and:
-        configurationCacheRun 'help'
-
-        then:
-        configurationCache.assertStateLoaded()
-        file('.gradle/configuration-cache').traverse {
-            println testDirectory.relativePath(it)
-        }
-    }
-
     def "configuration cache is out of incubation"() {
         given:
         settingsFile << ""

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheIntegrationTest.groovy
@@ -27,6 +27,7 @@ class ConfigurationCacheIntegrationTest extends AbstractConfigurationCacheIntegr
     def "humble beginnings"() {
         given:
         def configurationCache = newConfigurationCacheFixture()
+        file("gradle.properties") << "org.gradle.configuration-cache.entries-per-key=2"
 
         and:
         settingsFile ''

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheMultiEntriesPerKeyIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheMultiEntriesPerKeyIntegrationTest.groovy
@@ -23,7 +23,7 @@ class ConfigurationCacheMultiEntriesPerKeyIntegrationTest extends AbstractConfig
         def configurationCache = newConfigurationCacheFixture()
 
         and:
-        settingsFile ''
+        settingsFile.text = '// original branch'
 
         when:
         configurationCacheRun 'help'
@@ -32,10 +32,16 @@ class ConfigurationCacheMultiEntriesPerKeyIntegrationTest extends AbstractConfig
         configurationCache.assertStateStored()
 
         when:
-        settingsFile '// a change'
+        settingsFile.text = '// second branch'
 
         and:
         configurationCacheRun 'help'
+
+        then:
+        configurationCache.assertStateStored()
+
+        when: 'switching back to original branch'
+        settingsFile.text = '// original branch'
 
         then:
         configurationCache.assertStateStored()
@@ -47,7 +53,7 @@ class ConfigurationCacheMultiEntriesPerKeyIntegrationTest extends AbstractConfig
         file("gradle.properties") << "org.gradle.configuration-cache.entries-per-key=2"
 
         and:
-        settingsFile.text = '// initial'
+        settingsFile.text = '// original branch'
 
         when:
         configurationCacheRun 'help'
@@ -56,7 +62,7 @@ class ConfigurationCacheMultiEntriesPerKeyIntegrationTest extends AbstractConfig
         configurationCache.assertStateStored()
 
         when:
-        settingsFile.text = '// first change'
+        settingsFile.text = '// second branch'
 
         and:
         configurationCacheRun 'help'
@@ -64,8 +70,8 @@ class ConfigurationCacheMultiEntriesPerKeyIntegrationTest extends AbstractConfig
         then:
         configurationCache.assertStateStored()
 
-        when: 'switching back to original settings file'
-        settingsFile.text = '// initial'
+        when: 'switching back to original branch'
+        settingsFile.text = '// original branch'
 
         and:
         configurationCacheRun 'help'
@@ -74,7 +80,7 @@ class ConfigurationCacheMultiEntriesPerKeyIntegrationTest extends AbstractConfig
         configurationCache.assertStateLoaded()
 
         when:
-        settingsFile.text = '// first change'
+        settingsFile.text = '// second branch'
 
         and:
         configurationCacheRun 'help'
@@ -83,7 +89,7 @@ class ConfigurationCacheMultiEntriesPerKeyIntegrationTest extends AbstractConfig
         configurationCache.assertStateLoaded()
 
         when:
-        settingsFile.text = '// second change'
+        settingsFile.text = '// third branch'
 
         and:
         configurationCacheRun 'help'
@@ -91,13 +97,13 @@ class ConfigurationCacheMultiEntriesPerKeyIntegrationTest extends AbstractConfig
         then:
         configurationCache.assertStateStored()
 
-        when: 'switching back to original settings file'
-        settingsFile.text = '// initial'
+        when: 'switching back to original branch'
+        settingsFile.text = '// original branch'
 
         and:
         configurationCacheRun 'help'
 
-        then: 'old entries are evicted'
+        then: 'least recently used entries are evicted'
         configurationCache.assertStateStored()
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheMultiEntriesPerKeyIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheMultiEntriesPerKeyIntegrationTest.groovy
@@ -47,7 +47,7 @@ class ConfigurationCacheMultiEntriesPerKeyIntegrationTest extends AbstractConfig
         file("gradle.properties") << "org.gradle.configuration-cache.entries-per-key=2"
 
         and:
-        settingsFile ''
+        settingsFile.text = '// initial'
 
         when:
         configurationCacheRun 'help'
@@ -56,34 +56,7 @@ class ConfigurationCacheMultiEntriesPerKeyIntegrationTest extends AbstractConfig
         configurationCache.assertStateStored()
 
         when:
-        settingsFile '// a change'
-
-        and:
-        configurationCacheRun 'help'
-
-        then:
-        configurationCache.assertStateStored()
-
-        when: 'switching back to original settings file'
-        settingsFile.text = ''
-
-        and:
-        configurationCacheRun 'help'
-
-        then:
-        configurationCache.assertStateLoaded()
-
-        when:
-        settingsFile.text = '// a change'
-
-        and:
-        configurationCacheRun 'help'
-
-        then:
-        configurationCache.assertStateLoaded()
-
-        when:
-        settingsFile.text = '// a most recent change'
+        settingsFile.text = '// first change'
 
         and:
         configurationCacheRun 'help'
@@ -92,7 +65,34 @@ class ConfigurationCacheMultiEntriesPerKeyIntegrationTest extends AbstractConfig
         configurationCache.assertStateStored()
 
         when: 'switching back to original settings file'
-        settingsFile.text = ''
+        settingsFile.text = '// initial'
+
+        and:
+        configurationCacheRun 'help'
+
+        then:
+        configurationCache.assertStateLoaded()
+
+        when:
+        settingsFile.text = '// first change'
+
+        and:
+        configurationCacheRun 'help'
+
+        then:
+        configurationCache.assertStateLoaded()
+
+        when:
+        settingsFile.text = '// second change'
+
+        and:
+        configurationCacheRun 'help'
+
+        then:
+        configurationCache.assertStateStored()
+
+        when: 'switching back to original settings file'
+        settingsFile.text = '// initial'
 
         and:
         configurationCacheRun 'help'

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheMultiEntriesPerKeyIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheMultiEntriesPerKeyIntegrationTest.groovy
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl
+
+class ConfigurationCacheMultiEntriesPerKeyIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+
+    def 'store single entry per key by default'() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+
+        and:
+        settingsFile ''
+
+        when:
+        configurationCacheRun 'help'
+
+        then:
+        configurationCache.assertStateStored()
+
+        when:
+        settingsFile '// a change'
+
+        and:
+        configurationCacheRun 'help'
+
+        then:
+        configurationCache.assertStateStored()
+    }
+
+    def 'can store multiple entries per key'() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        file("gradle.properties") << "org.gradle.configuration-cache.entries-per-key=2"
+
+        and:
+        settingsFile ''
+
+        when:
+        configurationCacheRun 'help'
+
+        then:
+        configurationCache.assertStateStored()
+
+        when:
+        settingsFile '// a change'
+
+        and:
+        configurationCacheRun 'help'
+
+        then:
+        configurationCache.assertStateStored()
+
+        when: 'switching back to original settings file'
+        settingsFile.text = ''
+
+        and:
+        configurationCacheRun 'help'
+
+        then:
+        configurationCache.assertStateLoaded()
+
+        when:
+        settingsFile.text = '// a change'
+
+        and:
+        configurationCacheRun 'help'
+
+        then:
+        configurationCache.assertStateLoaded()
+
+        when:
+        settingsFile.text = '// a most recent change'
+
+        and:
+        configurationCacheRun 'help'
+
+        then:
+        configurationCache.assertStateStored()
+
+        when: 'switching back to original settings file'
+        settingsFile.text = ''
+
+        and:
+        configurationCacheRun 'help'
+
+        then: 'old entries are evicted'
+        configurationCache.assertStateStored()
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperations.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperations.kt
@@ -153,6 +153,7 @@ class FingerprintCheckResult(
     override fun getStatus(): CheckStatus = when (checkResult) {
         is CheckedFingerprint.NotFound -> CheckStatus.NOT_FOUND
         is CheckedFingerprint.Valid -> CheckStatus.VALID
+        is CheckedFingerprint.Found -> CheckStatus.VALID
         is CheckedFingerprint.EntryInvalid -> CheckStatus.INVALID
         is CheckedFingerprint.ProjectsInvalid -> CheckStatus.PARTIAL
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperations.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperations.kt
@@ -152,25 +152,25 @@ class FingerprintCheckResult(
 
     override fun getStatus(): CheckStatus = when (checkResult) {
         is CheckedFingerprint.NotFound -> CheckStatus.NOT_FOUND
-        is CheckedFingerprint.Found -> {
+        is CheckedFingerprint.Valid -> {
             when (checkResult.invalidProjects) {
                 null -> CheckStatus.VALID
                 else -> CheckStatus.PARTIAL
             }
         }
 
-        is CheckedFingerprint.EntryInvalid -> CheckStatus.INVALID
+        is CheckedFingerprint.Invalid -> CheckStatus.INVALID
     }
 
     override fun getBuildInvalidationReasons(): List<BuildInvalidationReasons> {
         return when (checkResult) {
-            is CheckedFingerprint.EntryInvalid -> listOf(BuildInvalidationReasonsImpl(checkResult.buildPath, checkResult.reason))
+            is CheckedFingerprint.Invalid -> listOf(BuildInvalidationReasonsImpl(checkResult.buildPath, checkResult.reason))
             else -> emptyList()
         }
     }
 
     override fun getProjectInvalidationReasons(): List<ProjectInvalidationReasons> = when {
-        checkResult is CheckedFingerprint.Found && checkResult.invalidProjects != null -> {
+        checkResult is CheckedFingerprint.Valid && checkResult.invalidProjects != null -> {
             val invalidProjects = checkResult.invalidProjects
             buildList(invalidProjects.size) {
                 // First reason is shown to the user.

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperations.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperations.kt
@@ -152,21 +152,21 @@ class FingerprintCheckResult(
 
     override fun getStatus(): CheckStatus = when (checkResult) {
         is CheckedFingerprint.NotFound -> CheckStatus.NOT_FOUND
+        is CheckedFingerprint.Invalid -> CheckStatus.INVALID
         is CheckedFingerprint.Valid -> {
             when (checkResult.invalidProjects) {
                 null -> CheckStatus.VALID
                 else -> CheckStatus.PARTIAL
             }
         }
-
-        is CheckedFingerprint.Invalid -> CheckStatus.INVALID
     }
 
-    override fun getBuildInvalidationReasons(): List<BuildInvalidationReasons> {
-        return when (checkResult) {
-            is CheckedFingerprint.Invalid -> listOf(BuildInvalidationReasonsImpl(checkResult.buildPath, checkResult.reason))
-            else -> emptyList()
-        }
+    override fun getBuildInvalidationReasons(): List<BuildInvalidationReasons> = when (checkResult) {
+        is CheckedFingerprint.Invalid -> listOf(
+            BuildInvalidationReasonsImpl(checkResult.buildPath, checkResult.reason)
+        )
+
+        else -> emptyList()
     }
 
     override fun getProjectInvalidationReasons(): List<ProjectInvalidationReasons> = when {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperations.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperations.kt
@@ -152,9 +152,14 @@ class FingerprintCheckResult(
 
     override fun getStatus(): CheckStatus = when (checkResult) {
         is CheckedFingerprint.NotFound -> CheckStatus.NOT_FOUND
-        is CheckedFingerprint.Found -> CheckStatus.VALID
+        is CheckedFingerprint.Found -> {
+            when (checkResult.invalidProjects) {
+                null -> CheckStatus.VALID
+                else -> CheckStatus.PARTIAL
+            }
+        }
+
         is CheckedFingerprint.EntryInvalid -> CheckStatus.INVALID
-        is CheckedFingerprint.ProjectsInvalid -> CheckStatus.PARTIAL
     }
 
     override fun getBuildInvalidationReasons(): List<BuildInvalidationReasons> {
@@ -164,23 +169,22 @@ class FingerprintCheckResult(
         }
     }
 
-    override fun getProjectInvalidationReasons(): List<ProjectInvalidationReasons> {
-        return when (checkResult) {
-            is CheckedFingerprint.ProjectsInvalid -> {
-                buildList(checkResult.invalidProjects.size) {
-                    // First reason is shown to the user.
-                    add(ProjectInvalidationReasonsImpl(checkResult.invalidProjects.getValue(checkResult.firstInvalidated)))
-                    // The rest is in alphabetical order.
-                    checkResult.invalidProjects.asSequence()
-                        .filterNot { it.key == checkResult.firstInvalidated }
-                        .map { ProjectInvalidationReasonsImpl(it.value) }
-                        .sortedWith(compareBy({ it.buildPath }, { it.projectPath }))
-                        .forEach { add(it) }
-                }
+    override fun getProjectInvalidationReasons(): List<ProjectInvalidationReasons> = when {
+        checkResult is CheckedFingerprint.Found && checkResult.invalidProjects != null -> {
+            val invalidProjects = checkResult.invalidProjects
+            buildList(invalidProjects.size) {
+                // First reason is shown to the user.
+                add(ProjectInvalidationReasonsImpl(invalidProjects.first))
+                // The rest is in alphabetical order.
+                invalidProjects.all.asSequence()
+                    .filterNot { it.key == invalidProjects.firstProjectPath }
+                    .map { ProjectInvalidationReasonsImpl(it.value) }
+                    .sortedWith(compareBy({ it.buildPath }, { it.projectPath }))
+                    .forEach { add(it) }
             }
-
-            else -> emptyList()
         }
+
+        else -> emptyList()
     }
 
     private
@@ -203,10 +207,10 @@ class FingerprintCheckResult(
         private val invalidationReasons: List<FingerprintInvalidationReason>
     ) : ProjectInvalidationReasons {
 
-        constructor(invalidation: CheckedFingerprint.ProjectInvalidationData) : this(
+        constructor(invalidation: CheckedFingerprint.InvalidProject) : this(
             invalidation.buildPath.path,
             invalidation.projectPath.path,
-            listOf(FingerprintInvalidationReasonImpl(invalidation.message.toString()))
+            listOf(FingerprintInvalidationReasonImpl(invalidation.reason.toString()))
         )
 
         override fun getBuildPath() = buildPath

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperations.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperations.kt
@@ -152,7 +152,6 @@ class FingerprintCheckResult(
 
     override fun getStatus(): CheckStatus = when (checkResult) {
         is CheckedFingerprint.NotFound -> CheckStatus.NOT_FOUND
-        is CheckedFingerprint.Valid -> CheckStatus.VALID
         is CheckedFingerprint.Found -> CheckStatus.VALID
         is CheckedFingerprint.EntryInvalid -> CheckStatus.INVALID
         is CheckedFingerprint.ProjectsInvalid -> CheckStatus.PARTIAL

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CheckedFingerprint.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CheckedFingerprint.kt
@@ -27,6 +27,8 @@ sealed class CheckedFingerprint {
     // Everything is up-to-date
     object Valid : CheckedFingerprint()
 
+    data class Found(val entryName: String) : CheckedFingerprint()
+
     // The entry cannot be reused at all and should be recreated from scratch
     class EntryInvalid(val buildPath: Path, val reason: StructuredMessage) : CheckedFingerprint()
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CheckedFingerprint.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CheckedFingerprint.kt
@@ -21,48 +21,53 @@ import org.gradle.util.Path
 
 
 sealed class CheckedFingerprint {
+
     // No fingerprint, which means no cache entry
     object NotFound : CheckedFingerprint()
 
-    // Everything is up-to-date
-    class Found(val entryId: String) : CheckedFingerprint()
-
     // The entry cannot be reused at all and should be recreated from scratch
-    class EntryInvalid(val buildPath: Path, val reason: StructuredMessage) : CheckedFingerprint()
+    class EntryInvalid(
+        val buildPath: Path,
+        val reason: StructuredMessage
+    ) : CheckedFingerprint()
+
+    /**
+     * The entry can be reused. However, the state of some projects might be invalid and should be recreated.
+     */
+    class Found(
+        val entryId: String,
+        val invalidProjects: InvalidProjects? = null
+    ) : CheckedFingerprint()
 
     // The entry can be reused, however the values for certain projects cannot be reused and should be recreated
     // TODO:isolated when keeping multiple entries per key, Gradle should look for the entry with the least number of invalid projects
-    class ProjectsInvalid(
-        /**
-         * Configuration cache entry id.
-         */
-        val entryId: String,
+    class InvalidProjects(
         /**
          * Identity path of the first project for which an invalidation was detected.
          */
-        val firstInvalidated: Path,
+        val firstProjectPath: Path,
         /**
-         * All invalidated projects with their invalidation reasons by identity path. Must contain [firstInvalidated].
+         * All invalidated projects with their invalidation reasons by identity path. Must contain [firstProjectPath].
          */
-        val invalidProjects: Map<Path, ProjectInvalidationData>
-    ) : CheckedFingerprint() {
+        val all: Map<Path, InvalidProject>
+    ) {
         init {
-            require(firstInvalidated in invalidProjects)
+            require(firstProjectPath in all)
         }
 
-        /**
-         * The first invalidation reason detected.
-         */
-        val firstReason: StructuredMessage
-            get() = invalidProjects.getValue(firstInvalidated).message
+        val size
+            get() = all.size
+
+        val first: InvalidProject
+            get() = all.getValue(firstProjectPath)
     }
 
     /**
      * Information about an invalidated project.
      */
-    data class ProjectInvalidationData(
+    data class InvalidProject(
         val buildPath: Path,
         val projectPath: Path,
-        val message: StructuredMessage
+        val reason: StructuredMessage
     )
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CheckedFingerprint.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CheckedFingerprint.kt
@@ -25,8 +25,6 @@ sealed class CheckedFingerprint {
     object NotFound : CheckedFingerprint()
 
     // Everything is up-to-date
-    object Valid : CheckedFingerprint()
-
     class Found(val entryName: String) : CheckedFingerprint()
 
     // The entry cannot be reused at all and should be recreated from scratch

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CheckedFingerprint.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CheckedFingerprint.kt
@@ -26,7 +26,7 @@ sealed class CheckedFingerprint {
     object NotFound : CheckedFingerprint()
 
     // The entry cannot be reused at all and should be recreated from scratch
-    class EntryInvalid(
+    class Invalid(
         val buildPath: Path,
         val reason: StructuredMessage
     ) : CheckedFingerprint()
@@ -34,13 +34,13 @@ sealed class CheckedFingerprint {
     /**
      * The entry can be reused. However, the state of some projects might be invalid and should be recreated.
      */
-    class Found(
+    // TODO:isolated when keeping multiple entries per key, Gradle should look for the entry with the least number of invalid projects
+    class Valid(
         val entryId: String,
         val invalidProjects: InvalidProjects? = null
     ) : CheckedFingerprint()
 
     // The entry can be reused, however the values for certain projects cannot be reused and should be recreated
-    // TODO:isolated when keeping multiple entries per key, Gradle should look for the entry with the least number of invalid projects
     class InvalidProjects(
         /**
          * Identity path of the first project for which an invalidation was detected.

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CheckedFingerprint.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CheckedFingerprint.kt
@@ -25,7 +25,7 @@ sealed class CheckedFingerprint {
     object NotFound : CheckedFingerprint()
 
     // Everything is up-to-date
-    class Found(val entryName: String) : CheckedFingerprint()
+    class Found(val entryId: String) : CheckedFingerprint()
 
     // The entry cannot be reused at all and should be recreated from scratch
     class EntryInvalid(val buildPath: Path, val reason: StructuredMessage) : CheckedFingerprint()

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CheckedFingerprint.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CheckedFingerprint.kt
@@ -33,7 +33,10 @@ sealed class CheckedFingerprint {
     // The entry can be reused, however the values for certain projects cannot be reused and should be recreated
     // TODO:isolated when keeping multiple entries per key, Gradle should look for the entry with the least number of invalid projects
     class ProjectsInvalid(
-        val entryName: String,
+        /**
+         * Configuration cache entry id.
+         */
+        val entryId: String,
         /**
          * Identity path of the first project for which an invalidation was detected.
          */

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CheckedFingerprint.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CheckedFingerprint.kt
@@ -31,6 +31,7 @@ sealed class CheckedFingerprint {
     class EntryInvalid(val buildPath: Path, val reason: StructuredMessage) : CheckedFingerprint()
 
     // The entry can be reused, however the values for certain projects cannot be reused and should be recreated
+    // TODO:isolated when keeping multiple entries per key, Gradle should look for the entry with the least number of invalid projects
     class ProjectsInvalid(
         val entryName: String,
         /**
@@ -56,5 +57,9 @@ sealed class CheckedFingerprint {
     /**
      * Information about an invalidated project.
      */
-    data class ProjectInvalidationData(val buildPath: Path, val projectPath: Path, val message: StructuredMessage)
+    data class ProjectInvalidationData(
+        val buildPath: Path,
+        val projectPath: Path,
+        val message: StructuredMessage
+    )
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CheckedFingerprint.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CheckedFingerprint.kt
@@ -27,13 +27,14 @@ sealed class CheckedFingerprint {
     // Everything is up-to-date
     object Valid : CheckedFingerprint()
 
-    data class Found(val entryName: String) : CheckedFingerprint()
+    class Found(val entryName: String) : CheckedFingerprint()
 
     // The entry cannot be reused at all and should be recreated from scratch
     class EntryInvalid(val buildPath: Path, val reason: StructuredMessage) : CheckedFingerprint()
 
     // The entry can be reused, however the values for certain projects cannot be reused and should be recreated
     class ProjectsInvalid(
+        val entryName: String,
         /**
          * Identity path of the first project for which an invalidation was detected.
          */

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheAction.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheAction.kt
@@ -17,7 +17,8 @@
 package org.gradle.internal.cc.impl
 
 
-internal
-enum class ConfigurationCacheAction {
-    LOAD, STORE, UPDATE
+internal sealed class ConfigurationCacheAction {
+    class LOAD(val entryId: String) : ConfigurationCacheAction()
+    object STORE : ConfigurationCacheAction()
+    object UPDATE : ConfigurationCacheAction()
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheAction.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheAction.kt
@@ -19,6 +19,6 @@ package org.gradle.internal.cc.impl
 
 internal sealed class ConfigurationCacheAction {
     class LOAD(val entryId: String) : ConfigurationCacheAction()
+    class UPDATE(val entryId: String) : ConfigurationCacheAction()
     object STORE : ConfigurationCacheAction()
-    object UPDATE : ConfigurationCacheAction()
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheAction.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheAction.kt
@@ -19,6 +19,6 @@ package org.gradle.internal.cc.impl
 
 internal sealed class ConfigurationCacheAction {
     class LOAD(val entryId: String) : ConfigurationCacheAction()
-    class UPDATE(val entryId: String) : ConfigurationCacheAction()
+    class UPDATE(val entryId: String, val invalidProjects: CheckedFingerprint.InvalidProjects) : ConfigurationCacheAction()
     object STORE : ConfigurationCacheAction()
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeIO.kt
@@ -109,4 +109,11 @@ interface ConfigurationCacheBuildTreeIO : ConfigurationCacheOperationIO {
         specialEncoders: SpecialEncoders,
         writeOperation: suspend WriteContext.(Codecs) -> R
     ): R
+
+    fun readCandidateEntries(stateFile: ConfigurationCacheStateFile): List<CandidateEntry>
+    fun writeCandidateEntries(stateFile: ConfigurationCacheStateFile, entries: List<CandidateEntry>)
 }
+
+data class CandidateEntry(
+    val id: String
+)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeIO.kt
@@ -96,7 +96,7 @@ interface ConfigurationCacheBuildTreeIO : ConfigurationCacheOperationIO {
     fun <R> withWriteContextFor(
         stateFile: ConfigurationCacheStateFile,
         profile: () -> String,
-        specialEncoders: SpecialEncoders,
+        specialEncoders: SpecialEncoders = SpecialEncoders(),
         writeOperation: suspend WriteContext.(Codecs) -> R
     ): R =
         withWriteContextFor(stateFile.stateFile.name, stateFile.stateType, stateFile::outputStream, profile, specialEncoders, writeOperation)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheRepository.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheRepository.kt
@@ -207,10 +207,10 @@ class ConfigurationCacheRepository(
         }
 
         override fun <T : Any> useForStateLoad(stateType: StateType, action: (ConfigurationCacheStateFile) -> T): ConfigurationCacheStateStore.StateAccessResult<T> {
-            return useForStateLoad { layout -> action(layout.fileFor(stateType)) }
+            return useForStateLoad { action(fileFor(stateType)) }
         }
 
-        override fun <T : Any> useForStateLoad(action: (Layout) -> T): ConfigurationCacheStateStore.StateAccessResult<T> {
+        override fun <T : Any> useForStateLoad(action: Layout.() -> T): ConfigurationCacheStateStore.StateAccessResult<T> {
             return withExclusiveAccessToCache(baseDir) { cacheDir ->
                 markAccessed(cacheDir)
                 // this needs to be thread-safe as we may have multiple adding threads
@@ -220,7 +220,7 @@ class ConfigurationCacheRepository(
             }
         }
 
-        override fun <T> useForStore(action: (Layout) -> T): ConfigurationCacheStateStore.StateAccessResult<T> =
+        override fun <T> useForStore(action: Layout.() -> T): ConfigurationCacheStateStore.StateAccessResult<T> =
             withExclusiveAccessToCache(baseDir) { cacheDir ->
                 // TODO GlobalCache require(!cacheDir.isDirectory)
                 Files.createDirectories(cacheDir.toPath())

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
@@ -131,7 +131,8 @@ enum class StateType(val encryptable: Boolean = false) {
     /**
      * The index file that points to all of these things
      */
-    Entry(false)
+    Entry(false),
+    Candidates(false)
 }
 
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
@@ -132,6 +132,11 @@ enum class StateType(val encryptable: Boolean = false) {
      * The index file that points to all of these things
      */
     Entry(false),
+
+    /**
+     * The per cache-key file that lists all known configuration cache entries
+     * for that key.
+     */
     Candidates(false)
 }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheStateStore.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheStateStore.kt
@@ -34,7 +34,7 @@ interface ConfigurationCacheStateStore {
     /**
      * Loads some value from zero or more state files.
      */
-    fun <T : Any> useForStateLoad(action: (ConfigurationCacheRepository.Layout) -> T): StateAccessResult<T>
+    fun <T : Any> useForStateLoad(action: ConfigurationCacheRepository.Layout.() -> T): StateAccessResult<T>
 
     /**
      * Loads some value from a specific state file.
@@ -44,7 +44,7 @@ interface ConfigurationCacheStateStore {
     /**
      * Writes some value to zero or more state files.
      */
-    fun <T> useForStore(action: (ConfigurationCacheRepository.Layout) -> T): StateAccessResult<T>
+    fun <T> useForStore(action: ConfigurationCacheRepository.Layout.() -> T): StateAccessResult<T>
 
     /**
      * Creates a new [ValueStore] that can be used to load and store multiple values.

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -409,20 +409,13 @@ class DefaultConfigurationCache internal constructor(
     private
     fun checkFingerprint(): CheckedFingerprint = buildOperationRunner.withFingerprintCheckOperations {
         // searching for a valid cc entry
-        val candidates = store.useForStateLoad { layout ->
-            cacheIO.readCandidateEntries(layout.fileFor(StateType.Candidates))
-        }.value
-
+        val candidates = readCandidateEntries()
         val invalidationReasons = mutableListOf<CheckedFingerprint>()
-
         for (candidate in candidates) {
             when (val result = checkCandidate(candidate)) {
                 is CheckedFingerprint.Valid -> {
-                    currentCandidateEntries = buildList {
-                        add(0, candidate)
-                        addAll(candidates.filter { it != candidate })
-                    }
-                    return@withFingerprintCheckOperations CheckedFingerprint.Found(candidate.id)
+                    currentCandidateEntries = updateMostRecentEntries(candidate, candidates)
+                    CheckedFingerprint.Found(candidate.id)
                 }
 
                 is CheckedFingerprint.EntryInvalid,
@@ -432,9 +425,18 @@ class DefaultConfigurationCache internal constructor(
             }
         }
         currentCandidateEntries = candidates
-
-        return@withFingerprintCheckOperations invalidationReasons.firstOrNull() ?: CheckedFingerprint.NotFound
+        invalidationReasons.firstOrNull() ?: CheckedFingerprint.NotFound
     }
+
+    private fun updateMostRecentEntries(candidate: CandidateEntry, candidates: List<CandidateEntry>) = buildList {
+        add(0, candidate)
+        addAll(candidates.filter { it != candidate })
+    }
+
+    private
+    fun readCandidateEntries() = store.useForStateLoad { layout ->
+        cacheIO.readCandidateEntries(layout.fileFor(StateType.Candidates))
+    }.value
 
     private
     fun checkCandidate(candidateEntry: CandidateEntry): CheckedFingerprint {
@@ -446,7 +448,8 @@ class DefaultConfigurationCache internal constructor(
         }.value
     }
 
-    private fun checkedFingerprint(layout: ConfigurationCacheRepository.Layout): CheckedFingerprint {
+    private
+    fun checkedFingerprint(layout: ConfigurationCacheRepository.Layout): CheckedFingerprint {
         val entryFile = layout.fileFor(StateType.Entry)
         val entryDetails = cacheIO.readCacheEntryDetailsFrom(entryFile)
         return if (entryDetails == null) {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -287,9 +287,7 @@ class DefaultConfigurationCache internal constructor(
             cacheIO.writeCacheEntryDetailsTo(buildStateRegistry, usedModels, usedMetadata, sideEffects, layout.fileFor(StateType.Entry))
         }
         store.useForStore { layout ->
-            val existingEntries = cacheIO.readCandidateEntries(layout.fileForRead(StateType.Candidates))
-            val newEntries = listOf(CandidateEntry(entryId)) + existingEntries
-//            val newEntries = calculateCandidateEntries(layout, startParameter.entriesPerKey)
+            val newEntries = calculateCandidateEntries(layout, startParameter.entriesPerKey)
             cacheIO.writeCandidateEntries(layout.fileFor(StateType.Candidates), newEntries)
         }
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -169,6 +169,7 @@ class DefaultConfigurationCache internal constructor(
         this.cacheAction = cacheAction
         this.entryId = when (cacheAction) {
             is ConfigurationCacheAction.LOAD -> cacheAction.entryId
+            is ConfigurationCacheAction.UPDATE -> cacheAction.entryId
             else -> UUID.randomUUID().toString()
         }
         problems.action(cacheAction, cacheActionDescription)
@@ -369,7 +370,7 @@ class DefaultConfigurationCache internal constructor(
                         checkedFingerprint.firstReason.render()
                     )
                     logBootstrapSummary(description)
-                    ConfigurationCacheAction.UPDATE to description
+                    ConfigurationCacheAction.UPDATE(checkedFingerprint.entryName) to description
                 }
 
                 is CheckedFingerprint.Found -> {
@@ -444,19 +445,19 @@ class DefaultConfigurationCache internal constructor(
         val entryName = candidateEntry.id
         val entryStore = cacheRepository.forKey(entryName)
         return entryStore.useForStateLoad { layout ->
-            checkedFingerprint(layout)
+            checkedFingerprint(layout, candidateEntry)
         }.value
     }
 
     private
-    fun checkedFingerprint(layout: ConfigurationCacheRepository.Layout): CheckedFingerprint {
+    fun checkedFingerprint(layout: ConfigurationCacheRepository.Layout, candidateEntry: CandidateEntry): CheckedFingerprint {
         val entryFile = layout.fileFor(StateType.Entry)
         val entryDetails = cacheIO.readCacheEntryDetailsFrom(entryFile)
         return if (entryDetails == null) {
             // No entry file -> treat the entry as empty/missing/invalid
             CheckedFingerprint.NotFound
         } else {
-            checkFingerprint(entryDetails, layout)
+            checkFingerprint(entryDetails, layout, candidateEntry)
         }
     }
 
@@ -645,7 +646,7 @@ class DefaultConfigurationCache internal constructor(
     }
 
     private
-    fun checkFingerprint(entryDetails: EntryDetails, layout: ConfigurationCacheRepository.Layout): CheckedFingerprint {
+    fun checkFingerprint(entryDetails: EntryDetails, layout: ConfigurationCacheRepository.Layout, candidateEntry: CandidateEntry): CheckedFingerprint {
         // Register all included build root directories as watchable hierarchies,
         // so we can load the fingerprint for build scripts and other files from included builds
         // without violating file system invariants.
@@ -653,7 +654,7 @@ class DefaultConfigurationCache internal constructor(
 
         loadGradleProperties()
 
-        return checkFingerprintAgainstLoadedProperties(entryDetails, layout).also { result ->
+        return checkFingerprintAgainstLoadedProperties(entryDetails, layout, candidateEntry).also { result ->
             if (result !== CheckedFingerprint.Valid) {
                 // Force Gradle properties to be reloaded so the Gradle properties files
                 // along with any Gradle property defining system properties and environment variables
@@ -664,7 +665,7 @@ class DefaultConfigurationCache internal constructor(
     }
 
     private
-    fun checkFingerprintAgainstLoadedProperties(entryDetails: EntryDetails, layout: ConfigurationCacheRepository.Layout): CheckedFingerprint {
+    fun checkFingerprintAgainstLoadedProperties(entryDetails: EntryDetails, layout: ConfigurationCacheRepository.Layout, candidateEntry: CandidateEntry): CheckedFingerprint {
         val result = checkBuildScopedFingerprint(layout.fileFor(StateType.BuildFingerprint))
         if (result !is CheckedFingerprint.Valid) {
             return result
@@ -672,7 +673,7 @@ class DefaultConfigurationCache internal constructor(
 
         // Build inputs are up-to-date, check project specific inputs
 
-        val projectResult = checkProjectScopedFingerprint(layout.fileFor(StateType.ProjectFingerprint))
+        val projectResult = checkProjectScopedFingerprint(layout.fileFor(StateType.ProjectFingerprint), candidateEntry)
         if (projectResult is CheckedFingerprint.ProjectsInvalid) {
             intermediateModels.restoreFromCacheEntry(entryDetails.intermediateModels, projectResult)
             projectMetadata.restoreFromCacheEntry(entryDetails.projectMetadata, projectResult)
@@ -696,10 +697,10 @@ class DefaultConfigurationCache internal constructor(
     }
 
     private
-    fun checkProjectScopedFingerprint(fingerprintFile: ConfigurationCacheStateFile): CheckedFingerprint {
+    fun checkProjectScopedFingerprint(fingerprintFile: ConfigurationCacheStateFile, candidateEntry: CandidateEntry): CheckedFingerprint {
         return readFingerprintFile(fingerprintFile) { host ->
             cacheFingerprintController.run {
-                checkProjectScopedFingerprint(host)
+                checkProjectScopedFingerprint(host, candidateEntry)
             }
         }
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -70,6 +70,7 @@ import org.gradle.util.Path
 import java.io.File
 import java.io.OutputStream
 import java.util.Locale
+import java.util.UUID
 
 
 @Suppress("LongParameterList")
@@ -120,6 +121,15 @@ class DefaultConfigurationCache internal constructor(
     val store by storeDelegate
 
     private
+    lateinit var entryId: String
+
+    private
+    val entryStoreDelegate = lazy { cacheRepository.forKey(entryId) }
+
+    private
+    val entryStore by entryStoreDelegate
+
+    private
     val cacheIO by lazy { host.service<ConfigurationCacheBuildTreeIO>() }
 
     private
@@ -148,11 +158,15 @@ class DefaultConfigurationCache internal constructor(
         get() = host.service()
 
     override val isLoaded: Boolean
-        get() = cacheAction == ConfigurationCacheAction.LOAD
+        get() = cacheAction is ConfigurationCacheAction.LOAD
 
     override fun initializeCacheEntry() {
         val (cacheAction, cacheActionDescription) = determineCacheAction()
         this.cacheAction = cacheAction
+        this.entryId = when (cacheAction) {
+            is ConfigurationCacheAction.LOAD -> cacheAction.entryId
+            else -> UUID.randomUUID().toString()
+        }
         problems.action(cacheAction, cacheActionDescription)
         // TODO:isolated find a way to avoid this late binding
         modelSideEffectExecutor.sideEffectStore = buildTreeModelSideEffects
@@ -231,7 +245,7 @@ class DefaultConfigurationCache internal constructor(
 
     override fun finalizeCacheEntry() {
         if (problems.shouldDiscardEntry) {
-            store.useForStore { layout ->
+            entryStore.useForStore { layout ->
                 layout.fileFor(StateType.Entry).delete()
             }
             cacheEntryRequiresCommit = false
@@ -241,7 +255,7 @@ class DefaultConfigurationCache internal constructor(
             problems.projectStateStats(projectUsage.reused.size, projectUsage.updated.size)
             cacheEntryRequiresCommit = false
             // Can reuse the cache entry for the rest of this build invocation
-            cacheAction = ConfigurationCacheAction.LOAD
+            cacheAction = ConfigurationCacheAction.LOAD(entryId)
         }
         try {
             cacheFingerprintController.stop()
@@ -264,12 +278,17 @@ class DefaultConfigurationCache internal constructor(
 
     private
     fun commitCacheEntry(reusedProjects: Set<Path>) {
-        store.useForStore { layout ->
+        entryStore.useForStore { layout ->
             writeConfigurationCacheFingerprint(layout, reusedProjects)
             val usedModels = intermediateModels.collectAccessedValues()
             val usedMetadata = projectMetadata.collectAccessedValues()
             val sideEffects = buildTreeModelSideEffects.collectSideEffects()
             cacheIO.writeCacheEntryDetailsTo(buildStateRegistry, usedModels, usedMetadata, sideEffects, layout.fileFor(StateType.Entry))
+        }
+        store.useForStore { layout ->
+            val existingEntries = cacheIO.readCandidateEntries(layout.fileForRead(StateType.Candidates))
+            val newEntries = listOf(CandidateEntry(entryId)) + existingEntries
+            cacheIO.writeCandidateEntries(layout.fileFor(StateType.Candidates), newEntries)
         }
     }
 
@@ -343,10 +362,14 @@ class DefaultConfigurationCache internal constructor(
                     ConfigurationCacheAction.UPDATE to description
                 }
 
-                is CheckedFingerprint.Valid -> {
+                is CheckedFingerprint.Found -> {
                     val description = StructuredMessage.forText("Reusing configuration cache.")
                     logBootstrapSummary(description)
-                    ConfigurationCacheAction.LOAD to description
+                    ConfigurationCacheAction.LOAD(checkedFingerprint.entryName) to description
+                }
+
+                is CheckedFingerprint.Valid -> {
+                    TODO("should be replaced by Found")
                 }
             }
         }
@@ -362,6 +385,7 @@ class DefaultConfigurationCache internal constructor(
         stoppable.addIfInitialized(lazyIntermediateModels)
         stoppable.addIfInitialized(lazyProjectMetadata)
         stoppable.addIfInitialized(storeDelegate)
+        stoppable.addIfInitialized(entryStoreDelegate)
         stoppable.stop()
     }
 
@@ -374,18 +398,38 @@ class DefaultConfigurationCache internal constructor(
 
     private
     fun checkFingerprint(): CheckedFingerprint {
-        return store.useForStateLoad { layout ->
-            val entryFile = layout.fileFor(StateType.Entry)
-            val entryDetails = cacheIO.readCacheEntryDetailsFrom(entryFile)
-            buildOperationRunner.withFingerprintCheckOperations {
-                if (entryDetails == null) {
-                    // No entry file -> treat the entry as empty/missing/invalid
-                    CheckedFingerprint.NotFound
-                } else {
-                    checkFingerprint(entryDetails, layout)
-                }
-            }
+        val candidates = store.useForStateLoad { layout ->
+            cacheIO.readCandidateEntries(layout.fileFor(StateType.Candidates))
         }.value
+        return candidates.firstNotNullOfOrNull {
+            checkCandidate(it)
+        } ?: CheckedFingerprint.NotFound
+    }
+
+    private fun checkCandidate(candidateEntry: CandidateEntry): CheckedFingerprint? {
+        val entryName = candidateEntry.id
+        val entryStore = cacheRepository.forKey(entryName)
+        return entryStore.useForStateLoad { layout ->
+            checkedFingerprint(layout)
+        }.value.let {
+            if (it is CheckedFingerprint.Valid)
+                CheckedFingerprint.Found(entryName)
+            else
+                null
+        }
+    }
+
+    private fun checkedFingerprint(layout: ConfigurationCacheRepository.Layout): CheckedFingerprint {
+        val entryFile = layout.fileFor(StateType.Entry)
+        val entryDetails = cacheIO.readCacheEntryDetailsFrom(entryFile)
+        return buildOperationRunner.withFingerprintCheckOperations {
+            if (entryDetails == null) {
+                // No entry file -> treat the entry as empty/missing/invalid
+                CheckedFingerprint.NotFound
+            } else {
+                checkFingerprint(entryDetails, layout)
+            }
+        }
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -248,9 +248,6 @@ class DefaultConfigurationCache internal constructor(
 
     override fun finalizeCacheEntry() {
         if (problems.shouldDiscardEntry) {
-            entryStore.useForStore {
-                fileFor(StateType.Entry).delete()
-            }
             discardEntry()
             cacheEntryRequiresCommit = false
         } else if (cacheEntryRequiresCommit) {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -134,6 +134,7 @@ class DefaultConfigurationCache internal constructor(
     private
     val cacheIO by lazy { host.service<ConfigurationCacheBuildTreeIO>() }
 
+    /** TODO:configuration-cache should these be using [store] or [entryStore]? */
     private
     val lazyBuildTreeModelSideEffects = lazy { BuildTreeModelSideEffectStore(isolateOwnerHost, cacheIO, store) }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -159,7 +159,7 @@ class DefaultConfigurationCache internal constructor(
         get() = host.service()
 
     private
-    val currentCandidateEntries = mutableListOf<CandidateEntry>()
+    var currentCandidateEntries: List<CandidateEntry>? = null
 
     override val isLoaded: Boolean
         get() = cacheAction is ConfigurationCacheAction.LOAD
@@ -292,15 +292,15 @@ class DefaultConfigurationCache internal constructor(
         store.useForStore { layout ->
             val newEntries = calculateCandidateEntries(startParameter.entriesPerKey)
             cacheIO.writeCandidateEntries(layout.fileFor(StateType.Candidates), newEntries)
-            currentCandidateEntries.clear()
+            currentCandidateEntries = null
         }
     }
 
     private
-    fun calculateCandidateEntries(entriesPerKey: Int): List<CandidateEntry> {
-        val tail = currentCandidateEntries.take(min(currentCandidateEntries.size, entriesPerKey - 1))
-        return listOf(CandidateEntry(entryId)) + tail
-    }
+    fun calculateCandidateEntries(entriesPerKey: Int): List<CandidateEntry> = currentCandidateEntries?.let { entries ->
+        val tail = entries.take(min(entries.size, entriesPerKey - 1))
+        listOf(CandidateEntry(entryId)) + tail
+    } ?: listOf(CandidateEntry(entryId))
 
     private
     fun determineCacheAction(): Pair<ConfigurationCacheAction, StructuredMessage> = when {
@@ -407,25 +407,24 @@ class DefaultConfigurationCache internal constructor(
     }
 
     private
-    fun checkFingerprint(): CheckedFingerprint {
-        return buildOperationRunner.withFingerprintCheckOperations {
-            // searching for a valid cc entry
-            val candidates = store.useForStateLoad { layout ->
-                cacheIO.readCandidateEntries(layout.fileFor(StateType.Candidates))
-            }.value
-            // how to best report changes?
-            // 1. could report all differences against each different entry
-            for (candidate in candidates) {
-                val result = checkCandidate(candidate)
-                if (result != null) {
-                    currentCandidateEntries.add(0, candidate)
-                    currentCandidateEntries.addAll(candidates.filter { it != candidate })
-                    return@withFingerprintCheckOperations result
+    fun checkFingerprint(): CheckedFingerprint = buildOperationRunner.withFingerprintCheckOperations {
+        // searching for a valid cc entry
+        val candidates = store.useForStateLoad { layout ->
+            cacheIO.readCandidateEntries(layout.fileFor(StateType.Candidates))
+        }.value
+
+        for (candidate in candidates) {
+            val result = checkCandidate(candidate)
+            if (result != null) {
+                currentCandidateEntries = buildList {
+                    add(0, candidate)
+                    addAll(candidates.filter { it != candidate })
                 }
+                return@withFingerprintCheckOperations result
             }
-            currentCandidateEntries.addAll(candidates)
-            return@withFingerprintCheckOperations CheckedFingerprint.NotFound
         }
+        currentCandidateEntries = candidates
+        return@withFingerprintCheckOperations CheckedFingerprint.NotFound
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -132,7 +132,6 @@ class DefaultConfigurationCache internal constructor(
     private
     val cacheIO by lazy { host.service<ConfigurationCacheBuildTreeIO>() }
 
-    /** TODO:configuration-cache should these be using [store] or [entryStore]? */
     private
     val lazyBuildTreeModelSideEffects = lazy {
         BuildTreeModelSideEffectStore(

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -363,7 +363,7 @@ class DefaultConfigurationCache internal constructor(
                         checkedFingerprint.firstReason.render()
                     )
                     logBootstrapSummary(description)
-                    ConfigurationCacheAction.UPDATE(checkedFingerprint.entryName) to description
+                    ConfigurationCacheAction.UPDATE(checkedFingerprint.entryId) to description
                 }
 
                 is CheckedFingerprint.Found -> {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -415,7 +415,7 @@ class DefaultConfigurationCache internal constructor(
             when (val result = checkCandidate(candidate)) {
                 is CheckedFingerprint.Valid -> {
                     currentCandidateEntries = updateMostRecentEntries(candidate, candidates)
-                    CheckedFingerprint.Found(candidate.id)
+                    return@withFingerprintCheckOperations CheckedFingerprint.Found(candidate.id)
                 }
 
                 is CheckedFingerprint.EntryInvalid,

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -724,8 +724,6 @@ class DefaultConfigurationCache internal constructor(
         cacheIO.withReadContextFor(fingerprintFile) { codecs ->
             withIsolate(isolateOwnerHost, codecs.fingerprintTypesCodec()) {
                 action(object : ConfigurationCacheFingerprintController.Host {
-                    override val buildPath: Path
-                        get() = buildPath()
                     override val valueSourceProviderFactory: ValueSourceProviderFactory
                         get() = host.service()
                     override val gradleProperties: GradleProperties

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -158,6 +158,9 @@ class DefaultConfigurationCache internal constructor(
     val gradlePropertiesController: GradlePropertiesController
         get() = host.service()
 
+    private
+    val currentCandidateEntries = mutableListOf<CandidateEntry>()
+
     override val isLoaded: Boolean
         get() = cacheAction is ConfigurationCacheAction.LOAD
 
@@ -287,15 +290,15 @@ class DefaultConfigurationCache internal constructor(
             cacheIO.writeCacheEntryDetailsTo(buildStateRegistry, usedModels, usedMetadata, sideEffects, layout.fileFor(StateType.Entry))
         }
         store.useForStore { layout ->
-            val newEntries = calculateCandidateEntries(layout, startParameter.entriesPerKey)
+            val newEntries = calculateCandidateEntries(startParameter.entriesPerKey)
             cacheIO.writeCandidateEntries(layout.fileFor(StateType.Candidates), newEntries)
+            currentCandidateEntries.clear()
         }
     }
 
     private
-    fun calculateCandidateEntries(layout: ConfigurationCacheRepository.Layout, entriesPerKey: Int): List<CandidateEntry> {
-        val existingEntries = cacheIO.readCandidateEntries(layout.fileForRead(StateType.Candidates))
-        val tail = existingEntries.take(min(existingEntries.size, entriesPerKey - 1))
+    fun calculateCandidateEntries(entriesPerKey: Int): List<CandidateEntry> {
+        val tail = currentCandidateEntries.take(min(currentCandidateEntries.size, entriesPerKey - 1))
         return listOf(CandidateEntry(entryId)) + tail
     }
 
@@ -412,9 +415,16 @@ class DefaultConfigurationCache internal constructor(
             }.value
             // how to best report changes?
             // 1. could report all differences against each different entry
-            candidates.firstNotNullOfOrNull {
-                checkCandidate(it)
-            } ?: CheckedFingerprint.NotFound
+            for (candidate in candidates) {
+                val result = checkCandidate(candidate)
+                if (result != null) {
+                    currentCandidateEntries.add(0, candidate)
+                    currentCandidateEntries.addAll(candidates.filter { it != candidate })
+                    return@withFingerprintCheckOperations result
+                }
+            }
+            currentCandidateEntries.addAll(candidates)
+            return@withFingerprintCheckOperations CheckedFingerprint.NotFound
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -71,6 +71,7 @@ import java.io.File
 import java.io.OutputStream
 import java.util.Locale
 import java.util.UUID
+import kotlin.math.min
 
 
 @Suppress("LongParameterList")
@@ -288,8 +289,16 @@ class DefaultConfigurationCache internal constructor(
         store.useForStore { layout ->
             val existingEntries = cacheIO.readCandidateEntries(layout.fileForRead(StateType.Candidates))
             val newEntries = listOf(CandidateEntry(entryId)) + existingEntries
+//            val newEntries = calculateCandidateEntries(layout, startParameter.entriesPerKey)
             cacheIO.writeCandidateEntries(layout.fileFor(StateType.Candidates), newEntries)
         }
+    }
+
+    private
+    fun calculateCandidateEntries(layout: ConfigurationCacheRepository.Layout, entriesPerKey: Int): List<CandidateEntry> {
+        val existingEntries = cacheIO.readCandidateEntries(layout.fileForRead(StateType.Candidates))
+        val tail = existingEntries.take(min(existingEntries.size, entriesPerKey - 1))
+        return listOf(CandidateEntry(entryId)) + tail
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -398,15 +398,22 @@ class DefaultConfigurationCache internal constructor(
 
     private
     fun checkFingerprint(): CheckedFingerprint {
-        val candidates = store.useForStateLoad { layout ->
-            cacheIO.readCandidateEntries(layout.fileFor(StateType.Candidates))
-        }.value
-        return candidates.firstNotNullOfOrNull {
-            checkCandidate(it)
-        } ?: CheckedFingerprint.NotFound
+        return buildOperationRunner.withFingerprintCheckOperations {
+            // searching for a valid cc entry
+            val candidates = store.useForStateLoad { layout ->
+                cacheIO.readCandidateEntries(layout.fileFor(StateType.Candidates))
+            }.value
+            // how to best report changes?
+            // 1. could report all differences against each different entry
+            candidates.firstNotNullOfOrNull {
+                checkCandidate(it)
+            } ?: CheckedFingerprint.NotFound
+        }
     }
 
-    private fun checkCandidate(candidateEntry: CandidateEntry): CheckedFingerprint? {
+    private
+    fun checkCandidate(candidateEntry: CandidateEntry): CheckedFingerprint? {
+        // checking a single fingerprint
         val entryName = candidateEntry.id
         val entryStore = cacheRepository.forKey(entryName)
         return entryStore.useForStateLoad { layout ->
@@ -422,13 +429,11 @@ class DefaultConfigurationCache internal constructor(
     private fun checkedFingerprint(layout: ConfigurationCacheRepository.Layout): CheckedFingerprint {
         val entryFile = layout.fileFor(StateType.Entry)
         val entryDetails = cacheIO.readCacheEntryDetailsFrom(entryFile)
-        return buildOperationRunner.withFingerprintCheckOperations {
-            if (entryDetails == null) {
-                // No entry file -> treat the entry as empty/missing/invalid
-                CheckedFingerprint.NotFound
-            } else {
-                checkFingerprint(entryDetails, layout)
-            }
+        return if (entryDetails == null) {
+            // No entry file -> treat the entry as empty/missing/invalid
+            CheckedFingerprint.NotFound
+        } else {
+            checkFingerprint(entryDetails, layout)
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -497,7 +497,7 @@ class DefaultConfigurationCache internal constructor(
         action: (ConfigurationCacheStateFile) -> Unit
     ): ConfigurationCacheStateStore.StateAccessResult<Throwable?> {
 
-        return store.useForStore { layout ->
+        return entryStore.useForStore { layout ->
             try {
                 val stateFile = layout.fileFor(stateType)
                 action(stateFile)
@@ -520,7 +520,7 @@ class DefaultConfigurationCache internal constructor(
         scopeRegistryListener.dispose()
 
         buildOperationRunner.withModelLoadOperation {
-            val storeLoadResult = store.useForStateLoad(StateType.Model) { stateFile: ConfigurationCacheStateFile ->
+            val storeLoadResult = entryStore.useForStateLoad(StateType.Model) { stateFile: ConfigurationCacheStateFile ->
                 cacheIO.readModelFrom(stateFile)
             }
 
@@ -540,7 +540,7 @@ class DefaultConfigurationCache internal constructor(
         scopeRegistryListener.dispose()
 
         buildOperationRunner.withWorkGraphLoadOperation {
-            val storeLoadResult = store.useForStateLoad(StateType.Work) { stateFile: ConfigurationCacheStateFile ->
+            val storeLoadResult = entryStore.useForStateLoad(StateType.Work) { stateFile: ConfigurationCacheStateFile ->
                 val (buildInvocationId, workGraph) = cacheIO.readRootBuildStateFrom(stateFile, loadAfterStore, graph, graphBuilder)
                 LoadResultMetadata(buildInvocationId) to workGraph
             }
@@ -589,8 +589,8 @@ class DefaultConfigurationCache internal constructor(
     private
     fun startCollectingCacheFingerprint() {
         cacheFingerprintController.maybeStartCollectingFingerprint(
-            store.assignSpoolFile(StateType.BuildFingerprint),
-            store.assignSpoolFile(StateType.ProjectFingerprint)
+            entryStore.assignSpoolFile(StateType.BuildFingerprint),
+            entryStore.assignSpoolFile(StateType.ProjectFingerprint)
         ) { stateFile ->
             cacheFingerprintWriteContextFor(stateFile.stateType, stateFile.file::outputStream) {
                 profileNameFor(stateFile)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
@@ -145,17 +145,20 @@ class DefaultConfigurationCacheIO internal constructor(
     }
 
     override fun writeCandidateEntries(stateFile: ConfigurationCacheStateFile, entries: List<CandidateEntry>) {
-        writeConfigurationCacheState(stateFile) {
+        withWriteContextFor(stateFile, { "candidates" }, SpecialEncoders()) {
             writeStrings(entries.map { it.id })
         }
     }
 
     override fun readCandidateEntries(stateFile: ConfigurationCacheStateFile): List<CandidateEntry> {
-        if (!stateFile.exists) {
-            return emptyList()
-        }
-        return readConfigurationCacheState(stateFile) {
-            readStrings().map { CandidateEntry(it) }
+        return when {
+            !stateFile.exists -> {
+                emptyList()
+            }
+
+            else -> withReadContextFor(stateFile, SpecialDecoders()) {
+                readStrings().map { CandidateEntry(it) }
+            }
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
@@ -59,10 +59,10 @@ import org.gradle.internal.serialize.graph.InlineStringEncoder
 import org.gradle.internal.serialize.graph.LoggingTracer
 import org.gradle.internal.serialize.graph.MutableReadContext
 import org.gradle.internal.serialize.graph.ReadContext
-import org.gradle.internal.serialize.graph.SpecialDecoders
-import org.gradle.internal.serialize.graph.SpecialEncoders
 import org.gradle.internal.serialize.graph.SharedObjectDecoder
 import org.gradle.internal.serialize.graph.SharedObjectEncoder
+import org.gradle.internal.serialize.graph.SpecialDecoders
+import org.gradle.internal.serialize.graph.SpecialEncoders
 import org.gradle.internal.serialize.graph.StringDecoder
 import org.gradle.internal.serialize.graph.StringEncoder
 import org.gradle.internal.serialize.graph.Tracer
@@ -71,11 +71,13 @@ import org.gradle.internal.serialize.graph.readCollection
 import org.gradle.internal.serialize.graph.readFile
 import org.gradle.internal.serialize.graph.readList
 import org.gradle.internal.serialize.graph.readNonNull
+import org.gradle.internal.serialize.graph.readStrings
 import org.gradle.internal.serialize.graph.readWith
 import org.gradle.internal.serialize.graph.runReadOperation
 import org.gradle.internal.serialize.graph.runWriteOperation
 import org.gradle.internal.serialize.graph.writeCollection
 import org.gradle.internal.serialize.graph.writeFile
+import org.gradle.internal.serialize.graph.writeStrings
 import org.gradle.internal.serialize.graph.writeWith
 import org.gradle.internal.serialize.kryo.KryoBackedDecoder
 import org.gradle.internal.serialize.kryo.KryoBackedEncoder
@@ -140,6 +142,21 @@ class DefaultConfigurationCacheIO internal constructor(
         writeNullableString(key.identityPath?.path)
         writeString(key.modelName)
         writeNullableString(key.parameterHash?.toString())
+    }
+
+    override fun writeCandidateEntries(stateFile: ConfigurationCacheStateFile, entries: List<CandidateEntry>) {
+        writeConfigurationCacheState(stateFile) {
+            writeStrings(entries.map { it.id })
+        }
+    }
+
+    override fun readCandidateEntries(stateFile: ConfigurationCacheStateFile): List<CandidateEntry> {
+        if (!stateFile.exists) {
+            return emptyList()
+        }
+        return readConfigurationCacheState(stateFile) {
+            readStrings().map { CandidateEntry(it) }
+        }
     }
 
     override fun readCacheEntryDetailsFrom(stateFile: ConfigurationCacheStateFile): EntryDetails? {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
@@ -137,29 +137,6 @@ class DefaultConfigurationCacheIO internal constructor(
         }
     }
 
-    private
-    fun WriteContext.writeModelKey(key: ModelKey) {
-        writeNullableString(key.identityPath?.path)
-        writeString(key.modelName)
-        writeNullableString(key.parameterHash?.toString())
-    }
-
-    override fun writeCandidateEntries(stateFile: ConfigurationCacheStateFile, entries: List<CandidateEntry>) {
-        withWriteContextFor(stateFile, { "candidates" }, SpecialEncoders()) {
-            writeStrings(entries.map { it.id })
-        }
-    }
-
-    override fun readCandidateEntries(stateFile: ConfigurationCacheStateFile): List<CandidateEntry> = when {
-        !stateFile.exists -> {
-            emptyList()
-        }
-
-        else -> withReadContextFor(stateFile, SpecialDecoders()) {
-            readStrings().map { CandidateEntry(it) }
-        }
-    }
-
     override fun readCacheEntryDetailsFrom(stateFile: ConfigurationCacheStateFile): EntryDetails? {
         if (!stateFile.exists) {
             return null
@@ -183,6 +160,29 @@ class DefaultConfigurationCacheIO internal constructor(
                 addressSerializer.read(this)
             }
             EntryDetails(rootDirs, intermediateModels, metadata, sideEffects)
+        }
+    }
+
+    private
+    fun WriteContext.writeModelKey(key: ModelKey) {
+        writeNullableString(key.identityPath?.path)
+        writeString(key.modelName)
+        writeNullableString(key.parameterHash?.toString())
+    }
+
+    override fun writeCandidateEntries(stateFile: ConfigurationCacheStateFile, entries: List<CandidateEntry>) {
+        withWriteContextFor(stateFile, { "candidates" }) {
+            writeStrings(entries.map { it.id })
+        }
+    }
+
+    override fun readCandidateEntries(stateFile: ConfigurationCacheStateFile): List<CandidateEntry> = when {
+        !stateFile.exists -> {
+            emptyList()
+        }
+
+        else -> withReadContextFor(stateFile) {
+            readStrings().map { CandidateEntry(it) }
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
@@ -150,15 +150,13 @@ class DefaultConfigurationCacheIO internal constructor(
         }
     }
 
-    override fun readCandidateEntries(stateFile: ConfigurationCacheStateFile): List<CandidateEntry> {
-        return when {
-            !stateFile.exists -> {
-                emptyList()
-            }
+    override fun readCandidateEntries(stateFile: ConfigurationCacheStateFile): List<CandidateEntry> = when {
+        !stateFile.exists -> {
+            emptyList()
+        }
 
-            else -> withReadContextFor(stateFile, SpecialDecoders()) {
-                readStrings().map { CandidateEntry(it) }
-            }
+        else -> withReadContextFor(stateFile, SpecialDecoders()) {
+            readStrings().map { CandidateEntry(it) }
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/extensions/ListExtensions.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/extensions/ListExtensions.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.extensions
+
+
+internal
+fun <T> List<T>.withMostRecentEntry(mostRecent: T, maxEntries: Int): List<T> {
+    if (isEmpty()) {
+        return listOf(mostRecent)
+    }
+    if (this[0] == mostRecent) {
+        return this
+    }
+    return buildList(maxEntries) {
+        add(mostRecent)
+        val remaining = maxEntries - 1
+        if (remaining > 0) {
+            addAll(
+                this@withMostRecentEntry.asSequence()
+                    .filter { it != mostRecent }
+                    .take(remaining))
+        }
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/extensions/ListExtensions.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/extensions/ListExtensions.kt
@@ -18,14 +18,10 @@ package org.gradle.internal.cc.impl.extensions
 
 
 internal
-fun <T> List<T>.withMostRecentEntry(mostRecent: T, maxEntries: Int): List<T> {
-    if (isEmpty()) {
-        return listOf(mostRecent)
-    }
-    if (this[0] == mostRecent) {
-        return this
-    }
-    return buildList(maxEntries) {
+fun <T> List<T>.withMostRecentEntry(mostRecent: T, maxEntries: Int): List<T> = when {
+    isEmpty() -> listOf(mostRecent)
+    first() == mostRecent -> this
+    else -> buildList(maxEntries) {
         add(mostRecent)
         val remaining = maxEntries - 1
         if (remaining > 0) {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintChecker.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintChecker.kt
@@ -46,13 +46,6 @@ typealias InvalidationReason = StructuredMessage
 
 
 internal
-sealed class BuildScopedFingerprintResult {
-    object Valid : BuildScopedFingerprintResult()
-    data class Invalid(val reason: InvalidationReason) : BuildScopedFingerprintResult()
-}
-
-
-internal
 class ConfigurationCacheFingerprintChecker(private val host: Host) {
 
     interface Host {
@@ -76,7 +69,7 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
         fun isRemoteScriptUpToDate(uri: URI): Boolean
     }
 
-    suspend fun ReadContext.checkBuildScopedFingerprint(): BuildScopedFingerprintResult {
+    suspend fun ReadContext.checkBuildScopedFingerprint(): InvalidationReason? {
         // TODO: log some debug info
         while (true) {
             when (val input = read()) {
@@ -85,14 +78,14 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
                     // An input that is not specific to a project. If it is out-of-date, then invalidate the whole cache entry and skip any further checks
                     val reason = check(input)
                     if (reason != null) {
-                        return BuildScopedFingerprintResult.Invalid(reason)
+                        return reason
                     }
                 }
 
                 else -> error("Unexpected configuration cache fingerprint: $input")
             }
         }
-        return BuildScopedFingerprintResult.Valid
+        return null
     }
 
     @Suppress("NestedBlockDepth")

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintChecker.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintChecker.kt
@@ -57,7 +57,6 @@ internal
 class ConfigurationCacheFingerprintChecker(private val host: Host) {
 
     interface Host {
-        val buildPath: Path
         val isEncrypted: Boolean
         val encryptionKeyHashCode: HashCode
         val gradleUserHomeDir: File

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintChecker.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintChecker.kt
@@ -25,6 +25,7 @@ import org.gradle.initialization.StartParameterBuildOptions
 import org.gradle.internal.RenderingUtils.oxfordListOf
 import org.gradle.internal.RenderingUtils.quotedOxfordListOf
 import org.gradle.internal.cc.base.logger
+import org.gradle.internal.cc.impl.CandidateEntry
 import org.gradle.internal.cc.impl.CheckedFingerprint
 import org.gradle.internal.configuration.problems.StructuredMessage
 import org.gradle.internal.configuration.problems.StructuredMessageBuilder
@@ -90,7 +91,7 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
     }
 
     @Suppress("NestedBlockDepth")
-    suspend fun ReadContext.checkProjectScopedFingerprint(): CheckedFingerprint {
+    suspend fun ReadContext.checkProjectScopedFingerprint(candidateEntry: CandidateEntry): CheckedFingerprint {
         // TODO: log some debug info
         var firstInvalidatedPath: Path? = null
         val projects = hashMapOf<Path, ProjectInvalidationState>()
@@ -141,7 +142,7 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
             val invalidatedProjects = projects.filterValues { it.isInvalid }.mapValues {
                 it.value.toProjectInvalidationData()
             }
-            CheckedFingerprint.ProjectsInvalid(firstInvalidatedPath, invalidatedProjects)
+            CheckedFingerprint.ProjectsInvalid(candidateEntry.id, firstInvalidatedPath, invalidatedProjects)
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -26,8 +26,6 @@ import org.gradle.api.internal.provider.DefaultValueSourceProviderFactory
 import org.gradle.api.internal.provider.ValueSourceProviderFactory
 import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.cc.base.services.ConfigurationCacheEnvironmentChangeTracker
-import org.gradle.internal.cc.impl.CandidateEntry
-import org.gradle.internal.cc.impl.CheckedFingerprint
 import org.gradle.internal.cc.impl.ConfigurationCacheStateFile
 import org.gradle.internal.cc.impl.ConfigurationCacheStateStore.StateFile
 import org.gradle.internal.cc.impl.InputTrackingState
@@ -353,9 +351,9 @@ class ConfigurationCacheFingerprintController internal constructor(
             checkBuildScopedFingerprint()
         }
 
-    suspend fun ReadContext.checkProjectScopedFingerprint(host: Host, candidateEntry: CandidateEntry): CheckedFingerprint =
+    suspend fun ReadContext.checkProjectScopedFingerprint(host: Host) =
         ConfigurationCacheFingerprintChecker(CacheFingerprintCheckerHost(host)).run {
-            checkProjectScopedFingerprint(candidateEntry)
+            checkProjectScopedFingerprint()
         }
 
     suspend fun ReadContext.collectFingerprintForReusedProjects(host: Host, reusedProjects: Set<Path>): Unit =

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -349,7 +349,7 @@ class ConfigurationCacheFingerprintController internal constructor(
         writingState = writingState.dispose()
     }
 
-    suspend fun ReadContext.checkBuildScopedFingerprint(host: Host): CheckedFingerprint =
+    suspend fun ReadContext.checkBuildScopedFingerprint(host: Host) =
         ConfigurationCacheFingerprintChecker(CacheFingerprintCheckerHost(host)).run {
             checkBuildScopedFingerprint()
         }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -103,7 +103,6 @@ class ConfigurationCacheFingerprintController internal constructor(
 ) : Stoppable, ProjectScopedScriptResolution {
 
     interface Host {
-        val buildPath: Path
         val valueSourceProviderFactory: ValueSourceProviderFactory
         val gradleProperties: GradleProperties
     }
@@ -459,9 +458,6 @@ class ConfigurationCacheFingerprintController internal constructor(
 
         private
         val gradleProperties by lazy(host::gradleProperties)
-
-        override val buildPath: Path
-            get() = host.buildPath
 
         override val isEncrypted: Boolean
             get() = encryptionService.isEncrypting

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -26,6 +26,7 @@ import org.gradle.api.internal.provider.DefaultValueSourceProviderFactory
 import org.gradle.api.internal.provider.ValueSourceProviderFactory
 import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.cc.base.services.ConfigurationCacheEnvironmentChangeTracker
+import org.gradle.internal.cc.impl.CandidateEntry
 import org.gradle.internal.cc.impl.CheckedFingerprint
 import org.gradle.internal.cc.impl.ConfigurationCacheStateFile
 import org.gradle.internal.cc.impl.ConfigurationCacheStateStore.StateFile
@@ -353,9 +354,9 @@ class ConfigurationCacheFingerprintController internal constructor(
             checkBuildScopedFingerprint()
         }
 
-    suspend fun ReadContext.checkProjectScopedFingerprint(host: Host): CheckedFingerprint =
+    suspend fun ReadContext.checkProjectScopedFingerprint(host: Host, candidateEntry: CandidateEntry): CheckedFingerprint =
         ConfigurationCacheFingerprintChecker(CacheFingerprintCheckerHost(host)).run {
-            checkProjectScopedFingerprint()
+            checkProjectScopedFingerprint(candidateEntry)
         }
 
     suspend fun ReadContext.collectFingerprintForReusedProjects(host: Host, reusedProjects: Set<Path>): Unit =

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheStartParameter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheStartParameter.kt
@@ -197,4 +197,7 @@ class ConfigurationCacheStartParameter internal constructor(
      */
     val isIsolatedProjects: Boolean
         get() = modelParameters.isIsolatedProjects
+
+    val entriesPerKey: Int
+        get() = startParameter.configurationCacheEntriesPerKey
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/models/ProjectStateStore.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/models/ProjectStateStore.kt
@@ -78,10 +78,10 @@ abstract class ProjectStateStore<K, V>(
     fun collectAccessedValues(): Map<K, BlockAddress> =
         currentValues.mapValues { it.value.get() }
 
-    fun restoreFromCacheEntry(entryDetails: Map<K, BlockAddress>, checkedFingerprint: CheckedFingerprint.ProjectsInvalid) {
+    fun restoreFromCacheEntry(entryDetails: Map<K, BlockAddress>, invalidProjects: CheckedFingerprint.InvalidProjects) {
         for (entry in entryDetails) {
             val identityPath = projectPathForKey(entry.key)
-            if (identityPath == null || identityPath !in checkedFingerprint.invalidProjects) {
+            if (identityPath == null || identityPath !in invalidProjects.all) {
                 // Can reuse the value
                 previousValues[entry.key] = entry.value
             }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -27,7 +27,6 @@ import org.gradle.api.problems.internal.InternalProblems
 import org.gradle.api.problems.internal.PropertyTraceDataSpec
 import org.gradle.initialization.RootBuildLifecycleListener
 import org.gradle.internal.cc.impl.ConfigurationCacheAction
-import org.gradle.internal.cc.impl.ConfigurationCacheAction.LOAD
 import org.gradle.internal.cc.impl.ConfigurationCacheAction.STORE
 import org.gradle.internal.cc.impl.ConfigurationCacheAction.UPDATE
 import org.gradle.internal.cc.impl.ConfigurationCacheKey
@@ -113,7 +112,7 @@ class ConfigurationCacheProblems(
 
     val shouldDiscardEntry: Boolean
         get() {
-            if (cacheAction == LOAD) {
+            if (cacheAction is ConfigurationCacheAction.LOAD) {
                 return false
             }
             if (isFailingBuildDueToSerializationError) {
@@ -303,7 +302,7 @@ class ConfigurationCacheProblems(
     private
     fun ConfigurationCacheAction.summaryText() =
         when (this) {
-            LOAD -> "reusing"
+            is ConfigurationCacheAction.LOAD -> "reusing"
             STORE -> "storing"
             UPDATE -> "updating"
         }
@@ -340,8 +339,8 @@ class ConfigurationCacheProblems(
                 cacheAction == STORE -> log("Configuration cache entry stored with {}.", problemCountString)
                 cacheAction == UPDATE && !hasProblems -> log("Configuration cache entry updated for {}, {} up-to-date.", updatedProjectsString, reusedProjectsString)
                 cacheAction == UPDATE -> log("Configuration cache entry updated for {} with {}, {} up-to-date.", updatedProjectsString, problemCountString, reusedProjectsString)
-                cacheAction == LOAD && !hasProblems -> log("Configuration cache entry reused.")
-                cacheAction == LOAD -> log("Configuration cache entry reused with {}.", problemCountString)
+                cacheAction is ConfigurationCacheAction.LOAD && !hasProblems -> log("Configuration cache entry reused.")
+                cacheAction is ConfigurationCacheAction.LOAD -> log("Configuration cache entry reused with {}.", problemCountString)
                 hasTooManyProblems -> log("Too many configuration cache problems found ({}).", problemCountString)
                 hasProblems -> log("Configuration cache problems found ({}).", problemCountString)
                 // else not storing or loading and no problems to report

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -304,7 +304,7 @@ class ConfigurationCacheProblems(
         when (this) {
             is ConfigurationCacheAction.LOAD -> "reusing"
             STORE -> "storing"
-            UPDATE -> "updating"
+            is UPDATE -> "updating"
         }
 
     private
@@ -337,8 +337,8 @@ class ConfigurationCacheProblems(
                 cacheAction == STORE && hasTooManyProblems -> log("Configuration cache entry discarded with too many problems ({}).", problemCountString)
                 cacheAction == STORE && !hasProblems -> log("Configuration cache entry stored.")
                 cacheAction == STORE -> log("Configuration cache entry stored with {}.", problemCountString)
-                cacheAction == UPDATE && !hasProblems -> log("Configuration cache entry updated for {}, {} up-to-date.", updatedProjectsString, reusedProjectsString)
-                cacheAction == UPDATE -> log("Configuration cache entry updated for {} with {}, {} up-to-date.", updatedProjectsString, problemCountString, reusedProjectsString)
+                cacheAction is UPDATE && !hasProblems -> log("Configuration cache entry updated for {}, {} up-to-date.", updatedProjectsString, reusedProjectsString)
+                cacheAction is UPDATE -> log("Configuration cache entry updated for {} with {}, {} up-to-date.", updatedProjectsString, problemCountString, reusedProjectsString)
                 cacheAction is ConfigurationCacheAction.LOAD && !hasProblems -> log("Configuration cache entry reused.")
                 cacheAction is ConfigurationCacheAction.LOAD -> log("Configuration cache entry reused with {}.", problemCountString)
                 hasTooManyProblems -> log("Too many configuration cache problems found ({}).", problemCountString)

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
@@ -297,10 +297,7 @@ class ConfigurationCacheFingerprintCheckerTest {
                 checkBuildScopedFingerprint()
             }
         }
-        return when (checkedFingerprint) {
-            is BuildScopedFingerprintResult.Valid -> null
-            is BuildScopedFingerprintResult.Invalid -> checkedFingerprint.reason.toString()
-        }
+        return checkedFingerprint?.toString()
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
@@ -24,7 +24,6 @@ import org.gradle.api.logging.Logger
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.internal.Try
-import org.gradle.internal.cc.impl.CheckedFingerprint
 import org.gradle.internal.configuration.problems.PropertyProblem
 import org.gradle.internal.configuration.problems.PropertyTrace
 import org.gradle.internal.configuration.problems.StructuredMessageBuilder
@@ -306,9 +305,8 @@ class ConfigurationCacheFingerprintCheckerTest {
             }
         }
         return when (checkedFingerprint) {
-            is CheckedFingerprint.Valid -> null
-            is CheckedFingerprint.EntryInvalid -> checkedFingerprint.reason.toString()
-            else -> throw IllegalArgumentException()
+            is BuildScopedFingerprintResult.Valid -> null
+            is BuildScopedFingerprintResult.Invalid -> checkedFingerprint.reason.toString()
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
@@ -46,7 +46,6 @@ import org.gradle.internal.serialize.graph.WriteIdentities
 import org.gradle.internal.serialize.graph.WriteIsolate
 import org.gradle.internal.serialize.graph.runReadOperation
 import org.gradle.internal.serialize.graph.runWriteOperation
-import org.gradle.util.Path
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
@@ -167,7 +166,6 @@ class ConfigurationCacheFingerprintCheckerTest {
                 mock {
                     on { hashCodeAndTypeOf(scriptFile) } doReturn (TestHashCodes.hashCodeFrom(1) to FileType.RegularFile)
                     on { displayNameOf(scriptFile) } doReturn "displayNameOf(scriptFile)"
-                    on { buildPath } doReturn Path.ROOT
                 },
                 ConfigurationCacheFingerprint.InputFile(
                     scriptFile,
@@ -189,7 +187,6 @@ class ConfigurationCacheFingerprintCheckerTest {
                 mock {
                     on { hashCodeAndTypeOf(inputFile) } doReturn (missingFileHash to FileType.Missing)
                     on { displayNameOf(inputFile) } doReturn "displayNameOf(inputFile)"
-                    on { buildPath } doReturn Path.ROOT
                 },
                 ConfigurationCacheFingerprint.InputFile(
                     inputFile,
@@ -211,7 +208,6 @@ class ConfigurationCacheFingerprintCheckerTest {
                 mock {
                     on { hashCodeAndTypeOf(inputFile) } doReturn (newDirectoryHash to FileType.Directory)
                     on { displayNameOf(inputFile) } doReturn "displayNameOf(inputFile)"
-                    on { buildPath } doReturn Path.ROOT
                 },
                 ConfigurationCacheFingerprint.InputFile(
                     inputFile,
@@ -230,7 +226,6 @@ class ConfigurationCacheFingerprintCheckerTest {
                 mock {
                     on { hashCodeAndTypeOf(inputFile) } doReturn (TestHashCodes.hashCodeFrom(1) to FileType.Missing)
                     on { displayNameOf(inputFile) } doReturn "displayNameOf(inputFile)"
-                    on { buildPath } doReturn Path.ROOT
                 },
                 ConfigurationCacheFingerprint.InputFileSystemEntry(
                     inputFile,
@@ -258,7 +253,6 @@ class ConfigurationCacheFingerprintCheckerTest {
             checkFingerprintGiven(
                 mock {
                     on { instantiateValueSourceOf(obtainedValue) } doReturn describableValueSource
-                    on { buildPath } doReturn Path.ROOT
                 },
                 ConfigurationCacheFingerprint.ValueSource(obtainedValue)
             ),
@@ -280,7 +274,6 @@ class ConfigurationCacheFingerprintCheckerTest {
                 on { displayNameOf(any()) }.then { invocation ->
                     invocation.getArgument<File>(0).name
                 }
-                on { buildPath } doReturn Path.ROOT
             },
             ConfigurationCacheFingerprint.InitScripts(
                 from.map { (file, hash) -> ConfigurationCacheFingerprint.InputFile(file, hash) }

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/CredentialsProviderIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/CredentialsProviderIntegrationTest.groovy
@@ -290,7 +290,7 @@ class CredentialsProviderIntegrationTest extends AbstractIntegrationSpec {
         then:
         succeeds 'finalTask'
         def configurationCacheDirs = file('.gradle/configuration-cache/').listFiles().findAll { it.isDirectory() }
-        configurationCacheDirs.size() == 1
+        configurationCacheDirs.size() == 2
         def configurationCacheFiles = configurationCacheDirs[0].listFiles()
         configurationCacheFiles.each {
             def content = it.getText()

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/action/BuildActionSerializer.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/action/BuildActionSerializer.java
@@ -153,6 +153,7 @@ public class BuildActionSerializer {
             encoder.writeBoolean(startParameter.isConfigurationCacheRecreateCache());
             encoder.writeBoolean(startParameter.isConfigurationCacheParallel());
             encoder.writeBoolean(startParameter.isConfigurationCacheQuiet());
+            encoder.writeSmallInt(startParameter.getConfigurationCacheEntriesPerKey());
             encoder.writeBoolean(startParameter.isConfigureOnDemand());
             encoder.writeBoolean(startParameter.isContinuous());
             encoder.writeLong(startParameter.getContinuousBuildQuietPeriod().toMillis());
@@ -246,6 +247,7 @@ public class BuildActionSerializer {
             startParameter.setConfigurationCacheRecreateCache(decoder.readBoolean());
             startParameter.setConfigurationCacheParallel(decoder.readBoolean());
             startParameter.setConfigurationCacheQuiet(decoder.readBoolean());
+            startParameter.setConfigurationCacheEntriesPerKey(decoder.readSmallInt());
             startParameter.setConfigureOnDemand(decoder.readBoolean());
             startParameter.setContinuous(decoder.readBoolean());
             startParameter.setContinuousBuildQuietPeriod(Duration.ofMillis(decoder.readLong()));

--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -41,6 +41,7 @@ public class StartParameterInternal extends StartParameter {
     private boolean configurationCacheParallel;
     private boolean configurationCacheRecreateCache;
     private boolean configurationCacheQuiet;
+    private int configurationCacheEntriesPerKey = 1;
     private boolean searchUpwards = true;
     private boolean useEmptySettings = false;
     private Duration continuousBuildQuietPeriod = Duration.ofMillis(250);
@@ -78,6 +79,7 @@ public class StartParameterInternal extends StartParameter {
         p.configurationCacheParallel = configurationCacheParallel;
         p.configurationCacheRecreateCache = configurationCacheRecreateCache;
         p.configurationCacheQuiet = configurationCacheQuiet;
+        p.configurationCacheEntriesPerKey = configurationCacheEntriesPerKey;
         p.searchUpwards = searchUpwards;
         p.useEmptySettings = useEmptySettings;
         p.enableProblemReportGeneration = enableProblemReportGeneration;
@@ -189,6 +191,14 @@ public class StartParameterInternal extends StartParameter {
 
     public void setConfigurationCacheParallel(boolean parallel) {
         this.configurationCacheParallel = parallel;
+    }
+
+    public int getConfigurationCacheEntriesPerKey() {
+        return configurationCacheEntriesPerKey;
+    }
+
+    public void setConfigurationCacheEntriesPerKey(int configurationCacheEntriesPerKey) {
+        this.configurationCacheEntriesPerKey = configurationCacheEntriesPerKey;
     }
 
     public int getConfigurationCacheMaxProblems() {

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -77,6 +77,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         new ConfigurationCacheParallelOption(),
         new ConfigurationCacheRecreateOption(),
         new ConfigurationCacheQuietOption(),
+        new ConfigurationCacheEntriesPerKeyOption(),
         new IsolatedProjectsOption(),
         new ProblemReportGenerationOption(),
         new PropertyUpgradeReportOption()
@@ -585,7 +586,20 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         public void applyTo(boolean value, StartParameterInternal settings, Origin origin) {
             settings.setConfigurationCacheParallel(value);
         }
+    }
 
+    public static class ConfigurationCacheEntriesPerKeyOption extends IntegerBuildOption<StartParameterInternal> {
+
+        public static final String PROPERTY_NAME = "org.gradle.configuration-cache.entries-per-key";
+
+        public ConfigurationCacheEntriesPerKeyOption() {
+            super(PROPERTY_NAME);
+        }
+
+        @Override
+        public void applyTo(int value, StartParameterInternal settings, Origin origin) {
+            settings.setConfigurationCacheEntriesPerKey(value);
+        }
     }
 
     public static class ConfigurationCacheRecreateOption extends BooleanBuildOption<StartParameterInternal> {


### PR DESCRIPTION
By introducing the ability to keep multiple CC entries with their own discovered inputs (fingerprint) per CC key, controlled by the `org.gradle.configuration-cache.entries-per-key` build option.

This works by changing the layout of CC repository (i.e. `.gradle/configuration-cache`):

* the directory named after the CC key (representing the static inputs of the entry) will only hold a list of known CC entries for that key, in most recently used order;
* each CC entry will be stored in an uniquely named directory (named after `UUID.random()`), with its own fingerprint files (discovered inputs);

In order to load a CC entry, Gradle will read the list of known CC entries from the directory named after the CC key (a direct lookup) then search for a valid entry by checking the fingerprints of each known CC entry directory.

This PR introduces the build option but doesn't change the default of a single entry per CC key. That will happen in a subsequent PR. 

### Context
This was prototyped in a mob programming session within @gradle/bt-configuration 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
