### PR TITLE
Downgrade fastjson to 1.x

### DIFF
--- a/.teamcity/pom.xml
+++ b/.teamcity/pom.xml
@@ -6,7 +6,7 @@
         <mockk.version>1.13.13</mockk.version>
         <bytebuddy.version>1.15.7</bytebuddy.version>
         <junit.version>5.11.3</junit.version>
-        <fastjson.version>2.0.53</fastjson.version>
+        <fastjson.version>1.2.83</fastjson.version>
         <dslContextParameter.branch>master</dslContextParameter.branch>
     </properties>
     <groupId>Gradle_Check</groupId>


### PR DESCRIPTION
Because TeamCity has issue running with 2.x:

```
    Runtime error Gradle_Master: com.alibaba.fastjson2.util.JDKUtils[80]: com.alibaba.fastjson2.JSONException: init unsafe error
    StackTrace
      jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0 [-2]
      jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance [77]
      jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance [45]
      java.lang.reflect.Constructor.newInstanceWithCaller [499]
      java.lang.reflect.Constructor.newInstance [480]
      jetbrains.buildServer.configs.dsl.kotlin.KotlinRunner.lambda$runScript$4 [442]
      jetbrains.buildServer.configs.dsl.SecurityPolicyBasedContext.runSecure [87]
```
