### PR TITLE
Do not expose ResolverResults on ResolveContext

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ConfigurationResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ConfigurationResolver.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts;
 import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
+import org.gradle.internal.model.CalculatedValue;
 
 import java.util.List;
 
@@ -32,7 +33,7 @@ public interface ConfigurationResolver {
     /**
      * Traverses enough of the graph to calculate the build dependencies of the given configuration. All failures are packaged in the result.
      */
-    ResolverResults resolveBuildDependencies(ConfigurationInternal configuration);
+    ResolverResults resolveBuildDependencies(ConfigurationInternal configuration, CalculatedValue<ResolverResults> futureCompleteResults);
 
     /**
      * Traverses the full dependency graph of the given configuration. All failures are packaged in the result.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ConfigurationResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ConfigurationResolver.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts;
 import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
+import org.gradle.api.internal.artifacts.transform.DefaultTransformUpstreamDependenciesResolver;
 import org.gradle.internal.model.CalculatedValue;
 
 import java.util.List;
@@ -32,6 +33,10 @@ import java.util.List;
 public interface ConfigurationResolver {
     /**
      * Traverses enough of the graph to calculate the build dependencies of the given configuration. All failures are packaged in the result.
+     *
+     * @param configuration The resolve context to resolve.
+     * @param futureCompleteResults The future value of the output of {@link #resolveGraph(ConfigurationInternal)}. See
+     * {@link DefaultTransformUpstreamDependenciesResolver} for why this is needed.
      */
     ResolverResults resolveBuildDependencies(ConfigurationInternal configuration, CalculatedValue<ResolverResults> futureCompleteResults);
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolveContext.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolveContext.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.internal.artifacts.configurations.ResolutionHost;
-import org.gradle.api.internal.artifacts.configurations.ResolutionResultProvider;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.Conflict;
@@ -61,22 +60,6 @@ public interface ResolveContext {
      * called on a configuration that does not permit this usage.
      */
     RootComponentMetadataBuilder.RootComponentState toRootComponent();
-
-    /**
-     * Returns the cached results of resolution. Will throw
-     * an exception in some cases when called and the results are not available.
-     * <p>
-     * <strong>Avoid this method at all costs</strong>.
-     * <p>
-     * This class is meant to be the _input_ of resolution, however in order to support
-     * resolving dependencies of artifact transforms, we currently provide the results
-     * of resolution here as well.
-     * <p>
-     * This method represents a cycle in the resolution logic. In order to perform
-     * a resolution, we must also have a lazy reference to the results of the resolution.
-     * This is not how resolution should work at all, and we should aim to remove this.
-     */
-    ResolutionResultProvider<ResolverResults> getStrictResolverResults();
 
     /**
      * Returns the synthetic dependencies for this context. These dependencies are generated

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolveContext.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolveContext.java
@@ -63,7 +63,8 @@ public interface ResolveContext {
     RootComponentMetadataBuilder.RootComponentState toRootComponent();
 
     /**
-     * Returns the cached results of resolution.
+     * Returns the cached results of resolution. Will throw
+     * an exception in some cases when called and the results are not available.
      * <p>
      * <strong>Avoid this method at all costs</strong>.
      * <p>
@@ -74,14 +75,6 @@ public interface ResolveContext {
      * This method represents a cycle in the resolution logic. In order to perform
      * a resolution, we must also have a lazy reference to the results of the resolution.
      * This is not how resolution should work at all, and we should aim to remove this.
-     */
-    ResolutionResultProvider<ResolverResults> getResolverResults();
-
-    /**
-     * Same as {@link #getResolverResults()} but is stricter in that it will throw
-     * an exception in some cases when called and the results are not available.
-     * <p>
-     * <strong>Avoid this method at all costs</strong>.
      */
     ResolutionResultProvider<ResolverResults> getStrictResolverResults();
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultArtifactCollection.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultArtifactCollection.java
@@ -43,7 +43,7 @@ public class DefaultArtifactCollection implements ArtifactCollectionInternal {
         this.lenient = lenient;
         this.result = calculatedValueFactory.create(resolutionHost.displayName("files"), () -> {
             ResolvedArtifactCollectingVisitor visitor = new ResolvedArtifactCollectingVisitor();
-            fileCollection.getSelectedArtifacts().visitArtifacts(visitor, lenient);
+            fileCollection.getArtifacts().visitArtifacts(visitor, lenient);
 
             Set<ResolvedArtifactResult> artifactResults = visitor.getArtifacts();
             Set<Throwable> failures = visitor.getFailures();
@@ -96,7 +96,7 @@ public class DefaultArtifactCollection implements ArtifactCollectionInternal {
     @Override
     public void visitArtifacts(ArtifactVisitor visitor) {
         // TODO - if already resolved, use the results
-        fileCollection.getSelectedArtifacts().visitArtifacts(visitor, lenient);
+        fileCollection.getArtifacts().visitArtifacts(visitor, lenient);
     }
 
     private void ensureResolved() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -932,11 +932,6 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     }
 
     @Override
-    public ResolutionResultProvider<ResolverResults> getResolverResults() {
-        return new ResolverResultsResolutionResultProvider(false);
-    }
-
-    @Override
     public ResolutionResultProvider<ResolverResults> getStrictResolverResults() {
         return new ResolverResultsResolutionResultProvider(true);
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -112,6 +112,7 @@ import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.model.CalculatedModelValue;
+import org.gradle.internal.model.CalculatedValue;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
@@ -686,7 +687,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
         @Override
         public ResolutionResultProvider<ResolverResults> getResults() {
-            return new ResolverResultsResolutionResultProvider(false);
+            return new ResolverResultsResolutionResultProvider();
         }
 
         @Override
@@ -706,23 +707,8 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
      */
     private class ResolverResultsResolutionResultProvider implements ResolutionResultProvider<ResolverResults> {
 
-        private final boolean strict;
-
-        /**
-         * @param strict Whether to fail if the configuration has not yet been resolved when the provider is queried.
-         */
-        public ResolverResultsResolutionResultProvider(boolean strict) {
-            this.strict = strict;
-        }
-
         @Override
         public ResolverResults getTaskDependencyValue() {
-            if (strict) {
-                return currentResolveState.get().orElseThrow(() ->
-                    new IllegalStateException("Cannot query results until resolution has happened.")
-                );
-            }
-
             if (getResolutionStrategy().resolveGraphToDetermineTaskDependencies()) {
                 // Force graph resolution as this is required to calculate build dependencies
                 return getValue();
@@ -733,18 +719,9 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
         @Override
         public ResolverResults getValue() {
-            if (strict) {
-                Optional<ResolverResults> currentState = currentResolveState.get();
-                if (!isFullyResoled(currentState)) {
-                    // Do not validate that the current thread holds the project lock.
-                    // TODO: Should instead assert that the results are available and fail if not.
-                    return resolveExclusivelyIfRequired();
-                }
-                return currentState.get();
-            }
-
             return resolveGraphIfRequired();
         }
+
     }
 
     private ResolverResults resolveGraphIfRequired() {
@@ -932,11 +909,6 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     }
 
     @Override
-    public ResolutionResultProvider<ResolverResults> getStrictResolverResults() {
-        return new ResolverResultsResolutionResultProvider(true);
-    }
-
-    @Override
     public <T> T callAndResetResolutionState(Factory<T> factory) {
         warnOnInvalidInternalAPIUsage("callAndResetResolutionState()", ProperMethodUsage.RESOLVABLE);
         try {
@@ -960,8 +932,19 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         assertIsResolvable();
         return currentResolveState.update(initial -> {
             if (!initial.isPresent()) {
+
+                CalculatedValue<ResolverResults> futureCompleteResults = calculatedValueContainerFactory.create(Describables.of("Full results for", getName()), context -> {
+                    Optional<ResolverResults> currentState = currentResolveState.get();
+                    if (!isFullyResoled(currentState)) {
+                        // Do not validate that the current thread holds the project lock.
+                        // TODO: Should instead assert that the results are available and fail if not.
+                        return resolveExclusivelyIfRequired();
+                    }
+                    return currentState.get();
+                });
+
                 try {
-                    return Optional.of(resolver.resolveBuildDependencies(this));
+                    return Optional.of(resolver.resolveBuildDependencies(this, futureCompleteResults));
                 } catch (Exception e) {
                     throw exceptionMapper.mapFailure(e, "dependencies", displayName.getDisplayName());
                 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -619,8 +619,10 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
             .nagUser();
 
         return new ResolutionBackedFileCollection(
-            resolutionAccess.getResults().map(resolverResults ->
-                resolverResults.getLegacyResults().getLegacyVisitedArtifactSet().select(dependencySpec)
+            new ResolutionResultProviderBackedSelectedArtifactSet(
+                resolutionAccess.getResults().map(resolverResults ->
+                    resolverResults.getLegacyResults().getLegacyVisitedArtifactSet().select(dependencySpec)
+                )
             ),
             false,
             getResolutionHost(),

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionBackedFileCollection.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionBackedFileCollection.java
@@ -27,19 +27,19 @@ import org.gradle.internal.component.resolution.failure.exception.ArtifactSelect
 import org.gradle.internal.logging.text.TreeFormatter;
 
 public class ResolutionBackedFileCollection extends AbstractFileCollection {
-    private final ResolutionResultProvider<SelectedArtifactSet> resultProvider;
+
+    private final SelectedArtifactSet artifacts;
     private final boolean lenient;
     private final ResolutionHost resolutionHost;
-    private SelectedArtifactSet selectedArtifacts;
 
     public ResolutionBackedFileCollection(
-        ResolutionResultProvider<SelectedArtifactSet> resultProvider,
+        SelectedArtifactSet artifacts,
         boolean lenient,
         ResolutionHost resolutionHost,
         TaskDependencyFactory taskDependencyFactory
     ) {
         super(taskDependencyFactory);
-        this.resultProvider = resultProvider;
+        this.artifacts = artifacts;
         this.lenient = lenient;
         this.resolutionHost = resolutionHost;
     }
@@ -54,9 +54,8 @@ public class ResolutionBackedFileCollection extends AbstractFileCollection {
 
     @Override
     public void visitDependencies(TaskDependencyResolveContext context) {
-        SelectedArtifactSet selected = resultProvider.getTaskDependencyValue();
         FailureCollectingTaskDependencyResolveContext collectingContext = new FailureCollectingTaskDependencyResolveContext(context);
-        selected.visitDependencies(collectingContext);
+        artifacts.visitDependencies(collectingContext);
         if (!lenient) {
             resolutionHost.consolidateFailures("dependencies", collectingContext.getFailures()).ifPresent(consolidatedFailure -> {
                 resolutionHost.reportProblems(consolidatedFailure);
@@ -73,7 +72,7 @@ public class ResolutionBackedFileCollection extends AbstractFileCollection {
     @Override
     protected void visitContents(FileCollectionStructureVisitor visitor) {
         ResolvedFileCollectionVisitor collectingVisitor = new ResolvedFileCollectionVisitor(visitor);
-        getSelectedArtifacts().visitFiles(collectingVisitor, lenient);
+        artifacts.visitFiles(collectingVisitor, lenient);
         maybeThrowResolutionFailures(collectingVisitor);
     }
 
@@ -93,10 +92,7 @@ public class ResolutionBackedFileCollection extends AbstractFileCollection {
         formatter.node("contains: " + getDisplayName());
     }
 
-    SelectedArtifactSet getSelectedArtifacts() {
-        if (selectedArtifacts == null) {
-            selectedArtifacts = resultProvider.getValue();
-        }
-        return selectedArtifacts;
+    SelectedArtifactSet getArtifacts() {
+        return artifacts;
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionResultProviderBackedSelectedArtifactSet.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionResultProviderBackedSelectedArtifactSet.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.configurations;
+
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.SelectedArtifactSet;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+
+/**
+ * A {@link SelectedArtifactSet} that is backed by a {@link ResolutionResultProvider}.
+ * <p>
+ * This is used as a source for constructing {@link ResolutionBackedFileCollection}
+ * instances derived from resolving a {@link Configuration}.
+ */
+public class ResolutionResultProviderBackedSelectedArtifactSet implements SelectedArtifactSet {
+
+    private final ResolutionResultProvider<SelectedArtifactSet> artifacts;
+
+    private SelectedArtifactSet delegate;
+
+    public ResolutionResultProviderBackedSelectedArtifactSet(
+        ResolutionResultProvider<SelectedArtifactSet> artifacts
+    ) {
+        this.artifacts = artifacts;
+    }
+
+    @Override
+    public void visitDependencies(TaskDependencyResolveContext context) {
+        artifacts.getTaskDependencyValue().visitDependencies(context);
+    }
+
+    @Override
+    public void visitArtifacts(ArtifactVisitor visitor, boolean continueOnSelectionFailure) {
+        if (delegate == null) {
+            delegate = artifacts.getValue();
+        }
+        delegate.visitArtifacts(visitor, continueOnSelectionFailure);
+    }
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -37,6 +37,7 @@ import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveState;
 import org.gradle.internal.component.local.model.LocalVariantGraphResolveState;
 import org.gradle.internal.deprecation.DeprecationLogger;
+import org.gradle.internal.model.CalculatedValue;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -65,7 +66,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
     }
 
     @Override
-    public ResolverResults resolveBuildDependencies(ConfigurationInternal configuration) {
+    public ResolverResults resolveBuildDependencies(ConfigurationInternal configuration, CalculatedValue<ResolverResults> futureCompleteResults) {
         RootComponentMetadataBuilder.RootComponentState rootComponent = configuration.toRootComponent();
 
         VisitedGraphResults missingConfigurationResults =
@@ -76,7 +77,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
             );
         }
 
-        return resolutionExecutor.resolveBuildDependencies(configuration);
+        return resolutionExecutor.resolveBuildDependencies(configuration, futureCompleteResults);
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolutionExecutor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolutionExecutor.java
@@ -100,12 +100,12 @@ import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.cache.internal.BinaryStore;
 import org.gradle.cache.internal.Store;
-import org.gradle.internal.Describables;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.GraphVariantSelector;
 import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
 import org.gradle.internal.locking.DependencyLockingGraphVisitor;
+import org.gradle.internal.model.CalculatedValue;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.operations.dependencies.configurations.ConfigurationIdentity;
@@ -239,7 +239,7 @@ public class ResolutionExecutor {
      *
      * @return An immutable result set, containing a subset of the graph that is sufficient to calculate the build dependencies.
      */
-    public ResolverResults resolveBuildDependencies(ResolveContext resolveContext) {
+    public ResolverResults resolveBuildDependencies(ResolveContext resolveContext, CalculatedValue<ResolverResults> futureCompleteResults) {
 
         ResolutionHost resolutionHost = resolveContext.getResolutionHost();
         RootComponentMetadataBuilder.RootComponentState rootComponent = resolveContext.toRootComponent();
@@ -272,7 +272,7 @@ public class ResolutionExecutor {
             defaultSortOrder,
             graphResults,
             visitedArtifacts,
-            calculatedValueContainerFactory.create(Describables.of("Full results for", resolutionHost.getDisplayName()), context -> resolveContext.getStrictResolverResults().getValue()),
+            futureCompleteResults,
             domainObjectContext,
             calculatedValueContainerFactory,
             attributesFactory,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolutionExecutor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolutionExecutor.java
@@ -436,7 +436,6 @@ public class ResolutionExecutor {
             requestAttributes,
             defaultSortOrder,
             resolveContext.getStrictResolverResults(),
-            resolveContext.getResolverResults(),
             domainObjectContext,
             calculatedValueContainerFactory,
             attributesFactory,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolutionExecutor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolutionExecutor.java
@@ -236,6 +236,8 @@ public class ResolutionExecutor {
      * Traverses enough of the graph to calculate the build dependencies of the graph.
      *
      * @param resolveContext Describes what and how to resolve
+     * @param futureCompleteResults The future value of the output of {@link #resolveGraph(ResolveContext, List)}. See
+     * {@link DefaultTransformUpstreamDependenciesResolver} for why this is needed.
      *
      * @return An immutable result set, containing a subset of the graph that is sufficient to calculate the build dependencies.
      */

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitingResolutionExecutor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitingResolutionExecutor.java
@@ -52,6 +52,7 @@ import org.gradle.internal.component.local.model.LocalVariantGraphResolveState;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.VariantGraphResolveState;
 import org.gradle.internal.deprecation.DeprecationLogger;
+import org.gradle.internal.model.CalculatedValue;
 
 import java.io.File;
 import java.util.Collections;
@@ -73,12 +74,12 @@ public class ShortCircuitingResolutionExecutor {
         this.attributeDesugaring = attributeDesugaring;
     }
 
-    public ResolverResults resolveBuildDependencies(ResolveContext resolveContext) {
+    public ResolverResults resolveBuildDependencies(ResolveContext resolveContext, CalculatedValue<ResolverResults> futureCompleteResults) {
         RootComponentMetadataBuilder.RootComponentState rootComponent = resolveContext.toRootComponent();
         LocalVariantGraphResolveState rootVariant = rootComponent.getRootVariant();
 
         if (hasDependencies(rootVariant)) {
-            return delegate.resolveBuildDependencies(resolveContext);
+            return delegate.resolveBuildDependencies(resolveContext, futureCompleteResults);
         }
 
         VisitedGraphResults graphResults = emptyGraphResults(rootComponent.getRootComponent(), rootVariant);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactSetToFileCollectionFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactSetToFileCollectionFactory.java
@@ -23,7 +23,6 @@ import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.configurations.ResolutionBackedFileCollection;
 import org.gradle.api.internal.artifacts.configurations.ResolutionHost;
-import org.gradle.api.internal.artifacts.configurations.ResolutionResultProvider;
 import org.gradle.api.internal.artifacts.ivyservice.TypedResolveException;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionStructureVisitor;
@@ -70,7 +69,7 @@ public class ArtifactSetToFileCollectionFactory {
      * Over time, this should be merged with the FileCollection implementation in DefaultConfiguration
      */
     public ResolutionBackedFileCollection asFileCollection(String displayName, boolean lenient, List<?> elements) {
-        return new ResolutionBackedFileCollection(new PartialSelectedArtifactProvider(elements), lenient, new NameBackedResolutionHost(problemsService, displayName), taskDependencyFactory);
+        return new ResolutionBackedFileCollection(new PartialSelectedArtifactSet(elements, buildOperationExecutor), lenient, new NameBackedResolutionHost(problemsService, displayName), taskDependencyFactory);
     }
 
     public ResolvedArtifactSet asResolvedArtifactSet(Throwable failure) {
@@ -280,25 +279,6 @@ public class ArtifactSetToFileCollectionFactory {
         @Override
         public void visitDependencies(TaskDependencyResolveContext context) {
             // No dependencies
-        }
-    }
-
-    // "partial" in the sense that some artifacts are only available as a File, and have no metadata
-    private class PartialSelectedArtifactProvider implements ResolutionResultProvider<SelectedArtifactSet> {
-        private final List<?> elements;
-
-        public PartialSelectedArtifactProvider(List<?> elements) {
-            this.elements = elements;
-        }
-
-        @Override
-        public SelectedArtifactSet getTaskDependencyValue() {
-            return getValue();
-        }
-
-        @Override
-        public SelectedArtifactSet getValue() {
-            return new PartialSelectedArtifactSet(elements, buildOperationExecutor);
         }
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultVisitedArtifactSet.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultVisitedArtifactSet.java
@@ -34,6 +34,11 @@ import org.gradle.internal.resolve.resolver.DefaultVariantArtifactResolver;
 
 /**
  * Selects artifacts from all visited artifacts in a graph.
+ * <p>
+ * There is an unfortunate object cycle between a {@link VisitedArtifactSet}
+ * and a {@link TransformUpstreamDependenciesResolver}. The artifact set needs
+ * to resolve transform dependencies, and the transform dependencies resolver
+ * needs to resolve artifacts. Hopefully one day we can clean up this cycle.
  */
 public class DefaultVisitedArtifactSet implements VisitedArtifactSet {
     private final VisitedGraphResults graphResults;
@@ -49,7 +54,7 @@ public class DefaultVisitedArtifactSet implements VisitedArtifactSet {
         VisitedArtifactResults artifactsResults,
         ResolvedArtifactSetResolver artifactSetResolver,
         TransformedVariantFactory transformedVariantFactory,
-        TransformUpstreamDependenciesResolver dependenciesResolver,
+        TransformUpstreamDependenciesResolver.Factory transformUpstreamDependenciesResolverFactory,
         ImmutableAttributesSchema consumerSchema,
         ConsumerProvidedVariantFinder consumerProvidedVariantFinder,
         AttributesFactory attributesFactory,
@@ -76,7 +81,7 @@ public class DefaultVisitedArtifactSet implements VisitedArtifactSet {
         this.consumerServices = new ArtifactSelectionServices(
             artifactVariantSelector,
             transformedVariantFactory,
-            dependenciesResolver,
+            transformUpstreamDependenciesResolverFactory.create(this), // Yuck
             new DefaultVariantArtifactResolver(artifactResolver, artifactTypeRegistry, resolvedVariantCache),
             graphVariantSelector,
             consumerSchema

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/resolver/DefaultResolutionOutputs.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/resolver/DefaultResolutionOutputs.java
@@ -28,6 +28,7 @@ import org.gradle.api.internal.artifacts.configurations.ArtifactCollectionIntern
 import org.gradle.api.internal.artifacts.configurations.DefaultArtifactCollection;
 import org.gradle.api.internal.artifacts.configurations.ResolutionBackedFileCollection;
 import org.gradle.api.internal.artifacts.configurations.ResolutionResultProvider;
+import org.gradle.api.internal.artifacts.configurations.ResolutionResultProviderBackedSelectedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSelectionSpec;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.SelectedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults;
@@ -193,7 +194,9 @@ public class DefaultResolutionOutputs implements ResolutionOutputsInternal {
         @Override
         public ResolutionBackedFileCollection getFiles() {
             return new ResolutionBackedFileCollection(
-                resolutionAccess.getResults().map(this::selectArtifacts),
+                new ResolutionResultProviderBackedSelectedArtifactSet(
+                    resolutionAccess.getResults().map(this::selectArtifacts)
+                ),
                 lenient,
                 resolutionAccess.getHost(),
                 taskDependencyFactory

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformUpstreamDependenciesResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformUpstreamDependenciesResolver.java
@@ -143,6 +143,7 @@ public class DefaultTransformUpstreamDependenciesResolver implements TransformUp
 
             @Override
             public VisitedGraphResults getValue() {
+                // TODO: We should acquire the project lock here, since this will resolve a configuration, which requires a project lock.
                 fullGraphResults.finalizeIfNotAlready();
                 return fullGraphResults.get().getVisitedGraph();
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformUpstreamDependenciesResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformUpstreamDependenciesResolver.java
@@ -29,6 +29,7 @@ import org.gradle.api.internal.artifacts.ResolverResults;
 import org.gradle.api.internal.artifacts.configurations.ResolutionBackedFileCollection;
 import org.gradle.api.internal.artifacts.configurations.ResolutionHost;
 import org.gradle.api.internal.artifacts.configurations.ResolutionResultProvider;
+import org.gradle.api.internal.artifacts.configurations.ResolutionResultProviderBackedSelectedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSelectionSpec;
 import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -164,10 +165,12 @@ public class DefaultTransformUpstreamDependenciesResolver implements TransformUp
 
         ImmutableAttributes fullAttributes = attributesFactory.concat(requestAttributes, fromAttributes);
         return new ResolutionBackedFileCollection(
-            resolverResults.map(results ->
-                results.getVisitedArtifacts().select(new ArtifactSelectionSpec(
-                    fullAttributes, filter, false, false, artifactDependencySortOrder
-                ))
+            new ResolutionResultProviderBackedSelectedArtifactSet(
+                resolverResults.map(results ->
+                    results.getVisitedArtifacts().select(new ArtifactSelectionSpec(
+                        fullAttributes, filter, false, false, artifactDependencySortOrder
+                    ))
+                )
             ),
             false,
             resolutionHost,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformUpstreamDependenciesResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformUpstreamDependenciesResolver.java
@@ -114,6 +114,16 @@ public class DefaultTransformUpstreamDependenciesResolver implements TransformUp
     private final AttributesFactory attributesFactory;
     private final TaskDependencyFactory taskDependencyFactory;
 
+    /**
+     * Construct a resolver used to resolve build dependencies of upstream dependencies for an artifact transform.
+     * <p>
+     * The {@code fullGraphResults} are required to calculate the true build dependencies of transforms
+     * with dependencies, as the incomplete graph used to initially determine upstream transforms does
+     * not represent the final dependency graph.
+     * <p>
+     * See {@link org.gradle.integtests.resolve.transform.ArtifactTransformWithDependenciesParallelIntegrationTest}
+     * for the test that exercises the scenario that necessitates this behavior.
+     */
     public DefaultTransformUpstreamDependenciesResolver(
         ResolutionHost resolutionHost,
         @Nullable ConfigurationIdentity configurationIdentity,
@@ -154,6 +164,9 @@ public class DefaultTransformUpstreamDependenciesResolver implements TransformUp
         this.taskDependencyFactory = taskDependencyFactory;
     }
 
+    /**
+     * Construct a resolver used to resolve the complete set of upstream dependencies for an artifact transform.
+     */
     public DefaultTransformUpstreamDependenciesResolver(
         ResolutionHost resolutionHost,
         @Nullable ConfigurationIdentity configurationIdentity,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformUpstreamDependenciesResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformUpstreamDependenciesResolver.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.transform;
 
 import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactSet;
 
 /**
  * Companion type to {@link TransformStepNode} that knows how to compute extra dependent nodes
@@ -34,4 +35,15 @@ public interface TransformUpstreamDependenciesResolver {
      * sourced from a component with the given identifier.
      */
     TransformUpstreamDependencies dependenciesFor(ComponentIdentifier componentId, TransformStep transformStep);
+
+    interface Factory {
+
+        /**
+         * Create a new instance of the resolver.
+         *
+         * @param visitedArtifacts The artifact set is used to resolve the dependencies of the transform steps.
+         */
+        TransformUpstreamDependenciesResolver create(VisitedArtifactSet visitedArtifacts);
+
+    }
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -540,7 +540,7 @@ class DefaultConfigurationSpec extends Specification {
         _ * artifactTaskDependencies.getDependencies(_) >> requiredTasks
 
         and:
-        _ * resolver.resolveBuildDependencies(_) >> DefaultResolverResults.buildDependenciesResolved(Stub(VisitedGraphResults), visitedArtifactSet, Mock(ResolverResults.LegacyResolverResults))
+        _ * resolver.resolveBuildDependencies(_, _) >> DefaultResolverResults.buildDependenciesResolved(Stub(VisitedGraphResults), visitedArtifactSet, Mock(ResolverResults.LegacyResolverResults))
 
         expect:
         configuration.buildDependencies.getDependencies(targetTask) == requiredTasks
@@ -1123,7 +1123,7 @@ class DefaultConfigurationSpec extends Specification {
 
         then:
         config.state == UNRESOLVED
-        1 * resolver.resolveBuildDependencies(config) >> buildDependenciesResolved()
+        1 * resolver.resolveBuildDependencies(config, _) >> buildDependenciesResolved()
         0 * resolver._
     }
 
@@ -1162,7 +1162,7 @@ class DefaultConfigurationSpec extends Specification {
 
         then:
         config.state == UNRESOLVED
-        1 * resolver.resolveBuildDependencies(config) >> buildDependenciesResolved()
+        1 * resolver.resolveBuildDependencies(config, _) >> buildDependenciesResolved()
         0 * resolver._
 
         when:

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -50,7 +50,8 @@ import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParserFactor
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider
 import org.gradle.api.internal.artifacts.ivyservice.TypedResolveException
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedFileVisitor
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.SelectedArtifactSet
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactSet
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.DefaultVisitedGraphResults
@@ -69,9 +70,11 @@ import org.gradle.api.problems.internal.DefaultProblems
 import org.gradle.api.problems.internal.ProblemSummarizer
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskDependency
+import org.gradle.internal.Describables
 import org.gradle.internal.Factories
 import org.gradle.internal.code.UserCodeApplicationContext
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.internal.component.external.model.ImmutableCapabilities
 import org.gradle.internal.component.model.DependencyMetadata
 import org.gradle.internal.dispatch.Dispatch
 import org.gradle.internal.event.AnonymousListenerBroadcast
@@ -1761,21 +1764,37 @@ class DefaultConfigurationSpec extends Specification {
     }
 
     private SelectedArtifactSet selectedArtifacts(Set<File> files = []) {
-        Stub(SelectedArtifactSet) {
-            visitFiles(_, _) >> { ResolvedFileVisitor visitor, boolean l ->
-                files.each {
-                    visitor.visitFile(it)
+        return new SelectedArtifactSet() {
+            @Override
+            void visitArtifacts(ArtifactVisitor visitor, boolean continueOnSelectionFailure) {
+                files.each { file ->
+                    visitor.visitArtifact(Describables.of(file.getName()), ImmutableAttributes.EMPTY, ImmutableCapabilities.EMPTY, resolvableArtifact(file))
                 }
                 visitor.endVisitCollection(null)
             }
+
+            @Override
+            void visitDependencies(TaskDependencyResolveContext context) { }
         }
     }
 
-    private SelectedArtifactSet selectedArtifacts(Throwable failure) {
-        Stub(SelectedArtifactSet) {
-            visitDependencies(_) >> { it[0].visitFailure(failure) }
-            visitFiles(_, _) >> { ResolvedFileVisitor v, boolean l ->
-                v.visitFailure(failure)
+    private ResolvableArtifact resolvableArtifact(file) {
+        Mock(ResolvableArtifact) {
+            getFile() >> file
+        }
+    }
+
+    private static SelectedArtifactSet selectedArtifacts(Throwable failure) {
+        return new SelectedArtifactSet() {
+            @Override
+            void visitArtifacts(ArtifactVisitor visitor, boolean continueOnSelectionFailure) {
+                visitor.visitFailure(failure)
+                visitor.endVisitCollection(null)
+            }
+
+            @Override
+            void visitDependencies(TaskDependencyResolveContext context) {
+                context.visitFailure(failure)
             }
         }
     }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitingResolutionExecutorSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitingResolutionExecutorSpec.groovy
@@ -32,6 +32,7 @@ import org.gradle.api.specs.Specs
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.local.model.LocalVariantGraphResolveState
 import org.gradle.internal.component.model.DependencyMetadata
+import org.gradle.internal.model.CalculatedValue
 import org.gradle.util.AttributeTestUtil
 import spock.lang.Specification
 
@@ -49,7 +50,7 @@ class ShortCircuitingResolutionExecutorSpec extends Specification {
         ResolveContext resolveContext = confWithoutDependencies()
 
         when:
-        def results = dependencyResolver.resolveBuildDependencies(resolveContext)
+        def results = dependencyResolver.resolveBuildDependencies(resolveContext, Stub(CalculatedValue))
 
         then:
         def visitedArtifacts = results.visitedArtifacts
@@ -116,7 +117,7 @@ class ShortCircuitingResolutionExecutorSpec extends Specification {
         resolveContext.resolutionStrategy >> resolutionStrategy
 
         when:
-        dependencyResolver.resolveBuildDependencies(resolveContext)
+        dependencyResolver.resolveBuildDependencies(resolveContext, Stub(CalculatedValue))
 
         then:
 
@@ -176,10 +177,10 @@ class ShortCircuitingResolutionExecutorSpec extends Specification {
         ResolveContext resolveContext = confWithDependencies()
 
         when:
-        def results = dependencyResolver.resolveBuildDependencies(resolveContext)
+        def results = dependencyResolver.resolveBuildDependencies(resolveContext, Stub(CalculatedValue))
 
         then:
-        1 * delegate.resolveBuildDependencies(resolveContext) >> delegateResults
+        1 * delegate.resolveBuildDependencies(resolveContext, _) >> delegateResults
         results == delegateResults
     }
 


### PR DESCRIPTION
A `ResolveContext` represents the inputs of dependency resolution. It contains all settings and dependencies needed to perform resolution. However, due to the way artifact transform dependency resolution was wired previously, it also needed to capture a lazy memoized _result_ of resolution. 

This PR reworks the wiring of transform dependencies to avoid needing to expose the results of resolution on the inputs of resolution. The core goal of this PR was to delete `getResolverResults` and `getStrictResolverResults` from `ResolveContext`.

Getting there was quite challenging, as these two methods as part of a logic/object cycle where `DefaultTransformUpstreamDependenciesResolver` accepted in its constructor a memoized future value that would contain _itself_. Much of the changes to this PR are as a result of handling and simplifying this cycle. 

A smaller, more contained cycle remains, now located in `DefaultVisitedArtifactSet`.

In all, this PR is able to remove a cycle that prevents us from continuing work replacing resolvable configurations. This should be one of the last remaining blockers to seriously considering introducing a replacement for resolvable configurations.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
