### PR TITLE
Uptate the documentation to use lazy API a bit more

### DIFF
--- a/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-attributeSubstitutionRule/groovy/consumer/build.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-attributeSubstitutionRule/groovy/consumer/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 // end::dependencies[]
 
 // tag::substitution_rule[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.dependencySubstitution {
         substitute(platform(module('com.google.guava:guava:28.2-jre'))).
             using module('com.google.guava:guava:28.2-jre')
@@ -18,7 +18,7 @@ configurations.all {
 // end::substitution_rule[]
 
 // tag::substitution_rule_alternative[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.dependencySubstitution {
         substitute variant(module('com.google.guava:guava:28.2-jre')) {
             attributes {

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-attributeSubstitutionRule/kotlin/consumer/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-attributeSubstitutionRule/kotlin/consumer/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
 // end::dependencies[]
 
 // tag::substitution_rule[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.dependencySubstitution {
         substitute(platform(module("com.google.guava:guava:28.2-jre")))
             .using(module("com.google.guava:guava:28.2-jre"))
@@ -18,7 +18,7 @@ configurations.all {
 // end::substitution_rule[]
 
 // tag::substitution_rule_alternative[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.dependencySubstitution {
         substitute(variant(module("com.google.guava:guava:28.2-jre")) {
             attributes {

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-classifierSubstitutionRule/groovy/consumer/build.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-classifierSubstitutionRule/groovy/consumer/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 // end::dependencies[]
 
 // tag::substitution_rule[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.dependencySubstitution {
         substitute module('co.paralleluniverse:quasar-core') using module('co.paralleluniverse:quasar-core:0.8.0') withoutClassifier()
     }

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-classifierSubstitutionRule/kotlin/consumer/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-classifierSubstitutionRule/kotlin/consumer/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
 // end::dependencies[]
 
 // tag::substitution_rule[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.dependencySubstitution {
         substitute(module("co.paralleluniverse:quasar-core"))
             .using(module("co.paralleluniverse:quasar-core:0.8.0"))

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-conditionalSubstitutionRule/groovy/consumer/build.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-conditionalSubstitutionRule/groovy/consumer/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 // tag::project_substitution[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.dependencySubstitution.all { DependencySubstitution dependency ->
         if (dependency.requested instanceof ModuleComponentSelector && dependency.requested.group == "org.example") {
             def targetProject = findProject(":${dependency.requested.module}")

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-conditionalSubstitutionRule/kotlin/consumer/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-conditionalSubstitutionRule/kotlin/consumer/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 // tag::project_substitution[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.dependencySubstitution.all {
         requested.let {
             if (it is ModuleComponentSelector && it.group == "org.example") {

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-resolutionStrategy/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-resolutionStrategy/groovy/build.gradle
@@ -1,5 +1,5 @@
 // tag::resolve-rules[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy {
         eachDependency {
             if (requested.group == "com.example" && requested.name == "old-library") {
@@ -12,7 +12,7 @@ configurations.all {
 // end::resolve-rules[]
 
 // tag::custom-versioning-scheme[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.eachDependency { DependencyResolveDetails details ->
         if (details.requested.version == 'default') {
             def version = findDefaultVersionInCatalog(details.requested.group, details.requested.name)
@@ -29,7 +29,7 @@ def findDefaultVersionInCatalog(String group, String name) {
 // end::custom-versioning-scheme[]
 
 // tag::denying_version[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.eachDependency { DependencyResolveDetails details ->
         if (details.requested.group == 'org.software' && details.requested.name == 'some-library' && details.requested.version == '1.2') {
             details.useVersion '1.2.1'
@@ -40,7 +40,7 @@ configurations.all {
 // end::denying_version[]
 
 // tag::module_substitution[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.eachDependency { DependencyResolveDetails details ->
         if (details.requested.name == 'groovy-all') {
             details.useTarget group: details.requested.group, name: 'groovy', version: details.requested.version

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-resolutionStrategy/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-resolutionStrategy/kotlin/build.gradle.kts
@@ -1,5 +1,5 @@
 // tag::resolve-rules[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy {
         eachDependency {
             if (requested.group == "com.example" && requested.name == "old-library") {
@@ -12,7 +12,7 @@ configurations.all {
 // end::resolve-rules[]
 
 // tag::custom-versioning-scheme[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.eachDependency {
         if (requested.version == "default") {
             val version = findDefaultVersionInCatalog(requested.group, requested.name)
@@ -31,7 +31,7 @@ fun findDefaultVersionInCatalog(group: String, name: String): DefaultVersion {
 // end::custom-versioning-scheme[]
 
 // tag::denying_version[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.eachDependency {
         if (requested.group == "org.software" && requested.name == "some-library" && requested.version == "1.2") {
             useVersion("1.2.1")
@@ -42,7 +42,7 @@ configurations.all {
 // end::denying_version[]
 
 // tag::module_substitution[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.eachDependency {
         if (requested.name == "groovy-all") {
             useTarget(mapOf("group" to requested.group, "name" to "groovy", "version" to requested.version))

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-selectionRule/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-selectionRule/groovy/build.gradle
@@ -56,7 +56,7 @@ tasks.register('printRejectConfig') {
 
 // tag::component-selection-with-metadata[]
 configurations {
-    metadataRulesConfig {
+    register("metadataRulesConfig") {
         resolutionStrategy {
             componentSelection {
                 // Reject any versions with a status of 'experimental'
@@ -91,7 +91,7 @@ tasks.register('printMetadataRulesConfig') {
 
 // tag::targeted-component-selection[]
 configurations {
-    targetConfig {
+    register("targetConfig") {
         resolutionStrategy {
             componentSelection {
                 withModule("org.sample:api") { ComponentSelection selection ->
@@ -117,7 +117,7 @@ tasks.register('printTargetConfig') {
 }
 
 configurations {
-    sampleConfig {
+    register("sampleConfig") {
         resolutionStrategy {
             componentSelection {
                 withModule("org.sample:api") { ComponentSelection selection ->

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-selectionRule/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-selectionRule/kotlin/build.gradle.kts
@@ -55,7 +55,7 @@ tasks.register("printRejectConfig") {
 
 // tag::component-selection-with-metadata[]
 configurations {
-    create("metadataRulesConfig") {
+    register("metadataRulesConfig") {
         resolutionStrategy {
             componentSelection {
                 // Reject any versions with a status of 'experimental'
@@ -90,7 +90,7 @@ tasks.register("printMetadataRulesConfig") {
 
 // tag::targeted-component-selection[]
 configurations {
-    create("targetConfig") {
+    register("targetConfig") {
         resolutionStrategy {
             componentSelection {
                 withModule("org.sample:api") {
@@ -116,7 +116,7 @@ tasks.register("printTargetConfig") {
 }
 
 configurations {
-    create("sampleConfig") {
+    register("sampleConfig") {
         resolutionStrategy {
             componentSelection {
                 withModule("org.sample:api") {

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-substitutionRule/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-substitutionRule/groovy/build.gradle
@@ -4,7 +4,7 @@ configurations {
 }
 
 // tag::module_to_project_substitution[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.dependencySubstitution {
         substitute module("org.utils:api") using project(":api") because "we work with the unreleased development version"
         substitute module("org.utils:util:2.5") using project(":util")
@@ -12,7 +12,7 @@ configurations.all {
 }
 // end::module_to_project_substitution[]
 // tag::project_to_module_substitution[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.dependencySubstitution {
         substitute project(":api") using module("org.utils:api:1.3") because "we use a stable version of org.utils:api"
     }

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-substitutionRule/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-substitutionRule/kotlin/build.gradle.kts
@@ -2,7 +2,7 @@
 val conf by configurations.creating
 
 // tag::module_to_project_substitution[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.dependencySubstitution {
         substitute(module("org.utils:api"))
             .using(project(":api")).because("we work with the unreleased development version")
@@ -11,7 +11,7 @@ configurations.all {
 }
 // end::module_to_project_substitution[]
 // tag::project_to_module_substitution[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.dependencySubstitution {
         substitute(project(":api"))
             .using(module("org.utils:api:1.3")).because("we use a stable version of org.utils:api")

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/groovy/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 // end::dependencies[]
 
 // tag::use_highest_asm[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.capabilitiesResolution.withCapability('org.ow2.asm:asm') {
         selectHighestVersion()
     }
@@ -71,7 +71,7 @@ class AsmCapability implements ComponentMetadataRule {
 
 if (project.hasProperty("replace")) {
     // tag::use_slf4j[]
-    configurations.all {
+    configurations.configureEach {
         resolutionStrategy.capabilitiesResolution.withCapability("log4j:log4j") {
             def toBeSelected = candidates.find { it.id instanceof ModuleComponentIdentifier && it.id.module == 'log4j-over-slf4j' }
             if (toBeSelected != null) {

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/kotlin/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
 // end::dependencies[]
 
 // tag::use_highest_asm[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.capabilitiesResolution.withCapability("org.ow2.asm:asm") {
         selectHighestVersion()
     }
@@ -66,7 +66,7 @@ class AsmCapability : ComponentMetadataRule {
 if (project.hasProperty("replace")) {
 
     // tag::use_slf4j[]
-    configurations.all {
+    configurations.configureEach {
         resolutionStrategy.capabilitiesResolution.withCapability("log4j:log4j") {
             val toBeSelected = candidates.firstOrNull { it.id.let { id -> id is ModuleComponentIdentifier && id.module == "log4j-over-slf4j" } }
             if (toBeSelected != null) {

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-disableForConfiguration/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-disableForConfiguration/groovy/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 // tag::transitive-per-configuration[]
-configurations.all {
+configurations.configureEach {
     transitive = false
 }
 

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-disableForConfiguration/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-disableForConfiguration/kotlin/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
 }
 
 // tag::transitive-per-configuration[]
-configurations.all {
+configurations.configureEach {
     isTransitive = false
 }
 

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-resolutionStrategy/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-resolutionStrategy/groovy/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 // end::dependencies[]
 
 // tag::fail-on-version-conflict[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy {
         failOnVersionConflict()
     }
@@ -23,7 +23,7 @@ configurations.all {
 // end::fail-on-version-conflict[]
 
 // tag::fail-on-dynamic[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy {
         failOnDynamicVersions()
     }
@@ -31,7 +31,7 @@ configurations.all {
 // end::fail-on-dynamic[]
 
 // tag::fail-on-changing[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy {
         failOnChangingVersions()
     }
@@ -39,7 +39,7 @@ configurations.all {
 // end::fail-on-changing[]
 
 // tag::fail-on-unstable[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy {
         failOnNonReproducibleResolution()
     }

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-resolutionStrategy/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-resolutionStrategy/kotlin/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
 // end::dependencies[]
 
 // tag::fail-on-version-conflict[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy {
         failOnVersionConflict()
     }
@@ -23,7 +23,7 @@ configurations.all {
 // end::fail-on-version-conflict[]
 
 // tag::fail-on-dynamic[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy {
         failOnDynamicVersions()
     }
@@ -31,7 +31,7 @@ configurations.all {
 // end::fail-on-dynamic[]
 
 // tag::fail-on-changing[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy {
         failOnChangingVersions()
     }
@@ -39,7 +39,7 @@ configurations.all {
 // end::fail-on-changing[]
 
 // tag::fail-on-unstable[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy {
         failOnNonReproducibleResolution()
     }

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/troubleshooting-cache-changing/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/troubleshooting-cache-changing/groovy/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 }
 
 // tag::changing-module-cache-control[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.cacheChangingModulesFor 4, 'hours'
 }
 // end::changing-module-cache-control[]

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/troubleshooting-cache-changing/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/troubleshooting-cache-changing/kotlin/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
 }
 
 // tag::changing-module-cache-control[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.cacheChangingModulesFor(4, "hours")
 }
 // end::changing-module-cache-control[]

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/troubleshooting-cache-dynamic/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/troubleshooting-cache-dynamic/groovy/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 // end::dynamic[]
 
 // tag::dynamic-version-cache-control[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.cacheDynamicVersionsFor 10, 'minutes'
 }
 // end::dynamic-version-cache-control[]

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/troubleshooting-cache-dynamic/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/troubleshooting-cache-dynamic/kotlin/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
 // end::dynamic[]
 
 // tag::dynamic-version-cache-control[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.cacheDynamicVersionsFor(10, "minutes")
 }
 // end::dynamic-version-cache-control[]

--- a/platforms/documentation/docs/src/snippets/workerApi/md5ProcessIsolation/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/workerApi/md5ProcessIsolation/groovy/build.gradle
@@ -4,11 +4,10 @@ repositories {
     mavenCentral()
 }
 
-configurations.create('codec') {
+configurations.register('codec') {
     attributes {
         attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
     }
-    visible = false
     canBeConsumed = false
 }
 

--- a/platforms/documentation/docs/src/snippets/workerApi/md5ProcessIsolation/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/workerApi/md5ProcessIsolation/kotlin/build.gradle.kts
@@ -4,11 +4,10 @@ repositories {
     mavenCentral()
 }
 
-val codec = configurations.create("codec") {
+val codec = configurations.register("codec") {
     attributes {
         attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
     }
-    isVisible = false
     isCanBeConsumed = false
 }
 


### PR DESCRIPTION
The user guide still uses eager api in most of its code snippets. This PR moves a few  straightforward examples to lazy API

Also removed one  occasion  of setting isVisible on a non consumeable configuration

 
### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
