### PR TITLE
Back short circuit resolver with variant state

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/BuildscriptResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/BuildscriptResolutionIntegrationTest.groovy
@@ -544,6 +544,7 @@ class BuildscriptResolutionIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         executer.expectDocumentedDeprecationWarning("Mutating configuration container for buildscript of root project 'root' using remove(Object) has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutating_buildscript_configurations")
+        executer.expectDeprecationWarning("Removing a configuration from the container before resolution This behavior has been deprecated. This will fail with an error in Gradle 9.0. Do not remove configurations from the container and resolve them after.")
         succeeds("help")
     }
 
@@ -558,6 +559,7 @@ class BuildscriptResolutionIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         executer.expectDocumentedDeprecationWarning("Mutating configuration container for settings file 'settings.gradle' using remove(Object) has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutating_buildscript_configurations")
+        executer.expectDeprecationWarning("Removing a configuration from the container before resolution This behavior has been deprecated. This will fail with an error in Gradle 9.0. Do not remove configurations from the container and resolve them after.")
         succeeds("help")
     }
 
@@ -593,6 +595,7 @@ class BuildscriptResolutionIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         executer.expectDocumentedDeprecationWarning("Mutating configuration container for script 'foo.gradle' using remove(Object) has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutating_buildscript_configurations")
+        executer.expectDeprecationWarning("Removing a configuration from the container before resolution This behavior has been deprecated. This will fail with an error in Gradle 9.0. Do not remove configurations from the container and resolve them after.")
         succeeds("help")
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolveContext.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolveContext.java
@@ -20,7 +20,6 @@ import org.gradle.api.internal.artifacts.configurations.ResolutionResultProvider
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.Conflict;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.operations.dependencies.configurations.ConfigurationIdentity;
 
@@ -57,15 +56,11 @@ public interface ResolveContext {
 
     ResolutionStrategyInternal getResolutionStrategy();
 
-    boolean hasDependencies();
-
     /**
      * @implSpec Usage: This method should only be called on resolvable configurations and should throw an exception if
      * called on a configuration that does not permit this usage.
      */
     RootComponentMetadataBuilder.RootComponentState toRootComponent();
-
-    AttributeContainerInternal getAttributes();
 
     /**
      * Returns the cached results of resolution.
@@ -100,12 +95,6 @@ public interface ResolveContext {
      * called on a configuration that does not permit this usage.
      */
     List<? extends DependencyMetadata> getSyntheticDependencies();
-
-    /**
-     * Marks this resolve context as observed, meaning its state has been seen by some external operation
-     * and further changes to this context that would change its public state are forbidden.
-     */
-    void markAsObserved();
 
     FailureResolutions getFailureResolutions();
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -43,6 +43,8 @@ public interface ConfigurationInternal extends ResolveContext, DeprecatableConfi
 
     String getDisplayName();
 
+    DisplayName asDescribable();
+
     @Override
     AttributeContainerInternal getAttributes();
 
@@ -53,6 +55,17 @@ public interface ConfigurationInternal extends ResolveContext, DeprecatableConfi
      */
     void runDependencyActions();
 
+    /**
+     * Marks this configuration as observed, meaning its state has been seen by some external operation
+     * and further changes to this context that would change its public state are forbidden.
+     */
+    void markAsObserved();
+
+    /**
+     * Legacy observation mechanism, will be removed in Gradle 9.0.
+     * <p>
+     * Prefer {@link #markAsObserved()}
+     */
     void markAsObserved(InternalState requestedState);
 
     DomainObjectContext getDomainObjectContext();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.artifacts.ResolverResults;
 import org.gradle.api.internal.artifacts.repositories.ContentFilteringRepository;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -54,8 +55,10 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
 
     @Override
     public ResolverResults resolveGraph(ResolveContext resolveContext) {
+        AttributeContainerInternal attributes = resolveContext.toRootComponent().getRootVariant().getAttributes();
+
         List<ResolutionAwareRepository> filteredRepositories = repositoriesSupplier.get().stream()
-            .filter(repository -> !shouldSkipRepository(repository, resolveContext.getName(), resolveContext.getAttributes()))
+            .filter(repository -> !shouldSkipRepository(repository, resolveContext.getName(), attributes))
             .collect(Collectors.toList());
 
         return resolutionExecutor.resolveGraph(resolveContext, filteredRepositories);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolutionExecutor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolutionExecutor.java
@@ -89,6 +89,7 @@ import org.gradle.api.internal.artifacts.transform.DefaultTransformUpstreamDepen
 import org.gradle.api.internal.artifacts.transform.TransformUpstreamDependenciesResolver;
 import org.gradle.api.internal.artifacts.transform.TransformedVariantFactory;
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributeSchemaServices;
 import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -237,16 +238,20 @@ public class ResolutionExecutor {
      * @return An immutable result set, containing a subset of the graph that is sufficient to calculate the build dependencies.
      */
     public ResolverResults resolveBuildDependencies(ResolveContext resolveContext) {
+
+        ResolutionHost resolutionHost = resolveContext.getResolutionHost();
+        RootComponentMetadataBuilder.RootComponentState rootComponent = resolveContext.toRootComponent();
+        ImmutableAttributes requestAttributes = rootComponent.getRootVariant().getAttributes();
+        ResolutionStrategy.SortOrder defaultSortOrder = resolveContext.getResolutionStrategy().getSortOrder();
+        ImmutableAttributesSchema consumerSchema = rootComponent.getRootComponent().getMetadata().getAttributesSchema();
+
         ResolutionFailureCollector failureCollector = new ResolutionFailureCollector(componentSelectorConverter);
         ResolutionStrategyInternal resolutionStrategy = resolveContext.getResolutionStrategy();
         InMemoryResolutionResultBuilder resolutionResultBuilder = new InMemoryResolutionResultBuilder(resolutionStrategy.getIncludeAllSelectableVariantResults());
         ResolvedLocalComponentsResultGraphVisitor localComponentsVisitor = new ResolvedLocalComponentsResultGraphVisitor(currentBuild, projectStateRegistry);
         DefaultResolvedArtifactsBuilder artifactsBuilder = new DefaultResolvedArtifactsBuilder(buildProjectDependencies);
 
-        RootComponentMetadataBuilder.RootComponentState rootComponent = resolveContext.toRootComponent();
-        ImmutableAttributesSchema consumerSchema = rootComponent.getRootComponent().getMetadata().getAttributesSchema();
-
-        ComponentResolvers resolvers = getResolvers(resolveContext, Collections.emptyList(), consumerSchema);
+        ComponentResolvers resolvers = getResolvers(resolveContext, Collections.emptyList(), consumerSchema, requestAttributes);
         DependencyGraphVisitor artifactsGraphVisitor = artifactVisitorFor(artifactsBuilder);
 
         ImmutableList<DependencyGraphVisitor> visitors = ImmutableList.of(failureCollector, resolutionResultBuilder, localComponentsVisitor, artifactsGraphVisitor);
@@ -256,15 +261,23 @@ public class ResolutionExecutor {
         Set<UnresolvedDependency> unresolvedDependencies = failureCollector.complete(Collections.emptySet());
         VisitedGraphResults graphResults = new DefaultVisitedGraphResults(resolutionResultBuilder.getResolutionResult(), unresolvedDependencies, null);
 
-        ResolutionHost resolutionHost = resolveContext.getResolutionHost();
-        VisitedArtifactSet visitedArtifacts = getVisitedArtifactSet(resolveContext, graphResults, resolutionHost, consumerSchema, artifactsBuilder.complete(), resolvers);
+        VisitedArtifactSet visitedArtifacts = getVisitedArtifactSet(
+            resolveContext,
+            graphResults,
+            resolutionHost,
+            consumerSchema,
+            artifactsBuilder.complete(),
+            resolvers,
+            requestAttributes,
+            defaultSortOrder
+        );
 
         ResolverResults.LegacyResolverResults legacyResolverResults = DefaultResolverResults.DefaultLegacyResolverResults.buildDependenciesResolved(
             // When resolving build dependencies, we ignore the dependencySpec, potentially capturing a greater
             // set of build dependencies than actually required. This is because it takes a lot of extra information
             // from the visited graph to properly filter artifacts by dependencySpec, and we don't want capture that when
             // calculating build dependencies.
-            dependencySpec -> visitedArtifacts.select(getImplicitSelectionSpec(resolveContext))
+            dependencySpec -> visitedArtifacts.select(getImplicitSelectionSpec(requestAttributes, defaultSortOrder))
         );
 
         return DefaultResolverResults.buildDependenciesResolved(graphResults, visitedArtifacts, legacyResolverResults);
@@ -279,7 +292,12 @@ public class ResolutionExecutor {
      * @return An immutable result set, containing the full graph of resolved components.
      */
     public ResolverResults resolveGraph(ResolveContext resolveContext, List<ResolutionAwareRepository> repositories) {
+
         ResolutionHost resolutionHost = resolveContext.getResolutionHost();
+        RootComponentMetadataBuilder.RootComponentState rootComponent = resolveContext.toRootComponent();
+        ImmutableAttributes requestAttributes = rootComponent.getRootVariant().getAttributes();
+        ResolutionStrategy.SortOrder defaultSortOrder = resolveContext.getResolutionStrategy().getSortOrder();
+        ImmutableAttributesSchema consumerSchema = rootComponent.getRootComponent().getMetadata().getAttributesSchema();
 
         StoreSet stores = storeFactory.createStoreSet();
 
@@ -319,10 +337,8 @@ public class ResolutionExecutor {
             dependencyLockingProvider.confirmNotLocked(resolveContext.getDependencyLockingId());
         }
 
-        RootComponentMetadataBuilder.RootComponentState rootComponent = resolveContext.toRootComponent();
-        ImmutableAttributesSchema consumerSchema = rootComponent.getRootComponent().getMetadata().getAttributesSchema();
 
-        ComponentResolvers resolvers = getResolvers(resolveContext, repositories, consumerSchema);
+        ComponentResolvers resolvers = getResolvers(resolveContext, repositories, consumerSchema, requestAttributes);
         CompositeDependencyArtifactsVisitor artifactVisitors = new CompositeDependencyArtifactsVisitor(ImmutableList.of(
             oldModelVisitor, fileDependencyVisitor, artifactsBuilder
         ));
@@ -361,7 +377,16 @@ public class ResolutionExecutor {
             lockingVisitor.writeLocks();
         }
 
-        VisitedArtifactSet visitedArtifacts = getVisitedArtifactSet(resolveContext, graphResults, resolutionHost, consumerSchema, artifactsResults, resolvers);
+        VisitedArtifactSet visitedArtifacts = getVisitedArtifactSet(
+            resolveContext,
+            graphResults,
+            resolutionHost,
+            consumerSchema,
+            artifactsResults,
+            resolvers,
+            requestAttributes,
+            defaultSortOrder
+        );
 
         // Legacy results
         TransientConfigurationResultsLoader transientConfigurationResultsFactory = new TransientConfigurationResultsLoader(oldTransientModelBuilder, legacyGraphResults);
@@ -372,7 +397,7 @@ public class ResolutionExecutor {
             fileDependencyResults,
             transientConfigurationResultsFactory,
             artifactSetResolver,
-            getImplicitSelectionSpec(resolveContext)
+            getImplicitSelectionSpec(requestAttributes, defaultSortOrder)
         );
         ResolverResults.LegacyResolverResults legacyResolverResults = DefaultResolverResults.DefaultLegacyResolverResults.graphResolved(
             lenientConfiguration,
@@ -382,9 +407,7 @@ public class ResolutionExecutor {
         return DefaultResolverResults.graphResolved(graphResults, visitedArtifacts, legacyResolverResults);
     }
 
-    private static ArtifactSelectionSpec getImplicitSelectionSpec(ResolveContext resolveContext) {
-        ImmutableAttributes requestAttributes = resolveContext.getAttributes().asImmutable();
-        ResolutionStrategy.SortOrder sortOrder = resolveContext.getResolutionStrategy().getSortOrder();
+    private static ArtifactSelectionSpec getImplicitSelectionSpec(ImmutableAttributes requestAttributes, ResolutionStrategy.SortOrder sortOrder) {
         return new ArtifactSelectionSpec(requestAttributes, Specs.satisfyAll(), false, false, sortOrder);
     }
 
@@ -403,13 +426,15 @@ public class ResolutionExecutor {
         ResolutionHost resolutionHost,
         ImmutableAttributesSchema consumerSchema,
         VisitedArtifactResults artifactsResults,
-        ComponentResolvers resolvers
+        ComponentResolvers resolvers,
+        ImmutableAttributes requestAttributes,
+        ResolutionStrategy.SortOrder defaultSortOrder
     ) {
         TransformUpstreamDependenciesResolver dependenciesResolver = new DefaultTransformUpstreamDependenciesResolver(
             resolveContext.getResolutionHost(),
             resolveContext.getConfigurationIdentity(),
-            resolveContext.getAttributes().asImmutable(),
-            resolveContext.getResolutionStrategy().getSortOrder(),
+            requestAttributes,
+            defaultSortOrder,
             resolveContext.getStrictResolverResults(),
             resolveContext.getResolverResults(),
             domainObjectContext,
@@ -488,7 +513,8 @@ public class ResolutionExecutor {
     private ComponentResolvers getResolvers(
         ResolveContext resolveContext,
         List<ResolutionAwareRepository> repositories,
-        ImmutableAttributesSchema consumerSchema
+        ImmutableAttributesSchema consumerSchema,
+        AttributeContainerInternal requestAttributes
     ) {
         List<ComponentResolvers> resolvers = new ArrayList<>(3);
         for (ResolverProviderFactory factory : resolverFactories) {
@@ -506,7 +532,7 @@ public class ResolutionExecutor {
             // We should not need to know _what_ we're resolving in order to construct a resolver for a set of repositories.
             // The request attributes and schema are used to support filtering components by attributes when using dynamic versions.
             // We should consider just removing that feature and making dynamic version selection dumber.
-            resolveContext.getAttributes(),
+            requestAttributes,
             consumerSchema
         ));
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
@@ -94,34 +94,27 @@ public class DefaultRootComponentMetadataBuilder implements RootComponentMetadat
             immutableSchema
         );
 
+        LocalComponentGraphResolveState rootComponent = getComponentState(owner, metadata);
+
+        // TODO: We should not ask the component for a resolvable configuration. Components should only
+        // expose variants -- which are by definition consumable only. Instead, we should create our own
+        // root variant and add it to a new one-off root component that holds only that root variant.
+        // The root variant should not live in a standard local component alongside other (consumable) variants.
+        @SuppressWarnings("deprecation")
+        LocalVariantGraphResolveState rootVariant = rootComponent.getConfigurationLegacy(configurationName);
+        if (rootVariant == null) {
+            throw new IllegalArgumentException(String.format("Expected root variant '%s' to be present in %s", configurationName, componentIdentifier));
+        }
+
         return new RootComponentState() {
             @Override
             public LocalComponentGraphResolveState getRootComponent() {
-                return getComponentState(owner, metadata);
+                return rootComponent;
             }
 
             @Override
-            public VariantGraphResolveState getRootVariant() {
-                // TODO: We should not ask the component for a resolvable configuration. Components should only
-                // expose variants -- which are by definition consumable only. Instead, we should create our own
-                // root variant and add it to a new one-off root component that holds only that root variant.
-                // The root variant should not live in a standard local component alongside other (consumable) variants.
-                @SuppressWarnings("deprecation")
-                LocalVariantGraphResolveState rootVariant = getRootComponent().getConfigurationLegacy(configurationName);
-                if (rootVariant == null) {
-                    throw new IllegalArgumentException(String.format("Expected root variant '%s' to be present in %s", configurationName, componentIdentifier));
-                }
+            public LocalVariantGraphResolveState getRootVariant() {
                 return rootVariant;
-            }
-
-            @Override
-            public ComponentIdentifier getComponentIdentifier() {
-                return metadata.getId();
-            }
-
-            @Override
-            public ModuleVersionIdentifier getModuleVersionIdentifier() {
-                return metadata.getModuleVersionId();
             }
         };
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
@@ -31,7 +31,6 @@ import org.gradle.internal.component.local.model.LocalComponentGraphResolveMetad
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveState;
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveStateFactory;
 import org.gradle.internal.component.local.model.LocalVariantGraphResolveState;
-import org.gradle.internal.component.model.VariantGraphResolveState;
 import org.gradle.internal.model.ModelContainer;
 
 import javax.annotation.Nullable;
@@ -96,16 +95,6 @@ public class DefaultRootComponentMetadataBuilder implements RootComponentMetadat
 
         LocalComponentGraphResolveState rootComponent = getComponentState(owner, metadata);
 
-        // TODO: We should not ask the component for a resolvable configuration. Components should only
-        // expose variants -- which are by definition consumable only. Instead, we should create our own
-        // root variant and add it to a new one-off root component that holds only that root variant.
-        // The root variant should not live in a standard local component alongside other (consumable) variants.
-        @SuppressWarnings("deprecation")
-        LocalVariantGraphResolveState rootVariant = rootComponent.getConfigurationLegacy(configurationName);
-        if (rootVariant == null) {
-            throw new IllegalArgumentException(String.format("Expected root variant '%s' to be present in %s", configurationName, componentIdentifier));
-        }
-
         return new RootComponentState() {
             @Override
             public LocalComponentGraphResolveState getRootComponent() {
@@ -114,6 +103,15 @@ public class DefaultRootComponentMetadataBuilder implements RootComponentMetadat
 
             @Override
             public LocalVariantGraphResolveState getRootVariant() {
+                // TODO: We should not ask the component for a resolvable configuration. Components should only
+                // expose variants -- which are by definition consumable only. Instead, we should create our own
+                // root variant and add it to a new one-off root component that holds only that root variant.
+                // The root variant should not live in a standard local component alongside other (consumable) variants.
+                @SuppressWarnings("deprecation")
+                LocalVariantGraphResolveState rootVariant = rootComponent.getConfigurationLegacy(configurationName);
+                if (rootVariant == null) {
+                    throw new IllegalStateException(String.format("Expected root variant '%s' to be present in %s", configurationName, componentIdentifier));
+                }
                 return rootVariant;
             }
         };

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
@@ -103,6 +103,10 @@ public class DefaultRootComponentMetadataBuilder implements RootComponentMetadat
 
             @Override
             public LocalVariantGraphResolveState getRootVariant() {
+                // TODO: It would be nice if we could calculate the rootVariant once, but it is possible
+                // that the root component changes between build dependency resolution and complete
+                // graph resolution. In 9.0, these changes will be forbidden.
+
                 // TODO: We should not ask the component for a resolvable configuration. Components should only
                 // expose variants -- which are by definition consumable only. Instead, we should create our own
                 // root variant and add it to a new one-off root component that holds only that root variant.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/RootComponentMetadataBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/RootComponentMetadataBuilder.java
@@ -15,13 +15,11 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.moduleconverter;
 
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationsProvider;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
 import org.gradle.api.internal.artifacts.configurations.MutationValidator;
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveState;
-import org.gradle.internal.component.model.VariantGraphResolveState;
+import org.gradle.internal.component.local.model.LocalVariantGraphResolveState;
 
 /**
  * Builds the root component to use as the root of a dependency graph.
@@ -51,10 +49,6 @@ public interface RootComponentMetadataBuilder {
     interface RootComponentState {
         LocalComponentGraphResolveState getRootComponent();
 
-        VariantGraphResolveState getRootVariant();
-
-        ComponentIdentifier getComponentIdentifier();
-
-        ModuleVersionIdentifier getModuleVersionIdentifier();
+        LocalVariantGraphResolveState getRootVariant();
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalVariantGraphResolveStateBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalVariantGraphResolveStateBuilder.java
@@ -93,8 +93,8 @@ public class DefaultLocalVariantGraphResolveStateBuilder implements LocalVariant
         configuration.markAsObserved();
 
         String configurationName = configuration.getName();
-        String description = configuration.getDescription();
-        ComponentConfigurationIdentifier configurationIdentifier = new ComponentConfigurationIdentifier(componentId, configuration.getName());
+        DisplayName description = configuration.asDescribable();
+        ComponentConfigurationIdentifier configurationIdentifier = new ComponentConfigurationIdentifier(componentId, configurationName);
 
         ImmutableAttributes attributes = configuration.getAttributes().asImmutable();
         ImmutableCapabilities capabilities = ImmutableCapabilities.of(Configurations.collectCapabilities(configuration, new HashSet<>(), new HashSet<>()));
@@ -168,7 +168,7 @@ public class DefaultLocalVariantGraphResolveStateBuilder implements LocalVariant
      * Lazily collect all dependencies and excludes of all configurations in the provided {@code hierarchy}.
      */
     private CalculatedValue<DefaultLocalVariantGraphResolveState.VariantDependencyMetadata> getConfigurationDependencyState(
-        String description,
+        DisplayName description,
         ImmutableSet<String> hierarchy,
         ImmutableAttributes attributes,
         ConfigurationsProvider configurationsProvider,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
@@ -141,8 +141,8 @@ public class ResolveState implements ComponentStateFactory<ComponentState> {
 
         LocalComponentGraphResolveState rootComponentState = root.getRootComponent();
         VariantGraphResolveState rootVariant = root.getRootVariant();
-        ModuleVersionIdentifier rootModuleVersionId = root.getModuleVersionIdentifier();
-        ComponentIdentifier rootComponentId = root.getComponentIdentifier();
+        ModuleVersionIdentifier rootModuleVersionId = rootComponentState.getModuleVersionId();
+        ComponentIdentifier rootComponentId = rootComponentState.getId();
         this.consumerSchema = rootComponentState.getMetadata().getAttributesSchema();
 
         int graphSize = estimateGraphSize(rootVariant);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolutionResultGraphBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolutionResultGraphBuilder.java
@@ -38,7 +38,6 @@ import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal;
 import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Describables;
-import org.gradle.internal.component.external.model.DefaultImmutableCapability;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
@@ -67,6 +66,7 @@ public class ResolutionResultGraphBuilder implements ResolvedComponentVisitor {
         ModuleVersionIdentifier id,
         ComponentIdentifier componentIdentifier,
         ImmutableAttributes attributes,
+        ImmutableCapabilities capabilities,
         String rootVariantName,
         AttributeDesugaring attributeDesugaring
     ) {
@@ -78,7 +78,7 @@ public class ResolutionResultGraphBuilder implements ResolvedComponentVisitor {
             componentIdentifier,
             Describables.of(rootVariantName),
             attributeDesugaring.desugar(attributes),
-            ImmutableCapabilities.of(DefaultImmutableCapability.defaultCapabilityForComponent(id)),
+            capabilities,
             null
         );
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -155,8 +155,6 @@ class DependencyGraphBuilderTest extends Specification {
     def rootComponent = Stub(RootComponentMetadataBuilder.RootComponentState) {
         getRootComponent() >> root
         getRootVariant() >> root.getConfigurationLegacy('root')
-        getComponentIdentifier() >> root.id
-        getModuleVersionIdentifier() >> root.moduleVersionId
         getAttributesSchema() >> attributesSchema
     }
 


### PR DESCRIPTION
Resolution should be a function of only the root component and variant, plus any resolution strategy. Having hasDependencies introduces multiple sources of truth that must be aligned.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
