### PR TITLE
Coordinate between reading shared objects and loading projects

### DIFF
--- a/platforms/core-configuration/configuration-cache-base/build.gradle.kts
+++ b/platforms/core-configuration/configuration-cache-base/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     api(projects.loggingApi)
 
     api(libs.kotlinStdlib)
+    api(libs.inject)
 
     implementation(projects.baseServices)
     implementation(projects.serviceLookup)

--- a/platforms/core-configuration/configuration-cache-base/src/main/kotlin/org/gradle/internal/cc/base/serialize/ProjectRef.kt
+++ b/platforms/core-configuration/configuration-cache-base/src/main/kotlin/org/gradle/internal/cc/base/serialize/ProjectRef.kt
@@ -16,12 +16,19 @@
 
 package org.gradle.internal.cc.base.serialize
 
+import org.gradle.api.Project
 import org.gradle.api.internal.project.ProjectInternal
-import org.gradle.internal.build.BuildState
+import org.gradle.internal.cc.base.services.ProjectRefResolver
 import org.gradle.internal.serialize.graph.ReadContext
+import org.gradle.internal.serialize.graph.WriteContext
 import org.gradle.internal.serialize.graph.ownerService
-import org.gradle.util.Path
 
 
-fun ReadContext.getProject(path: String): ProjectInternal =
-    ownerService<BuildState>().projects.getProject(Path.path(path)).mutableModel
+fun WriteContext.writeProjectRef(project: Project) {
+    writeString(project.path)
+}
+
+
+fun ReadContext.readProjectRef(): ProjectInternal {
+    return ownerService<ProjectRefResolver>().getProject(readString())
+}

--- a/platforms/core-configuration/configuration-cache-base/src/main/kotlin/org/gradle/internal/cc/base/serialize/ProjectRef.kt
+++ b/platforms/core-configuration/configuration-cache-base/src/main/kotlin/org/gradle/internal/cc/base/serialize/ProjectRef.kt
@@ -23,12 +23,19 @@ import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext
 import org.gradle.internal.serialize.graph.ownerService
 
-
+/**
+ * Writes a reference to a project.
+ */
 fun WriteContext.writeProjectRef(project: Project) {
     writeString(project.path)
 }
 
 
+/**
+ * Reads a reference to a project. May block or throw if the projects haven't been loaded yet.
+ *
+ * @see ProjectRefResolver
+ */
 fun ReadContext.readProjectRef(): ProjectInternal {
     return ownerService<ProjectRefResolver>().getProject(readString())
 }

--- a/platforms/core-configuration/configuration-cache-base/src/main/kotlin/org/gradle/internal/cc/base/services/ProjectRefResolver.kt
+++ b/platforms/core-configuration/configuration-cache-base/src/main/kotlin/org/gradle/internal/cc/base/services/ProjectRefResolver.kt
@@ -21,14 +21,87 @@ import org.gradle.internal.build.BuildState
 import org.gradle.internal.service.scopes.Scope
 import org.gradle.internal.service.scopes.ServiceScope
 import org.gradle.util.Path
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import javax.inject.Inject
+import kotlin.jvm.Throws
 
+/**
+ * A stateful service that prevents races in `readProjectRef` when looking up projects by their paths.
+ * Threads may opt into waiting the until the project structure is restored when trying to resolve a project reference by calling [withWaitingForProjectsAllowed].
+ * Unless projects are loaded, an attempt to resolve a project without the opt-in throws an exception to avoid deadlocks.
+ *
+ * Using this class should be limited to serialization.
+ *
+ * This class is thread-safe.
+ */
 @ServiceScope(Scope.Build::class)
 class ProjectRefResolver @Inject constructor(
     private val buildState: BuildState
 ) {
+    private val projectReadyLock = CountDownLatch(1)
 
+    @Volatile
+    private var projectsLoaded = false
+
+    private val waitingForProjectsAllowed: MutableSet<Thread> = ConcurrentHashMap.newKeySet()
+
+    /**
+     * Allows this thread to wait for the project structure to be restored when calling [getProject] inside `block`.
+     *
+     * The thread that is responsible for loading the projects mustn't call this method to help detect potential deadlocks.
+     */
+    fun withWaitingForProjectsAllowed(block: () -> Unit) {
+        val thread = Thread.currentThread()
+
+        waitingForProjectsAllowed.add(thread)
+        try {
+            block()
+        } finally {
+            waitingForProjectsAllowed.remove(thread)
+        }
+    }
+
+    /**
+     * Marks projects as restored.
+     */
+    fun projectsReady() {
+        projectsLoaded = true
+        projectReadyLock.countDown()
+    }
+
+    /**
+     * Resolves a project by a path relative to the root project or blocks until the projects are loaded if allowed.
+     *
+     * @throws InterruptedException if the thread is interrupted while waiting
+     * @throws TimeoutException if the projects weren't loaded within a reasonable time
+     * @throws IllegalStateException if the projects aren't ready and this thread isn't allowed to wait for them
+     */
+    @Throws(InterruptedException::class, TimeoutException::class)
     fun getProject(path: String): ProjectInternal {
+        waitForProjects(path)
+
         return buildState.projects.getProject(Path.path(path)).mutableModel
+    }
+
+    private fun waitForProjects(projectPath: String) {
+        if (projectsLoaded) {
+            return
+        }
+
+        check(waitingForProjectsAllowed.contains(Thread.currentThread())) {
+            // This may happen if something that requires a project is deserialized before the project structure is ready.
+            "Cannot resolve project path '$projectPath' because project structure is not yet loaded for build '${buildState.identityPath}'"
+        }
+
+        if (!projectReadyLock.await(5, TimeUnit.MINUTES)) {
+            // We're typically wait here from a shared object decoder thread.
+            // It may take some time for the main decoding logic to get to the actual projects and restore them, so this timeout should be generous.
+            // TODO(mlopatkin) a deadlock is still possible when the main decoder waits for some shared object and the shared decoder is stuck waiting for projects.
+            //   The blocked main thread is likely to give up earlier anyway.
+            throw TimeoutException("Cannot resolve project path '$projectPath' because project structure is not ready in time for build '${buildState.identityPath}'")
+        }
     }
 }

--- a/platforms/core-configuration/configuration-cache-base/src/main/kotlin/org/gradle/internal/cc/base/services/ProjectRefResolver.kt
+++ b/platforms/core-configuration/configuration-cache-base/src/main/kotlin/org/gradle/internal/cc/base/services/ProjectRefResolver.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.base.services
+
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.internal.build.BuildState
+import org.gradle.internal.service.scopes.Scope
+import org.gradle.internal.service.scopes.ServiceScope
+import org.gradle.util.Path
+import javax.inject.Inject
+
+@ServiceScope(Scope.Build::class)
+class ProjectRefResolver @Inject constructor(
+    private val buildState: BuildState
+) {
+
+    fun getProject(path: String): ProjectInternal {
+        return buildState.projects.getProject(Path.path(path)).mutableModel
+    }
+}

--- a/platforms/core-configuration/configuration-cache-base/src/main/kotlin/org/gradle/internal/cc/base/services/ProjectRefResolver.kt
+++ b/platforms/core-configuration/configuration-cache-base/src/main/kotlin/org/gradle/internal/cc/base/services/ProjectRefResolver.kt
@@ -56,11 +56,13 @@ class ProjectRefResolver @Inject constructor(
     fun withWaitingForProjectsAllowed(block: () -> Unit) {
         val thread = Thread.currentThread()
 
-        waitingForProjectsAllowed.add(thread)
+        val wasFirstToAdd = waitingForProjectsAllowed.add(thread)
         try {
             block()
         } finally {
-            waitingForProjectsAllowed.remove(thread)
+            if (wasFirstToAdd) {
+                waitingForProjectsAllowed.remove(thread)
+            }
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
@@ -55,6 +55,7 @@ import org.gradle.internal.cc.base.serialize.IsolateOwners
 import org.gradle.internal.cc.base.serialize.service
 import org.gradle.internal.cc.base.serialize.withGradleIsolate
 import org.gradle.internal.cc.base.services.ConfigurationCacheEnvironmentChangeTracker
+import org.gradle.internal.cc.base.services.ProjectRefResolver
 import org.gradle.internal.cc.impl.serialize.Codecs
 import org.gradle.internal.configuration.problems.DocumentationSection.NotYetImplementedSourceDependencies
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginAdapter
@@ -487,6 +488,7 @@ class ConfigurationCacheState(
             val projects = readProjects(gradle, build)
 
             build.createProjects()
+            gradle.serviceOf<ProjectRefResolver>().projectsReady()
 
             applyProjectStates(projects, gradle)
             readRequiredBuildServicesOf(gradle)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildModelControllerServices.kt
@@ -44,6 +44,7 @@ import org.gradle.internal.build.BuildModelControllerServices
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.buildtree.IntermediateBuildActionRunner
+import org.gradle.internal.cc.base.services.ProjectRefResolver
 import org.gradle.internal.cc.impl.fingerprint.ConfigurationCacheFingerprintController
 import org.gradle.internal.cc.impl.services.ConfigurationCacheEnvironment
 import org.gradle.internal.cc.impl.services.DefaultEnvironment
@@ -78,6 +79,7 @@ class DefaultBuildModelControllerServices(
             if (buildModelParameters.isConfigurationCache) {
                 registration.addProvider(ConfigurationCacheBuildControllerProvider())
                 registration.add(ConfigurationCacheEnvironment::class.java)
+                registration.add(ProjectRefResolver::class.java)
             } else {
                 registration.addProvider(VintageBuildControllerProvider())
                 registration.add(DefaultEnvironment::class.java)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/DefaultGlobalValueCodec.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/DefaultGlobalValueCodec.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.cc.impl.serialize
 
+import org.gradle.internal.cc.base.services.ProjectRefResolver
 import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.serialize.graph.CloseableReadContext
 import org.gradle.internal.serialize.graph.CloseableWriteContext
@@ -24,6 +25,7 @@ import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.SharedObjectDecoder
 import org.gradle.internal.serialize.graph.SharedObjectEncoder
 import org.gradle.internal.serialize.graph.WriteContext
+import org.gradle.internal.serialize.graph.ownerService
 import org.gradle.internal.serialize.graph.runReadOperation
 import org.gradle.internal.serialize.graph.runWriteOperation
 import java.util.concurrent.ConcurrentHashMap
@@ -128,26 +130,31 @@ class DefaultSharedObjectDecoder(
             "Unexpected state: $state"
         }
         globalContext.run {
-            while (state.get() == ReaderState.RUNNING) {
-                val id = readSmallInt()
-                if (id == EOF) {
-                    stopReading()
-                    break
-                }
-                val read = runReadOperation {
-                    read()!!
-                }
-                values.compute(id) { _, value ->
-                    when (value) {
-                        is FutureValue -> value.complete(read)
-                        else -> require(value == null)
+            projectRefResolver.withWaitingForProjectsAllowed {
+                while (state.get() == ReaderState.RUNNING) {
+                    val id = readSmallInt()
+                    if (id == EOF) {
+                        stopReading()
+                        break
                     }
-                    read
+                    val read = runReadOperation {
+                        read()!!
+                    }
+                    values.compute(id) { _, value ->
+                        when (value) {
+                            is FutureValue -> value.complete(read)
+                            else -> require(value == null)
+                        }
+                        read
+                    }
                 }
             }
             state.set(ReaderState.STOPPED)
         }
     }
+
+    private val ReadContext.projectRefResolver
+        get() = ownerService<ProjectRefResolver>()
 
     private
     fun ReadContext.resolveValue(id: Int): Any {

--- a/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/transform/TransformStepCodec.kt
+++ b/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/transform/TransformStepCodec.kt
@@ -20,7 +20,8 @@ import org.gradle.api.internal.DomainObjectContext
 import org.gradle.api.internal.artifacts.transform.Transform
 import org.gradle.api.internal.artifacts.transform.TransformInvocationFactory
 import org.gradle.api.internal.artifacts.transform.TransformStep
-import org.gradle.internal.cc.base.serialize.getProject
+import org.gradle.internal.cc.base.serialize.readProjectRef
+import org.gradle.internal.cc.base.serialize.writeProjectRef
 import org.gradle.internal.execution.InputFingerprinter
 import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.ReadContext
@@ -37,16 +38,15 @@ class TransformStepCodec(
     override suspend fun WriteContext.encode(value: TransformStep) {
         encodePreservingSharedIdentityOf(value) {
             val project = value.owningProject ?: throw UnsupportedOperationException("TransformStep must have an owning project to be encoded.")
-            writeString(project.path)
+            writeProjectRef(project)
             write(value.transform)
         }
     }
 
     override suspend fun ReadContext.decode(): TransformStep {
         return decodePreservingSharedIdentity {
-            val path = readString()
+            val project = readProjectRef()
             val transform = readNonNull<Transform>()
-            val project = getProject(path)
             val services = project.services
             TransformStep(
                 transform,


### PR DESCRIPTION
It is possible for the shared object decoder thread to reach some project-referring data faster than the main decoder thread sets up the project structure for the build. It may happen when some build-level data references shared objects and kicks off the auxiliary decoder.

The aux decoder now blocks if it encounters a project reference and waits for the main thread to do its job.

Of course, the build is still going to be broken if the build-level data has project references in it.

Fixes #31111.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
