### PR TITLE
Trigger ReadyForNightly and ReadyForRelease for `provider-api-migration/public-api-changes-test` branch

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/StageTriggers.kt
+++ b/.teamcity/src/main/kotlin/configurations/StageTriggers.kt
@@ -1,6 +1,7 @@
 package configurations
 
 import common.Os
+import common.VersionedSettingsBranch
 import common.applyDefaultSettings
 import common.toCapitalized
 import common.uuidPrefix
@@ -41,6 +42,11 @@ class StageTriggers(model: CIBuildModel, stage: Stage, prevStage: Stage?, stageP
     }
 }
 
+// TODO: remove this after the branch is merged
+fun VersionedSettingsBranch.determineBranchFilter(): String {
+    return branchFilter() + "\n+:provider-api-migration/public-api-changes-test"
+}
+
 class StageTrigger(
     model: CIBuildModel,
     stage: Stage,
@@ -67,7 +73,7 @@ class StageTrigger(
                 quietPeriodMode = VcsTrigger.QuietPeriodMode.USE_CUSTOM
                 quietPeriod = 90
                 triggerRules = triggerExcludes
-                branchFilter = model.branch.branchFilter()
+                branchFilter = model.branch.determineBranchFilter()
                 enabled = enableTriggers
             }
         } else if (stage.trigger != Trigger.never) {
@@ -86,7 +92,7 @@ class StageTrigger(
                 triggerBuild = always()
                 withPendingChangesOnly = true
                 param("revisionRule", "lastFinished")
-                branchFilter = model.branch.branchFilter()
+                branchFilter = model.branch.determineBranchFilter()
                 enabled = enableTriggers
             }
         }

--- a/.teamcity/src/main/kotlin/configurations/StageTriggers.kt
+++ b/.teamcity/src/main/kotlin/configurations/StageTriggers.kt
@@ -42,6 +42,9 @@ class StageTriggers(model: CIBuildModel, stage: Stage, prevStage: Stage?, stageP
     }
 }
 
+// https://github.com/gradle/gradle-private/issues/4527
+// https://github.com/gradle/gradle-private/issues/4528
+// Trigger ReadyForNightly and ReadyForRelease for provider-api-migration/public-api-changes-test branch
 // TODO: remove this after the branch is merged
 fun VersionedSettingsBranch.determineBranchFilter(): String {
     return branchFilter() + "\n+:provider-api-migration/public-api-changes-test"


### PR DESCRIPTION
We want to trigger the following builds on `provider-api-migration/public-api-changes-test` branch:

- RFN upon code push
- RFR daily (if there're pending changes)

Tested on experimental branch: https://builds.gradle.org/buildConfiguration/Gradle_Experimental_Check_Stage_ReadyforNightly_Trigger?mode=builds#all-projects