### PR TITLE
Leverage `EvaluationContext` in `Cached` to avoid tripping execution-time access checks

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/CacheableComputationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/CacheableComputationIntegrationTest.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl
+
+import org.gradle.internal.serialization.Cached
+
+class CacheableComputationIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+
+    def "cacheable computation that does not trigger execution-time deprecations"() {
+        given:
+        def projectName = "project1"
+        settingsFile """
+            enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
+            rootProject.name = '$projectName'
+        """
+
+        buildFile """
+        abstract class CompatibleTask extends DefaultTask {
+            // accessing Task.project via a cacheable computation should not trigger execution-time checks
+            private def projectName = ${cachableComputation} { project.name }
+            @TaskAction
+            def doIt() {
+                println "project name: \${projectName.get()}"
+            }
+        }
+
+        tasks.register("compatible", CompatibleTask)
+        """
+
+        // cacheable computations with CC will not produce problems
+        when:
+        configurationCacheRun("compatible")
+
+        then:
+        problems.assertNoProblemsSummary()
+
+        // cacheable computations without CC should not produce access-check deprecations
+        when:
+        succeeds("compatible")
+
+        then:
+        result.assertTaskExecuted(":compatible")
+        outputContains("project name: $projectName")
+
+        where:
+        cachableComputation << [
+            "${Cached.name}.of",
+            "project.providers.provider"
+        ]
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/TaskExecutionAccessCheckers.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/TaskExecutionAccessCheckers.kt
@@ -82,7 +82,7 @@ abstract class AbstractTaskProjectAccessChecker(
         // Check if we're evaluating something, and it can be reduced to value by CC store.
         // TODO(mlopatkin) This oversimplifies things a lot. We're getting false negatives for e.g. value sources and providers created at execution time.
         //  However, tracking such providers properly has a significant cost, so we prefer it to performance penalty or false positives.
-        return EvaluationContext.current().owner != null
+        return EvaluationContext.current().isEvaluating()
     }
 
     protected

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/TaskExecutionAccessCheckers.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/TaskExecutionAccessCheckers.kt
@@ -18,7 +18,7 @@ package org.gradle.internal.cc.impl
 
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.provider.ConfigurationTimeBarrier
-import org.gradle.api.internal.provider.EvaluationContext
+import org.gradle.internal.evaluation.EvaluationContext
 import org.gradle.api.internal.tasks.TaskExecutionAccessChecker
 import org.gradle.api.internal.tasks.execution.TaskExecutionAccessListener
 import org.gradle.internal.execution.WorkExecutionTracker

--- a/platforms/core-configuration/model-core/build.gradle.kts
+++ b/platforms/core-configuration/model-core/build.gradle.kts
@@ -38,7 +38,6 @@ dependencies {
     implementation(libs.kotlinStdlib)
     implementation(libs.slf4jApi)
     implementation(libs.commonsLang)
-    implementation(libs.fastutil)
 
     compileOnly(libs.errorProneAnnotations)
 

--- a/platforms/core-configuration/model-core/src/jmh/java/org/gradle/internal/evaluation/EvaluationContextPerfTest.java
+++ b/platforms/core-configuration/model-core/src/jmh/java/org/gradle/internal/evaluation/EvaluationContextPerfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.internal.provider;
+package org.gradle.internal.evaluation;
 
+import org.gradle.api.internal.provider.DefaultProperty;
+import org.gradle.api.internal.provider.DefaultProvider;
+import org.gradle.api.internal.provider.PropertyHost;
+import org.gradle.api.internal.provider.TransformBackedProvider;
 import org.gradle.api.provider.Property;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -29,7 +29,7 @@ import org.gradle.api.internal.provider.Collectors.SingleElement;
 import org.gradle.api.provider.HasMultipleValues;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
-import org.gradle.internal.evaluation.EvaluationContext;
+import org.gradle.internal.evaluation.ScopeContext;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -303,12 +303,12 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
     }
 
     @Override
-    protected Value<? extends C> calculateValueFrom(EvaluationContext.ScopeContext context, CollectionSupplier<T, C> value, ValueConsumer consumer) {
+    protected Value<? extends C> calculateValueFrom(ScopeContext context, CollectionSupplier<T, C> value, ValueConsumer consumer) {
         return value.calculateValue(consumer);
     }
 
     @Override
-    protected CollectionSupplier<T, C> finalValue(EvaluationContext.ScopeContext context, CollectionSupplier<T, C> value, ValueConsumer consumer) {
+    protected CollectionSupplier<T, C> finalValue(ScopeContext context, CollectionSupplier<T, C> value, ValueConsumer consumer) {
         Value<? extends C> result = value.calculateValue(consumer);
         if (!result.isMissing()) {
             return new FixedSupplier(result.getWithoutSideEffect(), Cast.uncheckedCast(result.getSideEffect()));
@@ -320,7 +320,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
     }
 
     @Override
-    protected ExecutionTimeValue<? extends C> calculateOwnExecutionTimeValue(EvaluationContext.ScopeContext context, CollectionSupplier<T, C> value) {
+    protected ExecutionTimeValue<? extends C> calculateOwnExecutionTimeValue(ScopeContext context, CollectionSupplier<T, C> value) {
         return value.calculateExecutionTimeValue();
     }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -29,6 +29,7 @@ import org.gradle.api.internal.provider.Collectors.SingleElement;
 import org.gradle.api.provider.HasMultipleValues;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
+import org.gradle.internal.evaluation.EvaluationContext;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -29,7 +29,7 @@ import org.gradle.api.internal.provider.Collectors.SingleElement;
 import org.gradle.api.provider.HasMultipleValues;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
-import org.gradle.internal.evaluation.ScopeContext;
+import org.gradle.internal.evaluation.EvaluationScopeContext;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -303,12 +303,12 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
     }
 
     @Override
-    protected Value<? extends C> calculateValueFrom(ScopeContext context, CollectionSupplier<T, C> value, ValueConsumer consumer) {
+    protected Value<? extends C> calculateValueFrom(EvaluationScopeContext context, CollectionSupplier<T, C> value, ValueConsumer consumer) {
         return value.calculateValue(consumer);
     }
 
     @Override
-    protected CollectionSupplier<T, C> finalValue(ScopeContext context, CollectionSupplier<T, C> value, ValueConsumer consumer) {
+    protected CollectionSupplier<T, C> finalValue(EvaluationScopeContext context, CollectionSupplier<T, C> value, ValueConsumer consumer) {
         Value<? extends C> result = value.calculateValue(consumer);
         if (!result.isMissing()) {
             return new FixedSupplier(result.getWithoutSideEffect(), Cast.uncheckedCast(result.getSideEffect()));
@@ -320,7 +320,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
     }
 
     @Override
-    protected ExecutionTimeValue<? extends C> calculateOwnExecutionTimeValue(ScopeContext context, CollectionSupplier<T, C> value) {
+    protected ExecutionTimeValue<? extends C> calculateOwnExecutionTimeValue(EvaluationScopeContext context, CollectionSupplier<T, C> value) {
         return value.calculateExecutionTimeValue();
     }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
@@ -25,6 +25,7 @@ import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.evaluation.EvaluationContext;
+import org.gradle.internal.evaluation.ScopeContext;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.state.Managed;
 
@@ -214,7 +215,7 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
      *
      * @return the scope
      */
-    protected EvaluationContext.ScopeContext openScope() {
+    protected ScopeContext openScope() {
         return EvaluationContext.current().open(this);
     }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
@@ -25,7 +25,7 @@ import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.evaluation.EvaluationContext;
-import org.gradle.internal.evaluation.ScopeContext;
+import org.gradle.internal.evaluation.EvaluationScopeContext;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.state.Managed;
 
@@ -215,7 +215,7 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
      *
      * @return the scope
      */
-    protected ScopeContext openScope() {
+    protected EvaluationScopeContext openScope() {
         return EvaluationContext.current().open(this);
     }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
@@ -24,6 +24,7 @@ import org.gradle.internal.Cast;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.deprecation.DeprecationLogger;
+import org.gradle.internal.evaluation.EvaluationContext;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.state.Managed;
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -21,6 +21,7 @@ import org.gradle.api.provider.SupportsConvention;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.UncheckedException;
+import org.gradle.internal.evaluation.EvaluationContext;
 import org.gradle.internal.exceptions.Contextual;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.state.ModelObject;

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -21,7 +21,7 @@ import org.gradle.api.provider.SupportsConvention;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.UncheckedException;
-import org.gradle.internal.evaluation.ScopeContext;
+import org.gradle.internal.evaluation.EvaluationScopeContext;
 import org.gradle.internal.exceptions.Contextual;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.state.ModelObject;
@@ -76,7 +76,7 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
 
     @Override
     public boolean calculatePresence(ValueConsumer consumer) {
-        try (ScopeContext context = openScope()) {
+        try (EvaluationScopeContext context = openScope()) {
             beforeRead(context, consumer); // may throw its own exception, which should not be wrapped.
             try {
                 return getSupplier(context).calculatePresence(consumer);
@@ -137,7 +137,7 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
         }
     }
 
-    protected final S getSupplier(@SuppressWarnings("unused") ScopeContext context) {
+    protected final S getSupplier(@SuppressWarnings("unused") EvaluationScopeContext context) {
         // context serves as a token here to ensure that the scope is opened.
         return value;
     }
@@ -151,7 +151,7 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
     }
 
     protected Value<? extends T> calculateOwnValueNoProducer(ValueConsumer consumer) {
-        try (ScopeContext context = openScope()) {
+        try (EvaluationScopeContext context = openScope()) {
             beforeReadNoProducer(context, consumer);
             return doCalculateValue(context, consumer);
         }
@@ -159,14 +159,14 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
 
     @Override
     protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
-        try (ScopeContext context = openScope()) {
+        try (EvaluationScopeContext context = openScope()) {
             beforeRead(context, consumer);
             return doCalculateValue(context, consumer);
         }
     }
 
     @Nonnull
-    private Value<? extends T> doCalculateValue(ScopeContext context, ValueConsumer consumer) {
+    private Value<? extends T> doCalculateValue(EvaluationScopeContext context, ValueConsumer consumer) {
         try {
             return calculateValueFrom(context, value, consumer);
         } catch (Exception e) {
@@ -178,11 +178,11 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
         }
     }
 
-    protected abstract Value<? extends T> calculateValueFrom(ScopeContext context, S value, ValueConsumer consumer);
+    protected abstract Value<? extends T> calculateValueFrom(EvaluationScopeContext context, S value, ValueConsumer consumer);
 
     @Override
     public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
-        try (ScopeContext context = openScope()) {
+        try (EvaluationScopeContext context = openScope()) {
             ExecutionTimeValue<? extends T> value = calculateOwnExecutionTimeValue(context, this.value);
             if (getProducerTask() == null) {
                 return value;
@@ -192,7 +192,7 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
         }
     }
 
-    protected abstract ExecutionTimeValue<? extends T> calculateOwnExecutionTimeValue(ScopeContext context, S value);
+    protected abstract ExecutionTimeValue<? extends T> calculateOwnExecutionTimeValue(EvaluationScopeContext context, S value);
 
     /**
      * Returns a diagnostic string describing the current source of value of this property. Should not realize the value.
@@ -215,7 +215,7 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
         if (task != null) {
             return ValueProducer.task(task);
         } else {
-            try (ScopeContext context = openScope()) {
+            try (EvaluationScopeContext context = openScope()) {
                 return getSupplier(context).getProducer();
             }
         }
@@ -224,7 +224,7 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
     @Override
     public void finalizeValue() {
         if (state.shouldFinalize(this.getDisplayName(), producer)) {
-            try (ScopeContext context = openScope()) {
+            try (EvaluationScopeContext context = openScope()) {
                 finalizeNow(context, ValueConsumer.IgnoreUnsafeRead);
             }
         }
@@ -261,7 +261,7 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
         state.disallowUnsafeRead();
     }
 
-    protected abstract S finalValue(ScopeContext context, S value, ValueConsumer consumer);
+    protected abstract S finalValue(EvaluationScopeContext context, S value, ValueConsumer consumer);
 
     protected void setSupplier(S supplier) {
         assertCanMutate();
@@ -276,19 +276,19 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
     /**
      * Call prior to reading the value of this property.
      */
-    protected void beforeRead(ScopeContext context, ValueConsumer consumer) {
+    protected void beforeRead(EvaluationScopeContext context, ValueConsumer consumer) {
         beforeRead(context, producer, consumer);
     }
 
-    protected void beforeReadNoProducer(ScopeContext context, ValueConsumer consumer) {
+    protected void beforeReadNoProducer(EvaluationScopeContext context, ValueConsumer consumer) {
         beforeRead(context, null, consumer);
     }
 
-    private void beforeRead(ScopeContext context, @Nullable ModelObject effectiveProducer, ValueConsumer consumer) {
+    private void beforeRead(EvaluationScopeContext context, @Nullable ModelObject effectiveProducer, ValueConsumer consumer) {
         state.finalizeOnReadIfNeeded(this.getDisplayName(), effectiveProducer, consumer, effectiveConsumer -> finalizeNow(context, effectiveConsumer));
     }
 
-    private void finalizeNow(ScopeContext context, ValueConsumer consumer) {
+    private void finalizeNow(EvaluationScopeContext context, ValueConsumer consumer) {
         try {
             value = finalValue(context, value, state.forUpstream(consumer));
         } catch (Exception e) {
@@ -452,21 +452,21 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
 
         @Override
         public ValueProducer getProducer() {
-            try (ScopeContext ignored = openScope()) {
+            try (EvaluationScopeContext ignored = openScope()) {
                 return copiedValue.getProducer();
             }
         }
 
         @Override
         public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
-            try (ScopeContext context = openScope()) {
+            try (EvaluationScopeContext context = openScope()) {
                 return calculateOwnExecutionTimeValue(context, copiedValue);
             }
         }
 
         @Override
         protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
-            try (ScopeContext context = openScope()) {
+            try (EvaluationScopeContext context = openScope()) {
                 return calculateValueFrom(context, copiedValue, consumer);
             }
         }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/BiProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/BiProvider.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.provider;
 
 import org.gradle.api.provider.Provider;
+import org.gradle.internal.evaluation.EvaluationContext;
 
 import javax.annotation.Nullable;
 import java.util.function.BiFunction;

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/BiProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/BiProvider.java
@@ -16,7 +16,7 @@
 package org.gradle.api.internal.provider;
 
 import org.gradle.api.provider.Provider;
-import org.gradle.internal.evaluation.ScopeContext;
+import org.gradle.internal.evaluation.EvaluationScopeContext;
 
 import javax.annotation.Nullable;
 import java.util.function.BiFunction;
@@ -42,7 +42,7 @@ public class BiProvider<R, A, B> extends AbstractMinimalProvider<R> {
 
     @Override
     public boolean calculatePresence(ValueConsumer consumer) {
-        try (ScopeContext ignored = openScope()) {
+        try (EvaluationScopeContext ignored = openScope()) {
             if (!left.calculatePresence(consumer) || !right.calculatePresence(consumer)) {
                 return false;
             }
@@ -53,7 +53,7 @@ public class BiProvider<R, A, B> extends AbstractMinimalProvider<R> {
 
     @Override
     public ExecutionTimeValue<? extends R> calculateExecutionTimeValue() {
-        try (ScopeContext ignored = openScope()) {
+        try (EvaluationScopeContext ignored = openScope()) {
             if (isChangingValue(left) || isChangingValue(right)) {
                 return ExecutionTimeValue.changingValue(this);
             }
@@ -67,7 +67,7 @@ public class BiProvider<R, A, B> extends AbstractMinimalProvider<R> {
 
     @Override
     protected Value<? extends R> calculateOwnValue(ValueConsumer consumer) {
-        try (ScopeContext ignored = openScope()) {
+        try (EvaluationScopeContext ignored = openScope()) {
             Value<? extends A> leftValue = left.calculateValue(consumer);
             if (leftValue.isMissing()) {
                 return leftValue.asType();
@@ -93,7 +93,7 @@ public class BiProvider<R, A, B> extends AbstractMinimalProvider<R> {
 
     @Override
     public ValueProducer getProducer() {
-        try (ScopeContext ignored = openScope()) {
+        try (EvaluationScopeContext ignored = openScope()) {
             return new PlusProducer(left.getProducer(), right.getProducer());
         }
     }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/BiProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/BiProvider.java
@@ -16,7 +16,7 @@
 package org.gradle.api.internal.provider;
 
 import org.gradle.api.provider.Provider;
-import org.gradle.internal.evaluation.EvaluationContext;
+import org.gradle.internal.evaluation.ScopeContext;
 
 import javax.annotation.Nullable;
 import java.util.function.BiFunction;
@@ -42,7 +42,7 @@ public class BiProvider<R, A, B> extends AbstractMinimalProvider<R> {
 
     @Override
     public boolean calculatePresence(ValueConsumer consumer) {
-        try (EvaluationContext.ScopeContext ignored = openScope()) {
+        try (ScopeContext ignored = openScope()) {
             if (!left.calculatePresence(consumer) || !right.calculatePresence(consumer)) {
                 return false;
             }
@@ -53,7 +53,7 @@ public class BiProvider<R, A, B> extends AbstractMinimalProvider<R> {
 
     @Override
     public ExecutionTimeValue<? extends R> calculateExecutionTimeValue() {
-        try (EvaluationContext.ScopeContext ignored = openScope()) {
+        try (ScopeContext ignored = openScope()) {
             if (isChangingValue(left) || isChangingValue(right)) {
                 return ExecutionTimeValue.changingValue(this);
             }
@@ -67,7 +67,7 @@ public class BiProvider<R, A, B> extends AbstractMinimalProvider<R> {
 
     @Override
     protected Value<? extends R> calculateOwnValue(ValueConsumer consumer) {
-        try (EvaluationContext.ScopeContext ignored = openScope()) {
+        try (ScopeContext ignored = openScope()) {
             Value<? extends A> leftValue = left.calculateValue(consumer);
             if (leftValue.isMissing()) {
                 return leftValue.asType();
@@ -93,7 +93,7 @@ public class BiProvider<R, A, B> extends AbstractMinimalProvider<R> {
 
     @Override
     public ValueProducer getProducer() {
-        try (EvaluationContext.ScopeContext ignored = openScope()) {
+        try (ScopeContext ignored = openScope()) {
             return new PlusProducer(left.getProducer(), right.getProducer());
         }
     }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -30,7 +30,7 @@ import org.gradle.api.internal.provider.MapCollectors.SingleEntry;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
-import org.gradle.internal.evaluation.EvaluationContext;
+import org.gradle.internal.evaluation.ScopeContext;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -337,12 +337,12 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
     }
 
     @Override
-    protected Value<? extends Map<K, V>> calculateValueFrom(EvaluationContext.ScopeContext context, MapSupplier<K, V> value, ValueConsumer consumer) {
+    protected Value<? extends Map<K, V>> calculateValueFrom(ScopeContext context, MapSupplier<K, V> value, ValueConsumer consumer) {
         return value.calculateValue(consumer);
     }
 
     @Override
-    protected MapSupplier<K, V> finalValue(EvaluationContext.ScopeContext context, MapSupplier<K, V> value, ValueConsumer consumer) {
+    protected MapSupplier<K, V> finalValue(ScopeContext context, MapSupplier<K, V> value, ValueConsumer consumer) {
         Value<? extends Map<K, V>> result = value.calculateValue(consumer);
         if (!result.isMissing()) {
             return new FixedSupplier(result.getWithoutSideEffect(), uncheckedCast(result.getSideEffect()));
@@ -354,7 +354,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
     }
 
     @Override
-    protected ExecutionTimeValue<? extends Map<K, V>> calculateOwnExecutionTimeValue(EvaluationContext.ScopeContext context, MapSupplier<K, V> value) {
+    protected ExecutionTimeValue<? extends Map<K, V>> calculateOwnExecutionTimeValue(ScopeContext context, MapSupplier<K, V> value) {
         return value.calculateExecutionTimeValue();
     }
 
@@ -392,7 +392,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
 
         @Override
         protected Value<? extends Set<K>> calculateOwnValue(ValueConsumer consumer) {
-            try (EvaluationContext.ScopeContext context = DefaultMapProperty.this.openScope()) {
+            try (ScopeContext context = DefaultMapProperty.this.openScope()) {
                 beforeRead(context, consumer);
                 return getSupplier(context).calculateKeys(consumer);
             }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -30,7 +30,7 @@ import org.gradle.api.internal.provider.MapCollectors.SingleEntry;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
-import org.gradle.internal.evaluation.ScopeContext;
+import org.gradle.internal.evaluation.EvaluationScopeContext;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -337,12 +337,12 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
     }
 
     @Override
-    protected Value<? extends Map<K, V>> calculateValueFrom(ScopeContext context, MapSupplier<K, V> value, ValueConsumer consumer) {
+    protected Value<? extends Map<K, V>> calculateValueFrom(EvaluationScopeContext context, MapSupplier<K, V> value, ValueConsumer consumer) {
         return value.calculateValue(consumer);
     }
 
     @Override
-    protected MapSupplier<K, V> finalValue(ScopeContext context, MapSupplier<K, V> value, ValueConsumer consumer) {
+    protected MapSupplier<K, V> finalValue(EvaluationScopeContext context, MapSupplier<K, V> value, ValueConsumer consumer) {
         Value<? extends Map<K, V>> result = value.calculateValue(consumer);
         if (!result.isMissing()) {
             return new FixedSupplier(result.getWithoutSideEffect(), uncheckedCast(result.getSideEffect()));
@@ -354,7 +354,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
     }
 
     @Override
-    protected ExecutionTimeValue<? extends Map<K, V>> calculateOwnExecutionTimeValue(ScopeContext context, MapSupplier<K, V> value) {
+    protected ExecutionTimeValue<? extends Map<K, V>> calculateOwnExecutionTimeValue(EvaluationScopeContext context, MapSupplier<K, V> value) {
         return value.calculateExecutionTimeValue();
     }
 
@@ -392,7 +392,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
 
         @Override
         protected Value<? extends Set<K>> calculateOwnValue(ValueConsumer consumer) {
-            try (ScopeContext context = DefaultMapProperty.this.openScope()) {
+            try (EvaluationScopeContext context = DefaultMapProperty.this.openScope()) {
                 beforeRead(context, consumer);
                 return getSupplier(context).calculateKeys(consumer);
             }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.provider.MapCollectors.SingleEntry;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
+import org.gradle.internal.evaluation.EvaluationContext;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -21,7 +21,7 @@ import org.gradle.api.Transformer;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
-import org.gradle.internal.evaluation.EvaluationContext;
+import org.gradle.internal.evaluation.ScopeContext;
 
 import javax.annotation.Nullable;
 
@@ -101,7 +101,7 @@ public class DefaultProperty<T> extends AbstractProperty<T, ProviderInternal<? e
     public ProviderInternal<? extends T> getProvider() {
         // TODO(mlopatkin) while calling getProvider is not going to cause StackOverflowError by itself, the returned provider is typically used in some recursive call.
         //  Without the safety net of the EvaluationContext, it can cause hard-to-debug exceptions.
-        try (EvaluationContext.ScopeContext context = openScope()) {
+        try (ScopeContext context = openScope()) {
             return getSupplier(context);
         }
     }
@@ -148,18 +148,18 @@ public class DefaultProperty<T> extends AbstractProperty<T, ProviderInternal<? e
     }
 
     @Override
-    protected ExecutionTimeValue<? extends T> calculateOwnExecutionTimeValue(EvaluationContext.ScopeContext context, ProviderInternal<? extends T> value) {
+    protected ExecutionTimeValue<? extends T> calculateOwnExecutionTimeValue(ScopeContext context, ProviderInternal<? extends T> value) {
         // Discard this property from a provider chain, as it does not contribute anything to the calculation.
         return value.calculateExecutionTimeValue();
     }
 
     @Override
-    protected Value<? extends T> calculateValueFrom(EvaluationContext.ScopeContext context, ProviderInternal<? extends T> value, ValueConsumer consumer) {
+    protected Value<? extends T> calculateValueFrom(ScopeContext context, ProviderInternal<? extends T> value, ValueConsumer consumer) {
         return value.calculateValue(consumer);
     }
 
     @Override
-    protected ProviderInternal<? extends T> finalValue(EvaluationContext.ScopeContext context, ProviderInternal<? extends T> value, ValueConsumer consumer) {
+    protected ProviderInternal<? extends T> finalValue(ScopeContext context, ProviderInternal<? extends T> value, ValueConsumer consumer) {
         return value.withFinalValue(consumer);
     }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -21,7 +21,7 @@ import org.gradle.api.Transformer;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
-import org.gradle.internal.evaluation.ScopeContext;
+import org.gradle.internal.evaluation.EvaluationScopeContext;
 
 import javax.annotation.Nullable;
 
@@ -101,7 +101,7 @@ public class DefaultProperty<T> extends AbstractProperty<T, ProviderInternal<? e
     public ProviderInternal<? extends T> getProvider() {
         // TODO(mlopatkin) while calling getProvider is not going to cause StackOverflowError by itself, the returned provider is typically used in some recursive call.
         //  Without the safety net of the EvaluationContext, it can cause hard-to-debug exceptions.
-        try (ScopeContext context = openScope()) {
+        try (EvaluationScopeContext context = openScope()) {
             return getSupplier(context);
         }
     }
@@ -148,18 +148,18 @@ public class DefaultProperty<T> extends AbstractProperty<T, ProviderInternal<? e
     }
 
     @Override
-    protected ExecutionTimeValue<? extends T> calculateOwnExecutionTimeValue(ScopeContext context, ProviderInternal<? extends T> value) {
+    protected ExecutionTimeValue<? extends T> calculateOwnExecutionTimeValue(EvaluationScopeContext context, ProviderInternal<? extends T> value) {
         // Discard this property from a provider chain, as it does not contribute anything to the calculation.
         return value.calculateExecutionTimeValue();
     }
 
     @Override
-    protected Value<? extends T> calculateValueFrom(ScopeContext context, ProviderInternal<? extends T> value, ValueConsumer consumer) {
+    protected Value<? extends T> calculateValueFrom(EvaluationScopeContext context, ProviderInternal<? extends T> value, ValueConsumer consumer) {
         return value.calculateValue(consumer);
     }
 
     @Override
-    protected ProviderInternal<? extends T> finalValue(ScopeContext context, ProviderInternal<? extends T> value, ValueConsumer consumer) {
+    protected ProviderInternal<? extends T> finalValue(EvaluationScopeContext context, ProviderInternal<? extends T> value, ValueConsumer consumer) {
         return value.withFinalValue(consumer);
     }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -21,6 +21,7 @@ import org.gradle.api.Transformer;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
+import org.gradle.internal.evaluation.EvaluationContext;
 
 import javax.annotation.Nullable;
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProvider.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.provider;
 
 import org.gradle.internal.Cast;
 import org.gradle.internal.UncheckedException;
-import org.gradle.internal.evaluation.EvaluationContext;
+import org.gradle.internal.evaluation.ScopeContext;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.ParameterizedType;
@@ -69,7 +69,7 @@ public class DefaultProvider<T> extends AbstractMinimalProvider<T> {
 
     @Override
     protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
-        try (EvaluationContext.ScopeContext ignored = openScope()) {
+        try (ScopeContext ignored = openScope()) {
             return Value.ofNullable(value.call());
         } catch (Exception e) {
             throw UncheckedException.throwAsUncheckedException(e);

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProvider.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.provider;
 
 import org.gradle.internal.Cast;
 import org.gradle.internal.UncheckedException;
-import org.gradle.internal.evaluation.ScopeContext;
+import org.gradle.internal.evaluation.EvaluationScopeContext;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.ParameterizedType;
@@ -69,7 +69,7 @@ public class DefaultProvider<T> extends AbstractMinimalProvider<T> {
 
     @Override
     protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
-        try (ScopeContext ignored = openScope()) {
+        try (EvaluationScopeContext ignored = openScope()) {
             return Value.ofNullable(value.call());
         } catch (Exception e) {
             throw UncheckedException.throwAsUncheckedException(e);

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProvider.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.provider;
 
 import org.gradle.internal.Cast;
 import org.gradle.internal.UncheckedException;
+import org.gradle.internal.evaluation.EvaluationContext;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.ParameterizedType;

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/FilteringProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/FilteringProvider.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.provider;
 
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.specs.Spec;
-import org.gradle.internal.evaluation.ScopeContext;
+import org.gradle.internal.evaluation.EvaluationScopeContext;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -47,14 +47,14 @@ public class FilteringProvider<T> extends AbstractMinimalProvider<T> {
 
     @Override
     public ValueProducer getProducer() {
-        try (ScopeContext ignored = openScope()) {
+        try (EvaluationScopeContext ignored = openScope()) {
             return provider.getProducer();
         }
     }
 
     @Override
     public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
-        try (ScopeContext context = openScope()) {
+        try (EvaluationScopeContext context = openScope()) {
             ExecutionTimeValue<? extends T> value = provider.calculateExecutionTimeValue();
             if (value.isMissing()) {
                 return value;
@@ -71,7 +71,7 @@ public class FilteringProvider<T> extends AbstractMinimalProvider<T> {
 
     @Override
     protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
-        try (ScopeContext context = openScope()) {
+        try (EvaluationScopeContext context = openScope()) {
             beforeRead(context);
             Value<? extends T> value = provider.calculateValue(consumer);
             return filterValue(context, value);
@@ -79,7 +79,7 @@ public class FilteringProvider<T> extends AbstractMinimalProvider<T> {
     }
 
     @Nonnull
-    protected Value<? extends T> filterValue(@SuppressWarnings("unused") ScopeContext context, Value<? extends T> value) {
+    protected Value<? extends T> filterValue(@SuppressWarnings("unused") EvaluationScopeContext context, Value<? extends T> value) {
         if (value.isMissing()) {
             return value.asType();
         }
@@ -91,7 +91,7 @@ public class FilteringProvider<T> extends AbstractMinimalProvider<T> {
         }
     }
 
-    protected void beforeRead(@SuppressWarnings("unused") ScopeContext context) {
+    protected void beforeRead(@SuppressWarnings("unused") EvaluationScopeContext context) {
         provider.getProducer().visitContentProducerTasks(producer -> {
             if (!producer.getState().getExecuted()) {
                 throw new InvalidUserCodeException(

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/FilteringProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/FilteringProvider.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.provider;
 
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.specs.Spec;
-import org.gradle.internal.evaluation.EvaluationContext;
+import org.gradle.internal.evaluation.ScopeContext;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -47,14 +47,14 @@ public class FilteringProvider<T> extends AbstractMinimalProvider<T> {
 
     @Override
     public ValueProducer getProducer() {
-        try (EvaluationContext.ScopeContext ignored = openScope()) {
+        try (ScopeContext ignored = openScope()) {
             return provider.getProducer();
         }
     }
 
     @Override
     public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
-        try (EvaluationContext.ScopeContext context = openScope()) {
+        try (ScopeContext context = openScope()) {
             ExecutionTimeValue<? extends T> value = provider.calculateExecutionTimeValue();
             if (value.isMissing()) {
                 return value;
@@ -71,7 +71,7 @@ public class FilteringProvider<T> extends AbstractMinimalProvider<T> {
 
     @Override
     protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
-        try (EvaluationContext.ScopeContext context = openScope()) {
+        try (ScopeContext context = openScope()) {
             beforeRead(context);
             Value<? extends T> value = provider.calculateValue(consumer);
             return filterValue(context, value);
@@ -79,7 +79,7 @@ public class FilteringProvider<T> extends AbstractMinimalProvider<T> {
     }
 
     @Nonnull
-    protected Value<? extends T> filterValue(@SuppressWarnings("unused") EvaluationContext.ScopeContext context, Value<? extends T> value) {
+    protected Value<? extends T> filterValue(@SuppressWarnings("unused") ScopeContext context, Value<? extends T> value) {
         if (value.isMissing()) {
             return value.asType();
         }
@@ -91,7 +91,7 @@ public class FilteringProvider<T> extends AbstractMinimalProvider<T> {
         }
     }
 
-    protected void beforeRead(@SuppressWarnings("unused") EvaluationContext.ScopeContext context) {
+    protected void beforeRead(@SuppressWarnings("unused") ScopeContext context) {
         provider.getProducer().visitContentProducerTasks(producer -> {
             if (!producer.getState().getExecuted()) {
                 throw new InvalidUserCodeException(

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/FilteringProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/FilteringProvider.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.provider;
 
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.specs.Spec;
+import org.gradle.internal.evaluation.EvaluationContext;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/FlatMapProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/FlatMapProvider.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.provider;
 
 import org.gradle.api.Transformer;
 import org.gradle.api.provider.Provider;
-import org.gradle.internal.evaluation.EvaluationContext;
+import org.gradle.internal.evaluation.ScopeContext;
 
 import javax.annotation.Nullable;
 
@@ -39,14 +39,14 @@ public class FlatMapProvider<S, T> extends AbstractMinimalProvider<S> {
 
     @Override
     public boolean calculatePresence(ValueConsumer consumer) {
-        try (EvaluationContext.ScopeContext context = openScope()) {
+        try (ScopeContext context = openScope()) {
             return backingProvider(context, consumer).calculatePresence(consumer);
         }
     }
 
     @Override
     protected Value<? extends S> calculateOwnValue(ValueConsumer consumer) {
-        try (EvaluationContext.ScopeContext context = openScope()) {
+        try (ScopeContext context = openScope()) {
             Value<? extends T> value = provider.calculateValue(consumer);
             if (value.isMissing()) {
                 return value.asType();
@@ -55,7 +55,7 @@ public class FlatMapProvider<S, T> extends AbstractMinimalProvider<S> {
         }
     }
 
-    private ProviderInternal<? extends S> doMapValue(@SuppressWarnings("unused") EvaluationContext.ScopeContext context, Value<? extends T> value) {
+    private ProviderInternal<? extends S> doMapValue(@SuppressWarnings("unused") ScopeContext context, Value<? extends T> value) {
         T unpackedValue = value.getWithoutSideEffect();
         Provider<? extends S> transformedProvider = transformer.transform(unpackedValue);
         if (transformedProvider == null) {
@@ -69,7 +69,7 @@ public class FlatMapProvider<S, T> extends AbstractMinimalProvider<S> {
         return Providers.internal(transformedProvider).withSideEffect(SideEffect.fixedFrom(value));
     }
 
-    private ProviderInternal<? extends S> backingProvider(EvaluationContext.ScopeContext context, ValueConsumer consumer) {
+    private ProviderInternal<? extends S> backingProvider(ScopeContext context, ValueConsumer consumer) {
         Value<? extends T> value = provider.calculateValue(consumer);
         if (value.isMissing()) {
             return Providers.notDefined();
@@ -79,14 +79,14 @@ public class FlatMapProvider<S, T> extends AbstractMinimalProvider<S> {
 
     @Override
     public ValueProducer getProducer() {
-        try (EvaluationContext.ScopeContext context = openScope()) {
+        try (ScopeContext context = openScope()) {
             return backingProvider(context, ValueConsumer.IgnoreUnsafeRead).getProducer();
         }
     }
 
     @Override
     public ExecutionTimeValue<? extends S> calculateExecutionTimeValue() {
-        try (EvaluationContext.ScopeContext context = openScope()) {
+        try (ScopeContext context = openScope()) {
             return backingProvider(context, ValueConsumer.IgnoreUnsafeRead).calculateExecutionTimeValue();
         }
     }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/FlatMapProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/FlatMapProvider.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.provider;
 
 import org.gradle.api.Transformer;
 import org.gradle.api.provider.Provider;
+import org.gradle.internal.evaluation.EvaluationContext;
 
 import javax.annotation.Nullable;
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/FlatMapProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/FlatMapProvider.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.provider;
 
 import org.gradle.api.Transformer;
 import org.gradle.api.provider.Provider;
-import org.gradle.internal.evaluation.ScopeContext;
+import org.gradle.internal.evaluation.EvaluationScopeContext;
 
 import javax.annotation.Nullable;
 
@@ -39,14 +39,14 @@ public class FlatMapProvider<S, T> extends AbstractMinimalProvider<S> {
 
     @Override
     public boolean calculatePresence(ValueConsumer consumer) {
-        try (ScopeContext context = openScope()) {
+        try (EvaluationScopeContext context = openScope()) {
             return backingProvider(context, consumer).calculatePresence(consumer);
         }
     }
 
     @Override
     protected Value<? extends S> calculateOwnValue(ValueConsumer consumer) {
-        try (ScopeContext context = openScope()) {
+        try (EvaluationScopeContext context = openScope()) {
             Value<? extends T> value = provider.calculateValue(consumer);
             if (value.isMissing()) {
                 return value.asType();
@@ -55,7 +55,7 @@ public class FlatMapProvider<S, T> extends AbstractMinimalProvider<S> {
         }
     }
 
-    private ProviderInternal<? extends S> doMapValue(@SuppressWarnings("unused") ScopeContext context, Value<? extends T> value) {
+    private ProviderInternal<? extends S> doMapValue(@SuppressWarnings("unused") EvaluationScopeContext context, Value<? extends T> value) {
         T unpackedValue = value.getWithoutSideEffect();
         Provider<? extends S> transformedProvider = transformer.transform(unpackedValue);
         if (transformedProvider == null) {
@@ -69,7 +69,7 @@ public class FlatMapProvider<S, T> extends AbstractMinimalProvider<S> {
         return Providers.internal(transformedProvider).withSideEffect(SideEffect.fixedFrom(value));
     }
 
-    private ProviderInternal<? extends S> backingProvider(ScopeContext context, ValueConsumer consumer) {
+    private ProviderInternal<? extends S> backingProvider(EvaluationScopeContext context, ValueConsumer consumer) {
         Value<? extends T> value = provider.calculateValue(consumer);
         if (value.isMissing()) {
             return Providers.notDefined();
@@ -79,14 +79,14 @@ public class FlatMapProvider<S, T> extends AbstractMinimalProvider<S> {
 
     @Override
     public ValueProducer getProducer() {
-        try (ScopeContext context = openScope()) {
+        try (EvaluationScopeContext context = openScope()) {
             return backingProvider(context, ValueConsumer.IgnoreUnsafeRead).getProducer();
         }
     }
 
     @Override
     public ExecutionTimeValue<? extends S> calculateExecutionTimeValue() {
-        try (ScopeContext context = openScope()) {
+        try (EvaluationScopeContext context = openScope()) {
             return backingProvider(context, ValueConsumer.IgnoreUnsafeRead).calculateExecutionTimeValue();
         }
     }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MappingProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MappingProvider.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.provider;
 
 import org.gradle.api.Transformer;
+import org.gradle.internal.evaluation.EvaluationContext;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MappingProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MappingProvider.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.provider;
 
 import org.gradle.api.Transformer;
-import org.gradle.internal.evaluation.EvaluationContext;
+import org.gradle.internal.evaluation.ScopeContext;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -47,14 +47,14 @@ public class MappingProvider<OUT, IN> extends TransformBackedProvider<OUT, IN> {
     @Override
     public boolean calculatePresence(ValueConsumer consumer) {
         // Rely on MappingProvider contract with regard to the transform always returning value
-        try (EvaluationContext.ScopeContext ignored = openScope()) {
+        try (ScopeContext ignored = openScope()) {
             return provider.calculatePresence(consumer);
         }
     }
 
     @Override
     public ExecutionTimeValue<? extends OUT> calculateExecutionTimeValue() {
-        try (EvaluationContext.ScopeContext context = openScope()) {
+        try (ScopeContext context = openScope()) {
             ExecutionTimeValue<? extends IN> value = provider.calculateExecutionTimeValue();
             if (value.isChangingValue()) {
                 return ExecutionTimeValue.changingValue(new MappingProvider<OUT, IN>(type, value.getChangingValue(), transformer));
@@ -66,7 +66,7 @@ public class MappingProvider<OUT, IN> extends TransformBackedProvider<OUT, IN> {
 
     @Nonnull
     @Override
-    protected Value<OUT> mapValue(EvaluationContext.ScopeContext context, Value<? extends IN> value) {
+    protected Value<OUT> mapValue(ScopeContext context, Value<? extends IN> value) {
         Value<OUT> transformedValue = super.mapValue(context, value);
         // Check MappingProvider contract with regard to the transform
         if (!value.isMissing() && transformedValue.isMissing()) {
@@ -76,7 +76,7 @@ public class MappingProvider<OUT, IN> extends TransformBackedProvider<OUT, IN> {
     }
 
     @Override
-    protected void beforeRead(EvaluationContext.ScopeContext context) {}
+    protected void beforeRead(ScopeContext context) {}
 
     @Override
     protected String toStringNoReentrance() {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MappingProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MappingProvider.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.provider;
 
 import org.gradle.api.Transformer;
-import org.gradle.internal.evaluation.ScopeContext;
+import org.gradle.internal.evaluation.EvaluationScopeContext;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -47,14 +47,14 @@ public class MappingProvider<OUT, IN> extends TransformBackedProvider<OUT, IN> {
     @Override
     public boolean calculatePresence(ValueConsumer consumer) {
         // Rely on MappingProvider contract with regard to the transform always returning value
-        try (ScopeContext ignored = openScope()) {
+        try (EvaluationScopeContext ignored = openScope()) {
             return provider.calculatePresence(consumer);
         }
     }
 
     @Override
     public ExecutionTimeValue<? extends OUT> calculateExecutionTimeValue() {
-        try (ScopeContext context = openScope()) {
+        try (EvaluationScopeContext context = openScope()) {
             ExecutionTimeValue<? extends IN> value = provider.calculateExecutionTimeValue();
             if (value.isChangingValue()) {
                 return ExecutionTimeValue.changingValue(new MappingProvider<OUT, IN>(type, value.getChangingValue(), transformer));
@@ -66,7 +66,7 @@ public class MappingProvider<OUT, IN> extends TransformBackedProvider<OUT, IN> {
 
     @Nonnull
     @Override
-    protected Value<OUT> mapValue(ScopeContext context, Value<? extends IN> value) {
+    protected Value<OUT> mapValue(EvaluationScopeContext context, Value<? extends IN> value) {
         Value<OUT> transformedValue = super.mapValue(context, value);
         // Check MappingProvider contract with regard to the transform
         if (!value.isMissing() && transformedValue.isMissing()) {
@@ -76,7 +76,7 @@ public class MappingProvider<OUT, IN> extends TransformBackedProvider<OUT, IN> {
     }
 
     @Override
-    protected void beforeRead(ScopeContext context) {}
+    protected void beforeRead(EvaluationScopeContext context) {}
 
     @Override
     protected String toStringNoReentrance() {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/OrElseFixedValueProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/OrElseFixedValueProvider.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.provider;
 
 import org.gradle.internal.Cast;
-import org.gradle.internal.evaluation.EvaluationContext;
+import org.gradle.internal.evaluation.ScopeContext;
 
 import javax.annotation.Nullable;
 
@@ -43,14 +43,14 @@ class OrElseFixedValueProvider<T> extends AbstractProviderWithValue<T> {
 
     @Override
     public ValueProducer getProducer() {
-        try (EvaluationContext.ScopeContext context = openScope()) {
+        try (ScopeContext context = openScope()) {
             return new OrElseValueProducer(context, provider);
         }
     }
 
     @Override
     public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
-        try (EvaluationContext.ScopeContext ignored = openScope()) {
+        try (ScopeContext ignored = openScope()) {
             ExecutionTimeValue<? extends T> value = provider.calculateExecutionTimeValue();
             if (value.isMissing()) {
                 // Use fallback value
@@ -67,7 +67,7 @@ class OrElseFixedValueProvider<T> extends AbstractProviderWithValue<T> {
 
     @Override
     protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
-        try (EvaluationContext.ScopeContext ignored = openScope()) {
+        try (ScopeContext ignored = openScope()) {
             Value<? extends T> value = provider.calculateValue(consumer);
             if (value.isMissing()) {
                 return Value.of(fallbackValue);

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/OrElseFixedValueProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/OrElseFixedValueProvider.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.provider;
 
 import org.gradle.internal.Cast;
-import org.gradle.internal.evaluation.ScopeContext;
+import org.gradle.internal.evaluation.EvaluationScopeContext;
 
 import javax.annotation.Nullable;
 
@@ -43,14 +43,14 @@ class OrElseFixedValueProvider<T> extends AbstractProviderWithValue<T> {
 
     @Override
     public ValueProducer getProducer() {
-        try (ScopeContext context = openScope()) {
+        try (EvaluationScopeContext context = openScope()) {
             return new OrElseValueProducer(context, provider);
         }
     }
 
     @Override
     public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
-        try (ScopeContext ignored = openScope()) {
+        try (EvaluationScopeContext ignored = openScope()) {
             ExecutionTimeValue<? extends T> value = provider.calculateExecutionTimeValue();
             if (value.isMissing()) {
                 // Use fallback value
@@ -67,7 +67,7 @@ class OrElseFixedValueProvider<T> extends AbstractProviderWithValue<T> {
 
     @Override
     protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
-        try (ScopeContext ignored = openScope()) {
+        try (EvaluationScopeContext ignored = openScope()) {
             Value<? extends T> value = provider.calculateValue(consumer);
             if (value.isMissing()) {
                 return Value.of(fallbackValue);

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/OrElseFixedValueProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/OrElseFixedValueProvider.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.provider;
 
 import org.gradle.internal.Cast;
+import org.gradle.internal.evaluation.EvaluationContext;
 
 import javax.annotation.Nullable;
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/OrElseProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/OrElseProvider.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.provider;
 
-import org.gradle.internal.evaluation.EvaluationContext;
+import org.gradle.internal.evaluation.ScopeContext;
 
 import javax.annotation.Nullable;
 
@@ -42,14 +42,14 @@ class OrElseProvider<T> extends AbstractMinimalProvider<T> {
 
     @Override
     public ValueProducer getProducer() {
-        try (EvaluationContext.ScopeContext context = openScope()) {
+        try (ScopeContext context = openScope()) {
             return new OrElseValueProducer(context, left, right);
         }
     }
 
     @Override
     public boolean calculatePresence(ValueConsumer consumer) {
-        try (EvaluationContext.ScopeContext ignored = openScope()) {
+        try (ScopeContext ignored = openScope()) {
             return left.calculatePresence(consumer) || right.calculatePresence(consumer);
         }
     }
@@ -57,7 +57,7 @@ class OrElseProvider<T> extends AbstractMinimalProvider<T> {
     @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
-        try (EvaluationContext.ScopeContext ignored = openScope()) {
+        try (ScopeContext ignored = openScope()) {
             ExecutionTimeValue<? extends T> leftValue = left.calculateExecutionTimeValue();
             if (leftValue.hasFixedValue()) {
                 return leftValue;
@@ -81,7 +81,7 @@ class OrElseProvider<T> extends AbstractMinimalProvider<T> {
 
     @Override
     protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
-        try (EvaluationContext.ScopeContext ignored = openScope()) {
+        try (ScopeContext ignored = openScope()) {
             Value<? extends T> leftValue = left.calculateValue(consumer);
             if (!leftValue.isMissing()) {
                 return leftValue;

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/OrElseProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/OrElseProvider.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.internal.provider;
 
+import org.gradle.internal.evaluation.EvaluationContext;
+
 import javax.annotation.Nullable;
 
 class OrElseProvider<T> extends AbstractMinimalProvider<T> {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/OrElseProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/OrElseProvider.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.provider;
 
-import org.gradle.internal.evaluation.ScopeContext;
+import org.gradle.internal.evaluation.EvaluationScopeContext;
 
 import javax.annotation.Nullable;
 
@@ -42,14 +42,14 @@ class OrElseProvider<T> extends AbstractMinimalProvider<T> {
 
     @Override
     public ValueProducer getProducer() {
-        try (ScopeContext context = openScope()) {
+        try (EvaluationScopeContext context = openScope()) {
             return new OrElseValueProducer(context, left, right);
         }
     }
 
     @Override
     public boolean calculatePresence(ValueConsumer consumer) {
-        try (ScopeContext ignored = openScope()) {
+        try (EvaluationScopeContext ignored = openScope()) {
             return left.calculatePresence(consumer) || right.calculatePresence(consumer);
         }
     }
@@ -57,7 +57,7 @@ class OrElseProvider<T> extends AbstractMinimalProvider<T> {
     @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
-        try (ScopeContext ignored = openScope()) {
+        try (EvaluationScopeContext ignored = openScope()) {
             ExecutionTimeValue<? extends T> leftValue = left.calculateExecutionTimeValue();
             if (leftValue.hasFixedValue()) {
                 return leftValue;
@@ -81,7 +81,7 @@ class OrElseProvider<T> extends AbstractMinimalProvider<T> {
 
     @Override
     protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
-        try (ScopeContext ignored = openScope()) {
+        try (EvaluationScopeContext ignored = openScope()) {
             Value<? extends T> leftValue = left.calculateValue(consumer);
             if (!leftValue.isMissing()) {
                 return leftValue;

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/OrElseValueProducer.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/OrElseValueProducer.java
@@ -20,7 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.internal.evaluation.EvaluationContext;
 import org.gradle.internal.evaluation.EvaluationOwner;
-import org.gradle.internal.evaluation.ScopeContext;
+import org.gradle.internal.evaluation.EvaluationScopeContext;
 
 import javax.annotation.Nullable;
 import java.util.Objects;
@@ -33,15 +33,15 @@ class OrElseValueProducer implements ValueSupplier.ValueProducer {
     private final ValueSupplier.ValueProducer leftProducer;
     private final ValueSupplier.ValueProducer rightProducer;
 
-    public OrElseValueProducer(ScopeContext context, ProviderInternal<?> left) {
+    public OrElseValueProducer(EvaluationScopeContext context, ProviderInternal<?> left) {
         this(context, left, null, ValueSupplier.ValueProducer.unknown());
     }
 
-    public OrElseValueProducer(ScopeContext context, ProviderInternal<?> left, ProviderInternal<?> right) {
+    public OrElseValueProducer(EvaluationScopeContext context, ProviderInternal<?> left, ProviderInternal<?> right) {
         this(context, left, right, right.getProducer());
     }
 
-    private OrElseValueProducer(ScopeContext context, ProviderInternal<?> left, @Nullable ProviderInternal<?> right, ValueSupplier.ValueProducer rightProducer) {
+    private OrElseValueProducer(EvaluationScopeContext context, ProviderInternal<?> left, @Nullable ProviderInternal<?> right, ValueSupplier.ValueProducer rightProducer) {
         this.owner = Objects.requireNonNull(context.getOwner());
         this.left = left;
         this.right = right;
@@ -57,7 +57,7 @@ class OrElseValueProducer implements ValueSupplier.ValueProducer {
 
     @Override
     public void visitProducerTasks(Action<? super Task> visitor) {
-        try (ScopeContext ignored = EvaluationContext.current().open(owner)) {
+        try (EvaluationScopeContext ignored = EvaluationContext.current().open(owner)) {
             if (mayHaveValue(left)) {
                 if (leftProducer.isKnown()) {
                     leftProducer.visitProducerTasks(visitor);

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/OrElseValueProducer.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/OrElseValueProducer.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.provider;
 
 import org.gradle.api.Action;
 import org.gradle.api.Task;
+import org.gradle.internal.evaluation.EvaluationContext;
 
 import javax.annotation.Nullable;
 import java.util.Objects;

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/OrElseValueProducer.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/OrElseValueProducer.java
@@ -19,27 +19,29 @@ package org.gradle.api.internal.provider;
 import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.internal.evaluation.EvaluationContext;
+import org.gradle.internal.evaluation.EvaluationOwner;
+import org.gradle.internal.evaluation.ScopeContext;
 
 import javax.annotation.Nullable;
 import java.util.Objects;
 
 class OrElseValueProducer implements ValueSupplier.ValueProducer {
-    private final EvaluationContext.EvaluationOwner owner;
+    private final EvaluationOwner owner;
     private final ProviderInternal<?> left;
     @Nullable
     private final ProviderInternal<?> right;
     private final ValueSupplier.ValueProducer leftProducer;
     private final ValueSupplier.ValueProducer rightProducer;
 
-    public OrElseValueProducer(EvaluationContext.ScopeContext context, ProviderInternal<?> left) {
+    public OrElseValueProducer(ScopeContext context, ProviderInternal<?> left) {
         this(context, left, null, ValueSupplier.ValueProducer.unknown());
     }
 
-    public OrElseValueProducer(EvaluationContext.ScopeContext context, ProviderInternal<?> left, ProviderInternal<?> right) {
+    public OrElseValueProducer(ScopeContext context, ProviderInternal<?> left, ProviderInternal<?> right) {
         this(context, left, right, right.getProducer());
     }
 
-    private OrElseValueProducer(EvaluationContext.ScopeContext context, ProviderInternal<?> left, @Nullable ProviderInternal<?> right, ValueSupplier.ValueProducer rightProducer) {
+    private OrElseValueProducer(ScopeContext context, ProviderInternal<?> left, @Nullable ProviderInternal<?> right, ValueSupplier.ValueProducer rightProducer) {
         this.owner = Objects.requireNonNull(context.getOwner());
         this.left = left;
         this.right = right;
@@ -55,7 +57,7 @@ class OrElseValueProducer implements ValueSupplier.ValueProducer {
 
     @Override
     public void visitProducerTasks(Action<? super Task> visitor) {
-        try (EvaluationContext.ScopeContext ignored = EvaluationContext.current().open(owner)) {
+        try (ScopeContext ignored = EvaluationContext.current().open(owner)) {
             if (mayHaveValue(left)) {
                 if (leftProducer.isKnown()) {
                     leftProducer.visitProducerTasks(visitor);

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
@@ -20,7 +20,7 @@ import org.gradle.api.Transformer;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.DisplayName;
-import org.gradle.internal.evaluation.EvaluationContext;
+import org.gradle.internal.evaluation.EvaluationOwner;
 
 import javax.annotation.Nullable;
 import java.util.function.BiFunction;
@@ -110,7 +110,7 @@ import java.util.function.BiFunction;
  * <p>There are further optimizations that could be implemented with configuration caching. For example, when a work node has only fixed inputs, the node could be executed prior to writing the work graph to
  * the configuration cache, so that its outputs in turn become fixed. The node can then be discarded from the graph and replaced with its (now fixed) outputs.</p>
  */
-public interface ProviderInternal<T> extends Provider<T>, ValueSupplier, TaskDependencyContainer, EvaluationContext.EvaluationOwner {
+public interface ProviderInternal<T> extends Provider<T>, ValueSupplier, TaskDependencyContainer, EvaluationOwner {
     /**
      * Return the upper bound on the type of all values that this provider may produce, if known.
      *

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
@@ -20,6 +20,7 @@ import org.gradle.api.Transformer;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.DisplayName;
+import org.gradle.internal.evaluation.EvaluationContext;
 
 import javax.annotation.Nullable;
 import java.util.function.BiFunction;

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/TransformBackedProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/TransformBackedProvider.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.provider;
 
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.Transformer;
-import org.gradle.internal.evaluation.EvaluationContext;
+import org.gradle.internal.evaluation.ScopeContext;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -56,14 +56,14 @@ public class TransformBackedProvider<OUT, IN> extends AbstractMinimalProvider<OU
 
     @Override
     public ValueProducer getProducer() {
-        try (EvaluationContext.ScopeContext ignored = openScope()) {
+        try (ScopeContext ignored = openScope()) {
             return provider.getProducer();
         }
     }
 
     @Override
     public ExecutionTimeValue<? extends OUT> calculateExecutionTimeValue() {
-        try (EvaluationContext.ScopeContext context = openScope()) {
+        try (ScopeContext context = openScope()) {
             ExecutionTimeValue<? extends IN> value = provider.calculateExecutionTimeValue();
             if (value.hasChangingContent()) {
                 // Need the value contents in order to transform it to produce the value of this provider,
@@ -77,7 +77,7 @@ public class TransformBackedProvider<OUT, IN> extends AbstractMinimalProvider<OU
 
     @Override
     protected Value<? extends OUT> calculateOwnValue(ValueConsumer consumer) {
-        try (EvaluationContext.ScopeContext context = openScope()) {
+        try (ScopeContext context = openScope()) {
             beforeRead(context);
             Value<? extends IN> value = provider.calculateValue(consumer);
             return mapValue(context, value);
@@ -85,14 +85,14 @@ public class TransformBackedProvider<OUT, IN> extends AbstractMinimalProvider<OU
     }
 
     @Nonnull
-    protected Value<OUT> mapValue(EvaluationContext.ScopeContext context, Value<? extends IN> value) {
+    protected Value<OUT> mapValue(ScopeContext context, Value<? extends IN> value) {
         if (value.isMissing()) {
             return value.asType();
         }
         return value.transform(transformer);
     }
 
-    protected void beforeRead(EvaluationContext.ScopeContext context) {
+    protected void beforeRead(ScopeContext context) {
         provider.getProducer().visitContentProducerTasks(producer -> {
             if (!producer.getState().getExecuted()) {
                 throw new InvalidUserCodeException(

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/TransformBackedProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/TransformBackedProvider.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.provider;
 
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.Transformer;
+import org.gradle.internal.evaluation.EvaluationContext;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.Transformer
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.internal.Describables
+import org.gradle.internal.evaluation.EvaluationContext
 import org.gradle.util.internal.TextUtil
 import org.spockframework.lang.Wildcard
 

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
@@ -22,7 +22,7 @@ import org.gradle.api.Transformer
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.internal.Describables
-import org.gradle.internal.evaluation.EvaluationContext
+import org.gradle.internal.evaluation.CircularEvaluationException
 import org.gradle.util.internal.TextUtil
 import org.spockframework.lang.Wildcard
 
@@ -1179,7 +1179,7 @@ The value of this property is derived from: <source>""")
             consumer.accept(property)
 
             then:
-            thrown(EvaluationContext.CircularEvaluationException)
+            thrown(CircularEvaluationException)
 
             where:
             consumer << throwingConsumers()
@@ -1197,7 +1197,7 @@ The value of this property is derived from: <source>""")
             consumer.accept(property)
 
             then:
-            thrown(EvaluationContext.CircularEvaluationException)
+            thrown(CircularEvaluationException)
 
             where:
             consumer << throwingConsumers() - [GET_PRODUCER]
@@ -1233,7 +1233,7 @@ The value of this property is derived from: <source>""")
             consumer.accept(property)
 
             then:
-            thrown(EvaluationContext.CircularEvaluationException)
+            thrown(CircularEvaluationException)
 
             where:
             consumer << throwingConsumers()
@@ -1251,7 +1251,7 @@ The value of this property is derived from: <source>""")
             consumer.accept(property)
 
             then:
-            thrown(EvaluationContext.CircularEvaluationException)
+            thrown(CircularEvaluationException)
 
             where:
             consumer << throwingConsumers() - [GET_PRODUCER]

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/EvaluationContextTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/EvaluationContextTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.provider
 
+import org.gradle.internal.evaluation.EvaluationContext
 import spock.lang.Specification
 
 import java.util.function.BiFunction

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
@@ -23,7 +23,7 @@ import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.internal.Describables
-import org.gradle.internal.evaluation.EvaluationContext
+import org.gradle.internal.evaluation.CircularEvaluationException
 import org.gradle.internal.state.ManagedFactory
 import org.gradle.util.TestUtil
 import org.gradle.util.internal.TextUtil
@@ -1794,7 +1794,7 @@ The value of this property is derived from: <source>""")
             consumer.accept(property)
 
             then:
-            thrown(EvaluationContext.CircularEvaluationException)
+            thrown(CircularEvaluationException)
 
             where:
             consumer << throwingConsumers()
@@ -1812,7 +1812,7 @@ The value of this property is derived from: <source>""")
             consumer.accept(property)
 
             then:
-            thrown(EvaluationContext.CircularEvaluationException)
+            thrown(CircularEvaluationException)
 
             where:
             consumer << throwingConsumers() - [GET_PRODUCER]
@@ -1848,7 +1848,7 @@ The value of this property is derived from: <source>""")
             consumer.accept(property)
 
             then:
-            thrown(EvaluationContext.CircularEvaluationException)
+            thrown(CircularEvaluationException)
 
             where:
             consumer << throwingConsumers()
@@ -1866,7 +1866,7 @@ The value of this property is derived from: <source>""")
             consumer.accept(property)
 
             then:
-            thrown(EvaluationContext.CircularEvaluationException)
+            thrown(CircularEvaluationException)
 
             where:
             consumer << throwingConsumers() - [GET_PRODUCER]

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.internal.Describables
+import org.gradle.internal.evaluation.EvaluationContext
 import org.gradle.internal.state.ManagedFactory
 import org.gradle.util.TestUtil
 import org.gradle.util.internal.TextUtil

--- a/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/CircularEvaluationSpec.groovy
+++ b/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/CircularEvaluationSpec.groovy
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.provider
 
 
-import org.gradle.internal.evaluation.EvaluationContext.CircularEvaluationException
+import org.gradle.internal.evaluation.CircularEvaluationException
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 

--- a/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/CircularEvaluationSpec.groovy
+++ b/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/CircularEvaluationSpec.groovy
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.provider
 
 
-import org.gradle.api.internal.provider.EvaluationContext.CircularEvaluationException
+import org.gradle.internal.evaluation.EvaluationContext.CircularEvaluationException
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 

--- a/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.specs.Spec
 import org.gradle.internal.Describables
 import org.gradle.internal.DisplayName
+import org.gradle.internal.evaluation.EvaluationContext
 import org.gradle.internal.state.Managed
 import org.gradle.internal.state.ModelObject
 import org.gradle.util.internal.TextUtil

--- a/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.specs.Spec
 import org.gradle.internal.Describables
 import org.gradle.internal.DisplayName
+import org.gradle.internal.evaluation.CircularEvaluationException
 import org.gradle.internal.evaluation.EvaluationContext
 import org.gradle.internal.state.Managed
 import org.gradle.internal.state.ModelObject
@@ -3060,7 +3061,7 @@ The value of this provider is derived from:
             consumer.accept(provider)
 
             then:
-            EvaluationContext.CircularEvaluationException ex = thrown()
+            CircularEvaluationException ex = thrown()
             assertExceptionHasExpectedCycle(ex, provider, prop)
 
             where:
@@ -3079,7 +3080,7 @@ The value of this provider is derived from:
             consumer.accept(provider)
 
             then:
-            EvaluationContext.CircularEvaluationException ex = thrown()
+            CircularEvaluationException ex = thrown()
             assertExceptionHasExpectedCycle(ex, provider, prop)
 
             where:

--- a/platforms/core-runtime/functional/build.gradle.kts
+++ b/platforms/core-runtime/functional/build.gradle.kts
@@ -7,9 +7,10 @@ description = "Tools to work with functional code, including data structures"
 
 dependencies {
     api(libs.jsr305)
+    api(projects.stdlibJavaExtensions)
 
-    implementation(projects.stdlibJavaExtensions)
     implementation(libs.guava)
+    implementation(libs.fastutil)
 }
 tasks.isolatedProjectsIntegTest {
     enabled = false

--- a/platforms/core-runtime/functional/src/main/java/org/gradle/api/internal/provider/EvaluationContext.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/api/internal/provider/EvaluationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platforms/core-runtime/functional/src/main/java/org/gradle/api/internal/provider/EvaluationContext.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/api/internal/provider/EvaluationContext.java
@@ -126,6 +126,13 @@ public final class EvaluationContext {
     }
 
     /**
+     * Returns whether an evaluation is in progress in the current thread.
+     */
+    public boolean isEvaluating() {
+        return getOwner() != null;
+    }
+
+    /**
      * Runs the {@code evaluation} with the {@code owner} being marked as "evaluating".
      * If the owner is already being evaluated, throws {@link CircularEvaluationException}.
      *

--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/evaluation/CircularEvaluationException.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/evaluation/CircularEvaluationException.java
@@ -49,7 +49,7 @@ public class CircularEvaluationException extends GradleException {
     }
 
     private static String formatEvaluationChain(List<EvaluationOwner> evaluationCycle) {
-        try (ScopeContext ignored = EvaluationContext.current().nested()) {
+        try (EvaluationScopeContext ignored = EvaluationContext.current().nested()) {
             return evaluationCycle.stream()
                 .map(CircularEvaluationException::safeToString)
                 .collect(Collectors.joining("\n -> "));

--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/evaluation/CircularEvaluationException.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/evaluation/CircularEvaluationException.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.evaluation;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.GradleException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * An exception caused by the circular evaluation.
+ */
+public class CircularEvaluationException extends GradleException {
+    private final ImmutableList<EvaluationOwner> evaluationCycle;
+
+    CircularEvaluationException(List<EvaluationOwner> evaluationCycle) {
+        this.evaluationCycle = ImmutableList.copyOf(evaluationCycle);
+    }
+
+    @Override
+    public String getMessage() {
+        return "Circular evaluation detected: " + formatEvaluationChain(evaluationCycle);
+    }
+
+    /**
+     * Returns the evaluation cycle.
+     * The list represents a "stack" of owners currently being evaluated, and is at least two elements long.
+     * The first and last elements of the list are the same owner.
+     *
+     * @return the evaluation cycle as a list
+     */
+    public List<EvaluationOwner> getEvaluationCycle() {
+        return evaluationCycle;
+    }
+
+    private static String formatEvaluationChain(List<EvaluationOwner> evaluationCycle) {
+        try (ScopeContext ignored = EvaluationContext.current().nested()) {
+            return evaluationCycle.stream()
+                .map(CircularEvaluationException::safeToString)
+                .collect(Collectors.joining("\n -> "));
+        }
+    }
+
+    /**
+     * Computes {@code Object.toString()}, but swallows all thrown exceptions.
+     */
+    private static String safeToString(Object owner) {
+        try {
+            return owner.toString();
+        } catch (Throwable e) {
+            // Calling e.getMessage() here can cause infinite recursion.
+            // It happens if e is CircularEvaluationException itself, because getMessage calls formatEvaluationChain.
+            // It can also happen for some other custom exceptions that wrap CircularEvaluationException and call its getMessage inside their.
+            // This is why we resort to losing the information and only providing exception class.
+            // A well-behaved toString should not throw anyway.
+            return owner.getClass().getName() + " (toString failed with " + e.getClass() + ")";
+        }
+    }
+}

--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/evaluation/EvaluationContext.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/evaluation/EvaluationContext.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.provider;
+package org.gradle.internal.evaluation;
 
 import com.google.common.collect.ImmutableList;
 import it.unimi.dsi.fastutil.objects.ReferenceArrayList;

--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/evaluation/EvaluationContext.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/evaluation/EvaluationContext.java
@@ -19,12 +19,10 @@ package org.gradle.internal.evaluation;
 import com.google.common.collect.ImmutableList;
 import it.unimi.dsi.fastutil.objects.ReferenceArrayList;
 import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
-import org.gradle.api.GradleException;
 
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * This class keeps track of all objects being evaluated at the moment.
@@ -35,62 +33,6 @@ import java.util.stream.Collectors;
  * This class is thread-safe, but the returned contexts must be closed by the same thread that opens them.
  */
 public final class EvaluationContext {
-    /**
-     * An evaluation that runs with the owner being added to the evaluation context.
-     *
-     * @param <R> the return type
-     * @param <E> (optional) exception type being thrown by the evaluation
-     */
-    @FunctionalInterface
-    public interface ScopedEvaluation<R, E extends Exception> {
-        R evaluate() throws E;
-    }
-
-    /**
-     * A marker interface for types that can be evaluating.
-     */
-    public interface EvaluationOwner {}
-
-    /**
-     * A scope context. One can obtain an instance by calling {@link #open(EvaluationOwner)}.
-     * Closing this context removes the owner from the evaluation context.
-     * The primary use case is to serve as an argument for the try-with-resources block.
-     * It can also serve as a token parameter of a method that must be executed within such a block.
-     * <p>
-     * It is not safe to call {@link #close()} multiple times.
-     * The instances of the class may not be unique for different owners being added.
-     * <p>
-     * Contexts must be closed in the order they are obtained.
-     * This context must be closed by the same thread that obtained it.
-     */
-    public interface ScopeContext extends AutoCloseable {
-        /**
-         * Returns the owner of the current scope, which is the last object that started its evaluation.
-         * Can be null if the current scope has no owner (e.g. a just opened nested context).
-         *
-         * @return the owner
-         */
-        @Nullable
-        EvaluationOwner getOwner();
-
-        /**
-         * Opens a nested context. A nested context allows to re-enter evaluation of the objects that are being evaluated in this context.
-         * The newly returned nested context has no owner.
-         * <p>
-         * This method may be marginally more effective than using {@link EvaluationContext#evaluateNested(ScopedEvaluation)}.
-         *
-         * @return the nested context, to close it when done
-         */
-        ScopeContext nested();
-
-        /**
-         * Removes the owner added to evaluation context when obtaining this class from the context.
-         * Must be called exactly once for every {@link #open(EvaluationOwner)} or {@link #nested()} call.
-         * Prefer to use try-with-resource instead of calling this method.
-         */
-        @Override
-        void close();
-    }
 
     private static final int EXPECTED_MAX_CONTEXT_SIZE = 64;
 
@@ -200,7 +142,7 @@ public final class EvaluationContext {
         return newContext;
     }
 
-    private ScopeContext nested() {
+    ScopeContext nested() {
         return getContext().nested();
     }
 
@@ -272,54 +214,4 @@ public final class EvaluationContext {
         }
     }
 
-    /**
-     * An exception caused by the circular evaluation.
-     */
-    public static class CircularEvaluationException extends GradleException {
-        private final ImmutableList<EvaluationOwner> evaluationCycle;
-
-        CircularEvaluationException(List<EvaluationOwner> evaluationCycle) {
-            this.evaluationCycle = ImmutableList.copyOf(evaluationCycle);
-        }
-
-        @Override
-        public String getMessage() {
-            return "Circular evaluation detected: " + formatEvaluationChain(evaluationCycle);
-        }
-
-        /**
-         * Returns the evaluation cycle.
-         * The list represents a "stack" of owners currently being evaluated, and is at least two elements long.
-         * The first and last elements of the list are the same owner.
-         *
-         * @return the evaluation cycle as a list
-         */
-        public List<EvaluationOwner> getEvaluationCycle() {
-            return evaluationCycle;
-        }
-
-        private static String formatEvaluationChain(List<EvaluationOwner> evaluationCycle) {
-            try (ScopeContext ignored = current().nested()) {
-                return evaluationCycle.stream()
-                    .map(CircularEvaluationException::safeToString)
-                    .collect(Collectors.joining("\n -> "));
-            }
-        }
-
-        /**
-         * Computes {@code Object.toString()}, but swallows all thrown exceptions.
-         */
-        private static String safeToString(Object owner) {
-            try {
-                return owner.toString();
-            } catch (Throwable e) {
-                // Calling e.getMessage() here can cause infinite recursion.
-                // It happens if e is CircularEvaluationException itself, because getMessage calls formatEvaluationChain.
-                // It can also happen for some other custom exceptions that wrap CircularEvaluationException and call its getMessage inside their.
-                // This is why we resort to losing the information and only providing exception class.
-                // A well-behaved toString should not throw anyway.
-                return owner.getClass().getName() + " (toString failed with " + e.getClass() + ")";
-            }
-        }
-    }
 }

--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/evaluation/EvaluationContext.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/evaluation/EvaluationContext.java
@@ -55,7 +55,7 @@ public final class EvaluationContext {
      * Adds the owner to the set of "evaluating" objects and returns the context instance to remove it from there upon closing.
      * This method is intended to be used in the try-with-resources block's initializer.
      */
-    public ScopeContext open(EvaluationOwner owner) {
+    public EvaluationScopeContext open(EvaluationOwner owner) {
         return getContext().open(owner);
     }
 
@@ -87,7 +87,7 @@ public final class EvaluationContext {
      * @throws CircularEvaluationException if the owner is currently being evaluated in the outer scope
      */
     public <R, E extends Exception> R evaluate(EvaluationOwner owner, ScopedEvaluation<? extends R, E> evaluation) throws E {
-        try (ScopeContext ignored = open(owner)) {
+        try (EvaluationScopeContext ignored = open(owner)) {
             return evaluation.evaluate();
         }
     }
@@ -127,7 +127,7 @@ public final class EvaluationContext {
      * @throws E exception from the {@code evaluation} is propagated
      */
     public <R, E extends Exception> R evaluateNested(ScopedEvaluation<? extends R, E> evaluation) throws E {
-        try (ScopeContext ignored = nested()) {
+        try (EvaluationScopeContext ignored = nested()) {
             return evaluation.evaluate();
         }
     }
@@ -142,11 +142,11 @@ public final class EvaluationContext {
         return newContext;
     }
 
-    ScopeContext nested() {
+    EvaluationScopeContext nested() {
         return getContext().nested();
     }
 
-    private final class PerThreadContext implements ScopeContext {
+    private final class PerThreadContext implements EvaluationScopeContext {
         private final Set<EvaluationOwner> objectsInScope = new ReferenceOpenHashSet<>(EXPECTED_MAX_CONTEXT_SIZE);
         private final List<EvaluationOwner> evaluationStack = new ReferenceArrayList<>(EXPECTED_MAX_CONTEXT_SIZE);
         @Nullable
@@ -175,7 +175,7 @@ public final class EvaluationContext {
         }
 
         @Override
-        public ScopeContext nested() {
+        public EvaluationScopeContext nested() {
             return setContext(new PerThreadContext(this));
         }
 

--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/evaluation/EvaluationOwner.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/evaluation/EvaluationOwner.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.evaluation;
+
+/**
+ * A marker interface for types that can be evaluating.
+ */
+public interface EvaluationOwner {}

--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/evaluation/EvaluationScopeContext.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/evaluation/EvaluationScopeContext.java
@@ -30,7 +30,7 @@ import javax.annotation.Nullable;
  * Contexts must be closed in the order they are obtained.
  * This context must be closed by the same thread that obtained it.
  */
-public interface ScopeContext extends AutoCloseable {
+public interface EvaluationScopeContext extends AutoCloseable {
     /**
      * Returns the owner of the current scope, which is the last object that started its evaluation.
      * Can be null if the current scope has no owner (e.g. a just opened nested context).
@@ -48,7 +48,7 @@ public interface ScopeContext extends AutoCloseable {
      *
      * @return the nested context, to close it when done
      */
-    ScopeContext nested();
+    EvaluationScopeContext nested();
 
     /**
      * Removes the owner added to evaluation context when obtaining this class from the context.

--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/evaluation/ScopeContext.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/evaluation/ScopeContext.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.evaluation;
+
+import javax.annotation.Nullable;
+
+/**
+ * A scope context. One can obtain an instance by calling {@link EvaluationContext#open(EvaluationOwner)}.
+ * Closing this context removes the owner from the evaluation context.
+ * The primary use case is to serve as an argument for the try-with-resources block.
+ * It can also serve as a token parameter of a method that must be executed within such a block.
+ * <p>
+ * It is not safe to call {@link #close()} multiple times.
+ * The instances of the class may not be unique for different owners being added.
+ * <p>
+ * Contexts must be closed in the order they are obtained.
+ * This context must be closed by the same thread that obtained it.
+ */
+public interface ScopeContext extends AutoCloseable {
+    /**
+     * Returns the owner of the current scope, which is the last object that started its evaluation.
+     * Can be null if the current scope has no owner (e.g. a just opened nested context).
+     *
+     * @return the owner
+     */
+    @Nullable
+    EvaluationOwner getOwner();
+
+    /**
+     * Opens a nested context. A nested context allows to re-enter evaluation of the objects that are being evaluated in this context.
+     * The newly returned nested context has no owner.
+     * <p>
+     * This method may be marginally more effective than using {@link EvaluationContext#evaluateNested(ScopedEvaluation)}.
+     *
+     * @return the nested context, to close it when done
+     */
+    ScopeContext nested();
+
+    /**
+     * Removes the owner added to evaluation context when obtaining this class from the context.
+     * Must be called exactly once for every {@link EvaluationContext#open(EvaluationOwner)} or {@link #nested()} call.
+     * Prefer to use try-with-resource instead of calling this method.
+     */
+    @Override
+    void close();
+}

--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/evaluation/ScopedEvaluation.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/evaluation/ScopedEvaluation.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.evaluation;
+
+/**
+ * An evaluation that runs with the owner being added to the evaluation context.
+ *
+ * @param <R> the return type
+ * @param <E> (optional) exception type being thrown by the evaluation
+ */
+@FunctionalInterface
+public interface ScopedEvaluation<R, E extends Exception> {
+    R evaluate() throws E;
+}

--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/evaluation/package-info.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/evaluation/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides support for evaluating objects that offers features such as:
+ * <ul>
+ * <li>nested scopes</li>
+ * <li>cycle detection to avoid infinite recursion</li>
+ * <li>user-friendly error messages in the presence of cycles</li>
+ * </ul>
+ */
+@NonNullApi
+package org.gradle.internal.evaluation;
+
+import org.gradle.api.NonNullApi;

--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/serialization/Cached.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/serialization/Cached.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.serialization;
 
-import org.gradle.api.internal.provider.EvaluationContext;
+import org.gradle.internal.evaluation.EvaluationContext;
 import org.gradle.internal.Try;
 
 import javax.annotation.Nonnull;

--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/serialization/Cached.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/serialization/Cached.java
@@ -18,6 +18,7 @@ package org.gradle.internal.serialization;
 
 import org.gradle.internal.evaluation.EvaluationContext;
 import org.gradle.internal.Try;
+import org.gradle.internal.evaluation.EvaluationOwner;
 
 import javax.annotation.Nonnull;
 import java.util.concurrent.Callable;
@@ -36,7 +37,7 @@ public abstract class Cached<T> {
 
     public abstract T get();
 
-    private static class Deferred<T> extends Cached<T> implements java.io.Serializable, EvaluationContext.EvaluationOwner {
+    private static class Deferred<T> extends Cached<T> implements java.io.Serializable, EvaluationOwner {
 
         private Callable<T> computation;
         private Try<T> result;

--- a/platforms/core-runtime/functional/src/test/groovy/org/gradle/internal/evaluation/EvaluationContextTest.groovy
+++ b/platforms/core-runtime/functional/src/test/groovy/org/gradle/internal/evaluation/EvaluationContextTest.groovy
@@ -118,7 +118,7 @@ class EvaluationContextTest extends Specification {
         }
 
         then:
-        EvaluationContext.CircularEvaluationException ex = thrown()
+        CircularEvaluationException ex = thrown()
         ex.evaluationCycle == [owner, owner]
 
         where:
@@ -132,7 +132,7 @@ class EvaluationContextTest extends Specification {
         }
 
         then:
-        EvaluationContext.CircularEvaluationException ex = thrown()
+        CircularEvaluationException ex = thrown()
         ex.evaluationCycle == [owner, owner]
 
         where:
@@ -152,7 +152,7 @@ class EvaluationContextTest extends Specification {
         }
 
         then:
-        EvaluationContext.CircularEvaluationException ex = thrown()
+        CircularEvaluationException ex = thrown()
         ex.evaluationCycle == [owner, otherOwner, owner]
 
         where:
@@ -170,7 +170,7 @@ class EvaluationContextTest extends Specification {
         }
 
         then:
-        EvaluationContext.CircularEvaluationException ex = thrown()
+        CircularEvaluationException ex = thrown()
         ex.evaluationCycle == [owner, owner]
 
         where:
@@ -205,7 +205,7 @@ class EvaluationContextTest extends Specification {
         }
 
         then:
-        EvaluationContext.CircularEvaluationException ex = thrown()
+        CircularEvaluationException ex = thrown()
         ex.evaluationCycle == [owner, owner]
 
         where:
@@ -222,7 +222,7 @@ class EvaluationContextTest extends Specification {
         }
 
         then:
-        EvaluationContext.CircularEvaluationException ex = thrown()
+        CircularEvaluationException ex = thrown()
         ex.evaluationCycle.size() == 2
         // Have to use reference check because owner's equals is broken
         ex.evaluationCycle[0] === owner
@@ -245,10 +245,10 @@ class EvaluationContextTest extends Specification {
         result == "fallback"
     }
 
-    BiFunction<EvaluationContext.EvaluationOwner, TestEvaluation, String> evaluateInLambda() {
-        return new BiFunction<EvaluationContext.EvaluationOwner, TestEvaluation, String>() {
+    BiFunction<EvaluationOwner, TestEvaluation, String> evaluateInLambda() {
+        return new BiFunction<EvaluationOwner, TestEvaluation, String>() {
             @Override
-            String apply(EvaluationContext.EvaluationOwner owner, TestEvaluation evaluation) {
+            String apply(EvaluationOwner owner, TestEvaluation evaluation) {
                 context().evaluate(owner, evaluation)
             }
 
@@ -259,11 +259,11 @@ class EvaluationContextTest extends Specification {
         }
     }
 
-    BiFunction<EvaluationContext.EvaluationOwner, TestEvaluation, String> evaluateInBlock() {
-        return new BiFunction<EvaluationContext.EvaluationOwner, TestEvaluation, String>() {
+    BiFunction<EvaluationOwner, TestEvaluation, String> evaluateInBlock() {
+        return new BiFunction<EvaluationOwner, TestEvaluation, String>() {
             @Override
             @SuppressWarnings('GroovyUnusedAssignment')
-            String apply(EvaluationContext.EvaluationOwner owner, TestEvaluation evaluation) {
+            String apply(EvaluationOwner owner, TestEvaluation evaluation) {
                 try (def scope = context().open(owner)) {
                     return evaluation.evaluate()
                 }
@@ -280,8 +280,8 @@ class EvaluationContextTest extends Specification {
         return EvaluationContext.current()
     }
 
-    EvaluationContext.EvaluationOwner createOwner() {
-        return Mock(EvaluationContext.EvaluationOwner)
+    EvaluationOwner createOwner() {
+        return Mock(EvaluationOwner)
     }
 
     static interface TestEvaluation extends ScopedEvaluation<String, RuntimeException> {}

--- a/platforms/core-runtime/functional/src/test/groovy/org/gradle/internal/evaluation/EvaluationContextTest.groovy
+++ b/platforms/core-runtime/functional/src/test/groovy/org/gradle/internal/evaluation/EvaluationContextTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.provider
+package org.gradle.internal.evaluation
 
-import org.gradle.internal.evaluation.EvaluationContext
 import spock.lang.Specification
 
 import java.util.function.BiFunction
@@ -285,5 +284,5 @@ class EvaluationContextTest extends Specification {
         return Mock(EvaluationContext.EvaluationOwner)
     }
 
-    static interface TestEvaluation extends EvaluationContext.ScopedEvaluation<String, RuntimeException> {}
+    static interface TestEvaluation extends ScopedEvaluation<String, RuntimeException> {}
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -33,7 +33,7 @@ import org.gradle.api.internal.collections.CollectionFilter;
 import org.gradle.api.internal.collections.ElementSource;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.internal.provider.AbstractMinimalProvider;
-import org.gradle.api.internal.provider.EvaluationContext;
+import org.gradle.internal.evaluation.EvaluationContext;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.provider.Provider;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -42,7 +42,7 @@ import org.gradle.api.specs.Specs;
 import org.gradle.internal.Actions;
 import org.gradle.internal.Cast;
 import org.gradle.internal.ImmutableActionSet;
-import org.gradle.internal.evaluation.ScopeContext;
+import org.gradle.internal.evaluation.EvaluationScopeContext;
 import org.gradle.internal.metaobject.AbstractDynamicObject;
 import org.gradle.internal.metaobject.DynamicInvokeResult;
 import org.gradle.internal.metaobject.DynamicObject;
@@ -996,14 +996,14 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
                 // Collect any container level add actions added since the last call to configure()
                 onCreate = onCreate.mergeFrom(getEventRegister().getAddActions());
 
-                try (ScopeContext scope = openScope()) {
+                try (EvaluationScopeContext scope = openScope()) {
                     // Create the domain object
                     object = createDomainObject();
                     // Configuring the domain object may cause circular evaluation, but after initializing this.object
                     // calculateOwnValue short-circuits it at a cost of exposing a partially constructed value.
                     // Because of that the circular evaluation that goes through this provider doesn't cause stack overflow.
                     // To avoid breaking existing code, we open a nested evaluation scope here to allow re-entering the chain.
-                    try (ScopeContext ignored = scope.nested()) {
+                    try (EvaluationScopeContext ignored = scope.nested()) {
                         // Register the domain object
                         doAdd(object, onCreate);
                         realized(AbstractDomainObjectCreatingProvider.this);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -33,7 +33,6 @@ import org.gradle.api.internal.collections.CollectionFilter;
 import org.gradle.api.internal.collections.ElementSource;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.internal.provider.AbstractMinimalProvider;
-import org.gradle.internal.evaluation.EvaluationContext;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.provider.Provider;
@@ -43,6 +42,7 @@ import org.gradle.api.specs.Specs;
 import org.gradle.internal.Actions;
 import org.gradle.internal.Cast;
 import org.gradle.internal.ImmutableActionSet;
+import org.gradle.internal.evaluation.ScopeContext;
 import org.gradle.internal.metaobject.AbstractDynamicObject;
 import org.gradle.internal.metaobject.DynamicInvokeResult;
 import org.gradle.internal.metaobject.DynamicObject;
@@ -996,14 +996,14 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
                 // Collect any container level add actions added since the last call to configure()
                 onCreate = onCreate.mergeFrom(getEventRegister().getAddActions());
 
-                try (EvaluationContext.ScopeContext scope = openScope()) {
+                try (ScopeContext scope = openScope()) {
                     // Create the domain object
                     object = createDomainObject();
                     // Configuring the domain object may cause circular evaluation, but after initializing this.object
                     // calculateOwnValue short-circuits it at a cost of exposing a partially constructed value.
                     // Because of that the circular evaluation that goes through this provider doesn't cause stack overflow.
                     // To avoid breaking existing code, we open a nested evaluation scope here to allow re-entering the chain.
-                    try (EvaluationContext.ScopeContext ignored = scope.nested()) {
+                    try (ScopeContext ignored = scope.nested()) {
                         // Register the domain object
                         doAdd(object, onCreate);
                         realized(AbstractDomainObjectCreatingProvider.this);

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/WorkerProcessClassPathProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/WorkerProcessClassPathProvider.java
@@ -87,6 +87,7 @@ public class WorkerProcessClassPathProvider implements ClassPathProvider {
         "gradle-enterprise-workers",
         "gradle-cli",
         "gradle-concurrent",
+        "gradle-functional",
         "gradle-io",
         "gradle-wrapper-shared",
         "gradle-native",


### PR DESCRIPTION
Related to: #30860

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
