### PR TITLE
Reduce usage of InstantiatorBackedObjectFactory

### DIFF
--- a/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
+++ b/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
@@ -196,19 +196,19 @@ public class DaemonParameters {
     }
 
     public void setDebugPort(int debug) {
-        jvmOptions.getDebugOptions().getPort().set(debug);
+        jvmOptions.getDebugOptions().setPort(debug);
     }
 
     public void setDebugHost(String host) {
-        jvmOptions.getDebugOptions().getHost().set(host);
+        jvmOptions.getDebugOptions().setHost(host);
     }
 
     public void setDebugSuspend(boolean suspend) {
-        jvmOptions.getDebugOptions().getSuspend().set(suspend);
+        jvmOptions.getDebugOptions().setSuspend(suspend);
     }
 
     public void setDebugServer(boolean server) {
-        jvmOptions.getDebugOptions().getServer().set(server);
+        jvmOptions.getDebugOptions().setServer(server);
     }
 
     public DaemonParameters setBaseDir(File baseDir) {

--- a/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
+++ b/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
@@ -196,19 +196,19 @@ public class DaemonParameters {
     }
 
     public void setDebugPort(int debug) {
-        jvmOptions.getDebugOptions().setPort(debug);
+        jvmOptions.getDebugSpec().setPort(debug);
     }
 
     public void setDebugHost(String host) {
-        jvmOptions.getDebugOptions().setHost(host);
+        jvmOptions.getDebugSpec().setHost(host);
     }
 
     public void setDebugSuspend(boolean suspend) {
-        jvmOptions.getDebugOptions().setSuspend(suspend);
+        jvmOptions.getDebugSpec().setSuspend(suspend);
     }
 
     public void setDebugServer(boolean server) {
-        jvmOptions.getDebugOptions().setServer(server);
+        jvmOptions.getDebugSpec().setServer(server);
     }
 
     public DaemonParameters setBaseDir(File baseDir) {

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/DefaultScript.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/DefaultScript.java
@@ -35,11 +35,11 @@ import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.HasScriptServices;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.initialization.ScriptHandlerFactory;
-import org.gradle.api.internal.model.InstantiatorBackedObjectFactory;
 import org.gradle.api.internal.plugins.DefaultObjectConfigurationAction;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.logging.LoggingManager;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.resources.ResourceHandler;
@@ -87,12 +87,13 @@ public abstract class DefaultScript extends BasicScript {
             if (sourceFile != null) {
                 FileResolver resolver = fileLookup.getFileResolver(sourceFile.getParentFile());
                 FileCollectionFactory fileCollectionFactoryWithBase = fileCollectionFactory.withResolver(resolver);
+                ObjectFactory objectFactory = services.get(ObjectFactory.class);
                 fileOperations = DefaultFileOperations.createSimple(resolver, fileCollectionFactoryWithBase, services);
                 deprecatedProcessOperations = new DeprecatedProcessOperations(services.get(ExecFactory.class).forContext()
                     .withFileResolver(resolver)
                     .withFileCollectionFactory(fileCollectionFactoryWithBase)
                     .withInstantiator(instantiator)
-                    .withObjectFactory(new InstantiatorBackedObjectFactory(instantiator))
+                    .withObjectFactory(objectFactory)
                     .build());
             } else {
                 fileOperations = DefaultFileOperations.createSimple(fileLookup.getFileResolver(), fileCollectionFactory, services);

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
@@ -155,8 +155,7 @@ public abstract class DefaultExecActionFactory implements ExecFactory {
         // NOTE: We do not want/need a decorated version of JvmOptions or JavaDebugOptions because
         // these immutable instances are held across builds and will retain classloaders/services in the decorated object
         DefaultFileCollectionFactory fileCollectionFactory = new DefaultFileCollectionFactory(fileResolver, DefaultTaskDependencyFactory.withNoAssociatedProject(), new DefaultDirectoryFileTreeFactory(), nonCachingPatternSetFactory, PropertyHost.NO_OP, FileSystems.getDefault());
-        ObjectFactory objectFactory = new InstantiatorBackedObjectFactory(DirectInstantiator.INSTANCE);
-        return options.toEffectiveJavaForkOptions(objectFactory, fileCollectionFactory);
+        return options.toEffectiveJavaForkOptions(fileCollectionFactory);
     }
 
     public JavaExecAction newDecoratedJavaExecAction() {

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaDebugOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaDebugOptions.java
@@ -16,12 +16,11 @@
 
 package org.gradle.process.internal;
 
-import org.gradle.api.internal.model.InstantiatorBackedObjectFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Optional;
-import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.process.JavaDebugOptions;
+import org.gradle.process.internal.JvmDebugOptions.DefaultJvmDebugOptions;
 
 import javax.inject.Inject;
 import java.util.Objects;
@@ -35,17 +34,12 @@ public class DefaultJavaDebugOptions implements JavaDebugOptions {
 
     @Inject
     public DefaultJavaDebugOptions(ObjectFactory objectFactory) {
-        this.enabled = objectFactory.property(Boolean.class).convention(false);
-        this.host = objectFactory.property(String.class);
-        this.port = objectFactory.property(Integer.class).convention(5005);
-        this.server = objectFactory.property(Boolean.class).convention(true);
-        this.suspend = objectFactory.property(Boolean.class).convention(true);
-    }
-
-    public DefaultJavaDebugOptions() {
-        // Ugly, but there are a few places where we need to instantiate a JavaDebugOptions and a regular ObjectFactory service
-        // is not available.
-        this(new InstantiatorBackedObjectFactory(DirectInstantiator.INSTANCE));
+        DefaultJvmDebugOptions defaultValues = new DefaultJvmDebugOptions();
+        this.enabled = objectFactory.property(Boolean.class).convention(defaultValues.isEnabled());
+        this.host = objectFactory.property(String.class).convention(defaultValues.getHost());
+        this.port = objectFactory.property(Integer.class).convention(defaultValues.getPort());
+        this.server = objectFactory.property(Boolean.class).convention(defaultValues.isServer());
+        this.suspend = objectFactory.property(Boolean.class).convention(defaultValues.isSuspend());
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaDebugOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaDebugOptions.java
@@ -20,7 +20,7 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Optional;
 import org.gradle.process.JavaDebugOptions;
-import org.gradle.process.internal.JvmDebugOptions.DefaultJvmDebugOptions;
+import org.gradle.process.internal.JvmDebugSpec.DefaultJvmDebugSpec;
 
 import javax.inject.Inject;
 import java.util.Objects;
@@ -34,7 +34,7 @@ public class DefaultJavaDebugOptions implements JavaDebugOptions {
 
     @Inject
     public DefaultJavaDebugOptions(ObjectFactory objectFactory) {
-        DefaultJvmDebugOptions defaultValues = new DefaultJvmDebugOptions();
+        DefaultJvmDebugSpec defaultValues = new DefaultJvmDebugSpec();
         this.enabled = objectFactory.property(Boolean.class).convention(defaultValues.isEnabled());
         this.host = objectFactory.property(String.class).convention(defaultValues.getHost());
         this.port = objectFactory.property(Integer.class).convention(defaultValues.getPort());

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
@@ -25,7 +25,7 @@ import org.gradle.internal.jvm.Jvm;
 import org.gradle.process.CommandLineArgumentProvider;
 import org.gradle.process.JavaDebugOptions;
 import org.gradle.process.JavaForkOptions;
-import org.gradle.process.internal.JvmDebugOptions.PropertyBackedJvmDebugOptions;
+import org.gradle.process.internal.JvmDebugSpec.JavaDebugOptionsBackedSpec;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
@@ -48,7 +48,7 @@ public class DefaultJavaForkOptions extends DefaultProcessForkOptions implements
         super(resolver);
         this.fileCollectionFactory = fileCollectionFactory;
         this.debugOptions = objectFactory.newInstance(DefaultJavaDebugOptions.class, objectFactory);
-        this.options = new JvmOptions(fileCollectionFactory, new PropertyBackedJvmDebugOptions(debugOptions));
+        this.options = new JvmOptions(fileCollectionFactory, new JavaDebugOptionsBackedSpec(debugOptions));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
@@ -25,6 +25,7 @@ import org.gradle.internal.jvm.Jvm;
 import org.gradle.process.CommandLineArgumentProvider;
 import org.gradle.process.JavaDebugOptions;
 import org.gradle.process.JavaForkOptions;
+import org.gradle.process.internal.JvmDebugOptions.PropertyBackedJvmDebugOptions;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
@@ -35,7 +36,7 @@ import java.util.Map;
 public class DefaultJavaForkOptions extends DefaultProcessForkOptions implements JavaForkOptionsInternal {
     private final JvmOptions options;
     private final FileCollectionFactory fileCollectionFactory;
-    private final ObjectFactory objectFactory;
+    private final JavaDebugOptions debugOptions;
     private List<CommandLineArgumentProvider> jvmArgumentProviders;
 
     @Inject
@@ -45,15 +46,15 @@ public class DefaultJavaForkOptions extends DefaultProcessForkOptions implements
         FileCollectionFactory fileCollectionFactory
     ) {
         super(resolver);
-        this.objectFactory = objectFactory;
         this.fileCollectionFactory = fileCollectionFactory;
-        this.options = new JvmOptions(objectFactory, fileCollectionFactory);
+        this.debugOptions = objectFactory.newInstance(DefaultJavaDebugOptions.class, objectFactory);
+        this.options = new JvmOptions(fileCollectionFactory, new PropertyBackedJvmDebugOptions(debugOptions));
     }
 
     @Override
     public List<String> getAllJvmArgs() {
         if (hasJvmArgumentProviders(this)) {
-            JvmOptions copy = options.createCopy(objectFactory, fileCollectionFactory);
+            JvmOptions copy = options.createCopy(fileCollectionFactory);
             for (CommandLineArgumentProvider jvmArgumentProvider : jvmArgumentProviders) {
                 copy.jvmArgs(jvmArgumentProvider.asArguments());
             }
@@ -204,12 +205,12 @@ public class DefaultJavaForkOptions extends DefaultProcessForkOptions implements
 
     @Override
     public JavaDebugOptions getDebugOptions() {
-        return options.getDebugOptions();
+        return debugOptions;
     }
 
     @Override
     public void debugOptions(Action<JavaDebugOptions> action) {
-        action.execute(options.getDebugOptions());
+        action.execute(getDebugOptions());
     }
 
     @Override
@@ -236,8 +237,8 @@ public class DefaultJavaForkOptions extends DefaultProcessForkOptions implements
     }
 
     @Override
-    public EffectiveJavaForkOptions toEffectiveJavaForkOptions(ObjectFactory objectFactory, FileCollectionFactory fileCollectionFactory) {
-        JvmOptions copy = options.createCopy(objectFactory, fileCollectionFactory);
+    public EffectiveJavaForkOptions toEffectiveJavaForkOptions(FileCollectionFactory fileCollectionFactory) {
+        JvmOptions copy = options.createCopy(fileCollectionFactory);
         if (jvmArgumentProviders != null) {
             for (CommandLineArgumentProvider jvmArgumentProvider : jvmArgumentProviders) {
                 copy.jvmArgs(jvmArgumentProvider.asArguments());

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
@@ -442,7 +442,7 @@ public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements 
     }
 
     @Override
-    public EffectiveJavaForkOptions toEffectiveJavaForkOptions(ObjectFactory objectFactory, FileCollectionFactory fileCollectionFactory) {
-        return javaOptions.toEffectiveJavaForkOptions(objectFactory, fileCollectionFactory);
+    public EffectiveJavaForkOptions toEffectiveJavaForkOptions(FileCollectionFactory fileCollectionFactory) {
+        return javaOptions.toEffectiveJavaForkOptions(fileCollectionFactory);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JavaForkOptionsInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JavaForkOptionsInternal.java
@@ -17,7 +17,6 @@
 package org.gradle.process.internal;
 
 import org.gradle.api.internal.file.FileCollectionFactory;
-import org.gradle.api.model.ObjectFactory;
 import org.gradle.process.JavaForkOptions;
 
 public interface JavaForkOptionsInternal extends JavaForkOptions {
@@ -37,5 +36,5 @@ public interface JavaForkOptionsInternal extends JavaForkOptions {
     /**
      * Creates EffectiveJavaForkOptions.
      */
-    EffectiveJavaForkOptions toEffectiveJavaForkOptions(ObjectFactory objectFactory, FileCollectionFactory fileCollectionFactory);
+    EffectiveJavaForkOptions toEffectiveJavaForkOptions(FileCollectionFactory fileCollectionFactory);
 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JvmDebugOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JvmDebugOptions.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.process.internal;
+
+import org.gradle.api.NonNullApi;
+import org.gradle.process.JavaDebugOptions;
+
+import javax.annotation.Nullable;
+
+@NonNullApi
+public interface JvmDebugOptions {
+
+    boolean isEnabled();
+
+    void setEnabled(boolean enabled);
+
+    @Nullable
+    String getHost();
+
+    void setHost(@Nullable String host);
+
+    int getPort();
+
+    void setPort(int port);
+
+    boolean isServer();
+
+    void setServer(boolean server);
+
+    boolean isSuspend();
+
+    void setSuspend(boolean suspend);
+
+    @NonNullApi
+    class DefaultJvmDebugOptions implements JvmDebugOptions {
+        private boolean enabled;
+        private String host;
+        private int port;
+        private boolean server;
+        private boolean suspend;
+
+        public DefaultJvmDebugOptions() {
+            this.enabled = false;
+            this.host = null;
+            this.port = 5005;
+            this.server = true;
+            this.suspend = true;
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        @Override
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        @Override
+        @Nullable
+        public String getHost() {
+            return host;
+        }
+
+        @Override
+        public void setHost(@Nullable String host) {
+            this.host = host;
+        }
+
+        @Override
+        public int getPort() {
+            return port;
+        }
+
+        @Override
+        public void setPort(int port) {
+            this.port = port;
+        }
+
+        @Override
+        public boolean isServer() {
+            return server;
+        }
+
+        @Override
+        public void setServer(boolean server) {
+            this.server = server;
+        }
+
+        @Override
+        public boolean isSuspend() {
+            return suspend;
+        }
+
+        @Override
+        public void setSuspend(boolean suspend) {
+            this.suspend = suspend;
+        }
+    }
+
+    @NonNullApi
+    class PropertyBackedJvmDebugOptions implements JvmDebugOptions {
+        private final JavaDebugOptions delegate;
+
+        public PropertyBackedJvmDebugOptions(JavaDebugOptions delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return delegate.getEnabled().get();
+        }
+
+        @Override
+        public void setEnabled(boolean enabled) {
+            delegate.getEnabled().set(enabled);
+        }
+
+        @Override
+        @Nullable
+        public String getHost() {
+            return delegate.getHost().getOrNull();
+        }
+
+        @Override
+        public void setHost(@Nullable String host) {
+            delegate.getHost().set(host);
+        }
+
+        @Override
+        public int getPort() {
+            return delegate.getPort().get();
+        }
+
+        @Override
+        public void setPort(int port) {
+            delegate.getPort().set(port);
+        }
+
+        @Override
+        public boolean isServer() {
+            return delegate.getServer().get();
+        }
+
+        @Override
+        public void setServer(boolean server) {
+            delegate.getServer().set(server);
+        }
+
+        @Override
+        public boolean isSuspend() {
+            return delegate.getSuspend().get();
+        }
+
+        @Override
+        public void setSuspend(boolean suspend) {
+            delegate.getSuspend().set(suspend);
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JvmDebugSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JvmDebugSpec.java
@@ -22,7 +22,7 @@ import org.gradle.process.JavaDebugOptions;
 import javax.annotation.Nullable;
 
 @NonNullApi
-public interface JvmDebugOptions {
+public interface JvmDebugSpec {
 
     boolean isEnabled();
 
@@ -46,14 +46,14 @@ public interface JvmDebugOptions {
     void setSuspend(boolean suspend);
 
     @NonNullApi
-    class DefaultJvmDebugOptions implements JvmDebugOptions {
+    class DefaultJvmDebugSpec implements JvmDebugSpec {
         private boolean enabled;
         private String host;
         private int port;
         private boolean server;
         private boolean suspend;
 
-        public DefaultJvmDebugOptions() {
+        public DefaultJvmDebugSpec() {
             this.enabled = false;
             this.host = null;
             this.port = 5005;
@@ -114,10 +114,10 @@ public interface JvmDebugOptions {
     }
 
     @NonNullApi
-    class PropertyBackedJvmDebugOptions implements JvmDebugOptions {
+    class JavaDebugOptionsBackedSpec implements JvmDebugSpec {
         private final JavaDebugOptions delegate;
 
-        public PropertyBackedJvmDebugOptions(JavaDebugOptions delegate) {
+        public JavaDebugOptionsBackedSpec(JavaDebugOptions delegate) {
             this.delegate = delegate;
         }
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JvmOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JvmOptions.java
@@ -22,10 +22,10 @@ import org.apache.commons.lang.StringUtils;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileCollectionFactory;
-import org.gradle.api.model.ObjectFactory;
 import org.gradle.cache.internal.HeapProportionalCacheSizer;
-import org.gradle.process.JavaDebugOptions;
 import org.gradle.process.JavaForkOptions;
+import org.gradle.process.internal.JvmDebugOptions.DefaultJvmDebugOptions;
+import org.gradle.process.internal.JvmDebugOptions.PropertyBackedJvmDebugOptions;
 import org.gradle.util.internal.ArgumentsSplitter;
 import org.gradle.util.internal.GUtil;
 import org.slf4j.Logger;
@@ -83,19 +83,15 @@ public class JvmOptions {
     private String maxHeapSize;
     private boolean assertionsEnabled;
 
-    private final JavaDebugOptions debugOptions;
+    private final JvmDebugOptions debugOptions;
 
     protected final Map<String, Object> immutableSystemProperties = new TreeMap<>();
 
-    public JvmOptions(ObjectFactory objectFactory, FileCollectionFactory fileCollectionFactory) {
-        this(fileCollectionFactory, objectFactory.newInstance(DefaultJavaDebugOptions.class, objectFactory));
-    }
-
     public JvmOptions(FileCollectionFactory fileCollectionFactory) {
-        this(fileCollectionFactory, new DefaultJavaDebugOptions());
+        this(fileCollectionFactory, new DefaultJvmDebugOptions());
     }
 
-    private JvmOptions(FileCollectionFactory fileCollectionFactory, DefaultJavaDebugOptions debugOptions) {
+    public JvmOptions(FileCollectionFactory fileCollectionFactory, JvmDebugOptions debugOptions) {
         this.debugOptions = debugOptions;
         this.fileCollectionFactory = fileCollectionFactory;
         immutableSystemProperties.put(FILE_ENCODING_KEY, Charset.defaultCharset().name());
@@ -165,7 +161,7 @@ public class JvmOptions {
             args.add("-ea");
         }
 
-        if (debugOptions.getEnabled().get()) {
+        if (debugOptions.isEnabled()) {
             args.add(getDebugArgument());
         }
         return args;
@@ -175,11 +171,11 @@ public class JvmOptions {
         return getDebugArgument(debugOptions);
     }
 
-    public static String getDebugArgument(JavaDebugOptions options) {
-        boolean server = options.getServer().get();
-        boolean suspend = options.getSuspend().get();
-        int port = options.getPort().get();
-        String host = options.getHost().map(h -> h + ":").getOrElse("");
+    public static String getDebugArgument(JvmDebugOptions options) {
+        boolean server = options.isServer();
+        boolean suspend = options.isSuspend();
+        int port = options.getPort();
+        String host = options.getHost() == null ? "" : options.getHost() + ":";
         String address = host + port;
         return getDebugArgument(server, suspend, address);
     }
@@ -197,7 +193,7 @@ public class JvmOptions {
         maxHeapSize = null;
         extraJvmArgs.clear();
         assertionsEnabled = false;
-        debugOptions.getEnabled().set(false);
+        debugOptions.setEnabled(false);
         jvmArgs(arguments);
     }
 
@@ -225,9 +221,9 @@ public class JvmOptions {
 
     public void checkDebugConfiguration(Iterable<?> arguments) {
         List<String> debugArgs = collectDebugArgs(arguments);
-        if (!debugArgs.isEmpty() && debugOptions.getEnabled().get()) {
+        if (!debugArgs.isEmpty() && debugOptions.isEnabled()) {
             LOGGER.warn("Debug configuration ignored in favor of the supplied JVM arguments: " + debugArgs);
-            debugOptions.getEnabled().set(false);
+            debugOptions.setEnabled(false);
         }
     }
 
@@ -369,14 +365,14 @@ public class JvmOptions {
     }
 
     public boolean getDebug() {
-        return debugOptions.getEnabled().get();
+        return debugOptions.isEnabled();
     }
 
     public void setDebug(boolean enabled) {
-        debugOptions.getEnabled().set(enabled);
+        debugOptions.setEnabled(enabled);
     }
 
-    public JavaDebugOptions getDebugOptions() {
+    public JvmDebugOptions getDebugOptions() {
         return debugOptions;
     }
 
@@ -387,12 +383,12 @@ public class JvmOptions {
         target.setMaxHeapSize(maxHeapSize);
         target.bootstrapClasspath(getBootstrapClasspath().getFiles());
         target.setEnableAssertions(assertionsEnabled);
-        copyDebugOptionsTo(target.getDebugOptions());
+        copyDebugOptionsTo(new PropertyBackedJvmDebugOptions(target.getDebugOptions()));
         target.systemProperties(immutableSystemProperties);
     }
 
-    public JvmOptions createCopy(ObjectFactory objectFactory, FileCollectionFactory fileCollectionFactory) {
-        JvmOptions target = new JvmOptions(objectFactory, fileCollectionFactory);
+    public JvmOptions createCopy(FileCollectionFactory fileCollectionFactory) {
+        JvmOptions target = new JvmOptions(fileCollectionFactory);
         target.setJvmArgs(extraJvmArgs);
         target.setSystemProperties(mutableSystemProperties);
         target.setMinHeapSize(minHeapSize);
@@ -406,17 +402,17 @@ public class JvmOptions {
         return target;
     }
 
-    private void copyDebugOptionsTo(JavaDebugOptions otherOptions) {
+    private void copyDebugOptionsTo(JvmDebugOptions otherOptions) {
         copyDebugOptions(debugOptions, otherOptions);
     }
 
-    static void copyDebugOptions(JavaDebugOptions from, JavaDebugOptions to) {
+    private static void copyDebugOptions(JvmDebugOptions from, JvmDebugOptions to) {
         // This severs the connection between from this debugOptions to the other debugOptions
-        to.getEnabled().set(from.getEnabled().get());
-        to.getHost().set(from.getHost().getOrNull());
-        to.getPort().set(from.getPort().get());
-        to.getServer().set(from.getServer().get());
-        to.getSuspend().set(from.getSuspend().get());
+        to.setEnabled(from.isEnabled());
+        to.setHost(from.getHost());
+        to.setPort(from.getPort());
+        to.setServer(from.isServer());
+        to.setSuspend(from.isSuspend());
     }
 
     public static List<String> fromString(String input) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
@@ -390,7 +390,7 @@ class DefaultJavaForkOptionsTest extends Specification {
         1 * target.setMaxHeapSize('1g')
         1 * target.bootstrapClasspath(_)
         1 * target.setEnableAssertions(false)
-        1 * target.getDebugOptions() >> new DefaultJavaDebugOptions()
+        1 * target.getDebugOptions() >> TestUtil.newInstance(DefaultJavaDebugOptions)
 
         then:
         1 * target.jvmArgs(['argFromProvider'])

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/JvmOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/JvmOptionsTest.groovy
@@ -150,8 +150,8 @@ class JvmOptionsTest extends Specification {
         JavaDebugOptions debugOptions = TestUtil.newInstance(DefaultJavaDebugOptions);
         JavaForkOptions target = Mock(JavaForkOptions) { it.debugOptions >> debugOptions }
         JvmOptions source = parse("-Dx=y")
-        source.debugOptions.host = "*"
-        source.debugOptions.port = 1234
+        source.debugSpec.host = "*"
+        source.debugSpec.port = 1234
 
         when:
         source.copyTo(target)
@@ -239,9 +239,9 @@ class JvmOptionsTest extends Specification {
 
         when:
         opts.debug = true
-        opts.debugOptions.port = port
-        opts.debugOptions.server = server
-        opts.debugOptions.suspend = suspend
+        opts.debugSpec.port = port
+        opts.debugSpec.server = server
+        opts.debugSpec.suspend = suspend
 
         then:
         opts.allJvmArgs.findAll { it.contains 'jdwp' } == [expected]

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/JvmOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/JvmOptionsTest.groovy
@@ -20,6 +20,7 @@ package org.gradle.process.internal
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.process.JavaDebugOptions
 import org.gradle.process.JavaForkOptions
+import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 import java.nio.charset.Charset
@@ -142,15 +143,15 @@ class JvmOptionsTest extends Specification {
         1 * target.systemProperties({
             it == new TreeMap(["file.encoding": "UTF-16"] + localeProperties())
         })
-        1 * target.getDebugOptions() >> new DefaultJavaDebugOptions()
+        1 * target.getDebugOptions() >> TestUtil.newInstance(DefaultJavaDebugOptions)
     }
 
     def "copyTo copies debugOptions"() {
-        JavaDebugOptions debugOptions = new DefaultJavaDebugOptions();
+        JavaDebugOptions debugOptions = TestUtil.newInstance(DefaultJavaDebugOptions);
         JavaForkOptions target = Mock(JavaForkOptions) { it.debugOptions >> debugOptions }
         JvmOptions source = parse("-Dx=y")
-        source.debugOptions.host.set("*")
-        source.debugOptions.port.set(1234)
+        source.debugOptions.host = "*"
+        source.debugOptions.port = 1234
 
         when:
         source.copyTo(target)
@@ -238,9 +239,9 @@ class JvmOptionsTest extends Specification {
 
         when:
         opts.debug = true
-        opts.debugOptions.port.set(port)
-        opts.debugOptions.server.set(server)
-        opts.debugOptions.suspend.set(suspend)
+        opts.debugOptions.port = port
+        opts.debugOptions.server = server
+        opts.debugOptions.suspend = suspend
 
         then:
         opts.allJvmArgs.findAll { it.contains 'jdwp' } == [expected]


### PR DESCRIPTION
This removes some usages of `InstantiatorBackedObjectFactory`, there are 2 more left but they are more complicated.
