### PR TITLE
Avoid making AbstractCopyTask.source lazy

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractCopyTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractCopyTask.java
@@ -169,7 +169,7 @@ public abstract class AbstractCopyTask extends ConventionTask implements CopySpe
      * @return The source files. Never returns null.
      */
     @Internal
-    @ToBeReplacedByLazyProperty
+    @NotToBeReplacedByLazyProperty(because = "Read-only nested like property")
     public FileCollection getSource() {
         return rootSpec.buildRootResolver().getAllSource();
     }


### PR DESCRIPTION
because it's a read-only file collection