### PR TITLE
Migrate properties for War task

### DIFF
--- a/platforms/jvm/war/build.gradle.kts
+++ b/platforms/jvm/war/build.gradle.kts
@@ -29,7 +29,6 @@ dependencies {
 
     api(libs.groovy)
     api(libs.inject)
-    api(libs.jsr305)
 
     implementation(projects.stdlibJavaExtensions)
     implementation(projects.dependencyManagement)

--- a/platforms/jvm/war/src/main/java/org/gradle/api/plugins/WarPlugin.java
+++ b/platforms/jvm/war/src/main/java/org/gradle/api/plugins/WarPlugin.java
@@ -84,7 +84,7 @@ public abstract class WarPlugin implements Plugin<Project> {
             task.getWebAppDirectory().convention(project.getLayout().dir(project.provider(() -> DeprecationLogger.whileDisabled(pluginConvention::getWebAppDir))));
             task.from(task.getWebAppDirectory());
             task.dependsOn((Callable<FileCollection>) () -> mainFeature.getSourceSet().getRuntimeClasspath());
-            task.classpath((Callable<FileCollection>) () -> {
+            task.getClasspath().from((Callable<FileCollection>) () -> {
                 Configuration providedRuntime = project.getConfigurations().getByName(PROVIDED_RUNTIME_CONFIGURATION_NAME);
                 return mainFeature.getSourceSet().getRuntimeClasspath().minus(providedRuntime);
             });

--- a/testing/architecture-test/src/changes/archunit-store/provider-task-file-collection.txt
+++ b/testing/architecture-test/src/changes/archunit-store/provider-task-file-collection.txt
@@ -5,7 +5,6 @@ Method <org.gradle.api.plugins.quality.Pmd.getSource()> does not have raw return
 Method <org.gradle.api.tasks.JavaExec.getClasspath()> does not have raw return type (org.gradle.api.file.FileCollection) assignable to any of [ConfigurableFileCollection] in (JavaExec.java:0)
 Method <org.gradle.api.tasks.SourceTask.getSource()> does not have raw return type (org.gradle.api.file.FileTree) assignable to any of [ConfigurableFileCollection] in (SourceTask.java:0)
 Method <org.gradle.api.tasks.Upload.getConfiguration()> does not have raw return type (org.gradle.api.artifacts.Configuration) assignable to any of [ConfigurableFileCollection] in (Upload.java:0)
-Method <org.gradle.api.tasks.bundling.War.getClasspath()> does not have raw return type (org.gradle.api.file.FileCollection) assignable to any of [ConfigurableFileCollection] in (War.java:0)
 Method <org.gradle.api.tasks.compile.AbstractCompile.getClasspath()> does not have raw return type (org.gradle.api.file.FileCollection) assignable to any of [ConfigurableFileCollection] in (AbstractCompile.java:0)
 Method <org.gradle.api.tasks.compile.GroovyCompile.getClasspath()> does not have raw return type (org.gradle.api.file.FileCollection) assignable to any of [ConfigurableFileCollection] in (GroovyCompile.java:0)
 Method <org.gradle.api.tasks.compile.GroovyCompile.getSource()> does not have raw return type (org.gradle.api.file.FileTree) assignable to any of [ConfigurableFileCollection] in (GroovyCompile.java:0)

--- a/testing/architecture-test/src/changes/archunit-store/public-api-symmetrical-accessors-nullability.txt
+++ b/testing/architecture-test/src/changes/archunit-store/public-api-symmetrical-accessors-nullability.txt
@@ -8,7 +8,6 @@ Accessors for org.gradle.api.tasks.AbstractExecTask.executable don't use symmetr
 Accessors for org.gradle.api.tasks.Exec.args don't use symmetrical @Nullable
 Accessors for org.gradle.api.tasks.JavaExec.executable don't use symmetrical @Nullable
 Accessors for org.gradle.api.tasks.SourceSetOutput.resourcesDir don't use symmetrical @Nullable
-Accessors for org.gradle.api.tasks.bundling.War.classpath don't use symmetrical @Nullable
 Accessors for org.gradle.api.tasks.bundling.Zip.metadataCharset don't use symmetrical @Nullable
 Accessors for org.gradle.api.tasks.compile.CompileOptions.annotationProcessorGeneratedSourcesDirectory don't use symmetrical @Nullable
 Accessors for org.gradle.api.tasks.diagnostics.DependencyInsightReportTask.configuration don't use symmetrical @Nullable


### PR DESCRIPTION
This PR updates properties for the `War` task:
- `getWebInf` is marked as *not* to be migrated to lazy, because there is no setter and it delegates to the `CopySpec`
- `classpath` is migrated to a `ConfigurableFileCollection` property