### PR TITLE
Let `TypeDiscovery` use the real `PropertyExtractor` from the schema builder

### DIFF
--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/DataSchemaBuilder.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/DataSchemaBuilder.kt
@@ -117,10 +117,15 @@ class DataSchemaBuilder(
     @Suppress("NestedBlockDepth")
     private
     fun createPreIndex(types: Iterable<KClass<*>>): PreIndex {
+        val typeDiscoveryServices = object : TypeDiscovery.TypeDiscoveryServices {
+            override val propertyExtractor: PropertyExtractor
+                get() = this@DataSchemaBuilder.propertyExtractor
+        }
+
         val allTypesToVisit = buildSet {
             fun visit(type: KClass<*>) {
                 if (add(type)) {
-                    typeDiscovery.getClassesToVisitFrom(type).forEach(::visit)
+                    typeDiscovery.getClassesToVisitFrom(typeDiscoveryServices, type).forEach(::visit)
                 }
             }
             types.forEach(::visit)

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/TypeDiscovery.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/TypeDiscovery.kt
@@ -20,19 +20,23 @@ import kotlin.reflect.KClass
 
 
 interface TypeDiscovery {
-    fun getClassesToVisitFrom(kClass: KClass<*>): Iterable<KClass<*>>
+    interface TypeDiscoveryServices {
+        val propertyExtractor: PropertyExtractor
+    }
+
+    fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscoveryServices, kClass: KClass<*>): Iterable<KClass<*>>
 
     companion object {
         val none = object : TypeDiscovery {
-            override fun getClassesToVisitFrom(kClass: KClass<*>): Iterable<KClass<*>> = emptyList()
+            override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscoveryServices, kClass: KClass<*>): Iterable<KClass<*>> = emptyList()
         }
     }
 }
 
 
 class CompositeTypeDiscovery(internal val implementations: Iterable<TypeDiscovery>) : TypeDiscovery {
-    override fun getClassesToVisitFrom(kClass: KClass<*>): Iterable<KClass<*>> =
-        implementations.flatMapTo(mutableSetOf()) { it.getClassesToVisitFrom(kClass) }
+    override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<KClass<*>> =
+        implementations.flatMapTo(mutableSetOf()) { it.getClassesToVisitFrom(typeDiscoveryServices, kClass) }
 }
 
 

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/common/GradlePropertyApiAnalysisSchemaComponent.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/common/GradlePropertyApiAnalysisSchemaComponent.kt
@@ -49,7 +49,7 @@ class GradlePropertyApiAnalysisSchemaComponent : AnalysisSchemaComponent {
 
     override fun propertyExtractors(): List<PropertyExtractor> = listOf(propertyExtractor)
 
-    override fun typeDiscovery(): List<TypeDiscovery> = listOf(PropertyReturnTypeDiscovery(propertyExtractor))
+    override fun typeDiscovery(): List<TypeDiscovery> = listOf(PropertyReturnTypeDiscovery())
 }
 
 
@@ -106,11 +106,9 @@ class GradlePropertyApiPropertyExtractor(
 
 
 private
-class PropertyReturnTypeDiscovery(
-    private val propertyExtractor: PropertyExtractor
-) : TypeDiscovery {
-    override fun getClassesToVisitFrom(kClass: KClass<*>): Iterable<KClass<*>> =
-        propertyExtractor.extractProperties(kClass).mapNotNullTo(mutableSetOf()) {
+class PropertyReturnTypeDiscovery : TypeDiscovery {
+    override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<KClass<*>> =
+        typeDiscoveryServices.propertyExtractor.extractProperties(kClass).mapNotNullTo(mutableSetOf()) {
             propertyValueType(it.originalReturnType).classifier as? KClass<*>
         }
 }
@@ -121,4 +119,7 @@ fun isGradlePropertyType(type: KType): Boolean = type.classifier == Property::cl
 
 
 private
-fun propertyValueType(type: KType): KType = type.arguments[0].type ?: error("expected a declared property type") // TODO: is this a user facing error?
+fun propertyValueType(type: KType): KType =
+    if (type.classifier == Property::class)
+        type.arguments[0].type ?: error("expected a declared property type") // TODO: is this a user facing error?
+    else type

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/common/SupertypeTypeDiscovery.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/common/SupertypeTypeDiscovery.kt
@@ -31,7 +31,7 @@ internal
 class SupertypeTypeDiscovery : AnalysisSchemaComponent {
     override fun typeDiscovery(): List<TypeDiscovery> = listOf(
         object : TypeDiscovery {
-            override fun getClassesToVisitFrom(kClass: KClass<*>): Iterable<KClass<*>> =
+            override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<KClass<*>> =
                 withAllPotentiallyDeclarativeSupertypes(kClass)
         }
     )

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/common/TypeDiscoveryFromRestrictedFunctions.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/common/TypeDiscoveryFromRestrictedFunctions.kt
@@ -50,7 +50,7 @@ class FunctionLambdaTypeDiscovery(
      * Collect everything that potentially looks like types configured by the lambdas.
      * TODO: this may be excessive
      */
-    override fun getClassesToVisitFrom(kClass: KClass<*>): Iterable<KClass<*>> =
+    override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<KClass<*>> =
         kClass.memberFunctions
             .filter { memberFilter.shouldIncludeMember(it) }
             .mapNotNullTo(mutableSetOf()) { fn ->
@@ -68,7 +68,7 @@ class FunctionReturnTypeDiscovery(
     /**
      * Collects everything that restricted functions mention as return values.
      */
-    override fun getClassesToVisitFrom(kClass: KClass<*>): Iterable<KClass<*>> =
+    override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<KClass<*>> =
         kClass.memberFunctions
             .filter { memberFilter.shouldIncludeMember(it) }
             .mapNotNullTo(mutableSetOf()) { fn ->

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/evaluationSchema/FixedTypeDiscovery.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/evaluationSchema/FixedTypeDiscovery.kt
@@ -25,7 +25,7 @@ import kotlin.reflect.KClass
  */
 internal
 class FixedTypeDiscovery(private val keyClass: KClass<*>, private val discoverClasses: List<KClass<*>>) : TypeDiscovery {
-    override fun getClassesToVisitFrom(kClass: KClass<*>): Iterable<KClass<*>> =
+    override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<KClass<*>> =
         when (kClass) {
             keyClass -> discoverClasses.distinct()
             else -> emptyList()

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/ndoc/ContainersSchemaComponent.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/ndoc/ContainersSchemaComponent.kt
@@ -120,7 +120,7 @@ internal class ContainersSchemaComponent : AnalysisSchemaComponent, ObjectConver
 
     override fun typeDiscovery(): List<TypeDiscovery> = listOf(
         object : TypeDiscovery {
-            override fun getClassesToVisitFrom(kClass: KClass<*>): Iterable<KClass<*>> =
+            override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<KClass<*>> =
                 containerProperties(kClass).flatMap { property ->
                     listOfNotNull(
                         property.elementType.classifier, // the element type

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/TypesafeProjectAccessorsComponent.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/TypesafeProjectAccessorsComponent.kt
@@ -99,7 +99,7 @@ class ProjectPropertyAccessorRuntimeResolver : RuntimePropertyResolver {
 
 private
 class TypesafeProjectAccessorTypeDiscovery : TypeDiscovery {
-    override fun getClassesToVisitFrom(kClass: KClass<*>): Iterable<KClass<*>> {
+    override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<KClass<*>> {
         return if (kClass.isGeneratedAccessors()) {
             allClassesReachableFromGetters(kClass)
         } else {

--- a/platforms/core-configuration/declarative-dsl-provider/src/test/kotlin/org/gradle/internal/declarativedsl/GeneralGradleDslSchemaTest.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/test/kotlin/org/gradle/internal/declarativedsl/GeneralGradleDslSchemaTest.kt
@@ -22,11 +22,14 @@ import org.gradle.declarative.dsl.model.annotations.Configuring
 import org.gradle.declarative.dsl.model.annotations.Restricted
 import org.gradle.declarative.dsl.schema.AnalysisSchema
 import org.gradle.declarative.dsl.schema.DataClass
+import org.gradle.internal.declarativedsl.analysis.DefaultFqName
 import org.gradle.internal.declarativedsl.analysis.analyzeEverything
+import org.gradle.internal.declarativedsl.common.gradleDslGeneralSchema
 import org.gradle.internal.declarativedsl.evaluationSchema.EvaluationSchemaBuilder
 import org.gradle.internal.declarativedsl.evaluationSchema.buildEvaluationSchema
-import org.gradle.internal.declarativedsl.common.gradleDslGeneralSchema
 import org.gradle.internal.declarativedsl.schemaUtils.findType
+import org.gradle.internal.declarativedsl.schemaUtils.findTypeFor
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import kotlin.reflect.KClass
@@ -43,6 +46,13 @@ class GeneralGradleDslSchemaTest {
     fun `general dsl schema has types discovered via factory functions`() {
         val schema = schemaFrom(UtilsContainer::class)
         assertHasNestedReceiverType(schema.analysisSchema)
+    }
+
+    @Test
+    fun `general dsl schema has types discovered via properties`() {
+        val schema = schemaFrom(TypeDiscoveryTestReceiver::class)
+        assertNotNull(schema.analysisSchema.dataClassTypesByFqName[DefaultFqName.parse(Enum::class.qualifiedName!!)])
+        assertNotNull(schema.analysisSchema.findTypeFor<UtilsContainer>())
     }
 
     @Test
@@ -98,8 +108,18 @@ class GeneralGradleDslSchemaTest {
         abstract fun nestedReceiver(): NestedReceiver
     }
 
+    @Suppress("unused")
     private
     enum class Enum {
         A, B, C
+    }
+
+    @Suppress("unused")
+    private interface TypeDiscoveryTestReceiver {
+        @get:Restricted
+        var javaBeanProperty: Enum
+
+        @get:Restricted
+        val propertyApiProperty: Property<UtilsContainer>
     }
 }


### PR DESCRIPTION

This fixes an issue of `TypeDiscovery` not visiting types
mentioned in Java Bean properties. That happened because
the type discovery implementation made some assumptions about
the property extractor (used a specific implementation of it).

The API shape with `TypeDiscoveryServices` is chosen because
some more services might be added in the future when we start
handling certain generic types.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
