### PR TITLE
Make `Cached` less unsafe for multi-threaded usage

### DIFF
--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/serialization/Cached.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/serialization/Cached.java
@@ -46,8 +46,8 @@ public abstract class Cached<T> {
 
     private static class Deferred<T> extends Cached<T> implements java.io.Serializable, EvaluationOwner {
 
-        private Callable<T> computation;
-        private Try<T> result;
+        private volatile Callable<T> computation;
+        private volatile Try<T> result;
 
         public Deferred(Callable<T> computation) {
             this.computation = computation;
@@ -59,6 +59,7 @@ public abstract class Cached<T> {
         }
 
         private Try<T> result() {
+            Callable<T> toCompute = computation;
             if (result == null) {
                 // copy reference into the call stack to avoid exacerbating https://github.com/gradle/gradle/issues/31239
                 result = tryComputation(computation);

--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/serialization/Cached.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/serialization/Cached.java
@@ -26,7 +26,10 @@ import java.util.concurrent.Callable;
 /**
  * Represents a computation that must execute only once and
  * whose result must be cached even (or specially) at serialization time.
- *
+ *<p>
+ * Instances of this type are mutable and ARE NOT thread-safe,
+ * so should not be used from multiple threads.
+ *</p>
  * @param <T> the resulting type
  */
 public abstract class Cached<T> {
@@ -46,6 +49,11 @@ public abstract class Cached<T> {
 
     private static class Deferred<T> extends Cached<T> implements java.io.Serializable, EvaluationOwner {
 
+        /*
+         * TODO-RC fields are volatile as a workaround for call sites still unwisely using Cached from multiple threads.
+         *
+         * @see: https://github.com/gradle/gradle/issues/31239
+         */
         private volatile Callable<T> computation;
         private volatile Try<T> result;
 

--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/serialization/Cached.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/serialization/Cached.java
@@ -62,7 +62,7 @@ public abstract class Cached<T> {
             Callable<T> toCompute = computation;
             if (result == null) {
                 // copy reference into the call stack to avoid exacerbating https://github.com/gradle/gradle/issues/31239
-                result = tryComputation(computation);
+                result = tryComputation(toCompute);
                 computation = null;
             }
             return result;

--- a/platforms/core-runtime/functional/src/test/groovy/org/gradle/internal/serialization/CachedTest.groovy
+++ b/platforms/core-runtime/functional/src/test/groovy/org/gradle/internal/serialization/CachedTest.groovy
@@ -34,7 +34,7 @@ class CachedTest extends Specification {
     def "Cached may misbehave when used from multiple threads"() {
         def repetitions = 1000
         repetitions.times {
-            def iteration = iteration * repetitions + it
+            def iteration = batch * repetitions + it
             int parties = Math.max((Runtime.getRuntime().availableProcessors() / 2) as int, 2)
             def barrier = new CyclicBarrier(parties + 1)
             def counter = new AtomicInteger(iteration)
@@ -55,7 +55,7 @@ class CachedTest extends Specification {
         }
 
         where:
-        iteration << (0..<5)
+        batch << (0..<5)
     }
 
 }

--- a/platforms/core-runtime/functional/src/test/groovy/org/gradle/internal/serialization/CachedTest.groovy
+++ b/platforms/core-runtime/functional/src/test/groovy/org/gradle/internal/serialization/CachedTest.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.serialization
+
+import org.gradle.test.fixtures.ConcurrentTestUtil
+import org.gradle.test.fixtures.Flaky
+import spock.lang.Specification
+
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.atomic.AtomicInteger
+
+class CachedTest extends Specification {
+
+    /**
+     * Once https://github.com/gradle/gradle/issues/31239 is addressed,
+     * and we can obtain a thread-safe instance of {@link Cached},
+     * this test should be fixed not to be flaky.
+     */
+    @Flaky(because = "https://github.com/gradle/gradle/issues/31239")
+    def "Cached may misbehave when used from multiple threads"() {
+        int parties = Math.max((Runtime.getRuntime().availableProcessors() / 2) as int, 2)
+        def barrier = new CyclicBarrier(parties + 1)
+        def counter = new AtomicInteger(0)
+        // FIXME should use a thread-safe factory method from Cached, once it is available
+        def cached = Cached.of(counter::incrementAndGet)
+        def concurrent = new ConcurrentTestUtil()
+        parties.times {
+            concurrent.start {
+                barrier.await()
+                // FIXME given enough opportunities, this will fail with a NPE
+                def value = cached.get()
+                // FIXME we should possibly require at-most-once semantics
+                // Such a weak guarantee is all we can provide at this time, as at-most-once is currently not honored
+                assert value > 0
+            }
+        }
+        barrier.await()
+        concurrent.finished()
+
+        where:
+        iteration << (1..10000)
+    }
+}


### PR DESCRIPTION
Related (but unfixed) issue: #31239

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
