### PR TITLE
Add additionalLinkFiles lazily

### DIFF
--- a/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/internal/DefaultStaticLibraryBinarySpec.java
+++ b/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/internal/DefaultStaticLibraryBinarySpec.java
@@ -61,7 +61,7 @@ public class DefaultStaticLibraryBinarySpec extends AbstractNativeLibraryBinaryS
     public FileCollection getLinkFiles() {
         ConfigurableFileCollection result = getFileCollectionFactory().configurableFiles("Link files for " + getDisplayName());
         result.from(getFileCollectionFactory().create(new StaticLibraryLinkOutputs()));
-        additionalLinkFiles.forEach(result::from);
+        result.from(additionalLinkFiles);
         return result;
     }
 


### PR DESCRIPTION
This way the result of getLinkFiles() can still see further changes to additionalLinkFiles.

Fixes #31147
