### PR TITLE
Wrap build action model requests in build operations

### DIFF
--- a/platforms/core-configuration/configuration-cache/build.gradle.kts
+++ b/platforms/core-configuration/configuration-cache/build.gradle.kts
@@ -13,6 +13,7 @@ tasks.configCacheIntegTest {
 
 dependencies {
     api(projects.baseServices)
+    api(projects.buildOperations)
     api(projects.concurrent)
     api(projects.configurationCacheBase)
     api(projects.configurationProblemsBase)
@@ -37,7 +38,6 @@ dependencies {
 
     // TODO - it might be good to allow projects to contribute state to save and restore, rather than have this project know about everything
     implementation(projects.buildEvents)
-    implementation(projects.buildOperations)
     implementation(projects.buildOption)
     implementation(projects.coreKotlinExtensions)
     implementation(projects.coreSerializationCodecs)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeLifecycleControllerFactory.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeLifecycleControllerFactory.kt
@@ -30,6 +30,8 @@ import org.gradle.internal.cc.impl.initialization.ConfigurationCacheStartParamet
 import org.gradle.internal.cc.impl.services.DefaultDeferredRootBuildGradle
 import org.gradle.internal.model.StateTransitionControllerFactory
 import org.gradle.internal.operations.BuildOperationExecutor
+import org.gradle.internal.operations.BuildOperationRunner
+import org.gradle.tooling.provider.model.internal.ToolingModelParameterCarrier
 
 
 class ConfigurationCacheBuildTreeLifecycleControllerFactory internal constructor(
@@ -42,9 +44,21 @@ class ConfigurationCacheBuildTreeLifecycleControllerFactory internal constructor
     private val configurationCacheStartParameter: ConfigurationCacheStartParameter,
     private val buildStateRegistry: BuildStateRegistry,
     private val deferredRootBuildGradle: DefaultDeferredRootBuildGradle,
+    parameterCarrierFactory: ToolingModelParameterCarrier.Factory,
+    buildOperationRunner: BuildOperationRunner
 ) : BuildTreeLifecycleControllerFactory {
+
     private
-    val vintageFactory = VintageBuildTreeLifecycleControllerFactory(buildModelParameters, taskGraph, buildOperationExecutor, stateTransitionControllerFactory, startParameter)
+    val vintageFactory = VintageBuildTreeLifecycleControllerFactory(
+        buildModelParameters,
+        taskGraph,
+        buildOperationExecutor,
+        stateTransitionControllerFactory,
+        startParameter,
+        parameterCarrierFactory,
+        buildStateRegistry,
+        buildOperationRunner
+    )
 
     override fun createRootBuildController(targetBuild: BuildLifecycleController, workExecutor: BuildTreeWorkExecutor, finishExecutor: BuildTreeFinishExecutor): BuildTreeLifecycleController {
         // Some temporary wiring: the cache implementation is still scoped to the root build rather than the build tree

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/VintageBuildTreeLifecycleControllerFactory.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/VintageBuildTreeLifecycleControllerFactory.kt
@@ -19,6 +19,7 @@ package org.gradle.internal.cc.impl
 import org.gradle.StartParameter
 import org.gradle.composite.internal.BuildTreeWorkGraphController
 import org.gradle.internal.build.BuildLifecycleController
+import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.buildtree.BuildTreeFinishExecutor
 import org.gradle.internal.buildtree.BuildTreeLifecycleController
@@ -30,6 +31,8 @@ import org.gradle.internal.buildtree.DefaultBuildTreeWorkPreparer
 import org.gradle.internal.buildtree.IntermediateBuildActionRunner
 import org.gradle.internal.model.StateTransitionControllerFactory
 import org.gradle.internal.operations.BuildOperationExecutor
+import org.gradle.internal.operations.BuildOperationRunner
+import org.gradle.tooling.provider.model.internal.ToolingModelParameterCarrier
 
 
 class VintageBuildTreeLifecycleControllerFactory(
@@ -38,6 +41,9 @@ class VintageBuildTreeLifecycleControllerFactory(
     private val buildOperationExecutor: BuildOperationExecutor,
     private val stateTransitionControllerFactory: StateTransitionControllerFactory,
     private val startParameter: StartParameter,
+    private val parameterCarrierFactory: ToolingModelParameterCarrier.Factory,
+    private val buildStateRegistry: BuildStateRegistry,
+    private val buildOperationRunner: BuildOperationRunner
 ) : BuildTreeLifecycleControllerFactory {
     // Used when CC is not enabled
     override fun createRootBuildController(targetBuild: BuildLifecycleController, workExecutor: BuildTreeWorkExecutor, finishExecutor: BuildTreeFinishExecutor): BuildTreeLifecycleController {
@@ -54,7 +60,7 @@ class VintageBuildTreeLifecycleControllerFactory(
 
     internal
     fun createModelCreator(targetBuild: BuildLifecycleController) =
-        DefaultBuildTreeModelCreator(targetBuild.gradle.owner, createIntermediateActionRunner())
+        DefaultBuildTreeModelCreator(targetBuild.gradle.owner, createIntermediateActionRunner(), parameterCarrierFactory, buildStateRegistry, buildOperationRunner)
 
     internal
     fun createWorkPreparer(targetBuild: BuildLifecycleController) =

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildControllerFactory.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildControllerFactory.java
@@ -18,21 +18,17 @@ package org.gradle.tooling.internal.provider.runner;
 
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.initialization.BuildEventConsumer;
-import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.buildtree.BuildTreeModelController;
 import org.gradle.internal.buildtree.BuildTreeModelSideEffectExecutor;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.work.WorkerThreadRegistry;
 import org.gradle.tooling.internal.provider.serialization.PayloadSerializer;
-import org.gradle.tooling.provider.model.internal.ToolingModelParameterCarrier;
 
 @ServiceScope(Scope.BuildTree.class)
 public class BuildControllerFactory {
     private final WorkerThreadRegistry workerThreadRegistry;
     private final BuildCancellationToken buildCancellationToken;
-    private final BuildStateRegistry buildStateRegistry;
-    private final ToolingModelParameterCarrier.Factory parameterCarrierFactory;
     private final BuildEventConsumer buildEventConsumer;
     private final BuildTreeModelSideEffectExecutor sideEffectExecutor;
     private final PayloadSerializer payloadSerializer;
@@ -40,22 +36,24 @@ public class BuildControllerFactory {
     public BuildControllerFactory(
         WorkerThreadRegistry workerThreadRegistry,
         BuildCancellationToken buildCancellationToken,
-        BuildStateRegistry buildStateRegistry,
-        ToolingModelParameterCarrier.Factory parameterCarrierFactory,
         BuildEventConsumer buildEventConsumer,
         BuildTreeModelSideEffectExecutor sideEffectExecutor,
         PayloadSerializer payloadSerializer
     ) {
         this.workerThreadRegistry = workerThreadRegistry;
         this.buildCancellationToken = buildCancellationToken;
-        this.buildStateRegistry = buildStateRegistry;
         this.buildEventConsumer = buildEventConsumer;
         this.sideEffectExecutor = sideEffectExecutor;
-        this.parameterCarrierFactory = parameterCarrierFactory;
         this.payloadSerializer = payloadSerializer;
     }
 
     public DefaultBuildController controllerFor(BuildTreeModelController controller) {
-        return new DefaultBuildController(controller, workerThreadRegistry, buildCancellationToken, buildStateRegistry, parameterCarrierFactory, buildEventConsumer, sideEffectExecutor, payloadSerializer);
+        return new DefaultBuildController(controller,
+            workerThreadRegistry,
+            buildCancellationToken,
+            buildEventConsumer,
+            sideEffectExecutor,
+            payloadSerializer
+        );
     }
 }

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildModelActionRunner.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildModelActionRunner.java
@@ -26,7 +26,6 @@ import org.gradle.tooling.internal.provider.action.BuildModelAction;
 import org.gradle.tooling.internal.provider.serialization.PayloadSerializer;
 import org.gradle.tooling.internal.provider.serialization.SerializedPayload;
 import org.gradle.tooling.provider.model.UnknownModelException;
-import org.gradle.tooling.provider.model.internal.ToolingModelScope;
 
 public class BuildModelActionRunner implements BuildActionRunner {
     private final PayloadSerializer payloadSerializer;
@@ -78,9 +77,8 @@ public class BuildModelActionRunner implements BuildActionRunner {
         @Override
         public Object fromBuildModel(BuildTreeModelController controller) {
             String modelName = buildModelAction.getModelName();
-            ToolingModelScope scope = controller.locateBuilderForDefaultTarget(modelName, false);
             try {
-                return scope.getModel(modelName, null);
+                return controller.getModel(null, modelName, null);
             } catch (UnknownModelException e) {
                 modelLookupFailure = e;
                 throw e;

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildModelActionRunner.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildModelActionRunner.java
@@ -20,6 +20,7 @@ import org.gradle.internal.buildtree.BuildActionRunner;
 import org.gradle.internal.buildtree.BuildTreeLifecycleController;
 import org.gradle.internal.buildtree.BuildTreeModelAction;
 import org.gradle.internal.buildtree.BuildTreeModelController;
+import org.gradle.internal.buildtree.BuildTreeModelTarget;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.tooling.internal.protocol.InternalUnsupportedModelException;
 import org.gradle.tooling.internal.provider.action.BuildModelAction;
@@ -78,7 +79,7 @@ public class BuildModelActionRunner implements BuildActionRunner {
         public Object fromBuildModel(BuildTreeModelController controller) {
             String modelName = buildModelAction.getModelName();
             try {
-                return controller.getModel(null, modelName, null);
+                return controller.getModel(BuildTreeModelTarget.ofDefault(), modelName, null);
             } catch (UnknownModelException e) {
                 modelLookupFailure = e;
                 throw e;

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/DefaultBuildController.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/DefaultBuildController.java
@@ -99,7 +99,7 @@ class DefaultBuildController implements org.gradle.tooling.internal.protocol.Int
             throw new BuildCancelledException(String.format("Could not build '%s' model. Build cancelled.", modelIdentifier.getName()));
         }
 
-        BuildTreeModelTarget scopedTarget = getTarget(target);
+        BuildTreeModelTarget scopedTarget = resolveTarget(target);
         try {
             Object model = controller.getModel(scopedTarget, modelIdentifier.getName(), parameter);
             return new ProviderBuildResult<>(model);
@@ -108,10 +108,9 @@ class DefaultBuildController implements org.gradle.tooling.internal.protocol.Int
         }
     }
 
-    @Nullable
-    private static BuildTreeModelTarget getTarget(@Nullable Object target) {
+    private static BuildTreeModelTarget resolveTarget(@Nullable Object target) {
         if (target == null) {
-            return null;
+            return BuildTreeModelTarget.ofDefault();
         } else if (target instanceof GradleProjectIdentity) {
             GradleProjectIdentity projectIdentity = (GradleProjectIdentity) target;
             return BuildTreeModelTarget.ofProject(projectIdentity.getRootDir(), projectIdentity.getProjectPath());
@@ -133,7 +132,6 @@ class DefaultBuildController implements org.gradle.tooling.internal.protocol.Int
         assertCanQuery();
         return controller.runQueryModelActions(actions);
     }
-
 
     private void assertCanQuery() {
         if (!workerThreadRegistry.isWorkerThread()) {

--- a/platforms/ide/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/DefaultBuildControllerTest.groovy
+++ b/platforms/ide/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/DefaultBuildControllerTest.groovy
@@ -71,7 +71,7 @@ class DefaultBuildControllerTest extends Specification {
 
         given:
         _ * workerThreadRegistry.workerThread >> true
-        1 * modelController.getModel(null, 'some.model', null) >> { throw failure }
+        1 * modelController.getModel(_, 'some.model', null) >> { throw failure }
 
         when:
         controller.getModel(null, modelId)
@@ -123,7 +123,7 @@ class DefaultBuildControllerTest extends Specification {
         _ * workerThreadRegistry.workerThread >> true
         _ * target.rootDir >> rootDir
         1 * modelController.getModel(_, "some.model", null) >> { BuildTreeModelTarget t, m, p ->
-            assert t.buildRootDir == rootDir && t.projectPath == null
+            assert t instanceof BuildTreeModelTarget.Build && t.buildRootDir == rootDir
             model
         }
 
@@ -139,7 +139,7 @@ class DefaultBuildControllerTest extends Specification {
 
         given:
         _ * workerThreadRegistry.workerThread >> true
-        1 * modelController.getModel(null, "some.model", null) >> model
+        1 * modelController.getModel(_, "some.model", null) >> model
 
         when:
         def result = controller.getModel(null, modelId)
@@ -175,7 +175,7 @@ class DefaultBuildControllerTest extends Specification {
 
         given:
         _ * workerThreadRegistry.workerThread >> true
-        1 * modelController.getModel(null, 'some.model', parameter) >> model
+        1 * modelController.getModel(_, 'some.model', parameter) >> model
 
         when:
         def result = controller.getModel(null, modelId, parameter)

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r812/BuildActionModelFetchProgressEventsCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r812/BuildActionModelFetchProgressEventsCrossVersionSpec.groovy
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r812
+
+import org.gradle.integtests.tooling.fixture.ProgressEvents
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.tooling.model.GradleProject
+
+@TargetGradleVersion('>=8.12')
+class BuildActionModelFetchProgressEventsCrossVersionSpec extends ToolingApiSpecification {
+
+    def setup() {
+        settingsFile << "rootProject.name = 'root'"
+    }
+
+    def "build model requests have build operations"() {
+        given:
+        def listener = ProgressEvents.create()
+
+        when:
+        def model = loadToolingModel(GradleProject) {
+            it.addProgressListener(listener)
+        }
+
+        then:
+        model != null
+
+        and:
+        listener.operation("Fetch model 'org.gradle.tooling.model.GradleProject' for default scope")
+            .descendant("Configure build")
+    }
+
+    def "build action model requests have build operations"() {
+        given:
+        def listener = ProgressEvents.create()
+
+        when:
+        def models = succeeds { connection ->
+            connection.action(new FetchBuildAndProjectModels())
+                .addProgressListener(listener)
+                .run()
+        }
+
+        then:
+        models != null
+
+        and:
+        listener.operation("Fetch model 'org.gradle.tooling.model.gradle.GradleBuild' for default scope")
+            .descendant("Load build")
+        listener.operation("Fetch model 'org.gradle.tooling.model.gradle.GradleBuild' for build scope")
+        listener.operation("Fetch model 'org.gradle.tooling.model.GradleProject' for project scope")
+            .descendant("Configure build")
+    }
+
+    def "phased build action model requests have build operations"() {
+        given:
+        def listener = ProgressEvents.create()
+
+        when:
+        def models = []
+        succeeds { connection ->
+            connection.action()
+                .projectsLoaded(new FetchGradleBuild()) {
+                    models.add(it)
+                }
+                .buildFinished(new FetchBuildEnvironment()) {
+                    models.add(it)
+                }
+                .build()
+                .addProgressListener(listener)
+                .run()
+            true
+        }
+
+        then:
+        models.size() == 2
+
+        and:
+        listener.operation("Fetch model 'org.gradle.tooling.model.gradle.GradleBuild' for default scope")
+            .descendant("Load build")
+
+        listener.operation("Fetch model 'org.gradle.tooling.model.build.BuildEnvironment' for default scope")
+            .descendant("Configure build")
+    }
+}

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r812/BuildActionModelFetchProgressEventsCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r812/BuildActionModelFetchProgressEventsCrossVersionSpec.groovy
@@ -21,7 +21,7 @@ import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.tooling.model.GradleProject
 
-@TargetGradleVersion('>=8.12')
+@TargetGradleVersion('>=8.13')
 class BuildActionModelFetchProgressEventsCrossVersionSpec extends ToolingApiSpecification {
 
     def setup() {

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r812/FetchBuildAndProjectModels.java
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r812/FetchBuildAndProjectModels.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r812;
+
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.GradleProject;
+import org.gradle.tooling.model.gradle.GradleBuild;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class FetchBuildAndProjectModels implements BuildAction<List<Object>> {
+    @Override
+    public List<Object> execute(BuildController controller) {
+        GradleBuild gradleBuild = controller.getBuildModel();
+        GradleBuild gradleBuild1 = controller.getModel(gradleBuild, GradleBuild.class);
+        GradleProject project = controller.getModel(gradleBuild.getRootProject(), GradleProject.class);
+        return Arrays.asList((Object) gradleBuild1, project);
+    }
+}

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r812/FetchBuildEnvironment.java
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r812/FetchBuildEnvironment.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r812;
+
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.build.BuildEnvironment;
+
+public class FetchBuildEnvironment implements BuildAction<BuildEnvironment> {
+    @Override
+    public BuildEnvironment execute(BuildController controller) {
+        return controller.getModel(BuildEnvironment.class);
+    }
+}

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r812/FetchGradleBuild.java
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r812/FetchGradleBuild.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r812;
+
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.gradle.GradleBuild;
+
+public class FetchGradleBuild implements BuildAction<GradleBuild> {
+    @Override
+    public GradleBuild execute(BuildController controller) {
+        return controller.getBuildModel();
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeModelController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeModelController.java
@@ -17,10 +17,9 @@
 package org.gradle.internal.buildtree;
 
 import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.project.ProjectState;
-import org.gradle.internal.build.BuildState;
-import org.gradle.tooling.provider.model.internal.ToolingModelScope;
+import org.gradle.tooling.provider.model.UnknownModelException;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -30,11 +29,8 @@ public interface BuildTreeModelController {
      */
     GradleInternal getConfiguredModel();
 
-    ToolingModelScope locateBuilderForDefaultTarget(String modelName, boolean param);
-
-    ToolingModelScope locateBuilderForTarget(BuildState target, String modelName, boolean param);
-
-    ToolingModelScope locateBuilderForTarget(ProjectState target, String modelName, boolean param);
+    @Nullable
+    Object getModel(@Nullable BuildTreeModelTarget target, String modelName, @Nullable Object parameter) throws UnknownModelException;
 
     boolean queryModelActionsRunInParallel();
 

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeModelController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeModelController.java
@@ -29,8 +29,16 @@ public interface BuildTreeModelController {
      */
     GradleInternal getConfiguredModel();
 
+    /**
+     * Creates the model with a given parameter in the target scope.
+     * <p>
+     * The model builder is resolved in the target scope, configuring the scope if necessary.
+     *
+     * @return the created model (null is a valid model)
+     * @throws UnknownModelException when the model builder cannot be found
+     */
     @Nullable
-    Object getModel(@Nullable BuildTreeModelTarget target, String modelName, @Nullable Object parameter) throws UnknownModelException;
+    Object getModel(BuildTreeModelTarget target, String modelName, @Nullable Object parameter) throws UnknownModelException;
 
     boolean queryModelActionsRunInParallel();
 

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeModelTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeModelTarget.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.buildtree;
+
+import org.gradle.util.Path;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.util.Objects;
+
+public class BuildTreeModelTarget {
+
+    public static BuildTreeModelTarget ofBuild(File buildRootDir) {
+        return new BuildTreeModelTarget(buildRootDir, null);
+    }
+
+    public static BuildTreeModelTarget ofProject(File buildRootDir, String projectPath) {
+        return new BuildTreeModelTarget(buildRootDir, Path.path(projectPath));
+    }
+
+    private final File buildRootDir;
+    @Nullable
+    private final Path projectPath;
+
+    public BuildTreeModelTarget(File buildRootDir, @Nullable Path projectPath) {
+        this.buildRootDir = buildRootDir;
+        this.projectPath = projectPath;
+    }
+
+    public File getBuildRootDir() {
+        return buildRootDir;
+    }
+
+    @Nullable
+    public Path getProjectPath() {
+        return projectPath;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof BuildTreeModelTarget)) {
+            return false;
+        }
+
+        BuildTreeModelTarget that = (BuildTreeModelTarget) o;
+        return buildRootDir.equals(that.buildRootDir) && Objects.equals(projectPath, that.projectPath);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = buildRootDir.hashCode();
+        result = 31 * result + Objects.hashCode(projectPath);
+        return result;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeModelTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeModelTarget.java
@@ -22,6 +22,12 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Objects;
 
+/**
+ * Either a build or a project as a target for model building.
+ * <p>
+ * The target is identified by minimal information provided via Tooling API,
+ * such as the root directory of the target build.
+ */
 public class BuildTreeModelTarget {
 
     public static BuildTreeModelTarget ofBuild(File buildRootDir) {

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeModelTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeModelTarget.java
@@ -18,61 +18,120 @@ package org.gradle.internal.buildtree;
 
 import org.gradle.util.Path;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Objects;
 
 /**
- * Either a build or a project as a target for model building.
+ * Target for model building.
  * <p>
  * The target is identified by minimal information provided via Tooling API,
  * such as the root directory of the target build.
  */
-public class BuildTreeModelTarget {
+public abstract class BuildTreeModelTarget {
 
-    public static BuildTreeModelTarget ofBuild(File buildRootDir) {
-        return new BuildTreeModelTarget(buildRootDir, null);
+    @SuppressWarnings("StaticInitializerReferencesSubClass")
+    private static final Default DEFAULT = new Default();
+
+    public static Default ofDefault() {
+        return DEFAULT;
     }
 
-    public static BuildTreeModelTarget ofProject(File buildRootDir, String projectPath) {
-        return new BuildTreeModelTarget(buildRootDir, Path.path(projectPath));
+    public static Build ofBuild(File buildRootDir) {
+        return new Build(buildRootDir);
     }
 
-    private final File buildRootDir;
-    @Nullable
-    private final Path projectPath;
-
-    public BuildTreeModelTarget(File buildRootDir, @Nullable Path projectPath) {
-        this.buildRootDir = buildRootDir;
-        this.projectPath = projectPath;
+    public static Project ofProject(File buildRootDir, String projectPath) {
+        return new Project(buildRootDir, Path.path(projectPath));
     }
 
-    public File getBuildRootDir() {
-        return buildRootDir;
-    }
+    public static class Default extends BuildTreeModelTarget {
+        private Default() {}
 
-    @Nullable
-    public Path getProjectPath() {
-        return projectPath;
-    }
-
-    @Override
-    public final boolean equals(Object o) {
-        if (this == o) {
-            return true;
+        @Override
+        public String toString() {
+            return "Default";
         }
-        if (!(o instanceof BuildTreeModelTarget)) {
-            return false;
+    }
+
+    public static class Build extends BuildTreeModelTarget {
+
+        private final File buildRootDir;
+
+        private Build(File buildRootDir) {
+            this.buildRootDir = buildRootDir;
         }
 
-        BuildTreeModelTarget that = (BuildTreeModelTarget) o;
-        return buildRootDir.equals(that.buildRootDir) && Objects.equals(projectPath, that.projectPath);
+        public File getBuildRootDir() {
+            return buildRootDir;
+        }
+
+        @Override
+        public final boolean equals(Object o) {
+            if (!(o instanceof Build)) {
+                return false;
+            }
+
+            Build build = (Build) o;
+            return buildRootDir.equals(build.buildRootDir);
+        }
+
+        @Override
+        public int hashCode() {
+            return buildRootDir.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "Build{" +
+                "buildRootDir=" + buildRootDir +
+                '}';
+        }
     }
 
-    @Override
-    public int hashCode() {
-        int result = buildRootDir.hashCode();
-        result = 31 * result + Objects.hashCode(projectPath);
-        return result;
+    public static class Project extends BuildTreeModelTarget {
+
+        private final File buildRootDir;
+        private final Path projectPath;
+
+        private Project(File buildRootDir, Path projectPath) {
+            this.buildRootDir = buildRootDir;
+            this.projectPath = projectPath;
+        }
+
+        public File getBuildRootDir() {
+            return buildRootDir;
+        }
+
+        public Path getProjectPath() {
+            return projectPath;
+        }
+
+        @Override
+        public final boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Project)) {
+                return false;
+            }
+
+            Project that = (Project) o;
+            return buildRootDir.equals(that.buildRootDir) && Objects.equals(projectPath, that.projectPath);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = buildRootDir.hashCode();
+            result = 31 * result + Objects.hashCode(projectPath);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "Project{" +
+                "buildRootDir=" + buildRootDir +
+                ", projectPath=" + projectPath +
+                '}';
+        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/DefaultBuildTreeModelCreator.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/DefaultBuildTreeModelCreator.java
@@ -19,23 +19,42 @@ package org.gradle.internal.buildtree;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.internal.build.BuildState;
+import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.build.BuildToolingModelController;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationRunner;
+import org.gradle.internal.operations.CallableBuildOperation;
 import org.gradle.tooling.provider.model.UnknownModelException;
+import org.gradle.tooling.provider.model.internal.ToolingModelParameterCarrier;
 import org.gradle.tooling.provider.model.internal.ToolingModelScope;
+import org.gradle.util.Path;
 
+import javax.annotation.Nullable;
+import java.io.File;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 public class DefaultBuildTreeModelCreator implements BuildTreeModelCreator {
     private final BuildState defaultTarget;
     private final IntermediateBuildActionRunner actionRunner;
+    private final ToolingModelParameterCarrier.Factory parameterCarrierFactory;
+    private final BuildStateRegistry buildStateRegistry;
+    private final BuildOperationRunner buildOperationRunner;
 
     public DefaultBuildTreeModelCreator(
         BuildState defaultTarget,
-        IntermediateBuildActionRunner actionRunner
+        IntermediateBuildActionRunner actionRunner,
+        ToolingModelParameterCarrier.Factory parameterCarrierFactory,
+        BuildStateRegistry buildStateRegistry,
+        BuildOperationRunner buildOperationRunner
     ) {
         this.defaultTarget = defaultTarget;
         this.actionRunner = actionRunner;
+        this.parameterCarrierFactory = parameterCarrierFactory;
+        this.buildStateRegistry = buildStateRegistry;
+        this.buildOperationRunner = buildOperationRunner;
     }
 
     @Override
@@ -55,18 +74,25 @@ public class DefaultBuildTreeModelCreator implements BuildTreeModelCreator {
         }
 
         @Override
-        public ToolingModelScope locateBuilderForDefaultTarget(String modelName, boolean param) throws UnknownModelException {
-            return locateBuilderForTarget(defaultTarget, modelName, param);
-        }
+        @Nullable
+        public Object getModel(@Nullable BuildTreeModelTarget target, String modelName, @Nullable Object parameter) throws UnknownModelException {
+            // Include target resolution into the operation to identify all work (including build configuration)
+            // that is executed to provide the requested model
+            return buildOperationRunner.call(new CallableBuildOperation<Object>() {
+                @Override
+                @Nullable
+                public Object call(BuildOperationContext context) {
+                    ToolingModelScope scope = getTarget(target, modelName, parameter != null);
+                    return getModelForScope(scope, modelName, parameter);
+                }
 
-        @Override
-        public ToolingModelScope locateBuilderForTarget(BuildState target, String modelName, boolean param) throws UnknownModelException {
-            return target.withToolingModels(controller -> controller.locateBuilderForTarget(modelName, param));
-        }
-
-        @Override
-        public ToolingModelScope locateBuilderForTarget(ProjectState target, String modelName, boolean param) throws UnknownModelException {
-            return target.getOwner().withToolingModels(controller -> controller.locateBuilderForTarget(target, modelName, param));
+                @Override
+                public BuildOperationDescriptor.Builder description() {
+                    String targetDescription = describeTarget(target);
+                    return BuildOperationDescriptor.displayName("Fetch model '" + modelName + "' for " + targetDescription)
+                        .progressDisplayName("Fetching model '" + modelName + "' for " + targetDescription);
+                }
+            });
         }
 
         @Override
@@ -77,6 +103,72 @@ public class DefaultBuildTreeModelCreator implements BuildTreeModelCreator {
         @Override
         public <T> List<T> runQueryModelActions(List<Supplier<T>> actions) {
             return actionRunner.run(actions);
+        }
+
+        private ToolingModelScope locateBuilderForDefaultTarget(String modelName, boolean param) {
+            return locateBuilderForTarget(defaultTarget, modelName, param);
+        }
+
+        private ToolingModelScope locateBuilderForTarget(BuildState target, String modelName, boolean param) {
+            return target.withToolingModels(controller -> controller.locateBuilderForTarget(modelName, param));
+        }
+
+        private ToolingModelScope locateBuilderForTarget(ProjectState target, String modelName, boolean param) throws UnknownModelException {
+            return target.getOwner().withToolingModels(controller -> controller.locateBuilderForTarget(target, modelName, param));
+        }
+
+        @Nullable
+        private Object getModelForScope(ToolingModelScope scope, String modelName, @Nullable Object parameter) {
+            if (parameter == null) {
+                return scope.getModel(modelName, null);
+            } else {
+                return scope.getModel(modelName, parameterCarrierFactory.createCarrier(parameter));
+            }
+        }
+
+        private String describeTarget(@Nullable BuildTreeModelTarget target) {
+            if (target == null) {
+                return "default scope";
+            } else if (target.getProjectPath() != null) {
+                return "project scope";
+            } else {
+                return "build scope";
+            }
+        }
+
+        private ToolingModelScope getTarget(@Nullable BuildTreeModelTarget target, String modelName, boolean parameter) {
+            if (target == null) {
+                return locateBuilderForDefaultTarget(modelName, parameter);
+            }
+
+            BuildState build = findBuild(target);
+            Path projectPath = target.getProjectPath();
+            if (projectPath == null) {
+                return locateBuilderForTarget(build, modelName, parameter);
+            } else {
+                ProjectState project = findProject(build, projectPath);
+                return locateBuilderForTarget(project, modelName, parameter);
+            }
+        }
+
+        private BuildState findBuild(BuildTreeModelTarget target) {
+            File targetBuildRootDir = target.getBuildRootDir();
+            AtomicReference<BuildState> match = new AtomicReference<>();
+            buildStateRegistry.visitBuilds(buildState -> {
+                if (buildState.isImportableBuild() && buildState.getBuildRootDir().equals(targetBuildRootDir)) {
+                    match.set(buildState);
+                }
+            });
+            if (match.get() != null) {
+                return match.get();
+            } else {
+                throw new IllegalArgumentException(targetBuildRootDir + " is not included in this build");
+            }
+        }
+
+        private ProjectState findProject(BuildState build, Path projectPath) {
+            build.ensureProjectsLoaded();
+            return build.getProjects().getProject(projectPath);
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/ToolingModelScope.java
+++ b/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/ToolingModelScope.java
@@ -17,7 +17,6 @@
 package org.gradle.tooling.provider.model.internal;
 
 import org.gradle.api.internal.project.ProjectState;
-import org.gradle.tooling.provider.model.UnknownModelException;
 
 import javax.annotation.Nullable;
 
@@ -36,8 +35,10 @@ public interface ToolingModelScope {
     /**
      * Creates a model with a given parameter.
      * <p>
-     * Can configure the target project to locate the corresponding model builder.
+     * Can configure the target build or project to locate the corresponding model builder.
+     *
+     * @return the created model (null is a valid model)
      */
     @Nullable
-    Object getModel(String modelName, @Nullable ToolingModelParameterCarrier parameter) throws UnknownModelException;
+    Object getModel(String modelName, @Nullable ToolingModelParameterCarrier parameter);
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildtree/DefaultBuildTreeModelCreatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildtree/DefaultBuildTreeModelCreatorTest.groovy
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.buildtree
+
+import org.gradle.internal.build.BuildState
+import org.gradle.internal.build.BuildStateRegistry
+import org.gradle.internal.build.BuildToolingModelController
+import org.gradle.internal.operations.TestBuildOperationRunner
+import org.gradle.tooling.provider.model.internal.ToolingModelParameterCarrier
+import org.gradle.tooling.provider.model.internal.ToolingModelScope
+import spock.lang.Specification
+
+import javax.annotation.Nullable
+import java.util.function.Consumer
+import java.util.function.Function
+
+class DefaultBuildTreeModelCreatorTest extends Specification {
+
+    def buildOperationRunner = new TestBuildOperationRunner()
+
+    def "importable builds can be used as targets for model building"() {
+        given:
+        def model = new Object()
+
+        def modelScope = Mock(ToolingModelScope) {
+            getModel(_, _) >> model
+        }
+        def modelController = Mock(BuildToolingModelController) {
+            locateBuilderForTarget(_, _) >> modelScope
+        }
+
+        def buildRootDir = new File("dummy")
+        def buildState1 = Stub(BuildState) {
+            isImportableBuild() >> true
+            getBuildRootDir() >> buildRootDir
+            withToolingModels(_) >> { Function action ->
+                action.apply(modelController)
+            }
+        }
+
+        def buildStateRegistry = Mock(BuildStateRegistry) {
+            visitBuilds(_) >> { Consumer consumer ->
+                consumer.accept(buildState1)
+            }
+        }
+
+        def modelCreator = new DefaultBuildTreeModelCreator(
+            Mock(BuildState),
+            Mock(IntermediateBuildActionRunner),
+            Mock(ToolingModelParameterCarrier.Factory),
+            buildStateRegistry,
+            buildOperationRunner
+        )
+
+        when:
+        def actualModel = getModel(modelCreator, BuildTreeModelTarget.ofBuild(buildRootDir), "model", null)
+
+        then:
+        actualModel == model
+    }
+
+    def "non-importable builds cannot be used as targets for model building"() {
+        given:
+        def buildRootDir = new File("dummy")
+
+        def buildState1 = Stub(BuildState) {
+            isImportableBuild() >> false
+            getBuildRootDir() >> buildRootDir
+        }
+
+        def buildStateRegistry = Mock(BuildStateRegistry) {
+            visitBuilds(_) >> { Consumer consumer ->
+                consumer.accept(buildState1)
+            }
+        }
+
+        def modelCreator = new DefaultBuildTreeModelCreator(
+            Mock(BuildState),
+            Mock(IntermediateBuildActionRunner),
+            Mock(ToolingModelParameterCarrier.Factory),
+            buildStateRegistry,
+            buildOperationRunner
+        )
+
+        when:
+        getModel(modelCreator, BuildTreeModelTarget.ofBuild(buildRootDir), "model", null)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == "dummy is not included in this build"
+    }
+
+    private static Object getModel(DefaultBuildTreeModelCreator modelCreator, BuildTreeModelTarget target, String modelName, @Nullable Object parameter) {
+        return modelCreator.fromBuildModel(new BuildTreeModelAction<Object>() {
+            @Override
+            void beforeTasks(BuildTreeModelController controller) {}
+
+            @Override
+            Object fromBuildModel(BuildTreeModelController controller) {
+                return controller.getModel(target, modelName, parameter)
+            }
+        })
+    }
+}

--- a/testing/architecture-test/src/changes/archunit-store/internal-api-nullability.txt
+++ b/testing/architecture-test/src/changes/archunit-store/internal-api-nullability.txt
@@ -4781,7 +4781,6 @@ Class <org.gradle.tooling.internal.provider.runner.ClientProvidedBuildActionRunn
 Class <org.gradle.tooling.internal.provider.runner.ClientProvidedBuildActionRunner> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (ClientProvidedBuildActionRunner.java:0)
 Class <org.gradle.tooling.internal.provider.runner.ClientProvidedPhasedActionRunner$ClientActionImpl> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (ClientProvidedPhasedActionRunner.java:0)
 Class <org.gradle.tooling.internal.provider.runner.ClientProvidedPhasedActionRunner> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (ClientProvidedPhasedActionRunner.java:0)
-Class <org.gradle.tooling.internal.provider.runner.DefaultBuildController> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (DefaultBuildController.java:0)
 Class <org.gradle.tooling.internal.provider.runner.FileDownloadOperationMapper> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (FileDownloadOperationMapper.java:0)
 Class <org.gradle.tooling.internal.provider.runner.OperationDependenciesResolver> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (OperationDependenciesResolver.java:0)
 Class <org.gradle.tooling.internal.provider.runner.OperationDependencyLookup> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (OperationDependencyLookup.java:0)


### PR DESCRIPTION
Introduce a new internal build operation that wraps the processing of the entire request to build a tooling model. The model request can either be a part of a build action or represent an entire TAPI request.

This is interesting mainly in the context of understanding and debugging IDE sync scenarios, because the IDE requests the models from a phased build action. With Isolated Projects and its ties to Configure-on-Demand, this change allows to make a connection between the lazy build/project configuration work and the part of Sync that caused it.

Inspecting these build operations and their factual parallelism can be a base of diagnosing changes and performance problems in Sync.

___

### Before

Notice how "Configure build" operation does not have any specific parent that represents the cause of configuring the build at this stage of the sync.

<img width="1359" alt="image" src="https://github.com/user-attachments/assets/d9ccdca5-17a4-465a-b225-b9f8286c6f79">

### After

Now it's clear that the build was configured (projects were prepared) due to IDE requesting the `BuildEnvironment` model. The previous model request only loaded the build (evaluated settings).

<img width="1660" alt="image" src="https://github.com/user-attachments/assets/dcc1756b-8182-415b-917e-3bed6be5feca">

