### PR TITLE
Adjust naming of the flag which is also used for tooling models

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheInputListenerLifecycleIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheInputListenerLifecycleIntegrationTest.groovy
@@ -89,5 +89,5 @@ class ConfigurationCacheInputListenerLifecycleIntegrationTest extends AbstractCo
         outputContains("because the value of ignored configuration inputs flag ($IGNORE_INPUTS_PROPERTY) has changed")
     }
 
-    private static final String IGNORE_INPUTS_PROPERTY = StartParameterBuildOptions.ConfigurationCacheIgnoreInputsInTaskGraphSerialization.PROPERTY_NAME
+    private static final String IGNORE_INPUTS_PROPERTY = StartParameterBuildOptions.ConfigurationCacheIgnoreInputsDuringStore.PROPERTY_NAME
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -415,8 +415,7 @@ class DefaultConfigurationCache internal constructor(
     fun saveModel(model: Any) {
         cacheEntryRequiresCommit = true
 
-        // TODO:configuration-cache rename the flag to be non-specific to tasks
-        if (startParameter.isIgnoreInputsInTaskGraphSerialization) {
+        if (startParameter.isIgnoreInputsDuringStore) {
             InstrumentedInputs.discardListener()
         }
 
@@ -434,7 +433,7 @@ class DefaultConfigurationCache internal constructor(
     fun saveWorkGraph() {
         cacheEntryRequiresCommit = true
 
-        if (startParameter.isIgnoreInputsInTaskGraphSerialization) {
+        if (startParameter.isIgnoreInputsDuringStore) {
             InstrumentedInputs.discardListener()
         }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprint.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprint.kt
@@ -33,11 +33,12 @@ sealed class ConfigurationCacheFingerprint {
         val jvm: String,
         val startParameterProperties: Map<String, Any?>,
         /**
-         * Whether the undeclared inputs accessed while serializing the task graph will be
-         * excluded from input tracking. This is a temporary opt-out flag after a change
-         * was made in that behavior.
+         * Whether to exclude from input tracking the undeclared inputs accessed
+         * while resolving and storing work graph or while building the model result of the build action.
+         *
+         * This is a temporary opt-out flag after a change was made in that behavior.
          */
-        val ignoreInputsInConfigurationCacheTaskGraphWriting: Boolean,
+        val ignoreInputsDuringConfigurationCacheStore: Boolean,
         /**
          * Whether the instrumentation agent was used when computing the cache.
          * With the agent, the class paths may be stored differently, making the caches incompatible with one another.

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintChecker.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintChecker.kt
@@ -57,7 +57,7 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
         val startParameterProperties: Map<String, Any?>
         val buildStartTime: Long
         val invalidateCoupledProjects: Boolean
-        val ignoreInputsInConfigurationCacheTaskGraphWriting: Boolean
+        val ignoreInputsDuringConfigurationCacheStore: Boolean
         val instrumentationAgentUsed: Boolean
         val ignoredFileSystemCheckInputs: String?
         fun gradleProperty(propertyName: String): String?
@@ -258,8 +258,8 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
                     host.startParameterProperties != startParameterProperties ->
                         text("the set of Gradle properties has changed: ").text(detailedMessageForChanges(startParameterProperties, host.startParameterProperties))
 
-                    host.ignoreInputsInConfigurationCacheTaskGraphWriting != ignoreInputsInConfigurationCacheTaskGraphWriting ->
-                        text("the value of ignored configuration inputs flag (${StartParameterBuildOptions.ConfigurationCacheIgnoreInputsInTaskGraphSerialization.PROPERTY_NAME}) has changed")
+                    host.ignoreInputsDuringConfigurationCacheStore != ignoreInputsDuringConfigurationCacheStore ->
+                        text("the value of ignored configuration inputs flag (${StartParameterBuildOptions.ConfigurationCacheIgnoreInputsDuringStore.PROPERTY_NAME}) has changed")
 
                     host.instrumentationAgentUsed != instrumentationAgentUsed ->
                         text("the instrumentation Java agent ${if (instrumentationAgentUsed) "is no longer available" else "is now applied"}")

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -410,8 +410,8 @@ class ConfigurationCacheFingerprintController internal constructor(
         override val modelAsProjectDependency: Boolean
             get() = modelParameters.isModelAsProjectDependency
 
-        override val ignoreInputsInConfigurationCacheTaskGraphWriting: Boolean
-            get() = startParameter.isIgnoreInputsInTaskGraphSerialization
+        override val ignoreInputsDuringConfigurationCacheStore: Boolean
+            get() = startParameter.isIgnoreInputsDuringStore
 
         override val instrumentationAgentUsed: Boolean
             get() = agentStatus.isAgentInstrumentationEnabled
@@ -483,8 +483,8 @@ class ConfigurationCacheFingerprintController internal constructor(
         override val invalidateCoupledProjects: Boolean
             get() = modelParameters.isInvalidateCoupledProjects
 
-        override val ignoreInputsInConfigurationCacheTaskGraphWriting: Boolean
-            get() = startParameter.isIgnoreInputsInTaskGraphSerialization
+        override val ignoreInputsDuringConfigurationCacheStore: Boolean
+            get() = startParameter.isIgnoreInputsDuringStore
 
         override val instrumentationAgentUsed: Boolean
             get() = agentStatus.isAgentInstrumentationEnabled

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -119,7 +119,7 @@ class ConfigurationCacheFingerprintWriter(
         val buildStartTime: Long
         val cacheIntermediateModels: Boolean
         val modelAsProjectDependency: Boolean
-        val ignoreInputsInConfigurationCacheTaskGraphWriting: Boolean
+        val ignoreInputsDuringConfigurationCacheStore: Boolean
         val instrumentationAgentUsed: Boolean
         val ignoredFileSystemCheckInputs: String?
         fun fingerprintOf(fileCollection: FileCollectionInternal): HashCode
@@ -183,7 +183,7 @@ class ConfigurationCacheFingerprintWriter(
                 host.gradleUserHomeDir,
                 jvmFingerprint(),
                 host.startParameterProperties,
-                host.ignoreInputsInConfigurationCacheTaskGraphWriting,
+                host.ignoreInputsDuringConfigurationCacheStore,
                 host.instrumentationAgentUsed,
                 host.ignoredFileSystemCheckInputs
             )

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheStartParameter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheStartParameter.kt
@@ -119,8 +119,8 @@ class ConfigurationCacheStartParameter internal constructor(
     val configurationCacheLogLevel: LogLevel
         get() = loggingParameters.logLevel
 
-    val isIgnoreInputsInTaskGraphSerialization: Boolean
-        get() = startParameter.isConfigurationCacheIgnoreInputsInTaskGraphSerialization
+    val isIgnoreInputsDuringStore: Boolean
+        get() = startParameter.isConfigurationCacheIgnoreInputsDuringStore
 
     val maxProblems: Int
         get() = startParameter.configurationCacheMaxProblems

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/action/BuildActionSerializer.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/action/BuildActionSerializer.java
@@ -146,7 +146,7 @@ public class BuildActionSerializer {
             valueSerializer.write(encoder, startParameter.getConfigurationCache());
             valueSerializer.write(encoder, startParameter.getIsolatedProjects());
             encoder.writeString(startParameter.getConfigurationCacheProblems().name());
-            encoder.writeBoolean(startParameter.isConfigurationCacheIgnoreInputsInTaskGraphSerialization());
+            encoder.writeBoolean(startParameter.isConfigurationCacheIgnoreInputsDuringStore());
             encoder.writeSmallInt(startParameter.getConfigurationCacheMaxProblems());
             encoder.writeNullableString(startParameter.getConfigurationCacheIgnoredFileSystemCheckInputs());
             encoder.writeBoolean(startParameter.isConfigurationCacheDebug());
@@ -239,7 +239,7 @@ public class BuildActionSerializer {
             startParameter.setConfigurationCache(valueSerializer.read(decoder));
             startParameter.setIsolatedProjects(valueSerializer.read(decoder));
             startParameter.setConfigurationCacheProblems(ConfigurationCacheProblemsOption.Value.valueOf(decoder.readString()));
-            startParameter.setConfigurationCacheIgnoreInputsInTaskGraphSerialization(decoder.readBoolean());
+            startParameter.setConfigurationCacheIgnoreInputsDuringStore(decoder.readBoolean());
             startParameter.setConfigurationCacheMaxProblems(decoder.readSmallInt());
             startParameter.setConfigurationCacheIgnoredFileSystemCheckInputs(decoder.readNullableString());
             startParameter.setConfigurationCacheDebug(decoder.readBoolean());

--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -35,7 +35,7 @@ public class StartParameterInternal extends StartParameter {
     private Option.Value<Boolean> isolatedProjects = Option.Value.defaultValue(false);
     private ConfigurationCacheProblemsOption.Value configurationCacheProblems = ConfigurationCacheProblemsOption.Value.FAIL;
     private boolean configurationCacheDebug;
-    private boolean configurationCacheIgnoreInputsInTaskGraphSerialization = false;
+    private boolean configurationCacheIgnoreInputsDuringStore = false;
     private int configurationCacheMaxProblems = 512;
     private @Nullable String configurationCacheIgnoredFileSystemCheckInputs = null;
     private boolean configurationCacheParallel;
@@ -175,12 +175,12 @@ public class StartParameterInternal extends StartParameter {
         this.configurationCacheDebug = configurationCacheDebug;
     }
 
-    public boolean isConfigurationCacheIgnoreInputsInTaskGraphSerialization() {
-        return configurationCacheIgnoreInputsInTaskGraphSerialization;
+    public boolean isConfigurationCacheIgnoreInputsDuringStore() {
+        return configurationCacheIgnoreInputsDuringStore;
     }
 
-    public void setConfigurationCacheIgnoreInputsInTaskGraphSerialization(boolean ignoreInputsInTaskGraphSerialization) {
-        configurationCacheIgnoreInputsInTaskGraphSerialization = ignoreInputsInTaskGraphSerialization;
+    public void setConfigurationCacheIgnoreInputsDuringStore(boolean ignoreInputsDuringStore) {
+        configurationCacheIgnoreInputsDuringStore = ignoreInputsDuringStore;
     }
 
     public boolean isConfigurationCacheParallel() {

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -70,7 +70,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         new ExportKeysOption(),
         new ConfigurationCacheProblemsOption(),
         new ConfigurationCacheOption(),
-        new ConfigurationCacheIgnoreInputsInTaskGraphSerialization(),
+        new ConfigurationCacheIgnoreInputsDuringStore(),
         new ConfigurationCacheMaxProblemsOption(),
         new ConfigurationCacheIgnoredFileSystemCheckInputs(),
         new ConfigurationCacheDebugOption(),
@@ -513,17 +513,17 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         }
     }
 
-    public static class ConfigurationCacheIgnoreInputsInTaskGraphSerialization extends BooleanBuildOption<StartParameterInternal> {
+    public static class ConfigurationCacheIgnoreInputsDuringStore extends BooleanBuildOption<StartParameterInternal> {
 
         public static final String PROPERTY_NAME = "org.gradle.configuration-cache.inputs.unsafe.ignore.in-serialization";
 
-        public ConfigurationCacheIgnoreInputsInTaskGraphSerialization() {
+        public ConfigurationCacheIgnoreInputsDuringStore() {
             super(PROPERTY_NAME);
         }
 
         @Override
         public void applyTo(boolean value, StartParameterInternal settings, Origin origin) {
-            settings.setConfigurationCacheIgnoreInputsInTaskGraphSerialization(value);
+            settings.setConfigurationCacheIgnoreInputsDuringStore(value);
         }
     }
 


### PR DESCRIPTION
The flag to ignore input tracking -- `org.gradle.configuration-cache.inputs.unsafe.ignore.in-serialization` can be used to opt-out from input tracking when either resolving+storing the work graph **or** when building+storing the resulting model of a build action.

However, the naming in code implied that it is only applicable for work graph related operations.

This PR adjusts the naming to make it more generic.

Follow-up for https://github.com/gradle/gradle/pull/31047