### PR TITLE
Fix redirect

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/redirects/programmatic_dependency_resolution.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/redirects/programmatic_dependency_resolution.adoc
@@ -1,3 +1,3 @@
 ++++
-<meta http-equiv="refresh" content="0;URL=artifact_resolution.html">
+<meta http-equiv="refresh" content="0;URL=dependency_graph_resolution.html">
 ++++


### PR DESCRIPTION
The proper target for its current use in release notes is the first page
 of that split content.

Fixes #31250