### PR TITLE
Avoid resolving configurations when using '=' for ConfigurableFileCollection in Groovy

### DIFF
--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -211,7 +211,9 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
                 if (DefaultConfigurableFileCollection.this == fileCollection) {
                     throw new UnsupportedOperationException("Self-referencing ConfigurableFileCollections are not supported. Use the from() method to add to a ConfigurableFileCollection.");
                 }
-                return true;
+                // Only visit the children of a CompositeFileCollection but not other types of FileCollections,
+                // since we might accidentally resolve them, for example we don't want to resolve Configurations
+                return fileCollection instanceof CompositeFileCollection;
             }
 
             @Override

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyAssignmentIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyAssignmentIntegrationTest.groovy
@@ -262,6 +262,27 @@ class PropertyAssignmentIntegrationTest extends AbstractIntegrationSpec {
         "FileCollection += Iterable<File>" | "+="      | "ConfigurableFileCollection" | '[file("a.txt")]'       | unsupportedWithCause("Failed to cast object")
     }
 
+    def "Groovy assignment for ConfigurableFileCollection doesn't resolve a Configuration"() {
+        buildFile """
+            configurations {
+                resolvable("customCompileClasspath")
+            }
+
+            abstract class MyTask extends DefaultTask {
+                @InputFiles
+                abstract ConfigurableFileCollection getMyConfiguration()
+            }
+
+            tasks.register("myTask", MyTask) {
+                myConfiguration = configurations.customCompileClasspath
+                assert configurations.customCompileClasspath.state.toString() == "UNRESOLVED"
+            }
+        """
+
+        expect:
+        run("myTask")
+    }
+
     def "test Kotlin eager FileCollection types assignment for #description"() {
         def inputDeclaration = "var input: $inputType = project.files()"
         kotlinBuildFile(inputDeclaration, inputValue, operation)


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/30273