### PR TITLE
Move model defaults handler to build scope

### DIFF
--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/evaluator/defaults/DeclarativeModelDefaultsHandler.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/evaluator/defaults/DeclarativeModelDefaultsHandler.kt
@@ -38,7 +38,6 @@ import org.gradle.internal.declarativedsl.language.LanguageTreeResult
 import org.gradle.internal.declarativedsl.language.SyntheticallyProduced
 import org.gradle.internal.declarativedsl.project.projectInterpretationSequenceStep
 import org.gradle.plugin.software.internal.ModelDefaultsHandler
-import org.gradle.plugin.software.internal.SoftwareFeatureApplicator
 import org.gradle.plugin.software.internal.SoftwareTypeRegistry
 import javax.inject.Inject
 
@@ -48,12 +47,9 @@ import javax.inject.Inject
  */
 abstract class DeclarativeModelDefaultsHandler @Inject constructor(softwareTypeRegistry: SoftwareTypeRegistry) : ModelDefaultsHandler {
     private
-    val step = lazy { projectInterpretationSequenceStep(softwareTypeRegistry) }
+    val step = projectInterpretationSequenceStep(softwareTypeRegistry)
     private
     val modelDefaultsRepository = softwareTypeRegistryBasedModelDefaultsRepository(softwareTypeRegistry)
-
-    @Inject
-    abstract fun getSoftwareFeatureApplicator(): SoftwareFeatureApplicator
 
     override fun <T : Any> apply(target: T, softwareTypeName: String, plugin: Plugin<*>) {
         val analysisStepRunner = ApplyDefaultsOnlyAnalysisStepRunner()
@@ -66,7 +62,7 @@ abstract class DeclarativeModelDefaultsHandler @Inject constructor(softwareTypeR
             .runInterpretationSequenceStep(
                 "<none>",
                 "",
-                step.value,
+                step,
                 ConversionStepContext(target, analysisStepContext)
             )
 

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/provider/DeclarativeDslServices.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/provider/DeclarativeDslServices.kt
@@ -41,10 +41,6 @@ class DeclarativeDslServices : AbstractGradleModuleServices() {
     override fun registerBuildServices(registration: ServiceRegistration) {
         registration.addProvider(BuildServices)
     }
-
-    override fun registerProjectServices(registration: ServiceRegistration) {
-        registration.addProvider(ProjectServices)
-    }
 }
 
 
@@ -73,13 +69,6 @@ object BuildServices : ServiceRegistrationProvider {
         StoringInterpretationSchemaBuilder(GradleProcessInterpretationSchemaBuilder(settingsUnderInitialization::instance, softwareTypeRegistry), buildLayoutFactory.settingsDir(gradleInternal))
     )
 
-    private
-    fun BuildLayoutFactory.settingsDir(gradle: GradleInternal): File =
-        getLayoutFor(BuildLayoutConfiguration(gradle.startParameter)).settingsDir
-}
-
-internal
-object ProjectServices : ServiceRegistrationProvider {
     @Provides
     fun createDeclarativeModelDefaultsHandler(
         softwareTypeRegistry: SoftwareTypeRegistry,
@@ -87,4 +76,8 @@ object ProjectServices : ServiceRegistrationProvider {
     ): ModelDefaultsHandler {
         return objectFactory.newInstance(DeclarativeModelDefaultsHandler::class.java, softwareTypeRegistry)
     }
+
+    private
+    fun BuildLayoutFactory.settingsDir(gradle: GradleInternal): File =
+        getLayoutFor(BuildLayoutConfiguration(gradle.startParameter)).settingsDir
 }


### PR DESCRIPTION
This fixes a performance regression when evaluating large multiproject builds with declarative scripts.

A [recent change](https://github.com/gradle/gradle/commit/396c4209ba335295a7e762bb57ffd0be0ef93571) removed the need for this service to live at project scope. 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
