### PR TITLE
Make problem stacktrace rendering thread-safe

### DIFF
--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/DecoratedReportProblem.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/DecoratedReportProblem.kt
@@ -165,9 +165,6 @@ data class StackTracePart(
 
 class FailureDecorator {
 
-    private
-    val stringBuilder = StringBuilder()
-
     fun decorate(failure: Failure): DecoratedFailure {
         return DecoratedFailure(
             exceptionSummaryFor(failure),
@@ -177,13 +174,10 @@ class FailureDecorator {
 
     private
     fun partitionedTraceFor(failure: Failure): List<StackTracePart> {
+        val stringBuilder = StringBuilder()
         val listener = PartitioningFailurePrinterListener(stringBuilder)
-        try {
-            FailurePrinter.print(stringBuilder, failure, listener)
-            return listener.parts
-        } finally {
-            stringBuilder.setLength(0)
-        }
+        FailurePrinter.print(stringBuilder, failure, listener)
+        return listener.parts
     }
 
     private


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/31284

Makes thread-safe the `FailureDecorator` class that is used for decorating stacktraces from CC problems and Problems API problems. With Parallel CC some configuration-time logic can run concurrently, which allows for concurrent reporting of any of those types of problems. The same is applicable for Isolated Projects.