### PR TITLE
Allow configure-on-demand with IP for task-running build actions

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsFixture.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsFixture.groovy
@@ -207,8 +207,12 @@ class IsolatedProjectsFixture {
      *
      * Also asserts that the appropriate console logging, reports and build operations are generated.
      */
-    void assertModelLoaded() {
-        configurationCache.assertStateLoaded(forModels(new ConfigurationCacheFixture.LoadDetails()))
+    void assertModelLoaded(@DelegatesTo(ConfigurationCacheFixture.LoadDetails) Closure closure = {}) {
+        def details = forModels(new ConfigurationCacheFixture.LoadDetails())
+        closure.delegate = details
+        closure()
+
+        configurationCache.assertStateLoaded(details)
 
         assertHasWarningThatIncubatingFeatureUsed()
         assertNoModelsQueried()

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiModelQueryIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiModelQueryIntegrationTest.groovy
@@ -174,7 +174,7 @@ class IsolatedProjectsToolingApiModelQueryIntegrationTest extends AbstractIsolat
         outputContains("Execution of dummyTask")
 
         when: "repeating the request"
-        withIsolatedProjects()
+        withIsolatedProjects("-Dorg.gradle.internal.isolated-projects.configure-on-demand.tasks=true")
         fetchModel(SomeToolingModel, ":dummyTask")
 
         then: "no projects are configured, work graph and the model are loaded, tasks are executed before the model is returned"

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiModelQueryIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiModelQueryIntegrationTest.groovy
@@ -114,26 +114,26 @@ class IsolatedProjectsToolingApiModelQueryIntegrationTest extends AbstractIsolat
             }
         """
 
-        when:
+        when: "requesting a model together with running a task"
         withIsolatedProjects()
         fetchModel(SomeToolingModel, ":dummyTask")
 
-        then:
+        then: "only relevant projects are configured, while work graph and the model are stored in cache"
         fixture.assertModelStored {
             runsTasks = true
             // TODO:isolated desired behavior
-//            projectsConfigured(":buildSrc", ":")
+//            projectsConfigured(":buildSrc", ":") // Note :a and :b were not configured
             projectsConfigured(":buildSrc", ":", ":a", ":b")
             modelsCreated(":")
         }
         outputContains("Configuration of dummyTask")
         outputContains("Execution of dummyTask")
 
-        when:
+        when: "repeating the request"
         withIsolatedProjects()
         fetchModel(SomeToolingModel, ":dummyTask")
 
-        then:
+        then: "no projects are configured, work graph and the model are loaded, tasks are executed before the model is returned"
         fixture.assertModelLoaded {
             runsTasks = true
         }
@@ -160,24 +160,24 @@ class IsolatedProjectsToolingApiModelQueryIntegrationTest extends AbstractIsolat
             }
         """
 
-        when:
+        when: "requesting a model together with running a task"
         withIsolatedProjects("-Dorg.gradle.internal.isolated-projects.configure-on-demand.tasks=true")
         fetchModel(SomeToolingModel, ":dummyTask")
 
-        then:
+        then: "only relevant projects are configured, while work graph and the model are stored in cache"
         fixture.assertModelStored {
             runsTasks = true
-            projectsConfigured(":buildSrc", ":")
+            projectsConfigured(":buildSrc", ":") // Note :a and :b were not configured
             modelsCreated(":")
         }
         outputContains("Configuration of dummyTask")
         outputContains("Execution of dummyTask")
 
-        when:
+        when: "repeating the request"
         withIsolatedProjects()
         fetchModel(SomeToolingModel, ":dummyTask")
 
-        then:
+        then: "no projects are configured, work graph and the model are loaded, tasks are executed before the model is returned"
         fixture.assertModelLoaded {
             runsTasks = true
         }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiModelQueryIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiModelQueryIntegrationTest.groovy
@@ -120,6 +120,7 @@ class IsolatedProjectsToolingApiModelQueryIntegrationTest extends AbstractIsolat
 
         then:
         fixture.assertModelStored {
+            runsTasks = true
             // TODO:isolated desired behavior
 //            projectsConfigured(":buildSrc", ":")
             projectsConfigured(":buildSrc", ":", ":a", ":b")
@@ -133,7 +134,9 @@ class IsolatedProjectsToolingApiModelQueryIntegrationTest extends AbstractIsolat
         fetchModel(SomeToolingModel, ":dummyTask")
 
         then:
-        fixture.assertModelLoaded()
+        fixture.assertModelLoaded {
+            runsTasks = true
+        }
         outputDoesNotContain("Configuration of dummyTask")
         outputDoesNotContain("creating model")
         outputContains("Execution of dummyTask")
@@ -163,6 +166,7 @@ class IsolatedProjectsToolingApiModelQueryIntegrationTest extends AbstractIsolat
 
         then:
         fixture.assertModelStored {
+            runsTasks = true
             projectsConfigured(":buildSrc", ":")
             modelsCreated(":")
         }
@@ -174,7 +178,9 @@ class IsolatedProjectsToolingApiModelQueryIntegrationTest extends AbstractIsolat
         fetchModel(SomeToolingModel, ":dummyTask")
 
         then:
-        fixture.assertModelLoaded()
+        fixture.assertModelLoaded {
+            runsTasks = true
+        }
         outputDoesNotContain("Configuration of dummyTask")
         outputDoesNotContain("creating model")
         outputContains("Execution of dummyTask")
@@ -207,6 +213,7 @@ class IsolatedProjectsToolingApiModelQueryIntegrationTest extends AbstractIsolat
         then:
         executed(":dummyTask")
         fixture.assertModelStored {
+            runsTasks = true
             projectsConfigured(":buildSrc", ":")
             modelsCreated(":")
         }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiPhasedBuildActionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiPhasedBuildActionIntegrationTest.groovy
@@ -234,7 +234,9 @@ class IsolatedProjectsToolingApiPhasedBuildActionIntegrationTest extends Abstrac
         model2[1].message == "It works from project :a"
 
         and:
-        fixture.assertModelLoaded()
+        fixture.assertModelLoaded {
+            runsTasks = true
+        }
         outputDoesNotContain("creating model")
         result.ignoreBuildSrc.assertTasksExecuted(":a:thing")
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildTreeModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildTreeModelControllerServices.kt
@@ -136,8 +136,9 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
         val modelAsProjectDependency = isolatedProjects && options.getOption(modelProjectDependencies).get()
 
         return if (requirements.isCreatesModel) {
-            val configureOnDemand = isolatedProjects && !requiresTasks &&
-                options.getOption(isolatedProjectsToolingModelsConfigureOnDemand).get()
+            val configureOnDemand = isolatedProjects &&
+                options.getOption(isolatedProjectsToolingModelsConfigureOnDemand).get() &&
+                (!requiresTasks || options.getOption(isolatedProjectsTasksConfigureOnDemand).get())
             DefaultBuildModelParameters(
                 requiresToolingModels = true,
                 parallelProjectExecution = parallelProjectExecution,

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheBuildOperationsFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheBuildOperationsFixture.groovy
@@ -76,16 +76,16 @@ class ConfigurationCacheBuildOperationsFixture {
     }
 
     void assertNoConfigurationCache() {
-        assertNoWorkGraphStore()
-        assertNoModelStore()
+        assertNoWorkGraphOperations()
+        assertNoModelOperations()
     }
 
-    void assertNoWorkGraphStore() {
+    void assertNoWorkGraphOperations() {
         assert workGraphStoreOperation() == null
         assert workGraphLoadOperation() == null
     }
 
-    void assertNoModelStore() {
+    void assertNoModelOperations() {
         assert modelStoreOperation() == null
         assert modelLoadOperation() == null
     }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
@@ -66,13 +66,7 @@ class ConfigurationCacheFixture {
     void assertStateStored(HasBuildActions details) {
         assertHasStoreReason(details)
 
-        assert details.runsTasks || details.createsModels
-        if (details.runsTasks) {
-            configurationCacheBuildOperations.assertStateStored(details.loadsOnStore)
-        }
-        if (details.createsModels) {
-            configurationCacheBuildOperations.assertModelStored()
-        }
+        assertWorkGraphOrModelStored(details.runsTasks, details.createsModels, details.loadsOnStore)
 
         spec.postBuildOutputContains("Configuration cache entry ${details.storeAction}.")
 
@@ -96,13 +90,7 @@ class ConfigurationCacheFixture {
     void assertStateStoredWithProblems(HasBuildActions details, HasProblems problemDetails) {
         assertHasStoreReason(details)
 
-        assert details.runsTasks || details.createsModels
-        if (details.runsTasks) {
-            configurationCacheBuildOperations.assertStateStored(details.runsTasks)
-        }
-        if (details.createsModels) {
-            configurationCacheBuildOperations.assertModelStored()
-        }
+        assertStateStored(details)
 
         spec.result.assertHasPostBuildOutput("Configuration cache entry ${details.storeAction}.")
 
@@ -133,13 +121,18 @@ class ConfigurationCacheFixture {
             } else {
                 configurationCacheBuildOperations.assertStateStored(false)
             }
+        } else {
+            configurationCacheBuildOperations.assertNoWorkGraphStore()
         }
+
         if (details.createsModels) {
             if (details.hasStoreFailure) {
                 configurationCacheBuildOperations.assertModelStoreFailed()
             } else {
                 configurationCacheBuildOperations.assertModelStored()
             }
+        } else {
+            configurationCacheBuildOperations.assertNoModelStore()
         }
 
         def message = "Configuration cache entry ${details.storeAction}"
@@ -170,13 +163,7 @@ class ConfigurationCacheFixture {
     void assertStateRecreated(HasBuildActions details, HasInvalidationReason invalidationDetails) {
         assertHasRecreateReason(details, invalidationDetails)
 
-        assert details.runsTasks || details.createsModels
-        if (details.runsTasks) {
-            configurationCacheBuildOperations.assertStateStored(details.runsTasks)
-        }
-        if (details.createsModels) {
-            configurationCacheBuildOperations.assertModelStored()
-        }
+        assertWorkGraphOrModelStored(details.runsTasks, details.createsModels, details.runsTasks)
 
         spec.postBuildOutputContains("Configuration cache entry ${details.storeAction}.")
         assertHasNoProblems()
@@ -199,13 +186,7 @@ class ConfigurationCacheFixture {
     void assertStateRecreatedWithProblems(HasBuildActions details, HasInvalidationReason invalidationDetails, HasProblems problemDetails) {
         assertHasRecreateReason(details, invalidationDetails)
 
-        assert details.runsTasks || details.createsModels
-        if (details.runsTasks) {
-            configurationCacheBuildOperations.assertStateStored(false)
-        }
-        if (details.createsModels) {
-            configurationCacheBuildOperations.assertModelStored()
-        }
+        assertWorkGraphOrModelStored(details.runsTasks, details.createsModels, false)
 
         spec.postBuildOutputContains("Configuration cache entry ${details.storeAction}.")
         assertHasProblems(problemDetails)
@@ -226,10 +207,15 @@ class ConfigurationCacheFixture {
         spec.postBuildOutputContains("Configuration cache entry ${details.storeAction}.")
 
         assert details.runsTasks || details.createsModels
-        if (details.createsModels) { // if the model is loaded, work-graph is not loaded
-            configurationCacheBuildOperations.assertModelLoaded()
-        } else if (details.runsTasks) {
+        if (details.runsTasks) {
             configurationCacheBuildOperations.assertStateLoaded()
+        } else {
+            configurationCacheBuildOperations.assertNoWorkGraphStore()
+        }
+        if (details.createsModels) {
+            configurationCacheBuildOperations.assertModelLoaded()
+        } else {
+            configurationCacheBuildOperations.assertNoModelStore()
         }
 
         assertNothingConfigured()
@@ -252,10 +238,25 @@ class ConfigurationCacheFixture {
         spec.postBuildOutputContains("Configuration cache entry ${details.storeAction}.")
 
         configurationCacheBuildOperations.assertStateLoaded()
+        configurationCacheBuildOperations.assertNoModelStore()
 
         assertNothingConfigured()
 
         assertHasProblems(details)
+    }
+
+    private void assertWorkGraphOrModelStored(boolean runsTasks, boolean createsModels, boolean loadAfterStore) {
+        assert runsTasks || createsModels
+        if (runsTasks) {
+            configurationCacheBuildOperations.assertStateStored(loadAfterStore)
+        } else {
+            configurationCacheBuildOperations.assertNoWorkGraphStore()
+        }
+        if (createsModels) {
+            configurationCacheBuildOperations.assertModelStored()
+        } else {
+            configurationCacheBuildOperations.assertNoModelStore()
+        }
     }
 
     private void assertHasProblems(HasProblems problemDetails) {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
@@ -122,7 +122,7 @@ class ConfigurationCacheFixture {
                 configurationCacheBuildOperations.assertStateStored(false)
             }
         } else {
-            configurationCacheBuildOperations.assertNoWorkGraphStore()
+            configurationCacheBuildOperations.assertNoWorkGraphOperations()
         }
 
         if (details.createsModels) {
@@ -132,7 +132,7 @@ class ConfigurationCacheFixture {
                 configurationCacheBuildOperations.assertModelStored()
             }
         } else {
-            configurationCacheBuildOperations.assertNoModelStore()
+            configurationCacheBuildOperations.assertNoModelOperations()
         }
 
         def message = "Configuration cache entry ${details.storeAction}"
@@ -210,12 +210,12 @@ class ConfigurationCacheFixture {
         if (details.runsTasks) {
             configurationCacheBuildOperations.assertStateLoaded()
         } else {
-            configurationCacheBuildOperations.assertNoWorkGraphStore()
+            configurationCacheBuildOperations.assertNoWorkGraphOperations()
         }
         if (details.createsModels) {
             configurationCacheBuildOperations.assertModelLoaded()
         } else {
-            configurationCacheBuildOperations.assertNoModelStore()
+            configurationCacheBuildOperations.assertNoModelOperations()
         }
 
         assertNothingConfigured()
@@ -238,7 +238,7 @@ class ConfigurationCacheFixture {
         spec.postBuildOutputContains("Configuration cache entry ${details.storeAction}.")
 
         configurationCacheBuildOperations.assertStateLoaded()
-        configurationCacheBuildOperations.assertNoModelStore()
+        configurationCacheBuildOperations.assertNoModelOperations()
 
         assertNothingConfigured()
 
@@ -250,12 +250,12 @@ class ConfigurationCacheFixture {
         if (runsTasks) {
             configurationCacheBuildOperations.assertStateStored(loadAfterStore)
         } else {
-            configurationCacheBuildOperations.assertNoWorkGraphStore()
+            configurationCacheBuildOperations.assertNoWorkGraphOperations()
         }
         if (createsModels) {
             configurationCacheBuildOperations.assertModelStored()
         } else {
-            configurationCacheBuildOperations.assertNoModelStore()
+            configurationCacheBuildOperations.assertNoModelOperations()
         }
     }
 


### PR DESCRIPTION
With Isolated Projects, the current condition for configure-on-demand (CoD) prevents trying it out for IDE Sync scenarios even with internal options. This is due to sync both requesting models and tasks.

The change in this PR updates the CoD condition such that for IDE Sync (or any other model-creating build action that runs tasks), it's possible to get CoD behavior by enabling both internal flags:
```
-Dorg.gradle.unsafe.isolated-projects=true
-Dorg.gradle.internal.isolated-projects.configure-on-demand.tooling=true
-Dorg.gradle.internal.isolated-projects.configure-on-demand.tasks=true
```

Note that this possibility is provided only for development and experimentation purposes, as CoD for tasks is not fully supported in all scenarios with Isolated Projects.

----

This PR also updates the CC/IP build operation fixtures to check stricter invariants with respect to when tasks are running and/or models are created.