### PR TITLE
Remove Configuration-specific logic from short circuit resolver

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheUnsupportedTypesIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheUnsupportedTypesIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.internal.cc.impl
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.project.IsolatedProject
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -69,7 +68,7 @@ import org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler
 import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyConstraintHandler
 import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler
 import org.gradle.api.internal.artifacts.ivyservice.DefaultResolvedConfiguration
-import org.gradle.api.internal.artifacts.ivyservice.ShortCircuitEmptyConfigurationResolver.EmptyLenientConfiguration
+import org.gradle.api.internal.artifacts.ivyservice.ShortCircuitingResolutionExecutor.EmptyLenientConfiguration
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy
 import org.gradle.api.internal.artifacts.query.DefaultArtifactResolutionQuery
 import org.gradle.api.internal.artifacts.repositories.DefaultMavenArtifactRepository
@@ -92,6 +91,7 @@ import org.gradle.api.internal.tasks.DefaultSourceSet
 import org.gradle.api.internal.tasks.DefaultSourceSetContainer
 import org.gradle.api.internal.tasks.DefaultTaskContainer
 import org.gradle.api.invocation.Gradle
+import org.gradle.api.project.IsolatedProject
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
 import org.gradle.api.tasks.SourceSet

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ConfigurationResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ConfigurationResolver.java
@@ -16,12 +16,13 @@
 package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.artifacts.ResolveException;
+import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
 
 import java.util.List;
 
 /**
- * Resolves {@link ResolveContext}s and produces {@link ResolverResults}.
+ * Resolves {@link ConfigurationInternal}s and produces {@link ResolverResults}.
  * <p>
  * This resolution is lenient, except for some fatal failure cases,
  * in the sense that resolution failures in most cases will not cause exceptions
@@ -29,17 +30,17 @@ import java.util.List;
  */
 public interface ConfigurationResolver {
     /**
-     * Traverses enough of the graph to calculate the build dependencies of the given resolve context. All failures are packaged in the result.
+     * Traverses enough of the graph to calculate the build dependencies of the given configuration. All failures are packaged in the result.
      */
-    ResolverResults resolveBuildDependencies(ResolveContext configuration);
+    ResolverResults resolveBuildDependencies(ConfigurationInternal configuration);
 
     /**
-     * Traverses the full dependency graph of the given resolve context. All failures are packaged in the result.
+     * Traverses the full dependency graph of the given configuration. All failures are packaged in the result.
      */
-    ResolverResults resolveGraph(ResolveContext resolveContext) throws ResolveException;
+    ResolverResults resolveGraph(ConfigurationInternal configuration) throws ResolveException;
 
     /**
-     * Returns the list of repositories available to resolve a given resolve context.
+     * Returns the list of repositories available to resolve a given configuration.
      */
     List<ResolutionAwareRepository> getAllRepositories();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -56,7 +56,7 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.UnknownProjectFinder;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultConfigurationResolver;
 import org.gradle.api.internal.artifacts.ivyservice.IvyContextManager;
 import org.gradle.api.internal.artifacts.ivyservice.ResolutionExecutor;
-import org.gradle.api.internal.artifacts.ivyservice.ShortCircuitEmptyConfigurationResolver;
+import org.gradle.api.internal.artifacts.ivyservice.ShortCircuitingResolutionExecutor;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ResolverProviderFactories;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser;
@@ -611,13 +611,14 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             ResolutionExecutor resolutionExecutor,
             AttributeDesugaring attributeDesugaring
         ) {
-            ConfigurationResolver defaultResolver = new DefaultConfigurationResolver(
-                repositoriesSupplier,
-                resolutionExecutor
+            ShortCircuitingResolutionExecutor shortCircuitingResolutionExecutor = new ShortCircuitingResolutionExecutor(
+                resolutionExecutor,
+                attributeDesugaring
             );
 
-            return new ShortCircuitEmptyConfigurationResolver(
-                defaultResolver,
+            return new DefaultConfigurationResolver(
+                repositoriesSupplier,
+                shortCircuitingResolutionExecutor,
                 attributeDesugaring
             );
         }


### PR DESCRIPTION
The short circuit resolver is responsible for skipping a bunch of work when we know a resolution will be empty.

We swap the order of the configuration resovler and the short-circuit resolver so that the short circuit resovler can be used to resolve non-configuration resolvables

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
