### PR TITLE
Disable XCTestPluginIntegrationTest until Swift 6 is supported

### DIFF
--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/plugins/XCTestPluginIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/plugins/XCTestPluginIntegrationTest.groovy
@@ -17,7 +17,9 @@
 package org.gradle.nativeplatform.test.xctest.plugins
 
 import org.gradle.integtests.fixtures.WellBehavedPluginTest
+import spock.lang.Ignore
 
+@Ignore("https://github.com/gradle/gradle/issues/31192")
 class XCTestPluginIntegrationTest extends WellBehavedPluginTest {
     @Override
     String getPluginName() {


### PR DESCRIPTION
We need this to unblock RfR for 8.11.1 following infrastructure changes

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
