### PR TITLE
Rewrite method references in interfaces properly

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/undeclared/MethodReferenceInstrumentationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/undeclared/MethodReferenceInstrumentationIntegrationTest.groovy
@@ -29,15 +29,13 @@ class MethodReferenceInstrumentationIntegrationTest extends AbstractConfiguratio
 
     def "reference #reference is instrumented in java"() {
         given:
-        testDirectory.create {
-            createDir("buildSrc") {
-                file("src/main/java/MethodRefInputs.java") << """
+        def classTemplate = { ownerKind, ownerName -> """
                 import java.io.*;
                 import java.nio.file.*;
                 import java.util.*;
                 import java.util.function.*;
 
-                public class MethodRefInputs {
+                public $ownerKind $ownerName {
                     @FunctionalInterface
                     interface ThrowingFunction<T, R> {
                         R apply(T value) throws Exception;
@@ -55,15 +53,23 @@ class MethodReferenceInstrumentationIntegrationTest extends AbstractConfiguratio
                         return new BufferedReader(new InputStreamReader(in, "UTF-8")).readLine();
                     }
                 }
-                """
+            """
+        }
+
+        testDirectory.create {
+            createDir("buildSrc") {
+                file("src/main/java/MethodRefInputsCls.java") << classTemplate("class", "MethodRefInputsCls")
+                file("src/main/java/MethodRefInputsInterface.java") << classTemplate("interface", "MethodRefInputsInterface")
             }
         }
 
         buildFile """
             tasks.register("echo") {
-                def value = MethodRefInputs.readInputWithReference(${input.expr})
+                def value1 = MethodRefInputsCls.readInputWithReference(${input.expr})
+                def value2 = MethodRefInputsInterface.readInputWithReference(${input.expr})
                 doLast {
-                    println("value = \$value")
+                    println("value1 = \$value1")
+                    println("value2 = \$value2")
                 }
             }
         """
@@ -72,7 +78,8 @@ class MethodReferenceInstrumentationIntegrationTest extends AbstractConfiguratio
         configurationCacheRun("echo", "-D${systemProperty().path}=${systemProperty().expectedValue}")
 
         then:
-        outputContains("value = ${input.expectedValue}")
+        outputContains("value1 = ${input.expectedValue}")
+        outputContains("value2 = ${input.expectedValue}")
 
         problems.assertResultHasProblems(result) {
             withInput("Build file 'build.gradle': ${input.expectedInput}")

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/undeclared/MethodReferenceInstrumentationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/undeclared/MethodReferenceInstrumentationIntegrationTest.groovy
@@ -49,7 +49,7 @@ class MethodReferenceInstrumentationIntegrationTest extends AbstractConfiguratio
                         $consumerStatement
                     }
 
-                    private static String readIS(InputStream in) throws Exception {
+                    static String readIS(InputStream in) throws Exception {
                         return new BufferedReader(new InputStreamReader(in, "UTF-8")).readLine();
                     }
                 }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/transforms/InstrumentingClassTransform.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/transforms/InstrumentingClassTransform.java
@@ -41,6 +41,7 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.MethodNode;
 
@@ -55,10 +56,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-import static org.gradle.model.internal.asm.AsmConstants.ASM_LEVEL;
 import static org.gradle.internal.classpath.transforms.CommonTypes.NO_EXCEPTIONS;
 import static org.gradle.internal.classpath.transforms.CommonTypes.STRING_TYPE;
 import static org.gradle.internal.instrumentation.api.types.BytecodeInterceptorFilter.INSTRUMENTATION_ONLY;
+import static org.gradle.model.internal.asm.AsmConstants.ASM_LEVEL;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
 import static org.objectweb.asm.Opcodes.ACC_SYNTHETIC;
@@ -73,7 +74,7 @@ public class InstrumentingClassTransform implements ClassTransform {
     /**
      * Decoration format. Increment this when making changes.
      */
-    private static final int DECORATION_FORMAT = 36;
+    private static final int DECORATION_FORMAT = 37;
 
     private static final Type INSTRUMENTED_TYPE = getType(Instrumented.class);
     private static final Type BYTECODE_INTERCEPTOR_FILTER_TYPE = Type.getType(BytecodeInterceptorFilter.class);
@@ -165,6 +166,7 @@ public class InstrumentingClassTransform implements ClassTransform {
         private final MethodInterceptionListener methodInterceptionListener;
         private int nextBridgeMethodIndex;
 
+        private boolean isInterface;
         private String className;
         private String sourceFileName;
         private boolean hasGroovyCallSites;
@@ -186,6 +188,7 @@ public class InstrumentingClassTransform implements ClassTransform {
         @Override
         public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
             super.visit(version, access, name, signature, superName, interfaces);
+            this.isInterface = (access & Opcodes.ACC_INTERFACE) != 0;
             this.className = name;
         }
 
@@ -287,7 +290,7 @@ public class InstrumentingClassTransform implements ClassTransform {
         }
 
         private Handle makeBridgeMethodHandle(String name, String desc) {
-            return new Handle(H_INVOKESTATIC, className, name, desc, false);
+            return new Handle(H_INVOKESTATIC, className, name, desc, isInterface);
         }
     }
 


### PR DESCRIPTION
The instrumentation expands references to interceptable methods into full-bodied lambdas that calls the interceptor method. The lambda body is held by a generated static "bridge" method, and a reference to the latter replaces the original reference.

The generated handle of the bridge method wasn't taking into account the type of the owner. However, when the owner of the bridge method is an interface it should be represented in the method handle properly. Otherwise, JVM fails to load the class.

This commit properly sets the type of the method handle.

Fixes #31310.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
