### PR TITLE
Resplit buckets for QuickFeedbackLinuxOnly and refine bucket split algorithm

### DIFF
--- a/.teamcity/src/main/kotlin/model/bucket-extensions.kt
+++ b/.teamcity/src/main/kotlin/model/bucket-extensions.kt
@@ -17,7 +17,6 @@
 package model
 
 import java.util.LinkedList
-import kotlin.math.min
 
 /**
  * Split a list of elements into nearly even sublist. If an element is too large, largeElementSplitFunction will be used to split the large element into several smaller pieces;
@@ -46,9 +45,8 @@ fun <T, R> splitIntoBuckets(
         return listOf(smallElementAggregateFunction(list))
     }
 
-    val expectedBucketSize = list.sumOf(toIntFunction) / expectedBucketNumber
-
-    if (expectedBucketSize == 0) {
+    val roughSizeOfEachBucket = list.sumOf(toIntFunction) / expectedBucketNumber
+    if (roughSizeOfEachBucket == 0) {
         // The elements in the list are so small that they can't even be divided into {expectedBucketNumber}.
         // For example, how do you split [0,0,0,0,0] into 3 buckets?
         // In this case, we simply put the elements into these buckets evenly.
@@ -59,24 +57,87 @@ fun <T, R> splitIntoBuckets(
 
     val largestElementSize = toIntFunction(largestElement)
 
-    return if (largestElementSize >= expectedBucketSize) {
-        val bucketNumberOfFirstElement = if (largestElementSize % expectedBucketSize == 0)
-            largestElementSize / expectedBucketSize
-        else
-        // Leave at least one bucket for the remaining elements
-            min(largestElementSize / expectedBucketSize + 1, expectedBucketNumber - 1)
+    if (largestElementSize >= roughSizeOfEachBucket) {
+        var bucketNumberOfFirstElement =
+            determineBucketNumberForLargeElment(
+                largestElementSize,
+                roughSizeOfEachBucket,
+                expectedBucketNumber,
+                list,
+                toIntFunction
+            )
+
         val bucketsOfFirstElement = largeElementSplitFunction(largestElement, bucketNumberOfFirstElement)
-        val bucketsOfRestElements = splitIntoBuckets(list, toIntFunction, largeElementSplitFunction, smallElementAggregateFunction, expectedBucketNumber - bucketsOfFirstElement.size, maxNumberInBucket, noElementSplitFunction, canRunTogether)
-        bucketsOfFirstElement + bucketsOfRestElements
+        val bucketsOfRestElements = splitIntoBuckets(
+            list,
+            toIntFunction,
+            largeElementSplitFunction,
+            smallElementAggregateFunction,
+            expectedBucketNumber - bucketsOfFirstElement.size,
+            maxNumberInBucket,
+            noElementSplitFunction,
+            canRunTogether
+        )
+        return bucketsOfFirstElement + bucketsOfRestElements
     } else {
         val buckets = arrayListOf(largestElement)
-        var restCapacity = expectedBucketSize - toIntFunction(largestElement)
+        var restCapacity = roughSizeOfEachBucket - toIntFunction(largestElement)
         while (restCapacity > 0 && list.isNotEmpty() && buckets.size < maxNumberInBucket) {
             val smallestElement = list.findLast { searched -> buckets.all { canRunTogether(it, searched) } } ?: break
             list.remove(smallestElement)
             buckets.add(smallestElement)
             restCapacity -= toIntFunction(smallestElement)
         }
-        listOf(smallElementAggregateFunction(buckets)) + splitIntoBuckets(list, toIntFunction, largeElementSplitFunction, smallElementAggregateFunction, expectedBucketNumber - 1, maxNumberInBucket, noElementSplitFunction, canRunTogether)
+        return listOf(smallElementAggregateFunction(buckets)) + splitIntoBuckets(
+            list,
+            toIntFunction,
+            largeElementSplitFunction,
+            smallElementAggregateFunction,
+            expectedBucketNumber - 1,
+            maxNumberInBucket,
+            noElementSplitFunction,
+            canRunTogether
+        )
     }
+}
+
+/**
+ * Determine the number of buckets for the first element in the list
+ * when it needs to be split into several smaller pieces.
+ *
+ * The basic idea is:
+ * 1. Make sure the rest elements has at least one bucket.
+ * 2. Make sure the "roughSizeOfEachBucket" for the rest elements is smaller than the current "roughSizeOfEachBucket".
+ */
+private fun <T> determineBucketNumberForLargeElment(
+    largestElementSize: Int,
+    roughSizeOfEachBucket: Int,
+    expectedBucketNumber: Int,
+    list: LinkedList<T>,
+    toIntFunction: (T) -> Int
+): Int {
+    var bucketNumberOfFirstElement = if (largestElementSize % roughSizeOfEachBucket == 0)
+        largestElementSize / roughSizeOfEachBucket
+    else
+        largestElementSize / roughSizeOfEachBucket + 1
+
+    while (true) {
+        if (bucketNumberOfFirstElement == 1) {
+            break
+        }
+
+        if (expectedBucketNumber - bucketNumberOfFirstElement <= 0) {
+            bucketNumberOfFirstElement--
+        } else {
+            val roughSizeOfEachBucketForRestElements =
+                list.sumOf(toIntFunction) / (expectedBucketNumber - bucketNumberOfFirstElement)
+
+            if (roughSizeOfEachBucketForRestElements > roughSizeOfEachBucket) {
+                bucketNumberOfFirstElement--
+            } else {
+                break
+            }
+        }
+    }
+    return bucketNumberOfFirstElement
 }

--- a/.teamcity/src/test/kotlin/SplitBucketTest.kt
+++ b/.teamcity/src/test/kotlin/SplitBucketTest.kt
@@ -1,0 +1,73 @@
+import model.splitIntoBuckets
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.LinkedList
+
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+data class Subproject(val name: String, val size: Int)
+interface SubprojectBucket
+data class SmallSubprojectCombination(val subprojects: List<Subproject>) : SubprojectBucket
+data class LargeSubprojectSplit(val subproject: Subproject, val split: Int) : SubprojectBucket
+
+class SplitBucketTest {
+    @Test
+    fun testUnbalancedBuckets() {
+        val subprojects = LinkedList(
+            listOf(
+                Subproject("a", 20),
+                Subproject("b", 19),
+                Subproject("c", 5),
+                Subproject("d", 5),
+                Subproject("e", 5),
+                Subproject("f", 5),
+                Subproject("g", 4),
+                Subproject("h", 4),
+                Subproject("i", 4),
+                Subproject("j", 4),
+            )
+        )
+
+        val buckets = splitIntoBuckets(
+            list = subprojects,
+            toIntFunction = { it: Subproject -> it.size },
+            largeElementSplitFunction = { subproject, split ->
+                List(split) { LargeSubprojectSplit(subproject, split) }
+            },
+            smallElementAggregateFunction = { SmallSubprojectCombination(it) },
+            expectedBucketNumber = 5,
+            maxNumberInBucket = 3
+        )
+
+        assertTrue(buckets.size == 5)
+        assertEquals("LargeSubprojectSplit(subproject=Subproject(name=a, size=20), split=1)", buckets[0].toString())
+        assertEquals("LargeSubprojectSplit(subproject=Subproject(name=b, size=19), split=1)", buckets[1].toString())
+        assertEquals(
+            "SmallSubprojectCombination(subprojects=[Subproject(name=c, size=5), Subproject(name=j, size=4), Subproject(name=i, size=4)])",
+            buckets[2].toString()
+        )
+        assertEquals(
+            "SmallSubprojectCombination(subprojects=[Subproject(name=d, size=5), Subproject(name=h, size=4), Subproject(name=g, size=4)])",
+            buckets[3].toString()
+        )
+        assertEquals(
+            "SmallSubprojectCombination(subprojects=[Subproject(name=e, size=5), Subproject(name=f, size=5)])",
+            buckets[4].toString()
+        )
+    }
+}

--- a/.teamcity/test-buckets.json
+++ b/.teamcity/test-buckets.json
@@ -38,89 +38,53 @@
 					"name":"TestDistribution"
 				},
 				"subprojects":[
-					"launcher",
-					"build-state",
-					"time",
-					"logging-api",
-					"public-api-tests",
-					"kotlin-dsl-plugins",
-					"serialization",
-					"toolchains-jvm-shared",
-					"build-process-services",
-					"docs-asciidoctor-extensions-base",
-					"internal-instrumentation-processor"
-				]
-			},
-			{
-				"parallelizationMethod":{
-					"name":"TestDistribution"
-				},
-				"subprojects":[
 					"testing-jvm",
-					"security",
-					"input-tracking",
-					"service-registry-impl",
-					"configuration-cache-base",
-					"base-ide-plugins",
-					"files",
-					"stdlib-java-extensions",
-					"gradle-cli",
-					"build-cache-packaging",
-					"build-operations"
-				]
-			},
-			{
-				"parallelizationMethod":{
-					"name":"TestDistribution"
-				},
-				"subprojects":[
-					"plugin-use",
-					"build-cache-example-client",
-					"report-rendering",
-					"precondition-tester",
-					"tooling-api-builders",
-					"daemon-services",
-					"hashing",
-					"service-registry-builder",
-					"base-services-groovy",
-					"declarative-dsl-internal-utils",
-					"worker-main"
-				]
-			},
-			{
-				"parallelizationMethod":{
-					"name":"TestDistribution"
-				},
-				"subprojects":[
-					"language-java",
-					"kotlin-dsl-provider-plugins",
-					"native",
-					"problems-rendering",
-					"java-compiler-plugin",
-					"file-temp",
-					"concurrent",
-					"functional",
-					"test-suites-base",
-					"internal-testing",
-					"client-services"
-				]
-			},
-			{
-				"parallelizationMethod":{
-					"name":"TestDistribution"
-				},
-				"subprojects":[
-					"language-native",
-					"io",
-					"testing-jvm-infrastructure",
-					"cli",
-					"daemon-protocol",
-					"build-cache-base",
-					"normalization-java",
-					"docs",
+					"time",
 					"stdlib-kotlin-extensions",
+					"stdlib-java-extensions",
+					"service-registry-impl",
+					"service-registry-builder",
+					"serialization",
+					"security",
+					"problems-rendering",
+					"normalization-java",
+					"logging-api"
+				]
+			},
+			{
+				"parallelizationMethod":{
+					"name":"TestDistribution"
+				},
+				"subprojects":[
+					"launcher",
+					"java-compiler-plugin",
+					"io",
+					"internal-testing",
+					"internal-instrumentation-api",
+					"input-tracking",
+					"hashing",
+					"functional",
+					"files",
+					"file-temp",
+					"docs-asciidoctor-extensions-base"
+				]
+			},
+			{
+				"parallelizationMethod":{
+					"name":"TestDistribution"
+				},
+				"subprojects":[
+					"build-init",
+					"concurrent",
+					"cli",
+					"build-state",
+					"build-process-services",
 					"build-option",
-					"internal-instrumentation-api"
+					"build-operations",
+					"build-cache-example-client",
+					"build-cache-base",
+					"public-api-tests",
+					"kotlin-dsl-plugins"
 				]
 			},
 			{
@@ -129,16 +93,52 @@
 				},
 				"subprojects":[
 					"kotlin-dsl-integ-tests",
+					"toolchains-jvm-shared",
+					"internal-instrumentation-processor",
+					"configuration-cache-base",
+					"base-ide-plugins",
+					"gradle-cli",
+					"build-init-specs",
+					"build-cache-packaging",
+					"report-rendering",
+					"precondition-tester",
+					"tooling-api-builders"
+				]
+			},
+			{
+				"parallelizationMethod":{
+					"name":"TestDistribution"
+				},
+				"subprojects":[
+					"plugin-use",
+					"daemon-services",
+					"base-services-groovy",
+					"declarative-dsl-internal-utils",
+					"worker-main",
+					"kotlin-dsl-provider-plugins",
+					"native",
+					"test-suites-base",
+					"client-services",
+					"testing-jvm-infrastructure",
+					"daemon-protocol"
+				]
+			},
+			{
+				"parallelizationMethod":{
+					"name":"TestDistribution"
+				},
+				"subprojects":[
+					"language-java",
+					"docs",
 					"toolchains-jvm",
-					"execution",
 					"resources",
+					"execution",
 					"resources-http",
 					"internal-performance-testing",
 					"unit-test-fixtures",
-					"wrapper-shared",
+					"internal-integ-testing",
 					"platform-jvm",
-					"build-cache-spi",
-					"snapshots"
+					"jvm-services"
 				]
 			},
 			{
@@ -147,16 +147,16 @@
 				},
 				"subprojects":[
 					"composite-builds",
-					"internal-integ-testing",
-					"jvm-services",
+					"snapshots",
 					"flow-services",
-					"persistent-cache",
 					"publish",
-					"base-services",
+					"build-cache-spi",
+					"wrapper-shared",
 					"process-memory-services",
+					"base-services",
+					"persistent-cache",
 					"problems-api",
-					"plugins-java-base",
-					"build-cache"
+					"plugins-java-base"
 				]
 			},
 			{
@@ -165,52 +165,16 @@
 				},
 				"subprojects":[
 					"workers",
-					"wrapper-main",
+					"build-cache",
 					"testing-base-infrastructure",
+					"instrumentation-agent-services",
 					"messaging",
 					"war",
-					"instrumentation-agent-services",
-					"build-profile",
 					"resources-gcs",
-					"ear",
 					"plugins-distribution",
-					"problems"
-				]
-			},
-			{
-				"parallelizationMethod":{
-					"name":"TestDistribution"
-				},
-				"subprojects":[
-					"scala",
-					"build-cache-local",
-					"build-cache-http",
-					"java-platform",
-					"plugins-test-report-aggregation",
-					"declarative-dsl-core",
-					"testing-base",
-					"resources-sftp",
-					"plugins-jvm-test-fixtures",
-					"model-groovy",
-					"core-api"
-				]
-			},
-			{
-				"parallelizationMethod":{
-					"name":"TestDistribution"
-				},
-				"subprojects":[
-					"kotlin-dsl-tooling-builders",
-					"build-events",
-					"resources-s3",
-					"plugins-jvm-test-suite",
-					"plugins-version-catalog",
-					"plugins-application",
-					"reporting",
-					"tooling-native",
-					"language-jvm",
-					"instrumentation-reporting",
-					"plugins-java-library"
+					"problems",
+					"ear",
+					"build-profile"
 				]
 			},
 			{
@@ -219,37 +183,95 @@
 				},
 				"subprojects":[
 					"model-core",
-					"language-groovy",
-					"plugins-groovy",
-					"code-quality",
-					"logging",
-					"plugin-development",
-					"plugins-java",
-					"build-init",
-					"integ-test",
-					"enterprise",
-					"samples",
-					"kotlin-dsl",
-					"maven",
-					"testing-native",
-					"platform-native",
-					"file-watching",
-					"jacoco",
-					"ivy",
-					"version-control",
-					"declarative-dsl-provider",
-					"execution-e2e-tests",
-					"file-collections",
-					"test-kit",
-					"ide-plugins",
-					"build-configuration",
-					"ide",
-					"ide-native",
-					"diagnostics",
+					"java-platform",
+					"wrapper-main",
+					"declarative-dsl-core",
+					"resources-sftp",
+					"build-cache-local",
+					"plugins-test-report-aggregation",
+					"testing-base",
+					"core-api",
+					"resources-s3",
+					"model-groovy"
+				]
+			},
+			{
+				"parallelizationMethod":{
+					"name":"TestDistribution"
+				},
+				"subprojects":[
+					"language-native",
+					"build-cache-http",
+					"plugins-jvm-test-fixtures",
+					"plugins-version-catalog",
+					"tooling-native",
+					"plugins-jvm-test-suite",
+					"declarative-dsl-tooling-builders",
 					"signing",
+					"reporting",
+					"plugins-application",
+					"instrumentation-reporting"
+				]
+			},
+			{
+				"parallelizationMethod":{
+					"name":"TestDistribution"
+				},
+				"subprojects":[
+					"scala",
+					"build-events",
+					"ide-native",
+					"plugins-java-library",
+					"language-jvm",
+					"diagnostics",
 					"antlr",
 					"platform-base",
-					"declarative-dsl-tooling-builders"
+					"ide",
+					"build-configuration",
+					"test-kit"
+				]
+			},
+			{
+				"parallelizationMethod":{
+					"name":"TestDistribution"
+				},
+				"subprojects":[
+					"kotlin-dsl-tooling-builders",
+					"execution-e2e-tests",
+					"declarative-dsl-provider",
+					"version-control",
+					"ide-plugins",
+					"platform-native",
+					"jacoco",
+					"file-collections",
+					"testing-native",
+					"ivy",
+					"file-watching"
+				]
+			},
+			{
+				"parallelizationMethod":{
+					"name":"TestDistribution"
+				},
+				"subprojects":[
+					"language-groovy",
+					"enterprise",
+					"integ-test",
+					"samples",
+					"maven",
+					"plugins-java",
+					"kotlin-dsl"
+				]
+			},
+			{
+				"parallelizationMethod":{
+					"name":"TestDistribution"
+				},
+				"subprojects":[
+					"plugin-development",
+					"code-quality",
+					"plugins-groovy",
+					"logging"
 				]
 			}
 		],


### PR DESCRIPTION
Our bucket split algorithm didn't work well for unbalanced buckets. For example, given subproject size (see `SplitBucketTest` in this PR) [20, 19, 5, 5, 5, 5, 4, 4, 4, 4], the old algorithm will split them as:

```
LargeSubprojectSplit(subproject=Subproject(name=a, size=20), split=2)
LargeSubprojectSplit(subproject=Subproject(name=a, size=20), split=2)
LargeSubprojectSplit(subproject=Subproject(name=b, size=19), split=2)
LargeSubprojectSplit(subproject=Subproject(name=b, size=19), split=2)
SmallSubprojectCombination(subprojects=[Subproject(name=c, size=5), Subproject(name=d, size=5), Subproject(name=e, size=5), Subproject(name=f, size=5), Subproject(name=g, size=4), Subproject(name=h, size=4), Subproject(name=i, size=4), Subproject(name=j, size=4)])
```

I.e. the last bucket split has size 36 while the first 4 buckets have size 9~10.

This PR refines the algorithm.

Each time when we want to do the bucket split, we'll calculate a "roughSizeOfEachBucket" by `totalSize/expectedBucketNumber`, then we simply calculate the bucketNumber of largest subproject by running:

```
        val bucketNumberOfFirstElement = if (largestElementSize % expectedBucketSize == 0)
            largestElementSize / expectedBucketSize
        else
            largestElementSize / expectedBucketSize + 1
```

Now, we do an extra step: we'll make sure the "roughSizeOfEachBucket" is decreasing to avoid too many elements are squashed in the last bucket (See `determineBucketNumberForLargeElment`).

This is the result before and after this PR (both running with `-PrerunAllTests`):

<img width="1076" alt="image" src="https://github.com/user-attachments/assets/33e4f685-ff5d-472b-98af-c61a25f68dca">


<img width="1266" alt="image" src="https://github.com/user-attachments/assets/e30f4ca7-f71d-400d-a1b6-62990d0afdd0">
