### PR TITLE
Make ServiceScope a Documented annotation

### DIFF
--- a/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/service/scopes/ServiceScope.java
+++ b/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/service/scopes/ServiceScope.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.service.scopes;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
@@ -35,6 +36,7 @@ import java.lang.annotation.Target;
  *
  * @see Scope
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Inherited


### PR DESCRIPTION
This makes the scope show up in the IDE when looking at constructor signatures/documentation.

before:
![image](https://github.com/user-attachments/assets/e29d8312-8b88-4747-9194-b2c8619c6c12)

after:
![image](https://github.com/user-attachments/assets/9adbb37c-cb17-4cba-82b9-a2f5151f26b0)

This applies to anywhere documentation for a type shows up

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
