### PR TITLE
Fix `:language-java`'s JavaDoc

### DIFF
--- a/platforms/jvm/language-java/build.gradle.kts
+++ b/platforms/jvm/language-java/build.gradle.kts
@@ -126,15 +126,14 @@ packageCycles {
 integTest.usesJavadocCodeSnippets = true
 
 tasks.javadoc {
-    // This project accesses JDK internals.
-    // We would ideally add --add-exports flags for the required packages, however
-    // due to limitations in the javadoc modeling API, we cannot specify multiple
-    // flags for the same key.
-    // Instead, we disable failure on javadoc errors.
-    isFailOnError = false
     options {
         this as StandardJavadocDocletOptions
-        addBooleanOption("quiet", true)
+        // This project accesses JDK internals, which we need to open up so that javadoc can access them
+        addMultilineStringsOption("-add-exports").value = listOf(
+            "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+            "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+            "jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED"
+        )
     }
 }
 tasks.isolatedProjectsIntegTest {

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/AbstractRecompilationSpecProvider.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/AbstractRecompilationSpecProvider.java
@@ -140,7 +140,7 @@ abstract class AbstractRecompilationSpecProvider implements RecompilationSpecPro
      * <p>
      * We will use name "independent classes" for classes that are in the sources that are passed to a compiler but are not a dependency to a changed class.
      * <p>
-     * Check also: <a href="https://github.com/gradle/gradle/issues/21644" />
+     * Check also: <a href="https://github.com/gradle/gradle/issues/21644">#21644</a>
      */
     private static void collectAllSourcePathsAndIndependentClasses(SourceFileChangeProcessor sourceFileChangeProcessor, RecompilationSpec spec, SourceFileClassNameConverter sourceFileClassNameConverter) {
         Set<String> classesToCompile = new LinkedHashSet<>(spec.getClassesToCompile());


### PR DESCRIPTION
I've realized that the JavaDoc issues caused recently were my doings, and this PR fixes them.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
