### PR TITLE
Add feature api to DependencyHandler to easier use the requireFeature api

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/DependencyHandlerDelegate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/DependencyHandlerDelegate.kt
@@ -149,6 +149,12 @@ abstract class DependencyHandlerDelegate : DependencyHandler {
     override fun testFixtures(notation: Any, configureAction: Action<in Dependency>): Dependency =
         delegate.testFixtures(notation, configureAction)
 
+    override fun feature(featureName: String, notation: Any): Dependency =
+        delegate.feature(featureName, notation)
+
+    override fun feature(featureName: String, notation: Any, configureAction: Action<in Dependency>): Dependency =
+        delegate.feature(featureName, notation, configureAction)
+
     override fun variantOf(dependencyProvider: Provider<MinimalExternalModuleDependency>, variantSpec: Action<in ExternalModuleDependencyVariantSpec>): Provider<MinimalExternalModuleDependency> =
         delegate.variantOf(dependencyProvider, variantSpec)
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -17,6 +17,7 @@ package org.gradle.api.artifacts.dsl;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.ArtifactView;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ExternalModuleDependency;
@@ -618,6 +619,27 @@ public interface DependencyHandler extends ExtensionAware {
      * @since 5.6
      */
     Dependency testFixtures(Object notation, Action<? super Dependency> configureAction);
+
+
+    /**
+     * Declares a dependency of a component with the required feature  and allows configuring
+     * the resulting dependency.
+     * @param notation the coordinates of the component providing the required feature
+     *
+     * @since 8.12
+     */
+    @Incubating
+    Dependency feature(String featureName, Object notation);
+
+    /**
+     * Declares a dependency of a component with the required feature  and allows configuring
+     * the resulting dependency.
+     * @param notation the coordinates of the component providing the required feature
+     *
+     * @since 8.12
+     */
+    @Incubating
+    Dependency feature(String featureName, Object notation, Action<? super Dependency> configureAction);
 
     /**
      * Allows fine-tuning what variant to select for the target dependency. This can be used to


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Add a direct api to define the feature directly without requireFeature
Related to the feedback of https://github.com/gradle/gradle/issues/25629

Or should I create a new issue?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
