### PR TITLE
Fix libs.version.toml typo

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/intro_multi_project_builds.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/intro_multi_project_builds.adoc
@@ -42,7 +42,7 @@ The directory structure should look as follows:
 ├── .gradle
 │   └── ⋮
 ├── gradle
-│   ├── libs.version.toml
+│   ├── libs.versions.toml
 │   └── wrapper
 ├── gradlew
 ├── gradlew.bat

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tutorial/partr1_gradle_init.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tutorial/partr1_gradle_init.adoc
@@ -81,7 +81,7 @@ When you are done with Gradle `init`, the directory should look as follows:
 ----
 .
 ├── gradle                              // <1>
-    ├── libs.version.toml               // <2>
+    ├── libs.versions.toml              // <2>
 │   └── wrapper
 ├── gradlew                             // <3>
 ├── gradlew.bat                         // <3>
@@ -112,7 +112,7 @@ When you are done with Gradle `init`, the directory should look as follows:
 ----
 .
 ├── gradle                              // <1>
-    ├── libs.version.toml               // <2>
+    ├── libs.versions.toml              // <2>
 │   └── wrapper
 ├── gradlew                             // <3>
 ├── gradlew.bat                         // <3>

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/centralizing-dependencies/version_catalogs.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/centralizing-dependencies/version_catalogs.adoc
@@ -26,10 +26,10 @@ include::sample[dir="snippets/dependencyManagement/catalogs-settings/groovy",fil
 
 In this example, `libs` represents the catalog, and `groovy` is a dependency available in it.
 
-Where the version catalog defining `libs.groovy.core` is a `libs.version.toml` file in the `gradle` directory:
+Where the version catalog defining `libs.groovy.core` is a `libs.versions.toml` file in the `gradle` directory:
 
 [source,toml]
-.gradle/libs.version.toml
+.gradle/libs.versions.toml
 ----
 [libraries]
 groovy-core = { group = "org.codehaus.groovy", name = "groovy", version = "3.0.5" }

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/tutorial/part1_gradle_init.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/tutorial/part1_gradle_init.adoc
@@ -92,7 +92,7 @@ When you are done, the directory should look as follows:
 ├── .gradle                 // <1>
 │   └── ⋮
 ├── gradle                  // <2>
-│   ├── libs.version.toml   // <3>
+│   ├── libs.versions.toml  // <3>
 │   └── wrapper
 ├── gradlew                 // <4>
 ├── gradlew.bat             // <5>
@@ -119,7 +119,7 @@ When you are done, the directory should look as follows:
 ├── .gradle                 // <1>
 │   └── ⋮
 ├── gradle                  // <2>
-│   ├── libs.version.toml   // <3>
+│   ├── libs.versions.toml  // <3>
 │   └── wrapper
 ├── gradlew                 // <4>
 ├── gradlew.bat             // <5>
@@ -213,7 +213,7 @@ A *build* contains:
 
 Some builds may contain a `build.gradle(.kts)` file in the root project but this is NOT recommended.
 
-The `libs.version.toml` file is a version catalog used for dependency management which you will learn about in a subsequent section of the tutorial.
+The `libs.versions.toml` file is a version catalog used for dependency management which you will learn about in a subsequent section of the tutorial.
 
 In this tutorial:
 

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/tutorial/part3_gradle_dep_man.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/tutorial/part3_gradle_dep_man.adoc
@@ -251,7 +251,7 @@ Let's change the `guava` version and look at how this affects the dependency tre
 
 Change the `guava` dependency in the version catalog to:
 
-.gradle/libs.version.toml
+.gradle/libs.versions.toml
 [source,text]
 ----
 [versions]


### PR DESCRIPTION
### Context
I was following the documentation at https://docs.gradle.org/current/userguide/version_catalogs.html and created a file `libs.version.toml` in the `./gradle` root folder. The file was not recognized by gradle and resulted in some errors. After changing it to `libs.versions.toml` it was instantly recognized so this seems to be an error in the docs.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
