### PR TITLE
Progress creating ABI stub variant

### DIFF
--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/ImplementationCompletenessAttribute.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/ImplementationCompletenessAttribute.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.basics
+
+import org.gradle.api.attributes.Attribute
+
+// TODO: Find a better name
+enum class ImplementationCompletenessAttribute {
+    STUBS, FULL;
+
+    companion object {
+        val attribute = Attribute.of(ImplementationCompletenessAttribute::class.java)
+    }
+}

--- a/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
+++ b/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
@@ -122,6 +122,7 @@ abstract class ExternalModulesExtension(isBundleGroovy4: Boolean) {
     val kotlinCompilerEmbeddable = futureKotlin("compiler-embeddable")
     val kotlinReflect = futureKotlin("reflect")
     val kotlinStdlib = futureKotlin("stdlib")
+    val kotlinJvmAbiGenEmbeddable = "org.jetbrains.kotlin:jvm-abi-gen-embeddable"
     val kotlinxSerializationCore = "org.jetbrains.kotlinx:kotlinx-serialization-core"
     val kotlinxSerializationJson = "org.jetbrains.kotlinx:kotlinx-serialization-json"
     val kryo = "com.esotericsoftware.kryo:kryo"

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -19,6 +19,7 @@ import com.gradle.develocity.agent.gradle.internal.test.TestDistributionConfigur
 import com.gradle.develocity.agent.gradle.test.DevelocityTestConfiguration
 import gradlebuild.basics.BuildEnvironment
 import gradlebuild.basics.FlakyTestStrategy
+import gradlebuild.basics.ImplementationCompletenessAttribute
 import gradlebuild.basics.accessors.kotlinMainSourceSet
 import gradlebuild.basics.buildRunningOnCi
 import gradlebuild.basics.flakyTestStrategy
@@ -96,6 +97,8 @@ configureCompileDefaults()
 addCompileAllTasks()
 configureSourcesVariant()
 configureTests()
+
+configureAttributes()
 
 tasks.registerCITestDistributionLifecycleTasks()
 
@@ -245,6 +248,27 @@ fun enforceKotlinCompatibility(targetVersion: Provider<Int>, useRelease: Provide
                     listOf()
                 }
             })
+        }
+    }
+}
+//
+//class ImplCompatibilityRule
+
+class ImplCompletenessDisambiguationRule : AttributeDisambiguationRule<ImplementationCompletenessAttribute> {
+    override fun execute(t: MultipleCandidatesDetails<ImplementationCompletenessAttribute>) {
+        val stubs = t.candidateValues.find { it.name == ImplementationCompletenessAttribute.STUBS.name }
+        if (stubs != null) {
+            t.closestMatch(stubs)
+        }
+    }
+}
+
+fun configureAttributes() {
+    dependencies {
+        attributesSchema {
+            attribute(ImplementationCompletenessAttribute.attribute) {
+                disambiguationRules.add(ImplCompletenessDisambiguationRule::class.java)
+            }
         }
     }
 }

--- a/build-logic/jvm/src/main/kotlin/gradlebuild/ConfigurationExtensions.kt
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild/ConfigurationExtensions.kt
@@ -16,6 +16,7 @@
 
 package gradlebuild
 
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConsumableConfiguration
 import org.gradle.api.artifacts.ResolvableConfiguration
 import org.gradle.api.attributes.Bundling
@@ -26,8 +27,17 @@ import org.gradle.api.attributes.java.TargetJvmEnvironment
 import org.gradle.api.model.ObjectFactory
 import org.gradle.kotlin.dsl.named
 
+fun Configuration.configureAsApiElements(objects: ObjectFactory) {
+    attributes {
+        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_API))
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.LIBRARY))
+        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.JAR))
+        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
+    }
+}
 
-fun ConsumableConfiguration.configureAsRuntimeElements(objects: ObjectFactory) {
+
+fun Configuration.configureAsRuntimeElements(objects: ObjectFactory) {
     attributes {
         attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
         attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.LIBRARY))
@@ -37,9 +47,21 @@ fun ConsumableConfiguration.configureAsRuntimeElements(objects: ObjectFactory) {
 }
 
 
-fun ResolvableConfiguration.configureAsRuntimeJarClasspath(objects: ObjectFactory) {
+fun Configuration.configureAsRuntimeJarClasspath(objects: ObjectFactory) {
     attributes {
         attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.LIBRARY))
+        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.JAR))
+        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
+        attribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE, objects.named(TargetJvmEnvironment.STANDARD_JVM))
+    }
+}
+
+
+
+fun ResolvableConfiguration.configureAsCompileJarClasspath(objects: ObjectFactory) {
+    attributes {
+        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_API))
         attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.LIBRARY))
         attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.JAR))
         attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))

--- a/build-logic/packaging/src/main/kotlin/gradlebuild.public-api-jar.gradle.kts
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild.public-api-jar.gradle.kts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import gradlebuild.basics.ImplementationCompletenessAttribute
+import gradlebuild.configureAsCompileJarClasspath
 import gradlebuild.configureAsRuntimeElements
 import gradlebuild.configureAsRuntimeJarClasspath
 import gradlebuild.packaging.transforms.ShrinkPublicApiClassesTransform
@@ -28,15 +30,6 @@ plugins {
 }
 
 description = "Generates a public API jar and corresponding component to publish it"
-
-// Defines configurations used to resolve the public Gradle API.
-val distribution = configurations.dependencyScope("distribution") {
-    description = "Dependencies to extract the public Gradle API from"
-}
-val distributionClasspath = configurations.resolvable("distributionClasspath") {
-    extendsFrom(distribution.get())
-    configureAsRuntimeJarClasspath(objects)
-}
 
 // Defines configurations used to resolve external dependencies
 // that the public API depends on.
@@ -54,31 +47,34 @@ val externalRuntimeClasspath = configurations.resolvable("externalRuntimeClasspa
     configureAsRuntimeJarClasspath(objects)
 }
 
-enum class Filtering {
-    PUBLIC_API, ALL
-}
-
-val filteredAttribute: Attribute<Filtering> = Attribute.of("org.gradle.apijar.filtered", Filtering::class.java)
-
 dependencies {
     artifactTypes.getByName("jar") {
-        attributes.attribute(filteredAttribute, Filtering.ALL)
+        attributes.attribute(ImplementationCompletenessAttribute.attribute, ImplementationCompletenessAttribute.FULL)
     }
 
     // Filter and shrink the published API.
     registerTransform(ShrinkPublicApiClassesTransform::class.java) {
-        from.attribute(filteredAttribute, Filtering.ALL)
+        from.attribute(ImplementationCompletenessAttribute.attribute, ImplementationCompletenessAttribute.FULL)
             .attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements::class.java, LibraryElements.JAR))
-        to.attribute(filteredAttribute, Filtering.PUBLIC_API)
+        to.attribute(ImplementationCompletenessAttribute.attribute, ImplementationCompletenessAttribute.STUBS)
+    }
+}
+
+// Defines configurations used to resolve the public Gradle API.
+val distribution = configurations.dependencyScope("distribution") {
+    description = "Dependencies to extract the public Gradle API from"
+}
+val distributionClasspath = configurations.resolvable("distributionClasspath") {
+    extendsFrom(distribution.get())
+    configureAsCompileJarClasspath(objects)
+    attributes {
+        attribute(ImplementationCompletenessAttribute.attribute, ImplementationCompletenessAttribute.STUBS)
     }
 }
 
 val task = tasks.register<Jar>("jarGradleApi") {
     from(distributionClasspath.map { configuration ->
         configuration.incoming.artifactView {
-            attributes {
-                attribute(filteredAttribute, Filtering.PUBLIC_API)
-            }
             componentFilter { componentId -> componentId is ProjectComponentIdentifier }
         }.files
     })

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.distribution.api-java.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.distribution.api-java.gradle.kts
@@ -1,3 +1,6 @@
+import gradle.kotlin.dsl.accessors._4d90ee38640727ba8d6a57a6ca35d262.apiElements
+import gradle.kotlin.dsl.accessors._4d90ee38640727ba8d6a57a6ca35d262.compileOnlyApi
+
 /*
  * Copyright 2020 the original author or authors.
  *
@@ -19,4 +22,18 @@ plugins {
     id("gradlebuild.distribution-module")
     id("gradlebuild.distribution.api")
     id("gradlebuild.instrumented-java-project")
+}
+
+configurations {
+    // TODO: Why are we not generating extensions for this configuration?
+    named("apiStubElements") {
+        extendsFrom(configurations.compileOnlyApi.get())
+
+        // For now, use the regular artifacts so things don't break.
+        // TODO: Use ABI filtered artifacts instead
+        artifacts.addAllLater(configurations.apiElements.map { it.artifacts })
+
+        // TODO: WRITE A TASK TO GET THE ABI CLASSES
+        // outgoing.artifact(abiClassesDirectory)
+    }
 }

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.distribution.api-kotlin.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.distribution.api-kotlin.gradle.kts
@@ -1,3 +1,8 @@
+import gradlebuild.configureAsRuntimeJarClasspath
+import org.jetbrains.kotlin.gradle.plugin.CompilerPluginConfig
+import org.jetbrains.kotlin.gradle.plugin.FilesSubpluginOption
+import org.jetbrains.kotlin.gradle.tasks.BaseKotlinCompile
+
 /*
  * Copyright 2020 the original author or authors.
  *
@@ -18,4 +23,39 @@ plugins {
     id("gradlebuild.kotlin-library")
     id("gradlebuild.distribution-module")
     id("gradlebuild.distribution.api")
+}
+
+val apiGenDependencies = configurations.dependencyScope("apiGen")
+val apiGenClasspath = configurations.resolvable("apiGenClasspath") {
+    extendsFrom(apiGenDependencies.get())
+    configureAsRuntimeJarClasspath(objects)
+}
+
+dependencies {
+    apiGenDependencies(libs.kotlinJvmAbiGenEmbeddable)
+}
+
+val abiClassesDirectory = layout.buildDirectory.dir("generated/kotlin-abi")
+kotlin {
+    target.compilations.named("main") {
+        compileTaskProvider.configure {
+            this as BaseKotlinCompile // TODO: Is there a way we can avoid a cast here?
+            pluginClasspath.from(apiGenClasspath)
+            pluginOptions.add(provider {
+                CompilerPluginConfig().apply {
+                    addPluginArgument("org.jetbrains.kotlin.jvm.abi", FilesSubpluginOption(
+                        "outputDir", listOf(abiClassesDirectory.get().asFile)
+                    ))
+                }
+            })
+        }
+    }
+}
+
+// TODO: DO THIS FOR JAVA
+configurations {
+    // TODO: Why are we not generating extensions for this configuration?
+    named("apiStubElements") {
+        outgoing.artifact(abiClassesDirectory)
+    }
 }

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.distribution.api.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.distribution.api.gradle.kts
@@ -15,7 +15,20 @@
  */
 
 import gradlebuild.basics.GradleModuleApiAttribute
+import gradlebuild.basics.ImplementationCompletenessAttribute
+import gradlebuild.configureAsApiElements
 
 configurations["runtimeElements"].attributes {
     attribute(GradleModuleApiAttribute.attribute, GradleModuleApiAttribute.API)
+}
+
+val apiStubElements = configurations.consumable("apiStubElements") {
+    isVisible = false
+    extendsFrom(configurations.named("implementation").get())
+    extendsFrom(configurations.named("compileOnly").get())
+//    extendsFrom(configurations.compileOnlyApi.get())
+    configureAsApiElements(objects)
+    attributes {
+        attribute(ImplementationCompletenessAttribute.attribute, ImplementationCompletenessAttribute.STUBS)
+    }
 }

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.distribution.uninstrumented.api-java.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.distribution.uninstrumented.api-java.gradle.kts
@@ -1,3 +1,6 @@
+import gradle.kotlin.dsl.accessors._4d90ee38640727ba8d6a57a6ca35d262.apiElements
+import gradle.kotlin.dsl.accessors._4d90ee38640727ba8d6a57a6ca35d262.compileOnlyApi
+
 /*
  * Copyright 2024 the original author or authors.
  *
@@ -21,3 +24,19 @@ plugins {
 }
 
 description = "Used for Gradle API projects that don't apply instrumentation"
+
+
+
+configurations {
+    // TODO: Why are we not generating extensions for this configuration?
+    named("apiStubElements") {
+        extendsFrom(configurations.compileOnlyApi.get())
+
+        // For now, use the regular artifacts so things don't break.
+        // TODO: Use ABI filtered artifacts instead
+        artifacts.addAllLater(configurations.apiElements.map { it.artifacts })
+
+        // TODO: WRITE A TASK TO GET THE ABI CLASSES
+        // outgoing.artifact(abiClassesDirectory)
+    }
+}

--- a/platforms/core-configuration/kotlin-dsl-tooling-models/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl-tooling-models/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("gradlebuild.distribution.api-kotlin")
+    id("gradlebuild.distribution.api-java")
 }
 
 description = "Kotlin DSL Tooling Models for IDEs"

--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -193,6 +193,7 @@ dependencies {
         api(libs.jtar)                  { version { strictly("2.3") }}
         api(libs.kotlinCoroutines)      { version { strictly("1.5.2") }}
         api(libs.kotlinCoroutinesDebug) { version { strictly("1.5.2") }}
+        api(libs.kotlinJvmAbiGenEmbeddable) { version { strictly(libs.kotlinVersion) }}
         api(libs.kotlinxSerializationCore)   { version { strictly("1.6.2") }}
         api(libs.kotlinxSerializationJson)   { version { strictly("1.6.2") }}
         api(libs.littleproxy)           { version { strictly("2.0.5") }}


### PR DESCRIPTION
We have a new apiStubElements configuration exposing ABI stubs of each project. This currently leverages Kotlin's ABI stub generation, and exposes Java projects' non-stub implementation artifacts. A future change should convert the ShrinkPublicApiClassesTransform to a task so that Java can also expose similar stubbed artifacts instead of their full implementation.

We have configured the compileClasspath of each project to prefer the stubbed classes if available. We are running into issues. It seems that when kotlin-dsl-tooling-builders compiles against kotlin-api, it fails to see some classes from it. Looking at the contents of kotlin-abi/build/generated/kotlin-abi, it appears at first glance that those clases are missing. Why are those classes not in the kotlin ABI outputs? Is this a bug in the ABI generator? Or, for some reason are these classes not considered ABI?

Running :public-api:jarGradleApi reproduces the problem we are seeing currently with kotlin compilation

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
