### PR TITLE
Deprecate TaskContainer.create: no nagging yet, limited to source level deprecation

### DIFF
--- a/build-logic/performance-testing/src/test/kotlin/gradlebuild/performance/tasks/DetermineBaselinesTest.kt
+++ b/build-logic/performance-testing/src/test/kotlin/gradlebuild/performance/tasks/DetermineBaselinesTest.kt
@@ -107,7 +107,7 @@ class DetermineBaselinesTest {
 
     private
     fun createDetermineBaselinesTask(isDistributed: Boolean) =
-        project.tasks.create("determineBaselines", DetermineBaselines::class.java, isDistributed, commandExecutor)
+        project.tasks.register("determineBaselines", DetermineBaselines::class.java, isDistributed, commandExecutor).get()
 
     private
     fun mockGitOperation(args: List<String>, expectedOutput: String) =

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginTemplatesTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginTemplatesTest.kt
@@ -179,6 +179,7 @@ class PrecompiledScriptPluginTemplatesTest : AbstractPrecompiledScriptPluginTest
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `implicit imports are available to precompiled scripts`() {
 

--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/TaskContainerDslIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/TaskContainerDslIntegrationTest.kt
@@ -319,6 +319,7 @@ class TaskContainerDslIntegrationTest : AbstractKotlinIntegrationTest() {
         )
     }
 
+    @Suppress("DEPRECATION")
     private
     val beforeDelegatedProperties: Project.() -> Unit = {
         // For cases not exercised by delegated properties

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ProjectExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ProjectExtensions.kt
@@ -197,11 +197,11 @@ inline fun <reified type : Task> Project.task(name: String, noinline configurati
  * @see [Project.getTasks]
  * @see [TaskContainer.create]
  */
-@Suppress("extension_shadowed_by_member")
+@Suppress("extension_shadowed_by_member", "DEPRECATION")
 inline fun <reified type : Task> Project.task(name: String) =
     tasks.create(name, type::class.java)
 
-
+@Suppress("DEPRECATION")
 fun <T : Task> Project.task(name: String, type: KClass<T>, configuration: T.() -> Unit) =
     tasks.create(name, type.java, configuration)
 

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/TaskContainerExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/TaskContainerExtensions.kt
@@ -276,5 +276,58 @@ inline fun <reified T : Task> TaskContainer.register(name: String, vararg argume
  * Creates a [Task] with the given [name] and type, passing the given arguments to the [javax.inject.Inject]-annotated constructor,
  * and adds it to this project tasks container.
  */
+@Deprecated("Use register instead. See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html for more information.", ReplaceWith("this.register<T>(name, *arguments)"))
+@Suppress("DEPRECATION")
 inline fun <reified T : Task> TaskContainer.create(name: String, vararg arguments: Any): T =
     create(name, T::class.java, *arguments)
+
+/**
+ * Creates a [Task] with the specified [name] and type, adds it to the container,
+ * and configures it with the specified action.
+ */
+@Deprecated("Use register instead. See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html for more information.", ReplaceWith("this.register<T>(name, configureAction)"))
+@Suppress("DEPRECATION")
+inline fun <reified T : Task> TaskContainer.create(name: String, noinline configureAction: T.() -> Unit): T =
+    create(name, T::class.java, configureAction)
+
+/**
+ * Provides a property delegate that creates tasks of the default type.
+ */
+@Deprecated("Use registering instead. See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html for more information.", ReplaceWith("registering"))
+val TaskContainer.creating
+    get() = NamedDomainObjectContainerCreatingDelegateProvider.of(this)
+
+/**
+ * Provides a property delegate that creates tasks of the default type with the given [configuration].
+ *
+ * `val someTask by tasks.creating { onlyIf = true }`
+ */
+@Deprecated("Use registering instead. See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html for more information.", ReplaceWith("registering(configuration)"))
+fun TaskContainer.creating(configuration: Task.() -> Unit) =
+    NamedDomainObjectContainerCreatingDelegateProvider.of(this, configuration)
+
+/**
+ * Provides a property delegate that creates tasks of the given [type].
+ */
+@Deprecated("Use registering instead. See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html for more information.", ReplaceWith("registering(type)"))
+fun <U : Task> TaskContainer.creating(type: KClass<U>) =
+    PolymorphicDomainObjectContainerCreatingDelegateProvider.of(this, type.java)
+
+
+/**
+ * Provides a property delegate that creates tasks of the given [type] with the given [configuration].
+ */
+@Deprecated("Use registering instead. See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html for more information.", ReplaceWith("registering(type, configuration)"))
+@Suppress("DEPRECATION")
+fun <U : Task> TaskContainer.creating(type: KClass<U>, configuration: U.() -> Unit) =
+    creating(type.java, configuration)
+
+
+/**
+ * Provides a property delegate that creates tasks of the given [type] expressed as a [java.lang.Class]
+ * with the given [configuration].
+ */
+@Deprecated("Use registering instead. See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html for more information.", ReplaceWith("registering(type, configuration)"))
+fun <U : Task> TaskContainer.creating(type: Class<U>, configuration: U.() -> Unit) =
+    PolymorphicDomainObjectContainerCreatingDelegateProvider.of(this, type, configuration)
+

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/TaskContainerDelegate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/TaskContainerDelegate.kt
@@ -76,27 +76,43 @@ abstract class TaskContainerDelegate : TaskContainer {
     override fun addAllLater(provider: Provider<out Iterable<Task>>) =
         delegate.addAllLater(provider)
 
+    @Deprecated("Use register instead. There is no matching method taking a map notation, so you will have replace the map with proper arguments. See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html for more information.")
+    @Suppress("DEPRECATION")
     override fun create(options: Map<String, *>): Task =
         delegate.create(options)
 
+    @Deprecated("Use register instead. There is no matching method taking a map notation, so you will have replace the map with proper arguments. See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html for more information.")
+    @Suppress("DEPRECATION")
     override fun create(options: Map<String, *>, configureClosure: Closure<Any>): Task =
         delegate.create(options, configureClosure)
 
+    @Deprecated("Use register instead. See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html for more information.", ReplaceWith("register(name, configureClosure)"))
+    @Suppress("DEPRECATION")
     override fun create(name: String, configureClosure: Closure<Any>): Task =
         delegate.create(name, configureClosure)
 
+    @Deprecated("Use register instead. See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html for more information.", ReplaceWith("register(name)"))
+    @Suppress("DEPRECATION")
     override fun create(name: String): Task =
         delegate.create(name)
 
+    @Deprecated("Use register instead. See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html for more information.", ReplaceWith("register(name, type)"))
+    @Suppress("DEPRECATION")
     override fun <T : Task> create(name: String, type: Class<T>): T =
         delegate.create(name, type)
 
+    @Deprecated("Use register instead. See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html for more information.", ReplaceWith("register(name, type, *constructorArgs)"))
+    @Suppress("DEPRECATION")
     override fun <T : Task> create(name: String, type: Class<T>, vararg constructorArgs: Any?): T =
         delegate.create(name, type, *constructorArgs)
 
+    @Deprecated("Use register instead. See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html for more information.", ReplaceWith("register(name, type, configuration)"))
+    @Suppress("DEPRECATION")
     override fun <T : Task> create(name: String, type: Class<T>, configuration: Action<in T>): T =
         delegate.create(name, type, configuration)
 
+    @Deprecated("Use register instead. See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html for more information.", ReplaceWith("register(name, configureAction)"))
+    @Suppress("DEPRECATION")
     override fun create(name: String, configureAction: Action<in Task>): Task =
         delegate.create(name, configureAction)
 

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensionsTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensionsTest.kt
@@ -225,6 +225,7 @@ class NamedDomainObjectContainerExtensionsTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `can create and configure tasks`() {
 
@@ -260,6 +261,7 @@ class NamedDomainObjectContainerExtensionsTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `can create element within configuration block via delegated property`() {
 

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/TaskContainerExtensionsTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/TaskContainerExtensionsTest.kt
@@ -25,6 +25,7 @@ import org.junit.Test
 
 class TaskContainerExtensionsTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun `can create tasks with injected constructor arguments`() {
 

--- a/platforms/documentation/docs/src/snippets/developingPlugins/conventionOverConfiguration/groovy/buildSrc/src/main/java/org/myorg/ServerPlugin.java
+++ b/platforms/documentation/docs/src/snippets/developingPlugins/conventionOverConfiguration/groovy/buildSrc/src/main/java/org/myorg/ServerPlugin.java
@@ -8,7 +8,6 @@ public class ServerPlugin implements Plugin<Project> {
     public void apply(Project project) {
         ServerExtension extension = project.getExtensions().create("server", ServerExtension.class);
         extension.getUrl().convention("https://www.myorg.com/server");
-        Deploy deployTask = project.getTasks().create("deploy", Deploy.class);
-        deployTask.getUrl().set(extension.getUrl());
+        project.getTasks().register("deploy", Deploy.class, deployTask -> deployTask.getUrl().set(extension.getUrl()));
     }
 }

--- a/platforms/documentation/docs/src/snippets/developingPlugins/conventionOverConfiguration/kotlin/buildSrc/src/main/java/org/myorg/ServerPlugin.java
+++ b/platforms/documentation/docs/src/snippets/developingPlugins/conventionOverConfiguration/kotlin/buildSrc/src/main/java/org/myorg/ServerPlugin.java
@@ -8,7 +8,6 @@ public class ServerPlugin implements Plugin<Project> {
     public void apply(Project project) {
         ServerExtension extension = project.getExtensions().create("server", ServerExtension.class);
         extension.getUrl().convention("https://www.myorg.com/server");
-        Deploy deployTask = project.getTasks().create("deploy", Deploy.class);
-        deployTask.getUrl().set(extension.getUrl());
+        project.getTasks().register("deploy", Deploy.class, deployTask -> deployTask.getUrl().set(extension.getUrl()));
     }
 }

--- a/platforms/ide/ide-native/src/main/java/org/gradle/ide/xcode/plugins/XcodePlugin.java
+++ b/platforms/ide/ide-native/src/main/java/org/gradle/ide/xcode/plugins/XcodePlugin.java
@@ -137,6 +137,7 @@ public abstract class XcodePlugin extends IdePlugin {
     }
 
     private void configureXcodeCleanTask(Project project) {
+        @SuppressWarnings("deprecation")
         Delete cleanTask = project.getTasks().create("cleanXcodeProject", Delete.class);
         cleanTask.delete(xcodeProject.getLocationDir());
         if (isRoot()) {
@@ -148,9 +149,11 @@ public abstract class XcodePlugin extends IdePlugin {
     private GenerateXcodeProjectFileTask createProjectTask(final ProjectInternal project) {
         File xcodeProjectPackageDir = xcodeProject.getLocationDir();
 
+        @SuppressWarnings("deprecation")
         GenerateWorkspaceSettingsFileTask workspaceSettingsFileTask = project.getTasks().create("xcodeProjectWorkspaceSettings", GenerateWorkspaceSettingsFileTask.class);
         workspaceSettingsFileTask.setOutputFile(new File(xcodeProjectPackageDir, "project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings"));
 
+        @SuppressWarnings("deprecation")
         GenerateXcodeProjectFileTask projectFileTask = project.getTasks().create("xcodeProject", GenerateXcodeProjectFileTask.class);
         projectFileTask.dependsOn(workspaceSettingsFileTask);
         projectFileTask.dependsOn(xcodeProject.getTaskDependencies());
@@ -167,9 +170,11 @@ public abstract class XcodePlugin extends IdePlugin {
         File xcodeWorkspacePackageDir = project.file(project.getName() + ".xcworkspace");
         workspace.getLocation().set(xcodeWorkspacePackageDir);
 
+        @SuppressWarnings("deprecation")
         GenerateWorkspaceSettingsFileTask workspaceSettingsFileTask = project.getTasks().create("xcodeWorkspaceWorkspaceSettings", GenerateWorkspaceSettingsFileTask.class);
         workspaceSettingsFileTask.setOutputFile(new File(xcodeWorkspacePackageDir, "xcshareddata/WorkspaceSettings.xcsettings"));
 
+        @SuppressWarnings("deprecation")
         GenerateXcodeWorkspaceFileTask workspaceFileTask = project.getTasks().create("xcodeWorkspace", GenerateXcodeWorkspaceFileTask.class);
         workspaceFileTask.dependsOn(workspaceSettingsFileTask);
         workspaceFileTask.setOutputFile(new File(xcodeWorkspacePackageDir, "contents.xcworkspacedata"));
@@ -393,6 +398,7 @@ public abstract class XcodePlugin extends IdePlugin {
         @Override
         public void execute(String taskName) {
             if (taskName.startsWith("_xcode")) {
+                @SuppressWarnings("deprecation")
                 Task bridgeTask = project.getTasks().create(taskName);
                 String action = xcodePropertyAdapter.getAction();
                 if (action.equals("clean")) {
@@ -430,6 +436,7 @@ public abstract class XcodePlugin extends IdePlugin {
             // XCTest executable
             // Sync the binary to the BUILT_PRODUCTS_DIR, otherwise Xcode won't find any tests
             final String builtProductsPath = xcodePropertyAdapter.getBuiltProductsDir();
+            @SuppressWarnings("deprecation")
             final Sync syncTask = project.getTasks().create("syncBundleToXcodeBuiltProductDir", Sync.class, new Action<Sync>() {
                 @Override
                 public void execute(Sync task) {

--- a/platforms/native/language-native/src/main/java/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPlugin.java
+++ b/platforms/native/language-native/src/main/java/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPlugin.java
@@ -90,6 +90,7 @@ public abstract class SwiftPackageManagerExportPlugin implements Plugin<Project>
 
     @Override
     public void apply(final Project project) {
+        @SuppressWarnings("deprecation")
         final GenerateSwiftPackageManagerManifest manifestTask = project.getTasks().create("generateSwiftPmManifest", GenerateSwiftPackageManagerManifest.class);
         manifestTask.getManifestFile().set(project.getLayout().getProjectDirectory().file("Package.swift"));
 

--- a/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/plugins/NativeComponentModelPlugin.java
+++ b/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/plugins/NativeComponentModelPlugin.java
@@ -273,6 +273,7 @@ public abstract class NativeComponentModelPlugin implements Plugin<Project> {
             });
         }
 
+        @SuppressWarnings("deprecation")
         @Mutate
         void configurePrefixHeaderGenerationTasks(final TaskContainer tasks, ComponentSpecContainer components) {
             for (final SourceComponentSpec nativeComponentSpec : components.withType(SourceComponentSpec.class).values()) {
@@ -303,6 +304,7 @@ public abstract class NativeComponentModelPlugin implements Plugin<Project> {
                                 nativeBinarySpec.addPreCompiledHeaderFor(dependentSourceSet);
                                 final SourceTransformTaskConfig pchTransformTaskConfig = transform.getPchTransformTask();
                                 String pchTaskName = pchTransformTaskConfig.getTaskPrefix() + StringUtils.capitalize(nativeBinarySpec.getProjectScopedName()) + StringUtils.capitalize(dependentSourceSet.getName()) + "PreCompiledHeader";
+                                @SuppressWarnings("deprecation")
                                 Task pchTask = tasks.create(pchTaskName, pchTransformTaskConfig.getTaskType(), new Action<DefaultTask>() {
                                     @Override
                                     public void execute(DefaultTask task) {

--- a/platforms/native/testing-native/src/main/java/org/gradle/nativeplatform/test/cunit/plugins/CUnitPlugin.java
+++ b/platforms/native/testing-native/src/main/java/org/gradle/nativeplatform/test/cunit/plugins/CUnitPlugin.java
@@ -90,6 +90,7 @@ public abstract class CUnitPlugin implements Plugin<Project> {
             for (final CUnitTestSuiteSpec suite : testSuites.withType(CUnitTestSuiteSpec.class).values()) {
 
                 String taskName = suite.getName() + "CUnitLauncher";
+                @SuppressWarnings("deprecation")
                 GenerateCUnitLauncher skeletonTask = tasks.create(taskName, GenerateCUnitLauncher.class);
 
                 CSourceSet launcherSources = findLauncherSources(suite);

--- a/platforms/software/platform-base/src/main/java/org/gradle/api/internal/plugins/BuildConfigurationRule.java
+++ b/platforms/software/platform-base/src/main/java/org/gradle/api/internal/plugins/BuildConfigurationRule.java
@@ -47,6 +47,7 @@ public class BuildConfigurationRule implements Rule {
             Configuration configuration = configurations.findByName(configurationName);
 
             if (configuration != null) {
+                @SuppressWarnings("deprecation")
                 Task task = tasks.create(taskName);
                 task.dependsOn(configuration.getAllArtifacts());
                 task.setDescription("Builds the artifacts belonging to " + configuration + ".");

--- a/platforms/software/platform-base/src/main/java/org/gradle/language/base/internal/model/BinarySourceTransformations.java
+++ b/platforms/software/platform-base/src/main/java/org/gradle/language/base/internal/model/BinarySourceTransformations.java
@@ -74,6 +74,7 @@ public class BinarySourceTransformations {
 
                 final SourceTransformTaskConfig taskConfig = languageTransform.getTransformTask();
                 String taskName = getTransformTaskName(languageTransform, taskConfig, binary, sourceSetToCompile);
+                @SuppressWarnings("deprecation")
                 Task task = tasks.create(taskName, taskConfig.getTaskType());
                 taskConfig.configureTask(task, binary, sourceSetToCompile, serviceRegistry);
 

--- a/platforms/software/platform-base/src/main/java/org/gradle/language/base/internal/plugins/CleanRule.java
+++ b/platforms/software/platform-base/src/main/java/org/gradle/language/base/internal/plugins/CleanRule.java
@@ -57,6 +57,7 @@ public class CleanRule implements Rule {
             return;
         }
 
+        @SuppressWarnings("deprecation")
         Delete clean = tasks.create(taskName, Delete.class);
         clean.delete(task.getOutputs().getFiles());
     }

--- a/platforms/software/signing/src/main/java/org/gradle/plugins/signing/SigningExtension.java
+++ b/platforms/software/signing/src/main/java/org/gradle/plugins/signing/SigningExtension.java
@@ -398,6 +398,7 @@ public abstract class SigningExtension {
         if (project.getTasks().getNames().contains(signTaskName)) {
             return project.getTasks().named(signTaskName, Sign.class).get();
         }
+        @SuppressWarnings("deprecation")
         final Sign signTask = project.getTasks().create(signTaskName, Sign.class, task -> {
             task.setDescription("Signs all artifacts in the '" + publicationToSign.getName() + "' publication.");
             task.sign(publicationToSign);
@@ -427,6 +428,7 @@ public abstract class SigningExtension {
         if (project.getTasks().getNames().contains(signTaskName)) {
             return project.getTasks().named(signTaskName, Sign.class).get();
         }
+        @SuppressWarnings("deprecation")
         final Sign signTask = project.getTasks().create(signTaskName, Sign.class, taskConfiguration);
         addSignaturesToConfiguration(signTask, getConfiguration());
         return signTask;

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
@@ -68,28 +68,28 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      *
      * <tr><th>Option</th><th>Description</th><th>Default Value</th></tr>
      *
-     * <tr><td><code>{@value org.gradle.api.Task#TASK_NAME}</code></td><td>The name of the task to create.</td><td>None.
+     * <tr><td><code>{@value Task#TASK_NAME}</code></td><td>The name of the task to create.</td><td>None.
      * Must be specified.</td></tr>
      *
-     * <tr><td><code>{@value org.gradle.api.Task#TASK_TYPE}</code></td><td>The class of the task to
+     * <tr><td><code>{@value Task#TASK_TYPE}</code></td><td>The class of the task to
      * create.</td><td>{@link org.gradle.api.DefaultTask}</td></tr>
      *
-     * <tr><td><code>{@value org.gradle.api.Task#TASK_ACTION}</code></td><td>The closure or {@link Action} to
+     * <tr><td><code>{@value Task#TASK_ACTION}</code></td><td>The closure or {@link Action} to
      * execute when the task executes. See {@link Task#doFirst(Action)}.</td><td><code>null</code></td></tr>
      *
-     * <tr><td><code>{@value org.gradle.api.Task#TASK_OVERWRITE}</code></td><td>Replace an existing
+     * <tr><td><code>{@value Task#TASK_OVERWRITE}</code></td><td>Replace an existing
      * task?</td><td><code>false</code></td></tr>
      *
-     * <tr><td><code>{@value org.gradle.api.Task#TASK_DEPENDS_ON}</code></td><td>The dependencies of the task. See <a
+     * <tr><td><code>{@value Task#TASK_DEPENDS_ON}</code></td><td>The dependencies of the task. See <a
      * href="../Task.html#dependencies">here</a> for more details.</td><td><code>[]</code></td></tr>
      *
-     * <tr><td><code>{@value org.gradle.api.Task#TASK_GROUP}</code></td><td>The group of the task.</td><td><code>null
+     * <tr><td><code>{@value Task#TASK_GROUP}</code></td><td>The group of the task.</td><td><code>null
      * </code></td></tr>
      *
-     * <tr><td><code>{@value org.gradle.api.Task#TASK_DESCRIPTION}</code></td><td>The description of the task.</td><td>
+     * <tr><td><code>{@value Task#TASK_DESCRIPTION}</code></td><td>The description of the task.</td><td>
      * <code>null</code></td></tr>
      *
-     * <tr><td><code>{@value org.gradle.api.Task#TASK_CONSTRUCTOR_ARGS}</code></td><td>The arguments to pass to the task class constructor.</td><td>
+     * <tr><td><code>{@value Task#TASK_CONSTRUCTOR_ARGS}</code></td><td>The arguments to pass to the task class constructor.</td><td>
      * <code>null</code></td></tr>
      *
      * </table>
@@ -97,15 +97,18 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * <p>After the task is added, it is made available as a property of the project, so that you can reference the task
      * by name in your build file.</p>
      *
-     * <p>If a task with the given name already exists in this container and the <code>{@value org.gradle.api.Task#TASK_OVERWRITE}</code>
+     * <p>If a task with the given name already exists in this container and the <code>{@value Task#TASK_OVERWRITE}</code>
      * option is not set to true, an exception is thrown.</p>
      *
      * @param options The task creation options.
      * @return The newly created task object
      * @throws InvalidUserDataException If a task with the given name already exists in this project.
-     * @throws NullPointerException If any of the values in <code>{@value org.gradle.api.Task#TASK_CONSTRUCTOR_ARGS}</code> is null.
+     * @throws NullPointerException If any of the values in <code>{@value Task#TASK_CONSTRUCTOR_ARGS}</code> is null.
      * @see Project#getProperties()  More information about how tasks are exposed by name in build scripts
+     *
+     * @deprecated Use {@link #register(String, Action)} or {@link #register(String, Class, Action)} instead. See <a href="https://docs.gradle.org/current/userguide/task_configuration_avoidance.html">documentation</a> for more information.
      */
+    @Deprecated
     Task create(Map<String, ?> options) throws InvalidUserDataException;
 
     /**
@@ -121,7 +124,10 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @return The newly created task object
      * @throws InvalidUserDataException If a task with the given name already exists in this project.
      * @see Project#getProperties()  More information about how tasks are exposed by name in build scripts
+     *
+     * @deprecated Use {@link #register(String, Action)} instead. See <a href="https://docs.gradle.org/current/userguide/task_configuration_avoidance.html">documentation</a> for more information.
      */
+    @Deprecated
     Task create(Map<String, ?> options, Closure configureClosure) throws InvalidUserDataException;
 
     /**
@@ -136,7 +142,10 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @return The newly created task object
      * @throws InvalidUserDataException If a task with the given name already exists in this project.
      * @see Project#getProperties()  More information about how tasks are exposed by name in build scripts
+     *
+     * @deprecated Use {@link #register(String, Action)} instead. See <a href="https://docs.gradle.org/current/userguide/task_configuration_avoidance.html">documentation</a> for more information.
      */
+    @Deprecated
     @Override
     Task create(String name, Closure configureClosure) throws InvalidUserDataException;
 
@@ -150,7 +159,10 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @return The newly created task object
      * @throws InvalidUserDataException If a task with the given name already exists in this project.
      * @see Project#getProperties()  More information about how tasks are exposed by name in build scripts
+     *
+     * @deprecated Use {@link #register(String)} instead. See <a href="https://docs.gradle.org/current/userguide/task_configuration_avoidance.html">documentation</a> for more information.
      */
+    @Deprecated
     @Override
     Task create(String name) throws InvalidUserDataException;
 
@@ -165,7 +177,10 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @return The newly created task object
      * @throws InvalidUserDataException If a task with the given name already exists in this project.
      * @see Project#getProperties()  More information about how tasks are exposed by name in build scripts
+     *
+     * @deprecated Use {@link #register(String, Class)} instead. See <a href="https://docs.gradle.org/current/userguide/task_configuration_avoidance.html">documentation</a> for more information.
      */
+    @Deprecated
     @Override
     <T extends Task> T create(String name, Class<T> type) throws InvalidUserDataException;
 
@@ -185,7 +200,10 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @throws NullPointerException If any of the values in {@code constructorArgs} is null.
      * @see Project#getProperties()  More information about how tasks are exposed by name in build scripts
      * @since 4.7
+     *
+     * @deprecated Use {@link #register(String, Class, Object...)} instead. See <a href="https://docs.gradle.org/current/userguide/task_configuration_avoidance.html">documentation</a> for more information.
      */
+    @Deprecated
     <T extends Task> T create(String name, Class<T> type, Object... constructorArgs) throws InvalidUserDataException;
 
     /**
@@ -200,9 +218,30 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @return The newly created task object.
      * @throws InvalidUserDataException If a task with the given name already exists in this project.
      * @see Project#getProperties()  More information about how tasks are exposed by name in build scripts
+     *
+     * @deprecated Use {@link #register(String, Class, Action)} instead. See <a href="https://docs.gradle.org/current/userguide/task_configuration_avoidance.html">documentation</a> for more information.
      */
+    @Deprecated
     @Override
     <T extends Task> T create(String name, Class<T> type, Action<? super T> configuration) throws InvalidUserDataException;
+
+    /**
+     * <p>Creates a {@link Task} with the given name and of type {@link org.gradle.api.DefaultTask}, configures it with the given action, and adds it to this container.</p>
+     *
+     * <p>After the task is added, it is made available as a property of the project, so that you can reference the task
+     * by name in your build file.</p>
+     *
+     * @param name The name of the task to be created.
+     * @param configuration The action to configure the task with.
+     * @return The newly created task object.
+     * @throws InvalidUserDataException If a task with the given name already exists in this project.
+     * @see Project#getProperties()  More information about how tasks are exposed by name in build scripts
+     *
+     * @deprecated Use {@link #register(String, Action)} instead. See <a href="https://docs.gradle.org/current/userguide/task_configuration_avoidance.html">documentation</a> for more information.
+     */
+    @Deprecated
+    @Override
+    Task create(String name, Action<? super Task> configuration) throws InvalidUserDataException;
 
     /**
      * Defines a new task, which will be created and configured when it is required. A task is 'required' when the task is located using query methods such as {@link TaskCollection#getByName(java.lang.String)}, when the task is added to the task graph for execution or when {@link Provider#get()} is called on the return value of this method.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultAntBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultAntBuilder.java
@@ -147,6 +147,7 @@ public class DefaultAntBuilder extends BasicAntBuilder implements GroovyObject {
         for (String name : newAntTargets) {
             final Target target = getAntProject().getTargets().get(name);
             String taskName = taskNamer.transform(target.getName());
+            @SuppressWarnings("deprecation")
             final AntTarget task = gradleProject.getTasks().create(taskName, AntTarget.class);
             configureTask(target, task, baseDir, taskNamer);
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -1387,23 +1387,27 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
         ConfigureUtil.configure(configureClosure, getBuildscript());
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public Task task(String task) {
         onMutableStateAccess();
         return taskContainer.create(task);
     }
 
+    @SuppressWarnings("deprecation")
     public Task task(Object task) {
         onMutableStateAccess();
         return taskContainer.create(task.toString());
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public Task task(String task, Action<? super Task> configureAction) {
         onMutableStateAccess();
         return taskContainer.create(task, configureAction);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public Task task(String task, Closure configureClosure) {
         onMutableStateAccess();
@@ -1415,6 +1419,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
         return task(task.toString(), configureClosure);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public Task task(Map options, String task) {
         onMutableStateAccess();
@@ -1426,6 +1431,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
         return task(options, task.toString());
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public Task task(Map options, String task, Closure configureClosure) {
         onMutableStateAccess();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -118,6 +118,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         this.projectRegistry = projectRegistry;
     }
 
+    @Deprecated
     @Override
     public Task create(Map<String, ?> options) {
         assertCanMutate("create(Map)");
@@ -270,18 +271,21 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         return create(name, type);
     }
 
+    @Deprecated
     @Override
     public Task create(Map<String, ?> options, Closure configureClosure) throws InvalidUserDataException {
         assertCanMutate("create(Map, Closure)");
         return doCreate(options, ConfigureUtil.configureUsing(configureClosure));
     }
 
+    @Deprecated
     @Override
     public <T extends Task> T create(String name, Class<T> type) {
         assertCanMutate("create(String, Class)");
         return doCreate(name, type, NO_ARGS, Actions.doNothing());
     }
 
+    @Deprecated
     @Override
     public <T extends Task> T create(final String name, final Class<T> type, final Object... constructorArgs) throws InvalidUserDataException {
         assertCanMutate("create(String, Class, Object...)");
@@ -332,12 +336,14 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         return taskFactory.create(identity, constructorArgs);
     }
 
+    @Deprecated
     @Override
     public Task create(String name) {
         assertCanMutate("create(String)");
         return doCreate(name, DefaultTask.class, NO_ARGS, Actions.doNothing());
     }
 
+    @Deprecated
     @Override
     public Task create(String name, Action<? super Task> configureAction) throws InvalidUserDataException {
         assertCanMutate("create(String, Action)");
@@ -359,12 +365,14 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         return replace(name, DefaultTask.class);
     }
 
+    @Deprecated
     @Override
     public Task create(String name, Closure configureClosure) {
         assertCanMutate("create(String, Closure)");
         return doCreate(name, DefaultTask.class, NO_ARGS, ConfigureUtil.configureUsing(configureClosure));
     }
 
+    @Deprecated
     @Override
     public <T extends Task> T create(String name, Class<T> type, Action<? super T> configuration) throws InvalidUserDataException {
         assertCanMutate("create(String, Class, Action)");

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -33,6 +33,62 @@
             ]
         },
         {
+            "type": "org.gradle.kotlin.dsl.TaskContainerExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.TaskContainerExtensionsKt.create(org.gradle.api.tasks.TaskContainer,java.lang.String,kotlin.jvm.functions.Function1)",
+            "acceptation": "Pulled down method to deprecate it",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.TaskContainerExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.TaskContainerExtensionsKt.creating(org.gradle.api.tasks.TaskContainer,java.lang.Class,kotlin.jvm.functions.Function1)",
+            "acceptation": "Pulled down method to deprecate it",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.TaskContainerExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.TaskContainerExtensionsKt.creating(org.gradle.api.tasks.TaskContainer,kotlin.jvm.functions.Function1)",
+            "acceptation": "Pulled down method to deprecate it",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.TaskContainerExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.TaskContainerExtensionsKt.creating(org.gradle.api.tasks.TaskContainer,kotlin.reflect.KClass)",
+            "acceptation": "Pulled down method to deprecate it",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.TaskContainerExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.TaskContainerExtensionsKt.creating(org.gradle.api.tasks.TaskContainer,kotlin.reflect.KClass,kotlin.jvm.functions.Function1)",
+            "acceptation": "Pulled down method to deprecate it",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.TaskContainerExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.TaskContainerExtensionsKt.getCreating$annotations(org.gradle.api.tasks.TaskContainer)",
+            "acceptation": "Pulled down method to deprecate it",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.TaskContainerExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.TaskContainerExtensionsKt.getCreating(org.gradle.api.tasks.TaskContainer)",
+            "acceptation": "Pulled down method to deprecate it",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
             "type": "org.gradle.language.swift.SwiftVersion",
             "member": "Field SWIFT6",
             "acceptation": "No need to incubate",


### PR DESCRIPTION
This does not include a logged deprecation warning and is limited to the methods on the container.

it is one step towards resolving #17705.