### PR TITLE
Rework TestStyledTextOutputFactory test fixture

### DIFF
--- a/platforms/core-runtime/launcher/src/test/groovy/org/gradle/tooling/internal/provider/continuous/ContinuousBuildActionExecutorTest.groovy
+++ b/platforms/core-runtime/launcher/src/test/groovy/org/gradle/tooling/internal/provider/continuous/ContinuousBuildActionExecutorTest.groovy
@@ -98,7 +98,7 @@ class ContinuousBuildActionExecutorTest extends ConcurrentSpec {
 
     def cleanup() {
         println("Build Output:")
-        println(textOutputFactory)
+        println(textOutputFactory.output)
         executorService.shutdownNow()
     }
 
@@ -364,7 +364,7 @@ class ContinuousBuildActionExecutorTest extends ConcurrentSpec {
     }
 
     private List<String> getLogLines() {
-        return textOutputFactory.toString().readLines().findAll { !it.empty }
+        return textOutputFactory.output.readLines().findAll { !it.empty }
     }
 
     private void continuousBuildDisabled() {

--- a/platforms/core-runtime/logging/src/testFixtures/groovy/org/gradle/internal/logging/text/TestStyledTextOutputFactory.java
+++ b/platforms/core-runtime/logging/src/testFixtures/groovy/org/gradle/internal/logging/text/TestStyledTextOutputFactory.java
@@ -20,26 +20,48 @@ import org.gradle.api.logging.LogLevel;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
+/**
+ * Test fixture for {@link StyledTextOutputFactory} that tracks the styled text produced.
+ *
+ * This is intended to be used in tests and only in cases where a single category/log level is used at a time.
+ *
+ * This fixture allows tests to assert that the correct log category, log level and styled output has been produced.
+ */
 public class TestStyledTextOutputFactory extends AbstractStyledTextOutputFactory implements StyledTextOutputFactory {
     private final List<StyledTextOutput> textOutputs = new ArrayList<StyledTextOutput>();
+    private String category;
+    private LogLevel logLevel;
 
+    /**
+     * {@inheritDoc}
+     *
+     * @implNote This implementation tracks the output of the most recently created category and log level. If the category or log level
+     * changes, the tracked output is reset.
+     */
     @Override
     public StyledTextOutput create(String logCategory, LogLevel logLevel) {
+        if (!Objects.equals(this.category, logCategory) || !Objects.equals(this.logLevel, logLevel)) {
+            reset();
+            this.category = logCategory;
+            this.logLevel = logLevel;
+        }
+
         StyledTextOutput textOutput = new TestStyledTextOutput();
-
-        if (logCategory != null) {
-            textOutput.append("{").append(logCategory).append("}");
-        }
-        if (logLevel != null) {
-            textOutput.append("{").append(logLevel.toString()).append("}");
-        }
-
         textOutputs.add(textOutput);
         return textOutput;
     }
 
+    @Override
     public String toString() {
+        return getOutput();
+    }
+
+    /**
+     * @return the output that has been seen so far.
+     */
+    public String getOutput() {
         StringBuilder builder = new StringBuilder();
         for (StyledTextOutput textOutput: textOutputs) {
             builder.append(textOutput);
@@ -47,7 +69,23 @@ public class TestStyledTextOutputFactory extends AbstractStyledTextOutputFactory
         return builder.toString();
     }
 
-    public void clear() {
+    /**
+     * @return category last seen by the factory.
+     */
+    public String getCategory() {
+        return category;
+    }
+
+    /**
+     * @return log level last seen by the factory.
+     */
+    public LogLevel getLogLevel() {
+        return logLevel;
+    }
+
+    private void reset() {
         textOutputs.clear();
+        category = null;
+        logLevel = null;
     }
 }

--- a/platforms/core-runtime/logging/src/testFixtures/groovy/org/gradle/internal/logging/text/TestStyledTextOutputFactory.java
+++ b/platforms/core-runtime/logging/src/testFixtures/groovy/org/gradle/internal/logging/text/TestStyledTextOutputFactory.java
@@ -31,22 +31,25 @@ import java.util.Objects;
  */
 public class TestStyledTextOutputFactory extends AbstractStyledTextOutputFactory implements StyledTextOutputFactory {
     private final List<StyledTextOutput> textOutputs = new ArrayList<StyledTextOutput>();
+    private boolean created;
     private String category;
     private LogLevel logLevel;
 
     /**
      * {@inheritDoc}
      *
-     * @implNote This implementation tracks the output of the most recently created category and log level. If the category or log level
-     * changes, the tracked output is reset.
+     * @implNote This implementation tracks the output of the first created category and log level. If the category or log level
+     * changes, the factory will fail to create a new styled text output.
      */
     @Override
     public StyledTextOutput create(String logCategory, LogLevel logLevel) {
-        if (!Objects.equals(this.category, logCategory) || !Objects.equals(this.logLevel, logLevel)) {
-            reset();
-            this.category = logCategory;
-            this.logLevel = logLevel;
+        if (created && (!Objects.equals(this.category, logCategory) || !Objects.equals(this.logLevel, logLevel))) {
+            throw new UnsupportedOperationException("This fixture can only be used with a single category and log level.");
         }
+
+        this.created = true;
+        this.category = logCategory;
+        this.logLevel = logLevel;
 
         StyledTextOutput textOutput = new TestStyledTextOutput();
         textOutputs.add(textOutput);
@@ -81,11 +84,5 @@ public class TestStyledTextOutputFactory extends AbstractStyledTextOutputFactory
      */
     public LogLevel getLogLevel() {
         return logLevel;
-    }
-
-    private void reset() {
-        textOutputs.clear();
-        category = null;
-        logLevel = null;
     }
 }

--- a/platforms/core-runtime/logging/src/testFixtures/groovy/org/gradle/internal/logging/text/TestStyledTextOutputFactory.java
+++ b/platforms/core-runtime/logging/src/testFixtures/groovy/org/gradle/internal/logging/text/TestStyledTextOutputFactory.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.logging.text;
 
 import org.gradle.api.logging.LogLevel;
+import org.gradle.util.internal.TextUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -69,7 +70,7 @@ public class TestStyledTextOutputFactory extends AbstractStyledTextOutputFactory
         for (StyledTextOutput textOutput: textOutputs) {
             builder.append(textOutput);
         }
-        return builder.toString();
+        return TextUtil.normaliseLineSeparators(builder.toString());
     }
 
     /**

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/AbstractTestLoggerTest.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/AbstractTestLoggerTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import org.gradle.internal.logging.text.TestStyledTextOutputFactory
 import org.gradle.util.internal.TextUtil
-
 import spock.lang.Specification
 
 class AbstractTestLoggerTest extends Specification {
@@ -44,7 +43,9 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(rootDescriptor, TestLogEvent.STARTED)
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{INFO}${sep}Test Run STARTED${sep}"
+        textOutputFactory.category == "TestEventLogger"
+        textOutputFactory.logLevel == LogLevel.INFO
+        textOutputFactory.output == "${sep}Test Run STARTED${sep}"
     }
 
     def "log Gradle worker event"() {
@@ -54,7 +55,9 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(workerDescriptor, TestLogEvent.STARTED)
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{INFO}${sep}Gradle Worker 2 STARTED${sep}"
+        textOutputFactory.category == "TestEventLogger"
+        textOutputFactory.logLevel == LogLevel.INFO
+        textOutputFactory.output == "${sep}Gradle Worker 2 STARTED${sep}"
     }
 
     def "log outer suite event"() {
@@ -64,7 +67,9 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(outerSuiteDescriptor, TestLogEvent.STARTED)
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{ERROR}${sep}OuterSuiteClass STARTED${sep}"
+        textOutputFactory.category == "TestEventLogger"
+        textOutputFactory.logLevel == LogLevel.ERROR
+        textOutputFactory.output == "${sep}OuterSuiteClass STARTED${sep}"
     }
 
     def "log inner suite event"() {
@@ -74,7 +79,9 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(innerSuiteDescriptor, TestLogEvent.PASSED)
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{QUIET}${sep}OuterSuiteClass > InnerSuiteClass {identifier}PASSED{normal}$sep"
+        textOutputFactory.category == "TestEventLogger"
+        textOutputFactory.logLevel == LogLevel.QUIET
+        textOutputFactory.output == "${sep}OuterSuiteClass > InnerSuiteClass {identifier}PASSED{normal}$sep"
 
     }
 
@@ -85,7 +92,9 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(classDescriptor, TestLogEvent.SKIPPED)
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{WARN}${sep}OuterSuiteClass > InnerSuiteClass > TestClass {info}SKIPPED{normal}${sep}"
+        textOutputFactory.category == "TestEventLogger"
+        textOutputFactory.logLevel == LogLevel.WARN
+        textOutputFactory.output == "${sep}OuterSuiteClass > InnerSuiteClass > TestClass {info}SKIPPED{normal}${sep}"
     }
 
     def "log test method event"() {
@@ -95,7 +104,9 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(methodDescriptor, TestLogEvent.FAILED)
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{LIFECYCLE}${sep}OuterSuiteClass > InnerSuiteClass > TestClass > a test {failure}FAILED{normal}${sep}"
+        textOutputFactory.category == "TestEventLogger"
+        textOutputFactory.logLevel == LogLevel.LIFECYCLE
+        textOutputFactory.output == "${sep}OuterSuiteClass > InnerSuiteClass > TestClass > a test {failure}FAILED{normal}${sep}"
     }
 
     def "log standard out event"() {
@@ -105,7 +116,7 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(methodDescriptor, TestLogEvent.STANDARD_OUT, "this is a${sep}standard out${sep}event")
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{INFO}${sep}OuterSuiteClass > InnerSuiteClass > TestClass > a test STANDARD_OUT${sep}this is a${sep}standard out${sep}event"
+        textOutputFactory.output == "${sep}OuterSuiteClass > InnerSuiteClass > TestClass > a test STANDARD_OUT${sep}this is a${sep}standard out${sep}event"
     }
 
     def "log standard error event"() {
@@ -115,7 +126,9 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(methodDescriptor, TestLogEvent.STANDARD_ERROR, "this is a${sep}standard error${sep}event")
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{DEBUG}${sep}OuterSuiteClass > InnerSuiteClass > TestClass > a test STANDARD_ERROR${sep}this is a${sep}standard error${sep}event"
+        textOutputFactory.category == "TestEventLogger"
+        textOutputFactory.logLevel == LogLevel.DEBUG
+        textOutputFactory.output == "${sep}OuterSuiteClass > InnerSuiteClass > TestClass > a test STANDARD_ERROR${sep}this is a${sep}standard error${sep}event"
     }
 
     def "log test method event with lowest display granularity"() {
@@ -125,7 +138,7 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(methodDescriptor, TestLogEvent.FAILED)
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{INFO}${sep}Test Run > Gradle Worker 2 > OuterSuiteClass > InnerSuiteClass > TestClass > a test {failure}FAILED{normal}${sep}"
+        textOutputFactory.output == "${sep}Test Run > Gradle Worker 2 > OuterSuiteClass > InnerSuiteClass > TestClass > a test {failure}FAILED{normal}${sep}"
     }
 
     def "log test method event with highest display granularity"() {
@@ -135,7 +148,7 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(methodDescriptor, TestLogEvent.FAILED)
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{INFO}${sep}a test {failure}FAILED{normal}${sep}"
+        textOutputFactory.output == "${sep}a test {failure}FAILED{normal}${sep}"
     }
 
     def "logging of atomic test whose ancestors don't have a test class"() {
@@ -147,7 +160,7 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(methodDescriptor, TestLogEvent.STARTED)
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{INFO}${sep}Tests > foo.bar.TestClass.a test STARTED${sep}"
+        textOutputFactory.output == "${sep}Tests > foo.bar.TestClass.a test STARTED${sep}"
     }
 
     def "logging of atomic test whose parent is a method"() {
@@ -159,7 +172,7 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(methodDescriptor, TestLogEvent.STARTED)
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{INFO}${sep}OuterSuiteClass > streamOfTests() > a test STARTED${sep}"
+        textOutputFactory.output == "${sep}OuterSuiteClass > streamOfTests() > a test STARTED${sep}"
     }
 
     def "logging of orphan atomic test"() {
@@ -170,7 +183,7 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(methodDescriptor, TestLogEvent.STARTED)
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{INFO}${sep}foo.bar.TestClass.a test STARTED${sep}"
+        textOutputFactory.output == "${sep}foo.bar.TestClass.a test STARTED${sep}"
     }
 
     def "logs header just once per batch of events with same type and for same test"() {
@@ -181,8 +194,8 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(methodDescriptor, TestLogEvent.STANDARD_OUT, "event 2")
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{INFO}${sep}OuterSuiteClass > InnerSuiteClass\
- > TestClass > a test STANDARD_OUT${sep}event 1{TestEventLogger}{INFO}event 2"
+        textOutputFactory.output == "${sep}OuterSuiteClass > InnerSuiteClass\
+ > TestClass > a test STANDARD_OUT${sep}event 1event 2"
     }
 
     void createLogger(LogLevel level, int displayGranularity = 2) {

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/AbstractTestLoggerTest.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/AbstractTestLoggerTest.groovy
@@ -20,12 +20,9 @@ import org.gradle.api.logging.LogLevel
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import org.gradle.internal.logging.text.TestStyledTextOutputFactory
-import org.gradle.util.internal.TextUtil
 import spock.lang.Specification
 
 class AbstractTestLoggerTest extends Specification {
-    static String sep = TextUtil.platformLineSeparator
-
     StyledTextOutputFactory textOutputFactory = new TestStyledTextOutputFactory()
     AbstractTestLogger logger
 
@@ -45,7 +42,9 @@ class AbstractTestLoggerTest extends Specification {
         then:
         textOutputFactory.category == "TestEventLogger"
         textOutputFactory.logLevel == LogLevel.INFO
-        textOutputFactory.output == "${sep}Test Run STARTED${sep}"
+        textOutputFactory.output == """
+Test Run STARTED
+"""
     }
 
     def "log Gradle worker event"() {
@@ -57,7 +56,9 @@ class AbstractTestLoggerTest extends Specification {
         then:
         textOutputFactory.category == "TestEventLogger"
         textOutputFactory.logLevel == LogLevel.INFO
-        textOutputFactory.output == "${sep}Gradle Worker 2 STARTED${sep}"
+        textOutputFactory.output == """
+Gradle Worker 2 STARTED
+"""
     }
 
     def "log outer suite event"() {
@@ -69,7 +70,9 @@ class AbstractTestLoggerTest extends Specification {
         then:
         textOutputFactory.category == "TestEventLogger"
         textOutputFactory.logLevel == LogLevel.ERROR
-        textOutputFactory.output == "${sep}OuterSuiteClass STARTED${sep}"
+        textOutputFactory.output == """
+OuterSuiteClass STARTED
+"""
     }
 
     def "log inner suite event"() {
@@ -81,7 +84,9 @@ class AbstractTestLoggerTest extends Specification {
         then:
         textOutputFactory.category == "TestEventLogger"
         textOutputFactory.logLevel == LogLevel.QUIET
-        textOutputFactory.output == "${sep}OuterSuiteClass > InnerSuiteClass {identifier}PASSED{normal}$sep"
+        textOutputFactory.output == """
+OuterSuiteClass > InnerSuiteClass {identifier}PASSED{normal}
+"""
 
     }
 
@@ -94,7 +99,9 @@ class AbstractTestLoggerTest extends Specification {
         then:
         textOutputFactory.category == "TestEventLogger"
         textOutputFactory.logLevel == LogLevel.WARN
-        textOutputFactory.output == "${sep}OuterSuiteClass > InnerSuiteClass > TestClass {info}SKIPPED{normal}${sep}"
+        textOutputFactory.output == """
+OuterSuiteClass > InnerSuiteClass > TestClass {info}SKIPPED{normal}
+"""
     }
 
     def "log test method event"() {
@@ -106,29 +113,45 @@ class AbstractTestLoggerTest extends Specification {
         then:
         textOutputFactory.category == "TestEventLogger"
         textOutputFactory.logLevel == LogLevel.LIFECYCLE
-        textOutputFactory.output == "${sep}OuterSuiteClass > InnerSuiteClass > TestClass > a test {failure}FAILED{normal}${sep}"
+        textOutputFactory.output == """
+OuterSuiteClass > InnerSuiteClass > TestClass > a test {failure}FAILED{normal}
+"""
     }
 
     def "log standard out event"() {
         createLogger(LogLevel.INFO)
 
         when:
-        logger.logEvent(methodDescriptor, TestLogEvent.STANDARD_OUT, "this is a${sep}standard out${sep}event")
+        logger.logEvent(methodDescriptor, TestLogEvent.STANDARD_OUT, """this is a
+standard out
+event""")
+
 
         then:
-        textOutputFactory.output == "${sep}OuterSuiteClass > InnerSuiteClass > TestClass > a test STANDARD_OUT${sep}this is a${sep}standard out${sep}event"
+        textOutputFactory.output == """
+OuterSuiteClass > InnerSuiteClass > TestClass > a test STANDARD_OUT
+this is a
+standard out
+event"""
     }
 
     def "log standard error event"() {
         createLogger(LogLevel.DEBUG)
 
         when:
-        logger.logEvent(methodDescriptor, TestLogEvent.STANDARD_ERROR, "this is a${sep}standard error${sep}event")
+        logger.logEvent(methodDescriptor, TestLogEvent.STANDARD_ERROR, """this is a
+standard error
+event""")
 
         then:
         textOutputFactory.category == "TestEventLogger"
         textOutputFactory.logLevel == LogLevel.DEBUG
-        textOutputFactory.output == "${sep}OuterSuiteClass > InnerSuiteClass > TestClass > a test STANDARD_ERROR${sep}this is a${sep}standard error${sep}event"
+        textOutputFactory.output == """
+OuterSuiteClass > InnerSuiteClass > TestClass > a test STANDARD_ERROR
+this is a
+standard error
+event"""
+
     }
 
     def "log test method event with lowest display granularity"() {
@@ -138,7 +161,9 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(methodDescriptor, TestLogEvent.FAILED)
 
         then:
-        textOutputFactory.output == "${sep}Test Run > Gradle Worker 2 > OuterSuiteClass > InnerSuiteClass > TestClass > a test {failure}FAILED{normal}${sep}"
+        textOutputFactory.output == """
+Test Run > Gradle Worker 2 > OuterSuiteClass > InnerSuiteClass > TestClass > a test {failure}FAILED{normal}
+"""
     }
 
     def "log test method event with highest display granularity"() {
@@ -148,7 +173,9 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(methodDescriptor, TestLogEvent.FAILED)
 
         then:
-        textOutputFactory.output == "${sep}a test {failure}FAILED{normal}${sep}"
+        textOutputFactory.output == """
+a test {failure}FAILED{normal}
+"""
     }
 
     def "logging of atomic test whose ancestors don't have a test class"() {
@@ -160,7 +187,9 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(methodDescriptor, TestLogEvent.STARTED)
 
         then:
-        textOutputFactory.output == "${sep}Tests > foo.bar.TestClass.a test STARTED${sep}"
+        textOutputFactory.output == """
+Tests > foo.bar.TestClass.a test STARTED
+"""
     }
 
     def "logging of atomic test whose parent is a method"() {
@@ -172,7 +201,9 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(methodDescriptor, TestLogEvent.STARTED)
 
         then:
-        textOutputFactory.output == "${sep}OuterSuiteClass > streamOfTests() > a test STARTED${sep}"
+        textOutputFactory.output == """
+OuterSuiteClass > streamOfTests() > a test STARTED
+"""
     }
 
     def "logging of orphan atomic test"() {
@@ -183,7 +214,9 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(methodDescriptor, TestLogEvent.STARTED)
 
         then:
-        textOutputFactory.output == "${sep}foo.bar.TestClass.a test STARTED${sep}"
+        textOutputFactory.output == """
+foo.bar.TestClass.a test STARTED
+"""
     }
 
     def "logs header just once per batch of events with same type and for same test"() {
@@ -194,8 +227,9 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(methodDescriptor, TestLogEvent.STANDARD_OUT, "event 2")
 
         then:
-        textOutputFactory.output == "${sep}OuterSuiteClass > InnerSuiteClass\
- > TestClass > a test STANDARD_OUT${sep}event 1event 2"
+        textOutputFactory.output == """
+OuterSuiteClass > InnerSuiteClass > TestClass > a test STANDARD_OUT
+event 1event 2"""
     }
 
     void createLogger(LogLevel level, int displayGranularity = 2) {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/DryRunBuildExecutionActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/DryRunBuildExecutionActionTest.groovy
@@ -43,7 +43,6 @@ class DryRunBuildExecutionActionTest extends Specification {
     def "print all selected tasks before proceeding when dry run is enabled"() {
         def task1 = Mock(TaskInternal.class)
         def task2 = Mock(TaskInternal.class)
-        def category = DryRunBuildExecutionAction.class.name
         def contents = Mock(QueryableExecutionPlan)
 
         given:
@@ -55,7 +54,8 @@ class DryRunBuildExecutionActionTest extends Specification {
         action.execute(gradle, executionPlan)
 
         then:
-        textOutputFactory.toString() == "{$category}:task1 {progressstatus}SKIPPED${EOL}{$category}:task2 {progressstatus}SKIPPED$EOL"
+        textOutputFactory.category == DryRunBuildExecutionAction.canonicalName
+        textOutputFactory.output == ":task1 {progressstatus}SKIPPED${EOL}:task2 {progressstatus}SKIPPED$EOL"
         1 * task1.getIdentityPath() >> Path.path(':task1')
         1 * task2.getIdentityPath() >> Path.path(':task2')
         0 * delegate.execute(_, _)

--- a/subprojects/core/src/test/groovy/org/gradle/execution/DryRunBuildExecutionActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/DryRunBuildExecutionActionTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.internal.TaskInternal
 import org.gradle.execution.plan.FinalizedExecutionPlan
 import org.gradle.execution.plan.QueryableExecutionPlan
-import org.gradle.internal.SystemProperties
 import org.gradle.internal.logging.text.TestStyledTextOutputFactory
 import org.gradle.util.Path
 import spock.lang.Specification
@@ -28,7 +27,7 @@ import spock.lang.Specification
 import static org.gradle.util.internal.WrapUtil.toList
 
 class DryRunBuildExecutionActionTest extends Specification {
-    private static final String EOL = SystemProperties.instance.lineSeparator
+
     def delegate = Mock(BuildWorkExecutor)
     def executionPlan = Mock(FinalizedExecutionPlan)
     def gradle = Mock(GradleInternal)
@@ -55,7 +54,9 @@ class DryRunBuildExecutionActionTest extends Specification {
 
         then:
         textOutputFactory.category == DryRunBuildExecutionAction.canonicalName
-        textOutputFactory.output == ":task1 {progressstatus}SKIPPED${EOL}:task2 {progressstatus}SKIPPED$EOL"
+        textOutputFactory.output == """:task1 {progressstatus}SKIPPED
+:task2 {progressstatus}SKIPPED
+"""
         1 * task1.getIdentityPath() >> Path.path(':task1')
         1 * task2.getIdentityPath() >> Path.path(':task2')
         0 * delegate.execute(_, _)

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildResultLoggerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildResultLoggerTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.internal.buildevents
 
 import org.gradle.BuildResult
+import org.gradle.api.logging.LogLevel
 import org.gradle.execution.WorkValidationWarningReporter
 import org.gradle.internal.logging.format.DurationFormatter
 import org.gradle.internal.logging.text.StyledTextOutputFactory
@@ -42,7 +43,9 @@ class BuildResultLoggerTest extends Specification {
 
         then:
         1 * durationFormatter.format(10L) >> { "10s" }
-        TextUtil.normaliseLineSeparators(textOutputFactory as String) == "{org.gradle.internal.buildevents.BuildResultLogger}{LIFECYCLE}\n{successheader}ACTION SUCCESSFUL{normal} in 10s\n"
+        textOutputFactory.category == BuildResultLogger.canonicalName
+        textOutputFactory.logLevel == LogLevel.LIFECYCLE
+        TextUtil.normaliseLineSeparators(textOutputFactory.output) == "\n{successheader}ACTION SUCCESSFUL{normal} in 10s\n"
     }
 
     def "logs build failure with total time"() {
@@ -52,6 +55,8 @@ class BuildResultLoggerTest extends Specification {
 
         then:
         1 * durationFormatter.format(10L) >> { "10s" }
-        TextUtil.normaliseLineSeparators(textOutputFactory as String) == "{org.gradle.internal.buildevents.BuildResultLogger}{ERROR}\n{failureheader}ACTION FAILED{normal} in 10s\n"
+        textOutputFactory.category == BuildResultLogger.canonicalName
+        textOutputFactory.logLevel == LogLevel.ERROR
+        TextUtil.normaliseLineSeparators(textOutputFactory.output) == "\n{failureheader}ACTION FAILED{normal} in 10s\n"
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildResultLoggerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildResultLoggerTest.groovy
@@ -23,7 +23,6 @@ import org.gradle.internal.logging.format.DurationFormatter
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import org.gradle.internal.logging.text.TestStyledTextOutputFactory
 import org.gradle.internal.time.Clock
-import org.gradle.util.internal.TextUtil
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -45,7 +44,9 @@ class BuildResultLoggerTest extends Specification {
         1 * durationFormatter.format(10L) >> { "10s" }
         textOutputFactory.category == BuildResultLogger.canonicalName
         textOutputFactory.logLevel == LogLevel.LIFECYCLE
-        TextUtil.normaliseLineSeparators(textOutputFactory.output) == "\n{successheader}ACTION SUCCESSFUL{normal} in 10s\n"
+        textOutputFactory.output == """
+{successheader}ACTION SUCCESSFUL{normal} in 10s
+"""
     }
 
     def "logs build failure with total time"() {
@@ -57,6 +58,8 @@ class BuildResultLoggerTest extends Specification {
         1 * durationFormatter.format(10L) >> { "10s" }
         textOutputFactory.category == BuildResultLogger.canonicalName
         textOutputFactory.logLevel == LogLevel.ERROR
-        TextUtil.normaliseLineSeparators(textOutputFactory.output) == "\n{failureheader}ACTION FAILED{normal} in 10s\n"
+        textOutputFactory.output == """
+{failureheader}ACTION FAILED{normal} in 10s
+"""
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/TaskExecutionStatisticsReporterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/TaskExecutionStatisticsReporterTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.internal.buildevents
 
 import org.gradle.api.internal.tasks.execution.statistics.TaskExecutionStatistics
+import org.gradle.api.logging.LogLevel
 import org.gradle.internal.logging.text.TestStyledTextOutputFactory
 import org.gradle.util.internal.TextUtil
 import spock.lang.Specification
@@ -32,7 +33,7 @@ class TaskExecutionStatisticsReporterTest extends Specification {
         reporter.buildFinished(new TaskExecutionStatistics(0, 0, 0))
 
         then:
-        (textOutputFactory as String) == ""
+        textOutputFactory.output == ""
         0 * _
     }
 
@@ -49,7 +50,9 @@ class TaskExecutionStatisticsReporterTest extends Specification {
         reporter.buildFinished(new TaskExecutionStatistics(1, 0, 0))
 
         then:
-        TextUtil.normaliseLineSeparators(textOutputFactory as String) == "{org.gradle.internal.buildevents.TaskExecutionStatisticsReporter}{LIFECYCLE}1 actionable task: 1 executed\n"
+        textOutputFactory.category == TaskExecutionStatisticsReporter.canonicalName
+        textOutputFactory.logLevel == LogLevel.LIFECYCLE
+        TextUtil.normaliseLineSeparators(textOutputFactory.output) == "1 actionable task: 1 executed\n"
     }
 
     def "reports only task counts > 0 (exec: #executed, from cache: #fromCache, up-to-date #upToDate)"() {
@@ -57,7 +60,7 @@ class TaskExecutionStatisticsReporterTest extends Specification {
         reporter.buildFinished(new TaskExecutionStatistics(executed, fromCache, upToDate))
 
         then:
-        TextUtil.normaliseLineSeparators(textOutputFactory as String) == "{org.gradle.internal.buildevents.TaskExecutionStatisticsReporter}{LIFECYCLE}$expected\n"
+        TextUtil.normaliseLineSeparators(textOutputFactory.output) == "$expected\n"
 
         where:
         executed | fromCache | upToDate | expected

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/TaskExecutionStatisticsReporterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/TaskExecutionStatisticsReporterTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.internal.buildevents
 import org.gradle.api.internal.tasks.execution.statistics.TaskExecutionStatistics
 import org.gradle.api.logging.LogLevel
 import org.gradle.internal.logging.text.TestStyledTextOutputFactory
-import org.gradle.util.internal.TextUtil
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -52,7 +51,8 @@ class TaskExecutionStatisticsReporterTest extends Specification {
         then:
         textOutputFactory.category == TaskExecutionStatisticsReporter.canonicalName
         textOutputFactory.logLevel == LogLevel.LIFECYCLE
-        TextUtil.normaliseLineSeparators(textOutputFactory.output) == "1 actionable task: 1 executed\n"
+        textOutputFactory.output == """1 actionable task: 1 executed
+"""
     }
 
     def "reports only task counts > 0 (exec: #executed, from cache: #fromCache, up-to-date #upToDate)"() {
@@ -60,7 +60,8 @@ class TaskExecutionStatisticsReporterTest extends Specification {
         reporter.buildFinished(new TaskExecutionStatistics(executed, fromCache, upToDate))
 
         then:
-        TextUtil.normaliseLineSeparators(textOutputFactory.output) == "$expected\n"
+        textOutputFactory.output == """$expected
+"""
 
         where:
         executed | fromCache | upToDate | expected


### PR DESCRIPTION
This makes it easier to assert separately on the
output, category and log level.

Previously, this was all mixed into/encoded in the output itself.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
