### PR TITLE
Improve stacktrace for calculating kotlin script classpath

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
@@ -17,6 +17,7 @@
 package org.gradle.kotlin.dsl.execution
 
 import com.google.common.annotations.VisibleForTesting
+import org.gradle.api.GradleException
 import org.gradle.api.GradleScriptException
 import org.gradle.api.Project
 import org.gradle.api.initialization.Settings
@@ -264,6 +265,14 @@ class Interpreter(val host: Host) {
         }
 
         val scriptPath = scriptHost.fileName
+
+        val parentCompileClasspath: ClassPath
+        try {
+             parentCompileClasspath = host.compilationClassPathOf(targetScope.parent)
+        } catch (e: Exception) {
+            throw GradleException("Failed to compute compilation classpath for script $scriptPath", e)
+        }
+
         val classesDir = compile(
             scriptHost,
             programId,
@@ -271,7 +280,7 @@ class Interpreter(val host: Host) {
             scriptSource,
             programKind,
             programTarget,
-            host.compilationClassPathOf(targetScope.parent),
+            parentCompileClasspath,
             stage1BlocksAccessorsClassPath,
             scriptHost.temporaryFileProvider
         )

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
@@ -121,7 +121,7 @@ class KotlinScriptClassPathProvider(
     internal
     fun exportClassPathFromHierarchyOf(scope: ClassLoaderScope): ClassPath {
         require(scope.isLocked) {
-            "$scope must be locked before it can be used to compute a classpath!"
+            "${scope.id} must be locked before it can be used to compute a classpath!"
         }
         val exportedClassPath = cachedClassLoaderClassPath.of(scope.exportClassLoader)
         return DefaultClassPath.of(exportedClassPath - gradleImplementationClassPath)


### PR DESCRIPTION
These changes should print more info to debug issues computing script classpaths

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
