### PR TITLE
Upgrade to latest wrapper

### DIFF
--- a/build-logic-commons/build-platform/build.gradle.kts
+++ b/build-logic-commons/build-platform/build.gradle.kts
@@ -23,7 +23,7 @@ val kotlinVersion = providers.gradleProperty("buildKotlinVersion")
 
 dependencies {
     constraints {
-        api("org.gradle.guides:gradle-guides-plugin:0.23")
+        api("org.gradle.guides:gradle-guides-plugin:0.23.1")
         api("org.apache.ant:ant:1.10.15") // Bump the version brought in transitively by gradle-guides-plugin
         api("com.gradle:develocity-gradle-plugin:3.18.2") // Run `java build-logic-settings/UpdateDevelocityPluginVersion.java <new-version>` to update
         api("com.gradle.publish:plugin-publish-plugin:1.2.1")

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -1403,9 +1403,9 @@
             <sha256 value="5ef4102929b54c1b368be19178475c941bff09322c838484bb4dee66b6649419" reason="Artifact is not signed"/>
          </artifact>
       </component>
-      <component group="org.gradle.guides" name="gradle-guides-plugin" version="0.23">
-         <artifact name="gradle-guides-plugin-0.23.jar">
-            <sha256 value="d645e5bf6fdd881541e085289e28fa298b64ac8d208a006ac649756074732a6f" origin="Verified" reason="Artifact is not signed"/>
+      <component group="org.gradle.guides" name="gradle-guides-plugin" version="0.23.1">
+         <artifact name="gradle-guides-plugin-0.23.1.jar">
+            <sha256 value="e2945335aadc5d6e9307d9daf57fc3b2fc19f6d933445cc8d47bab1d7d48adc1" origin="Verified" reason="Artifact is not signed"/>
          </artifact>
       </component>
       <component group="org.gradle.kotlin" name="plugins" version="1.3.6">

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.12-20241015195452+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.12-20241126002544+0000-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This PR upgrades wrapper to latest nightly. Also, it integrates https://github.com/gradle/guides/pull/419 to fix the error:

```
* What went wrong:
A problem was found with the configuration of task ':docs:installSampleBuildingCppApplicationsGroovy' (type 'InstallSample').
  - Method 'doInstall' is private and annotated with @TaskAction.

    Reason: Annotations on private methods are ignored.

    Possible solutions:
      1. Make the method public.
      2. Annotate the public version of the method.

    For more information, please refer to https://docs.gradle.org/8.12-20241101011813+0000/userguide/validation_problems.html#private_method_must_not_be_annotated in the Gradle documentation.
```