### PR TITLE
In `DefaultProblemSummarizer` use `merge` instead of `compute`

### DIFF
--- a/platforms/ide/problems/src/main/java/org/gradle/problems/internal/services/DefaultProblemSummarizer.java
+++ b/platforms/ide/problems/src/main/java/org/gradle/problems/internal/services/DefaultProblemSummarizer.java
@@ -98,10 +98,7 @@ public class DefaultProblemSummarizer implements ProblemSummarizer {
     }
 
     private boolean exceededThreshold(Problem problem) {
-        int count = seenProblemsWithCounts.compute(
-            problem.getDefinition().getId(),
-            (key, value) -> value == null ? 1 : value + 1
-        );
+        int count = seenProblemsWithCounts.merge(problem.getDefinition().getId(), 1, Integer::sum);
         return count > threshold;
     }
 }


### PR DESCRIPTION
Addressing the lost comment in #31373

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
