### PR TITLE
Fix invalid class generated when extracting ABI from non-static inner-class

### DIFF
--- a/build-logic/java-api-extractor/src/main/java/org/gradle/internal/tools/api/ApiMemberWriter.java
+++ b/build-logic/java-api-extractor/src/main/java/org/gradle/internal/tools/api/ApiMemberWriter.java
@@ -40,7 +40,7 @@ public interface ApiMemberWriter {
 
     void writeClass(ClassMember classMember, Set<MethodMember> methods, Set<FieldMember> fields, Set<InnerClassMember> innerClasses);
 
-    void writeMethod(MethodMember method);
+    void writeMethod(/* Nullable */ InnerClassMember declaringInnerClass, MethodMember method);
 
     void writeClassAnnotations(Set<AnnotationMember> annotationMembers);
 

--- a/build-logic/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/JavaApiMemberWriter.java
+++ b/build-logic/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/JavaApiMemberWriter.java
@@ -87,6 +87,7 @@ public class JavaApiMemberWriter implements ApiMemberWriter {
         // Without this parameter annotations for non-static inner class constructors would
         // end up having one more parameter than they should, because the first parameter
         // (pointing to `this` of the enclosing type) should not be listed.
+        // See https://gitlab.ow2.org/asm/asm/-/issues/318023
         if (method.getSignature() != null) {
             int parameterCount = SignatureParameterCounter.countParameters(method.getSignature());
             mv.visitAnnotableParameterCount(parameterCount, true);

--- a/build-logic/java-api-extractor/src/test/groovy/org/gradle/internal/tools/api/ApiClassExtractorInnerClassTest.groovy
+++ b/build-logic/java-api-extractor/src/test/groovy/org/gradle/internal/tools/api/ApiClassExtractorInnerClassTest.groovy
@@ -166,22 +166,26 @@ class ApiClassExtractorInnerClassTest extends ApiClassExtractorTestSupport {
             'Outer': '''
                 public class Outer {
                    public class NonStaticInner {
-                       public NonStaticInner(@Nullable String name) {
+                       public NonStaticInner(@RuntimeVisible @RuntimeInvisible String name) {
                            // Constructor
                        }
                    }
 
                    public static class StaticInner {
-                       public StaticInner(@Nullable String name) {
+                       public StaticInner(@RuntimeVisible @RuntimeInvisible String name) {
                            // Constructor
                        }
                    }
                 }
             ''',
-            'Nullable': '''
+            'RuntimeVisible': '''
                 @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
-                public @interface Nullable {}
-            '''
+                public @interface RuntimeVisible {}
+            ''',
+            'RuntimeInvisible': '''
+                @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.CLASS)
+                public @interface RuntimeInvisible {}
+            ''',
         ])
 
         def apiStubDir = new File(temporaryFolder, "api-stubs")

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/normalization/KotlinApiMemberWriter.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/normalization/KotlinApiMemberWriter.kt
@@ -81,11 +81,11 @@ class KotlinApiMemberWriter private constructor(apiMemberAdapter: ClassVisitor) 
         super.writeClassAnnotations(annotationMembers.filter { it.name != kotlinMetadataAnnotationSignature }.toSet())
     }
 
-    override fun writeMethod(method: MethodMember) {
+    override fun writeMethod(declaringInnerClass: InnerClassMember?, method: MethodMember) {
         when {
             method.isInternal() -> return
             method.isInline() -> throw publicInlineFunction(method)
-            else -> super.writeMethod(method)
+            else -> super.writeMethod(declaringInnerClass, method)
         }
     }
 

--- a/testing/architecture-test/src/changes/archunit-store/internal-api-nullability.txt
+++ b/testing/architecture-test/src/changes/archunit-store/internal-api-nullability.txt
@@ -2657,7 +2657,6 @@ Class <org.gradle.internal.tools.api.impl.ClassMember> is not annotated (directl
 Class <org.gradle.internal.tools.api.impl.EnumAnnotationValue> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (EnumAnnotationValue.java:0)
 Class <org.gradle.internal.tools.api.impl.FieldMember> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (FieldMember.java:0)
 Class <org.gradle.internal.tools.api.impl.InnerClassMember> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (InnerClassMember.java:0)
-Class <org.gradle.internal.tools.api.impl.JavaApiMemberWriter$SignatureParameterCounter> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (JavaApiMemberWriter.java:0)
 Class <org.gradle.internal.tools.api.impl.JavaApiMemberWriter> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (JavaApiMemberWriter.java:0)
 Class <org.gradle.internal.tools.api.impl.Member> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (Member.java:0)
 Class <org.gradle.internal.tools.api.impl.MethodMember> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (MethodMember.java:0)

--- a/testing/architecture-test/src/changes/archunit-store/internal-api-nullability.txt
+++ b/testing/architecture-test/src/changes/archunit-store/internal-api-nullability.txt
@@ -2657,6 +2657,7 @@ Class <org.gradle.internal.tools.api.impl.ClassMember> is not annotated (directl
 Class <org.gradle.internal.tools.api.impl.EnumAnnotationValue> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (EnumAnnotationValue.java:0)
 Class <org.gradle.internal.tools.api.impl.FieldMember> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (FieldMember.java:0)
 Class <org.gradle.internal.tools.api.impl.InnerClassMember> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (InnerClassMember.java:0)
+Class <org.gradle.internal.tools.api.impl.JavaApiMemberWriter$SignatureParameterCounter> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (JavaApiMemberWriter.java:0)
 Class <org.gradle.internal.tools.api.impl.JavaApiMemberWriter> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (JavaApiMemberWriter.java:0)
 Class <org.gradle.internal.tools.api.impl.Member> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (Member.java:0)
 Class <org.gradle.internal.tools.api.impl.MethodMember> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (MethodMember.java:0)


### PR DESCRIPTION
Fixes #31416

This fixes the problem with non-static inner-class constructors where the constructor would end up having one more `RuntimeVisibleAnnotations` entry recorded, causing compilation errors when trying to compile against the extracted class.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
