### PR TITLE
Relax `Task.usesService` requirement for 8.12

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheBuildServiceIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheBuildServiceIntegrationTest.groovy
@@ -244,7 +244,6 @@ class ConfigurationCacheBuildServiceIntegrationTest extends AbstractConfiguratio
             pluginManagement {
                 includeBuild 'counting-service-plugin'
             }
-            enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
         """
         file('build.gradle') << """
             plugins { id 'counting-service-plugin' version '1.0' }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
@@ -90,7 +90,7 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
         given:
         serviceImplementation()
         adhocTaskUsingUndeclaredService(1)
-        enableStableConfigurationCache()
+        enableServiceUsageDeclaration()
         executer.expectDocumentedDeprecationWarning(
             "Build service 'counter' is being used by task ':broken' without the corresponding declaration via 'Task#usesService'. " +
                 "This behavior has been deprecated. " +
@@ -139,7 +139,7 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
                 // reference will be set by name
             }
         """
-        enableStableConfigurationCache()
+        enableServiceUsageDeclaration()
         executer.expectDocumentedDeprecationWarning(
             "Build service 'counter' is being used by task ':broken' without the corresponding declaration via 'Task#usesService'. " +
                 "This behavior has been deprecated. " +
@@ -215,7 +215,7 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
         """
         file("src/main/java").createDir()
         file("src/main/java/Foo.java").createFile().text = """class Foo {}"""
-        enableStableConfigurationCache()
+        enableServiceUsageDeclaration()
         // should not be expected
         executer.expectDocumentedDeprecationWarning(
             "Build service 'counter' is being used by task ':compileJava' without the corresponding declaration via 'Task#usesService'. " +
@@ -255,7 +255,7 @@ service: closed with value 11
                 }
             }
         """
-        enableStableConfigurationCache()
+        enableServiceUsageDeclaration()
 
         when:
         succeeds 'explicit'
@@ -298,7 +298,7 @@ service: closed with value 11
                 }
             }
         """
-        enableStableConfigurationCache()
+        enableServiceUsageDeclaration()
 
         when:
         succeeds 'named'
@@ -334,7 +334,7 @@ service: closed with value 11
                 }
             }
         """
-        enableStableConfigurationCache()
+        enableServiceUsageDeclaration()
 
         when:
         succeeds 'named'
@@ -378,7 +378,7 @@ service: closed with value 11
                 }
             }
         """
-        enableStableConfigurationCache()
+        enableServiceUsageDeclaration()
 
         when:
         fails 'ambiguous'
@@ -416,7 +416,7 @@ service: closed with value 11
                 }
             }
         """
-        enableStableConfigurationCache()
+        enableServiceUsageDeclaration()
 
         when:
         succeeds 'unambiguous'
@@ -450,7 +450,7 @@ service: closed with value 11
                 usesService(counterProvider2)
             }
         """
-        enableStableConfigurationCache()
+        enableServiceUsageDeclaration()
 
         when:
         succeeds 'named'
@@ -479,7 +479,7 @@ service: closed with value 10001
                 counter.get().increment()
             }
         """
-        enableStableConfigurationCache()
+        enableServiceUsageDeclaration()
 
         when:
         succeeds 'named'
@@ -512,7 +512,7 @@ service: closed with value 12
             }
             task missingRequiredService(type: Consumer) {}
         """
-        enableStableConfigurationCache()
+        enableServiceUsageDeclaration()
 
         when:
         fails 'missingRequiredService'
@@ -541,7 +541,7 @@ service: closed with value 12
             }
             task missingOptionalService(type: Consumer) {}
         """
-        enableStableConfigurationCache()
+        enableServiceUsageDeclaration()
 
         when:
         succeeds 'missingOptionalService'
@@ -567,7 +567,7 @@ service: closed with value 12
                 // expect service to be injected by name (it won't though)
             }
         """
-        enableStableConfigurationCache()
+        enableServiceUsageDeclaration()
 
         when:
         fails 'missingService'
@@ -591,7 +591,7 @@ service: closed with value 12
             }
             task invalidServiceType(type: Consumer) {}
         """
-        enableStableConfigurationCache()
+        enableServiceUsageDeclaration()
 
         when:
         fails 'invalidServiceType'
@@ -1700,9 +1700,9 @@ Hello, subproject1
         succeeds("hello")
     }
 
-    private void enableStableConfigurationCache() {
+    private void enableServiceUsageDeclaration() {
         settingsFile '''
-            enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
+            enableFeaturePreview "${org.gradle.api.internal.FeaturePreviews.Feature.INTERNAL_BUILD_SERVICE_USAGE}"
         '''
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
@@ -29,7 +29,17 @@ public class FeaturePreviews {
     public enum Feature implements FeatureFlag {
         GROOVY_COMPILATION_AVOIDANCE(true, null),
         TYPESAFE_PROJECT_ACCESSORS(true, null),
-        STABLE_CONFIGURATION_CACHE(true, "org.gradle.configuration-cache.stable");
+        STABLE_CONFIGURATION_CACHE(true, "org.gradle.configuration-cache.stable"),
+        /**
+         * When enabled, service usage must be explicitly declared, or deprecation warnings will be issued.
+         * <p>
+         *     This functionality used to be behind {@link #STABLE_CONFIGURATION_CACHE}, but since it triggers false
+         *     positives and does not cover several required scenarios
+         *     (services used by work that is not tasks, services used at configuration time),
+         *     it is now behind a specific (internal) feature, used only by some internal tests.
+         * </p>
+         */
+        INTERNAL_BUILD_SERVICE_USAGE(true, null);
 
         public static Feature withName(String name) {
             try {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -789,7 +789,7 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
             listenerManager,
             isolatableFactory,
             sharedResourceLeaseRegistry,
-            featureFlags.isEnabled(FeaturePreviews.Feature.STABLE_CONFIGURATION_CACHE)
+            featureFlags.isEnabled(FeaturePreviews.Feature.INTERNAL_BUILD_SERVICE_USAGE)
                 ? new BuildServiceProviderNagger(services.get(WorkExecutionTracker.class))
                 : BuildServiceProvider.Listener.EMPTY
         );


### PR DESCRIPTION
until we can provide proper ways for non-task work to declare service usage.

Issue: #31140

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
