### PR TITLE
Replace winning module of conflict first before losing modules

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ReplaceSelectionWithConflictResultAction.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ReplaceSelectionWithConflictResultAction.java
@@ -32,7 +32,7 @@ class ReplaceSelectionWithConflictResultAction implements Action<ConflictResolut
             // Restart each configuration. For the evicted configuration, this means moving incoming dependencies across to the
             // matching selected configuration. For the select configuration, this mean traversing its dependencies.
             resolveState.getModule(moduleIdentifier).replaceWith(result.getSelected());
-        });
+        }, result);
     }
 
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/ConflictResolutionResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/ConflictResolutionResult.java
@@ -24,9 +24,11 @@ public interface ConflictResolutionResult {
 
     /**
      * Performs an action on all conflicting modules.
+     *
      * @param action the action to execute on each participating module
+     * @param result the result of the conflict, with the winning node
      */
-    void withParticipatingModules(Action<? super ModuleIdentifier> action);
+    void withParticipatingModules(Action<? super ModuleIdentifier> action, ConflictResolutionResult result);
 
     /**
      * The actual selected component.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
@@ -268,8 +268,15 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
         }
 
         @Override
-        public void withParticipatingModules(Action<? super ModuleIdentifier> action) {
+        public void withParticipatingModules(Action<? super ModuleIdentifier> action, ConflictResolutionResult result) {
             Set<ModuleIdentifier> seen = new HashSet<>();
+
+            // Visit the winning module first so that when we visit unattached dependencies of
+            // losing modules, the winning module always has a selected component.
+            ModuleIdentifier winningModule = result.getSelected().getModule().getId();
+            action.execute(winningModule);
+            seen.add(winningModule);
+
             for (NodeState node : conflict.nodes) {
                 ModuleIdentifier module = node.getComponent().getId().getModule();
                 if (seen.add(module)) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictResolutionResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictResolutionResult.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflic
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.ComponentState;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.ModuleResolveState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.NodeState;
 
 import java.util.Collection;
@@ -53,9 +54,14 @@ class DefaultConflictResolutionResult implements ConflictResolutionResult {
     }
 
     @Override
-    public void withParticipatingModules(Action<? super ModuleIdentifier> action) {
+    public void withParticipatingModules(Action<? super ModuleIdentifier> action, ConflictResolutionResult result) {
+        ModuleResolveState winningModule = result.getSelected().getModule();
+        action.execute(winningModule.getId());
+
         for (ModuleIdentifier module : participatingModules) {
-            action.execute(module);
+            if (!module.equals(winningModule.getId())) {
+                action.execute(module);
+            }
         }
     }
 


### PR DESCRIPTION
Visit the winning module first so that when we visit unattached dependencies of losing modules, the winning module always has a selected component.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
