### PR TITLE
Improve console output if build fails with Problems API report

### DIFF
--- a/platforms/ide/problems-rendering/build.gradle.kts
+++ b/platforms/ide/problems-rendering/build.gradle.kts
@@ -22,6 +22,8 @@ description = "Problems API rendering infrastructure"
 
 dependencies {
     api(projects.problemsApi)
+    implementation(libs.guava)
+    implementation(projects.baseServices)
 
     integTestImplementation(projects.internalTesting)
     integTestImplementation(testFixtures(projects.logging))

--- a/platforms/ide/problems-rendering/src/main/java/org/gradle/problems/internal/rendering/ProblemRenderer.java
+++ b/platforms/ide/problems-rendering/src/main/java/org/gradle/problems/internal/rendering/ProblemRenderer.java
@@ -56,7 +56,12 @@ public class ProblemRenderer {
     }
 
     static void renderProblemGroup(PrintWriter output, ProblemId id, List<Problem> groupedProblems) {
-        groupedProblems.forEach(problem -> renderProblem(output, problem));
+        String sep = "";
+        for (Problem problem : groupedProblems) {
+            output.printf(sep);
+            renderProblem(output, problem);
+            sep = "%n";
+        }
     }
 
     static void renderProblem(PrintWriter output, Problem problem) {
@@ -70,6 +75,7 @@ public class ProblemRenderer {
                 formatMultiline(output, problem.getDefinition().getId().getDisplayName(), 1);
             }
             if (problem.getDetails() != null) {
+                output.printf("%n");
                 formatMultiline(output, problem.getDetails(), 2);
             }
         }
@@ -79,11 +85,16 @@ public class ProblemRenderer {
         if (message == null) {
             return;
         }
-        for (String line : message.split("\n")) {
-            for (int i = 0; i < level; i++) {
+        String[] lines = message.split("\n");
+        for (int i = 0; i < lines.length; i++) {
+            for (int j = 0; j < level; j++) {
                 output.print("  ");
             }
-            output.printf("%s%n", line);
+            if (i == lines.length - 1) { // don't print extra newline at the end of the last line
+                output.printf("%s", lines[i]);
+            } else {
+                output.printf("%s%n", lines[i]);
+            }
         }
     }
 }

--- a/platforms/ide/problems-rendering/src/main/java/org/gradle/problems/internal/rendering/ProblemRenderer.java
+++ b/platforms/ide/problems-rendering/src/main/java/org/gradle/problems/internal/rendering/ProblemRenderer.java
@@ -16,10 +16,12 @@
 
 package org.gradle.problems.internal.rendering;
 
+import com.google.common.base.Strings;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.Problem;
+import org.gradle.util.internal.TextUtil;
 
 import java.io.PrintWriter;
 import java.io.Writer;
@@ -85,16 +87,9 @@ public class ProblemRenderer {
         if (message == null) {
             return;
         }
-        String[] lines = message.split("\n");
-        for (int i = 0; i < lines.length; i++) {
-            for (int j = 0; j < level; j++) {
-                output.print("  ");
-            }
-            if (i == lines.length - 1) { // don't print extra newline at the end of the last line
-                output.printf("%s", lines[i]);
-            } else {
-                output.printf("%s%n", lines[i]);
-            }
-        }
+        @SuppressWarnings("InlineMeInliner")
+        String prefix = Strings.repeat(" ", level * 2);
+        String formatted = TextUtil.indent(message, prefix);
+        output.print(formatted);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -419,6 +419,7 @@ public class BuildExceptionReporter implements Action<Throwable> {
                 if (throwable instanceof CompilationFailedIndicator) {
                     String diagnosticCounts = ((CompilationFailedIndicator) throwable).getDiagnosticCounts();
                     if (diagnosticCounts != null) {
+                        builder.append(System.lineSeparator());
                         builder.append(diagnosticCounts);
                     }
                 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle/issues/31434

If the build fails via an exception thrown via the Problems API similar to this:
```java
public abstract class FailingTask extends org.gradle.api.DefaultTask {

    @Inject
    public abstract Problems getProblems();

    @TaskAction
    public void run() {
        throw getProblems().getReporter().throwing(problemSpec -> {
            problemSpec.id("sample-error", "Sample Error");
            problemSpec.contextualLabel("This happened because ProblemReporter.throwing() was called\nSecond line in contextual label");
            problemSpec.details("I'm testing details\nsecond details\nthird details");
            problemSpec.documentedAt("https://example.com/docs");
            problemSpec.withException(new RuntimeException("Boom, runtime exception\nSecond line for exception message"));
            problemSpec.solution("Remove the Problems.throwing() method call from the task action");
        });
    }
}
```

Then the build failure will contain details from the problem report:
- no extra newline before the ` * Try` section
- if solutions are provided in the problem report then the generic resolutions are omitted

```
gradle :sample-project:sub-a:myFT
> Task :sample-project:sub-a:myFailingTask FAILED

[Incubating] Problems report is available at: file:///Users/donat/Development/sample/problems-api-sample/build/reports/problems/problems-report.html

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':sample-project:sub-a:myFailingTask'.
> Boom, runtime exception
  Second line for exception message
    This happened because ProblemReporter.throwing() was called
    Second line in contextual label
      I'm testing details
      second details
      third details

* Try:
> Remove the Problems.throwing() method call from the task action
> Run with --scan to get full insights.

BUILD FAILED in 535ms
16 actionable tasks: 3 executed, 13 up-to-date
```

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
