### PR TITLE
Fix invalid class generated when extracting ABI from enum type

### DIFF
--- a/build-logic/java-api-extractor/src/main/java/org/gradle/internal/tools/api/ApiMemberWriter.java
+++ b/build-logic/java-api-extractor/src/main/java/org/gradle/internal/tools/api/ApiMemberWriter.java
@@ -40,7 +40,7 @@ public interface ApiMemberWriter {
 
     void writeClass(ClassMember classMember, Set<MethodMember> methods, Set<FieldMember> fields, Set<InnerClassMember> innerClasses);
 
-    void writeMethod(/* Nullable */ InnerClassMember declaringInnerClass, MethodMember method);
+    void writeMethod(ClassMember classMember, /* Nullable */ InnerClassMember declaringInnerClass, MethodMember method);
 
     void writeClassAnnotations(Set<AnnotationMember> annotationMembers);
 

--- a/build-logic/java-api-extractor/src/test/groovy/org/gradle/internal/tools/api/ApiClassExtractorInnerClassTest.groovy
+++ b/build-logic/java-api-extractor/src/test/groovy/org/gradle/internal/tools/api/ApiClassExtractorInnerClassTest.groovy
@@ -189,9 +189,8 @@ class ApiClassExtractorInnerClassTest extends ApiClassExtractorTestSupport {
         ])
 
         def apiStubDir = new File(temporaryFolder, "api-stubs")
-        apiStubDir.mkdirs()
         ['Outer', 'Outer$NonStaticInner', 'Outer$StaticInner'].each {
-            new File(apiStubDir, "${it}.class").bytes = api.extractApiClassFrom(api.classes[it])
+            writeClass(api, it, apiStubDir)
         }
 
         when:

--- a/build-logic/java-api-extractor/src/test/groovy/org/gradle/internal/tools/api/ApiClassExtractorTestSupport.groovy
+++ b/build-logic/java-api-extractor/src/test/groovy/org/gradle/internal/tools/api/ApiClassExtractorTestSupport.groovy
@@ -176,6 +176,14 @@ class ApiClassExtractorTestSupport extends Specification {
         toApi([(fqn): script]).classes[fqn]
     }
 
+    @CompileStatic
+    protected static File writeClass(ClassContainer container, name, File targetDir) {
+        targetDir.mkdirs()
+        def classFile = new File(targetDir, "${name}.class")
+        classFile.bytes = container.extractApiClassFrom(container.classes[name])
+        return classFile
+    }
+
     protected void noSuchMethod(Class c, String name, Class... argTypes) {
         try {
             c.getDeclaredMethod(name, argTypes)

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/normalization/KotlinApiMemberWriter.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/normalization/KotlinApiMemberWriter.kt
@@ -81,11 +81,15 @@ class KotlinApiMemberWriter private constructor(apiMemberAdapter: ClassVisitor) 
         super.writeClassAnnotations(annotationMembers.filter { it.name != kotlinMetadataAnnotationSignature }.toSet())
     }
 
-    override fun writeMethod(declaringInnerClass: InnerClassMember?, method: MethodMember) {
+    override fun writeMethod(
+        classMember: ClassMember,
+        declaringInnerClass: InnerClassMember?,
+        method: MethodMember
+    ) {
         when {
             method.isInternal() -> return
             method.isInline() -> throw publicInlineFunction(method)
-            else -> super.writeMethod(declaringInnerClass, method)
+            else -> super.writeMethod(classMember, declaringInnerClass, method)
         }
     }
 


### PR DESCRIPTION
Fixes #31436

This fixes the problem with annotated enum constructors where the constructor would end up having one more `RuntimeVisibleAnnotations` entry recorded, causing compilation errors when trying to compile against the extracted class.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
