### PR TITLE
Auto update & test wrapper daily

### DIFF
--- a/.github/workflows/upgradle-to-latest-wrapper.yml
+++ b/.github/workflows/upgradle-to-latest-wrapper.yml
@@ -1,0 +1,44 @@
+name: Upgradle to latest wrapper
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  upgradle-latest-wrapper:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: bot/upgradle-to-latest-wrapper
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+      - name: Setup java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Updadle to latest nightly and push to bot/upgradle-to-latest-wrapper
+        run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
+          git reset origin/master --hard
+
+          ./gradlew wrapper --gradle-version=nightly
+
+          if ! git diff --quiet; then
+            ./gradlew -v 
+            VERSION=$(./gradlew -v | grep "Gradle" | cut -d' ' -f2)
+            git add .
+            git commit -m "Update Gradle wrapper to $VERSION"
+            git push --force origin bot/upgradle-to-latest-wrapper
+          else
+            echo "No changes to commit"
+          fi


### PR DESCRIPTION
We've been bitten a lot of times by "upgrading wrapper then something breaks" issue. To capture the issue earlier, this PR does:

Everyday ~4am UTC, we run `./gradlew wrapper --nightly` on `master`, and push to `bot/upgradle-to-latest-wrapper` if there's any change.

Then, TeamCity will see this branch and triggers a ReadyForNightly build.