### PR TITLE
Implicitly cast ints to longs for Property types

### DIFF
--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
@@ -380,6 +380,32 @@ assert custom.prop.get() == "value 4"
         succeeds()
     }
 
+    def "can set Long property value using an Integer"() {
+        given:
+        buildFile << """
+            interface SomeExtension {
+                Property<Long> getProp()
+            }
+
+            extensions.create('custom', SomeExtension)
+            custom.prop = 1
+            assert custom.prop.get() == 1L
+
+            custom.prop = providers.provider { 2 }
+            assert custom.prop.get() == 2L
+
+            custom.prop = null
+            custom.prop.convention(3)
+            assert custom.prop.get() == 3L
+
+            custom.prop.convention(providers.provider { 4 })
+            assert custom.prop.get() == 4L
+        """
+
+        expect:
+        succeeds()
+    }
+
     @Requires(
         value = IntegTestPreconditions.NotConfigCached,
         reason = "Config cache does not support extensions during execution, leading to 'Could not get unknown property 'custom' for task ':wrongValueTypeDsl' of type org.gradle.api.DefaultTask."

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueSanitizers.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueSanitizers.java
@@ -34,6 +34,19 @@ public class ValueSanitizers {
             }
         }
     };
+
+    private static final ValueSanitizer<Object> IMPLICIT_CAST_TO_LONG_SANITIZER = new ValueSanitizer<Object>() {
+        @Override
+        @Nullable
+        public Object sanitize(@Nullable Object value) {
+            if (value instanceof Integer) {
+                return ((Integer) value).longValue();
+            } else {
+                return value;
+            }
+        }
+    };
+
     private static final ValueSanitizer<Object> IDENTITY_SANITIZER = new ValueSanitizer<Object>() {
         @Override
         @Nullable
@@ -41,6 +54,7 @@ public class ValueSanitizers {
             return value;
         }
     };
+
     private static final ValueCollector<Object> IDENTITY_VALUE_COLLECTOR = new ValueCollector<Object>() {
         @Override
         public void add(@Nullable Object value, ImmutableCollection.Builder<Object> dest) {
@@ -52,6 +66,7 @@ public class ValueSanitizers {
             dest.addAll(values);
         }
     };
+
     private static final ValueCollector<Object> STRING_VALUE_COLLECTOR = new ValueCollector<Object>() {
         @Override
         public void add(@Nullable Object value, ImmutableCollection.Builder<Object> dest) {
@@ -69,6 +84,8 @@ public class ValueSanitizers {
     public static <T> ValueSanitizer<T> forType(Class<? extends T> targetType) {
         if (String.class.equals(targetType)) {
             return Cast.uncheckedCast(STRING_VALUE_SANITIZER);
+        } else if (Long.class.equals(targetType)) {
+            return Cast.uncheckedCast(IMPLICIT_CAST_TO_LONG_SANITIZER);
         } else {
             return Cast.uncheckedCast(IDENTITY_SANITIZER);
         }


### PR DESCRIPTION
Part of https://github.com/gradle/gradle/issues/31372

In https://github.com/gradle/gradle/pull/31235 we migrated Test task, where we migrated `long fork` to `Property<Long> fork`.

But that also meant we needed to change all usages of fork from:
```
// Groovy
test {
    forkEvery = 42
}
```
to
```
// Groovy
test {
    forkEvery = 42L
}
```

This PR implements value sanitizer that implicitly casts ints to longs.

---
Note:
For kotlin:
```
test {
    forkEvery = 42
}
```
 works as before since compiler does the implicit cast