### PR TITLE
Fix libs.versions.toml filename typos

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/dep-man/centralizing-dependencies/version_catalogs.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/centralizing-dependencies/version_catalogs.adoc
@@ -26,10 +26,10 @@ include::sample[dir="snippets/dependencyManagement/catalogs-settings/groovy",fil
 
 In this example, `libs` represents the catalog, and `groovy` is a dependency available in it.
 
-Where the version catalog defining `libs.groovy.core` is a `libs.version.toml` file in the `gradle` directory:
+Where the version catalog defining `libs.groovy.core` is a `libs.versions.toml` file in the `gradle` directory:
 
 [source,toml]
-.gradle/libs.version.toml
+.gradle/libs.versions.toml
 ----
 [libraries]
 groovy-core = { group = "org.codehaus.groovy", name = "groovy", version = "3.0.5" }


### PR DESCRIPTION
I wasted some time trying to figure out a error about `Unresolved reference: libs` because I named the file `libs.version.toml` - since that's what this doc says in the beginning. Later on, it starts talking about `libs.versions.toml`, and changing to that name worked.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
