### PR TITLE
Print more info in flaky test

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
@@ -134,7 +134,7 @@ class TaskParametersIntegrationTest extends AbstractIntegrationSpec implements V
         outputContains "Input property 'inputs2' file ${file("input2.txt")} has been added."
 
         when:
-        succeeds "test"
+        succeeds "test", "--info"
 
         then:
         skipped ':test'


### PR DESCRIPTION
Run task with --info in test to pinpoint the reason why the task can be not up-to-date under CC or IP executors

The test has been flaky recently:
https://ge.gradle.org/scans/tests?search.startTimeMax=1732876371753&search.startTimeMin=1730415600000&search.timeZoneId=Europe%2FBerlin&tests.container=org.gradle.api.tasks.TaskParametersIntegrationTest&tests.expandedTests=WzAsMiwxNl0&tests.test=task%20is%20not%20up-to-date%20after%20file%20moved%20between%20input%20properties