### PR TITLE
Fix NPE occuring during performance test runs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ develocity.internal.testdistribution.writeTraceFile=true
 gradle.internal.testdistribution.queryResponseTimeout=PT20S
 develocity.internal.testdistribution.queryResponseTimeout=PT20S
 # Default performance baseline
-defaultPerformanceBaselines=8.12-commit-a5309648a87
+defaultPerformanceBaselines=8.12-commit-c52930a8
 
 # Skip dependency analysis for tests
 systemProp.dependency.analysis.test.analysis=false

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapter.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapter.java
@@ -1186,15 +1186,18 @@ public class BuildProgressListenerAdapter implements InternalBuildProgressListen
         if (origFailure == null) {
             return null;
         }
-        List<InternalBasicProblemDetailsVersion3> problems = new ArrayList<>();
+        List<InternalBasicProblemDetailsVersion3> problemDetails = new ArrayList<>();
         try {
-            problems.addAll(origFailure.getProblems());
+            problemDetails.addAll(origFailure.getProblems());
         } catch (AbstractMethodError ignore) {
             // Older Gradle versions don't have this method
         }
-        List<Problem> clientProblems = new ArrayList<>(problems.size());
-        for (InternalBasicProblemDetailsVersion3 problem : problems) {
-            clientProblems.add(createProblemReport(problem));
+        List<Problem> clientProblems = new ArrayList<>(problemDetails.size());
+        for (InternalBasicProblemDetailsVersion3 problemDetail : problemDetails) {
+            if (problemDetail == null) { // Should not happen, but with some older snapshot versions we see this.
+                continue;
+            }
+            clientProblems.add(createProblemReport(problemDetail));
         }
         if (origFailure instanceof InternalTestAssertionFailure) {
             if (origFailure instanceof InternalFileComparisonTestAssertionFailure) {


### PR DESCRIPTION
During Performance tests the baseline version is executed to get the performance baseline.

The older snapshot version in this case causes a NullPointerException.

Fixes https://github.com/gradle/gradle-private/issues/4559

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
