### PR TITLE
Improve MethodsRemovedInInternalSuperClassRule

### DIFF
--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/MethodsRemovedInInternalSuperClassRule.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/MethodsRemovedInInternalSuperClassRule.groovy
@@ -102,8 +102,19 @@ class MethodsRemovedInInternalSuperClassRule extends AbstractSuperClassChangesRu
     }
 
     private boolean containsMethod(CtClass c, CtMethod method) {
-        // TODO signature contains return type
-        // but return type can be overridden
-        return collectAllPublicApiMethods(c).any { it.name == method.name && it.signature == method.signature }
+        return collectAllPublicApiMethods(c).any { it.name == method.name && methodSignaturesMatch(it, method) }
+    }
+
+    private static String methodSignaturesMatch(CtMethod methodInSubClass, CtMethod method) {
+        return methodParametersFromSignature(methodInSubClass) == methodParametersFromSignature(method)
+            // Subclass can override method return type
+            && methodInSubClass.returnType.subtypeOf(method.returnType)
+    }
+
+    /**
+     * Returns method parameters from method signature, e.g. "(Ljava/lang/String;I)V" -> "(Ljava/lang/String;I)"
+     */
+    private static String methodParametersFromSignature(CtMethod method) {
+        return method.signature.substring(0, method.signature.indexOf(")") + 1)
     }
 }

--- a/build-logic/binary-compatibility/src/test/groovy/gradlebuild/binarycompatibility/rules/MethodsRemovedInInternalSuperClassRuleTest.groovy
+++ b/build-logic/binary-compatibility/src/test/groovy/gradlebuild/binarycompatibility/rules/MethodsRemovedInInternalSuperClassRuleTest.groovy
@@ -28,13 +28,19 @@ class MethodsRemovedInInternalSuperClassRuleTest extends AbstractContextAwareRul
         void publicMethod() {}
 
         private void privateMethod() {}
+
+        OldSuperInternal returnTypeOverridenMethod() { return null }
     }
 
     static class OldBase extends OldSuperInternal {
         void anotherPublicMethod() {}
+
+        OldBase returnTypeOverridenMethod() { return null }
     }
 
-    static class OldSub extends OldBase {}
+    static class OldSub extends OldBase {
+        OldSub returnTypeOverridenMethod() { return null }
+    }
 
     static class NewSuperInternal {}
 
@@ -74,6 +80,7 @@ class MethodsRemovedInInternalSuperClassRuleTest extends AbstractContextAwareRul
 
         then:
         violation.humanExplanation.contains('SuperInternal.publicMethod()')
+        violation.humanExplanation.contains('SuperInternal.returnTypeOverridenMethod()')
         !violation.humanExplanation.contains('SuperInternal.privateMethod()')
     }
 


### PR DESCRIPTION
This improvement is needed so we correctly handle binary compatibility changes for upgraded properties that are inherited.

See this discussion for context: https://github.com/gradle/gradle/pull/30974#discussion_r1816896682