### PR TITLE
Update javadoc for ExternalModuleDependency

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExternalModuleDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExternalModuleDependency.java
@@ -27,7 +27,7 @@ public interface ExternalModuleDependency extends ExternalDependency {
     boolean isChanging();
 
     /**
-     * Sets whether Gradle may check for a change in the remote repository. If set to true, Gradle will
+     * Sets the dependency as "changing" or "not changing".
      * check the remote repository if the local entry has expired.
      * If set to false, Gradle will use the local entry even if there is a new artifact in the remote repository.
      * Defaults to false.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExternalModuleDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExternalModuleDependency.java
@@ -32,7 +32,8 @@ public interface ExternalModuleDependency extends ExternalDependency {
      * If set to false, Gradle will use the local entry even if there is a new artifact in the remote repository.
      * Defaults to false.
      *
-     * @param changing Gradle can check for a change in the remote repository, even if a local entry already exists
+     * @param changing if true, the dependency is considered changing and Gradle should
+     * check for a change in the remote repository, even if a local entry exists. 
      * @return this
      */
     ExternalModuleDependency setChanging(boolean changing);

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExternalModuleDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExternalModuleDependency.java
@@ -32,7 +32,7 @@ public interface ExternalModuleDependency extends ExternalDependency {
      * If set to false, Gradle will use the local entry even if there is a new artifact in the remote repository
      * and --refresh-dependencies was passed. Defaults to false.
      *
-     * @param changing Gradle checks for a change in the remote repository, even if a local entry already exists
+     * @param changing Gradle can check for a change in the remote repository, even if a local entry already exists
      * @return this
      */
     ExternalModuleDependency setChanging(boolean changing);

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExternalModuleDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExternalModuleDependency.java
@@ -20,18 +20,19 @@ package org.gradle.api.artifacts;
  */
 public interface ExternalModuleDependency extends ExternalDependency {
     /**
-     * Returns whether or not Gradle should always check for a change in the remote repository.
+     * Returns whether Gradle may check for a change in the remote repository
      *
      * @see #setChanging(boolean)
      */
     boolean isChanging();
 
     /**
-     * Sets whether or not Gradle should always check for a change in the remote repository. If set to true, Gradle will
-     * check the remote repository even if a dependency with the same version is already in the local cache. Defaults to
-     * false.
+     * Sets whether Gradle may check for a change in the remote repository. If set to true, Gradle will
+     * check the remote repository if either --refresh--dependencies was passed or the local entry has expired.
+     * If set to false, Gradle will use the local entry even if there is a new artifact in the remote repository
+     * and --refresh-dependencies was passed. Defaults to false.
      *
-     * @param changing Whether or not Gradle should always check for a change in the remote repository
+     * @param changing Gradle checks for a change in the remote repository, even if a local entry already exists
      * @return this
      */
     ExternalModuleDependency setChanging(boolean changing);

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExternalModuleDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExternalModuleDependency.java
@@ -28,9 +28,9 @@ public interface ExternalModuleDependency extends ExternalDependency {
 
     /**
      * Sets whether Gradle may check for a change in the remote repository. If set to true, Gradle will
-     * check the remote repository if either --refresh--dependencies was passed or the local entry has expired.
-     * If set to false, Gradle will use the local entry even if there is a new artifact in the remote repository
-     * and --refresh-dependencies was passed. Defaults to false.
+     * check the remote repository if the local entry has expired.
+     * If set to false, Gradle will use the local entry even if there is a new artifact in the remote repository.
+     * Defaults to false.
      *
      * @param changing Gradle can check for a change in the remote repository, even if a local entry already exists
      * @return this

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExternalModuleDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExternalModuleDependency.java
@@ -29,7 +29,6 @@ public interface ExternalModuleDependency extends ExternalDependency {
     /**
      * Sets the dependency as "changing" or "not changing".
      * check the remote repository if the local entry has expired.
-     * If set to false, Gradle will use the local entry even if there is a new artifact in the remote repository.
      * Defaults to false.
      *
      * @param changing if true, the dependency is considered changing and Gradle should

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExternalModuleDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExternalModuleDependency.java
@@ -28,7 +28,7 @@ public interface ExternalModuleDependency extends ExternalDependency {
 
     /**
      * Sets the dependency as "changing" or "not changing".
-     * check the remote repository if the local entry has expired.
+     * If set to true, the dependency is marked as "changing." Gradle will periodically check the remote repository for updates, even if the local cache entry has not yet expired.
      * Defaults to false.
      *
      * @param changing if true, the dependency is considered changing and Gradle should

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExternalModuleDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExternalModuleDependency.java
@@ -20,7 +20,7 @@ package org.gradle.api.artifacts;
  */
 public interface ExternalModuleDependency extends ExternalDependency {
     /**
-     * Returns whether Gradle may check for a change in the remote repository
+     * Indicates that the given dependency can have different content for the same identifier.
      *
      * @see #setChanging(boolean)
      */


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
This has always annoyed me. And its probably the most loose use of the word 'always' I have ever seen.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
