### PR TITLE
Use 12 chars for "defaultPerformanceBaselines" hash

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,6 @@ develocity.internal.testdistribution.writeTraceFile=true
 gradle.internal.testdistribution.queryResponseTimeout=PT20S
 develocity.internal.testdistribution.queryResponseTimeout=PT20S
 # Default performance baseline
-defaultPerformanceBaselines=8.12-commit-c52930a8
-
-# Skip dependency analysis for tests
+defaultPerformanceBaselines=8.12-commit-c52930a81244
+#-----------------------------------------till here^
 systemProp.dependency.analysis.test.analysis=false


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-private/issues/4559 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
