### PR TITLE
Apply artifact exclusions after build dependencies execute

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDescriptorDependencyExcludeResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDescriptorDependencyExcludeResolveIntegrationTest.groovy
@@ -482,6 +482,49 @@ task syncMerged(type: Sync) {
         file("libs").assertHasDescendants(['a-1.0.jar', 'b-1.0.jar', 'c-1.0.jar', 'e-1.0.jar'] as String[])
     }
 
+    def "build dependencies of artifacts excluded by name-based excludes are still executed"() {
+        // This is not necessarily desired behavior, but is a consequence of artifact selection occurring
+        // before task dependencies are executed. name-based excludes are applied to the resolved files,
+        // after the task dependencies that produce them are executed.
+
+        IvyModule moduleA = ivyRepo.module('a').dependsOn('b')
+        if (excludeAttributes != null) {
+            addExcludeRuleToModuleDependency(moduleA, 'b', excludeAttributes)
+        }
+        ivyRepo.module('b').dependsOn('c').publish()
+        moduleA.publish()
+
+        settingsFile << """
+            includeBuild('c')
+        """
+
+        file("c/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
+
+            group = 'org.gradle.test'
+            version = '1.0'
+        """
+
+        when:
+        succeedsDependencyResolution()
+
+        then:
+        assertResolvedFiles(resolvedJars)
+        if (taskDependenciesExecuted) {
+            result.assertTaskExecuted(":c:compileJava")
+        } else {
+            result.assertTaskNotExecuted(":c:compileJava")
+        }
+
+        where:
+        excludeAttributes | resolvedJars                            | taskDependenciesExecuted
+        null              | ['a-1.0.jar', 'b-1.0.jar', 'c-1.0.jar'] | true
+        [module: 'c']     | ['a-1.0.jar', 'b-1.0.jar']              | false
+        [name: 'c']       | ['a-1.0.jar', 'b-1.0.jar']              | true
+    }
+
     private void addExcludeRuleToModuleDependency(IvyModule module, String dependencyName, Map<String, String> excludeAttributes) {
         module.withXml {
             asNode().dependencies[0].dependency.findAll { it.@name == dependencyName }.each { Node moduleDependency ->

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactSet.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactSet.java
@@ -27,6 +27,8 @@ import org.gradle.internal.operations.RunnableBuildOperation;
 
 /**
  * A container for a set of files or artifacts. May or may not be immutable, and may require building and further resolution.
+ * <p>
+ * There are no guarantees of uniqueness of visited artifacts. This would be better named {@code ResolvedArtifactCollection}.
  */
 public interface ResolvedArtifactSet extends TaskDependencyContainer {
     /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedVariant.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedVariant.java
@@ -27,7 +27,7 @@ import javax.annotation.Nullable;
 
 /**
  * A set of artifacts that may be selected from a variant. This would be better named
- * {@code VariantArtifactSet}.
+ * {@code ResolvedVariantArtifactCollection}.
  */
 public interface ResolvedVariant extends HasAttributes {
     DisplayName asDescribable();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantResolvingArtifactSet.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantResolvingArtifactSet.java
@@ -48,7 +48,10 @@ public class VariantResolvingArtifactSet implements ArtifactSet {
     private final ComponentGraphResolveState component;
     private final VariantGraphResolveState variant;
     private final ImmutableAttributes overriddenAttributes;
+
+    // TODO: Create a separate implementation of ArtifactSet for when !requestedArtifacts.isEmpty()
     private final List<IvyArtifactName> requestedArtifacts;
+
     private final ExcludeSpec exclusions;
     private final Set<CapabilitySelector> capabilitySelectors;
 
@@ -163,17 +166,17 @@ public class VariantResolvingArtifactSet implements ArtifactSet {
         VariantGraphResolveState graphVariant,
         VariantArtifactResolver variantArtifactResolver
     ) {
-        ComponentArtifactResolveMetadata componentMetadata = component.prepareForArtifactResolution().getArtifactMetadata();
-        ImmutableList<ResolvedVariant> artifactSets = resolveVariantArtifactSets(graphVariant, componentMetadata, variantArtifactResolver);
+        ComponentArtifactResolveMetadata componentArtifacts = component.prepareForArtifactResolution().getArtifactMetadata();
+        ImmutableList<ResolvedVariant> variantArtifactSets = resolveVariantArtifactSets(graphVariant, componentArtifacts, variantArtifactResolver);
 
         // Only apply exclusions to the resolved variant artifact sets if necessary.
         if (!exclusions.mayExcludeArtifacts()) {
-            return artifactSets;
+            return variantArtifactSets;
         }
 
-        ImmutableList.Builder<ResolvedVariant> excluded = ImmutableList.builderWithExpectedSize(artifactSets.size());
-        ModuleIdentifier moduleId = componentMetadata.getModuleVersionId().getModule();
-        for (ResolvedVariant artifactSet : artifactSets) {
+        ImmutableList.Builder<ResolvedVariant> excluded = ImmutableList.builderWithExpectedSize(variantArtifactSets.size());
+        ModuleIdentifier moduleId = componentArtifacts.getModuleVersionId().getModule();
+        for (ResolvedVariant artifactSet : variantArtifactSets) {
             excluded.add(new ExcludingVariantArtifactSet(artifactSet, moduleId, exclusions));
         }
         return excluded.build();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/DelegatingExcludeFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/DelegatingExcludeFactory.java
@@ -27,6 +27,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ModuleSetExclude;
 import org.gradle.internal.component.model.IvyArtifactName;
 
+import javax.annotation.Nullable;
 import java.util.Set;
 
 public abstract class DelegatingExcludeFactory implements ExcludeFactory {
@@ -82,7 +83,7 @@ public abstract class DelegatingExcludeFactory implements ExcludeFactory {
     }
 
     @Override
-    public ExcludeSpec ivyPatternExclude(ModuleIdentifier moduleId, IvyArtifactName artifact, String matcher) {
+    public ExcludeSpec ivyPatternExclude(ModuleIdentifier moduleId, @Nullable IvyArtifactName artifact, String matcher) {
         return delegate.ivyPatternExclude(moduleId, artifact, matcher);
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/simple/DefaultExcludeFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/simple/DefaultExcludeFactory.java
@@ -29,6 +29,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ModuleSetExclude;
 import org.gradle.internal.component.model.IvyArtifactName;
 
+import javax.annotation.Nullable;
 import java.util.Set;
 
 public class DefaultExcludeFactory implements ExcludeFactory {
@@ -78,7 +79,7 @@ public class DefaultExcludeFactory implements ExcludeFactory {
     }
 
     @Override
-    public ExcludeSpec ivyPatternExclude(ModuleIdentifier moduleId, IvyArtifactName artifact, String matcher) {
+    public ExcludeSpec ivyPatternExclude(ModuleIdentifier moduleId, @Nullable IvyArtifactName artifact, String matcher) {
         return DefaultIvyPatternMatcherExcludeRuleSpec.of(moduleId, artifact, matcher);
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/simple/DefaultIvyPatternMatcherExcludeRuleSpec.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/simple/DefaultIvyPatternMatcherExcludeRuleSpec.java
@@ -33,16 +33,16 @@ final class DefaultIvyPatternMatcherExcludeRuleSpec implements IvyPatternMatcher
     private final boolean isArtifactExclude;
     private final int hashCode;
 
-    public static ExcludeSpec of(ModuleIdentifier moduleId, IvyArtifactName artifact, String matcher) {
+    public static ExcludeSpec of(ModuleIdentifier moduleId, @Nullable IvyArtifactName artifact, String matcher) {
         return new DefaultIvyPatternMatcherExcludeRuleSpec(moduleId, artifact, matcher);
     }
 
-    private DefaultIvyPatternMatcherExcludeRuleSpec(ModuleIdentifier moduleId, IvyArtifactName artifact, String matcher) {
+    private DefaultIvyPatternMatcherExcludeRuleSpec(ModuleIdentifier moduleId, @Nullable IvyArtifactName artifact, String matcher) {
         this.moduleId = moduleId;
         this.ivyArtifactName = artifact;
         this.matcher = PatternMatchers.getInstance().getMatcher(matcher);
-        isArtifactExclude = ivyArtifactName != null;
-        hashCode = Objects.hashCode(moduleId, ivyArtifactName, matcher, isArtifactExclude);
+        this.isArtifactExclude = ivyArtifactName != null;
+        this.hashCode = Objects.hashCode(moduleId, ivyArtifactName, matcher, isArtifactExclude);
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/VariantResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/VariantResolveMetadata.java
@@ -66,6 +66,8 @@ public interface VariantResolveMetadata {
 
     /**
      * An opaque identifier for a an artifact variant.
+     * <p>
+     * Implementations must implement equals and hashCode.
      */
     interface Identifier {
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/VariantResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/VariantResolveMetadata.java
@@ -24,7 +24,7 @@ import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import javax.annotation.Nullable;
 
 /**
- * Also known as an "Artifact Variant". We should find a better name for this.
+ * Would be better named {@code VariantArtifactMetadata}.
  * <p>
  * Describes the artifacts of a {@link VariantGraphResolveMetadata}. Graph variants may have multiple
  * artifact variants, where each artifact variant may have different artifacts, but inherit the dependencies

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultVariantArtifactResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultVariantArtifactResolver.java
@@ -17,15 +17,12 @@
 package org.gradle.internal.resolve.resolver;
 
 import com.google.common.collect.ImmutableList;
-import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactBackedResolvedVariant;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ExcludeSpec;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.immutable.artifact.ImmutableArtifactTypeRegistry;
 import org.gradle.internal.Describables;
-import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.DefaultImmutableCapability;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
@@ -61,56 +58,14 @@ public class DefaultVariantArtifactResolver implements VariantArtifactResolver {
             ImmutableCapabilities.EMPTY
         );
 
-        return toResolvedVariant(component, adhoc, identifier, artifacts);
+        return resolveVariantArtifactSet(component, adhoc);
     }
 
     @Override
-    public ResolvedVariant resolveVariant(ComponentArtifactResolveMetadata component, VariantResolveMetadata artifactVariant) {
-        return toResolvedVariant(component, artifactVariant, artifactVariant.getIdentifier(), artifactVariant.getArtifacts());
-    }
-
-    @Override
-    public ResolvedVariant resolveVariant(ComponentArtifactResolveMetadata component, VariantResolveMetadata artifactVariant, ExcludeSpec exclusions) {
-        ImmutableList<? extends ComponentArtifactMetadata> sourceArtifacts = artifactVariant.getArtifacts();
-        ImmutableList<ComponentArtifactMetadata> overrideArtifacts = maybeExcludeArtifacts(component, sourceArtifacts, exclusions);
-        if (overrideArtifacts != null) {
-            // If we override artifacts, this is an adhoc variant, therefore it has no identifier.
-            return toResolvedVariant(component, artifactVariant, null, overrideArtifacts);
-        } else {
-            return toResolvedVariant(component, artifactVariant, artifactVariant.getIdentifier(), sourceArtifacts);
-        }
-    }
-
-    @Nullable
-    private static ImmutableList<ComponentArtifactMetadata> maybeExcludeArtifacts(ComponentArtifactResolveMetadata component, ImmutableList<? extends ComponentArtifactMetadata> artifacts, ExcludeSpec exclusions) {
-        ModuleIdentifier module = component.getModuleVersionId().getModule();
-
-        // artifactsToResolve are those not excluded by their owning module
-        boolean hasExcludedArtifact = false;
-        ImmutableList.Builder<ComponentArtifactMetadata> artifactsToResolveBuilder = ImmutableList.builderWithExpectedSize(artifacts.size());
-        for (ComponentArtifactMetadata artifact : artifacts) {
-            if (!exclusions.excludesArtifact(module, artifact.getName())) {
-                artifactsToResolveBuilder.add(artifact);
-            } else {
-                hasExcludedArtifact = true;
-            }
-        }
-
-        if (hasExcludedArtifact) {
-            return artifactsToResolveBuilder.build();
-        }
-
-        return null;
-    }
-
-    private ResolvedVariant toResolvedVariant(
-        ComponentArtifactResolveMetadata component,
-        VariantResolveMetadata artifactVariant,
-        @Nullable VariantResolveMetadata.Identifier identifier,
-        ImmutableList<? extends ComponentArtifactMetadata> artifacts
-    ) {
-        if (identifier == null || !artifactVariant.isEligibleForCaching()) {
-            return createResolvedVariant(identifier, component, artifactVariant, artifacts, artifactTypeRegistry);
+    public ResolvedVariant resolveVariantArtifactSet(ComponentArtifactResolveMetadata component, VariantResolveMetadata artifactSet) {
+        VariantResolveMetadata.Identifier identifier = artifactSet.getIdentifier();
+        if (identifier == null || !artifactSet.isEligibleForCaching()) {
+            return createResolvedVariant(identifier, component, artifactSet, artifactTypeRegistry);
         }
 
         // We use the artifact type registry as a key here, since for each consumer the registry may be different.
@@ -127,7 +82,7 @@ public class DefaultVariantArtifactResolver implements VariantArtifactResolver {
 
         // Calculate the value with locking
         return resolvedVariantCache.computeIfAbsent(key, k ->
-            createResolvedVariant(k.variantIdentifier, component, artifactVariant, artifacts, k.artifactTypeRegistry)
+            createResolvedVariant(k.variantIdentifier, component, artifactSet, k.artifactTypeRegistry)
         );
     }
 
@@ -135,11 +90,15 @@ public class DefaultVariantArtifactResolver implements VariantArtifactResolver {
         @Nullable VariantResolveMetadata.Identifier identifier,
         ComponentArtifactResolveMetadata component,
         VariantResolveMetadata artifactVariant,
-        ImmutableList<? extends ComponentArtifactMetadata> artifacts,
         ImmutableArtifactTypeRegistry artifactTypeRegistry
     ) {
-        DisplayName displayName = artifactVariant.asDescribable();
+        // TODO: In order to apply the artifact type registry, we need to realize the artifacts now, earlier than we should.
+        // Since the artifact type registry must be applied before artifact selection, which occurs before task dependencies
+        // execute, and since the artifact type registry is a function of the artifacts themselves, which are only known after task
+        // dependencies execute, the artifact type registry is inherently flawed. It must be deprecated and removed.
+        ImmutableList<? extends ComponentArtifactMetadata> artifacts = artifactVariant.getArtifacts();
         ImmutableAttributes attributes = artifactTypeRegistry.mapAttributesFor(artifactVariant.getAttributes(), artifacts);
+
         ImmutableCapabilities capabilities = withImplicitCapability(artifactVariant.getCapabilities(), component);
 
         // TODO: This value gets cached in a build-tree-scoped cache. It captures a project-scoped `artifactResolver`, which
@@ -155,7 +114,14 @@ public class DefaultVariantArtifactResolver implements VariantArtifactResolver {
         // the same one that resolves its artifacts. This would benefit greatly from "repository deduplication", where we could
         // consider repositories from multiple projects as equivalent as long as they are configured the same (same url, cache policy,
         // component metadata rules, metadata sources, etc.). We should probably leverage ComponentArtifactResolveMetadata#getSources() for this.
-        return new ArtifactBackedResolvedVariant(identifier, displayName, attributes, capabilities, artifacts, new DefaultComponentArtifactResolver(component, artifactResolver));
+        return new ArtifactBackedResolvedVariant(
+            identifier,
+            artifactVariant.asDescribable(),
+            attributes,
+            capabilities,
+            artifacts,
+            new DefaultComponentArtifactResolver(component, artifactResolver)
+        );
     }
 
     private static ImmutableCapabilities withImplicitCapability(ImmutableCapabilities capabilities, ComponentArtifactResolveMetadata component) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultVariantArtifactResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultVariantArtifactResolver.java
@@ -92,7 +92,7 @@ public class DefaultVariantArtifactResolver implements VariantArtifactResolver {
         VariantResolveMetadata artifactVariant,
         ImmutableArtifactTypeRegistry artifactTypeRegistry
     ) {
-        // TODO: In order to apply the artifact type registry, we need to realize the artifacts now, earlier than we should.
+        // TODO #31538: In order to apply the artifact type registry, we need to realize the artifacts now, earlier than we should.
         // Since the artifact type registry must be applied before artifact selection, which occurs before task dependencies
         // execute, and since the artifact type registry is a function of the artifacts themselves, which are only known after task
         // dependencies execute, the artifact type registry is inherently flawed. It must be deprecated and removed.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultVariantArtifactResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultVariantArtifactResolver.java
@@ -62,17 +62,17 @@ public class DefaultVariantArtifactResolver implements VariantArtifactResolver {
     }
 
     @Override
-    public ResolvedVariant resolveVariantArtifactSet(ComponentArtifactResolveMetadata component, VariantResolveMetadata artifactSet) {
-        VariantResolveMetadata.Identifier identifier = artifactSet.getIdentifier();
-        if (identifier == null || !artifactSet.isEligibleForCaching()) {
-            return createResolvedVariant(identifier, component, artifactSet, artifactTypeRegistry);
+    public ResolvedVariant resolveVariantArtifactSet(ComponentArtifactResolveMetadata component, VariantResolveMetadata variantArtifacts) {
+        VariantResolveMetadata.Identifier artifactSetId = variantArtifacts.getIdentifier();
+        if (artifactSetId == null || !variantArtifacts.isEligibleForCaching()) {
+            return createResolvedVariant(artifactSetId, component, variantArtifacts, artifactTypeRegistry);
         }
 
         // We use the artifact type registry as a key here, since for each consumer the registry may be different.
         // The registry is interned and is safe to be used as a cache key. Ideally, we would do away with the concept of the
         // artifact type registry entirely, as by design it means we need to look at the artifacts of a variant in order to perform
         // artifact selection -- a process that occurs before artifact files are even created.
-        ResolvedVariantCache.CacheKey key = new ResolvedVariantCache.CacheKey(identifier, artifactTypeRegistry);
+        ResolvedVariantCache.CacheKey key = new ResolvedVariantCache.CacheKey(artifactSetId, artifactTypeRegistry);
 
         // Try first without locking
         ResolvedVariant value = resolvedVariantCache.get(key);
@@ -82,7 +82,7 @@ public class DefaultVariantArtifactResolver implements VariantArtifactResolver {
 
         // Calculate the value with locking
         return resolvedVariantCache.computeIfAbsent(key, k ->
-            createResolvedVariant(k.variantIdentifier, component, artifactSet, k.artifactTypeRegistry)
+            createResolvedVariant(k.variantIdentifier, component, variantArtifacts, k.artifactTypeRegistry)
         );
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/ExcludingVariantArtifactSet.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/ExcludingVariantArtifactSet.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resolve.resolver;
+
+import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ExcludeSpec;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.Describables;
+import org.gradle.internal.DisplayName;
+import org.gradle.internal.component.external.model.ImmutableCapabilities;
+import org.gradle.internal.component.model.VariantResolveMetadata;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+/**
+ * A {@link ResolvedVariant} that applies artifact exclusions to a delegate {@link ResolvedVariant}.
+ */
+public class ExcludingVariantArtifactSet implements ResolvedVariant, VariantResolveMetadata.Identifier {
+
+    private final ResolvedVariant delegate;
+    private final ModuleIdentifier moduleId;
+    private final ExcludeSpec exclusions;
+
+    public ExcludingVariantArtifactSet(ResolvedVariant delegate, ModuleIdentifier moduleId, ExcludeSpec exclusions) {
+        this.delegate = delegate;
+        this.moduleId = moduleId;
+        this.exclusions = exclusions;
+    }
+
+    @Override
+    public DisplayName asDescribable() {
+        return Describables.of(delegate.asDescribable(), exclusions);
+    }
+
+    @Nullable
+    @Override
+    public VariantResolveMetadata.Identifier getIdentifier() {
+        // Since we use ourselves as the identifier, we must implement equals and hashCode
+        return this;
+    }
+
+    @Override
+    public ImmutableAttributes getAttributes() {
+        return delegate.getAttributes();
+    }
+
+    @Override
+    public ImmutableCapabilities getCapabilities() {
+        return delegate.getCapabilities();
+    }
+
+    @Override
+    public ResolvedArtifactSet getArtifacts() {
+        ResolvedArtifactSet artifacts = delegate.getArtifacts();
+        return new FilteringResolvedArtifactSet(artifacts, this::include);
+    }
+
+    private boolean include(ResolvableArtifact artifact) {
+        return !exclusions.excludesArtifact(moduleId, artifact.getArtifactName());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hashCode(delegate.getIdentifier());
+        result = 31 * result + moduleId.hashCode();
+        result = 31 * result + exclusions.hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || obj.getClass() != getClass()) {
+            return false;
+        }
+        ExcludingVariantArtifactSet other = (ExcludingVariantArtifactSet) obj;
+        return equalId(delegate.getIdentifier(), other.delegate.getIdentifier()) &&
+            moduleId.equals(other.moduleId) &&
+            exclusions.equals(other.exclusions);
+    }
+
+    private static boolean equalId(
+        @Nullable VariantResolveMetadata.Identifier id1,
+        @Nullable VariantResolveMetadata.Identifier id2
+    ) {
+        // Artifact sets without ID are adhoc.
+        // We cannot compare them by ID so assume they are not equal.
+        if (id1 == null || id2 == null) {
+            return false;
+        }
+
+        return id1.equals(id2);
+    }
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/FilteringResolvedArtifactSet.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/FilteringResolvedArtifactSet.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resolve.resolver;
+
+import org.gradle.api.Action;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
+import org.gradle.api.internal.artifacts.transform.TransformStepNode;
+import org.gradle.api.internal.file.FileCollectionInternal;
+import org.gradle.api.internal.file.FileCollectionStructureVisitor;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+import org.gradle.internal.DisplayName;
+import org.gradle.internal.component.external.model.ImmutableCapabilities;
+import org.gradle.internal.operations.BuildOperationQueue;
+import org.gradle.internal.operations.RunnableBuildOperation;
+
+import java.util.function.Predicate;
+
+/**
+ * A {@link ResolvedArtifactSet} that applies a filter to the artifacts of a delegate {@link ResolvedArtifactSet}.
+ * <p>
+ * The filter is applied <strong>after</strong> build dependencies are calculated, meaning the filter is not
+ * applied to build dependencies. This is because the filter may be a function of the resolved artifact files,
+ * which are not known until after build dependencies are executed.
+ */
+class FilteringResolvedArtifactSet implements ResolvedArtifactSet {
+
+    private final ResolvedArtifactSet artifacts;
+    private final Predicate<ResolvableArtifact> filter;
+
+    public FilteringResolvedArtifactSet(ResolvedArtifactSet artifacts, Predicate<ResolvableArtifact> filter) {
+        this.artifacts = artifacts;
+        this.filter = filter;
+    }
+
+    @Override
+    public void visit(Visitor visitor) {
+        artifacts.visit(new Visitor() {
+            @Override
+            public FileCollectionStructureVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
+                return visitor.prepareForVisit(source);
+            }
+
+            @Override
+            public void visitArtifacts(Artifacts artifacts) {
+                visitor.visitArtifacts(new Artifacts() {
+                    @Override
+                    public void prepareForVisitingIfNotAlready() {
+                        artifacts.prepareForVisitingIfNotAlready();
+                    }
+
+                    @Override
+                    public void startFinalization(BuildOperationQueue<RunnableBuildOperation> actions, boolean requireFiles) {
+                        artifacts.startFinalization(actions, requireFiles);
+                    }
+
+                    @Override
+                    public void visit(ArtifactVisitor visitor) {
+                        artifacts.visit(new ArtifactVisitor() {
+                            @Override
+                            public FileCollectionStructureVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
+                                return visitor.prepareForVisit(source);
+                            }
+
+                            @Override
+                            public void visitArtifact(DisplayName variantName, AttributeContainer variantAttributes, ImmutableCapabilities capabilities, ResolvableArtifact artifact) {
+                                if (filter.test(artifact)) {
+                                    visitor.visitArtifact(variantName, variantAttributes, capabilities, artifact);
+                                }
+                            }
+
+                            @Override
+                            public boolean requireArtifactFiles() {
+                                return visitor.requireArtifactFiles();
+                            }
+
+                            @Override
+                            public void visitFailure(Throwable failure) {
+                                visitor.visitFailure(failure);
+                            }
+
+                            @Override
+                            public void endVisitCollection(FileCollectionInternal.Source source) {
+                                visitor.endVisitCollection(source);
+                            }
+                        });
+                    }
+                });
+            }
+        });
+    }
+
+    @Override
+    public void visitTransformSources(TransformSourceVisitor visitor) {
+        artifacts.visitTransformSources(new TransformSourceVisitor() {
+            @Override
+            public void visitArtifact(ResolvableArtifact artifact) {
+                if (filter.test(artifact)) {
+                    visitor.visitArtifact(artifact);
+                }
+            }
+
+            @Override
+            public void visitTransform(TransformStepNode source) {
+                if (filter.test(source.getInputArtifact())) {
+                    visitor.visitTransform(source);
+                }
+            }
+        });
+    }
+
+    @Override
+    public void visitExternalArtifacts(Action<ResolvableArtifact> visitor) {
+        artifacts.visitExternalArtifacts(artifact -> {
+            if (filter.test(artifact)) {
+                visitor.execute(artifact);
+            }
+        });
+    }
+
+    @Override
+    public void visitDependencies(TaskDependencyResolveContext context) {
+        // Do not apply exclusions to build dependencies, in order to permit filters that are
+        // a function of the artifact files.
+        // This means that we might build some filtered artifacts, but we filter those later.
+        artifacts.visitDependencies(context);
+    }
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/VariantArtifactResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/VariantArtifactResolver.java
@@ -18,24 +18,20 @@ package org.gradle.internal.resolve.resolver;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ExcludeSpec;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
 import org.gradle.internal.component.model.VariantResolveMetadata;
 
 public interface VariantArtifactResolver {
+
     /**
      * Creates an adhoc resolved variant which resolves the provided artifacts of the component.
      */
     ResolvedVariant resolveAdhocVariant(ComponentArtifactResolveMetadata component, ImmutableList<? extends ComponentArtifactMetadata> artifacts);
 
     /**
-     * Resolves the given variant metadata to its artifacts.
+     * Resolve the variant artifact set, owned by the given component.
      */
-    ResolvedVariant resolveVariant(ComponentArtifactResolveMetadata component, VariantResolveMetadata artifactVariant);
+    ResolvedVariant resolveVariantArtifactSet(ComponentArtifactResolveMetadata component, VariantResolveMetadata artifactSet);
 
-    /**
-     * Applies the provided exclusions and resolves the given variant metadata to its artifacts.
-     */
-    ResolvedVariant resolveVariant(ComponentArtifactResolveMetadata component, VariantResolveMetadata artifactVariant, ExcludeSpec exclusions);
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/VariantArtifactResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/VariantArtifactResolver.java
@@ -30,8 +30,8 @@ public interface VariantArtifactResolver {
     ResolvedVariant resolveAdhocVariant(ComponentArtifactResolveMetadata component, ImmutableList<? extends ComponentArtifactMetadata> artifacts);
 
     /**
-     * Resolve the variant artifact set, owned by the given component.
+     * Resolve the artifacts described by the given variant artifact metadata, owned by the given component.
      */
-    ResolvedVariant resolveVariantArtifactSet(ComponentArtifactResolveMetadata component, VariantResolveMetadata artifactSet);
+    ResolvedVariant resolveVariantArtifactSet(ComponentArtifactResolveMetadata component, VariantResolveMetadata variantArtifacts);
 
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantResolvingArtifactSetTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantResolvingArtifactSetTest.groovy
@@ -83,8 +83,8 @@ class VariantResolvingArtifactSetTest extends Specification {
         artifactSet.select(services, spec)
 
         then:
-        1 * variantResolver.resolveVariant(_, subvariant1) >> Mock(ResolvedVariant)
-        1 * variantResolver.resolveVariant(_, subvariant2) >> Mock(ResolvedVariant)
+        1 * variantResolver.resolveVariantArtifactSet(_, subvariant1) >> Mock(ResolvedVariant)
+        1 * variantResolver.resolveVariantArtifactSet(_, subvariant2) >> Mock(ResolvedVariant)
         0 * variantResolver._
     }
 
@@ -106,7 +106,7 @@ class VariantResolvingArtifactSetTest extends Specification {
 
         then:
         1 * selector.select(_, _, _) >> artifacts
-        _ * variantResolver.resolveVariant(_, _) >> Mock(ResolvedVariant)
+        _ * variantResolver.resolveVariantArtifactSet(_, _) >> Mock(ResolvedVariant)
         selected == artifacts
 
         where:


### PR DESCRIPTION
Some exclusions declared in ivy descriptors may exclude artifacts by name. We can only apply these exclusions after build dependencies are executed, as a task may create those files and we are not sure what those files may be until after the task has executed.

We delay applying these ivy artifact exclusions until after task dependencies have been visited, so we can ensure the file is present and therefore can apply the filter to the file name.

Baby steps toward fixing #24131

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
