### PR TITLE
Documentation Copyright update

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/api/groovy_build_script_primer.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/api/groovy_build_script_primer.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/api/kotlin_dsl.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/api/kotlin_dsl.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/build_lifecycle.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/build_lifecycle.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/gradle_directories.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/gradle_directories.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/intro_multi_project_builds.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/intro_multi_project_builds.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/plugins.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/plugins.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/tutorial_using_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/tutorial_using_tasks.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/writing_build_scripts.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/writing_build_scripts.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/writing_plugins.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/writing_plugins.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/writing_settings_files.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/writing_settings_files.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/writing_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/writing_tasks.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/best-practices/organizing_gradle_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/best-practices/organizing_gradle_projects.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/build_environment.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/build_environment.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/directory_layout.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/directory_layout.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/getting_started_dev.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/getting_started_dev.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/gradle-properties/collections.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/gradle-properties/collections.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/gradle-properties/properties_providers.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/gradle-properties/properties_providers.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/gradle-properties/service_injection.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/gradle-properties/service_injection.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/gradle-properties/working_with_files.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/gradle-properties/working_with_files.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/logging.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/logging.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/other/ant.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/other/ant.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/other/dataflow_actions.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/other/dataflow_actions.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/other/init_scripts.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/other/init_scripts.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/other/test_kit.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/other/test_kit.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/plugins/custom_plugins.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/plugins/custom_plugins.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/plugins/implementing_gradle_plugins.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/plugins/implementing_gradle_plugins.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/plugins/implementing_gradle_plugins_binary.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/plugins/implementing_gradle_plugins_binary.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/plugins/implementing_gradle_plugins_precompiled.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/plugins/implementing_gradle_plugins_precompiled.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/plugins/publishing_gradle_plugins.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/plugins/publishing_gradle_plugins.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/plugins/testing_gradle_plugins.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/plugins/testing_gradle_plugins.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/structuring/composite_builds.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/structuring/composite_builds.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/structuring/declaring_dependencies_between_subprojects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/structuring/declaring_dependencies_between_subprojects.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/structuring/multi_project_builds.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/structuring/multi_project_builds.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/structuring/multi_project_configuration_and_execution.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/structuring/multi_project_configuration_and_execution.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/structuring/sharing_build_logic_between_subprojects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/structuring/sharing_build_logic_between_subprojects.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/build_services.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/build_services.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/controlling_task_execution.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/controlling_task_execution.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/custom_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/custom_tasks.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/implementing_custom_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/implementing_custom_tasks.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/lazy_configuration.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/lazy_configuration.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/more_about_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/more_about_tasks.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/organizing_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/organizing_tasks.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/task_configuration_avoidance.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/task_configuration_avoidance.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/worker_api.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/worker_api.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tutorial/partr1_gradle_init.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tutorial/partr1_gradle_init.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tutorial/partr2_build_lifecycle.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tutorial/partr2_build_lifecycle.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tutorial/partr3_multi_project_builds.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tutorial/partr3_multi_project_builds.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tutorial/partr4_settings_file.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tutorial/partr4_settings_file.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tutorial/partr5_build_scripts.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tutorial/partr5_build_scripts.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tutorial/partr6_writing_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tutorial/partr6_writing_tasks.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tutorial/partr7_writing_plugins.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tutorial/partr7_writing_plugins.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/core-plugins/antlr_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/core-plugins/antlr_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/core-plugins/base_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/core-plugins/base_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/core-plugins/build_dashboard_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/core-plugins/build_dashboard_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/core-plugins/build_init_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/core-plugins/build_init_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/core-plugins/checkstyle_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/core-plugins/checkstyle_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/core-plugins/codenarc_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/core-plugins/codenarc_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/core-plugins/distribution_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/core-plugins/distribution_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/core-plugins/ear_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/core-plugins/ear_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/core-plugins/eclipse_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/core-plugins/eclipse_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/core-plugins/idea_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/core-plugins/idea_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/core-plugins/jacoco_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/core-plugins/jacoco_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/core-plugins/java_gradle_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/core-plugins/java_gradle_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/core-plugins/play_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/core-plugins/play_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/core-plugins/plugin_reference.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/core-plugins/plugin_reference.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/core-plugins/pmd_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/core-plugins/pmd_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/core-plugins/project_report_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/core-plugins/project_report_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/core-plugins/visual_studio_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/core-plugins/visual_studio_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/core-plugins/war_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/core-plugins/war_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/basics/centralizing_dependencies.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/basics/centralizing_dependencies.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/basics/declaring_dependencies.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/basics/declaring_dependencies.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/basics/declaring_repositories.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/basics/declaring_repositories.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/basics/dependency_configurations.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/basics/dependency_configurations.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/basics/dependency_constraints_conflicts.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/basics/dependency_constraints_conflicts.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/basics/dependency_resolution.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/basics/dependency_resolution.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/basics/variant_aware_resolution.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/basics/variant_aware_resolution.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/centralizing-dependencies/centralizing_catalog_platform.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/centralizing-dependencies/centralizing_catalog_platform.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/centralizing-dependencies/platforms.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/centralizing-dependencies/platforms.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/centralizing-dependencies/version_catalogs.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/centralizing-dependencies/version_catalogs.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/controlling-dependency-resolution/artifact_resolution.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/controlling-dependency-resolution/artifact_resolution.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/controlling-dependency-resolution/artifact_transforms.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/controlling-dependency-resolution/artifact_transforms.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-dependencies/declaring_configurations.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-dependencies/declaring_configurations.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-dependencies/declaring_dependencies_basics.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-dependencies/declaring_dependencies_basics.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-dependencies/dependency_constraints.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-dependencies/dependency_constraints.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-dependencies/dependency_versions.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-dependencies/dependency_versions.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-dependencies/viewing_debugging_dependencies.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-dependencies/viewing_debugging_dependencies.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-repositories/centralizing_repositories.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-repositories/centralizing_repositories.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-repositories/declaring_repositories_basics.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-repositories/declaring_repositories_basics.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-repositories/filtering_repository_content.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-repositories/filtering_repository_content.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-repositories/supported_metadata_formats.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-repositories/supported_metadata_formats.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-repositories/supported_repository_protocols.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-repositories/supported_repository_protocols.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-repositories/supported_repository_types.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-repositories/supported_repository_types.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/dependency-management/component_metadata_rules.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/dependency-management/component_metadata_rules.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/dependency-management/dependency_locking.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/dependency-management/dependency_locking.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/dependency-management/resolution_rules.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/dependency-management/resolution_rules.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/getting_started_dep_man.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/getting_started_dep_man.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/other/dependency_verification.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/other/dependency_verification.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/other/dependency_version_alignment.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/other/dependency_version_alignment.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/other/feature_variants.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/other/feature_variants.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/publishing/publishing_customization.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/publishing/publishing_customization.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/publishing/publishing_gradle_module_metadata.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/publishing/publishing_gradle_module_metadata.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/publishing/publishing_ivy.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/publishing/publishing_ivy.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/publishing/publishing_maven.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/publishing/publishing_maven.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/publishing/publishing_setup.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/publishing/publishing_setup.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/publishing/publishing_signing.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/publishing/publishing_signing.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/publishing/signing_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/publishing/signing_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/understanding-dependency-resolution/component_capabilities.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/understanding-dependency-resolution/component_capabilities.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/understanding-dependency-resolution/dependency_caching.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/understanding-dependency-resolution/dependency_caching.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/understanding-dependency-resolution/variant_attributes.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/understanding-dependency-resolution/variant_attributes.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/understanding-dependency-resolution/variant_model.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/understanding-dependency-resolution/variant_model.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/jvm/application_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/application_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/jvm/building_java_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/building_java_projects.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/jvm/dependency_management_for_java_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/dependency_management_for_java_projects.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/jvm/groovy_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/groovy_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/jvm/jacoco_report_aggregation_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/jacoco_report_aggregation_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/jvm/javaProjectGenericLayout.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/javaProjectGenericLayout.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/jvm/javaProjectMainLayout.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/javaProjectMainLayout.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/jvm/javaProjectTestLayout.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/javaProjectTestLayout.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/jvm/java_library_distribution_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/java_library_distribution_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/jvm/java_library_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/java_library_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/jvm/java_platform_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/java_platform_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/jvm/java_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/java_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/jvm/java_testing.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/java_testing.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/jvm/scala_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/scala_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/jvm/test_report_aggregation_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/test_report_aggregation_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/jvm/toolchain_plugins.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/toolchain_plugins.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/jvm/toolchains.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/toolchains.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/legacy/rule_source.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/legacy/rule_source.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/licenses.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/licenses.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/licenses.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/licenses.adoc
@@ -18,13 +18,14 @@
 [[sec:gradle_documentation]]
 == Gradle Documentation
 
-_Copyright © 2007-2023 Gradle, Inc._
+Copyright © 2024 Gradle, Inc. All rights reserved.
+Gradle is a trademark of Gradle, Inc.
 
-Gradle build tool source code is open-source and licensed under the link:https://github.com/gradle/gradle/blob/master/LICENSE[Apache License 2.0].
+Gradle's Build Tool source code is open-source and licensed under the link:https://github.com/gradle/gradle/blob/master/LICENSE[Apache License 2.0].
 
-Gradle user manual and DSL reference manual are licensed under link:http://creativecommons.org/licenses/by-nc-sa/4.0/[Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License].
+Gradle's User Manual and DSL Reference Manual are licensed under link:http://creativecommons.org/licenses/by-nc-sa/4.0/[Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License].
 
 [[licenses:build_scan_plugin]]
 == Gradle Build Scan Plugin
 
-Use of the link:https://scans.gradle.com/plugin/[build scan plugin] is subject to link:https://gradle.com/legal/terms-of-service/[Gradle's Terms of Service].
+Use of the link:https://scans.gradle.com/plugin/[Build Scan plugin] is subject to link:https://gradle.com/legal/terms-of-service/[Gradle's Terms of Service].

--- a/platforms/documentation/docs/src/docs/userguide/native/building_cpp_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/native/building_cpp_projects.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/native/building_swift_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/native/building_swift_projects.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/native/cpp_application_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/native/cpp_application_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/native/cpp_library_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/native/cpp_library_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/native/cpp_testing.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/native/cpp_testing.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/native/cpp_unit_test_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/native/cpp_unit_test_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/native/native_software.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/native/native_software.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/native/swift_application_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/native/swift_application_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/native/swift_library_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/native/swift_library_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/native/swift_testing.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/native/swift_testing.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/native/xcode_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/native/xcode_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/native/xctest_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/native/xctest_plugin.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache_concepts.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache_concepts.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache_debugging.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache_debugging.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache_performance.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache_performance.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache_use_cases.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache_use_cases.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/caching_android_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/caching_android_projects.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/caching_java_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/caching_java_projects.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/common_caching_problems.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/common_caching_problems.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/config_gradle.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/config_gradle.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/configuration_cache.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/configuration_cache.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/file_system_watching.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/file_system_watching.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/gradle_daemon.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/gradle_daemon.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/incremental_build.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/incremental_build.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/inspect.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/inspect.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/isolated_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/isolated_projects.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/networking.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/networking.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/performance.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/performance.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/project_properties.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/project_properties.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/overview/quick_start.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/overview/quick_start.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/overview/userguide.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/overview/userguide.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/overview/userguide.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/overview/userguide.adoc
@@ -69,9 +69,15 @@ The Gradle User Manual is the official documentation for the Gradle Build Tool:
 * **Forum** — The fastest way to get help is through the link:https://discuss.gradle.org/[Gradle Forum].
 * **Slack** — Community members and core contributors answer questions directly on our link:https://gradle-community.slack.com/[Slack Channel].
 
-
-
 == Licenses
+
 [.legalnotice]
 Gradle Build Tool source code is open and licensed under the link:https://github.com/gradle/gradle/blob/master/LICENSE[Apache License 2.0].
 Gradle user manual and DSL reference manual are licensed under link:https://creativecommons.org/licenses/by-nc-sa/4.0/[Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License].
+
+== Copyright
+
+Copyright © 2024 Gradle, Inc. All rights reserved.
+Gradle is a trademark of Gradle, Inc.
+
+For inquiries related to commercial use or licensing, contact Gradle Inc. directly.

--- a/platforms/documentation/docs/src/docs/userguide/reference/command_line_interface.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/command_line_interface.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle_wrapper.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle_wrapper.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/reference/third_party_integration.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/third_party_integration.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/releases/feature_lifecycle.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/feature_lifecycle.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/releases/installation.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/installation.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/releases/migrating/migrating_from_ant.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/migrating/migrating_from_ant.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/releases/migrating/migrating_from_groovy_to_kotlin_dsl.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/migrating/migrating_from_groovy_to_kotlin_dsl.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/releases/migrating/migrating_from_maven.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/migrating/migrating_from_maven.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/releases/troubleshooting.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/troubleshooting.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_4.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_4.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_5.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_5.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_6.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_6.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_7.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_7.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/additional/continuous_builds.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/additional/continuous_builds.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/additional/gradle_ides.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/additional/gradle_ides.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/getting_started_eng.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/getting_started_eng.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/build_file_basics.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/build_file_basics.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/build_scans.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/build_scans.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/command_line_interface_basics.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/command_line_interface_basics.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/dependency_management_basics.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/dependency_management_basics.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/gradle_basics.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/gradle_basics.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/gradle_optimizations.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/gradle_optimizations.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/gradle_wrapper_basics.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/gradle_wrapper_basics.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/plugin_basics.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/plugin_basics.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/settings_file_basics.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/settings_file_basics.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/task_basics.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/task_basics.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/tutorial/part1_gradle_init.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/tutorial/part1_gradle_init.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/tutorial/part2_gradle_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/tutorial/part2_gradle_tasks.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/tutorial/part3_gradle_dep_man.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/tutorial/part3_gradle_dep_man.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/tutorial/part4_gradle_plugins.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/tutorial/part4_gradle_plugins.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/tutorial/part5_gradle_inc_builds.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/tutorial/part5_gradle_inc_builds.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/tutorial/part6_gradle_caching.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/tutorial/part6_gradle_caching.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/tutorial/part7_gradle_refs.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/tutorial/part7_gradle_refs.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/troubleshooting/validation_problems.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/troubleshooting/validation_problems.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/troubleshooting/version_catalog_problems.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/troubleshooting/version_catalog_problems.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.

--- a/platforms/documentation/docs/src/docs/userguide/userguide_single.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/userguide_single.adoc
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gradle, Inc.
+// Copyright (C) 2024 Gradle, Inc.
 //
 // Licensed under the Creative Commons Attribution-Noncommercial-ShareAlike 4.0 International License.;
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Details
This is a Documentation change ONLY.

### Context
[Gradle issue #31402](https://github.com/gradle/gradle/issues/31452)
- "Gradle, Inc." is used for legal or formal documents (e.g., copyright statements, terms of service).
- "Gradle Inc" is used for branding, marketing, or informal contexts where simplicity is preferred.