### PR TITLE
Generate deprecated method when source is deprecated

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
@@ -1672,6 +1672,8 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
                 return;
             }
 
+            boolean deprecated = method.getAnnotation(Deprecated.class) != null;
+
             Type returnType = getType(method.getReturnType());
 
             Type[] originalParameterTypes = collectArray(method.getParameterTypes(), Type.class, Type::getType);
@@ -1686,6 +1688,10 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
 
             // GENERATE public <return type> <method>(Closure v) { return <method>(…, ConfigureUtil.configureUsing(v)); }
             publicMethod(method.getName(), methodDescriptor, methodVisitor -> new MethodVisitorScope(methodVisitor) {{
+
+                if (deprecated) {
+                    visitAnnotation("Ljava/lang/Deprecated;", true).visitEnd();
+                }
 
                 // GENERATE <method>(…, ConfigureUtil.configureUsing(v));
                 _ALOAD(0);

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
@@ -1065,6 +1065,13 @@ public class AsmBackedClassGeneratorTest {
     }
 
     @Test
+    public void mixedInClosureOverloadForActionPreservesDeprecation() throws Exception {
+        BeanWithDeprecatedMethod bean = newInstance(BeanWithDeprecatedMethod.class);
+        assertNull(bean.getClass().getMethod("doStuff", Closure.class).getAnnotation(Deprecated.class));
+        assertNotNull(bean.getClass().getMethod("doDeprecatedStuff", Closure.class).getAnnotation(Deprecated.class));
+    }
+
+    @Test
     public void doesNotOverrideExistingClosureOverload() throws Exception {
         BeanWithDslMethods bean = newInstance(BeanWithDslMethods.class);
         bean.prop = "value";
@@ -1228,6 +1235,13 @@ public class AsmBackedClassGeneratorTest {
         @Override
         public void doStuff(Action<String> action) {
             action.execute("overloaded");
+        }
+    }
+
+    public static class BeanWithDeprecatedMethod extends Bean {
+        @Deprecated
+        public void doDeprecatedStuff(Action<String> action) {
+            action.execute("deprecated");
         }
     }
 


### PR DESCRIPTION
Part of our decoration logic adds Closure taking methods for the Groovy DSL when the Gradle API takes an Action.

These methods should be generated with a @Deprecated annotation when the source method is itself deprecated.

While this does not have a direct user impact, if we ever publish decorated DSL APIs, doing this would make them more correct.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
