### PR TITLE
Fix flaky-under-CC test about rewired inputs

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
@@ -92,7 +92,7 @@ class TaskParametersIntegrationTest extends AbstractIntegrationSpec implements V
                 @InputFiles FileCollection inputs1
                 @InputFiles FileCollection inputs2
 
-                @OutputDirectory File output = project.buildDir
+                @OutputDirectory File output
 
                 @TaskAction void action() {}
             }
@@ -102,6 +102,7 @@ class TaskParametersIntegrationTest extends AbstractIntegrationSpec implements V
             task test(type: TaskWithTwoFileCollectionInputs) {
                 inputs1 = files("input1.txt", "input2.txt")
                 inputs2 = files("input3.txt")
+                output = layout.buildDirectory.dir("out").get().asFile
             }
         """
 
@@ -134,7 +135,7 @@ class TaskParametersIntegrationTest extends AbstractIntegrationSpec implements V
         outputContains "Input property 'inputs2' file ${file("input2.txt")} has been added."
 
         when:
-        succeeds "test", "--info"
+        succeeds "test"
 
         then:
         skipped ':test'


### PR DESCRIPTION
by avoiding having an entire `build` directory to be the task output, and instead by configuring a custom directory


The test is flaky when running with CC or IP executor. This is because `build/reports/problems-report.html` file is difference on a CC miss and CC hit, but the change is observed as task output change.