### PR TITLE
Restore Java compilation failure rendering in Build Scans

### DIFF
--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/exceptions/CompilationFailedIndicator.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/exceptions/CompilationFailedIndicator.java
@@ -22,4 +22,6 @@ public interface CompilationFailedIndicator extends NonGradleCause {
 
     @Nullable
     String getDiagnosticCounts();
+
+    String getShortMessage();
 }

--- a/platforms/jvm/language-java/build.gradle.kts
+++ b/platforms/jvm/language-java/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
     implementation(projects.loggingApi)
     implementation(projects.logging)
     implementation(projects.modelCore)
+    implementation(projects.problemsRendering)
     implementation(projects.toolingApi)
 
     api(libs.slf4jApi)

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CompilationFatalException.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CompilationFatalException.java
@@ -31,4 +31,9 @@ public class CompilationFatalException extends RuntimeException implements Compi
     public String getDiagnosticCounts() {
         return null;
     }
+
+    @Override
+    public String getShortMessage() {
+        return getMessage();
+    }
 }

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
@@ -81,7 +81,7 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
             System.err.println(diagnosticCounts);
         }
         if (!success) {
-            CompilationFailedException exception = new CompilationFailedException(result, diagnosticCounts);
+            CompilationFailedException exception = new CompilationFailedException(result, diagnosticToProblemListener.getReportedProblems(), diagnosticCounts);
             throw problemsService.getInternalReporter().throwing(exception, diagnosticToProblemListener.getReportedProblems());
         } else {
             problemsService.getInternalReporter().report(diagnosticToProblemListener.getReportedProblems());

--- a/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/CompilationFailedExceptionTest.groovy
+++ b/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/CompilationFailedExceptionTest.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile
+
+import org.gradle.api.problems.ProblemId
+import org.gradle.api.problems.internal.GradleCoreProblemGroup
+import org.gradle.api.problems.internal.Problem
+import org.gradle.api.problems.internal.ProblemDefinition
+import spock.lang.Issue
+import spock.lang.Specification
+
+class CompilationFailedExceptionTest extends Specification {
+
+    @Issue('https://github.com/gradle/gradle/issues/31513')
+    def "Exception message contains rendered compiler output when compilation problems are available as problem reports"() {
+        given:
+        def result = Mock(ApiCompilerResult)
+        def problem = compilationProblem()
+        def diagnosticCounts = "1 error"
+        def exception = new CompilationFailedException(result, [problem], diagnosticCounts)
+
+        expect:
+        exception.message.normalize() == """Compilation failed; see the compiler output below.
+Unknown symbol: foo
+1 error"""
+    }
+
+    def compilationProblem() {
+        Mock(Problem) {
+            getDefinition() >> Mock(ProblemDefinition) {
+                getId() >> Mock(ProblemId) {
+                    getName() >> ''
+                    getDisplayName() >> ''
+                    getGroup() >> GradleCoreProblemGroup.compilation().java()
+                }
+            }
+            getDetails() >> 'Unknown symbol: foo'
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -420,7 +420,7 @@ public class BuildExceptionReporter implements Action<Throwable> {
 
     private static String getMessage(Throwable throwable, ProblemLookup problemLookup) {
         try {
-            String msg = throwable.getMessage();
+            String msg = throwable instanceof CompilationFailedIndicator ? ((CompilationFailedIndicator) throwable).getShortMessage() : throwable.getMessage();
             StringBuilder builder = new StringBuilder(msg == null ? "" : msg);
             Collection<Problem> problems = problemLookup.findAll(throwable);
             if (!problems.isEmpty()) {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/TestCompilationFailureException.java
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/TestCompilationFailureException.java
@@ -27,4 +27,9 @@ class TestCompilationFailureException extends Exception implements CompilationFa
     public String getDiagnosticCounts() {
         return null;
     }
+
+    @Override
+    public String getShortMessage() {
+        return getMessage();
+    }
 }


### PR DESCRIPTION
Using the Problems API reports to render build failures made the build scans less readable. More specifically, we moved the compiler output from the exception message to `BuildExceptionRenderer`.

This PR restores the original error message for build scans while preserving the Problems API-based rendering on the CLI.


<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle/issues/31513

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
