### PR TITLE
Prevent deep recursion in collection properties implementations

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -42,6 +42,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
 
@@ -667,28 +668,31 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
             return mergedValue.withSideEffect(sideEffectBuilder.build());
         }
 
+        private Stream<ValueProducer> getProducers() {
+            return collectors.stream().map(ValueSupplier::getProducer);
+        }
+
         @Override
         public ValueProducer getProducer() {
-            List<ValueProducer> producers = getCollectors().stream().map(ValueSupplier::getProducer).collect(toList());
             return new ValueProducer() {
                 @Override
                 public void visitProducerTasks(Action<? super Task> visitor) {
-                    producers.forEach(c -> c.visitProducerTasks(visitor));
+                    getProducers().forEach(c -> c.visitProducerTasks(visitor));
                 }
 
                 @Override
                 public boolean isKnown() {
-                    return producers.stream().anyMatch(ValueProducer::isKnown);
+                    return getProducers().anyMatch(ValueProducer::isKnown);
                 }
 
                 @Override
                 public void visitDependencies(TaskDependencyResolveContext context) {
-                    producers.forEach(c -> c.visitDependencies(context));
+                    getProducers().forEach(c -> c.visitDependencies(context));
                 }
 
                 @Override
                 public void visitContentProducerTasks(Action<? super Task> visitor) {
-                    producers.forEach(c -> c.visitContentProducerTasks(visitor));
+                    getProducers().forEach(c -> c.visitContentProducerTasks(visitor));
                 }
             };
         }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -262,7 +262,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         if (elements == null) {
             unsetValueAndDefault();
         } else {
-            setSupplier(new CollectingSupplier<>(getType(), collectionFactory, valueCollector, new ElementsFromCollection<>(elements)));
+            setSupplier(newSupplierOf(new ElementsFromCollection<>(elements)));
         }
     }
 
@@ -281,7 +281,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
                 throw new IllegalArgumentException(String.format("Cannot set the value of a property of type %s with element type %s using a provider with element type %s.", collectionType.getName(), elementType.getName(), collectionProp.getElementType().getName()));
             }
         }
-        setSupplier(new CollectingSupplier<>(getType(), collectionFactory, valueCollector, new ElementsFromCollectionProvider<>(p)));
+        setSupplier(newSupplierOf(new ElementsFromCollectionProvider<>(p)));
     }
 
     private void unsetValueAndDefault() {
@@ -335,14 +335,14 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         if (elements == null) {
             unsetConvention();
         } else {
-            setConvention(new CollectingSupplier<>(getType(), collectionFactory, valueCollector, new ElementsFromCollection<>(elements)));
+            setConvention(newSupplierOf(new ElementsFromCollection<>(elements)));
         }
         return this;
     }
 
     @Override
     public HasMultipleValues<T> convention(Provider<? extends Iterable<? extends T>> provider) {
-        setConvention(new CollectingSupplier<>(getType(), collectionFactory, valueCollector, new ElementsFromCollectionProvider<>(Providers.internal(provider))));
+        setConvention(newSupplierOf(new ElementsFromCollectionProvider<>(Providers.internal(provider))));
         return this;
     }
 
@@ -412,7 +412,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         @Override
         public CollectionSupplier<T, C> plus(Collector<T> collector) {
             // empty + something = something
-            return new CollectingSupplier<>(getType(), collectionFactory, valueCollector, collector);
+            return newSupplierOf(collector);
         }
 
         @Override
@@ -462,7 +462,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
 
         @Override
         public CollectionSupplier<T, C> plus(Collector<T> collector) {
-            return new CollectingSupplier<>(getType(), collectionFactory, valueCollector, new FixedValueCollector<>(value, sideEffect)).plus(collector);
+            return newSupplierOf(new FixedValueCollector<>(value, sideEffect)).plus(collector);
         }
 
         @Override
@@ -479,6 +479,10 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         public String toString() {
             return value.toString();
         }
+    }
+
+    private CollectingSupplier<T, C> newSupplierOf(Collector<T> value) {
+        return new CollectingSupplier<>(getType(), collectionFactory, valueCollector, value);
     }
 
     private static class CollectingSupplier<T, C extends Collection<T>> extends AbstractMinimalProvider<C> implements CollectionSupplier<T, C> {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -216,7 +216,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
      */
     private void addExplicitCollector(Collector<T> collector, boolean ignoreAbsent) {
         assertCanMutate();
-        CollectionSupplier<T, C> explicitValue = getExplicitValue(defaultValue);
+        CollectionSupplier<T, C> explicitValue = getExplicitValue(defaultValue).absentIgnoringIfNeeded(ignoreAbsent);
         setSupplier(explicitValue.plus(ignoreAbsent ? new AbsentIgnoringCollector<>(collector) : collector));
     }
 
@@ -361,6 +361,11 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         }
 
         @Override
+        public CollectionSupplier<T, C> absentIgnoring() {
+            return Cast.uncheckedCast(emptySupplier());
+        }
+
+        @Override
         public boolean calculatePresence(ValueConsumer consumer) {
             return false;
         }
@@ -411,6 +416,11 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         }
 
         @Override
+        public CollectionSupplier<T, C> absentIgnoring() {
+            return this;
+        }
+
+        @Override
         public ExecutionTimeValue<? extends C> calculateExecutionTimeValue() {
             return ExecutionTimeValue.fixedValue(emptyCollection());
         }
@@ -433,6 +443,11 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         public FixedSupplier(C value, @Nullable SideEffect<? super C> sideEffect) {
             this.value = value;
             this.sideEffect = sideEffect;
+        }
+
+        @Override
+        public CollectionSupplier<T, C> absentIgnoring() {
+            return this;
         }
 
         @Override
@@ -497,6 +512,11 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         @Override
         public Class<C> getType() {
             return type;
+        }
+
+        @Override
+        public CollectionSupplier<T, C> absentIgnoring() {
+            return this;
         }
 
         @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -44,6 +44,7 @@ import java.util.Locale;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -477,7 +478,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         private final ValueCollector<T> valueCollector;
         // This list is shared by the collectors produced by `plus`, so we don't have to copy the collectors every time.
         // However, this also means that you can only call plus on a given collector once.
-        private final List<Collector<T>> collectors; // TODO - Replace with PersistentList? This may make value calculation inefficient because the PersistentList can only prepend to head.
+        private final ArrayList<Collector<T>> collectors; // TODO - Replace with PersistentList? This may make value calculation inefficient because the PersistentList can only prepend to head.
         private final int size;
 
         public CollectingSupplier(Class<C> type, Supplier<ImmutableCollection.Builder<T>> collectionFactory, ValueCollector<T> valueCollector, Collector<T> value) {
@@ -485,7 +486,13 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         }
 
         // A constructor for sharing.
-        private CollectingSupplier(Class<C> type, Supplier<ImmutableCollection.Builder<T>> collectionFactory, ValueCollector<T> valueCollector, List<Collector<T>> collectors, int size) {
+        private CollectingSupplier(
+            Class<C> type,
+            Supplier<ImmutableCollection.Builder<T>> collectionFactory,
+            ValueCollector<T> valueCollector,
+            @SuppressWarnings("NonApiType") ArrayList<Collector<T>> collectors,
+            int size
+        ) {
             this.type = type;
             this.collectionFactory = collectionFactory;
             this.valueCollector = valueCollector;
@@ -603,7 +610,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
                     collectorsWithValues.stream().map(pair -> {
                         Collector<T> elements = toCollector(pair.getRight());
                         return ignoreAbsentIfNeeded(elements, isAbsentIgnoring(pair.getLeft()));
-                    }).collect(toList()),
+                    }).collect(toCollection(ArrayList::new)),
                     collectorsWithValues.size()
                 )
             );

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/CollectionSupplier.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/CollectionSupplier.java
@@ -43,18 +43,4 @@ interface CollectionSupplier<T, C extends Collection<? extends T>> extends Value
     CollectionSupplier<T, C> plus(Collector<T> added);
 
     ExecutionTimeValue<? extends C> calculateExecutionTimeValue();
-
-    /**
-     * Returns a view of this supplier that will calculate its value as empty if it would be missing.
-     * If this supplier already ignores absent results, returns this supplier.
-     */
-    CollectionSupplier<T, C> absentIgnoring();
-
-    /**
-     * Returns a view of this supplier that will calculate its value as empty if it would be missing,
-     * if required. If not required, or this supplier already ignores absent results, returns this supplier.
-     */
-    default CollectionSupplier<T, C> absentIgnoringIfNeeded(boolean required) {
-        return required ? absentIgnoring() : this;
-    }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/CollectionSupplier.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/CollectionSupplier.java
@@ -37,24 +37,12 @@ interface CollectionSupplier<T, C extends Collection<? extends T>> extends Value
      * elements supplied by the given collector.
      *
      * @param added a collector that represents an addition to the collection to be returned by this supplier
+     * @param ignoreAbsent if the resulting supplier should ignore absent value of this supplier or added one and fallback to empty collection
+     *
      * @return a new supplier that produces a collection that contains the
      * same elements as this supplier, plus the elements obtained via the given <code>added</code> collector
      */
-    CollectionSupplier<T, C> plus(Collector<T> added);
+    CollectionSupplier<T, C> plus(Collector<T> added, boolean ignoreAbsent);
 
     ExecutionTimeValue<? extends C> calculateExecutionTimeValue();
-
-    /**
-     * Returns a view of this supplier that will calculate its value as empty if it would be missing.
-     * If this supplier already ignores absent results, returns this supplier.
-     */
-    CollectionSupplier<T, C> absentIgnoring();
-
-    /**
-     * Returns a view of this supplier that will calculate its value as empty if it would be missing,
-     * if required. If not required, or this supplier already ignores absent results, returns this supplier.
-     */
-    default CollectionSupplier<T, C> absentIgnoringIfNeeded(boolean required) {
-        return required ? absentIgnoring() : this;
-    }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/CollectionSupplier.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/CollectionSupplier.java
@@ -43,4 +43,18 @@ interface CollectionSupplier<T, C extends Collection<? extends T>> extends Value
     CollectionSupplier<T, C> plus(Collector<T> added);
 
     ExecutionTimeValue<? extends C> calculateExecutionTimeValue();
+
+    /**
+     * Returns a view of this supplier that will calculate its value as empty if it would be missing.
+     * If this supplier already ignores absent results, returns this supplier.
+     */
+    CollectionSupplier<T, C> absentIgnoring();
+
+    /**
+     * Returns a view of this supplier that will calculate its value as empty if it would be missing,
+     * if required. If not required, or this supplier already ignores absent results, returns this supplier.
+     */
+    default CollectionSupplier<T, C> absentIgnoringIfNeeded(boolean required) {
+        return required ? absentIgnoring() : this;
+    }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/Collector.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/Collector.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.provider;
 
 import com.google.common.collect.ImmutableCollection;
-import org.gradle.api.Action;
 
 
 /**
@@ -31,18 +30,5 @@ public interface Collector<T> extends ValueSupplier {
 
     int size();
 
-    void calculateExecutionTimeValue(Action<? super ExecutionTimeValue<? extends Iterable<? extends T>>> visitor);
-
-    /**
-     * Returns a view of this collector that never returns a missing value.
-     */
-    Collector<T> absentIgnoring();
-
-    /**
-     * Convenience method that returns a view of this collector that never returns a missing value,
-     * if that capability is required, or this very collector.
-     */
-    default Collector<T> absentIgnoringIfNeeded(boolean required) {
-        return required ? absentIgnoring() : this;
-    }
+    ExecutionTimeValue<? extends Iterable<? extends T>> calculateExecutionTimeValue();
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
@@ -20,13 +20,9 @@ import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import org.gradle.api.Action;
 import org.gradle.api.provider.Provider;
-import org.gradle.internal.Cast;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import java.util.Arrays;
 
 import static org.gradle.api.internal.lambdas.SerializableLambdas.transformer;
@@ -49,20 +45,14 @@ public class Collectors {
         }
 
         @Override
-        public Collector<T> absentIgnoring() {
-            // always present
-            return this;
-        }
-
-        @Override
         public Value<Void> collectEntries(ValueConsumer consumer, ValueCollector<T> collector, ImmutableCollection.Builder<T> collection) {
             collector.add(element, collection);
             return Value.present();
         }
 
         @Override
-        public void calculateExecutionTimeValue(Action<? super ExecutionTimeValue<? extends Iterable<? extends T>>> visitor) {
-            visitor.execute(ExecutionTimeValue.fixedValue(ImmutableList.of(element)));
+        public ExecutionTimeValue<? extends Iterable<? extends T>> calculateExecutionTimeValue() {
+            return ExecutionTimeValue.fixedValue(ImmutableList.of(element));
         }
 
         @Override
@@ -106,11 +96,6 @@ public class Collectors {
         }
 
         @Override
-        public Collector<T> absentIgnoring() {
-            return new ElementsFromCollectionProvider<>(provider.map(ImmutableList::of), true);
-        }
-
-        @Override
         public boolean calculatePresence(ValueConsumer consumer) {
             return provider.calculatePresence(consumer);
         }
@@ -132,9 +117,9 @@ public class Collectors {
         }
 
         @Override
-        public void calculateExecutionTimeValue(Action<? super ExecutionTimeValue<? extends Iterable<? extends T>>> visitor) {
+        public ExecutionTimeValue<? extends Iterable<? extends T>> calculateExecutionTimeValue() {
             ExecutionTimeValue<? extends T> value = provider.calculateExecutionTimeValue();
-            visitValue(visitor, value);
+            return visitValue(value);
         }
 
         @Override
@@ -170,14 +155,14 @@ public class Collectors {
         }
     }
 
-    private static <T> void visitValue(Action<? super ValueSupplier.ExecutionTimeValue<? extends Iterable<? extends T>>> visitor, ValueSupplier.ExecutionTimeValue<? extends T> value) {
+    private static <T> ValueSupplier.ExecutionTimeValue<? extends Iterable<? extends T>> visitValue(ValueSupplier.ExecutionTimeValue<? extends T> value) {
         if (value.isMissing()) {
-            visitor.execute(ValueSupplier.ExecutionTimeValue.missing());
+            return ValueSupplier.ExecutionTimeValue.missing();
         } else if (value.hasFixedValue()) {
             // transform preserving side effects
-            visitor.execute(ValueSupplier.ExecutionTimeValue.value(value.toValue().transform(ImmutableList::of)));
+            return ValueSupplier.ExecutionTimeValue.value(value.toValue().transform(ImmutableList::of));
         } else {
-            visitor.execute(ValueSupplier.ExecutionTimeValue.changingValue(value.getChangingValue().map(transformer(ImmutableList::of))));
+            return ValueSupplier.ExecutionTimeValue.changingValue(value.getChangingValue().map(transformer(ImmutableList::of)));
         }
     }
 
@@ -194,20 +179,14 @@ public class Collectors {
         }
 
         @Override
-        public Collector<T> absentIgnoring() {
-            // always present
-            return this;
-        }
-
-        @Override
         public Value<Void> collectEntries(ValueConsumer consumer, ValueCollector<T> collector, ImmutableCollection.Builder<T> collection) {
             collector.addAll(value, collection);
             return Value.present();
         }
 
         @Override
-        public void calculateExecutionTimeValue(Action<? super ExecutionTimeValue<? extends Iterable<? extends T>>> visitor) {
-            visitor.execute(ExecutionTimeValue.fixedValue(value));
+        public ExecutionTimeValue<? extends Iterable<? extends T>> calculateExecutionTimeValue() {
+            return ExecutionTimeValue.fixedValue(value);
         }
 
         @Override
@@ -249,30 +228,14 @@ public class Collectors {
 
     public static class ElementsFromCollectionProvider<T> implements ProvidedCollector<T> {
         private final ProviderInternal<? extends Iterable<? extends T>> provider;
-        private final boolean ignoreAbsent;
 
         public ElementsFromCollectionProvider(ProviderInternal<? extends Iterable<? extends T>> provider) {
-            this(provider, false);
-        }
-
-        private ElementsFromCollectionProvider(ProviderInternal<? extends Iterable<? extends T>> provider, boolean ignoreAbsent) {
-            this.provider = ignoreAbsent ? neverMissing(Cast.uncheckedNonnullCast(provider)) : provider;
-            this.ignoreAbsent = ignoreAbsent;
-        }
-
-        @Nonnull
-        private static <T> ProviderInternal<? extends Iterable<? extends T>> neverMissing(ProviderInternal<Iterable<? extends T>> provider) {
-            return Cast.uncheckedNonnullCast(provider.orElse(ImmutableList.of()));
-        }
-
-        @Override
-        public Collector<T> absentIgnoring() {
-            return ignoreAbsent ? this : new ElementsFromCollectionProvider<>(provider, true);
+            this.provider = provider;
         }
 
         @Override
         public boolean calculatePresence(ValueConsumer consumer) {
-            return ignoreAbsent || provider.calculatePresence(consumer);
+            return provider.calculatePresence(consumer);
         }
 
         @Override
@@ -283,7 +246,7 @@ public class Collectors {
 
         private ValueSupplier.Value<Void> collectEntriesFromValue(ValueCollector<T> collector, ImmutableCollection.Builder<T> collection, ValueSupplier.Value<? extends Iterable<? extends T>> value) {
             if (value.isMissing()) {
-                return ignoreAbsent ? Value.present() : value.asType();
+                return value.asType();
             }
 
             collector.addAll(value.getWithoutSideEffect(), collection);
@@ -291,8 +254,8 @@ public class Collectors {
         }
 
         @Override
-        public void calculateExecutionTimeValue(Action<? super ExecutionTimeValue<? extends Iterable<? extends T>>> visitor) {
-            visitor.execute(provider.calculateExecutionTimeValue());
+        public ExecutionTimeValue<? extends Iterable<? extends T>> calculateExecutionTimeValue() {
+            return provider.calculateExecutionTimeValue();
         }
 
         @Override
@@ -350,12 +313,6 @@ public class Collectors {
         }
 
         @Override
-        public Collector<T> absentIgnoring() {
-            // always present
-            return this;
-        }
-
-        @Override
         public Value<Void> collectEntries(ValueConsumer consumer, ValueCollector<T> collector, ImmutableCollection.Builder<T> dest) {
             for (T t : value) {
                 collector.add(t, dest);
@@ -364,8 +321,8 @@ public class Collectors {
         }
 
         @Override
-        public void calculateExecutionTimeValue(Action<? super ExecutionTimeValue<? extends Iterable<? extends T>>> visitor) {
-            visitor.execute(ExecutionTimeValue.fixedValue(ImmutableList.copyOf(value)));
+        public ExecutionTimeValue<? extends Iterable<? extends T>> calculateExecutionTimeValue() {
+            return ExecutionTimeValue.fixedValue(ImmutableList.copyOf(value));
         }
 
         @Override
@@ -401,11 +358,6 @@ public class Collectors {
         }
 
         @Override
-        public Collector<T> absentIgnoring() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
         public boolean calculatePresence(ValueConsumer consumer) {
             return delegate.calculatePresence(consumer);
         }
@@ -425,8 +377,8 @@ public class Collectors {
         }
 
         @Override
-        public void calculateExecutionTimeValue(Action<? super ExecutionTimeValue<? extends Iterable<? extends T>>> visitor) {
-            delegate.calculateExecutionTimeValue(visitor);
+        public ExecutionTimeValue<? extends Iterable<? extends T>> calculateExecutionTimeValue() {
+            return delegate.calculateExecutionTimeValue();
         }
 
         @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -18,37 +18,43 @@ package org.gradle.api.internal.provider;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableCollection;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import org.gradle.api.Action;
+import org.gradle.api.Task;
 import org.gradle.api.Transformer;
 import org.gradle.api.internal.provider.MapCollectors.EntriesFromMap;
 import org.gradle.api.internal.provider.MapCollectors.EntriesFromMapProvider;
 import org.gradle.api.internal.provider.MapCollectors.EntryWithValueFromProvider;
 import org.gradle.api.internal.provider.MapCollectors.SingleEntry;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
+import org.gradle.internal.Pair;
 import org.gradle.internal.evaluation.EvaluationScopeContext;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.toList;
 import static org.gradle.internal.Cast.uncheckedCast;
 import static org.gradle.internal.Cast.uncheckedNonnullCast;
 
 /**
  * The implementation for {@link MapProperty}.
  * <p>
- *     Value suppliers for map properties are implementations of {@link MapSupplier}.
+ * Value suppliers for map properties are implementations of {@link MapSupplier}.
  * </p>
  * <p>
- *     Increments to map property values are implementations of {@link MapCollector}.
+ * Increments to map property values are implementations of {@link MapCollector}.
  * </p>
  *
  * This class mimics much of the behavior {@link AbstractCollectionProperty} provides for regular collections
@@ -162,13 +168,13 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         if (entries == null) {
             unsetValueAndDefault();
         } else {
-            setSupplier(new CollectingSupplier(new EntriesFromMap<>(entries), false));
+            setSupplier(newCollectingSupplierOf(new EntriesFromMap<>(entries)));
         }
     }
 
     @Override
     public void set(Provider<? extends Map<? extends K, ? extends V>> provider) {
-        setSupplier(new CollectingSupplier(new MapCollectors.EntriesFromMapProvider<>(checkMapProvider(provider)), false));
+        setSupplier(newCollectingSupplierOf(new MapCollectors.EntriesFromMapProvider<>(checkMapProvider(provider))));
     }
 
     @Override
@@ -225,8 +231,8 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
 
     private void addExplicitCollector(MapCollector<K, V> collector, boolean ignoreAbsent) {
         assertCanMutate();
-        MapSupplier<K, V> explicitValue = getExplicitValue(defaultValue).absentIgnoringIfNeeded(ignoreAbsent);
-        setSupplier(explicitValue.plus(collector.absentIgnoringIfNeeded(ignoreAbsent)));
+        MapSupplier<K, V> explicitValue = getExplicitValue(defaultValue);
+        setSupplier(explicitValue.plus(collector, ignoreAbsent));
     }
 
     private Configurer getConfigurer() {
@@ -278,14 +284,14 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         if (value == null) {
             setConvention(noValueSupplier());
         } else {
-            setConvention(new CollectingSupplier(new EntriesFromMap<>(value), false));
+            setConvention(newCollectingSupplierOf(new EntriesFromMap<>(value)));
         }
         return this;
     }
 
     @Override
     public MapProperty<K, V> convention(Provider<? extends Map<? extends K, ? extends V>> valueProvider) {
-        setConvention(new CollectingSupplier(new EntriesFromMapProvider<>(Providers.internal(valueProvider)), false));
+        setConvention(newCollectingSupplierOf(new EntriesFromMapProvider<>(Providers.internal(valueProvider))));
         return this;
     }
 
@@ -312,8 +318,8 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         } else if (value.hasFixedValue()) {
             setSupplier(new FixedSupplier(uncheckedNonnullCast(value.getFixedValue()), uncheckedCast(value.getSideEffect())));
         } else {
-            CollectingProvider<K, V> asCollectingProvider = uncheckedNonnullCast(value.getChangingValue());
-            setSupplier(new CollectingSupplier(new EntriesFromMapProvider<>(asCollectingProvider)));
+            CollectingSupplier<K, V> asCollectingProvider = uncheckedNonnullCast(value.getChangingValue());
+            setSupplier(asCollectingProvider);
         }
     }
 
@@ -408,11 +414,6 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         }
 
         @Override
-        public MapSupplier<K, V> absentIgnoring() {
-            return emptySupplier();
-        }
-
-        @Override
         public boolean calculatePresence(ValueConsumer consumer) {
             return false;
         }
@@ -428,9 +429,9 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         }
 
         @Override
-        public MapSupplier<K, V> plus(MapCollector<K, V> collector) {
-            // nothing + something = nothing
-            return this;
+        public MapSupplier<K, V> plus(MapCollector<K, V> collector, boolean ignoreAbsent) {
+            // nothing + something = nothing, unless we ignoreAbsent.
+            return ignoreAbsent ? newCollectingSupplierOf(ignoreAbsentIfNeeded(collector, ignoreAbsent)) : this;
         }
 
         @Override
@@ -451,11 +452,6 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
 
     private class EmptySupplier implements MapSupplier<K, V> {
         @Override
-        public MapSupplier<K, V> absentIgnoring() {
-            return this;
-        }
-
-        @Override
         public boolean calculatePresence(ValueConsumer consumer) {
             return true;
         }
@@ -471,9 +467,9 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         }
 
         @Override
-        public MapSupplier<K, V> plus(MapCollector<K, V> collector) {
+        public MapSupplier<K, V> plus(MapCollector<K, V> collector, boolean ignoreAbsent) {
             // empty + something = something
-            return new CollectingSupplier(collector);
+            return newCollectingSupplierOf(ignoreAbsentIfNeeded(collector, ignoreAbsent));
         }
 
         @Override
@@ -517,15 +513,8 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         }
 
         @Override
-        public MapSupplier<K, V> plus(MapCollector<K, V> collector) {
-            MapCollector<K, V> left = new FixedValueCollector<>(entries, sideEffect);
-            PlusCollector<K, V> newCollector = new PlusCollector<>(left, collector);
-            return new CollectingSupplier(newCollector);
-        }
-
-        @Override
-        public MapSupplier<K, V> absentIgnoring() {
-            return this;
+        public MapSupplier<K, V> plus(MapCollector<K, V> collector, boolean ignoreAbsent) {
+            return newCollectingSupplierOf(new FixedValueCollector<>(entries, sideEffect)).plus(collector, ignoreAbsent);
         }
 
         @Override
@@ -544,39 +533,76 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         }
     }
 
-    private class CollectingSupplier implements MapSupplier<K, V> {
-        private final MapCollector<K, V> collector;
-        // TODO-RC: can we get rid of this? Can we only keep this in Collectors? Changing execution time value is the only case that needs this.
-        private final boolean ignoreAbsent;
+    private CollectingSupplier<K, V> newCollectingSupplierOf(MapCollector<K, V> collector) {
+        return new CollectingSupplier<>(keyCollector, entryCollector, collector);
+    }
 
-        public CollectingSupplier(MapCollector<K, V> collector, boolean ignoreAbsent) {
-            this.collector = collector;
-            this.ignoreAbsent = ignoreAbsent;
+    private static class CollectingSupplier<K, V> extends AbstractMinimalProvider<Map<K, V>> implements MapSupplier<K, V> {
+        private final ValueCollector<K> keyCollector;
+        private final MapEntryCollector<K, V> entryCollector;
+        private final List<MapCollector<K, V>> collectors;
+        private final int size;
+
+        public CollectingSupplier(ValueCollector<K> keyCollector, MapEntryCollector<K, V> entryCollector, MapCollector<K, V> collector) {
+            this(keyCollector, entryCollector, Lists.newArrayList(collector), 1);
         }
 
-        public CollectingSupplier(MapCollector<K, V> collector) {
-            this(collector, false);
+        public CollectingSupplier(ValueCollector<K> keyCollector, MapEntryCollector<K, V> entryCollector, List<MapCollector<K, V>> collectors, int size) {
+            this.keyCollector = keyCollector;
+            this.entryCollector = entryCollector;
+            this.size = size;
+            this.collectors = collectors;
         }
 
         @Override
-        public MapSupplier<K, V> absentIgnoring() {
-            return ignoreAbsent ? this : new CollectingSupplier(collector, true);
+        protected Value<? extends Map<K, V>> calculateOwnValue(ValueConsumer consumer) {
+            return calculateValue(consumer);
         }
 
         @Override
         public boolean calculatePresence(ValueConsumer consumer) {
-            return collector.calculatePresence(consumer);
+            for (MapCollector<K, V> collector : Lists.reverse(getCollectors())) {
+                if (!collector.calculatePresence(consumer)) {
+                    return false;
+                }
+                if (collector instanceof AbsentIgnoringCollector<?, ?>) {
+                    return true;
+                }
+            }
+            return true;
+        }
+
+        @Nullable
+        @Override
+        @SuppressWarnings("unchecked")
+        public Class<Map<K, V>> getType() {
+            return (Class) Map.class;
         }
 
         @Override
         public Value<? extends Set<K>> calculateKeys(ValueConsumer consumer) {
             // TODO - don't make a copy when the collector already produces an immutable collection
             ImmutableSet.Builder<K> builder = ImmutableSet.builder();
-            Value<Void> result = collector.collectKeys(consumer, keyCollector, builder);
-            if (result.isMissing()) {
-                return result.asType();
+            Value<Void> compositeResult = Value.present();
+            for (MapCollector<K, V> collector : getCollectors()) {
+                Value<Void> result = collector.collectKeys(consumer, keyCollector, builder);
+                if (result.isMissing()) {
+                    builder = ImmutableSet.builder();
+                    compositeResult = result;
+                } else if (compositeResult.isMissing()) {
+                    if (isAbsentIgnoring(collector)) {
+                        compositeResult = result;
+                    } else {
+                        builder = ImmutableSet.builder();
+                    }
+                } else {
+                    compositeResult = compositeResult.withSideEffect(SideEffect.fixedFrom(result));
+                }
             }
-            return Value.of(ImmutableSet.copyOf(builder.build())).withSideEffect(SideEffect.fixedFrom(result));
+            if (compositeResult.isMissing()) {
+                return compositeResult.asType();
+            }
+            return Value.of(ImmutableSet.copyOf(builder.build())).withSideEffect(SideEffect.fixedFrom(compositeResult));
         }
 
         @Override
@@ -586,28 +612,66 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
             // for MapProperty allows a provider to override the entries of earlier providers and so there can be multiple entries
             // with the same key
             Map<K, V> entries = new LinkedHashMap<>();
-            Value<Void> result = collector.collectEntries(consumer, entryCollector, entries);
-            if (result.isMissing()) {
-                return result.asType();
+            Value<Void> compositeResult = Value.present();
+            for (MapCollector<K, V> collector : getCollectors()) {
+                Value<Void> result = collector.collectEntries(consumer, entryCollector, entries);
+                if (result.isMissing()) {
+                    entries.clear();
+                    compositeResult = result;
+                } else if (compositeResult.isMissing()) {
+                    if (isAbsentIgnoring(collector)) {
+                        compositeResult = result;
+                    } else {
+                        entries.clear();
+                    }
+                } else {
+                    compositeResult = compositeResult.withSideEffect(SideEffect.fixedFrom(result));
+                }
             }
-            return Value.of(ImmutableMap.copyOf(entries)).withSideEffect(SideEffect.fixedFrom(result));
+            if (compositeResult.isMissing()) {
+                return compositeResult.asType();
+            }
+            return Value.of(ImmutableMap.copyOf(entries)).withSideEffect(SideEffect.fixedFrom(compositeResult));
         }
 
         @Override
-        public MapSupplier<K, V> plus(MapCollector<K, V> addedCollector) {
-            MapCollector<K, V> left = this.collector.absentIgnoringIfNeeded(ignoreAbsent);
-            MapCollector<K, V> right = addedCollector;
-            PlusCollector<K, V> newCollector = new PlusCollector<>(left, right);
-            return new CollectingSupplier(newCollector);
+        public MapSupplier<K, V> plus(MapCollector<K, V> addedCollector, boolean ignoreAbsent) {
+            Preconditions.checkState(collectors.size() == size);
+            collectors.add(ignoreAbsentIfNeeded(addedCollector, ignoreAbsent));
+            return new CollectingSupplier<>(keyCollector, entryCollector, collectors, size + 1);
         }
 
         @Override
         public ExecutionTimeValue<? extends Map<K, V>> calculateExecutionTimeValue() {
-            List<ExecutionTimeValue<? extends Map<? extends K, ? extends V>>> execTimeValues = collectExecutionTimeValues();
-            ExecutionTimeValue<Map<K, V>> fixedOrMissing = fixedOrMissingValueOf(execTimeValues);
-            return fixedOrMissing != null
-                ? fixedOrMissing
-                : ExecutionTimeValue.changingValue(new CollectingProvider<>(execTimeValues));
+            List<Pair<MapCollector<K, V>, ExecutionTimeValue<? extends Map<? extends K, ? extends V>>>> collectorsWithValues = collectExecutionTimeValues();
+            if (collectorsWithValues.isEmpty()) {
+                return ExecutionTimeValue.missing();
+            }
+            List<ExecutionTimeValue<? extends Map<? extends K, ? extends V>>> executionTimeValues = collectorsWithValues.stream().map(Pair::getRight).collect(Collectors.toList());
+            ExecutionTimeValue<Map<K, V>> fixedOrMissing = fixedOrMissingValueOf(executionTimeValues);
+            if (fixedOrMissing != null) {
+                return fixedOrMissing;
+            }
+
+            return ExecutionTimeValue.changingValue(new CollectingSupplier<>(
+                keyCollector,
+                entryCollector,
+                collectorsWithValues.stream().map(pair -> {
+                    MapCollector<K, V> elements = toCollector(pair.getRight());
+                    return isAbsentIgnoring(pair.getLeft())
+                        ? new AbsentIgnoringCollector<>(elements)
+                        : elements;
+                }).collect(toList()),
+                collectorsWithValues.size())
+            );
+        }
+
+        private MapCollector<K, V> toCollector(ExecutionTimeValue<? extends Map<? extends K, ? extends V>> value) {
+            Preconditions.checkArgument(!value.isMissing(), "Cannot get a collector for the missing value");
+            if (value.isChangingValue() || value.hasChangingContent() || value.getSideEffect() != null) {
+                return new EntriesFromMapProvider<>(value.toProvider());
+            }
+            return new EntriesFromMap<>(value.getFixedValue());
         }
 
         /**
@@ -636,10 +700,26 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
             return null;
         }
 
-        private List<ExecutionTimeValue<? extends Map<? extends K, ? extends V>>> collectExecutionTimeValues() {
-            List<ExecutionTimeValue<? extends Map<? extends K, ? extends V>>> values = new ArrayList<>();
-            collector.calculateExecutionTimeValue(values::add);
-            return values;
+        @Nonnull
+        private List<Pair<MapCollector<K, V>, ExecutionTimeValue<? extends Map<? extends K, ? extends V>>>> collectExecutionTimeValues() {
+            List<Pair<MapCollector<K, V>, ExecutionTimeValue<? extends Map<? extends K, ? extends V>>>> executionTimeValues = new ArrayList<>();
+            List<Pair<MapCollector<K, V>, ExecutionTimeValue<? extends Map<? extends K, ? extends V>>>> candidates = new ArrayList<>();
+
+            for (MapCollector<K, V> collector : Lists.reverse(getCollectors())) {
+                ExecutionTimeValue<? extends Map<? extends K, ? extends V>> result = collector.calculateExecutionTimeValue();
+                if (result.isMissing()) {
+                    return Lists.reverse(executionTimeValues);
+                }
+                if (isAbsentIgnoring(collector)) {
+                    executionTimeValues.addAll(candidates);
+                    executionTimeValues.add(Pair.of(collector, result));
+                    candidates.clear();
+                } else {
+                    candidates.add(Pair.of(collector, result));
+                }
+            }
+            executionTimeValues.addAll(candidates);
+            return Lists.reverse(executionTimeValues);
         }
 
         private ImmutableMap<K, V> collectEntries(List<ExecutionTimeValue<? extends Map<? extends K, ? extends V>>> values, SideEffectBuilder<? super Map<K, V>> sideEffectBuilder) {
@@ -651,54 +731,108 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
             return ImmutableMap.copyOf(entries);
         }
 
+        private List<MapCollector<K, V>> getCollectors() {
+            return collectors.subList(0, size);
+        }
+
         private ExecutionTimeValue<Map<K, V>> maybeChangingContent(ExecutionTimeValue<Map<K, V>> value, boolean changingContent) {
             return changingContent ? value.withChangingContent() : value;
         }
 
         @Override
         public ValueProducer getProducer() {
-            return collector.getProducer();
+            List<ValueProducer> producers = getCollectors().stream().map(ValueSupplier::getProducer).collect(toList());
+            return new ValueProducer() {
+                @Override
+                public void visitProducerTasks(Action<? super Task> visitor) {
+                    producers.forEach(c -> c.visitProducerTasks(visitor));
+                }
+
+                @Override
+                public boolean isKnown() {
+                    return producers.stream().anyMatch(ValueProducer::isKnown);
+                }
+
+                @Override
+                public void visitDependencies(TaskDependencyResolveContext context) {
+                    producers.forEach(c -> c.visitDependencies(context));
+                }
+
+                @Override
+                public void visitContentProducerTasks(Action<? super Task> visitor) {
+                    producers.forEach(c -> c.visitContentProducerTasks(visitor));
+                }
+            };
         }
 
         @Override
-        public String toString() {
-            return collector.toString();
+        protected String toStringNoReentrance() {
+            StringBuilder sb = new StringBuilder();
+            getCollectors().forEach(collector -> {
+                if (sb.length() > 0) {
+                    sb.append(" + ");
+                }
+                sb.append(collector.toString());
+            });
+            return sb.toString();
         }
     }
 
-    private static class CollectingProvider<K, V> extends AbstractMinimalProvider<Map<K, V>> {
-        private final List<ExecutionTimeValue<? extends Map<? extends K, ? extends V>>> values;
+    private static boolean isAbsentIgnoring(MapCollector<?, ?> collector) {
+        return collector instanceof AbsentIgnoringCollector<?, ?>;
+    }
 
-        public CollectingProvider(List<ExecutionTimeValue<? extends Map<? extends K, ? extends V>>> values) {
-            this.values = values;
+    private static <K, V> MapCollector<K, V> ignoreAbsentIfNeeded(MapCollector<K, V> collector, boolean ignoreAbsent) {
+        if (ignoreAbsent && !isAbsentIgnoring(collector)) {
+            return new AbsentIgnoringCollector<>(collector);
+        }
+        return collector;
+    }
+
+    private static class AbsentIgnoringCollector<K, V> implements MapCollector<K, V> {
+        private final MapCollector<K, V> delegate;
+
+        private AbsentIgnoringCollector(MapCollector<K, V> delegate) {
+            this.delegate = delegate;
         }
 
-        @Nullable
         @Override
-        public Class<Map<K, V>> getType() {
-            return uncheckedCast(Map.class);
-        }
-
-        @Override
-        public ExecutionTimeValue<? extends Map<K, V>> calculateExecutionTimeValue() {
-            return ExecutionTimeValue.changingValue(this);
-        }
-
-        @Override
-        protected Value<? extends Map<K, V>> calculateOwnValue(ValueConsumer consumer) {
-            Map<K, V> entries = new LinkedHashMap<>();
-            SideEffectBuilder<? super Map<K, V>> sideEffectBuilder = SideEffect.builder();
-            for (ExecutionTimeValue<? extends Map<? extends K, ? extends V>> executionTimeValue : values) {
-                Value<? extends Map<? extends K, ? extends V>> value = executionTimeValue.toProvider().calculateValue(consumer);
-                if (value.isMissing()) {
-                    return Value.missing();
-                } else {
-                    entries.putAll(value.getWithoutSideEffect());
-                    sideEffectBuilder.add(SideEffect.fixedFrom(value));
-                }
+        public Value<Void> collectEntries(ValueConsumer consumer, MapEntryCollector<K, V> collector, Map<K, V> dest) {
+            Map<K, V> candidates = new LinkedHashMap<>();
+            // we cannot use dest directly because we don't want to emit any entries if either left or right are missing
+            Value<Void> value = delegate.collectEntries(consumer, collector, candidates);
+            if (value.isMissing()) {
+                return Value.present();
             }
+            dest.putAll(candidates);
+            return Value.present().withSideEffect(SideEffect.fixedFrom(value));
+        }
 
-            return Value.of(ImmutableMap.copyOf(entries)).withSideEffect(sideEffectBuilder.build());
+        @Override
+        public Value<Void> collectKeys(ValueConsumer consumer, ValueCollector<K> collector, ImmutableCollection.Builder<K> dest) {
+            ImmutableSet.Builder<K> candidateKeys = ImmutableSet.builder();
+            Value<Void> value = delegate.collectKeys(consumer, collector, candidateKeys);
+            if (value.isMissing()) {
+                return Value.present();
+            }
+            dest.addAll(candidateKeys.build());
+            return value;
+        }
+
+        @Override
+        public ExecutionTimeValue<? extends Map<? extends K, ? extends V>> calculateExecutionTimeValue() {
+            ExecutionTimeValue<? extends Map<? extends K, ? extends V>> executionTimeValue = delegate.calculateExecutionTimeValue();
+            return executionTimeValue.isMissing() ? ExecutionTimeValue.fixedValue(ImmutableMap.of()) : executionTimeValue;
+        }
+
+        @Override
+        public ValueProducer getProducer() {
+            return delegate.getProducer();
+        }
+
+        @Override
+        public boolean calculatePresence(ValueConsumer consumer) {
+            return true;
         }
     }
 
@@ -767,14 +901,8 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         }
 
         @Override
-        public void calculateExecutionTimeValue(Action<ExecutionTimeValue<? extends Map<? extends K, ? extends V>>> visitor) {
-            visitor.execute(ExecutionTimeValue.fixedValue(entries).withSideEffect(sideEffect));
-        }
-
-        @Override
-        public MapCollector<K, V> absentIgnoring() {
-            // always present
-            return this;
+        public ExecutionTimeValue<? extends Map<? extends K, ? extends V>> calculateExecutionTimeValue() {
+            return ExecutionTimeValue.fixedValue(entries).withSideEffect(sideEffect);
         }
 
         @Override
@@ -790,147 +918,6 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         @Override
         public String toString() {
             return entries.toString();
-        }
-    }
-
-    private static abstract class AbstractPlusCollector<K, V> implements MapCollector<K, V> {
-
-        protected final MapCollector<K, V> left;
-        protected final MapCollector<K, V> right;
-
-        private AbstractPlusCollector(MapCollector<K, V> left, MapCollector<K, V> right) {
-            this.left = left;
-            this.right = right;
-        }
-
-        @Override
-        public ValueProducer getProducer() {
-            return left.getProducer().plus(right.getProducer());
-        }
-
-        @Override
-        public String toString() {
-            return left + " + " + right;
-        }
-    }
-
-    private static class PlusCollector<K, V> extends AbstractPlusCollector<K, V> {
-
-        public PlusCollector(MapCollector<K, V> left, MapCollector<K, V> right) {
-            super(left, right);
-        }
-
-        @Override
-        public MapCollector<K, V> absentIgnoring() {
-            return new AbsentIgnoringPlusCollector<K, V>(left, right);
-        }
-
-        @Override
-        public boolean calculatePresence(ValueConsumer consumer) {
-            return left.calculatePresence(consumer) && right.calculatePresence(consumer);
-        }
-
-        @Override
-        public Value<Void> collectEntries(ValueConsumer consumer, MapEntryCollector<K, V> collector, Map<K, V> dest) {
-            Value<Void> leftValue = left.collectEntries(consumer, collector, dest);
-            if (leftValue.isMissing()) {
-                return leftValue;
-            }
-            Value<Void> rightValue = right.collectEntries(consumer, collector, dest);
-            if (rightValue.isMissing()) {
-                return rightValue;
-            }
-
-            return Value.present()
-                .withSideEffect(SideEffect.fixedFrom(leftValue))
-                .withSideEffect(SideEffect.fixedFrom(rightValue));
-        }
-
-        @Override
-        public Value<Void> collectKeys(ValueConsumer consumer, ValueCollector<K> collector, ImmutableCollection.Builder<K> dest) {
-            Value<Void> result = left.collectKeys(consumer, collector, dest);
-            if (result.isMissing()) {
-                return result;
-            }
-            return right.collectKeys(consumer, collector, dest);
-        }
-
-        @Override
-        public void calculateExecutionTimeValue(Action<ExecutionTimeValue<? extends Map<? extends K, ? extends V>>> visitor) {
-            left.calculateExecutionTimeValue(visitor);
-            right.calculateExecutionTimeValue(visitor);
-        }
-    }
-
-    /**
-     * A plus collector that either produces a composition of both of its left and right sides,
-     * or Value.present() with empty content (if left or right side are missing).
-     */
-    private static class AbsentIgnoringPlusCollector<K, V> extends AbstractPlusCollector<K, V> {
-
-        private AbsentIgnoringPlusCollector(MapCollector<K, V> left, MapCollector<K, V> right) {
-            super(left, right);
-        }
-
-        @Override
-        public boolean calculatePresence(ValueConsumer consumer) {
-            return true;
-        }
-
-        @Override
-        public MapCollector<K, V> absentIgnoring() {
-            return this;
-        }
-
-        @Override
-        public Value<Void> collectEntries(ValueConsumer consumer, MapEntryCollector<K, V> collector, Map<K, V> dest) {
-            Map<K, V> candidates = new LinkedHashMap<>();
-            // we cannot use dest directly because we don't want to emit any entries if either left or right are missing
-            Value<Void> leftValue = left.collectEntries(consumer, collector, candidates);
-            if (leftValue.isMissing()) {
-                return Value.present();
-            }
-            Value<Void> rightValue = right.collectEntries(consumer, collector, candidates);
-            if (rightValue.isMissing()) {
-                return Value.present();
-            }
-            dest.putAll(candidates);
-            return Value.present()
-                .withSideEffect(SideEffect.fixedFrom(leftValue))
-                .withSideEffect(SideEffect.fixedFrom(rightValue));
-        }
-
-        @Override
-        public Value<Void> collectKeys(ValueConsumer consumer, ValueCollector<K> collector, ImmutableCollection.Builder<K> dest) {
-            ImmutableSet.Builder<K> candidateKeys = ImmutableSet.builder();
-            Value<Void> leftResult = left.collectKeys(consumer, collector, candidateKeys);
-            if (leftResult.isMissing()) {
-                return Value.present();
-            }
-            Value<Void> rightResult = right.collectKeys(consumer, collector, candidateKeys);
-            if (rightResult.isMissing()) {
-                return Value.present();
-            }
-            dest.addAll(candidateKeys.build());
-            return rightResult;
-        }
-
-        @Override
-        public void calculateExecutionTimeValue(Action<ExecutionTimeValue<? extends Map<? extends K, ? extends V>>> visitor) {
-            boolean[] anyMissing = {false};
-            ImmutableList.Builder<ExecutionTimeValue<? extends Map<? extends K, ? extends V>>> toVisit = ImmutableList.builder();
-            Action<ExecutionTimeValue<? extends Map<? extends K, ? extends V>>> safeVisitor = value -> {
-                if (value.isMissing()) {
-                    anyMissing[0] = true;
-                } else {
-                    toVisit.add(value);
-                }
-            };
-            left.calculateExecutionTimeValue(safeVisitor);
-            right.calculateExecutionTimeValue(safeVisitor);
-            if (!anyMissing[0]) {
-                toVisit.build().forEach(it -> visitor.execute(it));
-            }
         }
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MapCollector.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MapCollector.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.provider;
 
 import com.google.common.collect.ImmutableCollection;
-import org.gradle.api.Action;
 
 import java.util.Map;
 
@@ -25,7 +24,7 @@ import java.util.Map;
  * A supplier of zero or more mappings from value of type {@link K} to value of type {@link V}.
  *
  * <p>
- *     A <code>MapCollector</code> is for {@link DefaultMapProperty} and {@link MapSupplier} what {@link Collector} is for {@link AbstractCollectionProperty} and {@link CollectionSupplier}.
+ * A <code>MapCollector</code> is for {@link DefaultMapProperty} and {@link MapSupplier} what {@link Collector} is for {@link AbstractCollectionProperty} and {@link CollectionSupplier}.
  * </p>
  */
 public interface MapCollector<K, V> extends ValueSupplier {
@@ -34,14 +33,5 @@ public interface MapCollector<K, V> extends ValueSupplier {
 
     Value<Void> collectKeys(ValueConsumer consumer, ValueCollector<K> collector, ImmutableCollection.Builder<K> dest);
 
-    void calculateExecutionTimeValue(Action<ExecutionTimeValue<? extends Map<? extends K, ? extends V>>> visitor);
-
-    MapCollector<K, V> absentIgnoring();
-
-    /**
-     * Returns a collector that may never return a missing value.
-     */
-    default MapCollector<K, V> absentIgnoringIfNeeded(boolean ignoreAbsent) {
-        return ignoreAbsent ? absentIgnoring() : this;
-    }
+    ExecutionTimeValue<? extends Map<? extends K, ? extends V>> calculateExecutionTimeValue();
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MapSupplier.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MapSupplier.java
@@ -30,16 +30,7 @@ interface MapSupplier<K, V> extends ValueSupplier {
 
     Value<? extends Set<K>> calculateKeys(ValueConsumer consumer);
 
-    MapSupplier<K, V> plus(MapCollector<K, V> collector);
-
-    /**
-     * Returns a view of this supplier that may calculate its value as empty if it would be missing.
-     */
-    MapSupplier<K, V> absentIgnoring();
-
-    default MapSupplier<K, V> absentIgnoringIfNeeded(boolean required) {
-        return required ? absentIgnoring() : this;
-    }
+    MapSupplier<K, V> plus(MapCollector<K, V> collector, boolean ignoreAbsent);
 
     ExecutionTimeValue<? extends Map<K, V>> calculateExecutionTimeValue();
 }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
@@ -1620,6 +1620,15 @@ The value of this property is derived from: <source>""")
         !property.explicit
     }
 
+    def "append to an undefined property is undefined-safe"() {
+        given:
+        property.set((Iterable) null)
+        property.append('foo')
+
+        expect:
+        assertValueIs(['foo'])
+    }
+
     def "can add a lot of providers"() {
         given:
         (0..<100000).each {

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
@@ -29,6 +29,7 @@ import org.spockframework.lang.Wildcard
 import java.util.function.Consumer
 
 import static org.gradle.api.internal.provider.CircularEvaluationSpec.ProviderConsumer.GET_PRODUCER
+import static org.gradle.api.internal.provider.CircularEvaluationSpec.ProviderConsumer.TO_STRING
 import static org.gradle.api.internal.provider.Providers.notDefined
 
 abstract class CollectionPropertySpec<C extends Collection<String>> extends PropertySpec<C> {
@@ -1164,6 +1165,11 @@ The value of this property is derived from: <source>""")
     }
 
     static abstract class CollectionPropertyCircularChainEvaluationTest<T, C extends Collection<T>> extends PropertySpec.PropertyCircularChainEvaluationSpec<C> {
+        @Override
+        List<Consumer<ProviderInternal<?>>> safeConsumers() {
+            return [TO_STRING, GET_PRODUCER]
+        }
+
         @Override
         abstract AbstractCollectionProperty<T, C> property()
 

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
@@ -1385,48 +1385,48 @@ The value of this property is derived from: <source>""")
         }
 
         when:
-        operations.each {operation -> operation.call(property) }
+        operations.each { operation -> operation.call(property) }
 
         then:
         expected == null || property.getOrNull() == toImmutable(expected)
         expected != null || !property.present
 
         where:
-        expected    | explicit      | convention    | label                                             | operations
-        ["1"]       | _             | _             | "add"                                             | { it.add("1") }
-        ["1"]       | _             | _             | "append"                                          | { it.append("1") }
-        ["1"]       | []            | _             | "add to empty"                                    | { it.add("1") }
-        ["1"]       | []            | _             | "append to empty"                                 | { it.append("1") }
-        ["1"]       | _             | []            | "add to empty convention"                         | { it.add("1") }
-        ["1"]       | _             | []            | "append to empty convention"                      | { it.append("1") }
-        null        | null          | []            | "add to unset value w/ empty convention"          | { it.add("1") }
-        ["1"]       | null          | []            | "append to unset value w/ empty convention"       | { it.append("1") }
-        ["1"]       | _             | ["0"]         | "add to non-empty convention"                     | { it.add("1") }
-        ["0", "1"]  | _             | ["0"]         | "append to non-empty convention"                  | { it.append("1") }
-        null        | null          | ["0"]         | "add to unset value w/ non-empty convention"      | { it.add("1") }
-        ["0", "1"]  | null          | ["0"]         | "append to unset value w/ non-empty convention"   | { it.append("1") }
-        null        | notDefined()  | _             | "add to missing"                                  | { it.add("1") }
-        ["1"]       | notDefined()  | _             | "append to missing"                               | { it.append("1") }
-        null        | notDefined()  | ["0"]         | "add to missing w/ non-empty convention"          | { it.add("1") }
-        ["1"]       | notDefined()  | ["0"]         | "append to missing w/ non-empty convention"       | { it.append("1") }
-        null        | []            | _             | "add missing to empty value"                      | { it.add(notDefined()) }
-        []          | []            | _             | "append missing to empty value"                   | { it.append(notDefined()) }
-        null        | _             | _             | "add missing"                                     | { it.add(notDefined()) }
-        []          | _             | _             | "append missing"                                  | { it.append(notDefined()) }
-        ["1"]       | _             | _             | "add missing, then append"                        | { it.add(notDefined()) ; it.append("1") }
-        ["1"]       | _             | _             | "append missing, then add"                        | { it.append(notDefined()) ; it.add("1") }
-        ["1"]       | ["0"]         | _             | "add missing to non-empty value, then append"     | { it.add(notDefined()) ; it.append("1") }
-        ["0", "1"]  | ["0"]         | _             | "append missing to non-empty value, then add"     | { it.append(notDefined()) ; it.add("1") }
-        ["1"]       | _             | ["0"]         | "add missing to non-empty convention, then append"| { it.add(notDefined()) ; it.append("1") }
-        ["0", "1"]  | _             | ["0"]         | "append missing to non-empty convention, then add"| { it.append(notDefined()) ; it.add("1") }
-        ["1"]       | _             | _             | "add, then append missing"                        | { it.add("1") ; it.append(notDefined()) }
-        null        | _             | _             | "append, then add missing"                        | { it.append("1") ; it.add(notDefined()) }
-        ["0", "1"]  | ["0"]         | _             | "add to non-empty value, then append missing"     | { it.add("1") ; it.append(notDefined()) }
-        null        | ["0"]         | _             | "append to non-empty value, then add missing"     | { it.append("1") ; it.add(notDefined()) }
-        ["1"]       | _             | ["0"]         | "add to non-empty convention, then append missing"| { it.add("1") ; it.append(notDefined()) }
-        null        | _             | ["0"]         | "append to non-empty conventio, then add missing" | { it.append("1") ; it.add(notDefined()) }
-        ["1"]       | _             | _             | "add, then add missing, then append"              | { it.add("0") ; it.add(notDefined()) ; it.append("1") }
-        ["0", "1"]  | _             | _             | "add, then append missing, then add"              | { it.add("0") ; it.append(notDefined()) ; it.add("1") }
+        expected   | explicit     | convention | label                                              | operations
+        ["1"]      | _            | _          | "add"                                              | { it.add("1") }
+        ["1"]      | _            | _          | "append"                                           | { it.append("1") }
+        ["1"]      | []           | _          | "add to empty"                                     | { it.add("1") }
+        ["1"]      | []           | _          | "append to empty"                                  | { it.append("1") }
+        ["1"]      | _            | []         | "add to empty convention"                          | { it.add("1") }
+        ["1"]      | _            | []         | "append to empty convention"                       | { it.append("1") }
+        null       | null         | []         | "add to unset value w/ empty convention"           | { it.add("1") }
+        ["1"]      | null         | []         | "append to unset value w/ empty convention"        | { it.append("1") }
+        ["1"]      | _            | ["0"]      | "add to non-empty convention"                      | { it.add("1") }
+        ["0", "1"] | _            | ["0"]      | "append to non-empty convention"                   | { it.append("1") }
+        null       | null         | ["0"]      | "add to unset value w/ non-empty convention"       | { it.add("1") }
+        ["0", "1"] | null         | ["0"]      | "append to unset value w/ non-empty convention"    | { it.append("1") }
+        null       | notDefined() | _          | "add to missing"                                   | { it.add("1") }
+        ["1"]      | notDefined() | _          | "append to missing"                                | { it.append("1") }
+        null       | notDefined() | ["0"]      | "add to missing w/ non-empty convention"           | { it.add("1") }
+        ["1"]      | notDefined() | ["0"]      | "append to missing w/ non-empty convention"        | { it.append("1") }
+        null       | []           | _          | "add missing to empty value"                       | { it.add(notDefined()) }
+        []         | []           | _          | "append missing to empty value"                    | { it.append(notDefined()) }
+        null       | _            | _          | "add missing"                                      | { it.add(notDefined()) }
+        []         | _            | _          | "append missing"                                   | { it.append(notDefined()) }
+        ["1"]      | _            | _          | "add missing, then append"                         | { it.add(notDefined()); it.append("1") }
+        ["1"]      | _            | _          | "append missing, then add"                         | { it.append(notDefined()); it.add("1") }
+        ["1"]      | ["0"]        | _          | "add missing to non-empty value, then append"      | { it.add(notDefined()); it.append("1") }
+        ["0", "1"] | ["0"]        | _          | "append missing to non-empty value, then add"      | { it.append(notDefined()); it.add("1") }
+        ["1"]      | _            | ["0"]      | "add missing to non-empty convention, then append" | { it.add(notDefined()); it.append("1") }
+        ["0", "1"] | _            | ["0"]      | "append missing to non-empty convention, then add" | { it.append(notDefined()); it.add("1") }
+        ["1"]      | _            | _          | "add, then append missing"                         | { it.add("1"); it.append(notDefined()) }
+        null       | _            | _          | "append, then add missing"                         | { it.append("1"); it.add(notDefined()) }
+        ["0", "1"] | ["0"]        | _          | "add to non-empty value, then append missing"      | { it.add("1"); it.append(notDefined()) }
+        null       | ["0"]        | _          | "append to non-empty value, then add missing"      | { it.append("1"); it.add(notDefined()) }
+        ["1"]      | _            | ["0"]      | "add to non-empty convention, then append missing" | { it.add("1"); it.append(notDefined()) }
+        null       | _            | ["0"]      | "append to non-empty convention, then add missing" | { it.append("1"); it.add(notDefined()) }
+        ["1"]      | _            | _          | "add, then add missing, then append"               | { it.add("0"); it.add(notDefined()); it.append("1") }
+        ["0", "1"] | _            | _          | "add, then append missing, then add"               | { it.add("0"); it.append(notDefined()); it.add("1") }
     }
 
     def "execution time value is present if only undefined-safe operations are performed"() {
@@ -1445,7 +1445,7 @@ The value of this property is derived from: <source>""")
         def execTimeValue = property.calculateExecutionTimeValue()
 
         then:
-        assertCollectionIs(toImmutable(['2', '3', '4']), execTimeValue.toValue().get())
+        assertCollectionIs(execTimeValue.toValue().get(), toImmutable(['2', '3', '4']),)
     }
 
     def "property restores undefined-safe items"() {
@@ -1468,13 +1468,33 @@ The value of this property is derived from: <source>""")
         null  | ["1", "3"]
     }
 
+    def "property restores undefined-safe items that have #numProviders changing providers without values in front"() {
+        given:
+        numProviders.times {
+            property.add(Providers.changing { null as String })
+        }
+        property.append(Providers.changing { "1" })
+        property.add("2")
+
+        when:
+        def property2 = property()
+        property2.fromState(property.calculateExecutionTimeValue())
+
+        then:
+        assertValueIs(toImmutable(["1", "2"]), property2)
+
+        where:
+        // TODO(mlopatkin): Original implementation works only with numProviders == 1
+        numProviders << [1, 2]
+    }
+
     def "property remains undefined-safe after restored"() {
         given:
         property.append(notDefined())
         property.add("2")
         property.append(notDefined())
         property.append(notDefined())
-        property.addAll(supplierWithChangingExecutionTimeValues(['3'], ['3a'], ['3b'], ['3c'], ['3d']))
+        property.addAll(supplierWithChangingExecutionTimeValues(['3a'], ['3b'], ['3c'], ['3d']))
         property.addAll(supplierWithValues(['4']))
         property.append(notDefined())
 
@@ -1500,7 +1520,7 @@ The value of this property is derived from: <source>""")
         property3.fromState(execTimeValue2)
 
         then:
-        assertValueIs(['2', '3d', '4', '5', '6'], property3)
+        assertValueIs(['2', '3c', '4', '5', '6'], property3)
     }
 
     def "can alternate append and add"() {
@@ -1598,5 +1618,16 @@ The value of this property is derived from: <source>""")
         then:
         assertValueIs([])
         !property.explicit
+    }
+
+    def "can add a lot of providers"() {
+        given:
+        (0..<100000).each {
+            property.addAll(supplierWithProducer(Mock(Task), toImmutable([it.toString()])))
+        }
+
+        expect:
+        property.get().size() == 100000
+        property.getProducer().visitProducerTasks {}
     }
 }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
@@ -1488,6 +1488,26 @@ The value of this property is derived from: <source>""")
         numProviders << [1, 2]
     }
 
+    def "#opName to empty property is undefined-safe"() {
+        given:
+        property.set(null as Iterable)
+
+        when:
+        op(property)
+
+        then:
+        assertValueIs(toImmutable(expected), property)
+
+        where:
+        opName                      | op                                         | expected
+        "append(1)"                 | { it.append("1") }                         | ["1"]
+        "appendAll(1, 2)"           | { it.appendAll(["1", "2"]) }               | ["1", "2"]
+        "append(provider(1))"       | { it.append(Providers.of("1")) }           | ["1"]
+        "appendAll(provider(1, 2))" | { it.appendAll(Providers.of(["1", "2"])) } | ["1", "2"]
+        "append(notDefined())"      | { it.append(notDefined()) }                | []
+        "appendAll(notDefined())"   | { it.appendAll(notDefined()) }             | []
+    }
+
     def "property remains undefined-safe after restored"() {
         given:
         property.append(notDefined())
@@ -1618,15 +1638,6 @@ The value of this property is derived from: <source>""")
         then:
         assertValueIs([])
         !property.explicit
-    }
-
-    def "append to an undefined property is undefined-safe"() {
-        given:
-        property.set((Iterable) null)
-        property.append('foo')
-
-        expect:
-        assertValueIs(['foo'])
     }
 
     def "can add a lot of providers"() {

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
@@ -1536,7 +1536,7 @@ The value of this property is derived from: <source>""")
         property.put("a", notDefined())
         property.insert("b", "2")
         // changing execution time values or else we would end up with fixed values
-        property.putAll(supplierWithChangingExecutionTimeValues([c: '3'], [c: '3a'], [c: '3b'], [c: '3c'], [c: '3d'], [c: '3e']))
+        property.putAll(supplierWithChangingExecutionTimeValues([c: '3a'], [c: '3b'], [c: '3c'], [c: '3d'], [c: '3e']))
         property.putAll(supplierWithValues([d: '4']))
         property.insert("e", notDefined())
 
@@ -1562,7 +1562,7 @@ The value of this property is derived from: <source>""")
         property3.fromState(execTimeValue2)
 
         then:
-        assertValueIs([b: '2', c: '3d', d: '4', f: '6', g: '7'], property3)
+        assertValueIs([b: '2', c: '3c', d: '4', f: '6', g: '7'], property3)
     }
 
     def "keySet provider has some values when property with no value is added via insert"() {
@@ -1974,5 +1974,16 @@ The value of this property is derived from: <source>""")
 
         // The following case abuses Groovy lax type-checking to put an invalid value into the property.
         "[k: (Object) provider {v}]" | { property().value(k: Providers.of("v")) }              || "Map(String->String, {k=fixed(class ${String.name}, v)})"
+    }
+
+    def "can add a lot of providers"() {
+        given:
+        (0..<100000).each {
+            property.putAll(supplierWithProducer(Mock(Task), ImmutableMap.of(it.toString(), it.toString())))
+        }
+
+        expect:
+        property.get().size() == 100000
+        property.getProducer().visitProducerTasks {}
     }
 }

--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinApplicationInitIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinApplicationInitIntegrationTest.groovy
@@ -18,11 +18,13 @@ package org.gradle.buildinit.plugins
 
 import org.gradle.api.JavaVersion
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 
 import static org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl.KOTLIN
+import static org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects.Skip.FLAKY
 import static org.hamcrest.CoreMatchers.containsString
 
 @LeaksFileHandles
@@ -194,6 +196,7 @@ class KotlinApplicationInitIntegrationTest extends AbstractJvmLibraryInitIntegra
     }
 
     @Requires(value = UnitTestPreconditions.KotlinSupportedJdk.class)
+    @ToBeFixedForIsolatedProjects(skip = FLAKY, because = "KGP modifies service parameter properties concurrently")
     def "initializes Kotlin application with JUnit Jupiter test framework with --split-project"() {
         when:
         run('init', '--type', 'kotlin-application', '--test-framework', 'junit-jupiter', "--split-project", '--java-version', JavaVersion.current().majorVersion)

--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MultiProjectJvmApplicationInitIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MultiProjectJvmApplicationInitIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.JavaVersion
 import org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl
 import org.gradle.buildinit.plugins.internal.modifiers.Language
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
+import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
@@ -29,6 +30,7 @@ import static org.gradle.buildinit.plugins.internal.modifiers.Language.GROOVY
 import static org.gradle.buildinit.plugins.internal.modifiers.Language.JAVA
 import static org.gradle.buildinit.plugins.internal.modifiers.Language.KOTLIN
 import static org.gradle.buildinit.plugins.internal.modifiers.Language.SCALA
+import static org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects.Skip.FLAKY
 import static org.gradle.util.Matchers.containsLine
 import static org.gradle.util.Matchers.containsText
 import static org.hamcrest.core.AllOf.allOf
@@ -303,6 +305,7 @@ class GroovyDslMultiProjectGroovyApplicationInitIntegrationTest3 extends Abstrac
 }
 
 @Requires(value = UnitTestPreconditions.KotlinSupportedJdk.class)
+@ToBeFixedForIsolatedProjects(skip = FLAKY, because = "KGP modifies service parameter properties concurrently")
 class GroovyDslMultiProjectKotlinApplicationInitIntegrationTest1 extends AbstractMultiProjectJvmApplicationInitIntegrationTest1 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.GROOVY, KOTLIN)
@@ -310,6 +313,7 @@ class GroovyDslMultiProjectKotlinApplicationInitIntegrationTest1 extends Abstrac
 }
 
 @Requires(value = UnitTestPreconditions.KotlinSupportedJdk.class)
+@ToBeFixedForIsolatedProjects(skip = FLAKY, because = "KGP modifies service parameter properties concurrently")
 class GroovyDslMultiProjectKotlinApplicationInitIntegrationTest2 extends AbstractMultiProjectJvmApplicationInitIntegrationTest2 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.GROOVY, KOTLIN)
@@ -317,6 +321,7 @@ class GroovyDslMultiProjectKotlinApplicationInitIntegrationTest2 extends Abstrac
 }
 
 @Requires(value = UnitTestPreconditions.KotlinSupportedJdk.class)
+@ToBeFixedForIsolatedProjects(skip = FLAKY, because = "KGP modifies service parameter properties concurrently")
 class GroovyDslMultiProjectKotlinApplicationInitIntegrationTest3 extends AbstractMultiProjectJvmApplicationInitIntegrationTest3 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.GROOVY, KOTLIN)
@@ -381,6 +386,7 @@ class KotlinDslMultiProjectGroovyApplicationInitIntegrationTest3 extends Abstrac
 }
 
 @Requires(value = UnitTestPreconditions.KotlinSupportedJdk.class)
+@ToBeFixedForIsolatedProjects(skip = FLAKY, because = "KGP modifies service parameter properties concurrently")
 class KotlinDslMultiProjectKotlinApplicationInitIntegrationTest1 extends AbstractMultiProjectJvmApplicationInitIntegrationTest1 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.KOTLIN, KOTLIN)
@@ -388,6 +394,7 @@ class KotlinDslMultiProjectKotlinApplicationInitIntegrationTest1 extends Abstrac
 }
 
 @Requires(value = UnitTestPreconditions.KotlinSupportedJdk.class)
+@ToBeFixedForIsolatedProjects(skip = FLAKY, because = "KGP modifies service parameter properties concurrently")
 class KotlinDslMultiProjectKotlinApplicationInitIntegrationTest2 extends AbstractMultiProjectJvmApplicationInitIntegrationTest2 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.KOTLIN, KOTLIN)
@@ -395,6 +402,7 @@ class KotlinDslMultiProjectKotlinApplicationInitIntegrationTest2 extends Abstrac
 }
 
 @Requires(value = UnitTestPreconditions.KotlinSupportedJdk.class)
+@ToBeFixedForIsolatedProjects(skip = FLAKY, because = "KGP modifies service parameter properties concurrently")
 class KotlinDslMultiProjectKotlinApplicationInitIntegrationTest3 extends AbstractMultiProjectJvmApplicationInitIntegrationTest3 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.KOTLIN, KOTLIN)

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForIsolatedProjects.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForIsolatedProjects.groovy
@@ -26,7 +26,33 @@ import java.lang.annotation.Target
 @Retention(RetentionPolicy.RUNTIME)
 @Target([ElementType.METHOD, ElementType.TYPE])
 @ExtensionAnnotation(ToBeFixedForIsolatedProjectsExtension.class)
-public @interface ToBeFixedForIsolatedProjects {
+@interface ToBeFixedForIsolatedProjects {
+    /**
+     * Set to some {@link Skip} to skip the annotated test.
+     */
+    Skip skip() default Skip.DO_NOT_SKIP;
 
     String because() default "";
+
+    /**
+     * Reason for skipping a test with isolated projects.
+     */
+    enum Skip {
+
+        /**
+         * Do not skip this test, this is the default.
+         */
+        DO_NOT_SKIP {
+            @Override String getReason() { throw new UnsupportedOperationException("Must not be skipped") }
+        },
+
+        /**
+         * Use this reason on tests that intermittently fail with isolated projects.
+         */
+        FLAKY {
+            @Override String getReason() { "flaky" }
+        };
+
+        abstract String getReason();
+    }
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForIsolatedProjectsExtension.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForIsolatedProjectsExtension.groovy
@@ -22,22 +22,29 @@ import org.spockframework.runtime.model.FeatureInfo
 import org.spockframework.runtime.model.SpecElementInfo
 import org.spockframework.runtime.model.SpecInfo
 
+import static org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects.Skip.DO_NOT_SKIP
+
 class ToBeFixedForIsolatedProjectsExtension implements IAnnotationDrivenExtension<ToBeFixedForIsolatedProjects> {
 
     private final ToBeFixedSpecInterceptor toBeFixedSpecInterceptor = new ToBeFixedSpecInterceptor("Isolated Projects")
 
     @Override
     void visitSpecAnnotation(ToBeFixedForIsolatedProjects annotation, SpecInfo spec) {
-        visitAnnotation(spec)
+        visitAnnotation(annotation, spec)
     }
 
     @Override
     void visitFeatureAnnotation(ToBeFixedForIsolatedProjects annotation, FeatureInfo feature) {
-        visitAnnotation(feature)
+        visitAnnotation(annotation, feature)
     }
 
-    private void visitAnnotation(SpecElementInfo specElementInfo) {
+    private void visitAnnotation(ToBeFixedForIsolatedProjects annotation, SpecElementInfo specElementInfo) {
         if (GradleContextualExecuter.isNotIsolatedProjects()) {
+            return
+        }
+
+        if (annotation.skip() != DO_NOT_SKIP) {
+            specElementInfo.skip(annotation.skip().reason)
             return
         }
 


### PR DESCRIPTION
When many items are added to `List`-, `Set-`, or `MapProperty`, it led to a deep tree-ish structure of `PlusCollector` being created, which was then traversed recursively when evaluating the property. With enough elements, this caused `StackOverfowError`. 

This PR replaces tree-like structure with a plain list that can be traversed with O(1) stack space.

Fixes #30656.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
