### PR TITLE
Expose TaskPathLocation as contextual locations on Tooling API events

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/crossVersionTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsTapi812PlusCrossVersionTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/crossVersionTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsTapi812PlusCrossVersionTest.groovy
@@ -82,8 +82,8 @@ class ConfigurationCacheProblemsTapi812PlusCrossVersionTest extends ToolingApiSp
             definition.id.group.displayName == "configuration cache validation"
             definition.id.group.name == "configuration-cache"
             definition.severity == Severity.ERROR
-            (locations[0] as LineInFileLocation).path == "build file 'build.gradle'" // FIXME: the path should not contain a prefix nor extra quotes
-            (locations[1] as LineInFileLocation).path == "build file '$buildFile.path'"
+            (originLocations[0] as LineInFileLocation).path == "build file 'build.gradle'" // FIXME: the path should not contain a prefix nor extra quotes
+            (originLocations[1] as LineInFileLocation).path == "build file '$buildFile.path'"
             additionalData instanceof GeneralData
             additionalData.asMap.isEmpty()
         }

--- a/platforms/core-configuration/configuration-cache/src/crossVersionTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsTapi813PlusCrossVersionTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/crossVersionTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsTapi813PlusCrossVersionTest.groovy
@@ -29,9 +29,9 @@ import org.gradle.tooling.events.problems.Severity
 import org.gradle.tooling.events.problems.SingleProblemEvent
 import org.gradle.tooling.events.problems.internal.GeneralData
 
-@ToolingApiVersion(">=8.12 <8.13")
+@ToolingApiVersion(">=8.13")
 @TargetGradleVersion(">=8.10")
-class ConfigurationCacheProblemsTapi812PlusCrossVersionTest extends ToolingApiSpecification {
+class ConfigurationCacheProblemsTapi813PlusCrossVersionTest extends ToolingApiSpecification {
 
     class ProblemProgressListener implements ProgressListener {
 
@@ -82,8 +82,8 @@ class ConfigurationCacheProblemsTapi812PlusCrossVersionTest extends ToolingApiSp
             definition.id.group.displayName == "configuration cache validation"
             definition.id.group.name == "configuration-cache"
             definition.severity == Severity.ERROR
-            (locations[0] as LineInFileLocation).path == "build file 'build.gradle'" // FIXME: the path should not contain a prefix nor extra quotes
-            (locations[1] as LineInFileLocation).path == "build file '$buildFile.path'"
+            (originLocations[0] as LineInFileLocation).path == "build file 'build.gradle'" // FIXME: the path should not contain a prefix nor extra quotes
+            (originLocations[1] as LineInFileLocation).path == "build file '$buildFile.path'"
             additionalData instanceof GeneralData
             additionalData.asMap.isEmpty()
         }

--- a/platforms/documentation/docs/src/samples/templates/problems-api-usage/sample-ide/src/main/java/org/gradle/sample/SampleIde.java
+++ b/platforms/documentation/docs/src/samples/templates/problems-api-usage/sample-ide/src/main/java/org/gradle/sample/SampleIde.java
@@ -83,7 +83,7 @@ public class SampleIde {
             System.out.println(" - details: " + problem.getDetails().getDetails());
         }
         System.out.println(" - severity: " + toString(problem.getDefinition().getSeverity()));
-        for (Location location : problem.getLocations()) {
+        for (Location location : problem.getOriginLocations()) {
             if (location instanceof PluginIdLocation) {
                 System.out.println(" - plugin ID: " + ((PluginIdLocation) location).getPluginId());
             } else {

--- a/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
+++ b/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.problems
 
+
 import org.gradle.api.problems.internal.LineInFileLocation
 import org.gradle.api.problems.internal.OffsetInFileLocation
 import org.gradle.api.problems.internal.TaskPathLocation
@@ -24,7 +25,7 @@ import org.gradle.integtests.fixtures.GroovyBuildScriptLanguage
 
 import static org.gradle.api.problems.ReportingScript.getProblemReportingScript
 
-class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
+class   ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {
         enableProblemsApiCheck()
@@ -49,12 +50,16 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
         verifyAll(receivedProblem) {
             definition.id.fqid == 'problems-api:missing-id'
             definition.id.displayName == 'Problem id must be specified'
-            originLocations.size() == 2
-            with(firstLocationOfType(LineInFileLocation)) {
+            originLocations.size() == 1
+            contextualLocations.size() == 1
+            with(oneLocation(LineInFileLocation)) {
                 length == -1
                 column == -1
                 line == 11
                 path == "build file '$buildFile.absolutePath'"
+            }
+            with(oneLocation(TaskPathLocation)) {
+                buildTreePath == ':reportProblem'
             }
         }
     }
@@ -74,11 +79,14 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
         verifyAll(receivedProblem) {
             definition.id.fqid == 'generic:type'
             definition.id.displayName == 'label'
-            with(firstLocationOfType(LineInFileLocation)) {
+            with(oneLocation(LineInFileLocation)) {
                 length == -1
                 column == -1
                 line == 11
                 path == "build file '$buildFile.absolutePath'"
+            }
+            with(oneLocation(TaskPathLocation)) {
+                buildTreePath == ':reportProblem'
             }
         }
     }
@@ -100,7 +108,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
         verifyAll(receivedProblem) {
             definition.id.fqid == 'generic:type'
             definition.id.displayName == 'label'
-            with(firstLocationOfType(LineInFileLocation)) {
+            with(oneLocation(LineInFileLocation)) {
                 length == -1
                 column == -1
                 line == 11
@@ -140,7 +148,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         verifyAll(receivedProblem.originLocations) {
-            size() == 3
+            size() == 2
             with(get(0) as OffsetInFileLocation) {
                 path == 'test-location'
                 offset == 1
@@ -151,9 +159,6 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
                 column == -1
                 line == 11
                 path == "build file '$buildFile.absolutePath'"
-            }
-            with(get(2) as TaskPathLocation) {
-                buildTreePath == ':reportProblem'
             }
         }
     }
@@ -172,7 +177,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         verifyAll(receivedProblem.originLocations) {
-            size() == 3
+            size() == 2
             with(get(0) as LineInFileLocation) {
                 length == -1
                 column == 2
@@ -298,7 +303,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
         verifyAll(receivedProblem) {
             definition.id.fqid == 'problems-api:unsupported-additional-data'
             definition.id.displayName == 'Unsupported additional data type'
-            with(firstLocationOfType(LineInFileLocation)) {
+            with(oneLocation(LineInFileLocation)) {
                 length == -1
                 column == -1
                 line == 11

--- a/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
+++ b/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
@@ -25,7 +25,7 @@ import org.gradle.integtests.fixtures.GroovyBuildScriptLanguage
 
 import static org.gradle.api.problems.ReportingScript.getProblemReportingScript
 
-class   ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
+class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {
         enableProblemsApiCheck()

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemBuilder.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemBuilder.java
@@ -38,6 +38,7 @@ public class DefaultProblemBuilder implements InternalProblemBuilder {
     private String contextualLabel;
     private Severity severity;
     private final ImmutableList.Builder<ProblemLocation> locations = ImmutableList.builder();
+    private final ImmutableList.Builder<ProblemLocation> contextLocations = ImmutableList.builder();
     private String details;
     private DocLink docLink;
     private List<String> solutions;
@@ -63,9 +64,8 @@ public class DefaultProblemBuilder implements InternalProblemBuilder {
         this.contextualLabel = problem.getContextualLabel();
         this.solutions = new ArrayList<String>(problem.getSolutions());
         this.severity = problem.getDefinition().getSeverity();
-
-        locations.addAll(problem.getOriginLocations());
-
+        this.locations.addAll(problem.getOriginLocations());
+        this.contextLocations.addAll(problem.getContextualLocations());
         this.details = problem.getDetails();
         this.docLink = problem.getDefinition().getDocumentationLink();
         this.exception = problem.getException();
@@ -99,7 +99,7 @@ public class DefaultProblemBuilder implements InternalProblemBuilder {
             contextualLabel,
             solutions,
             locations.build(),
-            ImmutableList.<ProblemLocation>of(),
+            contextLocations.build(),
             details,
             exceptionForProblemInstantiation,
             additionalData
@@ -172,37 +172,37 @@ public class DefaultProblemBuilder implements InternalProblemBuilder {
 
     @Override
     public InternalProblemBuilder taskPathLocation(String buildTreePath) {
-        this.addLocation(new DefaultTaskPathLocation(buildTreePath));
+        this.contextLocations.add(new DefaultTaskPathLocation(buildTreePath));
         return this;
     }
 
     @Override
     public InternalProblemBuilder fileLocation(String path) {
-        this.addLocation(DefaultFileLocation.from(path));
+        this.locations.add(DefaultFileLocation.from(path));
         return this;
     }
 
     @Override
     public InternalProblemBuilder lineInFileLocation(String path, int line) {
-        this.addLocation(DefaultLineInFileLocation.from(path, line));
+        this.locations.add(DefaultLineInFileLocation.from(path, line));
         return this;
     }
 
     @Override
     public InternalProblemBuilder lineInFileLocation(String path, int line, int column) {
-        this.addLocation(DefaultLineInFileLocation.from(path, line, column));
+        this.locations.add(DefaultLineInFileLocation.from(path, line, column));
         return this;
     }
 
     @Override
     public InternalProblemBuilder offsetInFileLocation(String path, int offset, int length) {
-        this.addLocation(DefaultOffsetInFileLocation.from(path, offset, length));
+        this.locations.add(DefaultOffsetInFileLocation.from(path, offset, length));
         return this;
     }
 
     @Override
     public InternalProblemBuilder lineInFileLocation(String path, int line, int column, int length) {
-        this.addLocation(DefaultLineInFileLocation.from(path, line, column, length));
+        this.locations.add(DefaultLineInFileLocation.from(path, line, column, length));
         return this;
     }
 
@@ -278,10 +278,6 @@ public class DefaultProblemBuilder implements InternalProblemBuilder {
     @Nullable
     Throwable getException() {
         return exception;
-    }
-
-    protected void addLocation(ProblemLocation location) {
-        this.locations.add(location);
     }
 
     public ProblemId getId() {

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/Problem.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/Problem.java
@@ -61,6 +61,8 @@ public interface Problem {
     /**
      * Returns additional locations, which can help to understand the problem further.
      * <p>
+     * For example, if a problem was emitted during task execution, the task path will be available in this list.
+     * <p>
      * Might be empty if there is no meaningful contextual information.
      */
     List<ProblemLocation> getContextualLocations();

--- a/platforms/ide/problems-api/src/test/groovy/org/gradle/api/problems/internal/DefaultProblemBuilderTest.groovy
+++ b/platforms/ide/problems-api/src/test/groovy/org/gradle/api/problems/internal/DefaultProblemBuilderTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.problems.internal
 
+
 import org.gradle.internal.problems.NoOpProblemDiagnosticsFactory
 import spock.lang.Specification
 
@@ -109,5 +110,22 @@ class DefaultProblemBuilderTest extends Specification {
 
         then:
         data == null
+    }
+
+    def "can define contextual locations"() {
+        given:
+        def problemBuilder = new DefaultProblemBuilder(EMPTY_STREAM, new AdditionalDataBuilderFactory())
+
+        when:
+        //noinspection GroovyAssignabilityCheck
+        def problem = problemBuilder
+            .id("id", "displayName")
+            .taskPathLocation(":taskPath")
+            .build()
+
+
+        then:
+        problem.contextualLocations.every { it instanceof TaskPathLocation }
+        problem.contextualLocations.collect {(it as TaskPathLocation).buildTreePath } == [':taskPath']
     }
 }

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/Problem.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/Problem.java
@@ -56,12 +56,24 @@ public interface Problem {
     Details getDetails();
 
     /**
-     * Returns the locations associated with this problem.
+     * Returns the locations where the problem originated.
      *
      * @return the locations
-     * @since 8.12
+     * @since 8.13
      */
-    List<Location> getLocations();
+    List<Location> getOriginLocations();
+
+    /**
+     * Returns additional locations, which can help to understand the problem further.
+     * <p>
+     * For example, if a problem was emitted during task execution, the task path will be available in this list.
+     * <p>
+     * Might be empty if there is no meaningful contextual information.
+     *
+     * @return the locations
+     * @since 8.13
+     */
+    List<Location> getContextualLocations();
 
     /**
      * Returns the list of solutions.

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/internal/DefaultProblem.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/internal/DefaultProblem.java
@@ -34,7 +34,8 @@ public class DefaultProblem implements Problem {
     private final ProblemDefinition problemDefinition;
     private final ContextualLabel contextualLabel;
     private final Details details;
-    private final List<Location> locations;
+    private final List<Location> originLocations;
+    private final List<Location> contextualLocations;
     private final List<Solution> solutions;
     private final AdditionalData additionalData;
     private final Failure failure;
@@ -43,14 +44,16 @@ public class DefaultProblem implements Problem {
         ProblemDefinition problemDefinition,
         ContextualLabel contextualLabel,
         Details details,
-        List<Location> locations,
+        List<Location> originLocations,
+        List<Location> contextualLocations,
         List<Solution> solutions,
         AdditionalData additionalData,
         @Nullable Failure failure) {
         this.problemDefinition = problemDefinition;
         this.contextualLabel = contextualLabel;
         this.details = details;
-        this.locations = locations;
+        this.originLocations = originLocations;
+        this.contextualLocations = contextualLocations;
         this.solutions = solutions;
         this.additionalData = additionalData;
         this.failure = failure;
@@ -72,8 +75,13 @@ public class DefaultProblem implements Problem {
     }
 
     @Override
-    public List<Location> getLocations() {
-        return locations;
+    public List<Location> getOriginLocations() {
+        return originLocations;
+    }
+
+    @Override
+    public List<Location> getContextualLocations() {
+        return contextualLocations;
     }
 
     @Override

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileProblemsIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileProblemsIntegrationTest.groovy
@@ -526,7 +526,7 @@ ${fooFileLocation}:9: warning: [cast] redundant cast to $expectedType
     ) {
         assert problem.contextualLabel != null, "Expected contextual label to be non-null, but was null"
 
-        def locations = problem.originLocations
+        def locations = problem.originLocations + problem.contextualLocations
         // We use this counter to assert that we have visited all locations
         def assertedLocationCount = 1
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/ReceivedProblem.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/ReceivedProblem.groovy
@@ -84,19 +84,18 @@ class ReceivedProblem implements Problem {
         operationId
     }
 
-    <T> T firstLocationOfType(Class<T> type) {
-        def locations = getOriginLocations()
-        def location = locations.find { type.isInstance(it) } as T
-        assert location != null
-        assert type.isInstance(location)
-        location
+    <T> T oneLocation(Class<T> type) {
+        def result = allLocations(type)
+        assert result.size() == 1
+        result.first()
     }
 
-    <T> T oneLocation(Class<T> type) {
-        def locations = getOriginLocations()
-        assert locations.size() == 1
-        assert type.isInstance(locations[0])
-        locations[0] as T
+    private <T> List<T> allLocations(Class<T> type) {
+        allLocations.findAll { type.isInstance(it) } as List<T>
+    }
+
+    private List<?> getAllLocations() {
+        getOriginLocations() + getContextualLocations()
     }
 
     @Override


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->
Fixes https://github.com/gradle/gradle/issues/31553

When we introduced origin and contextual locations, we did not adjust how we expose that to the TAPI clients. Adding TaskPathLocation data to problem reports then went to the incorrect bucket (to the origin location bucket). 


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
