### PR TITLE
Simplify tracking of `buildSrc` dirs

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprint.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprint.kt
@@ -55,9 +55,8 @@ sealed class ConfigurationCacheFingerprint {
         val fingerprints: List<InputFile>
     ) : ConfigurationCacheFingerprint()
 
-    data class BuildSrcCandidate(
+    data class MissingBuildSrcDir(
         val buildSrcDir: File,
-        val valid: Boolean,
     ) : ConfigurationCacheFingerprint()
 
     data class WorkInputs(

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintChecker.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintChecker.kt
@@ -294,11 +294,11 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
                 }
             }
 
-            is ConfigurationCacheFingerprint.BuildSrcCandidate -> input.run {
-                val currentValid = host.hasValidBuildSrc(buildSrcDir)
-                ifOrNull(currentValid != valid) {
+            is ConfigurationCacheFingerprint.MissingBuildSrcDir -> input.run {
+                val hasBuildSrc = host.hasValidBuildSrc(buildSrcDir)
+                ifOrNull(hasBuildSrc) {
                     text("a buildSrc build at ").reference(displayNameOf(buildSrcDir))
-                        .text(" has been ${if (currentValid) "added" else "removed"}")
+                        .text(" has been added")
                 }
             }
         }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -214,7 +214,9 @@ class ConfigurationCacheFingerprintWriter(
         buildStateRegistry.visitBuilds { buildState ->
             val candidateBuildSrc = File(buildState.buildRootDir, SettingsInternal.BUILD_SRC)
             val valid = BuildSrcDetector.isValidBuildSrcBuild(candidateBuildSrc)
-            buildScopedSink.write(ConfigurationCacheFingerprint.BuildSrcCandidate(candidateBuildSrc, valid))
+            if (!valid) {
+                buildScopedSink.write(ConfigurationCacheFingerprint.MissingBuildSrcDir(candidateBuildSrc))
+            }
         }
     }
 


### PR DESCRIPTION
This is a follow-up to [#31460](https://github.com/gradle/gradle/pull/31460).

We only need to track missing `buildSrc` dirs, in order for an addition to be detected. Removals are already detected by other fingerprint bits.

Also add explicit expectations for `buildSrc` removals, which are tracked as usual, as file removals or task input changes.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
