### PR TITLE
Unignore ProblemThresholdCrossVersionTest

### DIFF
--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/DevelocityPluginEndOfBuildCallbackIntegrationTest.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/DevelocityPluginEndOfBuildCallbackIntegrationTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.internal.enterprise
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
-import static org.gradle.api.problems.ReportingScript.getProblemReportingScript
+import static org.gradle.api.problems.fixtures.ReportingScript.getProblemReportingScript
 
 class DevelocityPluginEndOfBuildCallbackIntegrationTest extends AbstractIntegrationSpec {
 

--- a/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
+++ b/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.api.problems.internal.TaskPathLocation
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.GroovyBuildScriptLanguage
 
-import static org.gradle.api.problems.ReportingScript.getProblemReportingScript
+import static org.gradle.api.problems.fixtures.ReportingScript.getProblemReportingScript
 
 class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
 

--- a/platforms/ide/problems-api/src/testFixtures/groovy/org/gradle/api/problems/fixtures/ReportingScript.groovy
+++ b/platforms/ide/problems-api/src/testFixtures/groovy/org/gradle/api/problems/fixtures/ReportingScript.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.problems
+package org.gradle.api.problems.fixtures
 
 import org.gradle.integtests.fixtures.GroovyBuildScriptLanguage
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r812/ProblemThresholdCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r812/ProblemThresholdCrossVersionTest.groovy
@@ -25,23 +25,21 @@ import org.gradle.tooling.events.ProgressEvent
 import org.gradle.tooling.events.ProgressListener
 import org.gradle.tooling.events.problems.ProblemSummariesEvent
 import org.gradle.tooling.events.problems.SingleProblemEvent
-import spock.lang.Ignore
 
-import static org.gradle.api.problems.ReportingScript.getProblemReportingScript
+import static org.gradle.api.problems.fixtures.ReportingScript.getProblemReportingScript
 import static org.gradle.integtests.tooling.r86.ProblemsServiceModelBuilderCrossVersionTest.getBuildScriptSampleContent
 import static org.gradle.integtests.tooling.r89.ProblemProgressEventCrossVersionTest.failureMessage
-import static org.gradle.problems.internal.services.DefaultProblemSummarizer.THRESHOLD_DEFAULT_VALUE
-import static org.gradle.problems.internal.services.DefaultProblemSummarizer.THRESHOLD_OPTION
 
-@Ignore("TODO fix this after master is stabilized")
 @ToolingApiVersion(">=8.12")
 @TargetGradleVersion(">=8.12")
 class ProblemThresholdCrossVersionTest extends ToolingApiSpecification {
 
+    static def threshold = 15
+
     def "The summary shows the amount of additional skipped events"() {
         given:
         def exceedingCount = 2
-        buildFile getProblemReportingScript("${getProblemReportingBody(THRESHOLD_DEFAULT_VALUE + exceedingCount)}")
+        buildFile getProblemReportingScript("${getProblemReportingBody(threshold + exceedingCount)}")
         def listener = new ProblemProgressListener()
 
         when:
@@ -54,8 +52,8 @@ class ProblemThresholdCrossVersionTest extends ToolingApiSpecification {
 
         then:
         def problems = listener.problems
-        problems.size() == THRESHOLD_DEFAULT_VALUE
-        validateProblemsRange(0..(THRESHOLD_DEFAULT_VALUE - 1), problems)
+        problems.size() == threshold
+        validateProblemsRange(0..(threshold - 1), problems)
         def problemSummariesEvent = listener.summariesEvent as ProblemSummariesEvent
         problemSummariesEvent != null
 
@@ -65,7 +63,7 @@ class ProblemThresholdCrossVersionTest extends ToolingApiSpecification {
     }
 
     def "No summaries if no events exceeded the threshold"() {
-        def totalSentEventsCount = THRESHOLD_DEFAULT_VALUE + exceedingCount
+        def totalSentEventsCount = threshold + exceedingCount
         given:
         buildFile getProblemReportingScript("${getProblemReportingBody(totalSentEventsCount)}")
         def listener = new ProblemProgressListener()
@@ -95,7 +93,7 @@ class ProblemThresholdCrossVersionTest extends ToolingApiSpecification {
     def "No summaries received from Gradle versions before 8.12"() {
         given:
         def exceedingCount = 2
-        buildFile getBuildScriptSampleContent(false, false, targetVersion, THRESHOLD_DEFAULT_VALUE + exceedingCount)
+        buildFile getBuildScriptSampleContent(false, false, targetVersion, threshold + exceedingCount)
         def listener = new ProblemProgressListener()
 
         when:
@@ -117,7 +115,7 @@ class ProblemThresholdCrossVersionTest extends ToolingApiSpecification {
         given:
         def exceedingCount = 2
         def differentProblemCount = 4
-        def threshold = THRESHOLD_DEFAULT_VALUE + exceedingCount
+        def threshold = threshold + exceedingCount
         buildFile getProblemReportingScript("""
             ${getProblemReportingBody(threshold)}
             ${getProblemReportingBody(differentProblemCount, "testCategory2", "label2")}
@@ -134,8 +132,8 @@ class ProblemThresholdCrossVersionTest extends ToolingApiSpecification {
 
         then:
         def problems = listener.problems
-        problems.size() == THRESHOLD_DEFAULT_VALUE + differentProblemCount
-        validateProblemsRange(0..(THRESHOLD_DEFAULT_VALUE - 1), problems)
+        problems.size() == ProblemThresholdCrossVersionTest.threshold + differentProblemCount
+        validateProblemsRange(0..(ProblemThresholdCrossVersionTest.threshold - 1), problems)
         def problemSummariesEvent = listener.summariesEvent as ProblemSummariesEvent
         def summaries = problemSummariesEvent.problemSummaries
         summaries.size() == 1
@@ -145,7 +143,7 @@ class ProblemThresholdCrossVersionTest extends ToolingApiSpecification {
         given:
         def exceedingCount = 2
         def differentProblemCount = 4
-        def threshold = THRESHOLD_DEFAULT_VALUE + exceedingCount
+        def threshold = threshold + exceedingCount
         buildFile getProblemReportingScript("""
             ${getProblemReportingBody(threshold)}
             ${getProblemReportingBody(threshold, "testCategory2", "label2")}
@@ -162,9 +160,9 @@ class ProblemThresholdCrossVersionTest extends ToolingApiSpecification {
 
         then:
         def problems = listener.problems
-        problems.size() == THRESHOLD_DEFAULT_VALUE * 2
-        validateProblemsRange(0..(THRESHOLD_DEFAULT_VALUE - 1), problems)
-        validateProblemsRange(THRESHOLD_DEFAULT_VALUE..(problems.size() - 1), problems, "label2", "Generic")
+        problems.size() == ProblemThresholdCrossVersionTest.threshold * 2
+        validateProblemsRange(0..(ProblemThresholdCrossVersionTest.threshold - 1), problems)
+        validateProblemsRange(ProblemThresholdCrossVersionTest.threshold..(problems.size() - 1), problems, "label2", "Generic")
         def problemSummariesEvent = listener.summariesEvent as ProblemSummariesEvent
         def summaries = problemSummariesEvent.problemSummaries
         summaries.size() == 2
@@ -183,7 +181,7 @@ class ProblemThresholdCrossVersionTest extends ToolingApiSpecification {
         when:
         withConnection {
             it.newBuild()
-                .withSystemProperties([(THRESHOLD_OPTION.systemPropertyName): thresholdInOption.toString()])
+                .withSystemProperties([('org.gradle.internal.problem.summary.threshold'): thresholdInOption.toString()])
                 .addProgressListener(listener, OperationType.PROBLEMS)
                 .forTasks("reportProblem")
                 .run()

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiClassLoaderProvider.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiClassLoaderProvider.groovy
@@ -88,6 +88,7 @@ class ToolingApiClassLoaderProvider {
         sharedSpec.allowPackage('org.gradle.launcher.daemon.testing')
         sharedSpec.allowPackage('org.gradle.tooling')
         sharedSpec.allowPackage('org.gradle.kotlin.dsl.tooling.fixtures')
+        sharedSpec.allowPackage('org.gradle.api.problems.fixtures')
         sharedSpec.allowClass(OperatingSystem)
         sharedSpec.allowClass(Requires)
         sharedSpec.allowClass(TestPrecondition)


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle/issues/31552

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
The cross-version tests use a special, TAPI-specific classpath that hide the test fixtures used by the test. Removing the TAPI-specific classes and adjusting the classpath filters make the test work again.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
