### PR TITLE
Move Kotlin DSL script compilation to the scripting host API

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/CompilePrecompiledScriptPluginPlugins.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/CompilePrecompiledScriptPluginPlugins.kt
@@ -38,7 +38,7 @@ import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.kotlin.dsl.precompile.v1.PrecompiledPluginsBlock
 import org.gradle.kotlin.dsl.support.ImplicitImports
 import org.gradle.kotlin.dsl.support.KotlinCompilerOptions
-import org.gradle.kotlin.dsl.support.compileKotlinScriptModuleTo
+import org.gradle.kotlin.dsl.support.compileKotlinScriptModuleForPrecompiledScriptPluginsTo
 import org.gradle.kotlin.dsl.support.kotlinCompilerOptions
 import org.gradle.kotlin.dsl.support.scriptDefinitionFromTemplate
 import javax.inject.Inject
@@ -101,7 +101,7 @@ abstract class CompilePrecompiledScriptPluginPlugins @Inject constructor(
         outputDir.withOutputDirectory { outputDir ->
             val scriptFiles = sourceFiles.map { it.path }
             if (scriptFiles.isNotEmpty())
-                compileKotlinScriptModuleTo(
+                compileKotlinScriptModuleForPrecompiledScriptPluginsTo(
                     outputDir,
                     compilerOptions.get(),
                     kotlinModuleName,

--- a/platforms/core-configuration/kotlin-dsl/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl/build.gradle.kts
@@ -68,6 +68,9 @@ dependencies {
     implementation(libs.futureKotlin("scripting-jvm")) {
         isTransitive = false
     }
+    implementation(libs.futureKotlin("scripting-jvm-host")) {
+        isTransitive = false
+    }
     implementation(libs.futureKotlin("scripting-compiler-embeddable")) {
         isTransitive = false
     }

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyAssignmentIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyAssignmentIntegrationTest.groovy
@@ -41,8 +41,8 @@ class PropertyAssignmentIntegrationTest extends AbstractIntegrationSpec {
         "Enum = String"                                 | "MyEnum"   | '"YES"'                                  | "YES"
         "File = T extends FileSystemLocation"           | "File"     | 'layout.buildDirectory.dir("out").get()' | unsupportedWithCause("Cannot cast object")
         "File = Provider<T extends FileSystemLocation>" | "File"     | 'layout.buildDirectory.dir("out")'       | unsupportedWithCause("Cannot cast object")
-        "File = File"                                   | "File"     | 'file("$buildDir/out")'                  | "out"
-        "File = Provider<File>"                         | "File"     | 'provider { file("$buildDir/out") }'     | unsupportedWithCause("Cannot cast object")
+        "File = File"                                   | "File"     | 'file("out")'                            | "out"
+        "File = Provider<File>"                         | "File"     | 'provider { file("out") }'               | unsupportedWithCause("Cannot cast object")
         "File = Object"                                 | "File"     | 'new MyObject("out")'                    | unsupportedWithCause("Cannot cast object")
     }
 
@@ -61,8 +61,8 @@ class PropertyAssignmentIntegrationTest extends AbstractIntegrationSpec {
         "Enum = String"                                 | "Property<MyEnum>"   | '"YES"'                                  | unsupportedWithCause("Cannot set the value of task ':myTask' property 'input'")
         "File = T extends FileSystemLocation"           | "DirectoryProperty"  | 'layout.buildDirectory.dir("out").get()' | "out"
         "File = Provider<T extends FileSystemLocation>" | "DirectoryProperty"  | 'layout.buildDirectory.dir("out")'       | "out"
-        "File = File"                                   | "DirectoryProperty"  | 'file("$buildDir/out")'                  | "out"
-        "File = Provider<File>"                         | "DirectoryProperty"  | 'provider { file("$buildDir/out") }'     | unsupportedWithCause("Cannot get the value of task ':myTask' property 'input'")
+        "File = File"                                   | "DirectoryProperty"  | 'file("out")'                            | "out"
+        "File = Provider<File>"                         | "DirectoryProperty"  | 'provider { file("out") }'               | unsupportedWithCause("Cannot get the value of task ':myTask' property 'input'")
         "File = Object"                                 | "DirectoryProperty"  | 'new MyObject("out")'                    | unsupportedWithCause("Cannot set the value of task ':myTask' property 'input'")
     }
 
@@ -81,8 +81,8 @@ class PropertyAssignmentIntegrationTest extends AbstractIntegrationSpec {
         "Enum = String"                                 | "MyEnum"   | '"YES"'                                  | unsupportedWithDescription("Type mismatch")
         "File = T extends FileSystemLocation"           | "File"     | 'layout.buildDirectory.dir("out").get()' | unsupportedWithDescription("Type mismatch")
         "File = Provider<T extends FileSystemLocation>" | "File"     | 'layout.buildDirectory.dir("out")'       | unsupportedWithDescription("Type mismatch")
-        "File = File"                                   | "File"     | 'file("$buildDir/out")'                  | "out"
-        "File = Provider<File>"                         | "File"     | 'provider { file("$buildDir/out") }'     | unsupportedWithDescription("Type mismatch")
+        "File = File"                                   | "File"     | 'file("out")'                            | "out"
+        "File = Provider<File>"                         | "File"     | 'provider { file("out") }'               | unsupportedWithDescription("Type mismatch")
         "File = Object"                                 | "File"     | 'MyObject("out")'                        | unsupportedWithDescription("Type mismatch")
     }
 
@@ -101,8 +101,8 @@ class PropertyAssignmentIntegrationTest extends AbstractIntegrationSpec {
         "Enum = String"                                 | "Property<MyEnum>"   | '"YES"'                                  | unsupportedWithDescription("Type mismatch")
         "File = T extends FileSystemLocation"           | "DirectoryProperty"  | 'layout.buildDirectory.dir("out").get()' | "out"
         "File = Provider<T extends FileSystemLocation>" | "DirectoryProperty"  | 'layout.buildDirectory.dir("out")'       | "out"
-        "File = File"                                   | "DirectoryProperty"  | 'file("$buildDir/out")'                  | "out"
-        "File = Provider<File>"                         | "DirectoryProperty"  | 'provider { file("$buildDir/out") }'     | "out"
+        "File = File"                                   | "DirectoryProperty"  | 'file("out")'                            | "out"
+        "File = Provider<File>"                         | "DirectoryProperty"  | 'provider { file("out") }'               | "out"
         "File = Object"                                 | "DirectoryProperty"  | 'MyObject("out")'                        | unsupportedWithDescription("Type mismatch")
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/component/DefaultSoftwareComponentContainerIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/component/DefaultSoftwareComponentContainerIntegrationTest.groovy
@@ -288,7 +288,8 @@ class DefaultSoftwareComponentContainerIntegrationTest extends AbstractIntegrati
             interface ${name} : SoftwareComponent {
                 val value: Property<Int>
             }
-            abstract class Default${name} @Inject constructor(val name: String) : ${name} {
+            abstract class Default${name} @Inject constructor(private val name: String) : ${name} {
+                override fun getName(): String = name
             }
         """
     }

--- a/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -34,7 +34,7 @@ import static org.hamcrest.MatcherAssert.assertThat
 
 abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
 
-    protected static final THIRD_PARTY_LIB_COUNT = 139
+    protected static final THIRD_PARTY_LIB_COUNT = 140
 
     @Shared
     String baseVersion = GradleVersion.current().baseVersion.version


### PR DESCRIPTION
Instead of using the old script compiler internal API.

There is still one use case that uses the old API: `compileKotlinScriptModuleForPrecompiledScriptPluginsTo`.
This will be addressed separately.

* Part of https://github.com/gradle/gradle/issues/24531

----

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
