### PR TITLE
Fix deprecation warning in docsTest

### DIFF
--- a/platforms/documentation/docs/src/snippets/java/fixtures/kotlin/lib/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/java/fixtures/kotlin/lib/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
 // tag::publishing_test_fixtures[]
 publishing {
     publications {
-        create<MavenPublication>("mavenJava") {
+        register<MavenPublication>("mavenJava") {
             from(components["java"])
         }
     }


### PR DESCRIPTION
Noticed this flaky test: https://ge.gradle.org/scans/tests?search.timeZoneId=Asia%2FShanghai&tests.container=org.gradle.docs.samples.Bucket2SnippetsTest&tests.sortField=FLAKY&tests.test=snippet-java-fixtures_kotlin_javaTestFixtures.sample

Because of an unexpected output:

```
java.lang.AssertionError: Unexpected value at line 2.
Expected: > Task :dependencyInsight
Actual: > Configure project :lib
Actual output:
> Configure project :lib
w: file:///home/user/gradle/samples/lib/build.gradle.kts:51:7: 'create(String!, Action<in Task!>!): Task!' is deprecated. Deprecated in Java
```
