### PR TITLE
Fix graph cleanup when a module goes back to pending

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -409,6 +409,7 @@ public abstract class DefaultDependencyHandler implements DependencyHandlerInter
         return dependencyProvider.map(dep -> {
             DefaultExternalModuleDependencyVariantSpec spec = objects.newInstance(DefaultExternalModuleDependencyVariantSpec.class, objects, dep);
             variantSpec.execute(spec);
+            // TODO: We "lose" endorsingStrictVersions here. We should copy that over to the returned variant.
             return new DefaultMinimalDependencyVariant(dep, spec.attributesAction, spec.capabilitiesMutator, spec.classifier, spec.artifactType);
         });
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphDependency.java
@@ -54,6 +54,9 @@ public interface ResolvedGraphDependency {
 
     /**
      * Returns the simple id of the selected variant, as per {@link ResolvedGraphVariant#getNodeId()}.
+     * <p>
+     * If at the end of graph traversal this method returns null, <strong>the graph is broken and a bug
+     * in the dependency resolution has been encountered.</strong>
      */
     @Nullable
     Long getSelectedVariant();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -294,6 +294,8 @@ public class DependencyGraphBuilder {
             SelectorState selector = edge.getSelector();
             ModuleResolveState module = selector.getTargetModule();
 
+            // TODO: It is odd that we have to check module.getSelectors().size() here.
+            //       We already have a selector, its module should know about it.
             if (selector.canAffectSelection() && module.getSelectors().size() > 0) {
                 // Have an unprocessed/new selector for this module. Need to re-select the target version (if there are any selectors that can be used).
                 performSelection(resolveState, module);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -386,17 +386,39 @@ public class ModuleResolveState implements CandidateModule {
         return platformState != null && !platformState.getParticipatingModules().isEmpty();
     }
 
-    void decreaseHardEdgeCount(NodeState removalSource) {
-        pendingDependencies.decreaseHardEdgeCount();
-        if (pendingDependencies.isPending()) {
-            // Back to being a pending dependency
-            // Clear remaining incoming edges, as they must be all from constraints
-            if (selected != null) {
-                for (NodeState node : selected.getNodes()) {
-                    node.clearConstraintEdges(pendingDependencies, removalSource);
-                }
+    void disconnectIncomingEdge(NodeState removalSource, EdgeState incomingEdge) {
+        removeUnattachedEdge(incomingEdge);
+        if (!incomingEdge.isConstraint()) {
+            pendingDependencies.decreaseHardEdgeCount();
+            if (pendingDependencies.isPending()) {
+                // We are back to pending, since we no longer have any hard edges targeting us.
+                // All incoming constraint edges must now be removed.
+                clearIncomingAttachedConstraints(removalSource);
+                clearIncomingUnattachedConstraints(removalSource);
             }
         }
+    }
+
+    private void clearIncomingAttachedConstraints(NodeState removalSource) {
+        if (selected != null) {
+            for (NodeState node : selected.getNodes()) {
+                node.clearIncomingConstraints(pendingDependencies, removalSource);
+            }
+        }
+    }
+
+    private void clearIncomingUnattachedConstraints(NodeState removalSource) {
+        for (EdgeState unattachedEdge : unattachedEdges) {
+            assert unattachedEdge.getDependencyMetadata().isConstraint();
+            NodeState from = unattachedEdge.getFrom();
+            if (from != removalSource) {
+                // Only remove edges that come from a different node than the source of the dependency
+                // going back to pending. The edges from the "From" will be removed first.
+                from.removeOutgoingEdge(unattachedEdge);
+            }
+            pendingDependencies.registerConstraintProvider(from);
+        }
+        unattachedEdges.clear();
     }
 
     boolean isPending() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
@@ -78,4 +78,9 @@ public class DefaultProjectDependencyMetadata extends DelegatingDependencyMetada
         }
         return this;
     }
+
+    @Override
+    public String toString() {
+        return "ProjectDependencyMetadata: " + selector;
+    }
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
@@ -52,8 +52,8 @@ class VariantMetadataSpec {
         attributes[name] = value
     }
 
-    void dependsOn(String group, String module, String version, String reason = null, Map<String, ?> attributes = [:]) {
-        dependencies << new DependencySpec(group, module, version, reason, attributes)
+    void dependsOn(String group, String module, String version, Map<String, ?> attributes = [:]) {
+        dependencies << new DependencySpec(group, module, version, null, attributes)
     }
 
     void dependsOn(String group, String module, String version, @DelegatesTo(value=DependencySpec, strategy=Closure.DELEGATE_FIRST) Closure<?> config) {


### PR DESCRIPTION
Before this change, we cleaned up attached edges only. This fix makes sure we clean up unattached edges as well.

The reproducer was provided by Block.
The fix also resolves a reproducer from AndroidX. We only keep its minimized version.

A new specific Junit reproducer is introduced, as a note for future investigation for potentially unstable graphs.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
