### PR TITLE
Upgrade embedded Kotlin to 2.1.20

### DIFF
--- a/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
+++ b/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
@@ -25,7 +25,7 @@ abstract class ExternalModulesExtension(isBundleGroovy4: Boolean) {
 
     val configurationCacheReportVersion = "1.23"
     val gradleIdeStarterVersion = "0.5"
-    val kotlinVersion = "2.0.21"
+    val kotlinVersion = "2.1.0"
 
     fun futureKotlin(module: String) = "org.jetbrains.kotlin:kotlin-$module:$kotlinVersion"
 

--- a/build-logic/packaging/src/main/kotlin/gradlebuild.distributions.gradle.kts
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild.distributions.gradle.kts
@@ -196,7 +196,11 @@ val gradleApiKotlinExtensions by tasks.registering(GenerateKotlinExtensionsForGr
 
 apply<KotlinBaseApiPlugin>()
 plugins.withType(KotlinBaseApiPlugin::class) {
-    registerKotlinJvmCompileTask("compileGradleApiKotlinExtensions", "gradle-kotlin-dsl-extensions")
+    @Suppress("DEPRECATION")
+    registerKotlinJvmCompileTask(
+        "compileGradleApiKotlinExtensions",
+        "gradle-kotlin-dsl-extensions"
+    )
 }
 
 val compileGradleApiKotlinExtensions = tasks.named("compileGradleApiKotlinExtensions", KotlinCompile::class) {

--- a/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/project/DeclarativeDSLCustomDependenciesExtensionsSpec.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/project/DeclarativeDSLCustomDependenciesExtensionsSpec.groovy
@@ -21,8 +21,11 @@ import org.gradle.api.internal.plugins.software.RegistersSoftwareTypes
 import org.gradle.api.internal.plugins.software.SoftwareType
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.versions.KotlinGradlePluginVersions
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.IntegTestPreconditions
 import org.jetbrains.kotlin.config.JvmTarget
 
+@Requires(IntegTestPreconditions.NotEmbeddedExecutor) // TODO temporary until wrapper update
 class DeclarativeDSLCustomDependenciesExtensionsSpec extends AbstractIntegrationSpec {
     def 'can configure an extension using DependencyCollector in declarative DSL'() {
         given: "a plugin that creates a custom extension using a DependencyCollector"

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslJvmTargetIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslJvmTargetIntegrationTest.kt
@@ -177,12 +177,12 @@ class KotlinDslJvmTargetIntegrationTest : AbstractKotlinIntegrationTest() {
 
     @Test
     @LeaksFileHandles("Kotlin compiler daemon  taking time to shut down")
-    fun `can use Java Toolchain to compile precompiled scripts on Java 23, with a warning`() {
+    fun `can use Java Toolchain to compile precompiled scripts on Java 24, with a warning`() {
 
         val currentJvm = Jvm.current()
         assumeNotNull(currentJvm)
 
-        val newerJvm = AvailableJavaHomes.getJdk23()
+        val newerJvm = AvailableJavaHomes.getJdk24()
         assumeNotNull(newerJvm)
 
         val installationPaths = listOf(currentJvm, newerJvm!!)
@@ -225,7 +225,7 @@ class KotlinDslJvmTargetIntegrationTest : AbstractKotlinIntegrationTest() {
             .withJvm(currentJvm)
             .withArgument("-Porg.gradle.java.installations.paths=$installationPaths")
             .run()
-        assertThat(pluginCompile.output, containsString("w: Inconsistent JVM-target compatibility detected for tasks 'compileJava' (23) and 'compileKotlin' (22)."))
+        assertThat(pluginCompile.output, containsString("w: Inconsistent JVM-target compatibility detected for tasks 'compileJava' (24) and 'compileKotlin' (23)."))
 
         withSettingsIn("consumer", """
             pluginManagement {

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginForOldestKotlinVersionTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginForOldestKotlinVersionTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.plugins.dsl
+
+import org.gradle.integtests.fixtures.versions.KotlinGradlePluginVersions
+import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.IntegTestPreconditions
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+
+/**
+ * Assert that the latest kotlin-dsl plugin can be used with an old Kotlin language version.
+ */
+class KotlinDslPluginForOldestKotlinVersionTest : AbstractKotlinIntegrationTest() {
+
+    private val oldestKotlinLanguageVersion = "1.6"
+
+    @Test
+    @Requires(
+        IntegTestPreconditions.NotEmbeddedExecutor::class,
+        reason = "Kotlin version leaks on the classpath when running embedded"
+    )
+    fun `can build plugin for oldest supported Kotlin language version using last published plugin`() {
+
+        `can build plugin for oldest supported Kotlin language version`()
+    }
+
+    @Test
+    @Requires(
+        IntegTestPreconditions.NotEmbeddedExecutor::class,
+        reason = "Kotlin version leaks on the classpath when running embedded"
+    )
+    fun `can build plugin for oldest supported Kotlin language version using locally built plugin`() {
+
+        doForceLocallyBuiltKotlinDslPlugins()
+
+        `can build plugin for oldest supported Kotlin language version`()
+    }
+
+    private
+    fun `can build plugin for oldest supported Kotlin language version`() {
+
+        withDefaultSettingsIn("producer")
+        withBuildScriptIn("producer", scriptWithKotlinDslPlugin()).appendText(
+            """
+            tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+                compilerOptions {
+                    languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("$oldestKotlinLanguageVersion")
+                    apiVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("$oldestKotlinLanguageVersion")
+                }
+            }
+            """
+        )
+        withFile("producer/src/main/kotlin/some.gradle.kts", """println("some!")""")
+
+        withDefaultSettings().appendText("""includeBuild("producer")""")
+        withBuildScript("""plugins { id("some") }""")
+
+        repeat(2) {
+            executer.expectDeprecationWarning("w: Language version $oldestKotlinLanguageVersion is deprecated and its support will be removed in a future version of Kotlin")
+        }
+
+        build("help").apply {
+            assertThat(output, containsString("some!"))
+        }
+    }
+}

--- a/platforms/core-configuration/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPlugins.kt
+++ b/platforms/core-configuration/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPlugins.kt
@@ -30,6 +30,7 @@ import org.gradle.kotlin.dsl.precompile.v1.PrecompiledPluginsBlock
 import org.gradle.kotlin.dsl.provider.PrecompiledScriptPluginsSupport
 import org.gradle.kotlin.dsl.provider.gradleKotlinDslJarsOf
 import org.gradle.kotlin.dsl.support.serviceOf
+import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinBaseApiPlugin
 import org.jetbrains.kotlin.gradle.scripting.internal.ScriptingGradleSubplugin
@@ -74,19 +75,20 @@ abstract class PrecompiledScriptPlugins : Plugin<Project> {
         dependencies {
             pluginDependencyScope.name(kotlin("scripting-compiler-embeddable"))
         }
-
         kotlinBaseApiPlugin.registerKotlinJvmCompileTask(
             taskName = taskName,
-            moduleName = "gradle-kotlin-dsl-plugins-blocks",
+            compilerOptions = kotlinBaseApiPlugin.createCompilerJvmOptions(),
+            explicitApiMode = provider { ExplicitApiMode.Disabled },
         ).configure { task ->
             task.enabled = false
             task.multiPlatformEnabled.set(false)
             if (target.jvmTarget.isPresent) {
                 task.compilerOptions.jvmTarget.set(target.jvmTarget.map { JvmTarget.fromTarget(it.toString()) })
             }
+            task.compilerOptions.moduleName.set("gradle-kotlin-dsl-plugins-blocks")
+            task.compilerOptions.freeCompilerArgs.addAll(listOf("-script-templates", PrecompiledPluginsBlock::class.qualifiedName))
             task.libraries.from(sourceSets["main"].compileClasspath)
             task.pluginClasspath.from(pluginClasspath.get())
-            task.compilerOptions.freeCompilerArgs.addAll(listOf("-script-templates", PrecompiledPluginsBlock::class.qualifiedName))
         }
     }
 

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -58,7 +58,7 @@ import org.jetbrains.kotlin.config.JvmClosureGenerationScheme
 import org.jetbrains.kotlin.config.JvmDefaultMode
 import org.jetbrains.kotlin.config.JvmTarget
 import org.jetbrains.kotlin.config.JvmTarget.JVM_1_8
-import org.jetbrains.kotlin.config.JvmTarget.JVM_22
+import org.jetbrains.kotlin.config.JvmTarget.JVM_23
 import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.config.LanguageVersion
 import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
@@ -457,10 +457,10 @@ fun compilerConfigurationFor(messageCollector: MessageCollector, compilerOptions
 @VisibleForTesting
 internal
 fun JavaVersion.toKotlinJvmTarget(): JvmTarget {
-    // JvmTarget.fromString(JavaVersion.majorVersion) works from Java 9 to Java 21
+    // JvmTarget.fromString(JavaVersion.majorVersion) works from Java 9 to Java 23
     return JvmTarget.fromString(majorVersion)
         ?: if (this <= JavaVersion.VERSION_1_8) JVM_1_8
-        else JVM_22
+        else JVM_23
 }
 
 

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/support/KotlinCompilerTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/support/KotlinCompilerTest.kt
@@ -27,6 +27,8 @@ class KotlinCompilerTest {
 
     @Test
     fun `Gradle JavaVersion to Kotlin JvmTarget direct conversion`() {
+        assertThat(JavaVersion.VERSION_23.toKotlinJvmTarget(), equalTo(JvmTarget.JVM_23))
+        assertThat(JavaVersion.VERSION_22.toKotlinJvmTarget(), equalTo(JvmTarget.JVM_22))
         assertThat(JavaVersion.VERSION_21.toKotlinJvmTarget(), equalTo(JvmTarget.JVM_21))
         assertThat(JavaVersion.VERSION_20.toKotlinJvmTarget(), equalTo(JvmTarget.JVM_20))
         assertThat(JavaVersion.VERSION_19.toKotlinJvmTarget(), equalTo(JvmTarget.JVM_19))
@@ -51,9 +53,9 @@ class KotlinCompilerTest {
     }
 
     @Test
-    fun `Gradle JavaVersion greater than 22 to Kotlin JvmTarget conversion`() {
-        JavaVersion.values().filter { it > JavaVersion.VERSION_22 }.forEach { javaVersion ->
-            assertThat(javaVersion.toKotlinJvmTarget(), equalTo(JvmTarget.JVM_22))
+    fun `Gradle JavaVersion greater than 23 to Kotlin JvmTarget conversion`() {
+        JavaVersion.values().filter { it > JavaVersion.VERSION_23 }.forEach { javaVersion ->
+            assertThat(javaVersion.toKotlinJvmTarget(), equalTo(JvmTarget.JVM_23))
         }
     }
 }

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
@@ -40,6 +40,10 @@ class ServiceScopeValidatorWorkarounds {
         // Because of this, it artificially puts it into the Build-scope to make it available
         "org.gradle.initialization.DefaultProjectDescriptorRegistry",
 
+        // It's supposed to be both in the UserHome and Build scopes
+        // However, with ProjectBuilder based tests it is not available in UserHome scope
+        "org.gradle.internal.classloader.ClasspathHasher",
+
         // Problematic with GradleBuild task and CC, because marking it as a service
         // makes CC skip serialization and instead use service look-up which yield a wrong value for this specially setup task
         "org.gradle.api.internal.StartParameterInternal",

--- a/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
@@ -96,6 +96,7 @@ Beta and RC versions may or may not work.
 | 1.9.24 | 8.10 | 1.8
 | 2.0.20 | 8.11 | 1.8
 | 2.0.21 | 8.12 | 1.8
+| 2.1.0  | 8.13 | 1.8
 |===
 
 == Groovy

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -80,6 +80,10 @@ reporting {
 Similarly, the `testType` property was removed from link:{javadocPath}/org/gradle/api/plugins/jvm/JvmTestSuite.html[JvmTestSuite] and both the `TestSuiteTargetName` and `TestSuiteType` attributes have been removed.
 Test reports and Jacoco reports can now be aggregated between projects by specifying the name of the test suite in the target project to aggregate.
 
+==== Upgrade to Kotlin 2.1.0
+
+The embedded Kotlin has been updated from 2.0.21 to link:https://github.com/JetBrains/kotlin/releases/tag/v2.1.0[Kotlin 2.1.0].
+
 === Deprecations
 
 ==== Recursively querying `AttributeContainer` in lazy provider

--- a/platforms/documentation/docs/src/samples/android-application/tests/sanityCheck.sample.conf
+++ b/platforms/documentation/docs/src/samples/android-application/tests/sanityCheck.sample.conf
@@ -1,4 +1,4 @@
 executable: gradle
 args: tasks
-# Do not fail for deprecation warnings: Android plugin 7.3.0 uses a deprecated Report.setDestination
+# Do not fail for deprecation warnings: Android plugin 7.3.1 uses a deprecated Report.setDestination
 flags: "--warning-mode=all"

--- a/platforms/documentation/docs/src/samples/build-organization/structuring-software-projects/groovy/platforms/plugins-platform/build.gradle
+++ b/platforms/documentation/docs/src/samples/build-organization/structuring-software-projects/groovy/platforms/plugins-platform/build.gradle
@@ -6,7 +6,7 @@ group = 'com.example.platform'
 
 dependencies {
     constraints {
-        api('com.android.tools.build:gradle:7.3.0')
+        api('com.android.tools.build:gradle:7.3.1')
         api('org.jetbrains.kotlin.android:org.jetbrains.kotlin.android.gradle.plugin:2.1.0')
         api('org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin:2.1.0')
         api('org.springframework.boot:org.springframework.boot.gradle.plugin:2.7.8')

--- a/platforms/documentation/docs/src/samples/build-organization/structuring-software-projects/groovy/platforms/plugins-platform/build.gradle
+++ b/platforms/documentation/docs/src/samples/build-organization/structuring-software-projects/groovy/platforms/plugins-platform/build.gradle
@@ -7,8 +7,8 @@ group = 'com.example.platform'
 dependencies {
     constraints {
         api('com.android.tools.build:gradle:7.3.0')
-        api('org.jetbrains.kotlin.android:org.jetbrains.kotlin.android.gradle.plugin:2.0.21')
-        api('org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin:2.0.21')
+        api('org.jetbrains.kotlin.android:org.jetbrains.kotlin.android.gradle.plugin:2.1.0')
+        api('org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin:2.1.0')
         api('org.springframework.boot:org.springframework.boot.gradle.plugin:2.7.8')
     }
 }

--- a/platforms/documentation/docs/src/samples/build-organization/structuring-software-projects/kotlin/platforms/plugins-platform/build.gradle.kts
+++ b/platforms/documentation/docs/src/samples/build-organization/structuring-software-projects/kotlin/platforms/plugins-platform/build.gradle.kts
@@ -7,8 +7,8 @@ group = "com.example.platform"
 dependencies {
     constraints {
         api("com.android.tools.build:gradle:7.3.1")
-        api("org.jetbrains.kotlin.android:org.jetbrains.kotlin.android.gradle.plugin:2.0.21")
-        api("org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin:2.0.21")
+        api("org.jetbrains.kotlin.android:org.jetbrains.kotlin.android.gradle.plugin:2.1.0")
+        api("org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin:2.1.0")
         api("org.springframework.boot:org.springframework.boot.gradle.plugin:2.7.8")
     }
 }

--- a/platforms/documentation/docs/src/snippets/buildCache/caching-android-projects/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/buildCache/caching-android-projects/groovy/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id("org.jetbrains.kotlin.jvm") version "2.0.21"
-    id("org.jetbrains.kotlin.kapt") version "2.0.21"
+    id("org.jetbrains.kotlin.jvm") version "2.1.0"
+    id("org.jetbrains.kotlin.kapt") version "2.1.0"
 }
 
 // tag::cacheKapt[]

--- a/platforms/documentation/docs/src/snippets/buildCache/caching-android-projects/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/buildCache/caching-android-projects/kotlin/build.gradle.kts
@@ -1,8 +1,8 @@
 import org.jetbrains.kotlin.gradle.plugin.KaptExtension
 
 plugins {
-    kotlin("jvm") version "2.0.21"
-    kotlin("kapt") version "2.0.21"
+    kotlin("jvm") version "2.1.0"
+    kotlin("kapt") version "2.1.0"
 }
 
 repositories {

--- a/platforms/documentation/docs/src/snippets/kotlinDsl/androidBuild/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/kotlinDsl/androidBuild/kotlin/build.gradle.kts
@@ -2,7 +2,7 @@
 plugins {
     id("com.android.application") version "7.3.0" apply false
 // end::android[]
-    kotlin("android") version "2.0.21" apply false
+    kotlin("android") version "2.1.0" apply false
 // tag::android[]
 }
 // end::android[]

--- a/platforms/documentation/docs/src/snippets/kotlinDsl/androidBuild/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/kotlinDsl/androidBuild/kotlin/build.gradle.kts
@@ -1,6 +1,6 @@
 // tag::android[]
 plugins {
-    id("com.android.application") version "7.3.0" apply false
+    id("com.android.application") version "7.3.1" apply false
 // end::android[]
     kotlin("android") version "2.1.0" apply false
 // tag::android[]
@@ -14,7 +14,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.3.0")
+        classpath("com.android.tools.build:gradle:7.3.1")
     }
 }
 // end::android-buildscript[]

--- a/platforms/documentation/docs/src/snippets/kotlinDsl/androidBuild/tests/sanityCheck.sample.conf
+++ b/platforms/documentation/docs/src/snippets/kotlinDsl/androidBuild/tests/sanityCheck.sample.conf
@@ -1,4 +1,4 @@
 executable: gradle
 args: tasks
-# Do not fail for deprecation warnings: Android plugin 7.3.0 uses a deprecated Report.setDestination
+# Do not fail for deprecation warnings: Android plugin 7.3.1 uses a deprecated Report.setDestination
 flags: "--warning-mode=all"

--- a/platforms/documentation/docs/src/snippets/kotlinDsl/androidSingleBuild/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/kotlinDsl/androidSingleBuild/kotlin/build.gradle.kts
@@ -2,7 +2,7 @@
 plugins {
     id("com.android.application") version "7.3.0"
 // end::android[]
-    kotlin("android") version "2.0.21"
+    kotlin("android") version "2.1.0"
 // tag::android[]
 }
 

--- a/platforms/documentation/docs/src/snippets/kotlinDsl/androidSingleBuild/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/kotlinDsl/androidSingleBuild/kotlin/build.gradle.kts
@@ -1,6 +1,6 @@
 // tag::android[]
 plugins {
-    id("com.android.application") version "7.3.0"
+    id("com.android.application") version "7.3.1"
 // end::android[]
     kotlin("android") version "2.1.0"
 // tag::android[]

--- a/platforms/documentation/docs/src/snippets/kotlinDsl/androidSingleBuild/tests/sanityCheck.sample.conf
+++ b/platforms/documentation/docs/src/snippets/kotlinDsl/androidSingleBuild/tests/sanityCheck.sample.conf
@@ -1,4 +1,4 @@
 executable: gradle
 args: tasks
-# Do not fail for deprecation warnings: Android plugin 7.3.0 uses a deprecated Report.setDestination
+# Do not fail for deprecation warnings: Android plugin 7.3.1 uses a deprecated Report.setDestination
 flags: "--warning-mode=all"

--- a/platforms/documentation/docs/src/snippets/plugins/pluginProject/groovy/buildSrc/build.gradle
+++ b/platforms/documentation/docs/src/snippets/plugins/pluginProject/groovy/buildSrc/build.gradle
@@ -11,5 +11,5 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin:2.0.21'
+    implementation 'org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin:2.1.0'
 }

--- a/platforms/documentation/docs/src/snippets/plugins/pluginProject/groovy/database-logic/build.gradle
+++ b/platforms/documentation/docs/src/snippets/plugins/pluginProject/groovy/database-logic/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-library'
-    id 'org.jetbrains.kotlin.jvm' version '2.0.21'
+    id 'org.jetbrains.kotlin.jvm' version '2.1.0'
 }
 
 repositories {

--- a/platforms/documentation/docs/src/snippets/plugins/pluginProject/kotlin/buildSrc/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/plugins/pluginProject/kotlin/buildSrc/build.gradle.kts
@@ -11,6 +11,6 @@ repositories {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin:2.0.21")
+    implementation("org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin:2.1.0")
 }
 

--- a/platforms/documentation/docs/src/snippets/plugins/pluginProject/kotlin/database-logic/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/plugins/pluginProject/kotlin/database-logic/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java-library")
-    id("org.jetbrains.kotlin.jvm") version "2.0.21"
+    id("org.jetbrains.kotlin.jvm") version "2.1.0"
 }
 
 repositories {

--- a/platforms/jvm/plugins-jvm-test-suite/src/main/java/org/gradle/api/testing/toolchains/internal/KotlinTestTestToolchain.java
+++ b/platforms/jvm/plugins-jvm-test-suite/src/main/java/org/gradle/api/testing/toolchains/internal/KotlinTestTestToolchain.java
@@ -29,7 +29,7 @@ abstract public class KotlinTestTestToolchain extends JUnitPlatformTestToolchain
     /**
      * The default version of KotlinTest to use for compiling and executing tests.
      */
-    public static final String DEFAULT_VERSION = "2.0.21";
+    public static final String DEFAULT_VERSION = "2.1.0";
     private static final String GROUP_NAME = "org.jetbrains.kotlin:kotlin-test-junit5";
 
     @Override

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AvailableJavaHomes.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AvailableJavaHomes.java
@@ -118,6 +118,11 @@ public abstract class AvailableJavaHomes {
     }
 
     @Nullable
+    public static Jvm getJdk24() {
+        return getJdk(JavaVersion.VERSION_24);
+    }
+
+    @Nullable
     public static Jvm getHighestSupportedLTS() {
         return getJdk21();
     }

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/JavaTestProjectGenerator.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/JavaTestProjectGenerator.groovy
@@ -161,7 +161,7 @@ enum JavaTestProjectGenerator {
             "otel" : "io.opentelemetry:opentelemetry-sdk:1.33.0",
             "jackson" : "com.fasterxml.jackson.core:jackson-databind:2.10.0",
             "junit5" : "org.junit.jupiter:junit-jupiter-engine:5.10.0",
-            "kotlin": "org.jetbrains.kotlin:kotlin-stdlib:2.0.21",
+            "kotlin": "org.jetbrains.kotlin:kotlin-stdlib:2.1.0",
             "testcontainers": "org.testcontainers:mysql:1.15.3",
             "vertx": "io.vertx:vertx-web:4.4.2",
             "keycloak": "org.keycloak:keycloak-core:24.0.1"

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -70,6 +70,7 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
 
         assumeFalse(version.startsWith("1.6."))
         assumeFalse(version.startsWith("1.7."))
+        // assumeFalse(version.startsWith("1.8."))
         setupForKotlinVersion(version)
 
         given:
@@ -212,6 +213,7 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
 
         assumeFalse(kotlinVersion.startsWith("1.6."))
         assumeFalse(kotlinVersion.startsWith("1.7."))
+        assumeFalse(kotlinVersion.startsWith("1.8."))
 
         given:
         buildFile << """

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -96,6 +96,8 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
                     implementation("org.jetbrains.kotlin:kotlin-test-junit5")
                 }
             }
+
+            $SKIP_METADATA_VERSION_CHECK
         """
 
         ["test", "integTest"].each {
@@ -182,6 +184,8 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
                 implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
                 implementation localGroovy()
             }
+
+            $SKIP_METADATA_VERSION_CHECK
         """
         file("src/main/groovy/Groovy.groovy") << "class Groovy { }"
         file("src/main/kotlin/Kotlin.kt") << "class Kotlin { val groovy = Groovy() }"
@@ -223,6 +227,8 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
             dependencies {
                 implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
             }
+
+            $SKIP_METADATA_VERSION_CHECK
         """
         file("src/main/kotlin/Kotlin.kt") << "class Kotlin { }"
         when:
@@ -240,6 +246,15 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
         where:
         kotlinVersion << TestedVersions.kotlin.versions
     }
+
+    private static String SKIP_METADATA_VERSION_CHECK =
+        """
+        tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+            kotlinOptions {
+                freeCompilerArgs += "-Xskip-metadata-version-check"
+            }
+        }
+        """
 
     @Override
     Map<String, Versions> getPluginsToValidate() {

--- a/testing/smoke-test/src/smokeTest/resources/org/gradle/smoketests/kotlin-example/build.gradle
+++ b/testing/smoke-test/src/smokeTest/resources/org/gradle/smoketests/kotlin-example/build.gradle
@@ -25,3 +25,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 }
 
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    kotlinOptions {
+        freeCompilerArgs += "-Xskip-metadata-version-check"
+    }
+}


### PR DESCRIPTION
See https://github.com/JetBrains/kotlin/releases/tag/v2.1.20

Kotlin 2.1 removes support for targetting Kotlin language 1.4 and 1.5, it also deprecates using Kotlin language 1.7.

While it is supported to override the target language version when using the `kotlin-dsl` plugin to write build logic, it is not part of its backwards compatibility contract to support all Kotlin language versions that were supported in previous Gradle minors.

Using older Kotlin language versions should still be possible by using a previous KGP version in combination with the `kotlin-dsl` plugin.

----

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
