### PR TITLE
Do not load file-system watching libraries on macOS 11

### DIFF
--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
@@ -99,6 +99,14 @@ public class NativeServices implements ServiceRegistrationProvider {
             @Override
             public boolean initialize(File nativeBaseDir, boolean useNativeIntegrations) {
                 if (useNativeIntegrations) {
+                    OperatingSystem operatingSystem = OperatingSystem.current();
+                    if (operatingSystem.isMacOsX()) {
+                        String version = operatingSystem.getVersion();
+                        if (VersionNumber.parse(version).getMajor() < 12) {
+                            LOGGER.info("Disabling file system watching on macOS {}, as it is only supported for macOS 12+", version);
+                            return false;
+                        }
+                    }
                     try {
                         FileEvents.init(nativeBaseDir);
                         LOGGER.info("Initialized file system watching services in: {}", nativeBaseDir);
@@ -475,14 +483,6 @@ public class NativeServices implements ServiceRegistrationProvider {
 
             @Override
             public boolean useFileSystemWatching() {
-                OperatingSystem operatingSystem = OperatingSystem.current();
-                if (operatingSystem.isMacOsX()) {
-                    String version = operatingSystem.getVersion();
-                    if (VersionNumber.parse(version).getMajor() < 12) {
-                        LOGGER.info("Disabling file system watching on macOS {}, as it is only supported for macOS 12+", version);
-                        return false;
-                    }
-                }
                 return isFeatureEnabled(NativeFeatures.FILE_SYSTEM_WATCHING);
             }
         };


### PR DESCRIPTION
Previously we had file-system watching on macOS disabled (since Gradel 8.9),
but we still loaded the native libraries. This doesn't work anymore with
the new gradle-fileevents libraries we are including with Gradle 8.12,
and there is actually no point in loading the libraries if we are not
about to use them anyway.
