### PR TITLE
Fix 'Argument list too long' error in check-bad-merge action

### DIFF
--- a/.github/workflows/CheckBadMerge.groovy
+++ b/.github/workflows/CheckBadMerge.groovy
@@ -17,6 +17,8 @@
 import java.util.concurrent.Callable
 import java.util.concurrent.Executors
 import java.util.concurrent.Future
+import java.nio.file.Files
+import java.nio.file.Paths
 
 /**
  * See https://github.com/gradle/gradle-private/issues/3919
@@ -39,7 +41,13 @@ class CheckBadMerge {
         "platforms/core-runtime/launcher/src/main/resources/release-features.txt"
     ]
 
-    static void main(String[] commits) {
+    static void main(String[] args) {
+        if (args.length != 1) {
+            System.err.println("Usage: groovy CheckBadMerge.groovy <commits_file>")
+            System.exit(1)
+        }
+
+        List<String> commits = Files.readAllLines(Paths.get(args[0]))
         println("Commits to check: ${Arrays.toString(commits)}")
         try {
             commits.each { checkCommit(it) }

--- a/.github/workflows/check-bad-merge.yml
+++ b/.github/workflows/check-bad-merge.yml
@@ -10,6 +10,7 @@ permissions: {}
 
 jobs:
   check_pr_commits:
+    if: github.event.pull_request.base.ref == 'master'
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -32,7 +33,7 @@ jobs:
       - name: Check PR commits
         id: run_check
         run: |
-          groovy .github/workflows/CheckBadMerge.groovy $(<pr_commits.txt) > output.txt 2>&1
+          groovy .github/workflows/CheckBadMerge.groovy pr_commits.txt > output.txt 2>&1
       - name: Read output file
         id: read_output
         if: ${{ always() }}


### PR DESCRIPTION
Closes https://github.com/gradle/gradle-private/issues/4569

1. Don't pass the commits via CLI args, use a file instead.
2. Only run the action when target branch is `master`.