### PR TITLE
Disable Classloader Caching in Isolated Workers

### DIFF
--- a/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/IsolatedClassloaderWorker.java
+++ b/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/IsolatedClassloaderWorker.java
@@ -30,16 +30,10 @@ import org.gradle.internal.service.ServiceRegistry;
 public class IsolatedClassloaderWorker extends AbstractClassLoaderWorker {
     private final GroovySystemLoaderFactory groovySystemLoaderFactory = new GroovySystemLoaderFactory();
     private ClassLoader workerClassLoader;
-    private boolean reuseClassloader;
 
     public IsolatedClassloaderWorker(ClassLoader workerClassLoader, ServiceRegistry workServices, ActionExecutionSpecFactory actionExecutionSpecFactory, InstantiatorFactory instantiatorFactory) {
         super(workServices, actionExecutionSpecFactory, instantiatorFactory);
         this.workerClassLoader = workerClassLoader;
-    }
-
-    public IsolatedClassloaderWorker(ClassLoader workerClassLoader, ServiceRegistry workServices, ActionExecutionSpecFactory actionExecutionSpecFactory, InstantiatorFactory instantiatorFactory, boolean reuseClassloader) {
-        this(workerClassLoader, workServices, actionExecutionSpecFactory, instantiatorFactory);
-        this.reuseClassloader = reuseClassloader;
     }
 
     @Override
@@ -50,10 +44,8 @@ public class IsolatedClassloaderWorker extends AbstractClassLoaderWorker {
         } finally {
             workerClasspathGroovy.shutdown();
             // TODO: we should just cache these classloaders and eject/stop them when they are no longer in use
-            if (!reuseClassloader) {
-                CompositeStoppable.stoppable(workerClassLoader).stop();
-                this.workerClassLoader = null;
-            }
+            CompositeStoppable.stoppable(workerClassLoader).stop();
+            this.workerClassLoader = null;
         }
     }
 

--- a/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/IsolatedClassloaderWorker.java
+++ b/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/IsolatedClassloaderWorker.java
@@ -23,7 +23,6 @@ import org.gradle.initialization.MixInLegacyTypesClassLoader;
 import org.gradle.internal.classloader.ClassLoaderSpec;
 import org.gradle.internal.classloader.FilteringClassLoader;
 import org.gradle.internal.classloader.VisitableURLClassLoader;
-import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.service.ServiceRegistry;
 
@@ -44,7 +43,6 @@ public class IsolatedClassloaderWorker extends AbstractClassLoaderWorker {
         } finally {
             workerClasspathGroovy.shutdown();
             // TODO: we should just cache these classloaders and eject/stop them when they are no longer in use
-            CompositeStoppable.stoppable(workerClassLoader).stop();
             this.workerClassLoader = null;
         }
     }

--- a/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonServer.java
+++ b/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonServer.java
@@ -117,7 +117,7 @@ public class WorkerDaemonServer implements RequestHandler<TransportableActionExe
         if (classLoaderStructure instanceof FlatClassLoaderStructure) {
             return new FlatClassLoaderWorker(this.getClass().getClassLoader(), workServices, actionExecutionSpecFactory, instantiatorFactory);
         } else {
-            return new IsolatedClassloaderWorker(getWorkerClassLoader(classLoaderStructure), workServices, actionExecutionSpecFactory, instantiatorFactory, true);
+            return new IsolatedClassloaderWorker(getWorkerClassLoader(classLoaderStructure), workServices, actionExecutionSpecFactory, instantiatorFactory);
         }
     }
 


### PR DESCRIPTION
The classloaders for Isolated Workers are stored in a cache, but never releaed, and loaded. This results in every growing metaspace, which is crippling. There is no workaround. The only alternative is process isolation, which also requires additional memory and more system resources, which can also be unreasonably high.

In lieu of an actual fix this PR disables the caching for classpath isolated workers.

Workaround for #18313


### Context

Without this change classloader isolated workers are completely unusable for many projects.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
