### PR TITLE
Revert "Fix deprecation warning in docsTest"

### DIFF
--- a/platforms/documentation/docs/src/snippets/java/fixtures/kotlin/lib/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/java/fixtures/kotlin/lib/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
 // tag::publishing_test_fixtures[]
 publishing {
     publications {
-        register<MavenPublication>("mavenJava") {
+        create<MavenPublication>("mavenJava") {
             from(components["java"])
         }
     }


### PR DESCRIPTION
Reverts gradle/gradle#31546

> Configure project :lib
w: file:///home/user/gradle/samples/lib/build.gradle.kts:51:7: 'create(String!, Action<in Task!>!): Task!' is deprecated. Deprecated in Java

Note that the reverted PR did not change line 51 - a task ~~creation~~ registration but instead changed the creation of a `MavenPublication` where `create` is the appropriate way of adding elements.