### PR TITLE
Fix flaky CancellationIntegrationTest

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/CancellationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/CancellationIntegrationTest.groovy
@@ -45,7 +45,9 @@ class CancellationIntegrationTest extends DaemonIntegrationSpec implements Direc
             task projectExecTask {
                 dependsOn 'compileJava'
                 doLast {
-                    def result = exec { commandLine '${fileToPath(Jvm.current().javaExecutable)}', '-cp', '${fileToPath(file('build/classes/java/main'))}', 'Block' }
+                    def result = services.get(ExecOperations).exec {
+                        commandLine '${fileToPath(Jvm.current().javaExecutable)}', '-cp', '${fileToPath(file('build/classes/java/main'))}', 'Block'
+                    }
                     assert result.exitValue == 0
                 }
             }


### PR DESCRIPTION
This is the second most flaky test in GBT builds: https://ge.gradle.org/scans/tests?search.relativeStartTime=P90D&search.timeZoneId=Asia%2FShanghai&tests.container=org.gradle.process.internal.CancellationIntegrationTest&tests.expandedTests=WzAsMzUsMSwyXQ&tests.test=can%20cancel%20project.exec

```
assertTaskIsCancellable(task)	
|                       |	
|                       projectExecTask	
java.lang.AssertionError: Standard output line 1035 contains an unexpected deprecation warning:	
 - Using method exec(Closure) has been deprecated. This is scheduled to be removed in Gradle 9.0. Use ExecOperations.exec(Action) or ProviderFactory.exec(Action) instead. Consult the upgrading guide for further information: https://docs.gradle.org/9.0-20241210144201+0000/userguide/upgrading_version_8.html#deprecated_project_exec	
Expected deprecation warnings:	
 - (optional) Executing Gradle on JVM versions 16 and lower has been deprecated. This will fail with an error in Gradle 9.0. Use JVM 17 or greater to execute Gradle. Projects can continue to use older JVM versions via toolchains. Consult the upgrading guide for further information: https://docs.gradle.org/9.0-20241210144201+0000/userguide/upgrading_version_8.html#minimum_daemon_jvm_version	
=====
```

This PR replaces `project.exec(Closure)` to `ExecOperations.exec()`.