### PR TITLE
Fix any broken links in the User Manual and rework lost links from 8.11

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/writing_build_scripts.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/writing_build_scripts.adoc
@@ -19,7 +19,7 @@ The initialization phase in the Gradle Build lifecycle finds the root project an
 
 image::author-gradle-6.png[]
 
-Then, for each project included in the settings file, Gradle creates a link:{javadocPath}org/gradle/api/Project.html[`Project`] instance.
+Then, for each project included in the settings file, Gradle creates a link:{javadocPath}/org/gradle/api/Project.html[`Project`] instance.
 
 Gradle then looks for a corresponding build script file, which is used in the configuration phase.
 

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/structuring/sharing_build_logic_between_subprojects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/structuring/sharing_build_logic_between_subprojects.adoc
@@ -345,7 +345,7 @@ include::sample[dir="snippets/multiproject/dependencies-java/groovy",files="api/
 [[sec:convention_plugins_vs_cross_configuration]]
 == Do not use cross-project configuration
 
-An improper way to share build logic between subprojects is _cross-project configuration_ via the link:{javadocPath}//org/gradle/api/Project.html#subprojects-groovy.lang.Closure-[`subprojects {}`] and link:{javadocPath}/org/gradle/api/Project.html#allprojects-groovy.lang.Closure-[`allprojects {}`] DSL constructs.
+An improper way to share build logic between subprojects is _cross-project configuration_ via the link:{javadocPath}/org/gradle/api/Project.html#subprojects-groovy.lang.Closure-[`subprojects {}`] and link:{javadocPath}/org/gradle/api/Project.html#allprojects-groovy.lang.Closure-[`allprojects {}`] DSL constructs.
 
 TIP:  Avoid using `subprojects {}` and `allprojects {}`.
 

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tutorial/part6_writing_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tutorial/part6_writing_tasks.adoc
@@ -85,8 +85,8 @@ tasks.named("task1") {  // <2>
     }
 }
 ----
-<1> You can use the link:{groovyDslPath}/org.gradle.api.tasks.TaskContainer:register(java.lang.String)[register()] method to create new tasks.
-<2> You can use the link:{groovyDslPath}/org.gradle.api.tasks.TaskContainer:named(java.lang.String)[named()] method to configure existing tasks.
+<1> You can use the link:{groovyDslPath}/org.gradle.api.tasks.TaskContainer.html#org.gradle.api.tasks.TaskContainer:register(java.lang.String)[register()] method to create new tasks.
+<2> You can use the link:{groovyDslPath}/org.gradle.api.tasks.TaskContainer.html#org.gradle.api.tasks.TaskContainer:named(java.lang.String)[named()] method to configure existing tasks.
 =====
 
 == Step 3. Create a custom Task

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-dependencies/declaring_configurations.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-dependencies/declaring_configurations.adoc
@@ -186,7 +186,7 @@ These methods help build authors document the purpose of a configuration and avo
 Configurations can inherit from other configurations, creating an inheritance hierarchy.
 
 Configurations form an inheritance hierarchy using the link:{groovyDslPath}/org.gradle.api.artifacts.Configuration.html#org.gradle.api.artifacts.Configuration:extendsFrom)[`Configuration.extendsFrom(Configuration...)`] method.
-A configuration can extend any other configuration other than a link:{kotlinDslPath}/gradle/org.gradle.api.artifacts/-configuration-container/detached-configuration[detached configuration], regardless of how it is defined in the build script or plugin.
+A configuration can extend any other configuration other than a link:{kotlinDslPath}/gradle/org.gradle.api.artifacts/-configuration-container/detached-configuration.html[detached configuration], regardless of how it is defined in the build script or plugin.
 
 TIP: Avoid extending consumable or resolvable configurations with configurations that are not consumable or resolvable, respectively.
 

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-dependencies/viewing_debugging_dependencies.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-dependencies/viewing_debugging_dependencies.adoc
@@ -218,3 +218,25 @@ Head over to the `Dependencies` tab and navigate to your desired dependency.
 Select the `Required By` tab to see the selection reason and origin of the dependency:
 
 image::dependency-management-dependency-insight-report-build-scan.png[]
+
+[[sub:resolving-unsafe-configuration-resolution-errors]]
+== Resolving unsafe configuration resolution errors
+
+Resolving a configuration can have side effects on Gradle's project model, so Gradle needs manage access to each project's configurations.
+There are a number of ways a configuration might be resolved unsafely.
+Gradle will produce a deprecation warning for each unsafe access.
+Each of these are bad practices and can cause strange and indeterminate errors.
+
+If your build has an unsafe access deprecation warning, it needs to be fixed.
+
+For example:
+
+* A task from one project directly resolves a configuration in another project in the task's action.
+* A task specifies a configuration from another project as an input file collection.
+* A build script for one project resolves a configuration in another project during evaluation.
+* Project configurations are resolved in the settings file.
+
+In most cases, this issue can be resolved by creating a cross-project dependency on the other project.
+See the documentation for <<cross_project_publications.adoc#cross_project_publications, sharing outputs between projects>> for more information.
+
+If you find a use case that can't be resolved using these techniques, please let us know by filing a https://github.com/gradle/gradle/issues[GitHub Issue] adhering to our issue guidelines.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/other/resolution_strategy_tuning.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/other/resolution_strategy_tuning.adoc
@@ -1,0 +1,143 @@
+[[resolution-strategy-safety-nets]]
+= Preventing accidental dependency upgrades
+
+In some situations, you might want to be in total control of the dependency graph.
+In particular, you may want to make sure that:
+
+- the versions declared in a build script actually correspond to the ones being resolved
+- or make sure that dependency resolution is reproducible over time
+
+Gradle provides ways to perform this by configuring the resolution strategy.
+
+[[fail-version-conflict]]
+== Failing on version conflict
+
+There's a version conflict whenever Gradle finds the same module in two different versions in a dependency graph.
+By default, Gradle performs _optimistic upgrades_, meaning that if version `1.1` and `1.3` are found in the graph, we resolve to the highest version, `1.3`.
+However, it is easy to miss that some dependencies are upgraded because of a transitive dependency.
+In the example above, if `1.1` was a version used in your build script and `1.3` a version brought transitively, you could use `1.3` without actually noticing.
+
+To make sure that you are aware of such upgrades, Gradle provides a mode that can be activated in the resolution strategy of a configuration.
+Imagine the following dependencies declaration:
+
+.Direct dependency version not matching a transitive version
+====
+include::sample[dir="snippets/dependencyManagement/managingTransitiveDependencies-resolutionStrategy/kotlin",files="build.gradle.kts[tags=dependencies]"]
+include::sample[dir="snippets/dependencyManagement/managingTransitiveDependencies-resolutionStrategy/groovy",files="build.gradle[tags=dependencies]"]
+====
+
+Then by default Gradle would upgrade `commons-lang3`, but it is possible to _fail_ the build:
+
+.Fail on version conflict
+====
+include::sample[dir="snippets/dependencyManagement/managingTransitiveDependencies-resolutionStrategy/kotlin",files="build.gradle.kts[tags=fail-on-version-conflict]"]
+include::sample[dir="snippets/dependencyManagement/managingTransitiveDependencies-resolutionStrategy/groovy",files="build.gradle[tags=fail-on-version-conflict]"]
+====
+
+[[reproducible-resolution]]
+== Making sure resolution is reproducible
+
+There are cases where dependency resolution can be _unstable_ over time.
+That is to say that if you build at date D, building at date D+x may give a different resolution result.
+
+This is possible in the following cases:
+
+- dynamic dependency versions are used (version ranges, `latest.release`, `1.+`, ...)
+- or _changing_ versions are used (SNAPSHOTs, fixed version with changing contents, ...)
+
+The recommended way to deal with dynamic versions is to use <<dependency_locking.adoc#dependency-locking,dependency locking>>.
+However, it is possible to prevent the use of dynamic versions altogether, which is an alternate strategy:
+
+.Failing on dynamic versions
+====
+include::sample[dir="snippets/dependencyManagement/managingTransitiveDependencies-resolutionStrategy/kotlin",files="build.gradle.kts[tags=fail-on-dynamic]"]
+include::sample[dir="snippets/dependencyManagement/managingTransitiveDependencies-resolutionStrategy/groovy",files="build.gradle[tags=fail-on-dynamic]"]
+====
+
+Likewise, it's possible to prevent the use of changing versions by activating this flag:
+
+.Failing on changing versions
+====
+include::sample[dir="snippets/dependencyManagement/managingTransitiveDependencies-resolutionStrategy/kotlin",files="build.gradle.kts[tags=fail-on-changing]"]
+include::sample[dir="snippets/dependencyManagement/managingTransitiveDependencies-resolutionStrategy/groovy",files="build.gradle[tags=fail-on-changing]"]
+====
+
+It's a good practice to fail on changing versions at release time.
+
+Eventually, it's possible to combine both failing on dynamic versions and changing versions using a single call:
+
+.Failing on non-reproducible resolution
+====
+include::sample[dir="snippets/dependencyManagement/managingTransitiveDependencies-resolutionStrategy/kotlin",files="build.gradle.kts[tags=fail-on-unstable]"]
+include::sample[dir="snippets/dependencyManagement/managingTransitiveDependencies-resolutionStrategy/groovy",files="build.gradle[tags=fail-on-unstable]"]
+====
+
+[[resolution_consistency]]
+== Getting consistent dependency resolution results
+
+NOTE: Dependency resolution consistency is an incubating feature
+
+It's a common misconception that there's a single dependency graph for an application.
+In fact Gradle will, during a build, resolve a number of distinct dependency graphs, even within a single project.
+For example, the graph of dependencies to use at compile time is different from the graph of dependencies to use at runtime.
+In general, the graph of dependencies at runtime is a superset of the compile dependencies (there are exceptions to the rule, for example in case some dependencies are repackaged within the runtime binary).
+
+Gradle resolves those dependency graphs independently.
+This means, in the Java ecosystem for example, that the resolution of the "compile classpath" doesn't influence the resolution of the "runtime classpath".
+Similarly, test dependencies could end up bumping the version of production dependencies, causing some surprising results when executing tests.
+
+These surprising behaviors can be mitigated by enabling dependency resolution consistency.
+
+[[sec::project_dependency_resolution_consistency]]
+=== Enabling project-local dependency resolution consistency
+
+For example, imagine that your Java library depends on the following libraries:
+
+.First-level dependencies
+====
+include::sample[dir="snippets/dependencyManagement/customizingResolution-consistentResolution/kotlin",files="build.gradle.kts[tags=dependencies]"]
+include::sample[dir="snippets/dependencyManagement/customizingResolution-consistentResolution/groovy",files="build.gradle[tags=dependencies]"]
+====
+
+Then resolving the `compileClasspath` configuration would resolve the `groovy` library to version `3.0.1` as expected.
+However, resolving the `runtimeClasspath` configuration would instead return `groovy 3.0.2`.
+
+The reason for this is that a transitive dependency of `vertx`, which is a `runtimeOnly` dependency, brings a higher version of `groovy`.
+In general, this isn't a problem, but it also means that the version of the Groovy library that you are going to use at runtime is going to be different from the one that you used for compilation.
+
+In order to avoid this situation, Gradle offers an API to explain that configurations should be resolved consistently.
+
+[[sec:configuration_consistency]]
+=== Declaring resolution consistency between configurations
+
+In the example above, we can declare that we want, at runtime, the same versions of the common dependencies as compile time, by declaring that the "runtime classpath" _should be consistent with_ the "compile classpath":
+
+.Declaring consistency between configurations
+====
+include::sample[dir="snippets/dependencyManagement/customizingResolution-consistentResolution/kotlin",files="build.gradle.kts[tags=explicit-configuration]"]
+include::sample[dir="snippets/dependencyManagement/customizingResolution-consistentResolution/groovy",files="build.gradle[tags=explicit-configuration]"]
+====
+
+As a result, both the `runtimeClasspath` and `compileClasspath` will resolve Groovy 3.0.1.
+
+The relationship is _directed_, which means that if the `runtimeClasspath` configuration has to be resolved, Gradle will _first_ resolve the `compileClasspath` and then "inject" the result of resolution as <<rich_versions.adoc#sec:strict-version,strict constraints>> into the `runtimeClasspath`.
+
+If, for some reason, the versions of the two graphs cannot be "aligned", then resolution will fail with a call to action.
+
+[[sec:java_consistency]]
+=== Declaring consistent resolution in the Java ecosystem
+
+The `runtimeClasspath` and `compileClasspath` example above are common in the Java ecosystem.
+However, it's often not enough to declare consistency between those two configurations only.
+For example, you most likely want the _test runtime classpath_ to be consistent with the
+_runtime classpath_.
+
+To make this easier, Gradle provides a way to configure consistent resolution for the Java ecosystem using the `java` extension:
+
+.Declaring consistency in the Java ecosystem
+====
+include::sample[dir="snippets/dependencyManagement/customizingResolution-consistentResolution/kotlin",files="build.gradle.kts[tags=java-convention]"]
+include::sample[dir="snippets/dependencyManagement/customizingResolution-consistentResolution/groovy",files="build.gradle[tags=java-convention]"]
+====
+
+Please refer to the link:{javadocPath}/org/gradle/api/plugins/JavaPluginExtension.html[Java Plugin Extension docs] for more configuration options.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/other/resolution_strategy_tuning.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/other/resolution_strategy_tuning.adoc
@@ -45,7 +45,7 @@ This is possible in the following cases:
 - dynamic dependency versions are used (version ranges, `latest.release`, `1.+`, ...)
 - or _changing_ versions are used (SNAPSHOTs, fixed version with changing contents, ...)
 
-The recommended way to deal with dynamic versions is to use <<dependency_locking.adoc#dependency-locking,dependency locking>>.
+The recommended way to deal with dynamic versions is to use <<dependency_locking.adoc#sec:dependency-locking,dependency locking>>.
 However, it is possible to prevent the use of dynamic versions altogether, which is an alternate strategy:
 
 .Failing on dynamic versions
@@ -120,7 +120,7 @@ include::sample[dir="snippets/dependencyManagement/customizingResolution-consist
 
 As a result, both the `runtimeClasspath` and `compileClasspath` will resolve Groovy 3.0.1.
 
-The relationship is _directed_, which means that if the `runtimeClasspath` configuration has to be resolved, Gradle will _first_ resolve the `compileClasspath` and then "inject" the result of resolution as <<rich_versions.adoc#sec:strict-version,strict constraints>> into the `runtimeClasspath`.
+The relationship is _directed_, which means that if the `runtimeClasspath` configuration has to be resolved, Gradle will _first_ resolve the `compileClasspath` and then "inject" the result of resolution as <<dependency_versions.adoc#sec:strict-version,strict constraints>> into the `runtimeClasspath`.
 
 If, for some reason, the versions of the two graphs cannot be "aligned", then resolution will fail with a call to action.
 

--- a/platforms/documentation/docs/src/docs/userguide/jvm/building_java_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/building_java_projects.adoc
@@ -319,7 +319,7 @@ It validates that the Java sources are not using language features introduced in
 The bytecode produced by the compiler also corresponds to the requested Java version, meaning that the compiled code cannot be executed on older JVMs.
 
 The `release` option of the Java compiler was introduced in Java 9.
-However, using this option with Gradle is only possible starting with Java 10, due to a https://bugs.openjdk.java.net/browse/JDK-8139607[bug in Java 9].
+However, using this option with Gradle is only possible starting with Java 10, due to a https://bugs.openjdk.org/browse/JDK-8139607[bug in Java 9].
 
 ==== Using Java compatibility options
 

--- a/platforms/documentation/docs/src/docs/userguide/jvm/groovy_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/groovy_plugin.adoc
@@ -78,7 +78,7 @@ image::groovyPluginTasks.png[]
 [[sec:groovy_project_layout]]
 == Project layout
 
-The Groovy plugin assumes the project layout shown in <<#groovylayout,Groovy Layout>>. All the Groovy source directories can contain Groovy _and_ Java code. The Java source directories may only contain Java source code.footnote:[Gradle uses the same conventions as introduced by Russel Winder's link:https://gant.github.io/[Gant tool].] None of these directories need to exist or have anything in them; the Groovy plugin will simply compile whatever it finds.
+The Groovy plugin assumes the project layout shown in <<#groovylayout,Groovy Layout>>. All the Groovy source directories can contain Groovy _and_ Java code. The Java source directories may only contain Java source code.footnote:[Gradle uses the same conventions as introduced by Russel Winder's link:https://github.com/Gant/Gant[Gant tool].] None of these directories need to exist or have anything in them; the Groovy plugin will simply compile whatever it finds.
 
 [[groovylayout]]
 include::javaProjectMainLayout.adoc[]
@@ -177,7 +177,7 @@ _Default value_: Not null
 +
 All Groovy source files of this source set. Contains only the `.groovy` files found in the Groovy source directories.
 
-These properties are provided by a convention object of type link:{groovyDslPath}/org.gradle.api.tasks.GroovySourceSet.html[GroovySourceSet].
+These properties are provided by a convention object of type link:{groovyDslPath}/org.gradle.api.tasks.SourceSet.html[GroovySourceSet].
 
 The Groovy plugin also modifies some source set properties:
 

--- a/platforms/documentation/docs/src/docs/userguide/jvm/java_testing.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/java_testing.adoc
@@ -396,7 +396,7 @@ include::sample[dir="snippets/testing/junitplatform-tagging/kotlin",files="build
 include::sample[dir="snippets/testing/junitplatform-tagging/groovy",files="build.gradle[tags=test-tags]"]
 ====
 
-The TestNG framework uses the concept of test groups for a similar effect.footnote:[The TestNG documentation contains more details about test groups: http://testng.org/doc/documentation-main.html#test-groups[].] You can configure which test groups to include or exclude during the test execution via the link:{groovyDslPath}/org.gradle.api.tasks.testing.Test.html#org.gradle.api.tasks.testing.Test:useTestNG(org.gradle.api.Action)[Test.useTestNG(org.gradle.api.Action)] setting, as seen here:
+The TestNG framework uses the concept of test groups for a similar effect.footnote:[The TestNG documentation contains more details about test groups: https://testng.org/#_test_groups[].] You can configure which test groups to include or exclude during the test execution via the link:{groovyDslPath}/org.gradle.api.tasks.testing.Test.html#org.gradle.api.tasks.testing.Test:useTestNG(org.gradle.api.Action)[Test.useTestNG(org.gradle.api.Action)] setting, as seen here:
 
 .Grouping TestNG tests
 ====

--- a/platforms/documentation/docs/src/docs/userguide/jvm/scala_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/scala_plugin.adoc
@@ -216,7 +216,7 @@ _Default value:_ `[__projectDir__/src/__name__/scala]`.
 `allScala` — link:{javadocPath}/org/gradle/api/file/FileTree.html[FileTree] (read-only)::
 All Scala source files of this source set. Contains only the `.scala` files found in the Scala source directories. _Default value:_ non-null.
 
-These extensions are backed by an object of type link:{groovyDslPath}/org.gradle.api.plugins.scala.ScalaSourceSet.html[ScalaSourceSet].
+These extensions are backed by an object of type link:{javadocPath}/org/gradle/api/tasks/ScalaSourceSet.html[ScalaSourceSet].
 
 The Scala plugin also modifies some source set properties:
 

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache_performance.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache_performance.adoc
@@ -115,4 +115,4 @@ How to do this depends on the remote cache in use and your network environment.
 
 The multi-node remote build cache provided by Develocity is a fast and efficient, purpose built, remote build cache.
 In particular, if your development team is geographically distributed, its replication features can significantly improve performance by allowing developers to use a cache that they have a good network link to.
-See the https://docs.gradle.com/enterprise/admin/current/#replication[“Build Cache Replication” section of the Develocity Admin Manual] for more information.
+See the https://docs.gradle.com/develocity/helm-admin/current/#replication[“Build Cache Replication” section of the Develocity Admin Manual] for more information.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/caching_android_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/build-cache/caching_android_projects.adoc
@@ -19,7 +19,7 @@ This is even more true for Android projects that include Kotlin source code (and
 
 == Disambiguation
 
-This guide is about Gradle’s build cache, but you may have also heard about the https://developer.android.com/studio/build/build-cache[Android build cache].
+This guide is about Gradle’s build cache, but you may have also heard about the Android build cache.
 These are different things.
 The Android cache is internal to certain tasks in the Android plugin, and will eventually be removed in favor of native Gradle support.
 

--- a/platforms/documentation/docs/src/docs/userguide/redirects/dependency_capability_conflict.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/redirects/dependency_capability_conflict.adoc
@@ -1,3 +1,22 @@
 ++++
-<meta http-equiv="refresh" content="0;URL=component_capabilities.html#capabilities">
+<script>
+const currentAnchor = window.location.hash.substring(1); // Remove the '#' symbol
+
+const redirectionRules = {
+  "sub:capabilities": "component_capabilities.html#capabilities",
+  "sub:declaring-component-capabilities": "component_capabilities.html#sec:declaring-component-capabilities",
+  "sub:selecting-between-candidates": "component_capabilities.html#sec:selecting-between-candidates",
+  "sub:selecting-preferred-capability-provider": "component_capabilities.html#sec:selecting-preferred-capability-provider"
+};
+
+const defaultRedirect = "component_capabilities.html";
+
+if (currentAnchor) {
+  if (redirectionRules[currentAnchor]) {
+    window.location.href = redirectionRules[currentAnchor];
+  }
+} else {
+  window.location.href = defaultRedirect;
+}
+</script>
 ++++

--- a/platforms/documentation/docs/src/docs/userguide/redirects/dependency_downgrade_and_exclude.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/redirects/dependency_downgrade_and_exclude.adoc
@@ -1,3 +1,22 @@
 ++++
-<meta http-equiv="refresh" content="0;URL=dependency_constraints.html#dependency-constraints">
+<script>
+const currentAnchor = window.location.hash.substring(1); // Remove the '#' symbol
+
+const redirectionRules = {
+  "sec:enforcing_dependency_version": "dependency_versions.html#sec:enforcing-dependency-version",
+  "sec:strict-version-consequences": "dependency_versions.html#sec:strict-version-consequences",
+  "forced_dependencies_vs_strict_dependencies": "resolution_rules.html#sec:forcing-dep-versions",
+  "sec:excluding-transitive-deps": "resolution_rules.html#sec:exclude-trans-deps"
+};
+
+const defaultRedirect = "dependency_versions.html";
+
+if (currentAnchor) {
+  if (redirectionRules[currentAnchor]) {
+    window.location.href = redirectionRules[currentAnchor];
+  }
+} else {
+  window.location.href = defaultRedirect;
+}
+</script>
 ++++

--- a/platforms/documentation/docs/src/docs/userguide/redirects/dynamic_versions.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/redirects/dynamic_versions.adoc
@@ -1,0 +1,3 @@
+++++
+<meta http-equiv="refresh" content="0;URL=dependency_versions.html#sec:dynamic-versions-and-changing-modules">
+++++

--- a/platforms/documentation/docs/src/docs/userguide/redirects/resolution_strategy_tuning.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/redirects/resolution_strategy_tuning.adoc
@@ -1,3 +1,0 @@
-++++
-<meta http-equiv="refresh" content="0;URL=dependency_resolution_basics.html#dependency-resolution-basics">
-++++

--- a/platforms/documentation/docs/src/docs/userguide/releases/migrating/migrating_from_maven.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/migrating/migrating_from_maven.adoc
@@ -88,7 +88,7 @@ If you want, you can also use a Gradle build scan to identify opportunities to <
  . <<migmvn:integration_tests,Configure integration and functional tests>>.
 +
 Many tests can simply be migrated by configuring an extra source set.
-If you are using a third-party library, such as http://docs.fitnesse.org/FrontPage[FitNesse], look to see whether  there is a suitable community plugin available on the https://plugins.gradle.org/[Gradle Plugin Portal].
+If you are using a third-party library, such as https://fitnesse.org/FitNesse/UserGuide.html[FitNesse], look to see whether  there is a suitable community plugin available on the https://plugins.gradle.org/[Gradle Plugin Portal].
 +
  . Replace Maven plugins with Gradle equivalents.
 +

--- a/platforms/documentation/docs/src/docs/userguide/releases/troubleshooting.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/troubleshooting.adoc
@@ -67,7 +67,7 @@ $ echo $JAVA_HOME
 /Users/user/Library/Java/JavaVirtualMachines/corretto-11.0.22/Contents/Home
 ----
 
-You must ensure that a link:{jdkDownloadUrl}[Java Development Kit] version {minJdkVersion} or higher is link:https://www.java.com/en/download/help/index_installing.xml[properly installed], the `JAVA_HOME` environment variable is set, and link:https://www.java.com/en/download/help/path.xml[Java is added to your `PATH`].
+You must ensure that a link:{jdkDownloadUrl}[Java Development Kit] version {minJdkVersion} or higher is link:https://www.java.com/en/download/help/index_installing.html[properly installed], the `JAVA_HOME` environment variable is set, and Java is added to your `PATH`.
 
 === Permission denied
 


### PR DESCRIPTION
### Details
This is a Documentation change ONLY.

### Context
- General cleanup
- Lost links from Gradle 8.11