### PR TITLE
Do not realize all configurations in a project by default

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheDependencyResolutionFailuresIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheDependencyResolutionFailuresIntegrationTest.groovy
@@ -55,7 +55,7 @@ class ConfigurationCacheDependencyResolutionFailuresIntegrationTest extends Abst
         configurationCacheFails 'test'
 
         then:
-        failure.assertHasFailure("Configuration cache state could not be cached: field `files` of `Bean` bean found in field `__bean__` of task `:test` of type `Test`: error writing value of type 'org.gradle.api.internal.artifacts.configurations.DefaultUnlockedConfiguration'") {
+        failure.assertHasFailure("Configuration cache state could not be cached: field `files` of `Bean` bean found in field `__bean__` of task `:test` of type `Test`: error writing value of type 'org.gradle.api.internal.artifacts.configurations.DefaultLegacyConfiguration'") {
             it.assertHasFirstCause("Could not resolve all files for configuration ':implementation'.")
         }
     }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheUnsupportedTypesIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheUnsupportedTypesIntegrationTest.groovy
@@ -60,7 +60,7 @@ import org.gradle.api.internal.artifacts.DefaultResolvedDependency
 import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.ConfigurationResolvableDependencies
 import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer
 import org.gradle.api.internal.artifacts.configurations.DefaultResolvableConfiguration
-import org.gradle.api.internal.artifacts.configurations.DefaultUnlockedConfiguration
+import org.gradle.api.internal.artifacts.configurations.DefaultLegacyConfiguration
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
 import org.gradle.api.internal.artifacts.dsl.DefaultComponentMetadataHandler
 import org.gradle.api.internal.artifacts.dsl.DefaultComponentModuleMetadataHandler
@@ -394,7 +394,7 @@ class ConfigurationCacheUnsupportedTypesIntegrationTest extends AbstractConfigur
 
         where:
         concreteType                   | baseType           | creator                                     | reference                                            | deserializedValue
-        DefaultUnlockedConfiguration   | Configuration      | "project.configurations.create('some')"     | "project.configurations.getByName('some')"           | 'file collection'
+        DefaultLegacyConfiguration     | Configuration      | "project.configurations.create('some')"     | "project.configurations.getByName('some')"           | 'file collection'
         DefaultResolvableConfiguration | Configuration      | "project.configurations.resolvable('some')" | "project.configurations.getByName('some')"           | 'file collection'
         DefaultSourceDirectorySet      | SourceDirectorySet | ""                                          | "project.objects.sourceDirectorySet('some', 'more')" | 'file tree'
     }
@@ -552,7 +552,7 @@ class ConfigurationCacheUnsupportedTypesIntegrationTest extends AbstractConfigur
 
         where:
         concreteType                   | baseType           | creator                                     | reference                                            | deserializedValue
-        DefaultUnlockedConfiguration   | Configuration      | "project.configurations.create('some')"     | "project.configurations.getByName('some')"           | 'file collection'
+        DefaultLegacyConfiguration     | Configuration      | "project.configurations.create('some')"     | "project.configurations.getByName('some')"           | 'file collection'
         DefaultResolvableConfiguration | Configuration      | "project.configurations.resolvable('some')" | "project.configurations.getByName('some')"           | 'file collection'
         DefaultSourceDirectorySet      | SourceDirectorySet | ""                                          | "project.objects.sourceDirectorySet('some', 'more')" | 'file tree'
     }

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -81,6 +81,19 @@ ADD RELEASE FEATURES ABOVE
 
 -->
 
+<a name="build-authoring"></a>
+### Build authoring improvements
+
+Gradle provides rich APIs for plugin authors and build engineers to develop custom build logic.
+
+#### Configurations are initialized lazily
+
+Similar to Tasks, Configurations are now initialized lazily, only when necessary.
+
+Now, when applying the `Base` plugin or any plugins derived from it such as the JVM plugins, configurations that are lazily declared using `register` or through the incubating role-based factory methods will no longer be eagerly realized unless required.
+
+Configurations should be declared using the `register` method instead of the `create` method to take advantage of the lazy initialization.
+
 ## Promoted features
 
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backward compatibility.

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -46,13 +46,13 @@ Gradle provides [rich APIs](userguide/getting_started_dev.html) for plugin autho
 
 #### Configurations are initialized lazily
 
-Similar to [tasks](userguide/lazy_configuration.html), Configurations are now only realized when necessary.
+Similar to [tasks](userguide/lazy_configuration.html), [configurations](userguide/declaring_configurations.html) are now realized only when necessary.
 
-Starting with this release, applying the `base` plugin or any plugin that applies the `base` plugin (e.g., JVM plugins) will no longer realize all configurations declared using `register` or the incubating role-based factory methods.
+Starting with this release, applying the `base` plugin (or any plugin that applies it, such as JVM plugins) no longer realizes all configurations declared using `register` or the incubating role-based factory methods.
 
-In some builds, this will reduce configuration time and memory usage.
+This change can reduce configuration time and memory usage in some builds.
 
-Configurations should be declared using the `register` method instead of the `create` methods to have the largest impact.
+To leverage these improvements, declare configurations using the `register` method instead of the `create` method:
 
 ```kotlin
 configurations {

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -46,18 +46,20 @@ Gradle provides [rich APIs](userguide/getting_started_dev.html) for plugin autho
 
 #### Configurations are initialized lazily
 
-Similar to [Tasks](userguide/lazy_configuration.html), Configurations are now initialized lazily when necessary.
+Similar to [tasks](userguide/lazy_configuration.html), Configurations are now only realized when necessary.
 
-Starting with this release, applying the `Base` plugin or any of its derived plugins (e.g., JVM plugins) will not cause configurations declared using `register` or using the incubating role-based factory methods to be eagerly realized unless required.
+Starting with this release, applying the `base` plugin or any plugin that applies the `base` plugin (e.g., JVM plugins) will no longer realize all configurations declared using `register` or the incubating role-based factory methods.
 
-Configurations should be declared using the `register` method instead of the `create` method to take advantage of the lazy initialization.
+In some builds, this will reduce configuration time and memory usage.
+
+Configurations should be declared using the `register` method instead of the `create` methods to have the largest impact.
 
 ```kotlin
 configurations {
     // Instead of using `create`
     create("myEagerConfiguration")
     
-    // Use `register` to lazily initialize the configuration
+    // Use `register` to avoid realizing the configuration
     register("myLazyConfiguration")
 }
 ```

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -39,6 +39,29 @@ For Java, Groovy, Kotlin, and Android compatibility, see the [full compatibility
 
 ## New features and usability improvements
 
+<a name="build-authoring"></a>
+### Build authoring improvements
+
+Gradle provides [rich APIs](userguide/getting_started_dev.html) for plugin authors and build engineers to develop custom build logic.
+
+#### Configurations are initialized lazily
+
+Similar to [Tasks](userguide/lazy_configuration.html), Configurations are now initialized lazily when necessary.
+
+Starting with this release, applying the `Base` plugin or any of its derived plugins (e.g., JVM plugins) will not cause configurations declared using `register` or using the incubating role-based factory methods to be eagerly realized unless required.
+
+Configurations should be declared using the `register` method instead of the `create` method to take advantage of the lazy initialization.
+
+```kotlin
+configurations {
+    // Instead of using `create`
+    create("myEagerConfiguration")
+    
+    // Use `register` to lazily initialize the configuration
+    register("myLazyConfiguration")
+}
+```
+
 <!-- Do not add breaking changes or deprecations here! Add them to the upgrade guide instead. -->
 
 <!--
@@ -80,19 +103,6 @@ ADD RELEASE FEATURES ABOVE
 ==========================================================
 
 -->
-
-<a name="build-authoring"></a>
-### Build authoring improvements
-
-Gradle provides rich APIs for plugin authors and build engineers to develop custom build logic.
-
-#### Configurations are initialized lazily
-
-Similar to Tasks, Configurations are now initialized lazily, only when necessary.
-
-Now, when applying the `Base` plugin or any plugins derived from it such as the JVM plugins, configurations that are lazily declared using `register` or through the incubating role-based factory methods will no longer be eagerly realized unless required.
-
-Configurations should be declared using the `register` method instead of the `create` method to take advantage of the lazy initialization.
 
 ## Promoted features
 

--- a/platforms/jvm/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaBasePluginTest.groovy
+++ b/platforms/jvm/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaBasePluginTest.groovy
@@ -16,7 +16,6 @@
 package org.gradle.api.plugins.scala
 
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.internal.artifacts.configurations.Configurations
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.tasks.SourceSet
@@ -44,7 +43,7 @@ class ScalaBasePluginTest extends AbstractProjectBuilderSpec {
         def configuration = project.configurations.getByName(ScalaBasePlugin.ZINC_CONFIGURATION_NAME)
 
         then:
-        Configurations.getNames(configuration.extendsFrom).empty
+        configuration.extendsFrom.empty
         !configuration.visible
         configuration.transitive
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
@@ -614,17 +614,17 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
             configurations {
                 additionalRuntimeClasspath
             }
-        """                                                                             | ConfigurationRoles.LEGACY     | true      | "legacy configuration with implicit allowed usage"
+        """                                                                             | ConfigurationRoles.ALL        | true  | "legacy configuration with implicit allowed usage"
         """
             configurations {
                 additionalRuntimeClasspath {
                     canBeConsumed = true
                 }
             }
-        """                                                                             | ConfigurationRoles.LEGACY     | true      | "legacy configuration with explicit set consumed = true"
-        "configurations.consumable('additionalRuntimeClasspath')"                       | ConfigurationRoles.CONSUMABLE | false     | "role-based configuration"
-        "configurations.consumableUnlocked('additionalRuntimeClasspath')"               | ConfigurationRoles.CONSUMABLE | true      | "internal unlocked role-based configuration"
-        "configurations.maybeCreateConsumableUnlocked('additionalRuntimeClasspath')"    | ConfigurationRoles.CONSUMABLE | true      | "internal unlocked role-based configuration, if it doesn't already exist"
+        """                                                                             | ConfigurationRoles.ALL        | true  | "legacy configuration with explicit set consumed = true"
+        "configurations.consumable('additionalRuntimeClasspath')"                       | ConfigurationRoles.CONSUMABLE | false | "role-based configuration"
+        "configurations.consumableUnlocked('additionalRuntimeClasspath')"               | ConfigurationRoles.CONSUMABLE | true  | "internal unlocked role-based configuration"
+        "configurations.maybeCreateConsumableUnlocked('additionalRuntimeClasspath')"    | ConfigurationRoles.CONSUMABLE | true  | "internal unlocked role-based configuration, if it doesn't already exist"
     }
 
     def "changing usage on detached configurations does not warn"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/LazyConfigurationResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/LazyConfigurationResolveIntegrationTest.groovy
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.api
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+/**
+ * Verifies behavior of lazily-registered configurations when performing dependency resolution.
+ *
+ * @see org.gradle.api.artifacts.ConfigurationContainer#register(String)
+ * @see org.gradle.api.artifacts.ConfigurationContainer#consumable(String)
+ * @see org.gradle.api.artifacts.ConfigurationContainer#resolvable(String)
+ * @see org.gradle.api.artifacts.ConfigurationContainer#dependencyScope(String)
+ */
+class LazyConfigurationResolveIntegrationTest extends AbstractIntegrationSpec {
+
+    def "does not realize non-consumable, unrelated, role-locked configurations in target project"() {
+        settingsFile << "include('producer')"
+
+        file("producer/build.gradle") << """
+            configurations.configureEach {
+                println("Realizing configuration \$name")
+            }
+
+            configurations {
+                resolvable("unrelatedResolvable") {
+                    assert false
+                }
+                dependencyScope("unrelatedDependencyScope") {
+                    assert false
+                }
+
+                // TODO: A lazy extendsFrom mechanism would allow us to avoid realizing otherDependencies
+                dependencyScope("otherDependencies")
+                consumable("otherConsumable") {
+                    extendsFrom(otherDependencies)
+                    attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "other"))
+                }
+
+                dependencyScope("mainDependencies")
+                consumable("main") {
+                    extendsFrom(mainDependencies)
+                    attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "main"))
+                    outgoing.artifact(file("main.txt"))
+                }
+            }
+        """
+
+        buildFile << """
+            configurations {
+                dependencyScope("deps")
+                resolvable("res") {
+                    extendsFrom(deps)
+                    attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "main"))
+                }
+            }
+
+            dependencies {
+                deps(project(":producer"))
+            }
+
+            tasks.register("resolve") {
+                def files = configurations.named("res").map { it.incoming.files }
+                doLast {
+                    assert files.get()*.name == ["main.txt"]
+                }
+            }
+        """
+
+        when:
+        succeeds("help")
+
+        then:
+        outputDoesNotContain("Realizing configuration")
+
+        when:
+        succeeds(":resolve")
+
+        then:
+        outputContains("""
+Realizing configuration otherConsumable
+Realizing configuration otherDependencies
+Realizing configuration main
+Realizing configuration mainDependencies
+        """)
+    }
+
+    def "realizes non-role-locked configurations in target project"() {
+        settingsFile << "include('producer')"
+
+        file("producer/build.gradle") << """
+            configurations.configureEach {
+                println("Realizing configuration \$name")
+            }
+
+            configurations {
+                register("unrelated")
+
+                consumable("main") {
+                    attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "main"))
+                    outgoing.artifact(file("main.txt"))
+                }
+            }
+        """
+
+        buildFile << """
+            configurations {
+                dependencyScope("deps")
+                resolvable("res") {
+                    extendsFrom(deps)
+                    attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "main"))
+                }
+            }
+
+            dependencies {
+                deps(project(":producer"))
+            }
+
+            tasks.register("resolve") {
+                def files = configurations.named("res").map { it.incoming.files }
+                doLast {
+                    assert files.get()*.name == ["main.txt"]
+                }
+            }
+        """
+
+        when:
+        succeeds("help")
+
+        then:
+        outputDoesNotContain("Realizing configuration")
+
+        when:
+        succeeds(":resolve")
+
+        then:
+        outputContains("""
+Realizing configuration main
+Realizing configuration unrelated
+        """)
+    }
+
+    def "can consume lazy legacy configuration from target project"() {
+        settingsFile << "include('producer')"
+
+        file("producer/build.gradle") << """
+            configurations {
+                register("main") {
+                    canBeResolved = false
+                    canBeDeclared = false
+
+                    attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "main"))
+                    outgoing.artifact(file("main.txt"))
+                }
+            }
+        """
+
+        buildFile << """
+            configurations {
+                dependencyScope("deps")
+                resolvable("res") {
+                    extendsFrom(deps)
+                    attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "main"))
+                }
+            }
+
+            dependencies {
+                deps(project(":producer"))
+            }
+
+            tasks.register("resolve") {
+                def files = configurations.named("res").map { it.incoming.files }
+                doLast {
+                    assert files.get()*.name == ["main.txt"]
+                }
+            }
+        """
+
+        when:
+        succeeds("help")
+
+        then:
+        outputDoesNotContain("Realizing configuration")
+
+        expect:
+        succeeds(":resolve")
+    }
+
+    def "unrelated lazy configurations in current project are not realized when resolving configuration"() {
+
+        mavenRepo.module("org", "foo").publish()
+
+        buildFile << """
+            configurations.configureEach {
+                println("Realizing configuration \$name")
+            }
+
+            configurations {
+                dependencyScope("unrelatedDependencies") {
+                    assert false
+                }
+                consumable("unrelatedConsumable") {
+                    assert false
+                }
+                resolvable("unrelatedResolvable") {
+                    assert false
+                }
+                register("unrelatedLegacy") {
+                    assert false
+                }
+
+                dependencyScope("deps") {
+                    // Add the dependency lazily without realizing the configuration
+                    dependencies.add(project.dependencies.create("org:foo:1.0"))
+                }
+                resolvable("res") {
+                    extendsFrom(deps)
+                }
+            }
+
+            ${mavenTestRepository()}
+
+            tasks.register("resolve") {
+                def files = configurations.named("res").map { it.incoming.files }
+                doLast {
+                    assert files.get()*.name == ["foo-1.0.jar"]
+                }
+            }
+        """
+
+        when:
+        succeeds("help")
+
+        then:
+        outputDoesNotContain("Realizing configuration")
+
+        when:
+        succeeds(":resolve")
+
+        then:
+        outputContains("""
+Realizing configuration res
+Realizing configuration deps
+        """)
+    }
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/Configurations.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/Configurations.java
@@ -15,28 +15,13 @@
  */
 package org.gradle.api.internal.artifacts.configurations;
 
-import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.capabilities.Capability;
 
-import java.util.Collection;
 import java.util.Set;
 
 public class Configurations {
-    public static ImmutableSet<String> getNames(Collection<Configuration> configurations) {
-        if (configurations.isEmpty()) {
-            return ImmutableSet.of();
-        }
-        if (configurations.size() == 1) {
-            return ImmutableSet.of(configurations.iterator().next().getName());
-        }
-        ImmutableSet.Builder<String> names = new ImmutableSet.Builder<>();
-        for (Configuration configuration : configurations) {
-            names.add(configuration.getName());
-        }
-        return names.build();
-    }
 
     public static Set<Capability> collectCapabilities(Configuration configuration, Set<Capability> out, Set<Configuration> visited) {
         if (visited.add(configuration)) {
@@ -52,4 +37,5 @@ public class Configurations {
     public static String uploadTaskName(String configurationName) {
         return "upload" + StringUtils.capitalize(configurationName);
     }
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationsProvider.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationsProvider.java
@@ -24,9 +24,9 @@ public interface ConfigurationsProvider {
      * Returns the number of configurations in this provider.
      * <p>
      * This method is provided for performance reasons. It should be more efficient to call this method
-     * than to call {@link #visitAll(Consumer)} and then call {@link Set#size()} on the result.
+     * than to call {@link #getAll()} and then call {@link Set#size()} on the result.
      *
-     * @return the number of configurations in this provider, the same count as would be visited by calling {@link #visitAll(Consumer)}
+     * @return the number of configurations in this provider, the same count as would be visited by calling {@link #getAll()}
      */
     int size();
 
@@ -34,7 +34,11 @@ public interface ConfigurationsProvider {
 
     Set<? extends ConfigurationInternal> getAll();
 
-    void visitAll(Consumer<ConfigurationInternal> visitor);
+    /**
+     * Visit all consumable configurations provided by this configurations provider.
+     * Lazy configurations which are known to be non-consumable are not realized.
+     */
+    void visitConsumable(Consumer<ConfigurationInternal> visitor);
 
     @Nullable
     ConfigurationInternal findByName(String name);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationsProvider.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationsProvider.java
@@ -35,8 +35,9 @@ public interface ConfigurationsProvider {
     Set<? extends ConfigurationInternal> getAll();
 
     /**
-     * Visit all consumable configurations provided by this configurations provider.
-     * Lazy configurations which are known to be non-consumable are not realized.
+     * Visit all consumable configurations provided by this configurations provider,
+     * realizing them if necessary. Lazily registered configurations which are known
+     * to be non-consumable are not realized.
      */
     void visitConsumable(Consumer<ConfigurationInternal> visitor);
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1567,8 +1567,8 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     @SuppressWarnings("deprecation")
     private void assertUsageIsMutable() {
         if (!usageCanBeMutated) {
-            // Don't print role message for legacy role - users might not have actively chosen this role
-            if (roleAtCreation != ConfigurationRoles.LEGACY) {
+            // Don't print role message for configurations with all usages - users might not have actively chosen this role
+            if (roleAtCreation != ConfigurationRoles.ALL) {
                 throw new GradleException(
                     String.format("Cannot change the allowed usage of %s, as it was locked upon creation to the role: '%s'.\n" +
                             "This role permits the following usage:\n" +
@@ -1599,7 +1599,10 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
      * thereafter.
      */
     private void maybeWarnOnChangingUsage(String methodName, boolean current, boolean newValue) {
-        if (isInLegacyRole()) {
+        if (hasAllUsages()) {
+            // We currently allow configurations with all usages -- those that are created with
+            // `create` and `register` -- to have mutable roles. This is likely to change in the future
+            // when we deprecate any configuration with mutable roles.
             return;
         }
 
@@ -1634,8 +1637,8 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     }
 
     @SuppressWarnings("deprecation")
-    private boolean isInLegacyRole() {
-        return roleAtCreation == ConfigurationRoles.LEGACY;
+    private boolean hasAllUsages() {
+        return roleAtCreation == ConfigurationRoles.ALL;
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -29,7 +29,7 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.DependencyScopeConfiguration;
 import org.gradle.api.artifacts.ResolvableConfiguration;
 import org.gradle.api.artifacts.UnknownConfigurationException;
-import org.gradle.api.artifacts.UnlockedConfiguration;
+import org.gradle.api.artifacts.LegacyConfiguration;
 import org.gradle.api.internal.AbstractNamedDomainObjectContainer;
 import org.gradle.api.internal.AbstractValidatingNamedDomainObjectContainer;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
@@ -101,18 +101,18 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
     protected Configuration doCreate(String name) {
         // TODO: Deprecate legacy configurations for consumption
         validateNameIsAllowed(name);
-        return defaultConfigurationFactory.create(name, this, resolutionStrategyFactory, rootComponentMetadataBuilder, ConfigurationRoles.LEGACY);
+        return defaultConfigurationFactory.create(name, this, resolutionStrategyFactory, rootComponentMetadataBuilder, ConfigurationRoles.ALL);
     }
 
     @Override
     protected NamedDomainObjectProvider<Configuration> createDomainObjectProvider(String name, @Nullable Action<? super Configuration> configurationAction) {
         // Called by `register` for registering legacy configurations.
-        // We override to set the public type to `UnlockedConfiguration`,
+        // We override to set the public type to `LegacyConfiguration`,
         // allowing us to filter for unlocked configurations using `withType`
 
         assertElementNotPresent(name);
         NamedDomainObjectProvider<Configuration> provider = Cast.uncheckedCast(
-            getInstantiator().newInstance(AbstractNamedDomainObjectContainer.NamedDomainObjectCreatingProvider.class, DefaultConfigurationContainer.this, name, UnlockedConfiguration.class, configurationAction)
+            getInstantiator().newInstance(AbstractNamedDomainObjectContainer.NamedDomainObjectCreatingProvider.class, DefaultConfigurationContainer.this, name, LegacyConfiguration.class, configurationAction)
         );
         doAddLater(provider);
 
@@ -139,7 +139,7 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
         );
 
         // Then, visit any configuration with unknown role, checking if it is consumable
-        withType(UnlockedConfiguration.class).forEach(configuration -> {
+        withType(LegacyConfiguration.class).forEach(configuration -> {
             if (configuration.isCanBeConsumed()) {
                 visitor.accept((ConfigurationInternal) configuration);
             }
@@ -216,7 +216,7 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
         RootComponentMetadataBuilder componentMetadataBuilder = rootComponentMetadataBuilder.newBuilder(componentIdentity, detachedConfigurationsProvider);
 
         @SuppressWarnings("deprecation")
-        DefaultUnlockedConfiguration detachedConfiguration = defaultConfigurationFactory.create(
+        DefaultLegacyConfiguration detachedConfiguration = defaultConfigurationFactory.create(
             name,
             detachedConfigurationsProvider,
             resolutionStrategyFactory,
@@ -255,13 +255,13 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
     @Override
     public Configuration resolvableUnlocked(String name) {
         assertCanMutate("resolvableUnlocked(String)");
-        return createUnlockedConfiguration(name, ConfigurationRoles.RESOLVABLE, Actions.doNothing());
+        return createLegacyConfiguration(name, ConfigurationRoles.RESOLVABLE, Actions.doNothing());
     }
 
     @Override
     public Configuration resolvableUnlocked(String name, Action<? super Configuration> action) {
         assertCanMutate("resolvableUnlocked(String, Action)");
-        return createUnlockedConfiguration(name, ConfigurationRoles.RESOLVABLE, action);
+        return createLegacyConfiguration(name, ConfigurationRoles.RESOLVABLE, action);
     }
 
     @Override
@@ -279,13 +279,13 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
     @Override
     public Configuration consumableUnlocked(String name) {
         assertCanMutate("consumableUnlocked(String)");
-        return createUnlockedConfiguration(name, ConfigurationRoles.CONSUMABLE, Actions.doNothing());
+        return createLegacyConfiguration(name, ConfigurationRoles.CONSUMABLE, Actions.doNothing());
     }
 
     @Override
     public Configuration consumableUnlocked(String name, Action<? super Configuration> action) {
         assertCanMutate("consumableUnlocked(String, Action)");
-        return createUnlockedConfiguration(name, ConfigurationRoles.CONSUMABLE, action);
+        return createLegacyConfiguration(name, ConfigurationRoles.CONSUMABLE, action);
     }
 
     @Override
@@ -303,27 +303,27 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
     @Override
     public Configuration dependencyScopeUnlocked(String name) {
         assertCanMutate("dependencyScopeUnlocked(String)");
-        return createUnlockedConfiguration(name, ConfigurationRoles.DEPENDENCY_SCOPE, Actions.doNothing());
+        return createLegacyConfiguration(name, ConfigurationRoles.DEPENDENCY_SCOPE, Actions.doNothing());
     }
 
     @Override
     public Configuration dependencyScopeUnlocked(String name, Action<? super Configuration> action) {
         assertCanMutate("dependencyScopeUnlocked(String, Action)");
-        return createUnlockedConfiguration(name, ConfigurationRoles.DEPENDENCY_SCOPE, action);
+        return createLegacyConfiguration(name, ConfigurationRoles.DEPENDENCY_SCOPE, action);
     }
 
     @Override
     @Deprecated
     public Configuration resolvableDependencyScopeUnlocked(String name) {
         assertCanMutate("resolvableDependencyScopeUnlocked(String)");
-        return createUnlockedConfiguration(name, ConfigurationRoles.RESOLVABLE_DEPENDENCY_SCOPE, Actions.doNothing());
+        return createLegacyConfiguration(name, ConfigurationRoles.RESOLVABLE_DEPENDENCY_SCOPE, Actions.doNothing());
     }
 
     @Override
     @Deprecated
     public Configuration resolvableDependencyScopeUnlocked(String name, Action<? super Configuration> action) {
         assertCanMutate("resolvableDependencyScopeUnlocked(String, Action)");
-        return createUnlockedConfiguration(name, ConfigurationRoles.RESOLVABLE_DEPENDENCY_SCOPE, action);
+        return createLegacyConfiguration(name, ConfigurationRoles.RESOLVABLE_DEPENDENCY_SCOPE, action);
     }
 
     @Override
@@ -337,7 +337,7 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
         assertCanMutate("migratingUnlocked(String, ConfigurationRole, Action)");
 
         if (ConfigurationRolesForMigration.ALL.contains(role)) {
-            return createUnlockedConfiguration(name, role, action);
+            return createLegacyConfiguration(name, role, action);
         } else {
             throw new InvalidUserDataException("Unknown migration role: " + role);
         }
@@ -396,7 +396,7 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
             }
         } else {
             if (VALID_MAYBE_CREATE_ROLES.contains(request.getRole())) {
-                return createUnlockedConfiguration(request.getConfigurationName(), request.getRole(), Actions.doNothing());
+                return createLegacyConfiguration(request.getConfigurationName(), request.getRole(), Actions.doNothing());
             } else {
                 throw new GradleException("Cannot maybe create invalid role: " + request.getRole());
             }
@@ -422,12 +422,10 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
     }
 
     @SuppressWarnings("deprecation")
-    private Configuration createUnlockedConfiguration(String name, ConfigurationRole role, Action<? super Configuration> configureAction) {
+    private Configuration createLegacyConfiguration(String name, ConfigurationRole role, Action<? super Configuration> configureAction) {
         // Sanity check to make sure we are locking all non-legacy configurations by 9.0
-        assert GradleVersion.current().getBaseVersion().compareTo(GradleVersion.version("9.0")) < 0 || role == ConfigurationRoles.LEGACY
+        assert GradleVersion.current().getBaseVersion().compareTo(GradleVersion.version("9.0")) < 0 || role == ConfigurationRoles.ALL
             : "Sanity check: All non-legacy configurations must be locked by 9.0";
-
-        // TODO: Deprecate changing roles of unlocked non-legacy configurations.
 
         assertElementNotPresent(name);
         validateNameIsAllowed(name);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationFactory.java
@@ -113,7 +113,7 @@ public class DefaultConfigurationFactory {
     /**
      * Creates a new unlocked configuration instance.
      */
-    DefaultUnlockedConfiguration create(
+    DefaultLegacyConfiguration create(
         String name,
         ConfigurationsProvider configurationsProvider,
         Factory<ResolutionStrategyInternal> resolutionStrategyFactory,
@@ -122,8 +122,8 @@ public class DefaultConfigurationFactory {
     ) {
         ListenerBroadcast<DependencyResolutionListener> dependencyResolutionListeners =
             listenerManager.createAnonymousBroadcaster(DependencyResolutionListener.class);
-        DefaultUnlockedConfiguration instance = instantiator.newInstance(
-            DefaultUnlockedConfiguration.class,
+        DefaultLegacyConfiguration instance = instantiator.newInstance(
+            DefaultLegacyConfiguration.class,
             domainObjectContext,
             name,
             configurationsProvider,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultLegacyConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultLegacyConfiguration.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.configurations;
 
 import org.gradle.api.artifacts.ConfigurablePublishArtifact;
 import org.gradle.api.artifacts.DependencyResolutionListener;
-import org.gradle.api.artifacts.UnlockedConfiguration;
+import org.gradle.api.artifacts.LegacyConfiguration;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
@@ -43,9 +43,9 @@ import org.gradle.internal.work.WorkerThreadRegistry;
 /**
  * A concrete {@link DefaultConfiguration} implementation which can change roles.
  */
-public class DefaultUnlockedConfiguration extends DefaultConfiguration implements UnlockedConfiguration {
+public class DefaultLegacyConfiguration extends DefaultConfiguration implements LegacyConfiguration {
 
-    public DefaultUnlockedConfiguration(
+    public DefaultLegacyConfiguration(
         DomainObjectContext domainObjectContext,
         String name,
         ConfigurationsProvider configurationsProvider,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultUnlockedConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultUnlockedConfiguration.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.configurations;
 
 import org.gradle.api.artifacts.ConfigurablePublishArtifact;
 import org.gradle.api.artifacts.DependencyResolutionListener;
+import org.gradle.api.artifacts.UnlockedConfiguration;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
@@ -42,7 +43,7 @@ import org.gradle.internal.work.WorkerThreadRegistry;
 /**
  * A concrete {@link DefaultConfiguration} implementation which can change roles.
  */
-public class DefaultUnlockedConfiguration extends DefaultConfiguration {
+public class DefaultUnlockedConfiguration extends DefaultConfiguration implements UnlockedConfiguration {
 
     public DefaultUnlockedConfiguration(
         DomainObjectContext domainObjectContext,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DetachedConfigurationsProvider.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DetachedConfigurationsProvider.java
@@ -39,8 +39,12 @@ public class DetachedConfigurationsProvider implements ConfigurationsProvider {
     }
 
     @Override
-    public void visitAll(Consumer<ConfigurationInternal> visitor) {
-        visitor.accept(theOnlyConfiguration);
+    public void visitConsumable(Consumer<ConfigurationInternal> visitor) {
+        // In Gradle 9.0, detached configurations will be guaranteed to be non-consumable.
+        // Until then, visit it.
+        if (theOnlyConfiguration.isCanBeConsumed()) {
+            visitor.accept(theOnlyConfiguration);
+        }
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/VariantIdentityUniquenessVerifier.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/VariantIdentityUniquenessVerifier.java
@@ -46,7 +46,7 @@ public class VariantIdentityUniquenessVerifier {
         ListMultimap<VariantIdentity, ConfigurationInternal> byIdentity =
             MultimapBuilder.linkedHashKeys().arrayListValues().build();
 
-        configurations.visitAll(configuration -> {
+        configurations.visitConsumable(configuration -> {
             if (!mustHaveUniqueAttributes(configuration)) {
                 return;
             }
@@ -61,8 +61,7 @@ public class VariantIdentityUniquenessVerifier {
      * Consumable, non-resolvable, non-default configurations with attributes must have unique attributes.
      */
     private static boolean mustHaveUniqueAttributes(Configuration configuration) {
-        return configuration.isCanBeConsumed() &&
-            !configuration.isCanBeResolved() &&
+        return !configuration.isCanBeResolved() &&
             !Dependency.DEFAULT_CONFIGURATION.equals(configuration.getName()) &&
             !configuration.getAttributes().isEmpty();
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
@@ -114,7 +114,6 @@ public class DefaultRootComponentMetadataBuilder implements RootComponentMetadat
             }
             return variantStateBuilder.createRootVariantState(
                 resolvedConf,
-                configurationsProvider,
                 componentIdentifier,
                 new DefaultLocalVariantGraphResolveStateBuilder.DependencyCache(),
                 owner.getModel(),

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/LocalVariantGraphResolveStateBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/LocalVariantGraphResolveStateBuilder.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
-import org.gradle.api.internal.artifacts.configurations.ConfigurationsProvider;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 import org.gradle.internal.component.local.model.LocalVariantGraphResolveMetadata;
 import org.gradle.internal.component.local.model.LocalVariantGraphResolveState;
@@ -46,7 +45,6 @@ public interface LocalVariantGraphResolveStateBuilder {
      */
     LocalVariantGraphResolveState createRootVariantState(
         ConfigurationInternal configuration,
-        ConfigurationsProvider configurationsProvider,
         ComponentIdentifier componentId,
         DependencyCache dependencyCache,
         ModelContainer<?> model,
@@ -58,7 +56,6 @@ public interface LocalVariantGraphResolveStateBuilder {
      */
     LocalVariantGraphResolveState createConsumableVariantState(
         ConfigurationInternal configuration,
-        ConfigurationsProvider configurationsProvider,
         ComponentIdentifier componentId,
         DependencyCache dependencyCache,
         ModelContainer<?> model,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalComponentGraphResolveStateFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalComponentGraphResolveStateFactory.java
@@ -213,11 +213,8 @@ public class LocalComponentGraphResolveStateFactory {
         public void visitConsumableVariants(Consumer<LocalVariantGraphResolveState> visitor) {
             model.applyToMutableState(p -> {
                 VariantIdentityUniquenessVerifier.buildReport(configurationsProvider).assertNoConflicts();
-
-                configurationsProvider.visitAll(configuration -> {
-                    if (configuration.isCanBeConsumed()) {
-                        visitor.accept(createVariantState(configuration));
-                    }
+                configurationsProvider.visitConsumable(configuration -> {
+                    visitor.accept(createVariantState(configuration));
                 });
             });
         }
@@ -243,7 +240,6 @@ public class LocalComponentGraphResolveStateFactory {
         private LocalVariantGraphResolveState createVariantState(ConfigurationInternal configuration) {
             return stateBuilder.createConsumableVariantState(
                 configuration,
-                configurationsProvider,
                 componentId,
                 cache,
                 model,

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/ConfigurationRoleSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/ConfigurationRoleSpec.groovy
@@ -25,7 +25,7 @@ class ConfigurationRoleSpec extends Specification {
 
         where:
         role                                            || usages
-        ConfigurationRoles.LEGACY                       || [UsageDescriber.CONSUMABLE, UsageDescriber.RESOLVABLE, UsageDescriber.DECLARABLE_AGAINST]
+        ConfigurationRoles.ALL                          || [UsageDescriber.CONSUMABLE, UsageDescriber.RESOLVABLE, UsageDescriber.DECLARABLE_AGAINST]
         ConfigurationRoles.CONSUMABLE                   || [UsageDescriber.CONSUMABLE]
         ConfigurationRoles.RESOLVABLE                   || [UsageDescriber.RESOLVABLE]
         ConfigurationRoles.RESOLVABLE_DEPENDENCY_SCOPE  || [UsageDescriber.RESOLVABLE, UsageDescriber.DECLARABLE_AGAINST]

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/ConfigurationRolesSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/ConfigurationRolesSpec.groovy
@@ -29,7 +29,7 @@ class ConfigurationRolesSpec extends Specification {
 
         where:
         consumable  | resolvable    | declarable        || role
-        true        | true          | true              || ConfigurationRoles.LEGACY
+        true        | true          | true              || ConfigurationRoles.ALL
         true        | false         | false             || ConfigurationRoles.CONSUMABLE
         false       | true          | false             || ConfigurationRoles.RESOLVABLE
         false       | true          | true              || ConfigurationRoles.RESOLVABLE_DEPENDENCY_SCOPE
@@ -56,6 +56,6 @@ class ConfigurationRolesSpec extends Specification {
         ConfigurationRoles.CONSUMABLE                   || "Consumable"
         ConfigurationRoles.RESOLVABLE                   || "Resolvable"
         ConfigurationRoles.RESOLVABLE_DEPENDENCY_SCOPE  || "Resolvable Dependency Scope"
-        ConfigurationRoles.LEGACY                       || "Legacy"
+        ConfigurationRoles.ALL                          || "Legacy"
     }
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
@@ -316,7 +316,7 @@ class DefaultConfigurationContainerTest extends Specification {
 
         where:
         role << [
-            ConfigurationRoles.LEGACY,
+            ConfigurationRoles.ALL,
             ConfigurationRoles.RESOLVABLE,
             ConfigurationRoles.CONSUMABLE,
             ConfigurationRoles.CONSUMABLE_DEPENDENCY_SCOPE,
@@ -386,7 +386,7 @@ class DefaultConfigurationContainerTest extends Specification {
         e.message == "Cannot maybe create invalid role: ${role.getName()}"
 
         where:
-        role << [ConfigurationRoles.LEGACY, ConfigurationRoles.CONSUMABLE_DEPENDENCY_SCOPE, ConfigurationRolesForMigration.RESOLVABLE_DEPENDENCY_SCOPE_TO_RESOLVABLE]
+        role << [ConfigurationRoles.ALL, ConfigurationRoles.CONSUMABLE_DEPENDENCY_SCOPE, ConfigurationRolesForMigration.RESOLVABLE_DEPENDENCY_SCOPE_TO_RESOLVABLE]
     }
 
     // withType when used with a class that is not a super-class of the container does not work with registered elements

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -735,7 +735,7 @@ class DefaultConfigurationSpec extends Specification {
 
         where:
         baseRole << [
-            ConfigurationRoles.LEGACY,
+            ConfigurationRoles.ALL,
             ConfigurationRoles.RESOLVABLE_DEPENDENCY_SCOPE,
             ConfigurationRoles.CONSUMABLE_DEPENDENCY_SCOPE
         ] + ConfigurationRolesForMigration.ALL
@@ -1741,7 +1741,7 @@ class DefaultConfigurationSpec extends Specification {
         new DefaultExternalModuleDependency(group, name, version)
     }
 
-    private DefaultConfiguration conf(String confName = "conf", String projectPath = ":", String buildPath = ":", ConfigurationRole role = ConfigurationRoles.LEGACY) {
+    private DefaultConfiguration conf(String confName = "conf", String projectPath = ":", String buildPath = ":", ConfigurationRole role = ConfigurationRoles.ALL) {
         return confFactory(projectPath, buildPath).create(confName, configurationsProvider, Factories.constant(resolutionStrategy), rootComponentMetadataBuilder, role)
     }
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilderTest.groovy
@@ -41,7 +41,7 @@ class DefaultRootComponentMetadataBuilderTest extends Specification {
     }
     ImmutableModuleIdentifierFactory moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
     LocalVariantGraphResolveStateBuilder configurationStateBuilder = Mock(LocalVariantGraphResolveStateBuilder) {
-        createConsumableVariantState(_, _, _, _, _, _) >> { args ->
+        createConsumableVariantState(_, _, _, _, _) >> { args ->
             Mock(LocalVariantGraphResolveState)
         }
     }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalVariantGraphResolveMetadataBuilderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalVariantGraphResolveMetadataBuilderTest.groovy
@@ -25,7 +25,6 @@ import org.gradle.api.artifacts.FileCollectionDependency
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
-import org.gradle.api.internal.artifacts.configurations.DetachedConfigurationsProvider
 import org.gradle.api.internal.attributes.AttributeContainerInternal
 import org.gradle.api.internal.initialization.StandaloneDomainObjectContext
 import org.gradle.internal.component.model.ComponentIdGenerator
@@ -52,7 +51,6 @@ class DefaultLocalVariantGraphResolveMetadataBuilderTest extends Specification {
     def dependencyConstraintSet = Mock(DependencyConstraintSet)
 
     def cache = new LocalVariantGraphResolveStateBuilder.DependencyCache();
-    def configurationsProvider = new DetachedConfigurationsProvider()
     def componentId = Mock(ComponentIdentifier)
 
     def setup() {
@@ -70,8 +68,6 @@ class DefaultLocalVariantGraphResolveMetadataBuilderTest extends Specification {
         configuration.excludeRules >> ([] as Set)
         dependencySet.iterator() >> [].iterator()
         dependencyConstraintSet.iterator() >> [].iterator()
-
-        configurationsProvider.setTheOnlyConfiguration(configuration)
     }
 
     def "builds configuration with no dependencies or exclude rules"() {
@@ -168,6 +164,6 @@ class DefaultLocalVariantGraphResolveMetadataBuilderTest extends Specification {
     }
 
     def create() {
-        return converter.createConsumableVariantState(configuration, configurationsProvider, componentId, cache, StandaloneDomainObjectContext.ANONYMOUS, TestUtil.calculatedValueContainerFactory())
+        return converter.createConsumableVariantState(configuration, componentId, cache, StandaloneDomainObjectContext.ANONYMOUS, TestUtil.calculatedValueContainerFactory())
     }
 }

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/api/internal/plugins/DefaultArtifactPublicationSetTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/api/internal/plugins/DefaultArtifactPublicationSetTest.groovy
@@ -15,21 +15,28 @@
  */
 package org.gradle.api.internal.plugins
 
-import org.gradle.util.TestUtil
-import spock.lang.Specification
-import org.gradle.api.artifacts.PublishArtifactSet
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.PublishArtifact
+import org.gradle.test.fixtures.AbstractProjectBuilderSpec
+import org.gradle.util.TestUtil
 
-class DefaultArtifactPublicationSetTest extends Specification {
-    final PublishArtifactSet publications = Mock()
-    final DefaultArtifactPublicationSet publication = TestUtil.newInstance(DefaultArtifactPublicationSet, publications)
+class DefaultArtifactPublicationSetTest extends AbstractProjectBuilderSpec {
+
+    Configuration aggregateConf
+    DefaultArtifactPublicationSet publication
+
+    def setup() {
+        aggregateConf = project.configurations.create(Dependency.ARCHIVES_CONFIGURATION)
+        publication = TestUtil.newInstance(DefaultArtifactPublicationSet, project.configurations, aggregateConf.name)
+    }
 
     def "adds provider to artifact set"() {
         when:
         publication.addCandidate(artifact(artifactType))
 
         then:
-        1 * publications.addAllLater(_)
+        aggregateConf.artifacts.size() == 1
 
         where:
         artifactType << ["jar", "war", "ear", "other"]

--- a/platforms/software/platform-base/src/main/java/org/gradle/api/internal/plugins/DefaultArtifactPublicationSet.java
+++ b/platforms/software/platform-base/src/main/java/org/gradle/api/internal/plugins/DefaultArtifactPublicationSet.java
@@ -16,8 +16,8 @@
 package org.gradle.api.internal.plugins;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import org.gradle.api.Action;
+import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.internal.provider.AbstractMinimalProvider;
@@ -31,7 +31,19 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
- * The policy for which artifacts should be published by default when none are explicitly declared.
+ * Controls which artifacts should be automatically added to the {@code archives} configuration, and
+ * therefore, when the {@code base} plugin is applied, which artifacts are built by default by the
+ * {@code assemble} task.
+ * <p>
+ * This class acts upon all configurations except a certain aggregate configuration. Most
+ * non-{@link Configuration#isVisible() visible} configurations' artifacts, other than those of the
+ * aggregate configuration, will be added to the aggregate configuration's artifacts. This class
+ * attempts to perform some preferential treatment to some artifact types, like ears and wars,
+ * in order to intelligently determine which artifacts should be automatically assembled. This logic
+ * has caused more trouble than its worth and should be removed in future Gradle versions.
+ * <p>
+ * TODO #15639: Deprecate DefaultArtifactPublicationSet and the `archives` configuration.
+ *  <a href="https://youtrack.jetbrains.com/issue/KT-74476/KGP-uses-internal-Gradle-API-DefaultArtifactPublicationSet">This internal class is currently in-use by Kotlin</a>
  */
 public abstract class DefaultArtifactPublicationSet {
 
@@ -51,6 +63,17 @@ public abstract class DefaultArtifactPublicationSet {
         return defaultArtifactProvider;
     }
 
+    /**
+     * A special Provider implementation determines which artifacts should be automatically added to the
+     * {@code archives} configuration, and therefore which should be built automatically by the {@code assemble} task.
+     * <p>
+     * By implementing {@link ChangingValue} and {@link CollectionProviderInternal}, this provider is able to notify containers
+     * which reference this provider that its value has changed. This contrasts with other providers, whose values are cached
+     * and never updated when a parent domain object container's value is read. This causes some complicated interactions and
+     * dependencies with eager plugins, like the signing plugin.
+     * <p>
+     * All of this logic should be removed in future Gradle versions.
+     */
     private static class DefaultArtifactProvider extends AbstractMinimalProvider<Set<PublishArtifact>> implements CollectionProviderInternal<PublishArtifact, Set<PublishArtifact>>, ChangingValue<Set<PublishArtifact>> {
 
         private final ConfigurationContainer configurations;
@@ -66,6 +89,8 @@ public abstract class DefaultArtifactPublicationSet {
             this.configurations = configurations;
             this.aggregateArtifactsConfName = aggregateArtifactsConfName;
 
+            // Whenever artifacts are added to any configuration, invalidate our cached value.
+            // The new value will be calculated lazily when it is next requested.
             configurations.configureEach(conf -> {
                 if (!conf.getName().equals(aggregateArtifactsConfName)) {
                     conf.getArtifacts().configureEach(artifact -> {
@@ -80,6 +105,8 @@ public abstract class DefaultArtifactPublicationSet {
                 explicitArtifacts = new LinkedHashSet<>();
             }
 
+            // A new artifact was added explicitly, invalidate our cached value.
+            // The new value will be calculated lazily when it is next requested.
             if (explicitArtifacts.add(artifact)) {
                 reset();
             }
@@ -89,7 +116,7 @@ public abstract class DefaultArtifactPublicationSet {
             if (defaultArtifacts != null) {
                 aggregateArtifacts = null;
 
-                Set<PublishArtifact> previousArtifacts = Sets.newLinkedHashSet(defaultArtifacts);
+                Set<PublishArtifact> previousArtifacts = new LinkedHashSet<>(defaultArtifacts);
                 defaultArtifacts = null;
                 changingValue.handle(previousArtifacts);
             }
@@ -142,6 +169,13 @@ public abstract class DefaultArtifactPublicationSet {
             return aggregateArtifacts;
         }
 
+        /**
+         * Logic which attempts to determine which artifacts should be included in {@link #defaultArtifacts}.
+         * This can cause confusing behavior to users.
+         *
+         * @see <a href="https://github.com/gradle/gradle/issues/6875">#6875</a>
+         * @see <a href="https://github.com/gradle/gradle/issues/26418">#26418</a>
+         */
         private void processArtifact(PublishArtifact artifact) {
             String thisType = artifact.getType();
 

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -531,7 +531,12 @@ public abstract class DependencyInsightReportTask extends DefaultTask {
                 out.text("---------------------");
                 out.println();
                 out.style(Normal);
-                for (ResolvedVariantResult variant : dependency.getAllVariants()) {
+
+                List<ResolvedVariantResult> sortedVariants = dependency.getAllVariants().stream()
+                    .sorted(Comparator.comparing(ResolvedVariantResult::getDisplayName))
+                    .collect(Collectors.toList());
+
+                for (ResolvedVariantResult variant : sortedVariants) {
                     if (selectedVariantNames.contains(variant.getDisplayName())) {
                         continue;
                     }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/LegacyConfiguration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/LegacyConfiguration.java
@@ -26,5 +26,5 @@ import org.gradle.api.Incubating;
  * @since 8.14
  */
 @Incubating
-public interface UnlockedConfiguration extends Configuration {
+public interface LegacyConfiguration extends Configuration {
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/UnlockedConfiguration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/UnlockedConfiguration.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.artifacts;
+
+import org.gradle.api.Incubating;
+
+/**
+ * A {@link Configuration} with a mutable role, that can potentially perform
+ * behavior of a {@link ConsumableConfiguration}, a {@link ResolvableConfiguration},
+ * or a {@link DependencyScopeConfiguration}.
+ *
+ * @since 8.14
+ */
+@Incubating
+public interface UnlockedConfiguration extends Configuration {
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/NestedConfigureDslIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/NestedConfigureDslIntegrationTest.groovy
@@ -274,7 +274,7 @@ configurations {
 
         expect:
         fails()
-        failure.assertHasCause("Could not find method noExist() for arguments [12] on configuration ':broken' of type org.gradle.api.internal.artifacts.configurations.DefaultUnlockedConfiguration.")
+        failure.assertHasCause("Could not find method noExist() for arguments [12] on configuration ':broken' of type org.gradle.api.internal.artifacts.configurations.DefaultLegacyConfiguration.")
     }
 
     def "reports set unknown property from polymorphic container configure closure"() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationRoles.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationRoles.java
@@ -42,7 +42,7 @@ public final class ConfigurationRoles {
      * the default role for configurations created when another more specific role is <strong>not</strong> specified.
      */
     @Deprecated
-    public static final ConfigurationRole LEGACY = createNonDeprecatedRole("Legacy", true, true, true);
+    public static final ConfigurationRole ALL = createNonDeprecatedRole("Legacy", true, true, true);
 
     /**
      * Meant to be used only for consumption by other projects.
@@ -84,8 +84,8 @@ public final class ConfigurationRoles {
         return new DefaultConfigurationRole(name, consumable, resolvable, declarable, false, false, false);
     }
 
-    private static final Set<ConfigurationRole> ALL = ImmutableSet.of(
-        LEGACY, CONSUMABLE, RESOLVABLE, RESOLVABLE_DEPENDENCY_SCOPE, CONSUMABLE_DEPENDENCY_SCOPE, DEPENDENCY_SCOPE
+    private static final Set<ConfigurationRole> ALL_ROLES = ImmutableSet.of(
+        ALL, CONSUMABLE, RESOLVABLE, RESOLVABLE_DEPENDENCY_SCOPE, CONSUMABLE_DEPENDENCY_SCOPE, DEPENDENCY_SCOPE
     );
 
     /**
@@ -98,7 +98,7 @@ public final class ConfigurationRoles {
      * @return the role enum token with matching usage characteristics, if one exists; otherwise {@link Optional#empty()}
      */
     public static Optional<ConfigurationRole> byUsage(boolean consumable, boolean resolvable, boolean declarable) {
-        for (ConfigurationRole role : ALL) {
+        for (ConfigurationRole role : ALL_ROLES) {
             if (role.isConsumable() == consumable && role.isResolvable() == resolvable && role.isDeclarable() == declarable) {
                 return Optional.of(role);
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationRolesForMigration.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationRolesForMigration.java
@@ -44,13 +44,13 @@ public final class ConfigurationRolesForMigration {
      * A legacy configuration that will become a resolvable dependency scope configuration in the next major version.
      */
     @Deprecated
-    public static final ConfigurationRole LEGACY_TO_RESOLVABLE_DEPENDENCY_SCOPE = difference(ConfigurationRoles.LEGACY, ConfigurationRoles.RESOLVABLE_DEPENDENCY_SCOPE);
+    public static final ConfigurationRole LEGACY_TO_RESOLVABLE_DEPENDENCY_SCOPE = difference(ConfigurationRoles.ALL, ConfigurationRoles.RESOLVABLE_DEPENDENCY_SCOPE);
 
     /**
      * A legacy configuration that will become a consumable configuration in the next major version.
      */
     @SuppressWarnings("deprecation")
-    public static final ConfigurationRole LEGACY_TO_CONSUMABLE = difference(ConfigurationRoles.LEGACY, ConfigurationRoles.CONSUMABLE);
+    public static final ConfigurationRole LEGACY_TO_CONSUMABLE = difference(ConfigurationRoles.ALL, ConfigurationRoles.CONSUMABLE);
 
     /**
      * A resolvable dependency scope that will become a resolvable configuration in the next major version.

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/WellBehavedPluginTest.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/WellBehavedPluginTest.groovy
@@ -137,6 +137,30 @@ abstract class WellBehavedPluginTest extends AbstractIntegrationSpec {
         }
     }
 
+    def "does not realize all possible configurations"() {
+        applyPlugin()
+
+        buildFile """
+            // Most of our plugins create configurations eagerly.
+            // Just test that we don't realize registered configurations.
+            configurations.register("foo") {
+                assert false
+            }
+            configurations.resolvable("res") {
+                assert false
+            }
+            configurations.consumable("con") {
+                assert false
+            }
+            configurations.dependencyScope("deps") {
+                assert false
+            }
+        """
+
+        expect:
+        succeeds("help")
+    }
+
     def "does not realize all possible tasks if the build is included"() {
         Assume.assumeFalse(pluginName in ['xctest', 'visual-studio', 'xcode', 'play-application'])
 


### PR DESCRIPTION
Fixes #28192

Previously, unlike tasks, Configurations of a project are automatically realized, even if they are 'register'ed or even if the new role-based factory methods are used, which are intended to be lazy.

This happens for two reasons
1. The base plugin had a configurations.all call in it in order to implement behavior related to the assemble task
2. When resolving a dependency against a target project, we would previously realize all configurations in the target project, even if they were non consumable.

This commit makes two significant changes
1. We no longer call configurations.all in the base plugin, but rather lazily add the artifacts of all visible configurations to the assemble task. This prevents all configurations from being realized instantly if the base plugin is applied.

2. We no longer realize all configurations of a target project when resolving a dependency against it. We now only realize the configurations known to be consumable or with an unknown/mutable role.

We add a new test to WellBehavedPluginTest to ensure it does not add configurations.all calls or other calls to instantly realize configurations We also add a new test suite to verify dependency resolution only realizes consumable configurations or configurations with unknown an unknown role, but does not realize configurations with a known non-consumable type.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
