### PR TITLE
Fix performance channel

### DIFF
--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -67,6 +67,7 @@ import gradlebuild.basics.BuildParams.VENDOR_MAPPING
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.jvm.toolchain.JvmVendorSpec
 import org.gradle.jvm.toolchain.internal.LocationListInstallationSupplier.JAVA_INSTALLATIONS_PATHS_PROPERTY
 import org.jetbrains.kotlin.util.capitalizeDecapitalize.toUpperCaseAsciiOnly
@@ -288,7 +289,10 @@ val Project.performanceBaselines: String?
     get() = stringPropertyOrNull(PERFORMANCE_BASELINES)
 
 val Project.performanceChannel: Provider<String>
-    get() = environmentVariable(PERFORMANCE_CHANNEL_ENV)
+    get() = environmentVariable(PERFORMANCE_CHANNEL_ENV).orElse(provider {
+        val channelSuffix = if (OperatingSystem.current().isLinux) "" else "-${OperatingSystem.current().familyName.toLowerCase()}"
+        "commits$channelSuffix-${buildBranch.get()}"
+     })
 
 val Project.performanceDbPassword: Provider<String>
     get() = environmentVariable(PERFORMANCE_DB_PASSWORD_ENV)

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -33,7 +33,6 @@ import gradlebuild.basics.performanceTestVerbose
 import gradlebuild.basics.propertiesForPerformanceDb
 import gradlebuild.basics.releasedVersionsFile
 import gradlebuild.basics.repoRoot
-import gradlebuild.basics.toLowerCase
 import gradlebuild.basics.toolchainInstallationPaths
 import gradlebuild.integrationtests.addDependenciesAndConfigurations
 import gradlebuild.integrationtests.ide.AndroidStudioProvisioningExtension
@@ -65,7 +64,6 @@ import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Zip
 import org.gradle.api.tasks.testing.Test
-import org.gradle.internal.os.OperatingSystem
 import org.gradle.jvm.toolchain.internal.LocationListInstallationSupplier.JAVA_INSTALLATIONS_PATHS_PROPERTY
 import org.gradle.kotlin.dsl.*
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
@@ -192,7 +190,7 @@ class PerformanceTestPlugin : Plugin<Project> {
             reportDir = project.layout.buildDirectory.dir(this@configureEach.name)
             databaseParameters = project.propertiesForPerformanceDb
             branchName = buildBranch
-            channel = project.performanceChannel.orElse(branchName.map { "commits-$it" })
+            channel = project.performanceChannel.get()
             val prefix = channel.map { channelName ->
                 val osIndependentPrefix = if (channelName.startsWith("flakiness-detection")) {
                     "flakiness-detection"
@@ -413,12 +411,10 @@ class PerformanceTestExtension(
             }
         )
 
-        val channelSuffix = if (OperatingSystem.current().isLinux) "" else "-${OperatingSystem.current().familyName.toLowerCase()}"
-
         registeredPerformanceTests.add(
             createPerformanceTest("${testProject}PerformanceTest", generatorTask) {
                 description = "Runs performance tests on $testProject - supposed to be used on CI"
-                channel.set("commits$channelSuffix")
+                channel.set(project.performanceChannel)
 
                 extensions.findByType<DevelocityTestConfiguration>()?.testRetry?.maxRetries = 1
 


### PR DESCRIPTION
We expect the performance channel to be: `commits-(windows|macos)-%teamcity.build.branch%`. However, in the past, it was [incorrectly set as `"commits-(windows|macos)"`](https://github.com/gradle/gradle/commit/77d89bba8fcbd2585021902aa9b6d2ad7d66f152#diff-a052adbd9a363cd66f3bbc170b8161bfbbcde9133aa0416105044f31275cb2d8R285) and overwritten as correct value by `--channel`.

In https://github.com/gradle/gradle/pull/30473, we removed `--channel`, and the value was wrong since then. This results in [the SQL queries returning empty results for some scenarios](https://github.com/gradle/gradle/blob/1a5e48701b602def428d9c79e3793adff7a4f798/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AbstractWritableResultsStore.groovy#L77), and [incorrect performance test duration update](https://github.com/gradle/gradle/pull/31507/files).
