### PR TITLE
Slf4j markers should be compared structurally rather than referentially

### DIFF
--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/slf4j/BuildOperationAwareLogger.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/slf4j/BuildOperationAwareLogger.java
@@ -507,10 +507,10 @@ abstract class BuildOperationAwareLogger implements Logger {
         if (marker == null) {
             return LogLevel.INFO;
         }
-        if (marker == Logging.LIFECYCLE) {
+        if (marker.equals(Logging.LIFECYCLE)) {
             return LogLevel.LIFECYCLE;
         }
-        if (marker == Logging.QUIET) {
+        if (marker.equals(Logging.QUIET)) {
             return LogLevel.QUIET;
         }
         return LogLevel.INFO;


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
This tiny change allows a JVM library compiled against `slf4j-api` to log at Gradle's lifecycle and quiet log levels, without using reflection to obtain Gradle's `LIFECYELE` and `QUIET` markers.

```kotlin
val LIFECYCLE = MarkerFactory.getMarker("LIFECYCLE")
val logger = LoggingFactory.getLogger(MyClass::class.java)

logger.info(LIFECYCLE, "message")
```

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
