### PR TITLE
Stop adding OS as inputs for archTest

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -423,7 +423,10 @@ fun configureTests() {
         maxParallelForks = project.maxParallelForks
 
         configureJvmForTest()
-        addOsAsInputs()
+        if (name != "archTest") {
+            // TODO distinguish archTest and other tests
+            addOsAsInputs()
+        }
         configureRerun()
 
         if (BuildEnvironment.isCiServer) {


### PR DESCRIPTION
In the past, we [added OS as an input for all test task unconditionally](https://github.com/gradle/gradle-private/issues/2831), which is not correct for at least `archTest`.

This PR stops doing that for archTest.