### PR TITLE
Back AttributeContainer with MapProperty

### DIFF
--- a/platforms/jvm/plugins-java-base/build.gradle.kts
+++ b/platforms/jvm/plugins-java-base/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
 
     implementation(projects.fileCollections)
     implementation(projects.fileOperations)
+    implementation(projects.functional)
     implementation(projects.jvmServices)
     implementation(projects.logging)
     implementation(projects.platformBase)

--- a/platforms/jvm/plugins-java-base/src/integTest/groovy/org/gradle/api/plugins/jvm/internal/AbstractJvmPluginServicesTest.groovy
+++ b/platforms/jvm/plugins-java-base/src/integTest/groovy/org/gradle/api/plugins/jvm/internal/AbstractJvmPluginServicesTest.groovy
@@ -75,7 +75,6 @@ abstract class AbstractJvmPluginServicesTest extends Specification {
     )
 
     DefaultJvmLanguageUtilities jvmLanguageUtilities = new DefaultJvmLanguageUtilities(
-        TestUtil.providerFactory(),
         instanceGenerator,
         project
     )

--- a/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmLanguageUtilities.java
+++ b/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmLanguageUtilities.java
@@ -22,15 +22,18 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.attributes.java.TargetJvmVersion;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.provider.AbstractProviderWithValue;
 import org.gradle.api.internal.tasks.compile.HasCompileOptions;
 import org.gradle.api.plugins.JavaPluginExtension;
-import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.internal.Cast;
+import org.gradle.internal.UncheckedException;
+import org.gradle.internal.evaluation.EvaluationScopeContext;
 import org.gradle.internal.instantiation.InstanceGenerator;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -38,19 +41,18 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 public class DefaultJvmLanguageUtilities implements JvmLanguageUtilities {
-    private final ProviderFactory providerFactory;
     private final ProjectInternal project;
     private final InstanceGenerator instanceGenerator;
     private final Map<ConfigurationInternal, Set<TaskProvider<?>>> configurationToCompileTasks; // ? is really AbstractCompile & HasCompileOptions
 
     @Inject
     public DefaultJvmLanguageUtilities(
-            ProviderFactory providerFactory,
-            InstanceGenerator instanceGenerator,
-            ProjectInternal project) {
-        this.providerFactory = providerFactory;
+        InstanceGenerator instanceGenerator,
+        ProjectInternal project
+    ) {
         this.instanceGenerator = instanceGenerator;
         this.project = project;
         configurationToCompileTasks = new HashMap<>(5);
@@ -65,8 +67,40 @@ public class DefaultJvmLanguageUtilities implements JvmLanguageUtilities {
         JavaPluginExtension java = project.getExtensions().getByType(JavaPluginExtension.class);
         configurationInternal.getAttributes().attributeProvider(
             TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE,
-            providerFactory.provider(() -> getDefaultTargetPlatform(configuration, java, compileTasks))
+            new DefaultProviderWithValue<>(Integer.class, () -> getDefaultTargetPlatform(configuration, java, compileTasks))
         );
+    }
+
+    /**
+     * Avoids executing the supplier (which has side effects) when determining whether the provider is present.
+     * <p>
+     * We should get rid of this when calling {@link #getDefaultTargetPlatform} no longer causes
+     * toolchains to be downloaded.
+     */
+    private static class DefaultProviderWithValue<T> extends AbstractProviderWithValue<T> {
+
+        private final Class<T> type;
+        private final Supplier<T> supplier;
+
+        public DefaultProviderWithValue(Class<T> type, Supplier<T> supplier) {
+            this.type = type;
+            this.supplier = supplier;
+        }
+
+        @Override
+        protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
+            try (EvaluationScopeContext ignored = openScope()) {
+                return Value.of(supplier.get());
+            } catch (Exception e) {
+                throw UncheckedException.throwAsUncheckedException(e);
+            }
+        }
+
+        @Nullable
+        @Override
+        public Class<T> getType() {
+            return type;
+        }
     }
 
     @Override

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/AttributeContainerResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/AttributeContainerResolutionIntegrationTest.groovy
@@ -20,8 +20,9 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Issue
 
 class AttributeContainerResolutionIntegrationTest extends AbstractIntegrationSpec {
+
     @Issue("https://github.com/gradle/gradle/issues/26298")
-    def "lazy attributes provided to a Configuration do not fail resolution when they have side effects"() {
+    def "lazy attributes provided to a Configuration fail when they query the same attribute container"() {
         buildFile << """
             configurations {
                 conf {
@@ -43,9 +44,11 @@ class AttributeContainerResolutionIntegrationTest extends AbstractIntegrationSpe
             }
         """
 
-        expect:
-        // When this has failed in the past, building the task graph hits a NPE from the attribute container
-        executer.expectDocumentedDeprecationWarning("Querying the contents of an attribute container while realizing attributes of the container. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#attribute_container_recursive_query")
-        succeeds("resolve")
+        when:
+        fails("resolve")
+
+        then:
+        failure.assertHasCause("Circular evaluation detected")
     }
+
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -1417,19 +1417,6 @@ class DefaultConfigurationSpec extends Specification {
         conf.attributes.getAttribute(buildType).name == 'release'
     }
 
-    def "cannot define two attributes with the same name but different types"() {
-        def conf = conf()
-        def flavor = Attribute.of('flavor', Flavor)
-
-        when:
-        conf.getAttributes().attribute(flavor, new FlavorImpl(name: 'free'))
-        conf.getAttributes().attribute(Attribute.of('flavor', String.class), 'paid')
-
-        then:
-        def e = thrown(IllegalArgumentException)
-        e.message == 'Cannot have two attributes with the same name but different types. This container already has an attribute named \'flavor\' of type \'org.gradle.api.internal.artifacts.configurations.DefaultConfigurationSpec$Flavor\' and you are trying to store another one of type \'java.lang.String\''
-    }
-
     def "can overwrite a configuration attribute"() {
         def conf = conf()
         def flavor = Attribute.of(Flavor)

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/attributes/immutable/ImmutableAttributesTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/attributes/immutable/ImmutableAttributesTest.groovy
@@ -18,15 +18,24 @@ package org.gradle.api.internal.attributes.immutable
 
 import org.gradle.api.attributes.Usage
 import org.gradle.api.internal.artifacts.JavaEcosystemSupport
+import org.gradle.api.internal.attributes.AttributesFactory
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.internal.snapshot.impl.CoercingStringValueSnapshot
+import org.gradle.util.AttributeTestUtil
 import org.gradle.util.TestUtil
 import spock.lang.Specification
+
+import static org.gradle.api.internal.attributes.immutable.TestAttributes.BAR
+import static org.gradle.api.internal.attributes.immutable.TestAttributes.BAZ
+import static org.gradle.api.internal.attributes.immutable.TestAttributes.FOO
 
 /**
  * Unit tests for {@link ImmutableAttributes}.
  */
-class ImmutableAttributesTest extends Specification implements TestsImmutableAttributes {
+class ImmutableAttributesTest extends Specification  {
+
+    static AttributesFactory factory = AttributeTestUtil.attributesFactory()
+
     def "empty set is empty"() {
         when:
         def attributes = ImmutableAttributes.EMPTY

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/attributes/immutable/ImmutableAttributesTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/attributes/immutable/ImmutableAttributesTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.attributes.Usage
 import org.gradle.api.internal.artifacts.JavaEcosystemSupport
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.internal.snapshot.impl.CoercingStringValueSnapshot
+import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 /**
@@ -99,7 +100,7 @@ class ImmutableAttributesTest extends Specification implements TestsImmutableAtt
     }
 
     def "translates deprecated usage values"() {
-        def result = factory.of(Usage.USAGE_ATTRIBUTE, instantiator.named(Usage, JavaEcosystemSupport.DEPRECATED_JAVA_API_JARS))
+        def result = factory.of(Usage.USAGE_ATTRIBUTE, TestUtil.objectInstantiator().named(Usage, JavaEcosystemSupport.DEPRECATED_JAVA_API_JARS))
 
         expect:
         result.findEntry(Usage.USAGE_ATTRIBUTE).get().name == "java-api"
@@ -107,7 +108,7 @@ class ImmutableAttributesTest extends Specification implements TestsImmutableAtt
 
     @SuppressWarnings('GroovyAssignabilityCheck')
     def "translates deprecated usage values as Isolatable"() {
-        def result = factory.of(Usage.USAGE_ATTRIBUTE, new CoercingStringValueSnapshot(JavaEcosystemSupport.DEPRECATED_JAVA_RUNTIME_JARS, instantiator))
+        def result = factory.of(Usage.USAGE_ATTRIBUTE, new CoercingStringValueSnapshot(JavaEcosystemSupport.DEPRECATED_JAVA_RUNTIME_JARS, TestUtil.objectInstantiator()))
 
         expect:
         result.findEntry(Usage.USAGE_ATTRIBUTE).get().toString() == "java-runtime"

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesFactory.java
@@ -24,8 +24,6 @@ import org.gradle.api.internal.provider.PropertyFactory;
 import org.gradle.internal.Cast;
 import org.gradle.internal.isolation.Isolatable;
 import org.gradle.internal.isolation.IsolatableFactory;
-import org.gradle.internal.service.scopes.Scope;
-import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -33,7 +31,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
-@ServiceScope(Scope.BuildSession.class)
 public final class DefaultAttributesFactory implements AttributesFactory {
 
     private final AttributeValueIsolator attributeValueIsolator;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultMutableAttributeContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultMutableAttributeContainer.java
@@ -16,106 +16,123 @@
 
 package org.gradle.api.internal.attributes;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.provider.MappingProvider;
+import org.gradle.api.internal.provider.PropertyFactory;
 import org.gradle.api.internal.provider.ProviderInternal;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.isolation.Isolatable;
 
 import javax.annotation.Nullable;
-import java.util.Collections;
 import java.util.Comparator;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 
 public final class DefaultMutableAttributeContainer extends AbstractAttributeContainer {
-    private final Map<Attribute<?>, Isolatable<?>> attributes = new LinkedHashMap<>(); // Need to maintain insertion order here, this is indirectly tested
-    private Map<Attribute<?>, Provider<?>> lazyAttributes = Cast.uncheckedCast(Collections.EMPTY_MAP);
-    private boolean realizingAttributes = false;
 
+    // Services
     private final AttributesFactory attributesFactory;
     private final AttributeValueIsolator attributeValueIsolator;
 
-    private ImmutableAttributes immutableValue;
+    // Mutable State
+    private final MapProperty<Attribute<?>, Isolatable<?>> state;
+    private boolean realizingAttributes;
 
-    public DefaultMutableAttributeContainer(AttributesFactory attributesFactory, AttributeValueIsolator attributeValueIsolator) {
+    public DefaultMutableAttributeContainer(
+        AttributesFactory attributesFactory,
+        AttributeValueIsolator attributeValueIsolator,
+        PropertyFactory propertyFactory
+    ) {
         this.attributesFactory = attributesFactory;
         this.attributeValueIsolator = attributeValueIsolator;
+        this.state = Cast.uncheckedNonnullCast(propertyFactory.mapProperty(Attribute.class, Isolatable.class));
     }
 
     @Override
     public String toString() {
-        maybeEmitRecursiveQueryDeprecation();
         final Map<Attribute<?>, Object> sorted = new TreeMap<>(Comparator.comparing(Attribute::getName));
-        lazyAttributes.keySet().forEach(key -> sorted.put(key, lazyAttributes.get(key).toString()));
-        attributes.keySet().forEach(key -> sorted.put(key, attributes.get(key).toString()));
+        sorted.putAll(getRealizedMap());
         return sorted.toString();
     }
 
     @Override
     public Set<Attribute<?>> keySet() {
-        maybeEmitRecursiveQueryDeprecation();
-        // Need to copy the result since if the user calls getAttribute() while iterating over the returned set,
-        // realizing a lazy attribute will add to the eager `attributes` map and remove from the `lazyAttributes`.
-        // This avoids a ConcurrentModificationException.
-        return ImmutableSet.copyOf(Sets.union(attributes.keySet(), lazyAttributes.keySet()));
+        return getRealizedMap().keySet();
     }
 
     @Override
     public <T> AttributeContainer attribute(Attribute<T> key, T value) {
         checkInsertionAllowed(key);
-        doInsertion(key, value);
-        return this;
-    }
-
-    private <T> void doInsertion(Attribute<T> key, T value) {
         assertAttributeValueIsNotNull(value);
         assertAttributeTypeIsValid(value.getClass(), key);
-        immutableValue = null;
-        attributes.put(key, attributeValueIsolator.isolate(value));
-        removeLazyAttributeIfPresent(key);
-    }
-
-    private <T> void removeLazyAttributeIfPresent(Attribute<T> key) {
-        lazyAttributes.remove(key);
+        state.put(key, attributeValueIsolator.isolate(value));
+        return this;
     }
 
     @Override
     public <T> AttributeContainer attributeProvider(Attribute<T> key, Provider<? extends T> provider) {
         checkInsertionAllowed(key);
         assertAttributeValueIsNotNull(provider);
-        // We can only sometimes check the type of the provider ahead of time.
-        // When realizing this provider and inserting its value into the container, we still
-        // check the value type is appropriate. see doInsertion
-        if (provider instanceof ProviderInternal) {
-            Class<T> valueType = Cast.<ProviderInternal<T>>uncheckedCast(provider).getType();
-            if (valueType != null) {
-                assertAttributeTypeIsValid(valueType, key);
-            }
+
+        ProviderInternal<T> providerInternal = Cast.uncheckedCast(provider);
+
+        Provider<Isolatable<T>> isolated;
+        Class<T> valueType = providerInternal.getType();
+        Class<Isolatable<T>> typedIsolatable = Cast.uncheckedCast(Isolatable.class);
+        if (valueType != null) {
+            // We can only sometimes check the type of the provider ahead of time.
+            assertAttributeTypeIsValid(valueType, key);
+            isolated = new MappingProvider<>(typedIsolatable, providerInternal, attributeValueIsolator::isolate);
+        } else {
+            // Otherwise, check the type when the value is realized.
+            isolated = new MappingProvider<>(typedIsolatable, providerInternal, t -> {
+                assertAttributeTypeIsValid(t.getClass(), key);
+                return attributeValueIsolator.isolate(t);
+            });
         }
-        doInsertionLazy(key, provider);
+
+        state.put(key, isolated);
+
         return this;
     }
 
     private <T> void checkInsertionAllowed(Attribute<T> key) {
+        // TODO: This check should be handled by the provider API infrastructure
         if (realizingAttributes) {
             throw new IllegalStateException("Cannot add new attribute '" + key.getName() + "' while realizing all attributes of the container.");
         }
-        for (Attribute<?> attribute : keySet()) {
-            String name = key.getName();
-            if (attribute.getName().equals(name) && attribute.getType() != key.getType()) {
-                throw new IllegalArgumentException("Cannot have two attributes with the same name but different types. "
-                    + "This container already has an attribute named '" + name + "' of type '" + attribute.getType().getName()
-                    + "' and you are trying to store another one of type '" + key.getType().getName() + "'");
+    }
+
+    private Map<Attribute<?>, Isolatable<?>> getRealizedMap() {
+        Map<Attribute<?>, Isolatable<?>> realizedMap = doRealizeAttributes();
+
+        Map<String, Attribute<?>> attributesByName = new HashMap<>();
+        for (Map.Entry<Attribute<?>, Isolatable<?>> entry : realizedMap.entrySet()) {
+            Attribute<?> attribute = entry.getKey();
+            String name = attribute.getName();
+            Attribute<?> existing = attributesByName.put(name, attribute);
+            if (existing != null) {
+                throw new IllegalStateException("Cannot have two attributes with the same name but different types. "
+                    + "This container has an attribute named '" + name + "' of type '" + existing.getType().getName()
+                    + "' and another attribute of type '" + attribute.getType().getName() + "'");
             }
+        }
+
+        return realizedMap;
+    }
+
+    private Map<Attribute<?>, Isolatable<?>> doRealizeAttributes() {
+        realizingAttributes = true;
+        try {
+            return state.get();
+        } finally {
+            realizingAttributes = false;
         }
     }
 
@@ -143,37 +160,12 @@ public final class DefaultMutableAttributeContainer extends AbstractAttributeCon
         if (!isValidAttributeRequest(key)) {
             return null;
         }
-        maybeEmitRecursiveQueryDeprecation();
-
-        Isolatable<?> value = attributes.get(key);
-        if (value == null) {
-            if (lazyAttributes.containsKey(key)) {
-                return realizeLazyAttribute(key);
-            } else {
-                return null;
-            }
-        } else {
-            return Cast.uncheckedCast(value.isolate());
-        }
+        return Cast.uncheckedCast(state.getting(key).map(Isolatable::isolate).getOrNull());
     }
 
     @Override
     public ImmutableAttributes asImmutable() {
-        maybeEmitRecursiveQueryDeprecation();
-        realizeAllLazyAttributes();
-        if (immutableValue == null) {
-            immutableValue = attributesFactory.fromMap(attributes);
-        }
-        return immutableValue;
-    }
-
-    private void maybeEmitRecursiveQueryDeprecation() {
-        if (realizingAttributes) {
-            DeprecationLogger.deprecateBehaviour("Querying the contents of an attribute container while realizing attributes of the container.")
-                .willBecomeAnErrorInGradle9()
-                .withUpgradeGuideSection(8, "attribute_container_recursive_query")
-                .nagUser();
-        }
+        return attributesFactory.fromMap(getRealizedMap());
     }
 
     @Override
@@ -193,47 +185,5 @@ public final class DefaultMutableAttributeContainer extends AbstractAttributeCon
     @Override
     public int hashCode() {
         return asImmutable().hashCode();
-    }
-
-    private <T> void doInsertionLazy(Attribute<T> key, Provider<? extends T> provider) {
-        if (lazyAttributes == Collections.EMPTY_MAP) {
-            lazyAttributes = new LinkedHashMap<>(1);
-        }
-        lazyAttributes.put(key, provider);
-        removeAttributeIfPresent(key);
-    }
-
-    private <T> void removeAttributeIfPresent(Attribute<T> key) {
-        immutableValue = null;
-        attributes.remove(key);
-    }
-
-    private <T> T realizeLazyAttribute(Attribute<T> key) {
-        @SuppressWarnings("unchecked") final T value = (T) lazyAttributes.get(key).get();
-        doInsertion(key, value);
-        return value;
-    }
-
-    private void realizeAllLazyAttributes() {
-        if (!lazyAttributes.isEmpty()) {
-            // As doInsertion will remove an item from lazyAttributes, we can't iterate that collection directly here, or else we'll get ConcurrentModificationException
-            final Set<Attribute<?>> savedKeys = new LinkedHashSet<>(lazyAttributes.keySet());
-            try {
-                realizingAttributes = true;
-                savedKeys.forEach(key -> {
-                    Provider<?> value = lazyAttributes.get(key);
-                    // Between getting the list of keys and realizing the values
-                    // some lazy attributes have been realized and removed from the map
-                    // This can happen when a side effect of calculating the value of a Provider
-                    // causes dependency resolution or evaluation of the attributes of
-                    // the same AttributeContainer
-                    if (value != null) {
-                        doInsertion(Cast.uncheckedNonnullCast(key), value.get());
-                    }
-                });
-            } finally {
-                realizingAttributes = false;
-            }
-        }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesFactoryTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.attributes
 
 import org.gradle.api.internal.attributes.immutable.TestsImmutableAttributes
+import org.gradle.util.AttributeTestUtil
 import spock.lang.Specification
 
 /**
@@ -111,7 +112,7 @@ class DefaultAttributesFactoryTest extends Specification implements TestsImmutab
 
     def "can compare attribute sets created by two different factories"() {
         given:
-        def otherFactory = new DefaultAttributesFactory(attributeValueIsolator, isolatableFactory, instantiator)
+        def otherFactory = AttributeTestUtil.attributesFactory()
 
         when:
         def set1 = factory.concat(factory.of(FOO, "foo"), BAR, "bar")
@@ -123,7 +124,7 @@ class DefaultAttributesFactoryTest extends Specification implements TestsImmutab
 
     def "can append to a set created with a different factory"() {
         given:
-        def otherFactory = new DefaultAttributesFactory(attributeValueIsolator, isolatableFactory, instantiator)
+        def otherFactory = AttributeTestUtil.attributesFactory()
         def attributes = otherFactory.of(FOO, 'foo')
 
         when:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesFactoryTest.groovy
@@ -16,16 +16,24 @@
 
 package org.gradle.api.internal.attributes
 
-import org.gradle.api.internal.attributes.immutable.TestsImmutableAttributes
+
 import org.gradle.util.AttributeTestUtil
 import spock.lang.Specification
+
+import static org.gradle.api.internal.attributes.immutable.TestAttributes.BAR
+import static org.gradle.api.internal.attributes.immutable.TestAttributes.BAZ
+import static org.gradle.api.internal.attributes.immutable.TestAttributes.FOO
+import static org.gradle.api.internal.attributes.immutable.TestAttributes.OTHER_BAR
 
 /**
  * Unit tests for {@link DefaultAttributesFactory}.
  * <p>
  * Not responsible for testing {@link ImmutableAttributes} directly.
  */
-class DefaultAttributesFactoryTest extends Specification implements TestsImmutableAttributes {
+class DefaultAttributesFactoryTest extends Specification {
+
+    AttributesFactory factory = AttributeTestUtil.attributesFactory()
+
     def "can create a single entry immutable set"() {
         when:
         def attributes = factory.of(FOO, "foo")

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
@@ -25,9 +25,9 @@ import org.gradle.api.internal.provider.DefaultProperty
 import org.gradle.api.internal.provider.DefaultProvider
 import org.gradle.api.internal.provider.PropertyHost
 import org.gradle.api.internal.provider.Providers
-import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.internal.evaluation.CircularEvaluationException
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.TestUtil
 
@@ -35,9 +35,10 @@ import org.gradle.util.TestUtil
  * Unit tests for the {@link DefaultMutableAttributeContainer} class.
  */
 final class DefaultMutableAttributeContainerTest extends BaseAttributeContainerTest {
+
     @Override
     protected DefaultMutableAttributeContainer createContainer(Map<Attribute<?>, ?> attributes = [:], Map<Attribute<?>, ?> moreAttributes = [:]) {
-        DefaultMutableAttributeContainer container = new DefaultMutableAttributeContainer(attributesFactory, AttributeTestUtil.attributeValueIsolator())
+        DefaultMutableAttributeContainer container = new DefaultMutableAttributeContainer(attributesFactory, AttributeTestUtil.attributeValueIsolator(), TestUtil.propertyFactory())
         attributes.forEach {key, value ->
             container.attribute(key, value)
         }
@@ -64,7 +65,7 @@ final class DefaultMutableAttributeContainerTest extends BaseAttributeContainerT
         actual == expected
     }
 
-    def "realizing the value of lazy attributes may cause other attributes to be realized"() {
+    def "cannot query container while realizing the value of lazy attributes"() {
         def container = createContainer()
         def firstAttribute = Attribute.of("first", String)
         def secondAttribute = Attribute.of("second", String)
@@ -76,13 +77,11 @@ final class DefaultMutableAttributeContainerTest extends BaseAttributeContainerT
         })
         container.attributeProvider(secondAttribute, Providers.of("second"))
 
-        expect:
-        container.asImmutable().keySet() == [secondAttribute, firstAttribute] as Set
+        when:
+        container.asImmutable()
 
-        and:
-        def events = outputEventListener.events.findAll { it.logLevel == LogLevel.WARN }
-        events.size() == 1
-        events[0].message.startsWith("Querying the contents of an attribute container while realizing attributes of the container. This behavior has been deprecated. This will fail with an error in Gradle 9.0")
+        then:
+        thrown(CircularEvaluationException)
     }
 
     def "realizing the value of lazy attributes cannot add new attributes to the container"() {
@@ -96,6 +95,7 @@ final class DefaultMutableAttributeContainerTest extends BaseAttributeContainerT
 
         when:
         container.asImmutable()
+
         then:
         def e = thrown(IllegalStateException)
         e.message == "Cannot add new attribute 'second' while realizing all attributes of the container."
@@ -112,6 +112,7 @@ final class DefaultMutableAttributeContainerTest extends BaseAttributeContainerT
 
         when:
         container.asImmutable()
+
         then:
         def e = thrown(IllegalStateException)
         e.message == "Cannot add new attribute 'second' while realizing all attributes of the container."
@@ -234,35 +235,6 @@ final class DefaultMutableAttributeContainerTest extends BaseAttributeContainerT
         "lazy value" == container.getAttribute(testAttr)
     }
 
-    @SuppressWarnings('GroovyAccessibility')
-    def "toString should not change the internal state of the class"() {
-        given: "a container and a lazy and non-lazy attribute"
-        def container = createContainer()
-        def testEager = Attribute.of("eager", String)
-        def testLazy = Attribute.of("lazy", String)
-        Property<String> testProvider = new DefaultProperty<>(Mock(PropertyHost), String).convention("lazy value")
-
-        when: "the attributes are added to the container"
-        container.attribute(testEager, "eager value")
-        container.attributeProvider(testLazy, testProvider)
-
-        then: "they are located in proper internal collections"
-        container.@attributes.containsKey(testEager)
-        !container.@attributes.containsKey(testLazy)
-        container.@lazyAttributes.containsKey(testLazy)
-        !container.@lazyAttributes.containsKey(testEager)
-
-        when: "calling toString"
-        def result = container.toString()
-
-        then: "the result should not change the internals of the class"
-        result == "{eager=eager value, lazy=property(java.lang.String, fixed(class java.lang.String, lazy value))}"
-        container.@attributes.containsKey(testEager)
-        !container.@attributes.containsKey(testLazy)
-        container.@lazyAttributes.containsKey(testLazy)
-        !container.@lazyAttributes.containsKey(testEager)
-    }
-
     def "can query contents of container"() {
         def thing = Attribute.of("thing", String)
         def thing2 = Attribute.of("thing2", String)
@@ -366,7 +338,7 @@ final class DefaultMutableAttributeContainerTest extends BaseAttributeContainerT
         container.attributeProvider(a, Providers.of("a"))
 
         then:
-        container.toString() == "{a=fixed(class java.lang.String, a), b=b, c=c}"
+        container.toString() == "{a=a, b=b, c=c}"
         container.asImmutable().toString() == "{a=a, b=b, c=c}"
     }
 
@@ -423,5 +395,20 @@ final class DefaultMutableAttributeContainerTest extends BaseAttributeContainerT
             assert it.size() == 1
             assert it[Attribute.of("test", String)] == "b" // Second attribute to be added remains
         }
+    }
+
+    def "cannot define two attributes with the same name but different types"() {
+        def container = createContainer()
+
+        given:
+        container.attribute(Attribute.of('flavor', Boolean), true)
+        container.attribute(Attribute.of('flavor', String.class), 'paid')
+
+        when:
+        container.asImmutable()
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == "Cannot have two attributes with the same name but different types. This container has an attribute named 'flavor' of type 'java.lang.Boolean' and another attribute of type 'java.lang.String'"
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/FreezableAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/FreezableAttributeContainerTest.groovy
@@ -26,7 +26,7 @@ import org.gradle.util.AttributeTestUtil
 final class FreezableAttributeContainerTest extends BaseAttributeContainerTest {
     @Override
     protected FreezableAttributeContainer createContainer(Map<Attribute<?>, ?> attributes = [:], Map<Attribute<?>, ?> moreAttributes = [:]) {
-        def mutableContainer = new DefaultMutableAttributeContainer(attributesFactory, AttributeTestUtil.attributeValueIsolator())
+        def mutableContainer = AttributeTestUtil.attributesFactory().mutable()
         FreezableAttributeContainer container = new FreezableAttributeContainer(mutableContainer, { "owner" } as Describable);
         attributes.forEach { key, value ->
             container.attribute(key, value)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/HierarchicalMutableAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/HierarchicalMutableAttributeContainerTest.groovy
@@ -24,12 +24,13 @@ import org.gradle.util.AttributeTestUtil
  * Unit tests for the {@link HierarchicalMutableAttributeContainer} class.
  */
 final class HierarchicalMutableAttributeContainerTest extends BaseAttributeContainerTest {
-    private one = Attribute.of("one", String)
-    private two = Attribute.of("two", String)
+
+    private Attribute<String> one = Attribute.of("one", String)
+    private Attribute<String> two = Attribute.of("two", String)
 
     @Override
     protected DefaultMutableAttributeContainer createContainer(Map<Attribute<?>, ?> attributes = [:], Map<Attribute<?>, ?> moreAttributes = [:]) {
-        DefaultMutableAttributeContainer container = new DefaultMutableAttributeContainer(attributesFactory, AttributeTestUtil.attributeValueIsolator())
+        DefaultMutableAttributeContainer container = AttributeTestUtil.attributesFactory().mutable()
         attributes.forEach { key, value ->
             container.attribute(key, value)
         }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/IncubatingAttributesCheckerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/IncubatingAttributesCheckerTest.groovy
@@ -24,8 +24,6 @@ import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 class IncubatingAttributesCheckerTest extends Specification {
-    def attributeValueIsolator = AttributeTestUtil.attributeValueIsolator()
-    def attributesFactory = AttributeTestUtil.attributesFactory()
 
     // region: Single Attribute tests
     def "attribute without any @Incubating is not reported"() {
@@ -56,7 +54,7 @@ class IncubatingAttributesCheckerTest extends Specification {
 
     // region: AttributeContainer tests
     def "container with attribute which doesn't use @Incubating is not reported"() {
-        def container = new DefaultMutableAttributeContainer(attributesFactory, attributeValueIsolator)
+        def container = AttributeTestUtil.attributesFactory().mutable()
         container.attribute(Usage.USAGE_ATTRIBUTE, TestUtil.objectFactory().named(Usage, Usage.JAVA_API))
 
         expect:
@@ -64,7 +62,7 @@ class IncubatingAttributesCheckerTest extends Specification {
     }
 
     def "container with @Incubating attribute is reported"() {
-        def container = new DefaultMutableAttributeContainer(attributesFactory, attributeValueIsolator)
+        def container = AttributeTestUtil.attributesFactory().mutable()
         container.attribute(TestSuiteName.TEST_SUITE_NAME_ATTRIBUTE, TestUtil.objectFactory().named(TestSuiteName, "foo"))
 
         expect:
@@ -72,7 +70,7 @@ class IncubatingAttributesCheckerTest extends Specification {
     }
 
     def "container with attribute without @Incubating annotation on class, with @Incubating on value is reported"() {
-        def container = new DefaultMutableAttributeContainer(attributesFactory, attributeValueIsolator)
+        def container = AttributeTestUtil.attributesFactory().mutable()
         container.attribute(Category.CATEGORY_ATTRIBUTE, TestUtil.objectFactory().named(Category, Category.VERIFICATION))
 
         expect:
@@ -80,7 +78,7 @@ class IncubatingAttributesCheckerTest extends Specification {
     }
 
     def "container with attribute without @Incubating annotation on class, with @Incubating on different value is not reported"() {
-        def container = new DefaultMutableAttributeContainer(attributesFactory, attributeValueIsolator)
+        def container = AttributeTestUtil.attributesFactory().mutable()
         container.attribute(Category.CATEGORY_ATTRIBUTE, TestUtil.objectFactory().named(Category, Category.LIBRARY))
 
         expect:

--- a/subprojects/core/src/test/java/org/gradle/api/internal/attributes/MyNamed.java
+++ b/subprojects/core/src/test/java/org/gradle/api/internal/attributes/MyNamed.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.attributes;
+
+import org.gradle.api.Named;
+
+import java.io.Serializable;
+
+/**
+ * This class lives in the Java source set to avoid Groovy adding a bunch of extra stuff to it.
+ * This is used in {@link BaseAttributeContainerTest}, and must not contain extra references to
+ * classes, as it is loaded in an isolated classloader.
+ */
+public final class MyNamed implements Named, Serializable {
+
+    private final String name;
+
+    public MyNamed(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+}

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/attributes/immutable/TestAttributes.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/attributes/immutable/TestAttributes.groovy
@@ -17,18 +17,14 @@
 package org.gradle.api.internal.attributes.immutable
 
 import org.gradle.api.attributes.Attribute
-import org.gradle.api.internal.attributes.AttributesFactory
 import org.gradle.api.internal.attributes.ImmutableAttributes
-import org.gradle.util.AttributeTestUtil
 
 /**
- * Supplies some example attributes and a factory for easy testing of {@link ImmutableAttributes} and related types.
+ * Supplies some example attributes for easy testing of {@link ImmutableAttributes} and related types.
  */
-trait TestsImmutableAttributes {
+final class TestAttributes {
     static final Attribute<String> FOO = Attribute.of("foo", String)
     static final Attribute<String> BAR = Attribute.of("bar", String)
     static final Attribute<Object> OTHER_BAR = Attribute.of("bar", Object.class)
     static final Attribute<String> BAZ = Attribute.of("baz", String)
-
-    AttributesFactory factory = AttributeTestUtil.attributesFactory()
 }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/attributes/immutable/TestsImmutableAttributes.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/attributes/immutable/TestsImmutableAttributes.groovy
@@ -17,15 +17,9 @@
 package org.gradle.api.internal.attributes.immutable
 
 import org.gradle.api.attributes.Attribute
-import org.gradle.api.internal.attributes.AttributeValueIsolator
 import org.gradle.api.internal.attributes.AttributesFactory
-import org.gradle.api.internal.attributes.DefaultAttributesFactory
 import org.gradle.api.internal.attributes.ImmutableAttributes
-import org.gradle.api.internal.model.NamedObjectInstantiator
-import org.gradle.internal.isolation.IsolatableFactory
 import org.gradle.util.AttributeTestUtil
-import org.gradle.util.SnapshotTestUtil
-import org.gradle.util.TestUtil
 
 /**
  * Supplies some example attributes and a factory for easy testing of {@link ImmutableAttributes} and related types.
@@ -36,9 +30,5 @@ trait TestsImmutableAttributes {
     static final Attribute<Object> OTHER_BAR = Attribute.of("bar", Object.class)
     static final Attribute<String> BAZ = Attribute.of("baz", String)
 
-    IsolatableFactory isolatableFactory = SnapshotTestUtil.isolatableFactory()
-    NamedObjectInstantiator instantiator = TestUtil.objectInstantiator()
-    AttributeValueIsolator attributeValueIsolator = AttributeTestUtil.attributeValueIsolator()
-
-    AttributesFactory factory = new DefaultAttributesFactory(attributeValueIsolator, isolatableFactory, instantiator)
+    AttributesFactory factory = AttributeTestUtil.attributesFactory()
 }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/AttributeTestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/AttributeTestUtil.groovy
@@ -37,7 +37,7 @@ class AttributeTestUtil {
     }
 
     static DefaultAttributesFactory attributesFactory() {
-        return new DefaultAttributesFactory(attributeValueIsolator(), SnapshotTestUtil.isolatableFactory(), TestUtil.objectInstantiator())
+        return new DefaultAttributesFactory(attributeValueIsolator(), SnapshotTestUtil.isolatableFactory(), TestUtil.objectInstantiator(), TestUtil.propertyFactory())
     }
 
     /**


### PR DESCRIPTION
This will allow us to implement an addAll feature on AttributeContainers, allowing all
attribute from one container to be included in another container.
    
The implementation must be even more lazy than before, where before we know all attributes that will be present eagerly, even if we don't know their values. Now, we do not know even the attribute keys until the container is realized.
    
For this reason, validating actions and error checking some times may need to be delayed until the container is realized.
    
Furthermore, this implementation does away with the immutable attributes cache. Previously, reading the attribute values caused the container to realize all attributes and cache the result. Now, the container will re-calculate the attributes each time the container is queried. This may lead to a performance degradation that would require us to either optimize or to add-back caching and eager realization in some cases.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
