### PR TITLE
Do not inject ObjectFactory to HttpBuildCache

### DIFF
--- a/platforms/core-execution/build-cache-http/src/main/java/org/gradle/caching/http/HttpBuildCache.java
+++ b/platforms/core-execution/build-cache-http/src/main/java/org/gradle/caching/http/HttpBuildCache.java
@@ -17,13 +17,11 @@
 package org.gradle.caching.http;
 
 import org.gradle.api.Action;
-import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.Nested;
 import org.gradle.caching.configuration.AbstractBuildCache;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 
 import javax.annotation.Nullable;
-import javax.inject.Inject;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -61,12 +59,7 @@ public abstract class HttpBuildCache extends AbstractBuildCache {
     private boolean useExpectContinue;
 
     public HttpBuildCache() {
-        this.credentials = getObjectFactory().newInstance(HttpBuildCacheCredentials.class);
-    }
-
-    @Inject
-    protected ObjectFactory getObjectFactory() {
-        throw new UnsupportedOperationException();
+        this.credentials = new HttpBuildCacheCredentials();
     }
 
     /**


### PR DESCRIPTION
Partly revert change from https://github.com/gradle/gradle/pull/30778

Fixes https://github.com/gradle/gradle/issues/31705