### PR TITLE
Use a class instead of id for metadata tab of new report

### DIFF
--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/PerRootTabRenderer.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/PerRootTabRenderer.java
@@ -273,7 +273,7 @@ public abstract class PerRootTabRenderer extends ReportRenderer<TestTreeModel, S
 
         @Override
         protected void render(TestTreeModel.PerRootInfo info, SimpleHtmlWriter htmlWriter) throws IOException {
-            htmlWriter.startElement("div").attribute("id", "metadata");
+            htmlWriter.startElement("div").attribute("class", "metadata");
                 renderMetadataTable(info, htmlWriter);
             htmlWriter.endElement();
         }

--- a/platforms/software/testing-base/src/main/resources/org/gradle/api/internal/tasks/testing/report/generic/style.css
+++ b/platforms/software/testing-base/src/main/resources/org/gradle/api/internal/tasks/testing/report/generic/style.css
@@ -83,24 +83,24 @@ ul.linkList li {
     margin-bottom: 5px;
 }
 
-#metadata tr.odd {
+.metadata tr.odd {
     background-color: #f7f7f7;
     border: solid 1px #d0d0d0;
 }
 
-#metadata tr.even {
+.metadata tr.even {
     border: solid 1px #d0d0d0;
 }
 
-#metadata th, #metadata td {
+.metadata th, .metadata td {
     padding: 10px;
     text-align: left;
 }
 
-#metadata a {
+.metadata a {
     color: blue;
 }
 
-#metadata .unrenderable {
+.metadata .unrenderable {
     color: darkred;
 }

--- a/platforms/software/testing-base/src/testFixtures/groovy/org/gradle/api/internal/tasks/testing/report/generic/GenericHtmlTestExecutionResult.groovy
+++ b/platforms/software/testing-base/src/testFixtures/groovy/org/gradle/api/internal/tasks/testing/report/generic/GenericHtmlTestExecutionResult.groovy
@@ -193,15 +193,15 @@ class GenericHtmlTestExecutionResult implements GenericTestExecutionResult {
 
         @Override
         TestPathExecutionResult assertMetadata(List<String> expectedKeys) {
-            def metadataKeys = html.select('#metadata td.key').collect() { it.text() }
+            def metadataKeys = html.select('.metadata td.key').collect() { it.text() }
             assertThat(metadataKeys, equalTo(expectedKeys))
             return this
         }
 
         @Override
         TestPathExecutionResult assertMetadata(LinkedHashMap<String, String> expectedMetadata) {
-            def metadataKeys = html.select('#metadata td.key').collect() { it.text() }
-            def metadataRenderedValues = html.select('#metadata td.value').collect { it.html()}
+            def metadataKeys = html.select('.metadata td.key').collect() { it.text() }
+            def metadataRenderedValues = html.select('.metadata td.value').collect { it.html()}
             def metadata = [metadataKeys, metadataRenderedValues].transpose().collectEntries { key, value -> [key, value] }
             assertThat(metadata, equalTo(expectedMetadata))
             return this


### PR DESCRIPTION
### Context
The per-root tabs may be rendered multiple times, so they cannot use any simple ids as ids must be unique across the whole page.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
