### PR TITLE
Deprecate recursively querying AttributeContainer in value provider

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -42,21 +42,21 @@ The previous step will help you identify potential problems by issuing deprecati
 
 ==== Recursively querying `AttributeContainer` in lazy provider
 
-In Gradle 9.0, querying the contents of an `AttributeContainer` from within an attribute value provider of the same container will become an error
+In Gradle 9.0, querying the contents of an `AttributeContainer` from within an attribute value provider of the same container will become an error.
 
 The following example showcases the forbidden behavior:
 
-[source,groovy]
+[source,java]
 ----
-def container = getAttributeContainer()
-def firstAttribute = Attribute.of("first", String)
-def secondAttribute = Attribute.of("second", String)
-container.attributeProvider(firstAttribute, providers.provider(() -> {
+AttributeContainer container = getAttributeContainer();
+Attribute<String> firstAttribute = Attribute.of("first", String.class);
+Attribute<String> secondAttribute = Attribute.of("second", String.class);
+container.attributeProvider(firstAttribute, project.getProviders().provider(() -> {
     // Querying the contents of the container within an attribute value provider
-    // will become an error
-    container.getAttribute(secondAttribute)
-    "first"
-}))
+    // will become an error.
+    container.getAttribute(secondAttribute);
+    return "first";
+}));
 ----
 
 [[changes_8.12]]

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -35,6 +35,30 @@ The previous step will help you identify potential problems by issuing deprecati
 . Run `gradle wrapper --gradle-version {gradleVersion}` to update the project to {gradleVersion}.
 . Try to run the project and debug any errors using the <<troubleshooting.adoc#troubleshooting, Troubleshooting Guide>>.
 
+[[change_8.13]]
+== Upgrading from 8.12 and earlier
+
+=== Deprecations
+
+==== Recursively querying `AttributeContainer` in lazy provider
+
+In Gradle 9.0, querying the contents of an `AttributeContainer` from within an attribute value provider of the same container will become an error
+
+The following example showcases the forbidden behavior:
+
+[source,groovy]
+----
+def container = getAttributeContainer()
+def firstAttribute = Attribute.of("first", String)
+def secondAttribute = Attribute.of("second", String)
+container.attributeProvider(firstAttribute, providers.provider(() -> {
+    // Querying the contents of the container within an attribute value provider
+    // will become an error
+    container.getAttribute(secondAttribute)
+    "first"
+}))
+----
+
 [[changes_8.12]]
 == Upgrading from 8.11 and earlier
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/AttributeContainerResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/AttributeContainerResolutionIntegrationTest.groovy
@@ -42,8 +42,10 @@ class AttributeContainerResolutionIntegrationTest extends AbstractIntegrationSpe
                 inputs.files(configurations.conf)
             }
         """
+
         expect:
         // When this has failed in the past, building the task graph hits a NPE from the attribute container
+        executer.expectDocumentedDeprecationWarning("Querying the contents of an attribute container while realizing attributes of the container. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#attribute_container_recursive_query")
         succeeds("resolve")
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultMutableAttributeContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultMutableAttributeContainer.java
@@ -23,6 +23,7 @@ import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.isolation.Isolatable;
 
 import javax.annotation.Nullable;
@@ -50,6 +51,7 @@ final class DefaultMutableAttributeContainer extends AbstractAttributeContainer 
 
     @Override
     public String toString() {
+        maybeEmitRecursiveQueryDeprecation();
         final Map<Attribute<?>, Object> sorted = new TreeMap<>(Comparator.comparing(Attribute::getName));
         lazyAttributes.keySet().forEach(key -> sorted.put(key, lazyAttributes.get(key).toString()));
         attributes.keySet().forEach(key -> sorted.put(key, attributes.get(key).toString()));
@@ -58,6 +60,7 @@ final class DefaultMutableAttributeContainer extends AbstractAttributeContainer 
 
     @Override
     public Set<Attribute<?>> keySet() {
+        maybeEmitRecursiveQueryDeprecation();
         // Need to copy the result since if the user calls getAttribute() while iterating over the returned set,
         // realizing a lazy attribute will add to the eager `attributes` map and remove from the `lazyAttributes`.
         // This avoids a ConcurrentModificationException.
@@ -134,6 +137,7 @@ final class DefaultMutableAttributeContainer extends AbstractAttributeContainer 
 
     @Override
     public <T> T getAttribute(Attribute<T> key) {
+        maybeEmitRecursiveQueryDeprecation();
         Isolatable<?> value = attributes.get(key);
         if (value == null) {
             if (lazyAttributes.containsKey(key)) {
@@ -148,11 +152,21 @@ final class DefaultMutableAttributeContainer extends AbstractAttributeContainer 
 
     @Override
     public ImmutableAttributes asImmutable() {
+        maybeEmitRecursiveQueryDeprecation();
         realizeAllLazyAttributes();
         if (immutableValue == null) {
             immutableValue = attributesFactory.fromMap(attributes);
         }
         return immutableValue;
+    }
+
+    private void maybeEmitRecursiveQueryDeprecation() {
+        if (realizingAttributes) {
+            DeprecationLogger.deprecateBehaviour("Querying the contents of an attribute container while realizing attributes of the container.")
+                .willBecomeAnErrorInGradle9()
+                .withUpgradeGuideSection(8, "attribute_container_recursive_query")
+                .nagUser();
+        }
     }
 
     @Override


### PR DESCRIPTION
In Gradle 9.0, we will update the AttributeContainer to be backed by a MapProperty

Constraints monitored by the MapProperty infrastructure restrict recursively querying the value of the map property while calculating the value of the MapProperty.

This deprecation prepares us for future changes to AttributeContainer

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
