### PR TITLE
Delete stale test report if no test failures

### DIFF
--- a/platforms/software/testing-base/src/integTest/groovy/org/gradle/testing/TestEventReporterHtmlReportIntegrationTest.groovy
+++ b/platforms/software/testing-base/src/integTest/groovy/org/gradle/testing/TestEventReporterHtmlReportIntegrationTest.groovy
@@ -150,6 +150,25 @@ class TestEventReporterHtmlReportIntegrationTest extends AbstractIntegrationSpec
             .assertChildCount(1, 1, 0)
     }
 
+    def "stale aggregate reports are deleted if no tests were executed"() {
+        given:
+        buildFile << failingTask("failing")
+
+        when:
+        fails("failing")
+
+        then:
+        def aggregateReportFile = file("build/reports/aggregate-test-results/index.html")
+        aggregateReportFile.assertExists()
+
+        // Run again without any tests
+        when:
+        succeeds("help")
+
+        then:
+        aggregateReportFile.assertDoesNotExist()
+    }
+
     def passingTask(String name, boolean print = false) {
         assert !name.toCharArray().any { it.isWhitespace() }
 

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/AggregateTestEventReporter.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/AggregateTestEventReporter.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.testing.results;
 
+import org.apache.commons.io.FileUtils;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.internal.tasks.testing.GenericTestReportGenerator;
 import org.gradle.api.internal.tasks.testing.TestDescriptorInternal;
@@ -29,6 +30,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -85,8 +88,16 @@ public class AggregateTestEventReporter implements ProblemReporter, TestExecutio
             if (numFailedResults.get() > 1) {
                 emitReport(reportIndexFile);
             }
+        } else {
+            // Delete any stale report
+            if (Files.exists(reportLocation)) {
+                try {
+                    FileUtils.deleteDirectory(reportLocation.toFile());
+                } catch (IOException e) {
+                    LOGGER.debug("Failed to delete stale aggregate report directory", e);
+                }
+            }
         }
-
     }
 
     /**


### PR DESCRIPTION
Avoids confusion when page is refreshed after passing build is executed and failing test report remains

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
