### PR TITLE
Isolate internal elements on Problem interface

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultTypeAwareProblemBuilder.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultTypeAwareProblemBuilder.java
@@ -20,8 +20,8 @@ import org.gradle.api.NonNullApi;
 import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.internal.AdditionalDataBuilderFactory;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
+import org.gradle.api.problems.internal.InternalProblem;
 import org.gradle.api.problems.internal.InternalProblemBuilder;
-import org.gradle.api.problems.internal.Problem;
 import org.gradle.api.problems.internal.TypeValidationData;
 import org.gradle.api.problems.internal.TypeValidationDataSpec;
 
@@ -71,8 +71,8 @@ public class DefaultTypeAwareProblemBuilder extends DelegatingProblemBuilder imp
     }
 
     @Override
-    public Problem build() {
-        Problem problem = super.build();
+    public InternalProblem build() {
+        InternalProblem problem = super.build();
         Optional<TypeValidationData> additionalData = Optional.ofNullable((TypeValidationData) problem.getAdditionalData());
         String prefix = introductionFor(additionalData, isTypeIrrelevantInErrorMessage(problem.getDefinition().getId()));
         String text = Optional.ofNullable(problem.getContextualLabel()).orElseGet(() -> problem.getDefinition().getId().getDisplayName());

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/validation/DelegatingProblemBuilder.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/reflect/validation/DelegatingProblemBuilder.java
@@ -23,8 +23,8 @@ import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.AdditionalDataSpec;
 import org.gradle.api.problems.internal.DocLink;
+import org.gradle.api.problems.internal.InternalProblem;
 import org.gradle.api.problems.internal.InternalProblemBuilder;
-import org.gradle.api.problems.internal.Problem;
 
 import javax.annotation.Nullable;
 
@@ -38,7 +38,7 @@ class DelegatingProblemBuilder implements InternalProblemBuilder {
     }
 
     @Override
-    public Problem build() {
+    public InternalProblem build() {
         return delegate.build();
     }
 

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/DeprecatedFeatureUsage.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/DeprecatedFeatureUsage.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.gradle.api.problems.internal.DeprecationData;
 import org.gradle.api.problems.internal.DocLink;
+import org.gradle.api.problems.internal.InternalDocLink;
 import org.gradle.internal.featurelifecycle.FeatureUsage;
 
 import javax.annotation.Nullable;
@@ -172,7 +173,7 @@ public class DeprecatedFeatureUsage extends FeatureUsage {
         append(outputBuilder, contextualAdvice);
         append(outputBuilder, advice);
         if (documentation != null) {
-            append(outputBuilder, documentation.getConsultDocumentationMessage());
+            append(outputBuilder, ((InternalDocLink) documentation).getConsultDocumentationMessage());
         }
         return outputBuilder.toString();
     }

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/Documentation.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/Documentation.java
@@ -19,11 +19,12 @@ package org.gradle.internal.deprecation;
 import com.google.common.base.Preconditions;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.problems.internal.DocLink;
+import org.gradle.api.problems.internal.InternalDocLink;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 
-public abstract class Documentation implements DocLink {
+public abstract class Documentation implements InternalDocLink {
     public static final String RECOMMENDATION = "For more %s, please refer to %s in the Gradle documentation.";
     private static final DocumentationRegistry DOCUMENTATION_REGISTRY = new DocumentationRegistry();
 

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/DocumentedFailure.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/DocumentedFailure.java
@@ -19,6 +19,7 @@ package org.gradle.internal.deprecation;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.GradleException;
 import org.gradle.api.problems.internal.DocLink;
+import org.gradle.api.problems.internal.InternalDocLink;
 import org.gradle.internal.exceptions.Contextual;
 
 import javax.annotation.CheckReturnValue;
@@ -72,7 +73,7 @@ public class DocumentedFailure {
             StringBuilder outputBuilder = new StringBuilder(summary);
             append(outputBuilder, contextualAdvice);
             append(outputBuilder, advice);
-            append(outputBuilder, documentation.getConsultDocumentationMessage());
+            append(outputBuilder, ((InternalDocLink) documentation).getConsultDocumentationMessage());
             return cause == null
                 ? new GradleException(outputBuilder.toString())
                 : new DocumentedExceptionWithCause(outputBuilder.toString(), cause);

--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerialization.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerialization.java
@@ -49,6 +49,7 @@ import org.gradle.api.problems.internal.DeprecationData;
 import org.gradle.api.problems.internal.DocLink;
 import org.gradle.api.problems.internal.FileLocation;
 import org.gradle.api.problems.internal.GeneralData;
+import org.gradle.api.problems.internal.InternalDocLink;
 import org.gradle.api.problems.internal.LineInFileLocation;
 import org.gradle.api.problems.internal.OffsetInFileLocation;
 import org.gradle.api.problems.internal.Problem;
@@ -401,7 +402,7 @@ public class ValidationProblemSerialization {
 
             out.beginObject();
             out.name("url").value(value.getUrl());
-            out.name("consultDocumentationMessage").value(value.getConsultDocumentationMessage());
+            out.name("consultDocumentationMessage").value(((InternalDocLink) value).getConsultDocumentationMessage());
             out.endObject();
         }
 
@@ -429,7 +430,7 @@ public class ValidationProblemSerialization {
 
             final String finalUrl = url;
             final String finalConsultDocumentationMessage = consultDocumentationMessage;
-            return new DocLink() {
+            return new InternalDocLink() {
                 @Override
                 public String getUrl() {
                     return finalUrl;

--- a/platforms/extensibility/plugin-development/src/test/groovy/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerializationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/test/groovy/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerializationTest.groovy
@@ -23,11 +23,11 @@ import org.gradle.api.problems.internal.AdditionalDataBuilderFactory
 import org.gradle.api.problems.internal.DefaultProblemReporter
 import org.gradle.api.problems.internal.DeprecationData
 import org.gradle.api.problems.internal.DeprecationDataSpec
-import org.gradle.api.problems.internal.DocLink
 import org.gradle.api.problems.internal.ExceptionProblemRegistry
 import org.gradle.api.problems.internal.GeneralData
 import org.gradle.api.problems.internal.GeneralDataSpec
 import org.gradle.api.problems.internal.GradleCoreProblemGroup
+import org.gradle.api.problems.internal.InternalDocLink
 import org.gradle.api.problems.internal.InternalProblemReporter
 import org.gradle.api.problems.internal.ProblemSummarizer
 import org.gradle.api.problems.internal.TypeValidationData
@@ -123,7 +123,7 @@ class ValidationProblemSerializationTest extends Specification {
      * Required to be a named, static class for serialization to work.
      * See https://google.github.io/gson/UserGuide.html#nested-classes-including-inner-classes
      */
-    class TestDocLink implements DocLink {
+    class TestDocLink implements InternalDocLink {
 
         @Override
         String getUrl() {

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultDocLink.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultDocLink.java
@@ -18,7 +18,7 @@ package org.gradle.api.problems.internal;
 
 import com.google.common.base.Preconditions;
 
-public class DefaultDocLink implements DocLink {
+public class DefaultDocLink implements InternalDocLink {
 
     private final String url;
 

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblem.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblem.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 
 @NonNullApi
-public class DefaultProblem implements Serializable, Problem {
+public class DefaultProblem implements Serializable, InternalProblem {
     private final ProblemDefinition problemDefinition;
     private final String contextualLabel;
     private final List<String> solutions;

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemBuilder.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemBuilder.java
@@ -73,7 +73,7 @@ public class DefaultProblemBuilder implements InternalProblemBuilder {
     }
 
     @Override
-    public Problem build() {
+    public InternalProblem build() {
         // id is mandatory
         if (getId() == null) {
             return invalidProblem("missing-id", "Problem id must be specified", null);
@@ -128,7 +128,7 @@ public class DefaultProblemBuilder implements InternalProblemBuilder {
         return DefaultLineInFileLocation.from(path, line);
     }
 
-    private Problem invalidProblem(String id, String displayName, @Nullable String contextualLabel) {
+    private InternalProblem invalidProblem(String id, String displayName, @Nullable String contextualLabel) {
         id(id, displayName, ProblemGroup.create(
             "problems-api",
             "Problems API")

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemReporter.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemReporter.java
@@ -80,7 +80,7 @@ public class DefaultProblemReporter implements InternalProblemReporter {
     @Override
     public RuntimeException throwing(Throwable exception, Collection<? extends Problem> problems) {
         for (Problem problem : problems) {
-            report(problem.toBuilder(additionalDataBuilderFactory).withException(transform(exception)).build());
+            report(((InternalProblem) problem).toBuilder(additionalDataBuilderFactory).withException(transform(exception)).build());
         }
         if (exception instanceof RuntimeException) {
             return (RuntimeException) exception;
@@ -140,7 +140,7 @@ public class DefaultProblemReporter implements InternalProblemReporter {
     @Override
     public void report(Problem problem, OperationIdentifier id) {
         String taskPath = ProblemTaskPathTracker.getTaskIdentityPath();
-        problem = taskPath == null ? problem : problem.toBuilder(additionalDataBuilderFactory).taskPathLocation(taskPath).build();
+        problem = taskPath == null ? problem : ((InternalProblem) problem).toBuilder(additionalDataBuilderFactory).taskPathLocation(taskPath).build();
         Throwable exception = problem.getException();
         if (exception != null) {
             exceptionProblemRegistry.onProblem(transform(exception), problem);

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalDocLink.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalDocLink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,12 @@
 
 package org.gradle.api.problems.internal;
 
+import java.io.Serializable;
 
-/**
- * A link to a documentation page.
- * <p>
- * Subtypes can represent different parts of the gradle documentation, e.g. the DSL reference, the user guide, etc.
- */
-public interface DocLink {
-
+public interface InternalDocLink extends DocLink, Serializable  {
     /**
-     * The URL to the documentation page.
+     * A message that tells the user to consult the documentation.
+     * There are currently 2 different messages used for this, hence this method.
      */
-    String getUrl();
+    String getConsultDocumentationMessage();
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblem.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,10 @@
 
 package org.gradle.api.problems.internal;
 
-
-/**
- * A link to a documentation page.
- * <p>
- * Subtypes can represent different parts of the gradle documentation, e.g. the DSL reference, the user guide, etc.
- */
-public interface DocLink {
+public interface InternalProblem extends Problem {
 
     /**
-     * The URL to the documentation page.
+     * Returns a problem builder with fields initialized with values from this instance.
      */
-    String getUrl();
+    InternalProblemBuilder toBuilder(AdditionalDataBuilderFactory additionalDataBuilderFactory);
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblemBuilder.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblemBuilder.java
@@ -28,7 +28,7 @@ public interface InternalProblemBuilder extends InternalProblemSpec {
      *
      * @return the new problem
      */
-    Problem build();
+    InternalProblem build();
 
     @Override
     InternalProblemBuilder id(ProblemId problemId);

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/Problem.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/Problem.java
@@ -80,9 +80,4 @@ public interface Problem {
      */
     @Nullable
     AdditionalData getAdditionalData();
-
-    /**
-     * Returns a problem builder with fields initialized with values from this instance.
-     */
-    InternalProblemBuilder toBuilder(AdditionalDataBuilderFactory additionalDataBuilderFactory);
 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/request/Receiver.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/request/Receiver.java
@@ -17,6 +17,7 @@
 package org.gradle.process.internal.worker.request;
 
 import org.gradle.api.NonNullApi;
+import org.gradle.api.problems.internal.InternalProblem;
 import org.gradle.api.problems.internal.Problem;
 import org.gradle.api.problems.internal.ProblemTaskPathTracker;
 import org.gradle.internal.UncheckedException;
@@ -126,7 +127,7 @@ public class Receiver implements ResponseProtocol, StreamCompletion, StreamFailu
 
     @Override
     public void reportProblem(Problem problem, OperationIdentifier id) {
-        problem = this.taskPath == null ? problem : problem.toBuilder(null).taskPathLocation(this.taskPath).build();
+        problem = this.taskPath == null ? problem : ((InternalProblem) problem).toBuilder(null).taskPathLocation(this.taskPath).build();
         problemProtocol.reportProblem(problem, id);
     }
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/ReceivedProblem.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/ReceivedProblem.groovy
@@ -22,13 +22,13 @@ import org.gradle.api.problems.ProblemId
 import org.gradle.api.problems.Severity
 import org.gradle.api.problems.internal.AdditionalData
 import org.gradle.api.problems.internal.AdditionalDataBuilderFactory
-import org.gradle.api.problems.internal.DocLink
 import org.gradle.api.problems.internal.FileLocation
+import org.gradle.api.problems.internal.InternalDocLink
+import org.gradle.api.problems.internal.InternalProblem
 import org.gradle.api.problems.internal.InternalProblemBuilder
 import org.gradle.api.problems.internal.LineInFileLocation
 import org.gradle.api.problems.internal.OffsetInFileLocation
 import org.gradle.api.problems.internal.PluginIdLocation
-import org.gradle.api.problems.internal.Problem
 import org.gradle.api.problems.internal.ProblemDefinition
 import org.gradle.api.problems.internal.ProblemLocation
 import org.gradle.api.problems.internal.TaskPathLocation
@@ -37,7 +37,7 @@ import org.gradle.api.problems.internal.TaskPathLocation
  * A deserialized representation of a problem received from the build operation trace.
  */
 @CompileStatic
-class ReceivedProblem implements Problem {
+class ReceivedProblem implements InternalProblem {
     private final long operationId
     private final ReceivedProblemDefinition definition
     private final String contextualLabel
@@ -257,7 +257,7 @@ class ReceivedProblem implements Problem {
         }
     }
 
-    static class ReceivedDocumentationLink implements DocLink {
+    static class ReceivedDocumentationLink implements InternalDocLink {
         private final String url
         private final String consultDocumentationMessage
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

Cleanup work before moving the `Problem` interface to the public API
- Introduce InternalProblem interface and move `toBuilder()` method from Problem to InternalProblem
- Introduce `InternalDocLink` and  move Gradle internal-specific parts to it.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
