### PR TITLE
Fix Open Graph metadata on release notes for Gradle 8.12

### DIFF
--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -1,4 +1,4 @@
-<meta property="og:image" content="https://gradle.org/images/releases/gradle-8.12" />
+<meta property="og:image" content="https://gradle.org/images/releases/gradle-8.12.png" />
 <meta property="og:type"  content="website" />
 <meta property="og:title" content="Gradle 8.12 Release Notes" />
 

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -1,6 +1,14 @@
 <meta property="og:image" content="https://gradle.org/images/releases/gradle-8.12.png" />
-<meta property="og:type"  content="website" />
+<meta property="og:type"  content="article" />
 <meta property="og:title" content="Gradle 8.12 Release Notes" />
+<meta property="og:site_name" content="Gradle Release Notes">
+<meta property="og:description" content="Enhanced error and warning reporting, file-system watching on Alpine Linux, and Swift 6 support.">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@gradle">
+<meta name="twitter:creator" content="@gradle">
+<meta name="twitter:title" content="Gradle 8.12 Release Notes">
+<meta name="twitter:description" content="Enhanced error and warning reporting, file-system watching on Alpine Linux, and Swift 6 support.">
+<meta name="twitter:image" content="https://gradle.org/images/releases/gradle-8.12.png">
 
 The Gradle team is excited to announce Gradle @version@.
 


### PR DESCRIPTION
### Details
This is a Documentation change ONLY.

### Context
- Open Graph metadata is broken on Gradle 8.12 release notes
- https://github.com/gradle/gradle/issues/31664