### PR TITLE
Correct suggestion about printing stack traces for deprecation warning

### DIFF
--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.internal.deprecation.DeprecationLogger
 import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler
 import org.gradle.util.internal.DefaultGradleVersion
-import org.gradle.util.internal.TextUtil
 
 class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
     public static final String PLUGIN_DEPRECATION_MESSAGE = 'The DeprecatedPlugin plugin has been deprecated'
@@ -305,10 +304,10 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         succeeds "tasks"
 
         and: "stack trace suggestion is printed"
-        result.assertOutputContains("\t(Run with -Dorg.gradle.deprecation.trace=true to print the full stack trace for this deprecation warning.)")
+        outputContains("\t(Run with -Dorg.gradle.deprecation.trace=true to print the full stack trace for this deprecation warning.)")
 
         and: "we can verify the stack trace is not printed"
-        String notExpected = """run(${TextUtil.normaliseFileAndLineSeparators(buildFile.absolutePath)}:4)
+        String notExpected = """run(${buildFile.absolutePath}:4)
 \tat org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory\$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java"""
         result.assertNotOutput(notExpected)
     }
@@ -328,10 +327,10 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         succeeds "tasks", "--stacktrace"
 
         and: "stack trace suggestion is printed"
-        result.assertOutputContains("\t(Run with -Dorg.gradle.deprecation.trace=true to print the full stack trace for this deprecation warning.)")
+        outputContains("\t(Run with -Dorg.gradle.deprecation.trace=true to print the full stack trace for this deprecation warning.)")
 
         and: "we can verify the stack trace is not printed"
-        String notExpected = """run(${TextUtil.normaliseFileAndLineSeparators(buildFile.absolutePath)}:4)
+        String notExpected = """run($buildFile.absolutePath}:4)
 \tat org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory\$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java"""
         result.assertNotOutput(notExpected)
     }
@@ -354,9 +353,9 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         result.assertNotOutput("\t(Run with -Dorg.gradle.deprecation.trace=true to print the full stack trace for this deprecation warning.)")
 
         and: "we can verify the part of the stack trace that should be unchanged is printed"
-        String expected = """run(${TextUtil.normaliseFileAndLineSeparators(buildFile.absolutePath)}:4)
+        String expected = """run(${buildFile.absolutePath}:4)
 \tat org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory\$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java"""
-        result.assertOutputContains(expected)
+        outputContains(expected)
     }
 
     String deprecatedMethodUsage() {

--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -21,10 +21,11 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.internal.deprecation.DeprecationLogger
 import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler
 import org.gradle.util.internal.DefaultGradleVersion
+import org.gradle.util.internal.TextUtil
 
 class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
     public static final String PLUGIN_DEPRECATION_MESSAGE = 'The DeprecatedPlugin plugin has been deprecated'
-    private static final String RUN_WITH_STACKTRACE = '(Run with --stacktrace to get the full stack trace of this deprecation warning.)'
+    private static final String RUN_WITH_STACKTRACE = "(Run with -D${LoggingDeprecatedFeatureHandler.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME}=true to print the full stack trace for this deprecation warning.)"
 
     def setup() {
         file('buildSrc/src/main/java/DeprecatedTask.java') << """
@@ -180,7 +181,7 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         output.count(PLUGIN_DEPRECATION_MESSAGE) == 1
 
         output.count('\tat') == 1
-        output.count('(Run with --stacktrace to get the full stack trace of this deprecation warning.)') == 1
+        output.count(RUN_WITH_STACKTRACE) == 1
     }
 
     def 'DeprecatedPlugin from applied script - #scenario'() {
@@ -287,6 +288,75 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
             outputContains("Build file '${file("buildSrc/build.gradle")}': line 5")
             outputContains("Build file '${buildFile}': line 5")
         }
+    }
+
+    def "prints correct deprecation trace property value to use to display stack traces for deprecation warnings"() {
+        disableProblemsApiCheck()
+
+        given:
+        buildFile << """
+            def myConf = project.configurations.resolvable("myConf")
+            def myDetached = project.configurations.detachedConfiguration()
+            myDetached.extendsFrom(myConf.get())
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Calling extendsFrom on configuration ':detachedConfiguration1' has been deprecated. This will fail with an error in Gradle 9.0. Detached configurations should not extend other configurations, this was extending: 'myConf'. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#detached_configurations_cannot_extend")
+        succeeds "tasks"
+
+        and: "stack trace suggestion is printed"
+        result.assertOutputContains("\t(Run with -Dorg.gradle.deprecation.trace=true to print the full stack trace for this deprecation warning.)")
+
+        and: "we can verify the stack trace is not printed"
+        String notExpected = """run(${TextUtil.normaliseFileAndLineSeparators(buildFile.absolutePath)}:4)
+\tat org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory\$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java"""
+        result.assertNotOutput(notExpected)
+    }
+
+    def "does not print stack traces for deprecation warnings if --stacktrace is set"() {
+        disableProblemsApiCheck()
+
+        given:
+        buildFile << """
+            def myConf = project.configurations.resolvable("myConf")
+            def myDetached = project.configurations.detachedConfiguration()
+            myDetached.extendsFrom(myConf.get())
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Calling extendsFrom on configuration ':detachedConfiguration1' has been deprecated. This will fail with an error in Gradle 9.0. Detached configurations should not extend other configurations, this was extending: 'myConf'. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#detached_configurations_cannot_extend")
+        succeeds "tasks", "--stacktrace"
+
+        and: "stack trace suggestion is printed"
+        result.assertOutputContains("\t(Run with -Dorg.gradle.deprecation.trace=true to print the full stack trace for this deprecation warning.)")
+
+        and: "we can verify the stack trace is not printed"
+        String notExpected = """run(${TextUtil.normaliseFileAndLineSeparators(buildFile.absolutePath)}:4)
+\tat org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory\$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java"""
+        result.assertNotOutput(notExpected)
+    }
+
+    def "prints stack traces for deprecation warnings if deprecation trace property value is set"() {
+        disableProblemsApiCheck()
+
+        given:
+        buildFile << """
+            def myConf = project.configurations.resolvable("myConf")
+            def myDetached = project.configurations.detachedConfiguration()
+            myDetached.extendsFrom(myConf.get())
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Calling extendsFrom on configuration ':detachedConfiguration1' has been deprecated. This will fail with an error in Gradle 9.0. Detached configurations should not extend other configurations, this was extending: 'myConf'. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#detached_configurations_cannot_extend")
+        succeeds "tasks", "-Dorg.gradle.deprecation.trace=true"
+
+        and: "stack trace suggestion is not printed"
+        result.assertNotOutput("\t(Run with -Dorg.gradle.deprecation.trace=true to print the full stack trace for this deprecation warning.)")
+
+        and: "we can verify the part of the stack trace that should be unchanged is printed"
+        String expected = """run(${TextUtil.normaliseFileAndLineSeparators(buildFile.absolutePath)}:4)
+\tat org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory\$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java"""
+        result.assertOutputContains(expected)
     }
 
     String deprecatedMethodUsage() {

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
@@ -55,7 +55,7 @@ public class LoggingDeprecatedFeatureHandler implements FeatureHandler<Deprecate
     private static final DocumentationRegistry DOCUMENTATION_REGISTRY = new DocumentationRegistry();
     private static final Logger LOGGER = LoggerFactory.getLogger(LoggingDeprecatedFeatureHandler.class);
     private static final String ELEMENT_PREFIX = "\tat ";
-    private static final String RUN_WITH_STACKTRACE_INFO = "\t(Run with --stacktrace to get the full stack trace of this deprecation warning.)";
+    private static final String RUN_WITH_STACKTRACE_INFO = "\t(Run with -D" + ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME + "=true to print the full stack trace for this deprecation warning.)";
     private static boolean traceLoggingEnabled;
 
     private final Set<String> loggedMessages = new CopyOnWriteArraySet<String>();

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/deprecation/LoggingDeprecatedFeatureHandlerTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/deprecation/LoggingDeprecatedFeatureHandlerTest.groovy
@@ -135,10 +135,10 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         and:
         events[0].message == TextUtil.toPlatformLineSeparators("""feature1 removal
 \tat some.KotlinGradleScript.foo(GradleScript.gradle.kts:31337)
-\t(Run with --stacktrace to get the full stack trace of this deprecation warning.)""")
+\t(Run with -D${LoggingDeprecatedFeatureHandler.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME}=true to print the full stack trace for this deprecation warning.)""")
         events[1].message == TextUtil.toPlatformLineSeparators("""feature1 removal
 \tat some.KotlinGradleScript.foo(GradleScript.gradle.kts:7)
-\t(Run with --stacktrace to get the full stack trace of this deprecation warning.)""")
+\t(Run with -D${LoggingDeprecatedFeatureHandler.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME}=true to print the full stack trace for this deprecation warning.)""")
 
         where:
         fakeStackTrace1 = [

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -37,6 +37,12 @@ It renders metadata!
 
 TODO: JVM Team should finish this placeholder
 
+### Error and warning reporting improvements
+
+#### Deprecation warnings full stack trace flag corrected
+
+The instructions printed under a deprecation warning now correctly indicate how to enable full stack traces for deprecation warnings.
+
 <!-- Do not add breaking changes or deprecations here! Add them to the upgrade guide instead. -->
 
 <!--


### PR DESCRIPTION
Gradle's printed suggestion was incorrect - it's not `--stacktrace` that makes these appear, it's `org.gradle.deprecation.trace`.