### PR TITLE
Refactor report tabs to allow multiple levels

### DIFF
--- a/platforms/core-runtime/report-rendering/src/main/java/org/gradle/reporting/TabsRenderer.java
+++ b/platforms/core-runtime/report-rendering/src/main/java/org/gradle/reporting/TabsRenderer.java
@@ -34,23 +34,19 @@ public class TabsRenderer<T> extends ReportRenderer<T, SimpleHtmlWriter> {
 
     @Override
     public void render(T model, SimpleHtmlWriter htmlWriterWriter) throws IOException {
-        htmlWriterWriter.startElement("div").attribute("id", "tabs");
+        htmlWriterWriter.startElement("div").attribute("class", "tab-container");
             htmlWriterWriter.startElement("ul").attribute("class", "tabLinks");
-                for (int i = 0; i < this.tabs.size(); i++) {
-                    TabDefinition tab = this.tabs.get(i);
-                    String tabId = "tab" + i;
+                for (TabDefinition tab : this.tabs) {
                     htmlWriterWriter.startElement("li");
-                        htmlWriterWriter.startElement("a").attribute("href", "#" + tabId).characters(tab.title).endElement();
+                    htmlWriterWriter.startElement("a").attribute("href", "#").characters(tab.title).endElement();
                     htmlWriterWriter.endElement();
                 }
             htmlWriterWriter.endElement();
 
-            for (int i = 0; i < this.tabs.size(); i++) {
-                TabDefinition tab = this.tabs.get(i);
-                String tabId = "tab" + i;
-                htmlWriterWriter.startElement("div").attribute("id", tabId).attribute("class", "tab");
-                    htmlWriterWriter.startElement("h2").characters(tab.title).endElement();
-                    tab.renderer.render(model, htmlWriterWriter);
+            for (TabDefinition tab : this.tabs) {
+                htmlWriterWriter.startElement("div").attribute("class", "tab");
+                htmlWriterWriter.startElement("h2").characters(tab.title).endElement();
+                tab.renderer.render(model, htmlWriterWriter);
                 htmlWriterWriter.endElement();
             }
         htmlWriterWriter.endElement();

--- a/platforms/core-runtime/report-rendering/src/test/groovy/org/gradle/reporting/TabsRendererTest.groovy
+++ b/platforms/core-runtime/report-rendering/src/test/groovy/org/gradle/reporting/TabsRendererTest.groovy
@@ -42,11 +42,12 @@ class TabsRendererTest extends Specification {
 
         def html = html(writer.toString());
         then:
-        html.select("div#tabs > ul > li > a").find { it.text() == "tab 1" }
-        html.select("div#tabs > ul > li > a").find { it.text() == "tab 2" }
+        html.select("div.tab-container > ul > li > a").find { it.text() == "tab 1" }
+        html.select("div.tab-container > ul > li > a").find { it.text() == "tab 2" }
 
-        html.select("div#tabs > div#tab0 > h2").find { it.text() == "tab 1" }
-        html.select("div#tabs > div#tab1 > h2").find { it.text() == "tab 2" }
+        // There is a <ul> for the tabs above, so this starts from 2 and not 1 for the :nth-child selector
+        html.select("div.tab-container > div:nth-child(2) > h2").find { it.text() == "tab 1" }
+        html.select("div.tab-container > div:nth-child(3) > h2").find { it.text() == "tab 2" }
     }
 
     Document html(String renderedString) {

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/GenericPageRenderer.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/GenericPageRenderer.java
@@ -111,22 +111,23 @@ final class GenericPageRenderer extends TabbedPageRenderer<TestTreeModel> {
 
     @Override
     protected ReportRenderer<TestTreeModel, SimpleHtmlWriter> getContentRenderer() {
-        final TabsRenderer<TestTreeModel> tabsRenderer = new TabsRenderer<>();
+        TabsRenderer<TestTreeModel> rootTabsRenderer = new TabsRenderer<>();
         getModel().getPerRootInfo().forEach((rootName, info) -> {
-            // If there is only one root, don't show the root name in the tab title, since it's just confusing.
-            String tabPrefix = rootDisplayNames.size() == 1 ? "" : ("'" + rootDisplayNames.get(rootName) + "' ");
-            tabsRenderer.add(tabPrefix + "summary", new PerRootTabRenderer.ForSummary(rootName));
+            final TabsRenderer<TestTreeModel> tabsRenderer = new TabsRenderer<>();
+            tabsRenderer.add("summary", new PerRootTabRenderer.ForSummary(rootName));
             SerializableTestResultStore.OutputReader outputReader = outputReaders.get(rootName);
             if (outputReader.hasOutput(info.getOutputId(), TestOutputEvent.Destination.StdOut)) {
-                tabsRenderer.add(tabPrefix + "standard output", new PerRootTabRenderer.ForOutput(rootName, outputReader, TestOutputEvent.Destination.StdOut));
+                tabsRenderer.add("standard output", new PerRootTabRenderer.ForOutput(rootName, outputReader, TestOutputEvent.Destination.StdOut));
             }
             if (outputReader.hasOutput(info.getOutputId(), TestOutputEvent.Destination.StdErr)) {
-                tabsRenderer.add(tabPrefix + "error output", new PerRootTabRenderer.ForOutput(rootName, outputReader, TestOutputEvent.Destination.StdErr));
+                tabsRenderer.add("error output", new PerRootTabRenderer.ForOutput(rootName, outputReader, TestOutputEvent.Destination.StdErr));
             }
             if (!info.getMetadatas().isEmpty()) {
-                tabsRenderer.add(tabPrefix + "metadata", new PerRootTabRenderer.ForMetadata(rootName, metadataRendererRegistry));
+                tabsRenderer.add("metadata", new PerRootTabRenderer.ForMetadata(rootName, metadataRendererRegistry));
             }
+
+            rootTabsRenderer.add(rootDisplayNames.get(rootName), tabsRenderer);
         });
-        return tabsRenderer;
+        return rootTabsRenderer;
     }
 }

--- a/subprojects/core/src/main/resources/org/gradle/reporting/base-style.css
+++ b/subprojects/core/src/main/resources/org/gradle/reporting/base-style.css
@@ -11,10 +11,7 @@ body, a, a:visited {
 }
 
 #content {
-    padding-left: 50px;
-    padding-right: 50px;
-    padding-top: 30px;
-    padding-bottom: 30px;
+    padding: 30px 50px;
 }
 
 #content h1 {
@@ -52,30 +49,33 @@ h2 {
     font-size: 120%;
 }
 
+.tab-container .tab-container {
+    margin-left: 8px;
+}
+
 ul.tabLinks {
-    padding-left: 0;
-    padding-top: 10px;
-    padding-bottom: 10px;
+    padding: 0;
+    margin-bottom: 0;
     overflow: auto;
     min-width: 800px;
-    width: auto !important;
-    width: 800px;
+    width: auto;
+    border-bottom: solid 1px #aaa;
 }
 
 ul.tabLinks li {
     float: left;
     height: 100%;
     list-style: none;
-    padding-left: 10px;
-    padding-right: 10px;
-    padding-top: 5px;
-    padding-bottom: 5px;
-    margin-bottom: 0;
-    -moz-border-radius: 7px;
-    border-radius: 7px;
-    margin-right: 25px;
-    border: solid 1px #d4d4d4;
+    padding: 5px 10px;
+    border-radius: 7px 7px 0 0;
+    border: solid 1px transparent;
+    border-bottom: none;
+    margin-right: 6px;
     background-color: #f0f0f0;
+}
+
+ul.tabLinks li.deselected > a {
+    color: #6d6d6d;
 }
 
 ul.tabLinks li:hover {
@@ -84,7 +84,7 @@ ul.tabLinks li:hover {
 
 ul.tabLinks li.selected {
     background-color: #c5f0f5;
-    border-color: #c5f0f5;
+    border-color: #aaa;
 }
 
 ul.tabLinks a {
@@ -114,13 +114,12 @@ div.deselected {
 
 div.tab table {
     min-width: 350px;
-    width: auto !important;
-    width: 350px;
+    width: auto;
     border-collapse: collapse;
 }
 
 div.tab th, div.tab table {
-    border-bottom: solid #d0d0d0 1px;
+    border-bottom: solid 1px #d0d0d0;
 }
 
 div.tab th {
@@ -150,22 +149,18 @@ div.tab td.numeric, div.tab th.numeric {
 
 span.code {
     display: inline-block;
-    margin-top: 0em;
+    margin-top: 0;
     margin-bottom: 1em;
 }
 
 span.code pre {
     font-size: 11pt;
-    padding-top: 10px;
-    padding-bottom: 10px;
-    padding-left: 10px;
-    padding-right: 10px;
+    padding: 10px;
     margin: 0;
     background-color: #f7f7f7;
     border: solid 1px #d0d0d0;
     min-width: 700px;
-    width: auto !important;
-    width: 700px;
+    width: auto;
 }
 
 span.wrapped pre {

--- a/subprojects/core/src/main/resources/org/gradle/reporting/report.js
+++ b/subprojects/core/src/main/resources/org/gradle/reporting/report.js
@@ -1,8 +1,6 @@
 (function (window, document) {
     "use strict";
 
-    var tabs = {};
-
     function changeElementClass(element, classValue) {
         if (element.getAttribute("className")) {
             element.setAttribute("className", classValue);
@@ -27,19 +25,6 @@
         changeElementClass(element, getClassAttribute(element).replace(classValue, ""));
     }
 
-    function initTabs() {
-        var container = document.getElementById("tabs");
-
-        tabs.tabs = findTabs(container);
-        tabs.titles = findTitles(tabs.tabs);
-        tabs.headers = findHeaders(container);
-        tabs.select = select;
-        tabs.deselectAll = deselectAll;
-        tabs.select(0);
-
-        return true;
-    }
-
     function getCheckBox() {
         return document.getElementById("line-wrapping-toggle");
     }
@@ -49,26 +34,29 @@
     }
 
     function findCodeBlocks() {
-        var spans = document.getElementById("tabs").getElementsByTagName("span");
-        var codeBlocks = [];
-        for (var i = 0; i < spans.length; ++i) {
-            if (spans[i].className.indexOf("code") >= 0) {
-                codeBlocks.push(spans[i]);
+        const codeBlocks = [];
+        const tabContainers = getTabContainers();
+        for (let i = 0; i < tabContainers.length; i++) {
+            const spans = tabContainers[i].getElementsByTagName("span");
+            for (let i = 0; i < spans.length; ++i) {
+                if (spans[i].className.indexOf("code") >= 0) {
+                    codeBlocks.push(spans[i]);
+                }
             }
         }
         return codeBlocks;
     }
 
     function forAllCodeBlocks(operation) {
-        var codeBlocks = findCodeBlocks();
+        const codeBlocks = findCodeBlocks();
 
-        for (var i = 0; i < codeBlocks.length; ++i) {
+        for (let i = 0; i < codeBlocks.length; ++i) {
             operation(codeBlocks[i], "wrapped");
         }
     }
 
     function toggleLineWrapping() {
-        var checkBox = getCheckBox();
+        const checkBox = getCheckBox();
 
         if (checkBox.checked) {
             forAllCodeBlocks(addClass);
@@ -79,8 +67,8 @@
 
     function initControls() {
         if (findCodeBlocks().length > 0) {
-            var checkBox = getCheckBox();
-            var label = getLabelForCheckBox();
+            const checkBox = getCheckBox();
+            const label = getLabelForCheckBox();
 
             checkBox.onclick = toggleLineWrapping;
             checkBox.checked = false;
@@ -89,53 +77,89 @@
          }
     }
 
-    function switchTab() {
-        var id = this.id.substr(1);
+    class TabManager {
+        baseId;
+        tabs;
+        titles;
+        headers;
 
-        for (var i = 0; i < tabs.tabs.length; i++) {
-            if (tabs.tabs[i].id === id) {
-                tabs.select(i);
-                break;
-            }
+        constructor(baseId, tabs, titles, headers) {
+            this.baseId = baseId;
+            this.tabs = tabs;
+            this.titles = titles;
+            this.headers = headers;
         }
 
-        return false;
-    }
+        select(i) {
+            this.deselectAll();
 
-    function select(i) {
-        this.deselectAll();
-
-        changeElementClass(this.tabs[i], "tab selected");
-        changeElementClass(this.headers[i], "selected");
-
-        while (this.headers[i].firstChild) {
-            this.headers[i].removeChild(this.headers[i].firstChild);
-        }
-
-        var h2 = document.createElement("H2");
-
-        h2.appendChild(document.createTextNode(this.titles[i]));
-        this.headers[i].appendChild(h2);
-    }
-
-    function deselectAll() {
-        for (var i = 0; i < this.tabs.length; i++) {
-            changeElementClass(this.tabs[i], "tab deselected");
-            changeElementClass(this.headers[i], "deselected");
+            changeElementClass(this.tabs[i], "tab selected");
+            changeElementClass(this.headers[i], "selected");
 
             while (this.headers[i].firstChild) {
                 this.headers[i].removeChild(this.headers[i].firstChild);
             }
 
-            var a = document.createElement("A");
+            const a = document.createElement("a");
 
-            a.setAttribute("id", "ltab" + i);
-            a.setAttribute("href", "#tab" + i);
-            a.onclick = switchTab;
             a.appendChild(document.createTextNode(this.titles[i]));
-
             this.headers[i].appendChild(a);
         }
+
+        deselectAll() {
+            for (let i = 0; i < this.tabs.length; i++) {
+                changeElementClass(this.tabs[i], "tab deselected");
+                changeElementClass(this.headers[i], "deselected");
+
+                while (this.headers[i].firstChild) {
+                    this.headers[i].removeChild(this.headers[i].firstChild);
+                }
+
+                const a = document.createElement("a");
+
+                const id = this.baseId + "-tab" + i;
+                a.setAttribute("id", id);
+                a.setAttribute("href", "#tab" + i);
+                a.onclick = () => {
+                    this.select(i);
+                    return false;
+                };
+                a.appendChild(document.createTextNode(this.titles[i]));
+
+                this.headers[i].appendChild(a);
+            }
+        }
+    }
+
+    function getTabContainers() {
+        const tabContainers = Array.from(document.getElementsByClassName("tab-container"));
+
+        // Used by existing TabbedPageRenderer users, which have not adjusted to use TabsRenderer yet.
+        const legacyContainer = document.getElementById("tabs");
+        if (legacyContainer) {
+            tabContainers.push(legacyContainer);
+        }
+
+        return tabContainers;
+    }
+
+    function initTabs() {
+        let tabGroups = 0;
+
+        function createTab(num, container) {
+            const tabElems = findTabs(container);
+            const tabManager = new TabManager("tabs" + num, tabElems, findTitles(tabElems), findHeaders(container));
+            tabManager.select(0);
+        }
+
+        const tabContainers = getTabContainers();
+
+        for (let i = 0; i < tabContainers.length; i++) {
+            createTab(tabGroups, tabContainers[i]);
+            tabGroups++;
+        }
+
+        return true;
     }
 
     function findTabs(container) {
@@ -143,16 +167,16 @@
     }
 
     function findHeaders(container) {
-        var owner = findChildElements(container, "UL", "tabLinks");
+        const owner = findChildElements(container, "UL", "tabLinks");
         return findChildElements(owner[0], "LI", null);
     }
 
     function findTitles(tabs) {
-        var titles = [];
+        const titles = [];
 
-        for (var i = 0; i < tabs.length; i++) {
-            var tab = tabs[i];
-            var header = findChildElements(tab, "H2", null)[0];
+        for (let i = 0; i < tabs.length; i++) {
+            const tab = tabs[i];
+            const header = findChildElements(tab, "H2", null)[0];
 
             header.parentNode.removeChild(header);
 
@@ -167,11 +191,11 @@
     }
 
     function findChildElements(container, name, targetClass) {
-        var elements = [];
-        var children = container.childNodes;
+        const elements = [];
+        const children = container.childNodes;
 
-        for (var i = 0; i < children.length; i++) {
-            var child = children.item(i);
+        for (let i = 0; i < children.length; i++) {
+            const child = children.item(i);
 
             if (child.nodeType === 1 && child.nodeName === name) {
                 if (targetClass && child.className.indexOf(targetClass) < 0) {


### PR DESCRIPTION
### Context
The existing design of tabs did not allow multiple levels of tabs, restricting the design of the new test report. This PR refactors the script that manages the tabs, and slightly adjusts the new test report to take advantage of this new feature, showing a level for the roots and a level for the summary/metadata/output of that root.

<img width="1674" alt="Screenshot 2024-12-18 at 11 22 10 AM" src="https://github.com/user-attachments/assets/8ae41595-ea15-4c82-85cd-470e6f0357ad" />

A side-effect of this PR is that the existing test report and the `--profile` report also have the new tab design, but given that IMO they look more like actual tabs now, I think this is a strict improvement.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
