### PR TITLE
Fix compatibility check for Kotlin collections

### DIFF
--- a/build-logic/binary-compatibility/src/main/kotlin/gradlebuild/binarycompatibility/sources/KotlinSourceQueries.kt
+++ b/build-logic/binary-compatibility/src/main/kotlin/gradlebuild/binarycompatibility/sources/KotlinSourceQueries.kt
@@ -274,7 +274,7 @@ fun CtClass.isLikelyEquivalentTo(ktTypeReference: KtTypeReference): Boolean {
         .trimEnd('?') // nullability is not part of JVM types
         .substringBefore('<') // generics are not part of parameter types in JVM method signatures
 
-    val thisTypeAsKt = primitiveTypeStrings[name] ?: name
+    val thisTypeAsKt = name.mapJavaTypeToKotlinType()
     return thisTypeAsKt.endsWith(ktTypeRawName)
 }
 
@@ -292,6 +292,13 @@ fun KtDeclaration.isDocumentedAsSince(version: String) =
 private
 fun KDoc.isSince(version: String) =
     text.contains("@since $version")
+
+
+private
+fun String.mapJavaTypeToKotlinType(): String {
+    val javaTypeName = this
+    return primitiveTypeStrings[javaTypeName] ?: collectionTypeStrings[javaTypeName] ?: javaTypeName
+}
 
 
 // TODO:kotlin-dsl dedupe with KotlinTypeStrings.primitiveTypeStrings
@@ -316,4 +323,24 @@ val primitiveTypeStrings =
         "float" to "Float",
         "java.lang.Double" to "Double",
         "double" to "Double"
+    )
+
+
+// See `org.gradle.kotlin.dsl.internal.sharedruntime.codegen.ApiTypeProviderKt.mappedTypeStrings`
+private
+val collectionTypeStrings =
+    mapOf(
+        "java.lang.Iterable" to "kotlin.collections.Iterable",
+        "java.util.Iterator" to "kotlin.collections.Iterator",
+        "java.util.ListIterator" to "kotlin.collections.ListIterator",
+        "java.util.Collection" to "kotlin.collections.Collection",
+        "java.util.List" to "kotlin.collections.List",
+        "java.util.ArrayList" to "kotlin.collections.ArrayList",
+        "java.util.Set" to "kotlin.collections.Set",
+        "java.util.HashSet" to "kotlin.collections.HashSet",
+        "java.util.LinkedHashSet" to "kotlin.collections.LinkedHashSet",
+        "java.util.Map" to "kotlin.collections.Map",
+        "java.util.Map\$Entry" to "kotlin.collections.Map.Entry",
+        "java.util.HashMap" to "kotlin.collections.HashMap",
+        "java.util.LinkedHashMap" to "kotlin.collections.LinkedHashMap"
     )

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractBinaryCompatibilityTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractBinaryCompatibilityTest.kt
@@ -20,8 +20,9 @@ import org.gradle.kotlin.dsl.*
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.UnexpectedBuildFailure
-import org.hamcrest.CoreMatchers
+import org.hamcrest.Matcher
 import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -380,23 +381,23 @@ abstract class AbstractBinaryCompatibilityTest {
         }
 
         fun assertHasErrors(vararg errors: String) {
-            assertThat("Has errors", richReport.errors.map { it.message }, CoreMatchers.equalTo(errors.toList()))
+            assertThat("Has errors", richReport.errors.map { it.message }, inAnyOrder(errors))
         }
 
         fun assertHasWarnings(vararg warnings: String) {
-            assertThat("Has warnings", richReport.warnings.map { it.message }, CoreMatchers.equalTo(warnings.toList()))
+            assertThat("Has warnings", richReport.warnings.map { it.message }, inAnyOrder(warnings))
         }
 
         fun assertHasInformation(vararg information: String) {
-            assertThat("Has information", richReport.information.map { it.message }, CoreMatchers.equalTo(information.toList()))
+            assertThat("Has information", richReport.information.map { it.message }, inAnyOrder(information))
         }
 
         fun assertHasAccepted(vararg accepted: String) {
-            assertThat("Has accepted", richReport.accepted.map { it.message }, CoreMatchers.equalTo(accepted.toList()))
+            assertThat("Has accepted", richReport.accepted.map { it.message }, inAnyOrder(accepted))
         }
 
         fun assertHasAccepted(vararg accepted: Pair<String, List<String>>) {
-            assertThat("Has accepted", richReport.accepted, CoreMatchers.equalTo(accepted.map { ReportMessage(it.first, it.second) }))
+            assertThat("Has accepted", richReport.accepted, inAnyOrder(accepted.map { ReportMessage(it.first, it.second) }))
         }
 
         fun assertHasErrors(vararg errors: List<String>) {
@@ -404,8 +405,18 @@ abstract class AbstractBinaryCompatibilityTest {
         }
 
         fun assertHasErrors(vararg errorWithDetail: Pair<String, List<String>>) {
-            assertThat("Has errors", richReport.errors, CoreMatchers.equalTo(errorWithDetail.map { ReportMessage(it.first, it.second) }))
+            assertThat("Has errors", richReport.errors, inAnyOrder(errorWithDetail.map { ReportMessage(it.first, it.second) }))
         }
+
+        private
+        inline fun <reified T> inAnyOrder(items: List<T>): Matcher<Iterable<T>> = inAnyOrder(items.toTypedArray())
+
+        /**
+         * Matcher checking each item is present exactly once in a given iterable, but an any position,
+         * and that there are no unexpected items.
+         */
+        private
+        fun <T> inAnyOrder(items: Array<out T>): Matcher<Iterable<T>> = Matchers.containsInAnyOrder(*items)
 
         fun newApi(thing: String, desc: String): String =
             "$thing ${describe(thing, desc)}: New public API in 2.0 (@Incubating)"

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/SinceAndIncubatingRulesKotlinTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/SinceAndIncubatingRulesKotlinTest.kt
@@ -51,6 +51,20 @@ class SinceAndIncubatingRulesKotlinTest : AbstractBinaryCompatibilityTest() {
 
         operator fun String.invoke(p: String, block: String.() -> Unit) = Unit
 
+        ${""/* For Kotlin DSL, we generate sources with collection types mapped to the Kotlin ones. See `org.gradle.kotlin.dsl.internal.sharedruntime.codegen.ApiTypeProviderKt#mappedTypeStrings` */}
+
+        fun wrap(a: kotlin.collections.Iterable<String>, b: kotlin.collections.Iterator<String>, c: kotlin.collections.ListIterator<String>): Unit = Unit
+
+        fun wrap(a: kotlin.collections.Collection<String>): Unit = Unit
+
+        fun wrap(a: kotlin.collections.List<String>, b: kotlin.collections.ArrayList<String>): Unit = Unit
+
+        fun wrap(a: kotlin.collections.Set<String>, b: kotlin.collections.HashSet<String>, c: kotlin.collections.LinkedHashSet<String>): Unit = Unit
+
+        fun wrap(a: kotlin.collections.Map<String, String>, b: kotlin.collections.Map.Entry<String, String>): Unit = Unit
+
+        fun wrap(a: kotlin.collections.HashMap<String, String>, b: kotlin.collections.LinkedHashMap<String, String>): Unit = Unit
+
     """
 
     private
@@ -111,6 +125,30 @@ class SinceAndIncubatingRulesKotlinTest : AbstractBinaryCompatibilityTest() {
         @Incubating
         operator fun String.invoke(p: String, block: String.() -> Unit) = Unit
 
+        /** @since 2.0 */
+        @Incubating
+        fun wrap(a: kotlin.collections.Iterable<String>, b: kotlin.collections.Iterator<String>, c: kotlin.collections.ListIterator<String>): Unit = Unit
+
+        /** @since 2.0 */
+        @Incubating
+        fun wrap(a: kotlin.collections.Collection<String>): Unit = Unit
+
+        /** @since 2.0 */
+        @Incubating
+        fun wrap(a: kotlin.collections.List<String>, b: kotlin.collections.ArrayList<String>): Unit = Unit
+
+        /** @since 2.0 */
+        @Incubating
+        fun wrap(a: kotlin.collections.Set<String>, b: kotlin.collections.HashSet<String>, c: kotlin.collections.LinkedHashSet<String>): Unit = Unit
+
+        /** @since 2.0 */
+        @Incubating
+        fun wrap(a: kotlin.collections.Map<String, String>, b: kotlin.collections.Map.Entry<String, String>): Unit = Unit
+
+        /** @since 2.0 */
+        @Incubating
+        fun wrap(a: kotlin.collections.HashMap<String, String>, b: kotlin.collections.LinkedHashMap<String, String>): Unit = Unit
+
     """
 
     @Test
@@ -150,6 +188,12 @@ class SinceAndIncubatingRulesKotlinTest : AbstractBinaryCompatibilityTest() {
                 added("Method", "SourceKt.setBazarExt(int,java.lang.String)"),
                 added("Method", "SourceKt.setBazool(boolean)"),
                 added("Method", "SourceKt.setFool(boolean)"),
+                added("Method", "SourceKt.wrap(java.lang.Iterable,java.util.Iterator,java.util.ListIterator)"),
+                added("Method", "SourceKt.wrap(java.util.Collection)"),
+                added("Method", "SourceKt.wrap(java.util.HashMap,java.util.LinkedHashMap)"),
+                added("Method", "SourceKt.wrap(java.util.List,java.util.ArrayList)"),
+                added("Method", "SourceKt.wrap(java.util.Map,java.util.Map\$Entry)"),
+                added("Method", "SourceKt.wrap(java.util.Set,java.util.HashSet,java.util.LinkedHashSet)"),
             )
         }
 
@@ -188,6 +232,12 @@ class SinceAndIncubatingRulesKotlinTest : AbstractBinaryCompatibilityTest() {
                 newApi("Method", "SourceKt.setBazarExt(int,java.lang.String)"),
                 newApi("Method", "SourceKt.setBazool(boolean)"),
                 newApi("Method", "SourceKt.setFool(boolean)"),
+                newApi("Method", "SourceKt.wrap(java.lang.Iterable,java.util.Iterator,java.util.ListIterator)"),
+                newApi("Method", "SourceKt.wrap(java.util.Collection)"),
+                newApi("Method", "SourceKt.wrap(java.util.HashMap,java.util.LinkedHashMap)"),
+                newApi("Method", "SourceKt.wrap(java.util.List,java.util.ArrayList)"),
+                newApi("Method", "SourceKt.wrap(java.util.Map,java.util.Map\$Entry)"),
+                newApi("Method", "SourceKt.wrap(java.util.Set,java.util.HashSet,java.util.LinkedHashSet)"),
             )
         }
 
@@ -231,6 +281,12 @@ class SinceAndIncubatingRulesKotlinTest : AbstractBinaryCompatibilityTest() {
                 newApi("Method", "SourceKt.setBazarExt(int,java.lang.String)"),
                 newApi("Method", "SourceKt.setBazool(boolean)"),
                 newApi("Method", "SourceKt.setFool(boolean)"),
+                newApi("Method", "SourceKt.wrap(java.lang.Iterable,java.util.Iterator,java.util.ListIterator)"),
+                newApi("Method", "SourceKt.wrap(java.util.Collection)"),
+                newApi("Method", "SourceKt.wrap(java.util.HashMap,java.util.LinkedHashMap)"),
+                newApi("Method", "SourceKt.wrap(java.util.List,java.util.ArrayList)"),
+                newApi("Method", "SourceKt.wrap(java.util.Map,java.util.Map\$Entry)"),
+                newApi("Method", "SourceKt.wrap(java.util.Set,java.util.HashSet,java.util.LinkedHashSet)"),
             )
         }
     }
@@ -359,7 +415,13 @@ class SinceAndIncubatingRulesKotlinTest : AbstractBinaryCompatibilityTest() {
                 added("Method", "Bar.setBazarExt(int,java.lang.String)"),
                 added("Method", "Bar.setBazool(boolean)"),
                 added("Method", "Bar.setFool(boolean)"),
-                added("Method", "Foo.foo()")
+                added("Method", "Foo.foo()"),
+                added("Method", "Bar.wrap(java.lang.Iterable,java.util.Iterator,java.util.ListIterator)"),
+                added("Method", "Bar.wrap(java.util.Collection)"),
+                added("Method", "Bar.wrap(java.util.HashMap,java.util.LinkedHashMap)"),
+                added("Method", "Bar.wrap(java.util.List,java.util.ArrayList)"),
+                added("Method", "Bar.wrap(java.util.Map,java.util.Map\$Entry)"),
+                added("Method", "Bar.wrap(java.util.Set,java.util.HashSet,java.util.LinkedHashSet)"),
             )
         }
 
@@ -407,6 +469,12 @@ class SinceAndIncubatingRulesKotlinTest : AbstractBinaryCompatibilityTest() {
                 newApi("Method", "Bar.setBazool(boolean)"),
                 newApi("Method", "Bar.setFool(boolean)"),
                 newApi("Method", "Foo.foo()"),
+                newApi("Method", "Bar.wrap(java.lang.Iterable,java.util.Iterator,java.util.ListIterator)"),
+                newApi("Method", "Bar.wrap(java.util.Collection)"),
+                newApi("Method", "Bar.wrap(java.util.HashMap,java.util.LinkedHashMap)"),
+                newApi("Method", "Bar.wrap(java.util.List,java.util.ArrayList)"),
+                newApi("Method", "Bar.wrap(java.util.Map,java.util.Map\$Entry)"),
+                newApi("Method", "Bar.wrap(java.util.Set,java.util.HashSet,java.util.LinkedHashSet)"),
             )
         }
     }

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/SinceAndIncubatingRulesKotlinTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/SinceAndIncubatingRulesKotlinTest.kt
@@ -135,8 +135,8 @@ class SinceAndIncubatingRulesKotlinTest : AbstractBinaryCompatibilityTest() {
 
                 added("Field", "cathedral"),
                 added("Method", "SourceKt.foo()"),
-                added("Method", "SourceKt.fooExt(java.lang.String)"),
                 added("Method", "SourceKt.fooExt(int)"),
+                added("Method", "SourceKt.fooExt(java.lang.String)"),
                 added("Method", "SourceKt.getBar()"),
                 added("Method", "SourceKt.getBarExt(java.lang.String)"),
                 added("Method", "SourceKt.getBazar()"),
@@ -149,7 +149,7 @@ class SinceAndIncubatingRulesKotlinTest : AbstractBinaryCompatibilityTest() {
                 added("Method", "SourceKt.setBazar(java.lang.String)"),
                 added("Method", "SourceKt.setBazarExt(int,java.lang.String)"),
                 added("Method", "SourceKt.setBazool(boolean)"),
-                added("Method", "SourceKt.setFool(boolean)")
+                added("Method", "SourceKt.setFool(boolean)"),
             )
         }
 
@@ -173,8 +173,8 @@ class SinceAndIncubatingRulesKotlinTest : AbstractBinaryCompatibilityTest() {
             assertHasInformation(
                 newApi("Field", "cathedral"),
                 newApi("Method", "SourceKt.foo()"),
-                newApi("Method", "SourceKt.fooExt(java.lang.String)"),
                 newApi("Method", "SourceKt.fooExt(int)"),
+                newApi("Method", "SourceKt.fooExt(java.lang.String)"),
                 newApi("Method", "SourceKt.getBar()"),
                 newApi("Method", "SourceKt.getBarExt(java.lang.String)"),
                 newApi("Method", "SourceKt.getBazar()"),
@@ -187,7 +187,7 @@ class SinceAndIncubatingRulesKotlinTest : AbstractBinaryCompatibilityTest() {
                 newApi("Method", "SourceKt.setBazar(java.lang.String)"),
                 newApi("Method", "SourceKt.setBazarExt(int,java.lang.String)"),
                 newApi("Method", "SourceKt.setBazool(boolean)"),
-                newApi("Method", "SourceKt.setFool(boolean)")
+                newApi("Method", "SourceKt.setFool(boolean)"),
             )
         }
 
@@ -216,8 +216,8 @@ class SinceAndIncubatingRulesKotlinTest : AbstractBinaryCompatibilityTest() {
                 newApi("Class", "SourceKt"),
                 newApi("Field", "cathedral"),
                 newApi("Method", "SourceKt.foo()"),
-                newApi("Method", "SourceKt.fooExt(java.lang.String)"),
                 newApi("Method", "SourceKt.fooExt(int)"),
+                newApi("Method", "SourceKt.fooExt(java.lang.String)"),
                 newApi("Method", "SourceKt.getBar()"),
                 newApi("Method", "SourceKt.getBarExt(java.lang.String)"),
                 newApi("Method", "SourceKt.getBazar()"),
@@ -230,7 +230,7 @@ class SinceAndIncubatingRulesKotlinTest : AbstractBinaryCompatibilityTest() {
                 newApi("Method", "SourceKt.setBazar(java.lang.String)"),
                 newApi("Method", "SourceKt.setBazarExt(int,java.lang.String)"),
                 newApi("Method", "SourceKt.setBazool(boolean)"),
-                newApi("Method", "SourceKt.setFool(boolean)")
+                newApi("Method", "SourceKt.setFool(boolean)"),
             )
         }
     }
@@ -258,14 +258,14 @@ class SinceAndIncubatingRulesKotlinTest : AbstractBinaryCompatibilityTest() {
             assertHasNoWarning()
             assertHasErrors(
                 added("Class", "Bar"),
-                added("Constructor", "Bar()"),
                 added("Class", "Bazar"),
+                added("Class", "Cathedral"),
+                added("Class", "Foo"),
+                added("Constructor", "Bar()"),
+                added("Field", "INSTANCE"),
                 added("Method", "Bazar.getEntries()"),
                 added("Method", "Bazar.valueOf(java.lang.String)"),
                 added("Method", "Bazar.values()"),
-                added("Class", "Cathedral"),
-                added("Field", "INSTANCE"),
-                added("Class", "Foo")
             )
         }
 
@@ -295,12 +295,12 @@ class SinceAndIncubatingRulesKotlinTest : AbstractBinaryCompatibilityTest() {
             assertHasInformation(
                 newApi("Class", "Bar"),
                 newApi("Class", "Bazar"),
+                newApi("Class", "Cathedral"),
+                newApi("Class", "Foo"),
+                newApi("Field", "INSTANCE"),
                 newApi("Method", "Bazar.getEntries()"),
                 newApi("Method", "Bazar.valueOf(java.lang.String)"),
                 newApi("Method", "Bazar.values()"),
-                newApi("Class", "Cathedral"),
-                newApi("Field", "INSTANCE"),
-                newApi("Class", "Foo")
             )
         }
     }
@@ -342,9 +342,10 @@ class SinceAndIncubatingRulesKotlinTest : AbstractBinaryCompatibilityTest() {
             assertHasNoInformation()
             assertHasNoWarning()
             assertHasErrors(
+                added("Constructor", "Bar(java.lang.String)"),
                 added("Method", "Bar.foo()"),
-                added("Method", "Bar.fooExt(java.lang.String)"),
                 added("Method", "Bar.fooExt(int)"),
+                added("Method", "Bar.fooExt(java.lang.String)"),
                 added("Method", "Bar.getBar()"),
                 added("Method", "Bar.getBarExt(java.lang.String)"),
                 added("Method", "Bar.getBazar()"),
@@ -358,7 +359,6 @@ class SinceAndIncubatingRulesKotlinTest : AbstractBinaryCompatibilityTest() {
                 added("Method", "Bar.setBazarExt(int,java.lang.String)"),
                 added("Method", "Bar.setBazool(boolean)"),
                 added("Method", "Bar.setFool(boolean)"),
-                added("Constructor", "Bar(java.lang.String)"),
                 added("Method", "Foo.foo()")
             )
         }
@@ -391,8 +391,8 @@ class SinceAndIncubatingRulesKotlinTest : AbstractBinaryCompatibilityTest() {
             assertHasNoWarning()
             assertHasInformation(
                 newApi("Method", "Bar.foo()"),
-                newApi("Method", "Bar.fooExt(java.lang.String)"),
                 newApi("Method", "Bar.fooExt(int)"),
+                newApi("Method", "Bar.fooExt(java.lang.String)"),
                 newApi("Method", "Bar.getBar()"),
                 newApi("Method", "Bar.getBarExt(java.lang.String)"),
                 newApi("Method", "Bar.getBazar()"),
@@ -406,7 +406,7 @@ class SinceAndIncubatingRulesKotlinTest : AbstractBinaryCompatibilityTest() {
                 newApi("Method", "Bar.setBazarExt(int,java.lang.String)"),
                 newApi("Method", "Bar.setBazool(boolean)"),
                 newApi("Method", "Bar.setFool(boolean)"),
-                newApi("Method", "Foo.foo()")
+                newApi("Method", "Foo.foo()"),
             )
         }
     }

--- a/build-logic/kotlin-dsl-shared-runtime/src/main/kotlin/org/gradle/kotlin/dsl/internal/sharedruntime/codegen/ApiTypeProvider.kt
+++ b/build-logic/kotlin-dsl-shared-runtime/src/main/kotlin/org/gradle/kotlin/dsl/internal/sharedruntime/codegen/ApiTypeProvider.kt
@@ -633,7 +633,7 @@ val mappedTypeStrings =
         "java.util.HashSet" to "kotlin.collections.HashSet",
         "java.util.LinkedHashSet" to "kotlin.collections.LinkedHashSet",
         "java.util.Map" to "kotlin.collections.Map",
-        "java.util.Map.Entry" to "kotlin.collections.Map.Entry",
+        "java.util.Map\$Entry" to "kotlin.collections.Map.Entry",
         "java.util.HashMap" to "kotlin.collections.HashMap",
         "java.util.LinkedHashMap" to "kotlin.collections.LinkedHashMap"
     )

--- a/build-logic/kotlin-dsl-shared-runtime/src/main/kotlin/org/gradle/kotlin/dsl/internal/sharedruntime/codegen/ApiTypeProvider.kt
+++ b/build-logic/kotlin-dsl-shared-runtime/src/main/kotlin/org/gradle/kotlin/dsl/internal/sharedruntime/codegen/ApiTypeProvider.kt
@@ -623,7 +623,7 @@ val mappedTypeStrings =
         "java.lang.Number" to "kotlin.Number",
         "java.lang.Throwable" to "kotlin.Throwable",
         // Collections
-        "java.util.Iterable" to "kotlin.collections.Iterable",
+        "java.lang.Iterable" to "kotlin.collections.Iterable",
         "java.util.Iterator" to "kotlin.collections.Iterator",
         "java.util.ListIterator" to "kotlin.collections.ListIterator",
         "java.util.Collection" to "kotlin.collections.Collection",


### PR DESCRIPTION
This PR fixes a case for our binary compatibility check by making it understand Kotlin collection types.

Specifically, the validation of presence of `@Incubating` and `@since` was not complete with respect to Kotlin collection types, because the corresponding functions were not properly located in the Kotlin sources. We validate the annotation and kdoc elements based on the parsed Kotlin source.

Additionally, this PR fixes the mapping from some collection-related Java types (binary class names) to Kotlin types (class name to be used in generated source). Classes like `Iterable` and `Map.Entry` were misattributed in the existing mapping. However, it might not have been a problem, if we never generated Kotlin functions taking values of those types as parameters.

---

What sparked this fix was an attempt to add a new public API class that had the following structure:
```
/**
 * TBD
 *
 * @since 8.13
 */
@Incubating
interface ProjectModelScope {

    /**
     * TBD
     *
     * @since 8.13
     */
    <T> ProjectScopeModelRequest<T> request(Class<T> modelType, Collection<Project> projects);   
}
```

This new interface is correctly marked as incubating and the method has the `@since` javadoc. Because the method has a `Class<T>` parameter, we generate a Kotlin DSL accessor for it in the form of Kotlin sources:
```
/**
 * Kotlin extension function taking [kotlin.reflect.KClass] for [org.gradle.api.isolated.models.ProjectModelScope.request].
 *
 * @see org.gradle.api.isolated.models.ProjectModelScope.request
 * @since 8.13
 */
@org.gradle.api.Incubating
inline fun <T : Any> org.gradle.api.isolated.models.ProjectModelScope.`request`(`modelType`: kotlin.reflect.KClass<T>, `projects`: kotlin.collections.Collection<org.gradle.api.Project>): org.gradle.api.isolated.models.ProjectScopeModelRequest<T> =
    `request`(`modelType`.java, `projects`)
```

Note that we use a mapped `kotlin.collections.Collection` type. However, the binary compatibility infrastructure validates changes on the level of JVM signatures, which contain only the Java types and no Kotlin types, because the Kotlin compiler maps them back.

As a result, the Incubating+since validation was not able to locate this function in the generated Kotlin sources, because it's JVM type to Kotlin type mapping was flawed.