### PR TITLE
Fix branch qualifier in branch promotion

### DIFF
--- a/.teamcity/src/main/kotlin/promotion/PublishBranchSnapshotFromQuickFeedback.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishBranchSnapshotFromQuickFeedback.kt
@@ -21,12 +21,12 @@ import jetbrains.buildServer.configs.kotlin.RelativeId
 import vcsroots.gradlePromotionBranches
 
 object PublishBranchSnapshotFromQuickFeedback : PublishGradleDistributionFullBuild(
-    promotedBranch = "%branch.to.promote%",
+    promotedBranch = "%branch.qualifier%",
     triggerName = "QuickFeedback",
     prepTask = "prepSnapshot",
     promoteTask = "promoteSnapshot",
-    extraParameters = "-PpromotedBranch=%branch.qualifier% ",
-    vcsRootId = gradlePromotionBranches
+    extraParameters = "-PpromotedBranch=%branch.qualifier%",
+    vcsRootId = gradlePromotionBranches,
 ) {
     init {
         id("Promotion_PublishBranchSnapshotFromQuickFeedback")
@@ -36,12 +36,11 @@ object PublishBranchSnapshotFromQuickFeedback : PublishGradleDistributionFullBui
         val triggerName = this.triggerName
 
         params {
-            param("branch.qualifier", "%dep.${RelativeId("Check_Stage_${triggerName}_Trigger")}.teamcity.build.branch%")
             text(
-                "branch.to.promote",
-                "%branch.qualifier%",
-                label = "Branch to promote",
-                description = "Type in the branch of gradle/gradle you want to promote. Leave the default value when promoting an existing build.",
+                "branch.qualifier",
+                "%dep.${RelativeId("Check_Stage_${triggerName}_Trigger")}.teamcity.build.branch%",
+                label = "Branch qualifier for the distribution name",
+                description = "The published distribution name looks like '8.13-branch-%branch.qualifier%-20241217145847+0000'.",
                 display = ParameterDisplay.PROMPT,
                 allowEmpty = false
             )

--- a/.teamcity/src/test/kotlin/PromotionProjectTests.kt
+++ b/.teamcity/src/test/kotlin/PromotionProjectTests.kt
@@ -147,7 +147,7 @@ class PromotionProjectTests {
         val steps = nightlySnapshot.steps.items
         assertEquals(3, steps.size)
 
-        val expectedGradleParams = """-PcommitId=%dep.Gradle_Master_Check_Stage_QuickFeedback_Trigger.build.vcs.number% -PpromotedBranch=%branch.qualifier%  '-PgitUserName=bot-teamcity' '-PgitUserEmail=bot-teamcity@gradle.com' $pluginPortalUrlOverride -DenablePredictiveTestSelection=false %additional.gradle.parameters%"""
+        val expectedGradleParams = """-PcommitId=%dep.Gradle_Master_Check_Stage_QuickFeedback_Trigger.build.vcs.number% -PpromotedBranch=%branch.qualifier% '-PgitUserName=bot-teamcity' '-PgitUserEmail=bot-teamcity@gradle.com' $pluginPortalUrlOverride -DenablePredictiveTestSelection=false %additional.gradle.parameters%"""
 
         val checkReady = gradleStep(steps, 0)
         checkReady.assertTasks("prepSnapshot checkNeedToPromote")


### PR DESCRIPTION
In branch promotion, we have a `%branch.qualifier%` param, which is intended to be displayed in the published distribution: https://github.com/search?q=repo%3Agradle%2Fgradle-promote%20promotedBranch&type=code

Unfortunately, [it didn't work](https://gradle.slack.com/archives/CBSJ2GUTV/p1734515904851359). The description is also misleading: the param doesn't determine which revision to promote - it only determine the name of published distribution.

This PR made the following changes:

1. Remove the unnecessary `%branch.to.promote%` parameter.
2. Polish the description of `%branch.qualifier%`.

