### PR TITLE
Reapply "Disable PTS for promotion builds"

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -298,8 +298,22 @@ fun functionalTestParameters(os: Os, arch: Arch = Arch.AMD64): List<String> {
     )
 }
 
-fun promotionBuildParameters(dependencyBuildId: RelativeId, extraParameters: String, gitUserName: String, gitUserEmail: String) =
-    """-PcommitId=%dep.$dependencyBuildId.build.vcs.number% $extraParameters "-PgitUserName=$gitUserName" "-PgitUserEmail=$gitUserEmail" $pluginPortalUrlOverride %additional.gradle.parameters%"""
+fun promotionBuildParameters(
+    dependencyBuildId: RelativeId,
+    extraParameters: String,
+    gitUserName: String,
+    gitUserEmail: String
+): String {
+    return listOf(
+        "-PcommitId=%dep.$dependencyBuildId.build.vcs.number%",
+        extraParameters,
+        "\"-PgitUserName=$gitUserName\"",
+        "\"-PgitUserEmail=$gitUserEmail\"",
+        pluginPortalUrlOverride,
+        "-DenablePredictiveTestSelection=false",
+        "%additional.gradle.parameters%"
+    ).joinToString(" ")
+}
 
 /**
  * Align with build-logic/cleanup/src/main/java/gradlebuild/cleanup/services/KillLeakingJavaProcesses.java

--- a/.teamcity/src/test/kotlin/PromotionProjectTests.kt
+++ b/.teamcity/src/test/kotlin/PromotionProjectTests.kt
@@ -75,7 +75,7 @@ class PromotionProjectTests {
         val steps = nightlySnapshot.steps.items
         assertEquals(3, steps.size)
 
-        val expectedGradleParams = """-PcommitId=%dep.Gradle_Release_Check_Stage_ReadyforNightly_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" $pluginPortalUrlOverride %additional.gradle.parameters%"""
+        val expectedGradleParams = """-PcommitId=%dep.Gradle_Release_Check_Stage_ReadyforNightly_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" $pluginPortalUrlOverride -DenablePredictiveTestSelection=false %additional.gradle.parameters%"""
 
         val checkReady = gradleStep(steps, 0)
         checkReady.assertTasks("prepReleaseNightly checkNeedToPromote")
@@ -100,7 +100,7 @@ class PromotionProjectTests {
 
         val step = gradleStep(steps, 0)
         step.assertTasks("clean promoteStartReleaseCycle")
-        assertEquals("""-PcommitId=%dep.Gradle_Master_Check_Stage_ReadyforNightly_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" $pluginPortalUrlOverride %additional.gradle.parameters%""", step.gradleParams)
+        assertEquals("""-PcommitId=%dep.Gradle_Master_Check_Stage_ReadyforNightly_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" $pluginPortalUrlOverride -DenablePredictiveTestSelection=false %additional.gradle.parameters%""", step.gradleParams)
     }
 
     @Test
@@ -124,7 +124,7 @@ class PromotionProjectTests {
         val steps = nightlySnapshot.steps.items
         assertEquals(3, steps.size)
 
-        val expectedGradleParams = """-PcommitId=%dep.Gradle_Release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" $pluginPortalUrlOverride %additional.gradle.parameters%"""
+        val expectedGradleParams = """-PcommitId=%dep.Gradle_Release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" $pluginPortalUrlOverride -DenablePredictiveTestSelection=false %additional.gradle.parameters%"""
 
         val checkReady = gradleStep(steps, 0)
         checkReady.assertTasks("prepReleaseNightly checkNeedToPromote")
@@ -147,7 +147,7 @@ class PromotionProjectTests {
         val steps = nightlySnapshot.steps.items
         assertEquals(3, steps.size)
 
-        val expectedGradleParams = """-PcommitId=%dep.Gradle_Master_Check_Stage_QuickFeedback_Trigger.build.vcs.number% -PpromotedBranch=%branch.qualifier% "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" $pluginPortalUrlOverride %additional.gradle.parameters%"""
+        val expectedGradleParams = """-PcommitId=%dep.Gradle_Master_Check_Stage_QuickFeedback_Trigger.build.vcs.number% -PpromotedBranch=%branch.qualifier% "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" $pluginPortalUrlOverride -DenablePredictiveTestSelection=false %additional.gradle.parameters%"""
 
         val checkReady = gradleStep(steps, 0)
         checkReady.assertTasks("prepSnapshot checkNeedToPromote")
@@ -170,7 +170,7 @@ class PromotionProjectTests {
         val steps = nightlySnapshot.steps.items
         assertEquals(2, steps.size)
 
-        val expectedParams = """-PcommitId=%dep.Gradle_Release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" $pluginPortalUrlOverride %additional.gradle.parameters%"""
+        val expectedParams = """-PcommitId=%dep.Gradle_Release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" $pluginPortalUrlOverride -DenablePredictiveTestSelection=false %additional.gradle.parameters%"""
 
         val checkReady = gradleStep(steps, 0)
         checkReady.assertTasks("prepReleaseNightly checkNeedToPromote")
@@ -189,7 +189,7 @@ class PromotionProjectTests {
         val steps = nightlySnapshot.steps.items
         assertEquals(2, steps.size)
 
-        val expectedGradleParams = """-PcommitId=%dep.Gradle_Release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" $pluginPortalUrlOverride %additional.gradle.parameters%"""
+        val expectedGradleParams = """-PcommitId=%dep.Gradle_Release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" $pluginPortalUrlOverride -DenablePredictiveTestSelection=false %additional.gradle.parameters%"""
 
         val checkReady = gradleStep(steps, 0)
         checkReady.assertTasks("prepReleaseNightly checkNeedToPromote")
@@ -208,7 +208,7 @@ class PromotionProjectTests {
         val steps = nightlySnapshot.steps.items
         assertEquals(3, steps.size)
 
-        val expectedGradleParams = """-PcommitId=%dep.Gradle_Release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" $pluginPortalUrlOverride %additional.gradle.parameters%"""
+        val expectedGradleParams = """-PcommitId=%dep.Gradle_Release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" $pluginPortalUrlOverride -DenablePredictiveTestSelection=false %additional.gradle.parameters%"""
 
         val checkReady = gradleStep(steps, 0)
         checkReady.assertTasks("prepFinalRelease checkNeedToPromote")
@@ -231,7 +231,7 @@ class PromotionProjectTests {
         val steps = nightlySnapshot.steps.items
         assertEquals(3, steps.size)
 
-        val expectedGradleParams = """-PcommitId=%dep.Gradle_Release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" $pluginPortalUrlOverride %additional.gradle.parameters%"""
+        val expectedGradleParams = """-PcommitId=%dep.Gradle_Release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" $pluginPortalUrlOverride -DenablePredictiveTestSelection=false %additional.gradle.parameters%"""
 
         val checkReady = gradleStep(steps, 0)
         checkReady.assertTasks("prepRc checkNeedToPromote")
@@ -260,7 +260,7 @@ class PromotionProjectTests {
         val steps = nightlySnapshot.steps.items
         assertEquals(3, steps.size)
 
-        val expectedGradleParams = """-PcommitId=%dep.Gradle_${branch.toCapitalized()}_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" $pluginPortalUrlOverride %additional.gradle.parameters%"""
+        val expectedGradleParams = """-PcommitId=%dep.Gradle_${branch.toCapitalized()}_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" $pluginPortalUrlOverride -DenablePredictiveTestSelection=false %additional.gradle.parameters%"""
 
         val checkReady = gradleStep(steps, 0)
         checkReady.assertTasks("prepMilestone checkNeedToPromote")


### PR DESCRIPTION
This PR reapplies https://github.com/gradle/gradle/pull/31832. That PR was broken because the single quoted param was recognized as task:

```
Task ''-PgitUserName=bot-teamcity'' not found in root project 'promote' and its subprojects
```

Now we use double quotes.