### PR TITLE
ProblemReporter methods take all mandatory info as arguments

### DIFF
--- a/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorProblemsApiIntegrationTest.groovy
+++ b/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorProblemsApiIntegrationTest.groovy
@@ -61,6 +61,8 @@ class WorkerExecutorProblemsApiIntegrationTest extends AbstractIntegrationSpec {
             import java.io.File;
             import java.io.FileWriter;
             import org.gradle.api.problems.Problems;
+            import org.gradle.api.problems.ProblemId;
+            import org.gradle.api.problems.ProblemGroup;
             import org.gradle.internal.operations.CurrentBuildOperationRef;
 
             import org.gradle.workers.WorkAction;
@@ -77,8 +79,8 @@ class WorkerExecutorProblemsApiIntegrationTest extends AbstractIntegrationSpec {
                     Exception wrappedException = new Exception("Wrapped cause");
                     // Create and report a problem
                     // This needs to be Java 6 compatible, as we are in a worker
-                     getProblems().getReporter().report(problem -> problem
-                            .id(org.gradle.api.problems.ProblemId.create("type", "label", org.gradle.api.problems.ProblemGroup.create("generic", "Generic")))
+                    ProblemId problemId = ProblemId.create("type", "label", ProblemGroup.create("generic", "Generic"));
+                    getProblems().getReporter().report(problemId, problem -> problem
                             .stackLocation()
                             .withException(new RuntimeException("Exception message", wrappedException))
                     );

--- a/platforms/documentation/docs/src/samples/ide/problems-api-usage/groovy/reporters/script-plugin/src/main/groovy/reporters.script.plugin.gradle
+++ b/platforms/documentation/docs/src/samples/ide/problems-api-usage/groovy/reporters/script-plugin/src/main/groovy/reporters.script.plugin.gradle
@@ -10,18 +10,16 @@ interface Injected {
 def problems = project.objects.newInstance(Injected).getProblems()
 def problemGroup = ProblemGroup.create("root", "Root Group")
 
-problems.getReporter().report {
-    it.id(ProblemId.create('adhoc-script-deprecation', 'Deprecated script plugin', problemGroup))
-        .contextualLabel("Deprecated script plugin 'demo-script-plugin'")
+problems.getReporter().report(ProblemId.create('adhoc-script-deprecation', 'Deprecated script plugin', problemGroup)) {
+    it.contextualLabel("Deprecated script plugin 'demo-script-plugin'")
         .severity(Severity.WARNING)
         .solution("Please use 'standard-plugin-2' instead of this plugin")
 }
 
 tasks.register('warningTask') {
     doLast {
-        problems.getReporter().report {
-            it.id(ProblemId.create('adhoc-task-deprecation', 'Deprecated task', problemGroup))
-                .contextualLabel("Task 'warningTask' is deprecated")
+        problems.getReporter().report(ProblemId.create('adhoc-task-deprecation', 'Deprecated task', problemGroup)) {
+            it.contextualLabel("Task 'warningTask' is deprecated")
                 .severity(Severity.WARNING)
                 .solution("Please use 'warningTask2' instead of this task")
         }
@@ -30,9 +28,8 @@ tasks.register('warningTask') {
 
 tasks.register('failingTask') {
     doLast {
-        problems.getReporter().throwing(new RuntimeException("The 'failingTask' should not be called")) {
-            it.id(ProblemId.create('broken-task', 'Task should not be called', problemGroup))
-                .contextualLabel("Task 'failingTask' should not be called")
+        problems.getReporter().throwing(new RuntimeException("The 'failingTask' should not be called"), ProblemId.create('broken-task', 'Task should not be called', problemGroup)) {
+            it.contextualLabel("Task 'failingTask' should not be called")
                 .severity(Severity.ERROR)
                 .solution("Please use 'successfulTask' instead of this task")
         }

--- a/platforms/documentation/docs/src/samples/ide/problems-api-usage/kotlin/reporters/script-plugin/src/main/kotlin/reporters/script.plugin.gradle.kts
+++ b/platforms/documentation/docs/src/samples/ide/problems-api-usage/kotlin/reporters/script-plugin/src/main/kotlin/reporters/script.plugin.gradle.kts
@@ -10,9 +10,8 @@ interface Injected {
 val problems = project.objects.newInstance<Injected>().problems
 val problemGroup = ProblemGroup.create("root", "Root Group")
 
-problems.getReporter().report {
-    id(ProblemId.create("adhoc-script-deprecation", "Deprecated script plugin", problemGroup))
-        .contextualLabel("Deprecated script plugin 'demo-script-plugin'")
+problems.getReporter().report(ProblemId.create("adhoc-script-deprecation", "Deprecated script plugin", problemGroup)) {
+    contextualLabel("Deprecated script plugin 'demo-script-plugin'")
         .severity(Severity.WARNING)
         .solution("Please use 'standard-plugin-2' instead of this plugin")
 }
@@ -20,9 +19,8 @@ problems.getReporter().report {
 tasks {
     val warningTask by registering {
         doLast {
-            problems.getReporter().report {
-                id(ProblemId.create("adhoc-task-deprecation", "Deprecated task", problemGroup))
-                    .contextualLabel("Task 'warningTask' is deprecated")
+            problems.getReporter().report(ProblemId.create("adhoc-task-deprecation", "Deprecated task", problemGroup)) {
+                contextualLabel("Task 'warningTask' is deprecated")
                     .severity(Severity.WARNING)
                     .solution("Please use 'warningTask2' instead of this task")
             }
@@ -31,9 +29,8 @@ tasks {
 
     val failingTask by registering {
         doLast {
-            problems.getReporter().throwing(RuntimeException("The 'failingTask' should not be called")) {
-                id(ProblemId.create("broken-task", "Task should not be called", problemGroup))
-                    .contextualLabel("Task 'failingTask' should not be called")
+            problems.getReporter().throwing(RuntimeException("The 'failingTask' should not be called"), ProblemId.create("broken-task", "Task should not be called", problemGroup)) {
+                    contextualLabel("Task 'failingTask' should not be called")
                     .severity(Severity.ERROR)
                     .solution("Please use 'successfulTask' instead of this task")
             }

--- a/platforms/documentation/docs/src/samples/templates/problems-api-usage/reporters/model-builder-plugin/src/main/java/reporters/ModelBuilder.java
+++ b/platforms/documentation/docs/src/samples/templates/problems-api-usage/reporters/model-builder-plugin/src/main/java/reporters/ModelBuilder.java
@@ -24,8 +24,7 @@ public class ModelBuilder implements ToolingModelBuilder {
 
     @Override
     public Object buildAll(String modelName, Project project) {
-        problems.getReporter().report(problem -> problem
-            .id(ProblemId.create("unused", "Demo model", ModelBuilderPlugin.PROBLEM_GROUP))
+        problems.getReporter().report(ProblemId.create("unused", "Demo model", ModelBuilderPlugin.PROBLEM_GROUP), problem -> problem
             .severity(Severity.WARNING)
             .details("This is a demo model and doesn't do anything useful")
         );

--- a/platforms/documentation/docs/src/samples/templates/problems-api-usage/reporters/standard-plugin/src/main/java/reporters/FailingTask.java
+++ b/platforms/documentation/docs/src/samples/templates/problems-api-usage/reporters/standard-plugin/src/main/java/reporters/FailingTask.java
@@ -16,8 +16,8 @@ public abstract class FailingTask extends DefaultTask {
     @TaskAction
     public void run() {
         // tag::problems-api-fail-the-build[]
-        throw getProblems().getReporter().throwing((new RuntimeException("Message from runtime exception")), problemSpec -> {
-            problemSpec.id(ProblemId.create("sample-error", "Sample Error", StandardPlugin.PROBLEM_GROUP));
+        ProblemId id = ProblemId.create("sample-error", "Sample Error", StandardPlugin.PROBLEM_GROUP);
+        throw getProblems().getReporter().throwing((new RuntimeException("Message from runtime exception")), id, problemSpec -> {
             problemSpec.contextualLabel("This happened because ProblemReporter.throwing() was called");
             problemSpec.details("This is a demonstration of how to add\ndetailed information to a build failure");
             problemSpec.documentedAt("https://example.com/docs");

--- a/platforms/documentation/docs/src/samples/templates/problems-api-usage/reporters/standard-plugin/src/main/java/reporters/StandardPlugin.java
+++ b/platforms/documentation/docs/src/samples/templates/problems-api-usage/reporters/standard-plugin/src/main/java/reporters/StandardPlugin.java
@@ -27,8 +27,8 @@ public class StandardPlugin implements Plugin<Project> {
     public void apply(Project project) {
         project.getTasks().register("myFailingTask", FailingTask.class);
         // tag::problems-api-report[]
-        problems.getReporter().report(problem -> problem
-                .id(ProblemId.create("adhoc-plugin-deprecation", "Plugin is deprecated", PROBLEM_GROUP))
+        ProblemId problemId = ProblemId.create("adhoc-plugin-deprecation", "Plugin is deprecated", PROBLEM_GROUP);
+        problems.getReporter().report(problemId, problem -> problem
                 .contextualLabel("The 'standard-plugin' is deprecated")
                 .documentedAt("https://github.com/gradle/gradle/README.md")
                 .severity(Severity.WARNING)

--- a/platforms/documentation/docs/src/snippets/developingPlugins/problemReporting/kotlin/buildSrc/src/main/java/org/myorg/ProblemReportingPlugin.java
+++ b/platforms/documentation/docs/src/snippets/developingPlugins/problemReporting/kotlin/buildSrc/src/main/java/org/myorg/ProblemReportingPlugin.java
@@ -23,8 +23,8 @@ public class ProblemReportingPlugin implements Plugin<Project> {
     }
 
     public void apply(Project project) {
-        this.problemReporter.report(builder -> builder // <3>
-            .id(ProblemId.create("adhoc-deprecation", "Plugin 'x' is deprecated", PROBLEM_GROUP))
+        ProblemId problemId = ProblemId.create("adhoc-deprecation", "Plugin 'x' is deprecated", PROBLEM_GROUP);
+        this.problemReporter.report(problemId, builder -> builder // <3>
             .details("The plugin 'x' is deprecated since version 2.5")
             .solution("Please use plugin 'y'")
             .severity(Severity.WARNING)

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/DevelocityPluginEndOfBuildCallbackIntegrationTest.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/DevelocityPluginEndOfBuildCallbackIntegrationTest.groovy
@@ -36,9 +36,8 @@ class DevelocityPluginEndOfBuildCallbackIntegrationTest extends AbstractIntegrat
         ${ProblemGroup.name} problemGroup = ${ProblemGroup.name}.create("generic", "group label");
         ${ProblemId.name} problemId = ${ProblemId.name}.create("type", "label", problemGroup)
             ${getProblemReportingScript """
-                problems.getReporter().throwing(new RuntimeException('failed')) {
-                    it.id(problemId)
-            }"""}
+                problems.getReporter().throwing(new RuntimeException('failed'), problemId) {}
+            """}
 
             task $succeedingTaskName
         """

--- a/platforms/extensibility/plugin-development/src/test/groovy/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerializationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/test/groovy/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerializationTest.groovy
@@ -17,8 +17,8 @@
 package org.gradle.plugin.devel.tasks.internal
 
 import com.google.gson.Gson
-import org.gradle.api.problems.ProblemId
 import org.gradle.api.problems.GeneralData
+import org.gradle.api.problems.ProblemId
 import org.gradle.api.problems.Severity
 import org.gradle.api.problems.internal.AdditionalDataBuilderFactory
 import org.gradle.api.problems.internal.DefaultProblemReporter
@@ -52,9 +52,7 @@ class ValidationProblemSerializationTest extends Specification {
 
     def "can serialize and deserialize a validation problem"() {
         given:
-        def problem = problemReporter.create {
-            it.id(problemId)
-        }
+        def problem = problemReporter.create(problemId, {})
 
         when:
         def json = gson.toJson([problem])
@@ -76,9 +74,8 @@ class ValidationProblemSerializationTest extends Specification {
 
     def "can serialize and deserialize a validation problem with a location"() {
         given:
-        def problem = problemReporter.create {
-            it.id(problemId)
-                .lineInFileLocation("location", 1, 2, 3)
+        def problem = problemReporter.create(problemId) {
+            it.lineInFileLocation("location", 1, 2, 3)
         }
 
         when:
@@ -98,9 +95,8 @@ class ValidationProblemSerializationTest extends Specification {
 
     def "can serialize and deserialize a validation problem with a documentation link"() {
         given:
-        def problem = problemReporter.create {
-            it.id(problemId)
-                .documentedAt(new TestDocLink())
+        def problem = problemReporter.create(problemId) {
+            it.documentedAt(new TestDocLink())
                 .lineInFileLocation("location", 1, 1)
         }
 
@@ -138,9 +134,8 @@ class ValidationProblemSerializationTest extends Specification {
 
     def "can serialize and deserialize a validation problem with a cause"() {
         given:
-        def problem = problemReporter.create {
-            it.id(problemId)
-                .withException(new RuntimeException("cause"))
+        def problem = problemReporter.create(problemId) {
+            it.withException(new RuntimeException("cause"))
         }
 
         when:
@@ -158,9 +153,8 @@ class ValidationProblemSerializationTest extends Specification {
 
     def "can serialize and deserialize a validation problem with a severity"(Severity severity) {
         given:
-        def problem = problemReporter.create {
-            it.id(problemId)
-                .severity(severity)
+        def problem = problemReporter.create(problemId) {
+            it.severity(severity)
         }
 
         when:
@@ -181,9 +175,8 @@ class ValidationProblemSerializationTest extends Specification {
 
     def "can serialize and deserialize a validation problem with a solution"() {
         given:
-        def problem = problemReporter.create {
-            it.id(problemId)
-                .solution("solution 0")
+        def problem = problemReporter.create(problemId) {
+            it.solution("solution 0")
                 .solution("solution 1")
         }
 
@@ -203,7 +196,7 @@ class ValidationProblemSerializationTest extends Specification {
 
     def "can serialize and deserialize a validation problem with additional data"() {
         given:
-        def problem = problemReporter.create {
+        def problem = problemReporter.internalCreate {
             it.id(problemId)
                 .additionalData(TypeValidationDataSpec.class) {
                     it.propertyName("property")
@@ -231,7 +224,7 @@ class ValidationProblemSerializationTest extends Specification {
 
     def "can serialize generic additional data"() {
         given:
-        def problem = problemReporter.create {
+        def problem = problemReporter.internalCreate {
             it.id(problemId)
                 .additionalData(GeneralDataSpec) {
                     it.put('foo', 'bar')
@@ -252,7 +245,7 @@ class ValidationProblemSerializationTest extends Specification {
 
     def "can serialize deprecation additional data"() {
         given:
-        def problem = problemReporter.create {
+        def problem = problemReporter.internalCreate {
             it.id(problemId)
                 .additionalData(DeprecationDataSpec) {
                     it.type(DeprecationData.Type.BUILD_INVOCATION)

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/ProblemReporter.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/ProblemReporter.java
@@ -33,21 +33,23 @@ public interface ProblemReporter {
      * Creates a new problem without reporting it immediately.
      * The created problem can be later reported with {@link #report(Problem)}.
      *
+     * @param problemId The problem id
      * @param action The problem configuration.
      * @return The new problem.
      * @since 8.13
      */
-    Problem create(Action<? super ProblemSpec> action);
+    Problem create(ProblemId problemId, Action<? super ProblemSpec> action);
 
     /**
      * Configures and reports a new problem.
      * <p>
      * The spec must specify the problem label and the category. Any additional configuration is optional.
      *
+     * @param problemId the problem id
      * @param spec the problem configuration
      * @since 8.13
      */
-    void report(Action<? super ProblemSpec> spec);
+    void report(ProblemId problemId, Action<? super ProblemSpec> spec);
 
     /**
      * Reports the target problem.
@@ -72,10 +74,13 @@ public interface ProblemReporter {
      * <p>
      * The spec must specify the exception, the problem label, and the category. Any additional configuration is optional.
      *
+     * @param exception the exception to throw after reporting the problems
+     * @param problemId the problem id
+     * @param spec the problem configuration
      * @return never returns by throwing the exception, but using {@code throw} statement at the call site is encouraged to indicate the intent and benefit from local control flow.
      * @since 8.13
      */
-    RuntimeException throwing(Throwable exception, Action<? super ProblemSpec> spec);
+    RuntimeException throwing(Throwable exception, ProblemId problemId, Action<? super ProblemSpec> spec);
 
     /**
      * Configures a new problem, reports it, and uses it to throw a new exception.
@@ -84,6 +89,8 @@ public interface ProblemReporter {
      * <p>
      * The spec must specify the exception, the problem label, and the category. Any additional configuration is optional.
      *
+     * @param exception the exception to throw after reporting the problems
+     * @param problem the problem to report
      * @return never returns by throwing the exception, but using {@code throw} statement at the call site is encouraged to indicate the intent and benefit from local control flow.
      * @since 8.13
      */

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/ProblemSpec.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/ProblemSpec.java
@@ -26,19 +26,6 @@ import org.gradle.api.Incubating;
  */
 @Incubating
 public interface ProblemSpec {
-
-    /**
-     * Defines the context-independent identifier for this problem.
-     * <p>
-     * It is a mandatory property to configure when emitting a problem with {@link ProblemReporter}.
-     * ProblemId instances can be created via {@link ProblemId#create(String, String, ProblemGroup)}.
-     *
-     * @param problemId the problem id
-     * @return this
-     * @since 8.13
-     */
-    ProblemSpec id(ProblemId problemId);
-
     /**
      * Declares a short, but context-dependent message for this problem.
      *

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemReporter.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemReporter.java
@@ -18,6 +18,7 @@ package org.gradle.api.problems.internal;
 
 import org.gradle.api.Action;
 import org.gradle.api.problems.Problem;
+import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.ProblemSpec;
 import org.gradle.internal.exception.ExceptionAnalyser;
 import org.gradle.internal.operations.CurrentBuildOperationRef;
@@ -53,8 +54,9 @@ public class DefaultProblemReporter implements InternalProblemReporter {
     }
 
     @Override
-    public void report(Action<? super ProblemSpec> spec) {
+    public void report(ProblemId problemId, Action<? super ProblemSpec> spec) {
         DefaultProblemBuilder problemBuilder = createProblemBuilder();
+        problemBuilder.id(problemId);
         spec.execute(problemBuilder);
         report(problemBuilder.build());
     }
@@ -65,8 +67,9 @@ public class DefaultProblemReporter implements InternalProblemReporter {
     }
 
     @Override
-    public RuntimeException throwing(Throwable exception, Action<? super ProblemSpec> spec) {
+    public RuntimeException throwing(Throwable exception, ProblemId problemId, Action<? super ProblemSpec> spec) {
         DefaultProblemBuilder problemBuilder = createProblemBuilder();
+        problemBuilder.id(problemId);
         spec.execute(problemBuilder);
         problemBuilder.withException(exception);
         report(problemBuilder.build());
@@ -97,8 +100,9 @@ public class DefaultProblemReporter implements InternalProblemReporter {
     }
 
     @Override
-    public Problem create(Action<? super ProblemSpec> action) {
+    public Problem create(ProblemId problemId, Action<? super ProblemSpec> action) {
         DefaultProblemBuilder defaultProblemBuilder = createProblemBuilder();
+        defaultProblemBuilder.id(problemId);
         action.execute(defaultProblemBuilder);
         return defaultProblemBuilder.build();
     }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblemSpec.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblemSpec.java
@@ -57,7 +57,15 @@ public interface InternalProblemSpec extends ProblemSpec {
      */
     InternalProblemSpec documentedAt(@Nullable DocLink doc);
 
-    @Override
+    /**
+     * Defines the context-independent identifier for this problem.
+     * <p>
+     * It is a mandatory property to configure when emitting a problem with {@link ProblemReporter}.
+     * ProblemId instances can be created via {@link ProblemId#create(String, String, ProblemGroup)}.
+     *
+     * @param problemId the problem id
+     * @return this
+     */
     InternalProblemSpec id(ProblemId problemId);
 
     /**

--- a/platforms/ide/problems/src/integTest/groovy/org/gradle/api/problems/InjectedProblemsTransformerIntegrationTest.groovy
+++ b/platforms/ide/problems/src/integTest/groovy/org/gradle/api/problems/InjectedProblemsTransformerIntegrationTest.groovy
@@ -50,9 +50,7 @@ class InjectedProblemsTransformerIntegrationTest extends AbstractIntegrationSpec
                 protected abstract Problems getProblems();
 
                 public void apply(Project project) {
-                    getProblems().getReporter().report(builder ->
-                        builder.id(ProblemId.create("type", "label", ProblemGroup.create("generic", "Generic")))
-                    );
+                    getProblems().getReporter().report(ProblemId.create("type", "label", ProblemGroup.create("generic", "Generic")), builder -> {});
                     project.getTasks().register("reportProblem", t -> {
                         t.doLast(t2 -> {
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/fixture/ProblemsApiGroovyScriptUtils.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/fixture/ProblemsApiGroovyScriptUtils.groovy
@@ -20,7 +20,7 @@ import org.gradle.util.GradleVersion
 
 class ProblemsApiGroovyScriptUtils {
 
-    static String report(GradleVersion targetVersion) {
+    static String report(GradleVersion targetVersion, String idName = 'id', String idDisplayName = 'shortProblemMessage') {
         if (targetVersion < GradleVersion.version("8.6")) {
             'create'
         } else if (targetVersion < GradleVersion.version("8.11")) {
@@ -28,7 +28,7 @@ class ProblemsApiGroovyScriptUtils {
         } else if (targetVersion < GradleVersion.version("8.13")) {
             'getReporter().reporting '
         } else {
-            'getReporter().report '
+            "getReporter().report(org.gradle.api.problems.ProblemId.create(\"$idName\", \"$idDisplayName\", org.gradle.api.problems.ProblemGroup.create(\"generic\", \"Generic\"))) "
         }
     }
 
@@ -38,7 +38,11 @@ class ProblemsApiGroovyScriptUtils {
         } else if (targetVersion < GradleVersion.version("8.13")) {
             "id(\"$name\", \"$displayName\")"
         } else {
-            "id(org.gradle.api.problems.ProblemId.create(\"$name\", \"$displayName\", org.gradle.api.problems.ProblemGroup.create(\"generic\", \"Generic\")))"
+            "id(${createIdExpression(name, displayName)})"
         }
+    }
+
+    static String createIdExpression(String name = 'type', String displayName = 'label') {
+        "org.gradle.api.problems.ProblemId.create(\"$name\", \"$displayName\", org.gradle.api.problems.ProblemGroup.create(\"generic\", \"Generic\"))"
     }
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r812/ProblemThresholdCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r812/ProblemThresholdCrossVersionTest.groovy
@@ -230,7 +230,7 @@ class ProblemThresholdCrossVersionTest extends ToolingApiSpecification {
     String getProblemReportingBody(int threshold, String category = "testcategory", String label = "label") {
         """
            ($threshold).times {
-                 getProblems().${ProblemsApiGroovyScriptUtils.report(targetVersion)} {
+                 getProblems().${ProblemsApiGroovyScriptUtils.report(targetVersion, category, label)} {
                     it.${ProblemsApiGroovyScriptUtils.id(targetVersion, category, label)}
                       .details('Wrong API usage, will not show up anywhere')
                  }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r86/ProblemsServiceModelBuilderCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r86/ProblemsServiceModelBuilderCrossVersionTest.groovy
@@ -63,7 +63,7 @@ class ProblemsServiceModelBuilderCrossVersionTest extends ToolingApiSpecificatio
                 }
                 Object buildAll(String modelName, Project project) {
                     ($threshold).times{
-                        problemsService.${ProblemsApiGroovyScriptUtils.report(targetVersion)} {
+                        problemsService.${ProblemsApiGroovyScriptUtils.report(targetVersion, 'testCategory', 'label')} {
                             it.${ProblemsApiGroovyScriptUtils.id(targetVersion, 'testcategory', 'label')}
                                 .withException(new RuntimeException("test"))
                                 ${pre86api ? ".undocumented()" : ""}

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/ProblemProgressEventCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/ProblemProgressEventCrossVersionTest.groovy
@@ -212,7 +212,7 @@ class ProblemProgressEventCrossVersionTest extends ToolingApiSpecification {
     def withMultipleProblems(String name, String displayName) {
         withReportProblemTask """
             for(int i = 0; i < 10; i++) {
-                problems.${ProblemsApiGroovyScriptUtils.report(targetVersion)} {
+                problems.${ProblemsApiGroovyScriptUtils.report(targetVersion, name, displayName)} {
                     it.${ProblemsApiGroovyScriptUtils.id(targetVersion, name, displayName)}
                         .severity(Severity.WARNING)
                         .solution("Please use 'standard-plugin-2' instead of this plugin")

--- a/platforms/jvm/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
+++ b/platforms/jvm/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
@@ -117,8 +117,8 @@ public class DaemonGroovyCompiler extends AbstractDaemonCompiler<GroovyJavaJoint
             File toolsJar = jvm.getToolsJar();
             if (toolsJar == null) {
                 String contextualMessage = String.format("The 'tools.jar' cannot be found in the JDK '%s'.", jvm.getJavaHome());
-                throw problemReporter.throwing(new IllegalStateException(contextualMessage), problemSpec -> problemSpec
-                    .id(ProblemId.create("groovy-daemon-compiler", "Missing tools.jar", GradleCoreProblemGroup.compilation().groovy()))
+                ProblemId problemId = ProblemId.create("missing-tools-jar", "Missing tools.jar", GradleCoreProblemGroup.compilation().groovy());
+                throw problemReporter.throwing(new IllegalStateException(contextualMessage), problemId, problemSpec -> problemSpec
                     .contextualLabel(contextualMessage)
                     .solution("Check if the installation is not a JRE but a JDK.")
                     .severity(Severity.ERROR)

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
@@ -82,8 +82,13 @@ public class DiagnosticToProblemListener implements DiagnosticListener<JavaFileO
                 break;
         }
 
-        Problem reportedProblem = problemReporter.create(spec -> buildProblem(diagnostic, spec));
+        Problem reportedProblem = problemReporter.create(id(diagnostic), spec -> buildProblem(diagnostic, spec));
         problemsReported.add(reportedProblem);
+    }
+
+    private static ProblemId id(Diagnostic<? extends JavaFileObject> diagnostic) {
+        String idName = diagnostic.getCode().replace('.', '-');
+        return ProblemId.create(idName, mapKindToDisplayName(diagnostic.getKind()), GradleCoreProblemGroup.compilation().java());
     }
 
     /**
@@ -156,18 +161,12 @@ public class DiagnosticToProblemListener implements DiagnosticListener<JavaFileO
     void buildProblem(Diagnostic<? extends JavaFileObject> diagnostic, ProblemSpec spec) {
         Severity severity = mapKindToSeverity(diagnostic.getKind());
         spec.severity(severity);
-        addId(spec, diagnostic);
         addFormattedMessage(spec, diagnostic);
         addDetails(spec, diagnostic);
         addLocations(spec, diagnostic);
         if (severity == Severity.ERROR) {
             spec.solution(CompilationFailedException.RESOLUTION_MESSAGE);
         }
-    }
-
-    private static void addId(ProblemSpec spec, Diagnostic<? extends JavaFileObject> diagnostic) {
-        String idName = diagnostic.getCode().replace('.', '-');
-        spec.id(ProblemId.create(idName, mapKindToDisplayName(diagnostic.getKind()), GradleCoreProblemGroup.compilation().java()));
     }
 
     private void addFormattedMessage(ProblemSpec spec, Diagnostic<? extends JavaFileObject> diagnostic) {

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
@@ -72,7 +72,8 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
         try {
             task = createCompileTask(spec, result);
         } catch (RuntimeException ex) {
-            throw problemsService.getInternalReporter().throwing(ex, builder -> {
+            ProblemId id = ProblemId.create("initialization-failed", "Java compilation initialization error", GradleCoreProblemGroup.compilation().java());
+            throw problemsService.getInternalReporter().throwing(ex, id, builder -> {
                 buildProblemFrom(ex, builder);
             });
         }
@@ -135,7 +136,6 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
 
     private static void buildProblemFrom(RuntimeException ex, ProblemSpec spec) {
         spec.severity(Severity.ERROR);
-        spec.id(ProblemId.create("initialization-failed", "Java compilation initialization error", GradleCoreProblemGroup.compilation().java()));
         spec.contextualLabel(ex.getLocalizedMessage());
         spec.withException(ex);
     }

--- a/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListenerTest.groovy
+++ b/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListenerTest.groovy
@@ -16,8 +16,7 @@
 
 package org.gradle.api.internal.tasks.compile
 
-import org.gradle.api.problems.ProblemId
-import org.gradle.api.problems.internal.GradleCoreProblemGroup
+
 import org.gradle.api.problems.internal.InternalProblemSpec
 import spock.lang.Specification
 
@@ -33,21 +32,6 @@ class DiagnosticToProblemListenerTest extends Specification {
     def spec = Mock(InternalProblemSpec)
 
     def diagnosticToProblemListener = new DiagnosticToProblemListener(null, null)
-
-    def "diagnostic id is correctly reported"() {
-        given:
-        def diagnostic = getMockDiagnostics()
-        diagnostic.source >> Mock(JavaFileObject) {
-            name >> "SomeFile.java"
-        }
-
-        when:
-        diagnosticToProblemListener.buildProblem(diagnostic, spec)
-
-        then:
-        1 * spec.id({ (it as ProblemId).group.equals(GradleCoreProblemGroup.compilation().java()) && (it as ProblemId).name == 'dummy-code' })
-        1 * spec.details(_)
-    }
 
     def "file location is correctly reported"() {
         given:

--- a/platforms/software/dependency-management/src/crossVersionTest/groovy/org/gradle/integtests/api/problems/internal/ResolutionFailureDataCrossVersionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/crossVersionTest/groovy/org/gradle/integtests/api/problems/internal/ResolutionFailureDataCrossVersionIntegrationTest.groovy
@@ -112,7 +112,7 @@ class ResolutionFailureDataCrossVersionIntegrationTest extends ToolingApiSpecifi
         } else if (targetVersion < GradleVersion.version("8.13")) {
             'getReporter().reporting '
         } else {
-            'getReporter().report '
+            'getReporter().report(org.gradle.api.problems.ProblemId.create("type", "label", org.gradle.api.problems.ProblemGroup.create("generic", "Generic"))) '
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ImperativeOnlyPluginTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ImperativeOnlyPluginTarget.java
@@ -71,10 +71,10 @@ public class ImperativeOnlyPluginTarget<T extends PluginAwareInternal> implement
         }
 
         String message = String.format("The plugin must be applied %s, but was applied %s", actualTargetType.getApplyTargetDescription(), targetType.getApplyTargetDescription());
+        ProblemId id = ProblemId.create("target-type-mismatch", "Unexpected plugin type", GradleCoreProblemGroup.pluginApplication());
         throw problems.getInternalReporter()
-            .throwing(new IllegalArgumentException(message), spec -> {
-                spec.id(ProblemId.create("target-type-mismatch", "Unexpected plugin type", GradleCoreProblemGroup.pluginApplication()))
-                    .severity(Severity.ERROR)
+            .throwing(new IllegalArgumentException(message), id, spec -> {
+                spec.severity(Severity.ERROR)
                     .withException(new IllegalArgumentException(message))
                     .contextualLabel(message)
                     .documentedAt(Documentation.userManual("custom_plugins", "project_vs_settings_vs_init_plugins").toString());

--- a/subprojects/core/src/main/java/org/gradle/execution/DefaultTaskSelector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DefaultTaskSelector.java
@@ -97,7 +97,7 @@ public class DefaultTaskSelector implements TaskSelector {
 
         if (context.getOriginalPath().getPath().equals(taskName)) {
             String message = matcher.formatErrorMessage("Task", searchContext);
-            throw getProblemsService().getInternalReporter().throwing(new TaskSelectionException(message), spec -> {
+            throw getProblemsService().getInternalReporter().throwing(new TaskSelectionException(message), matcher.problemId(), spec -> {
                 configureProblem(spec, matcher, context);
                 spec.contextualLabel(message);
             });
@@ -105,14 +105,13 @@ public class DefaultTaskSelector implements TaskSelector {
         String message = String.format("Cannot locate %s that match '%s' as %s", context.getType(), context.getOriginalPath(),
             matcher.formatErrorMessage("task", searchContext));
 
-        throw getProblemsService().getInternalReporter().throwing(new TaskSelectionException(message) /* this instead of cause */, spec ->
+        throw getProblemsService().getInternalReporter().throwing(new TaskSelectionException(message) /* this instead of cause */, matcher.problemId(), spec ->
             configureProblem(spec, matcher, context)
               .contextualLabel(message)
         );
     }
 
     private static ProblemSpec configureProblem(ProblemSpec spec, NameMatcher matcher, SelectionContext context) {
-        matcher.configureProblemId(spec);
         ((InternalProblemSpec) spec).additionalData(GeneralDataSpec.class, data -> data.put("requestedPath", Objects.requireNonNull(context.getOriginalPath().getPath())));
         spec.severity(Severity.ERROR);
         return spec;

--- a/subprojects/core/src/main/java/org/gradle/execution/selection/DefaultBuildTaskSelector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/selection/DefaultBuildTaskSelector.java
@@ -176,8 +176,7 @@ public class DefaultBuildTaskSelector implements BuildTaskSelector {
         }
 
         String message = String.format("Cannot locate %s that match '%s' as %s", context.getType(), context.getOriginalPath(), nameMatcher.formatErrorMessage("project", project.getDisplayName()));
-        throw problemsService.getInternalReporter().throwing(new ProjectSelectionException(message), spec -> {
-            nameMatcher.configureProblemId(spec);
+        throw problemsService.getInternalReporter().throwing(new ProjectSelectionException(message), nameMatcher.problemId(), spec -> {
             configureProblem(spec, message, context.getOriginalPath().getPath());
         });
     }
@@ -196,8 +195,8 @@ public class DefaultBuildTaskSelector implements BuildTaskSelector {
 
         if (name.isEmpty() || StringUtils.isBlank(name)) {
             String message = String.format("Cannot locate matching %s for an empty path. The path should include a task name (for example %s).", type, examplePaths());
-            throw problemsService.getInternalReporter().throwing(new TaskSelectionException(message), spec -> {
-                spec.id(ProblemId.create("empty-path", "Empty path", GradleCoreProblemGroup.taskSelection()));
+            ProblemId id = ProblemId.create("empty-path", "Empty path", GradleCoreProblemGroup.taskSelection());
+            throw problemsService.getInternalReporter().throwing(new TaskSelectionException(message), id, spec -> {
                 configureProblem(spec, message, name);
             });
         }
@@ -205,8 +204,8 @@ public class DefaultBuildTaskSelector implements BuildTaskSelector {
         Pattern root = Pattern.compile("\\s*:(\\s*:)*\\s*");
         if (root.matcher(name).matches()) {
             String message = String.format("Cannot locate %s that match '%s'. The path should include a task name (for example %s).", type, name, examplePaths());
-            throw problemsService.getInternalReporter().throwing(new TaskSelectionException(message), spec -> {
-                spec.id(ProblemId.create("missing-task-name", "Missing task name", GradleCoreProblemGroup.taskSelection()));
+            ProblemId id = ProblemId.create("missing-task-name", "Missing task name", GradleCoreProblemGroup.taskSelection());
+            throw problemsService.getInternalReporter().throwing(new TaskSelectionException(message), id, spec -> {
                 configureProblem(spec, message, name);
             });
         }
@@ -225,8 +224,8 @@ public class DefaultBuildTaskSelector implements BuildTaskSelector {
             }
 
             String message = String.format("Cannot locate %s that match '%s'. The path should not include an empty segment (try '%s' instead).", type, name, normalized);
-            throw problemsService.getInternalReporter().throwing(new TaskSelectionException(message), spec -> {
-                spec.id(ProblemId.create("empty-segments", "Empty segments", GradleCoreProblemGroup.taskSelection()));
+            ProblemId id = ProblemId.create("empty-segments", "Empty segments", GradleCoreProblemGroup.taskSelection());
+            throw problemsService.getInternalReporter().throwing(new TaskSelectionException(message), id, spec -> {
                 configureProblem(spec, message, name);
             });
         }

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandler.java
@@ -217,8 +217,8 @@ public class DefaultScriptCompilationHandler implements ScriptCompilationHandler
         SyntaxException syntaxError = e.getErrorCollector().getSyntaxError(0);
         int lineNumber = syntaxError == null ? -1 : syntaxError.getLine();
         String message = String.format("Could not compile %s.", source.getDisplayName());
-        throw ((InternalProblems) getProblemsService()).getInternalReporter().throwing(new ScriptCompilationException(message, e, source, lineNumber), builder -> builder
-            .id(ProblemId.create(TextUtil.screamingSnakeToKebabCase("compilation-failed"), "Groovy DSL script compilation problem", GradleCoreProblemGroup.compilation().groovyDsl()))
+        ProblemId problemId = ProblemId.create(TextUtil.screamingSnakeToKebabCase("compilation-failed"), "Groovy DSL script compilation problem", GradleCoreProblemGroup.compilation().groovyDsl());
+        throw ((InternalProblems) getProblemsService()).getInternalReporter().throwing(new ScriptCompilationException(message, e, source, lineNumber), problemId, builder -> builder
             .contextualLabel(message)
             .lineInFileLocation(source.getFileName(), lineNumber)
             .severity(Severity.ERROR)

--- a/subprojects/core/src/main/java/org/gradle/util/internal/NameMatcher.java
+++ b/subprojects/core/src/main/java/org/gradle/util/internal/NameMatcher.java
@@ -18,7 +18,6 @@ package org.gradle.util.internal;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.function.TriConsumer;
 import org.gradle.api.problems.ProblemId;
-import org.gradle.api.problems.ProblemSpec;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 
 import java.util.Collection;
@@ -224,13 +223,13 @@ public class NameMatcher {
         return String.format("%s '%s' not found in %s.", singularItemDescription, pattern, container);
     }
 
-    public void configureProblemId(ProblemSpec spec) {
+    public ProblemId problemId() {
         if (!getMatches().isEmpty()) {
-            spec.id(ProblemId.create("ambiguous-matches", "Ambiguous matches", GradleCoreProblemGroup.taskSelection()));
+            return ProblemId.create("ambiguous-matches", "Ambiguous matches", GradleCoreProblemGroup.taskSelection());
         } else if (!getCandidates().isEmpty()) {
-            spec.id(ProblemId.create("no-matches", "No matches", GradleCoreProblemGroup.taskSelection()));
+            return ProblemId.create("no-matches", "No matches", GradleCoreProblemGroup.taskSelection());
         } else {
-            spec.id(ProblemId.create("selection-failed", "Selection failed", GradleCoreProblemGroup.taskSelection()));
+            return ProblemId.create("selection-failed", "Selection failed", GradleCoreProblemGroup.taskSelection());
         }
     }
 }


### PR DESCRIPTION
In other words, the definition of `ProblemId` is moved from `ProblemSpec` to  a method argument of `ProblemReporter` members.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
