### PR TITLE
Add logs for ArtifactTransformParallelIntegrationTest

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformParallelIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformParallelIntegrationTest.groovy
@@ -76,6 +76,11 @@ class ArtifactTransformParallelIntegrationTest extends AbstractDependencyResolut
 
                     void transform(TransformOutputs outputs) {
                         def input = inputArtifact.get().asFile
+                        def timestampFormatter = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+                        def currentTime = java.time.LocalDateTime.now().format(timestampFormatter)
+
+                        println "[" + currentTime + "] Running transform for " + input.name
+
                         ${server.callFromBuildUsingExpression("input.name")}
                         if (input.name.startsWith("bad")) {
                             throw new RuntimeException("Transform Failure: " + input.name)

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/BlockingHttpServer.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/BlockingHttpServer.java
@@ -34,6 +34,8 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -52,6 +54,7 @@ import java.util.logging.Logger;
  * For example, can be used to that certain tasks do or do not execute in parallel.
  */
 public class BlockingHttpServer extends ExternalResource implements ResettableExpectations {
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
     private static final AtomicInteger COUNTER = new AtomicInteger();
     private static final ExecutorService EXECUTOR_SERVICE = Executors.newCachedThreadPool();
     private final Lock lock = new ReentrantLock();
@@ -86,6 +89,10 @@ public class BlockingHttpServer extends ExternalResource implements ResettableEx
         this.context = server.createContext("/", handler);
         this.timeout = Duration.ofMillis(timeoutMs);
         this.scheme = scheme;
+    }
+
+    static String getCurrentTimestamp() {
+        return LocalDateTime.now().format(TIMESTAMP_FORMATTER);
     }
 
     /**

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/ChainingHttpHandler.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/ChainingHttpHandler.java
@@ -39,6 +39,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 
+import static org.gradle.test.fixtures.server.http.BlockingHttpServer.getCurrentTimestamp;
+
 class ChainingHttpHandler implements HttpHandler, ResettableExpectations {
     private final int timeoutMs;
     private final AtomicInteger counter;
@@ -130,11 +132,11 @@ class ChainingHttpHandler implements HttpHandler, ResettableExpectations {
             int id = counter.incrementAndGet();
 
             RequestOutcome outcome = requestStarted(httpExchange);
-            System.out.printf("[%d] handling %s%n", id, outcome.getDisplayName());
+            System.out.printf("[%s][%d] handling %s%n", getCurrentTimestamp(), id, outcome.getDisplayName());
 
             try {
                 ResponseProducer responseProducer = selectProducer(id, httpExchange);
-                System.out.printf("[%d] sending response for %s%n", id, outcome.getDisplayName());
+                System.out.printf("[%s][%d] sending response for %s%n", getCurrentTimestamp(), id, outcome.getDisplayName());
                 if (!responseProducer.isFailure()) {
                     responseProducer.writeTo(id, httpExchange);
                 } else {
@@ -142,11 +144,11 @@ class ChainingHttpHandler implements HttpHandler, ResettableExpectations {
                     requestFailed(outcome, failure);
                     String stacktrace = ExceptionUtils.getStackTrace(failure);
                     dumpThreadsUponTimeout(stacktrace);
-                    System.out.printf("[%d] handling failed with exception %s%n", id, stacktrace);
+                    System.out.printf("[%s][%d] handling failed with exception %s%n", getCurrentTimestamp(), id, stacktrace);
                     sendFailure(httpExchange, 400, outcome);
                 }
             } catch (Throwable t) {
-                System.out.printf("[%d] handling %s failed with exception%n", id, outcome.getDisplayName());
+                System.out.printf("[%s][%d] handling %s failed with exception%n", getCurrentTimestamp(), id, outcome.getDisplayName());
                 try {
                     sendFailure(httpExchange, 500, outcome);
                 } catch (IOException e) {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/SendPartialResponseThenBlock.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/SendPartialResponseThenBlock.java
@@ -27,6 +27,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 
+import static org.gradle.test.fixtures.server.http.BlockingHttpServer.getCurrentTimestamp;
+
 class SendPartialResponseThenBlock implements BlockingHttpServer.BlockingRequest, ResponseProducer {
     private final byte[] content;
     private final Lock lock;
@@ -64,7 +66,7 @@ class SendPartialResponseThenBlock implements BlockingHttpServer.BlockingRequest
             while (!released && failure == null) {
                 long waitMs = mostRecentEvent + timeout.toMillis() - clock.getCurrentTime();
                 if (waitMs < 0) {
-                    System.out.println(String.format("[%d] timeout waiting to be released after sending some content", requestId));
+                    System.out.printf("[%s][%d] timeout waiting to be released after sending some content%n", getCurrentTimestamp(), requestId);
                     failure = new AssertionError("Timeout waiting to be released after sending some content.");
                     condition.signalAll();
                     throw failure;


### PR DESCRIPTION
To troubleshooting flaky [ArtifactTransformParallelIntegrationTest](https://ge.gradle.org/scans/tests?search.relativeStartTime=P7D&search.timeZoneId=Europe%2FBerlin&tests.container=org.gradle.integtests.resolve.transform.ArtifactTransformParallelIntegrationTest&tests.sortField=FLAKY), this PR adds some logs to the test and fixtures.