### PR TITLE
Rebaseline performance tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,6 +24,6 @@ develocity.internal.testdistribution.writeTraceFile=true
 gradle.internal.testdistribution.queryResponseTimeout=PT20S
 develocity.internal.testdistribution.queryResponseTimeout=PT20S
 # Default performance baseline
-defaultPerformanceBaselines=8.13-commit-94c98230b1cc
+defaultPerformanceBaselines=8.13-commit-a6bf0de82e44
 #-----------------------------------------till here^
 systemProp.dependency.analysis.test.analysis=false


### PR DESCRIPTION
Because the perf tests are failing with non-production-only changes.