### PR TITLE
GitHub action for closing linked issue on PR merged into release

### DIFF
--- a/.github/workflows/close-linked-issue-when-merged-into-release.yml
+++ b/.github/workflows/close-linked-issue-when-merged-into-release.yml
@@ -1,0 +1,20 @@
+name: Close linked issues when PR merged into release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - release
+      - release7x
+
+permissions:
+  issues: write
+
+jobs:
+  closeIssueOnPrMerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Closes issues related to a merged pull request.
+        uses: ldez/gha-mjolnir@50ef6170214a84277545578a308ad77a1a30d78d
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We want a linked issue to be closed when the PR is merged to not only master but release. There seems to be an action doing this: https://github.com/ldez/gha-mjolnir