### PR TITLE
Extract and separate roots for report testing

### DIFF
--- a/platforms/software/testing-base/src/integTest/groovy/org/gradle/testing/CustomTestTaskHTMLTestReportMetadataTest.groovy
+++ b/platforms/software/testing-base/src/integTest/groovy/org/gradle/testing/CustomTestTaskHTMLTestReportMetadataTest.groovy
@@ -39,15 +39,19 @@ final class CustomTestTaskHTMLTestReportMetadataTest extends AbstractIntegration
         and: "Verify the metadata is present in the single test report for the suite"
         def results = resultsFor("failing")
         results.testPath(":failing suite")
+            .onlyRoot()
             .assertMetadata(["suitekey"])
         results.testPath(":failing suite:failing test")
+            .onlyRoot()
             .assertMetadata(["testkey", "testkey2", "testkey3", "testkey4"])
 
         and: "Also in the aggregate report"
         def aggregateResults = aggregateResults()
         aggregateResults.testPath(":failing suite")
+            .onlyRoot()
             .assertChildCount(1, 1, 0)
         aggregateResults.testPath(":failing suite:failing test")
+            .onlyRoot()
             .assertMetadata(["testkey", "testkey2", "testkey3", "testkey4"])
     }
 
@@ -65,6 +69,7 @@ final class CustomTestTaskHTMLTestReportMetadataTest extends AbstractIntegration
         and:
         def results = resultsFor("failing")
         results.testPath(":failing suite:failing test")
+            .onlyRoot()
             .assertMetadata(["group1key1", "group1key2", "group2key1", "group2key2"])
     }
 
@@ -83,24 +88,32 @@ final class CustomTestTaskHTMLTestReportMetadataTest extends AbstractIntegration
         def aggregateResults = aggregateResults()
 
         aggregateResults.testPath("Unit Tests Suite")
+            .onlyRoot()
             .assertChildCount(2, 0, 0)
         aggregateResults.testPath("Unit Tests Suite:test1")
+            .onlyRoot()
             .assertMetadata(["key1"])
         aggregateResults.testPath("Unit Tests Suite:test2")
+            .onlyRoot()
             .assertMetadata(["key2"])
 
         aggregateResults.testPath("Slow Integration Tests Suite")
+            .onlyRoot()
             .assertChildCount(1, 0, 0)
             .assertMetadata(["suitekey1"])
         aggregateResults.testPath("Slow Integration Tests Suite:intTest1")
+            .onlyRoot()
             .assertMetadata(["ikey1"])
 
         aggregateResults.testPath("Slower Integration Tests Suite")
+            .onlyRoot()
             .assertChildCount(2, 1, 0)
             .assertMetadata(["suitekey2", "suitekey2-another"])
         aggregateResults.testPath("Slower Integration Tests Suite:intTest2")
+            .onlyRoot()
             .assertMetadata(["ikey2"])
         aggregateResults.testPath("Slower Integration Tests Suite:intTest3")
+            .onlyRoot()
             .assertMetadata(["ikey3"])
     }
 
@@ -118,6 +131,7 @@ final class CustomTestTaskHTMLTestReportMetadataTest extends AbstractIntegration
         and:
         def results = resultsFor("failing")
         results.testPath(":failing suite:failing test")
+            .onlyRoot()
             .assertMetadata(["stringKey": "This is a string",
                              "stringKey2": "This is another string",
                              "booleanKey1": "true",

--- a/platforms/software/testing-base/src/integTest/groovy/org/gradle/testing/TestEventReporterHtmlReportIntegrationTest.groovy
+++ b/platforms/software/testing-base/src/integTest/groovy/org/gradle/testing/TestEventReporterHtmlReportIntegrationTest.groovy
@@ -23,7 +23,6 @@ import org.gradle.internal.logging.ConsoleRenderer
 
 import static org.gradle.util.Matchers.containsText
 import static org.hamcrest.CoreMatchers.equalTo
-import static org.hamcrest.Matchers.allOf
 
 class TestEventReporterHtmlReportIntegrationTest extends AbstractIntegrationSpec implements VerifiesGenericTestReportResults {
 
@@ -41,6 +40,7 @@ class TestEventReporterHtmlReportIntegrationTest extends AbstractIntegrationSpec
         // Aggregate results are still emitted even if we don't print the URL to console
         aggregateResults()
             .testPath(":passing suite")
+            .onlyRoot()
             .assertChildCount(1, 0, 0)
     }
 
@@ -55,10 +55,12 @@ class TestEventReporterHtmlReportIntegrationTest extends AbstractIntegrationSpec
         def results = aggregateResults()
         results
             .testPath(":passing suite")
+            .onlyRoot()
             .assertStdout(equalTo(""))
             .assertStderr(equalTo(""))
         results
             .testPath(":passing suite:passing test")
+            .onlyRoot()
             .assertStdout(equalTo("standard out text"))
             .assertStderr(equalTo("standard error text"))
     }
@@ -74,6 +76,7 @@ class TestEventReporterHtmlReportIntegrationTest extends AbstractIntegrationSpec
         def results = aggregateResults()
         results
             .testPath(":failing suite:failing test")
+            .onlyRoot()
             .assertHasResult(TestResult.ResultType.FAILURE)
             .assertFailureMessages(containsText("failure message"))
     }
@@ -90,16 +93,18 @@ class TestEventReporterHtmlReportIntegrationTest extends AbstractIntegrationSpec
         failure.assertHasErrorOutput("See the test results for more details: " + resultsUrlFor("failing"))
         resultsFor("failing")
             .testPath(":failing suite")
+            .onlyRoot()
             .assertChildCount(1, 1, 0)
 
         // Aggregate results are still emitted even if we don't print the URL to console
         outputDoesNotContain("Aggregate test results")
         aggregateResults()
             .testPath(":failing suite")
+            .onlyRoot()
             .assertChildCount(1, 1, 0)
     }
 
-    def "does not emit aggregate test results if only one test task fails"() {
+    def "does not print aggregate test results URL if only one test task fails"() {
         given:
         buildFile << passingTask("passing")
         buildFile << failingTask("failing")
@@ -114,12 +119,14 @@ class TestEventReporterHtmlReportIntegrationTest extends AbstractIntegrationSpec
         outputDoesNotContain("Aggregate test results")
         def aggregateResults = aggregateResults()
         aggregateResults.testPath(":passing suite")
+            .onlyRoot()
             .assertChildCount(1, 0, 0)
         aggregateResults.testPath(":failing suite")
+            .onlyRoot()
             .assertChildCount(1, 1, 0)
     }
 
-    def "emits aggregate test results if multiple test tasks fail"() {
+    def "prints aggregate test results URL if multiple test tasks fail"() {
         given:
         buildFile << failingTask("failing1")
         buildFile << failingTask("failing2")
@@ -132,12 +139,14 @@ class TestEventReporterHtmlReportIntegrationTest extends AbstractIntegrationSpec
         failure.assertHasErrorOutput("See the test results for more details: " + resultsUrlFor("failing1"))
         resultsFor("failing1")
             .testPath("failing1 suite")
+            .onlyRoot()
             .assertChildCount(1, 1, 0)
 
         failure.assertHasDescription("Execution failed for task ':failing2'.")
         failure.assertHasErrorOutput("See the test results for more details: " + resultsUrlFor("failing2"))
         resultsFor("failing2")
             .testPath("failing2 suite")
+            .onlyRoot()
             .assertChildCount(1, 1, 0)
 
         def aggregateReportFile = file("build/reports/aggregate-test-results/index.html")
@@ -145,8 +154,10 @@ class TestEventReporterHtmlReportIntegrationTest extends AbstractIntegrationSpec
         outputContains("Aggregate test results: " + renderedUrl)
         def aggregateResults = aggregateResults()
         aggregateResults.testPath("failing1 suite")
+            .onlyRoot()
             .assertChildCount(1, 1, 0)
         aggregateResults.testPath("failing2 suite")
+            .onlyRoot()
             .assertChildCount(1, 1, 0)
     }
 
@@ -167,6 +178,23 @@ class TestEventReporterHtmlReportIntegrationTest extends AbstractIntegrationSpec
 
         then:
         aggregateReportFile.assertDoesNotExist()
+    }
+
+    def "aggregate test results has roots in order by path to roots"() {
+        given:
+        buildFile << passingTask("aFirst")
+        buildFile << failingTask("bSecond")
+        buildFile << failingTask("cThird")
+        buildFile << passingTask("dFourth")
+
+        when:
+        fails("--continue", "aFirst", "bSecond", "cThird", "dFourth")
+
+        then:
+        failure.assertHasFailures(2)
+
+        def aggregateResults = aggregateResults()
+        assert aggregateResults.testPath(":").rootNames == ["aFirst", "bSecond", "cThird", "dFourth"]
     }
 
     def "aggregate report with roots of same name disambiguates the roots and has both results"() {
@@ -217,18 +245,17 @@ class TestEventReporterHtmlReportIntegrationTest extends AbstractIntegrationSpec
 
 
         then:
-        def rootIndexFile = file("build/reports/aggregate-test-results/index.html")
-        rootIndexFile.exists()
-        rootIndexFile.assertContents(allOf(
-            containsText("TheSameName (1)"),
-            containsText("TheSameName (2)")
-        ))
-
         def results = aggregateResults()
         results
             .testPath("TheSameName suite")
-            .assertChildCount(2, 0, 0)
-            .assertChildrenExecuted("theSameName1 test", "theSameName2 test")
+            .root("TheSameName (1)")
+            .assertChildCount(1, 0, 0)
+            .assertChildrenExecuted("theSameName1 test")
+        results
+            .testPath("TheSameName suite")
+            .root("TheSameName (2)")
+            .assertChildCount(1, 0, 0)
+            .assertChildrenExecuted("theSameName2 test")
     }
 
     def passingTask(String name, boolean print = false) {

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/AggregateTestEventReporter.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/AggregateTestEventReporter.java
@@ -33,6 +33,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -106,7 +109,10 @@ public class AggregateTestEventReporter implements ProblemReporter, TestExecutio
      * @return The path to the index file that should be reported to the user.
      */
     private Path generateTestReport(Path reportDirectory) {
-        new GenericTestReportGenerator(results.values(), metadataRendererRegistry).generateReport(buildOperationRunner, buildOperationExecutor, reportDirectory);
+        // Generate a consistent ordering by sorting the Paths
+        List<Path> sortedResults = new ArrayList<>(results.values());
+        sortedResults.sort(Comparator.naturalOrder());
+        new GenericTestReportGenerator(sortedResults, metadataRendererRegistry).generateReport(buildOperationRunner, buildOperationExecutor, reportDirectory);
         return reportDirectory.resolve("index.html");
     }
 

--- a/platforms/software/testing-base/src/testFixtures/groovy/org/gradle/api/internal/tasks/testing/report/generic/TestPathExecutionResult.java
+++ b/platforms/software/testing-base/src/testFixtures/groovy/org/gradle/api/internal/tasks/testing/report/generic/TestPathExecutionResult.java
@@ -16,52 +16,24 @@
 
 package org.gradle.api.internal.tasks.testing.report.generic;
 
-import org.gradle.api.tasks.testing.TestResult;
-import org.hamcrest.Matcher;
-
-import java.util.LinkedHashMap;
 import java.util.List;
 
-// For now, I think this works enough. It will need to be rewritten to account for different root tabs.
+/**
+ * Represents the result of executing a test path.
+ */
 public interface TestPathExecutionResult {
     /**
-     * Asserts that the given child paths (and only the given child paths) were executed for the current test path.
-     *
-     * <p>
-     * For example, if you want to know if {@code :TestClass:testMethod} executed {@code subTest1} and {@code subTest2},
-     * you would call {@code testPath(":TestClass:testMethod").assertPathsExecuted("subTest1", "subTest2")}.
-     * </p>
-     *
-     * <p>
-     * This method only works on direct children of the current test path.
-     * </p>
+     * Assert that a single root is present, and provides access to the results of the test path execution.
      */
-    TestPathExecutionResult assertChildrenExecuted(String... testNames);
-
-    TestPathExecutionResult assertChildCount(int tests, int failures, int errors);
-
-    TestPathExecutionResult assertStdout(Matcher<? super String> matcher);
-
-    TestPathExecutionResult assertStderr(Matcher<? super String> matcher);
-
-    TestPathExecutionResult assertHasResult(TestResult.ResultType resultType);
-
-    TestPathExecutionResult assertFailureMessages(Matcher<? super String> matcher);
+    TestPathRootExecutionResult onlyRoot();
 
     /**
-     * Asserts that the given metadata keys are present in the test result.
-     *
-     * @param keys the keys to verify, in the order they were recorded
-     * @return {@code this}
+     * Assert that there is a root with the given root name, and provides access to the results of the test path execution.
      */
-    TestPathExecutionResult assertMetadata(List<String> keys);
-
+    TestPathRootExecutionResult root(String rootName);
 
     /**
-     * Asserts that the given metadata keys are present in the test result with the given rendered text.
-     *
-     * @param metadata the metadata to verify, in the order they were recorded
-     * @return {@code this}
+     * Returns the names of the roots that were executed.
      */
-    TestPathExecutionResult assertMetadata(LinkedHashMap<String, String> metadata);
+    List<String> getRootNames();
 }

--- a/platforms/software/testing-base/src/testFixtures/groovy/org/gradle/api/internal/tasks/testing/report/generic/TestPathRootExecutionResult.java
+++ b/platforms/software/testing-base/src/testFixtures/groovy/org/gradle/api/internal/tasks/testing/report/generic/TestPathRootExecutionResult.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing.report.generic;
+
+import org.gradle.api.tasks.testing.TestResult;
+import org.hamcrest.Matcher;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+
+/**
+ * Represents the result of executing a test path in a specific root.
+ */
+public interface TestPathRootExecutionResult {
+    /**
+     * Asserts that the given child paths (and only the given child paths) were executed for the current test path.
+     *
+     * <p>
+     * For example, if you want to know if {@code :TestClass:testMethod} executed {@code subTest1} and {@code subTest2},
+     * you would call {@code testPath(":TestClass:testMethod").assertPathsExecuted("subTest1", "subTest2")}.
+     * </p>
+     *
+     * <p>
+     * This method only works on direct children of the current test path.
+     * </p>
+     */
+    TestPathRootExecutionResult assertChildrenExecuted(String... testNames);
+
+    TestPathRootExecutionResult assertChildCount(int tests, int failures, int errors);
+
+    TestPathRootExecutionResult assertStdout(Matcher<? super String> matcher);
+
+    TestPathRootExecutionResult assertStderr(Matcher<? super String> matcher);
+
+    TestPathRootExecutionResult assertHasResult(TestResult.ResultType resultType);
+
+    TestPathRootExecutionResult assertFailureMessages(Matcher<? super String> matcher);
+
+    /**
+     * Asserts that the given metadata keys are present in the test result.
+     *
+     * @param keys the keys to verify, in the order they were recorded
+     * @return {@code this}
+     */
+    TestPathRootExecutionResult assertMetadata(List<String> keys);
+
+
+    /**
+     * Asserts that the given metadata keys are present in the test result with the given rendered text.
+     *
+     * @param metadata the metadata to verify, in the order they were recorded
+     * @return {@code this}
+     */
+    TestPathRootExecutionResult assertMetadata(LinkedHashMap<String, String> metadata);
+}


### PR DESCRIPTION
This allows more specific assertions for some aggregate tests

### Context
We wrote some aggregate report tests without this that used text contains to validate root names. Additionally, there was no control over which test results to select in the event they differed.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
