### PR TITLE
Refactor LenientPlatformGraphResolveState to not extend DefaultExternalComponentGraphResolveState

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -236,12 +236,11 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
             for (ComponentState version : module.getAllVersions()) {
                 if (version != this) {
                     ComponentGraphResolveState versionState = version.getResolveStateOrNull();
-                    if (versionState != null) {
-                        ComponentGraphResolveState lenient = versionState.maybeAsLenientPlatform((ModuleComponentIdentifier) componentIdentifier, id);
-                        if (lenient != null) {
-                            setState(lenient, ComponentGraphSpecificResolveState.EMPTY_STATE);
-                            return true;
-                        }
+                    if (versionState instanceof LenientPlatformGraphResolveState) {
+                        LenientPlatformGraphResolveState lenientState = (LenientPlatformGraphResolveState) versionState;
+                        ComponentGraphResolveState withIds = lenientState.copyWithIds((ModuleComponentIdentifier) componentIdentifier, id);
+                        setState(withIds, ComponentGraphSpecificResolveState.EMPTY_STATE);
+                        return true;
                     }
                 }
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
@@ -81,9 +81,11 @@ class LenientPlatformDependencyMetadata implements ModuleDependencyMetadata, For
     @Override
     public GraphVariantSelectionResult selectVariants(GraphVariantSelector variantSelector, ImmutableAttributes consumerAttributes, ComponentGraphResolveState targetComponentState, ImmutableAttributesSchema consumerSchema, Set<CapabilitySelector> explicitRequestedCapabilities) {
         if (targetComponentState instanceof LenientPlatformGraphResolveState) {
-            VariantGraphResolveState variant = ((LenientPlatformGraphResolveState) targetComponentState).getDefaultVariant(from, platformId);
+            LenientPlatformGraphResolveState lenientPlatform = (LenientPlatformGraphResolveState) targetComponentState;
+            VariantGraphResolveState variant = lenientPlatform.getCandidatesForGraphVariantSelection().getVariantForSourceNode(from, platformId);
             return new GraphVariantSelectionResult(Collections.singletonList(variant), false);
         }
+
         // the target component exists, so we need to fallback to the traditional selection process
         return new LocalComponentDependencyMetadata(cs, null, Collections.emptyList(), Collections.emptyList(), false, false, true, false, false, null).selectVariants(variantSelector, consumerAttributes, targetComponentState, consumerSchema, explicitRequestedCapabilities);
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformGraphResolveState.java
@@ -18,21 +18,39 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.internal.component.external.model.DefaultConfigurationMetadata;
+import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchema;
+import org.gradle.internal.Describables;
+import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactMetadata;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
+import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
-import org.gradle.internal.component.external.model.VariantMetadataRules;
+import org.gradle.internal.component.model.AbstractComponentGraphResolveState;
+import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
+import org.gradle.internal.component.model.ComponentConfigurationIdentifier;
 import org.gradle.internal.component.model.ComponentGraphResolveState;
 import org.gradle.internal.component.model.ComponentIdGenerator;
-import org.gradle.internal.component.model.ConfigurationMetadata;
-import org.gradle.internal.component.model.DefaultExternalComponentGraphResolveState;
+import org.gradle.internal.component.model.DefaultVariantMetadata;
+import org.gradle.internal.component.model.DependencyMetadata;
+import org.gradle.internal.component.model.ExcludeMetadata;
+import org.gradle.internal.component.model.GraphSelectionCandidates;
+import org.gradle.internal.component.model.ImmutableModuleSources;
+import org.gradle.internal.component.model.IvyArtifactName;
+import org.gradle.internal.component.model.ModuleSources;
+import org.gradle.internal.component.model.VariantArtifactResolveState;
+import org.gradle.internal.component.model.VariantGraphResolveMetadata;
 import org.gradle.internal.component.model.VariantGraphResolveState;
+import org.gradle.internal.component.model.VariantResolveMetadata;
+import org.gradle.internal.deprecation.DeprecationLogger;
+import org.gradle.internal.lazy.Lazy;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -40,49 +58,414 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-public class LenientPlatformGraphResolveState extends DefaultExternalComponentGraphResolveState<LenientPlatformResolveMetadata, LenientPlatformResolveMetadata> {
-    private final ComponentIdGenerator componentIdGenerator;
+public class LenientPlatformGraphResolveState extends AbstractComponentGraphResolveState<LenientPlatformResolveMetadata> {
+
+    private final ComponentIdGenerator idGenerator;
+    private final NodeState platformNode;
     private final ResolveState resolveState;
+    private final VirtualPlatformState virtualPlatformState;
 
     public static LenientPlatformGraphResolveState of(
         ComponentIdGenerator componentIdGenerator,
         ModuleComponentIdentifier moduleComponentIdentifier,
         ModuleVersionIdentifier moduleVersionIdentifier,
-        VirtualPlatformState platformState,
+        VirtualPlatformState virtualPlatformState,
         NodeState platformNode,
         ResolveState resolveState
     ) {
-        LenientPlatformResolveMetadata metadata = new LenientPlatformResolveMetadata(moduleComponentIdentifier, moduleVersionIdentifier, platformState, platformNode, resolveState);
-        return new LenientPlatformGraphResolveState(componentIdGenerator.nextComponentId(), metadata, componentIdGenerator, resolveState);
+        LenientPlatformResolveMetadata metadata = new LenientPlatformResolveMetadata(moduleComponentIdentifier, moduleVersionIdentifier);
+        return new LenientPlatformGraphResolveState(componentIdGenerator.nextComponentId(), metadata, componentIdGenerator, virtualPlatformState, platformNode, resolveState);
     }
 
-    private LenientPlatformGraphResolveState(long instanceId, LenientPlatformResolveMetadata metadata, ComponentIdGenerator componentIdGenerator, ResolveState resolveState) {
-        super(instanceId, metadata, metadata, resolveState.getAttributeDesugaring(), componentIdGenerator);
-        this.componentIdGenerator = componentIdGenerator;
+    private LenientPlatformGraphResolveState(
+        long instanceId,
+        LenientPlatformResolveMetadata metadata,
+        ComponentIdGenerator idGenerator,
+        VirtualPlatformState virtualPlatformState,
+        NodeState platformNode,
+        ResolveState resolveState
+    ) {
+        super(instanceId, metadata, resolveState.getAttributeDesugaring());
+        this.idGenerator = idGenerator;
+        this.platformNode = platformNode;
         this.resolveState = resolveState;
-    }
-
-    @Nullable
-    @Override
-    public ComponentGraphResolveState maybeAsLenientPlatform(ModuleComponentIdentifier componentIdentifier, ModuleVersionIdentifier moduleVersionIdentifier) {
-        return new LenientPlatformGraphResolveState(componentIdGenerator.nextComponentId(), getMetadata().withVersion(componentIdentifier, moduleVersionIdentifier), componentIdGenerator, resolveState);
+        this.virtualPlatformState = virtualPlatformState;
     }
 
     /**
-     * @param platformId The consuming platform.
+     * Create a copy of this component with the given ids.
      */
-    public VariantGraphResolveState getDefaultVariant(NodeState from, @Nullable ComponentIdentifier platformId) {
-        return newResolveStateFor(new LenientPlatformConfigurationMetadata(getMetadata().getPlatformState(), getMetadata().getId(), from, platformId));
+    public ComponentGraphResolveState copyWithIds(ModuleComponentIdentifier componentIdentifier, ModuleVersionIdentifier moduleVersionIdentifier) {
+        return new LenientPlatformGraphResolveState(
+            idGenerator.nextComponentId(),
+            getMetadata().copyWithIds(componentIdentifier, moduleVersionIdentifier),
+            idGenerator,
+            virtualPlatformState,
+            platformNode,
+            resolveState
+        );
     }
 
-    private class LenientPlatformConfigurationMetadata extends DefaultConfigurationMetadata implements ConfigurationMetadata {
-        private final VirtualPlatformState platformState;
+    @Override
+    public ComponentArtifactResolveMetadata getArtifactMetadata() {
+        return new LenientPlatformArtifactResolveMetadata(getMetadata());
+    }
+
+    /**
+     * Artifact metadata for a lenient platform.
+     */
+    private static class LenientPlatformArtifactResolveMetadata implements ComponentArtifactResolveMetadata {
+
+        private final LenientPlatformResolveMetadata metadata;
+
+        LenientPlatformArtifactResolveMetadata(LenientPlatformResolveMetadata metadata) {
+            this.metadata = metadata;
+        }
+
+        @Override
+        public ComponentIdentifier getId() {
+            return metadata.getId();
+        }
+
+        @Override
+        public ModuleVersionIdentifier getModuleVersionId() {
+            return metadata.getModuleVersionId();
+        }
+
+        @Override
+        public ModuleSources getSources() {
+            return ImmutableModuleSources.of();
+        }
+
+        @Override
+        public ImmutableAttributes getAttributes() {
+            return ImmutableAttributes.EMPTY;
+        }
+
+        @Override
+        public ImmutableAttributesSchema getAttributesSchema() {
+            return metadata.getAttributesSchema();
+        }
+
+    }
+
+    @Override
+    public List<ResolvedVariantResult> getAllSelectableVariantResults() {
+        // Variants are not selected from a lenient platform in the conventional manner.
+        return Collections.emptyList();
+    }
+
+    @Override
+    public LenientPlatformGraphSelectionCandidates getCandidatesForGraphVariantSelection() {
+        return new LenientPlatformGraphSelectionCandidates(this);
+    }
+
+    public static class LenientPlatformGraphSelectionCandidates implements GraphSelectionCandidates {
+
+        private final LenientPlatformGraphResolveState component;
+        private final Lazy<LenientPlatformVariantGraphResolveState> implicitVariantState;
+
+        public LenientPlatformGraphSelectionCandidates(LenientPlatformGraphResolveState component) {
+            this.component = component;
+            this.implicitVariantState = Lazy.locking().of(() -> createImplicitVariant(component));
+        }
+
+        @Override
+        public List<? extends VariantGraphResolveState> getVariantsForAttributeMatching() {
+            // Variants are not selected from a lenient platform in the conventional manner.
+            return Collections.emptyList();
+        }
+
+        @Nullable
+        @Override
+        public VariantGraphResolveState getLegacyVariant() {
+            return doGetVariantByConfigurationName(Dependency.DEFAULT_CONFIGURATION);
+        }
+
+        @Nullable
+        @Override
+        public VariantGraphResolveState getVariantByConfigurationName(String name) {
+            DeprecationLogger.deprecateBehaviour("Selecting a variant by configuration name from a non-Ivy external component.")
+                .willBecomeAnErrorInGradle9()
+                .withUpgradeGuideSection(8, "selecting_variant_by_configuration_name")
+                .nagUser();
+
+            return doGetVariantByConfigurationName(name);
+        }
+
+        @Nullable
+        private VariantGraphResolveState doGetVariantByConfigurationName(String name) {
+            if (!name.equals(Dependency.DEFAULT_CONFIGURATION)) {
+                return null;
+            }
+
+            return implicitVariantState.get();
+        }
+
+        /**
+         * The variant that is selected when a normal dependency targets this component.
+         */
+        private static LenientPlatformVariantGraphResolveState createImplicitVariant(LenientPlatformGraphResolveState component) {
+            VariantDependencyFactory dependencyFactory = new ImplicitVariantDependencyFactory(
+                component.virtualPlatformState,
+                component.resolveState,
+                component.platformNode,
+                component.getMetadata().getModuleVersionId()
+            );
+
+            return new LenientPlatformVariantGraphResolveState(
+                component.idGenerator.nextVariantId(),
+                component.getMetadata().getId(),
+                new LenientPlatformVariantGraphResolveMetadata(Dependency.DEFAULT_CONFIGURATION, false, dependencyFactory)
+            );
+        }
+
+        /**
+         * The variant that is selected when another lenient platform targets this component.
+         *
+         * @param platformId The consuming platform.
+         */
+        public VariantGraphResolveState getVariantForSourceNode(
+            NodeState from,
+            @Nullable ComponentIdentifier platformId
+        ) {
+            VariantDependencyFactory dependencyFactory = new SourceAwareVariantDependencyFactory(
+                component.virtualPlatformState,
+                component.resolveState,
+                from,
+                platformId
+            );
+
+            return new LenientPlatformVariantGraphResolveState(
+                component.idGenerator.nextVariantId(),
+                component.getMetadata().getId(),
+                new LenientPlatformVariantGraphResolveMetadata(Dependency.DEFAULT_CONFIGURATION, true, dependencyFactory)
+            );
+        }
+
+    }
+
+    /**
+     * Metadata for a variant of a lenient platform.
+     */
+    private static class LenientPlatformVariantGraphResolveMetadata implements VariantGraphResolveMetadata {
+
+        private final String name;
+        private final boolean transitive;
+        private final VariantDependencyFactory dependencyFactory;
+
+        public LenientPlatformVariantGraphResolveMetadata(
+            String name,
+            boolean transitive,
+            VariantDependencyFactory dependencyFactory
+        ) {
+            this.name = name;
+            this.transitive = transitive;
+            this.dependencyFactory = dependencyFactory;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public ImmutableAttributes getAttributes() {
+            return ImmutableAttributes.EMPTY;
+        }
+
+        @Override
+        public ImmutableCapabilities getCapabilities() {
+            return ImmutableCapabilities.EMPTY;
+        }
+
+        public List<? extends ModuleDependencyMetadata> getDependencies() {
+            return dependencyFactory.getDependencies();
+        }
+
+        @Override
+        public boolean isTransitive() {
+            return transitive;
+        }
+
+        @Override
+        public boolean isExternalVariant() {
+            return false;
+        }
+
+    }
+
+    /**
+     * State for a variant of a lenient platform.
+     */
+    private static class LenientPlatformVariantGraphResolveState implements VariantGraphResolveState {
+
+        private final long instanceId;
+        private final LenientPlatformVariantGraphResolveMetadata metadata;
+        private final LenientPlatformVariantArtifactResolveState artifactResolveState;
+
+        public LenientPlatformVariantGraphResolveState(
+            long instanceId,
+            ModuleComponentIdentifier componentId,
+            LenientPlatformVariantGraphResolveMetadata metadata
+        ) {
+            this.instanceId = instanceId;
+            this.metadata = metadata;
+            this.artifactResolveState = new LenientPlatformVariantArtifactResolveState(componentId, metadata);
+        }
+
+        @Override
+        public long getInstanceId() {
+            return instanceId;
+        }
+
+        @Override
+        public String getName() {
+            return metadata.getName();
+        }
+
+        @Override
+        public ImmutableAttributes getAttributes() {
+            return metadata.getAttributes();
+        }
+
+        @Override
+        public ImmutableCapabilities getCapabilities() {
+            return metadata.getCapabilities();
+        }
+
+        @Override
+        public List<? extends DependencyMetadata> getDependencies() {
+            return metadata.getDependencies();
+        }
+
+        @Override
+        public List<? extends ExcludeMetadata> getExcludes() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public VariantGraphResolveMetadata getMetadata() {
+            return metadata;
+        }
+
+        @Override
+        public VariantArtifactResolveState prepareForArtifactResolution() {
+            return artifactResolveState;
+        }
+    }
+
+    /**
+     * Artifact state for a variant of a lenient platform.
+     */
+    private static class LenientPlatformVariantArtifactResolveState implements VariantArtifactResolveState {
+
+        private final ModuleComponentIdentifier componentId;
+        private final VariantGraphResolveMetadata variant;
+
+        public LenientPlatformVariantArtifactResolveState(ModuleComponentIdentifier componentId, VariantGraphResolveMetadata variant) {
+            this.componentId = componentId;
+            this.variant = variant;
+        }
+
+        @Override
+        public ImmutableList<ComponentArtifactMetadata> getAdhocArtifacts(List<IvyArtifactName> dependencyArtifacts) {
+            ImmutableList.Builder<ComponentArtifactMetadata> artifacts = ImmutableList.builderWithExpectedSize(dependencyArtifacts.size());
+            for (IvyArtifactName dependencyArtifact : dependencyArtifacts) {
+                artifacts.add(new DefaultModuleComponentArtifactMetadata(componentId, dependencyArtifact));
+            }
+            return artifacts.build();
+        }
+
+        @Override
+        public Set<? extends VariantResolveMetadata> getArtifactVariants() {
+            String name = variant.getName();
+            return ImmutableSet.of(new DefaultVariantMetadata(
+                name,
+                new ComponentConfigurationIdentifier(componentId, name),
+                Describables.of(componentId, "variant", name),
+                variant.getAttributes(),
+                ImmutableList.of(),
+                variant.getCapabilities()
+            ));
+        }
+
+    }
+
+    /**
+     * Factory for dependencies of a variant.
+     * <p>
+     * Lenient platforms have both an implicit variant and a source-aware variant.
+     * The implicit variant is selected when a normal dependency targets the platform,
+     * while the source-aware variant is selected when another lenient platform targets the platform.
+     * <p>
+     * These two schemes have different approaches to selecting dependencies.
+     */
+    interface VariantDependencyFactory {
+
+        List<? extends ModuleDependencyMetadata> getDependencies();
+
+    }
+
+    /**
+     * Dependencies for the implicit variant of a lenient platform.
+     */
+    private static class ImplicitVariantDependencyFactory implements VariantDependencyFactory {
+
+        private final VirtualPlatformState virtualPlatformState;
+        private final ResolveState resolveState;
+        private final NodeState platformNode;
+        private final ModuleVersionIdentifier moduleVersionIdentifier;
+
+        public ImplicitVariantDependencyFactory(
+            VirtualPlatformState virtualPlatformState,
+            ResolveState resolveState,
+            NodeState platformNode,
+            ModuleVersionIdentifier moduleVersionIdentifier
+        ) {
+            this.virtualPlatformState = virtualPlatformState;
+            this.resolveState = resolveState;
+            this.platformNode = platformNode;
+            this.moduleVersionIdentifier = moduleVersionIdentifier;
+        }
+
+        @Override
+        public List<? extends ModuleDependencyMetadata> getDependencies() {
+            ImmutableList.Builder<ModuleDependencyMetadata> dependencies = new ImmutableList.Builder<>();
+            Set<ModuleResolveState> participatingModules = virtualPlatformState.getParticipatingModules();
+            for (ModuleResolveState module : participatingModules) {
+                dependencies.add(new LenientPlatformDependencyMetadata(
+                    resolveState,
+                    platformNode,
+                    DefaultModuleComponentSelector.newSelector(module.getId(), moduleVersionIdentifier.getVersion()),
+                    DefaultModuleComponentIdentifier.newId(module.getId(), moduleVersionIdentifier.getVersion()),
+                    virtualPlatformState.getSelectedPlatformId(),
+                    virtualPlatformState.isForced(),
+                    true
+                ));
+            }
+            return dependencies.build();
+        }
+    }
+
+    /**
+     * Dependencies for the source-aware variant of a lenient platform.
+     */
+    private static class SourceAwareVariantDependencyFactory implements VariantDependencyFactory {
+
+        private final VirtualPlatformState virtualPlatformState;
+        private final ResolveState resolveState;
         private final NodeState from;
         private final ComponentIdentifier platformId;
 
-        public LenientPlatformConfigurationMetadata(VirtualPlatformState platform, ModuleComponentIdentifier componentId, NodeState from, @Nullable ComponentIdentifier platformId) {
-            super(componentId, "default", true, false, ImmutableSet.of("default"), ImmutableList.of(), VariantMetadataRules.noOp(), ImmutableList.of(), ImmutableAttributes.EMPTY, false);
-            this.platformState = platform;
+        public SourceAwareVariantDependencyFactory(
+            VirtualPlatformState virtualPlatformState,
+            ResolveState resolveState,
+            NodeState from,
+            @Nullable ComponentIdentifier platformId
+        ) {
+            this.virtualPlatformState = virtualPlatformState;
+            this.resolveState = resolveState;
             this.from = from;
             this.platformId = platformId;
         }
@@ -90,8 +473,8 @@ public class LenientPlatformGraphResolveState extends DefaultExternalComponentGr
         @Override
         public List<? extends ModuleDependencyMetadata> getDependencies() {
             List<ModuleDependencyMetadata> result = null;
-            List<String> candidateVersions = platformState.getCandidateVersions();
-            Set<ModuleResolveState> modules = platformState.getParticipatingModules();
+            List<String> candidateVersions = virtualPlatformState.getCandidateVersions();
+            Set<ModuleResolveState> modules = virtualPlatformState.getParticipatingModules();
             for (ModuleResolveState module : modules) {
                 ComponentState selected = module.getSelected();
                 if (selected != null) {
@@ -99,31 +482,38 @@ public class LenientPlatformGraphResolveState extends DefaultExternalComponentGr
                     for (String target : candidateVersions) {
                         ModuleComponentIdentifier leafId = DefaultModuleComponentIdentifier.newId(module.getId(), target);
                         ModuleComponentSelector leafSelector = DefaultModuleComponentSelector.newSelector(module.getId(), target);
-                        ComponentIdentifier platformId = platformState.getSelectedPlatformId();
+                        ComponentIdentifier platformId = virtualPlatformState.getSelectedPlatformId();
                         if (platformId == null) {
                             // Not sure this can happen, unless in error state
                             platformId = this.platformId;
                         }
                         if (!componentVersion.equals(target)) {
                             // We will only add dependencies to the leaves if there is such a published module
-                            PotentialEdge potentialEdge = PotentialEdge.of(resolveState, from, leafId, leafSelector, platformId, platformState.isForced(), false);
+                            PotentialEdge potentialEdge = PotentialEdge.of(resolveState, from, leafId, leafSelector, platformId, virtualPlatformState.isForced(), false);
                             if (potentialEdge.state != null) {
-                                result = registerPlatformEdge(result, modules, leafId, leafSelector, platformId, platformState.isForced());
+                                result = registerPlatformEdge(result, modules, leafId, leafSelector, platformId, virtualPlatformState.isForced());
                                 break;
                             }
                         } else {
                             // at this point we know the component exists
-                            result = registerPlatformEdge(result, modules, leafId, leafSelector, platformId, platformState.isForced());
+                            result = registerPlatformEdge(result, modules, leafId, leafSelector, platformId, virtualPlatformState.isForced());
                             break;
                         }
                     }
-                    platformState.attachOrphanEdges();
+                    virtualPlatformState.attachOrphanEdges();
                 }
             }
             return result == null ? Collections.emptyList() : result;
         }
 
-        private List<ModuleDependencyMetadata> registerPlatformEdge(@Nullable List<ModuleDependencyMetadata> result, Set<ModuleResolveState> modules, ModuleComponentIdentifier leafId, ModuleComponentSelector leafSelector, ComponentIdentifier platformId, boolean force) {
+        private List<ModuleDependencyMetadata> registerPlatformEdge(
+            @Nullable List<ModuleDependencyMetadata> result,
+            Set<ModuleResolveState> modules,
+            ModuleComponentIdentifier leafId,
+            ModuleComponentSelector leafSelector,
+            ComponentIdentifier platformId,
+            boolean force
+        ) {
             if (result == null) {
                 result = new ArrayList<>(modules.size());
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformResolveMetadata.java
@@ -16,49 +16,23 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.internal.attributes.AttributesFactory;
-import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchema;
-import org.gradle.internal.component.external.model.ComponentVariant;
-import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
-import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
-import org.gradle.internal.component.external.model.ExternalVariantGraphResolveMetadata;
-import org.gradle.internal.component.external.model.ImmutableCapabilities;
-import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
-import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
-import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
-import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
-import org.gradle.internal.component.external.model.NoOpDerivationStrategy;
-import org.gradle.internal.component.external.model.RealisedConfigurationMetadata;
-import org.gradle.internal.component.external.model.VariantDerivationStrategy;
-import org.gradle.internal.component.external.model.VariantMetadataRules;
 import org.gradle.internal.component.external.model.VirtualComponentIdentifier;
-import org.gradle.internal.component.model.ImmutableModuleSources;
-import org.gradle.internal.component.model.ModuleConfigurationMetadata;
-import org.gradle.internal.component.model.ModuleSources;
+import org.gradle.internal.component.model.ComponentGraphResolveMetadata;
 
-import javax.annotation.Nullable;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-
-class LenientPlatformResolveMetadata implements ModuleComponentResolveMetadata {
+/**
+ * Metadata for a lenient platform component.
+ */
+public class LenientPlatformResolveMetadata implements ComponentGraphResolveMetadata {
 
     private final ModuleComponentIdentifier moduleComponentIdentifier;
     private final ModuleVersionIdentifier moduleVersionIdentifier;
-    private final VirtualPlatformState platformState;
-    private final NodeState platformNode;
-    private final ResolveState resolveState;
 
-    LenientPlatformResolveMetadata(ModuleComponentIdentifier moduleComponentIdentifier, ModuleVersionIdentifier moduleVersionIdentifier, VirtualPlatformState platformState, NodeState platformNode, ResolveState resolveState) {
+    LenientPlatformResolveMetadata(ModuleComponentIdentifier moduleComponentIdentifier, ModuleVersionIdentifier moduleVersionIdentifier) {
         this.moduleComponentIdentifier = moduleComponentIdentifier;
         this.moduleVersionIdentifier = moduleVersionIdentifier;
-        this.platformState = platformState;
-        this.platformNode = platformNode;
-        this.resolveState = resolveState;
     }
 
     @Override
@@ -72,57 +46,12 @@ class LenientPlatformResolveMetadata implements ModuleComponentResolveMetadata {
     }
 
     @Override
-    public ModuleSources getSources() {
-        return ImmutableModuleSources.of();
-    }
-
-    @Override
     public ImmutableAttributesSchema getAttributesSchema() {
         return ImmutableAttributesSchema.EMPTY;
     }
 
-    @Override
-    public Set<String> getConfigurationNames() {
-        return Collections.singleton("default");
-    }
-
-    LenientPlatformResolveMetadata withVersion(ModuleComponentIdentifier moduleComponentIdentifier, ModuleVersionIdentifier moduleVersionIdentifier) {
-        return new LenientPlatformResolveMetadata(moduleComponentIdentifier, moduleVersionIdentifier, platformState, platformNode, resolveState);
-    }
-
-    @Nullable
-    @Override
-    public ModuleConfigurationMetadata getConfiguration(String name) {
-        if ("default".equals(name)) {
-            ImmutableList.Builder<ModuleDependencyMetadata> dependencies = new ImmutableList.Builder<>();
-            Set<ModuleResolveState> participatingModules = platformState.getParticipatingModules();
-            for (ModuleResolveState module : participatingModules) {
-                dependencies.add(new LenientPlatformDependencyMetadata(
-                    resolveState,
-                    platformNode,
-                    DefaultModuleComponentSelector.newSelector(module.getId(), moduleVersionIdentifier.getVersion()),
-                    DefaultModuleComponentIdentifier.newId(module.getId(), moduleVersionIdentifier.getVersion()),
-                    platformState.getSelectedPlatformId(),
-                    platformState.isForced(),
-                    true
-                ));
-            }
-            return new RealisedConfigurationMetadata(
-                moduleComponentIdentifier, name, false, false,
-                ImmutableSet.of(name), ImmutableList.of(), ImmutableList.of(), ImmutableAttributes.EMPTY, ImmutableCapabilities.EMPTY, dependencies.build(), false, false
-            );
-        }
-        return null;
-    }
-
-    @Override
-    public List<? extends ExternalVariantGraphResolveMetadata> getVariantsForGraphTraversal() {
-        return Collections.emptyList();
-    }
-
-    @Override
-    public boolean isMissing() {
-        return false;
+    LenientPlatformResolveMetadata copyWithIds(ModuleComponentIdentifier moduleComponentIdentifier, ModuleVersionIdentifier moduleVersionIdentifier) {
+        return new LenientPlatformResolveMetadata(moduleComponentIdentifier, moduleVersionIdentifier);
     }
 
     @Override
@@ -136,76 +65,8 @@ class LenientPlatformResolveMetadata implements ModuleComponentResolveMetadata {
     }
 
     @Override
-    public List<String> getStatusScheme() {
-        return null;
-    }
-
-    @Override
     public ImmutableList<? extends VirtualComponentIdentifier> getPlatformOwners() {
         return ImmutableList.of();
     }
 
-    @Override
-    public MutableModuleComponentResolveMetadata asMutable() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public ModuleComponentResolveMetadata withSources(ModuleSources sources) {
-        return this;
-    }
-
-    @Override
-    public ModuleComponentResolveMetadata withDerivationStrategy(VariantDerivationStrategy derivationStrategy) {
-        return this;
-    }
-
-    @Override
-    public VariantDerivationStrategy getVariantDerivationStrategy() {
-        return NoOpDerivationStrategy.getInstance();
-    }
-
-    @Override
-    public boolean isExternalVariant() {
-        return false;
-    }
-
-    @Override
-    public boolean isComponentMetadataRuleCachingEnabled() {
-        return true;
-    }
-
-    @Override
-    public ModuleComponentArtifactMetadata artifact(String type, @Nullable String extension, @Nullable String classifier) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public ModuleComponentArtifactMetadata optionalArtifact(String type, @Nullable String extension, @Nullable String classifier) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public ImmutableList<? extends ComponentVariant> getVariants() {
-        return ImmutableList.of();
-    }
-
-    @Override
-    public AttributesFactory getAttributesFactory() {
-        return null;
-    }
-
-    @Override
-    public VariantMetadataRules getVariantMetadataRules() {
-        return VariantMetadataRules.noOp();
-    }
-
-    @Override
-    public ImmutableAttributes getAttributes() {
-        return ImmutableAttributes.EMPTY;
-    }
-
-    VirtualPlatformState getPlatformState() {
-        return platformState;
-    }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/AbstractComponentGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/AbstractComponentGraphResolveState.java
@@ -16,9 +16,7 @@
 
 package org.gradle.internal.component.model;
 
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.internal.artifacts.result.DefaultResolvedVariantResult;
 import org.gradle.api.internal.attributes.AttributeDesugaring;
@@ -76,12 +74,6 @@ public abstract class AbstractComponentGraphResolveState<T extends ComponentGrap
 
     protected AttributeDesugaring getAttributeDesugaring() {
         return attributeDesugaring;
-    }
-
-    @Nullable
-    @Override
-    public ComponentGraphResolveState maybeAsLenientPlatform(ModuleComponentIdentifier componentIdentifier, ModuleVersionIdentifier moduleVersionIdentifier) {
-        return null;
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentGraphResolveState.java
@@ -16,9 +16,7 @@
 
 package org.gradle.internal.component.model;
 
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.internal.capabilities.ImmutableCapability;
 
@@ -83,12 +81,6 @@ public interface ComponentGraphResolveState {
      * @return true when this instance is ad hoc, false when this instance is not ad hoc and can be cached.
      */
     boolean isAdHoc();
-
-    /**
-     * When this component is a lenient platform, create a copy with the given ids. Otherwise, returns {@code null}.
-     */
-    @Nullable
-    ComponentGraphResolveState maybeAsLenientPlatform(ModuleComponentIdentifier componentIdentifier, ModuleVersionIdentifier moduleVersionIdentifier);
 
     /**
      * Creates the state that can be used for artifact resolution for this component instance.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultExternalComponentGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultExternalComponentGraphResolveState.java
@@ -105,10 +105,6 @@ public class DefaultExternalComponentGraphResolveState<G extends ExternalCompone
         return variants.computeIfAbsent(configuration, c -> newVariantState(configuration));
     }
 
-    protected VariantGraphResolveState newResolveStateFor(ModuleConfigurationMetadata configuration) {
-        return newVariantState(configuration);
-    }
-
     private DefaultConfigurationGraphResolveState newVariantState(ModuleConfigurationMetadata configuration) {
         return new DefaultConfigurationGraphResolveState(idGenerator.nextVariantId(), configuration);
     }


### PR DESCRIPTION
A lenient platform component is unlike any other external components.

It does not have configurations or variants in the conventional sense, so prior logic did some odd things in order to make a lenient platform component conform to the format required for an external component state.

This commit reimplements lenient platform components standalone, to avoid some confusing logic and untangle external and module components so that we can  make further changes to module components in future changes

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
