### PR TITLE
Publish test directories if they're not empty

### DIFF
--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild/testcleanup/TestFilesCleanupService.kt
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild/testcleanup/TestFilesCleanupService.kt
@@ -227,7 +227,7 @@ abstract class TestFilesCleanupService @Inject constructor(
     fun TestFilesCleanupProjectState.prepareReportsForCiPublishing(executedTaskPaths: List<String>, tmpTestFiles: Collection<File>) {
         val reports = executedTaskPaths
             .flatMap { taskPathReports.getOrDefault(it, emptyList()) }
-        if (isAnyTestTaskFailed(projectPath.get())) {
+        if (isAnyTestTaskFailed(projectPath.get()) || tmpTestFiles.isNotEmpty()) {
             prepareReportForCiPublishing(tmpTestFiles + reports)
         } else {
             prepareReportForCiPublishing(reports)


### PR DESCRIPTION
While investigating https://github.com/gradle/gradle-private/issues/4587, I found that test directories are not published as CI artifacts when there's no test failures, even though they would trigger another `Found non-empty test files dir` failure later.

This PR also publishes directories if they are not empty.