### PR TITLE
Use isolated daemon and gradle user home for `JavaExecWithLongCommandLineIntegrationTest`

### DIFF
--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecWithLongCommandLineIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecWithLongCommandLineIntegrationTest.groovy
@@ -27,6 +27,9 @@ class JavaExecWithLongCommandLineIntegrationTest extends AbstractIntegrationSpec
     def veryLongFileNames = getLongCommandLine()
 
     def setup() {
+        executer.requireIsolatedDaemons()
+        executer.requireOwnGradleUserHomeDir("It generates {GRADLE_USER_HOME}/.tmp/gradle-javaexec-classpathXXXX.jar (https://github.com/gradle/gradle-private/issues/4587)")
+
         file("src/main/java/Driver.java") << """
             package driver;
 


### PR DESCRIPTION
This fixes https://github.com/gradle/gradle-private/issues/4587

Here's what's going on:

1. `AggregatingIncrementalAnnotationProcessingIntegrationTest` [uses its own gradle user home](https://github.com/gradle/gradle/blob/19cf1a1ac5d2bc0c8e0413823b796467bac60d5f/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AbstractIncrementalAnnotationProcessingIntegrationTest.groovy#L36) but the [daemon base dir is shared](https://github.com/gradle/gradle/blob/8f28bf5b48db1e00996494cb034b370ff9e10bc9/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java#L1190), which means that the daemon registry file is shared.
2. Now `AggregatingIncrementalAnnotationProcessingIntegrationTest` runs and starts a daemon X with an isolated gradle user home `platforms/jvm/language-java/build/tmp/teŝt files/Aggregating.Test/XXXX/user-home`.
3. Then `JavaExecWithLongCommandLineIntegrationTest` runs and connects to daemon X because of the shared registry file.
4. Daemon X writes to `platforms/jvm/language-java/build/tmp/teŝt files/Aggregating.Test/XXXX/user-home/.tmp/gradle-javaexec-classpathXXXX.jar`. But because `AggregatingIncrementalAnnotationProcessingIntegrationTest` is already finished, so the file doesn't get cleaned up.
5. After all tests pass, `testFilesCleanupBuildService` detects the file and fails the build, like [this](https://ge.gradle.org/s/xgo5vdbwdvtqa/failure). 

This PR fixes this by using isolated daemon and gradle user home in `JavaExecWithLongCommandLineIntegrationTest`