### PR TITLE
Polish service scopes for Configuration Cache services

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeIO.kt
@@ -28,10 +28,13 @@ import org.gradle.internal.serialize.graph.MutableReadContext
 import org.gradle.internal.serialize.graph.SpecialDecoders
 import org.gradle.internal.serialize.graph.SpecialEncoders
 import org.gradle.internal.serialize.graph.WriteContext
+import org.gradle.internal.service.scopes.Scope
+import org.gradle.internal.service.scopes.ServiceScope
 import org.gradle.util.Path
 import java.io.InputStream
 import java.io.OutputStream
 
+@ServiceScope(Scope.Build::class)
 internal
 interface ConfigurationCacheBuildTreeIO : ConfigurationCacheOperationIO {
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheHost.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheHost.kt
@@ -18,8 +18,11 @@ package org.gradle.internal.cc.impl
 
 import org.gradle.internal.Factory
 import org.gradle.internal.cc.base.serialize.HostServiceProvider
+import org.gradle.internal.service.scopes.Scope.Build
+import org.gradle.internal.service.scopes.ServiceScope
 import java.io.File
 
+@ServiceScope(Build::class)
 interface ConfigurationCacheHost : HostServiceProvider {
 
     val currentBuild: VintageGradleBuild

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheIncludedBuildIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheIncludedBuildIO.kt
@@ -18,8 +18,11 @@ package org.gradle.internal.cc.impl
 
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext
+import org.gradle.internal.service.scopes.Scope
+import org.gradle.internal.service.scopes.ServiceScope
 
 
+@ServiceScope(Scope.Build::class)
 internal
 interface ConfigurationCacheIncludedBuildIO {
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheServices.kt
@@ -80,8 +80,8 @@ class ConfigurationCacheServices : AbstractGradleModuleServices() {
         registration.run {
             add(RelevantProjectsRegistry::class.java)
             addProvider(TaskExecutionAccessCheckerProvider)
-            add(DefaultConfigurationCacheHost::class.java)
-            add(DefaultConfigurationCacheIO::class.java)
+            add(ConfigurationCacheHost::class.java, DefaultConfigurationCacheHost::class.java)
+            add(ConfigurationCacheBuildTreeIO::class.java, ConfigurationCacheIncludedBuildIO::class.java, DefaultConfigurationCacheIO::class.java)
             add(
                 IsolatedProjectEvaluationListenerProvider::class.java,
                 GradleLifecycleActionExecutor::class.java,

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
@@ -83,8 +83,6 @@ import org.gradle.internal.serialize.kryo.KryoBackedDecoder
 import org.gradle.internal.serialize.kryo.KryoBackedEncoder
 import org.gradle.internal.serialize.kryo.StringDeduplicatingKryoBackedDecoder
 import org.gradle.internal.serialize.kryo.StringDeduplicatingKryoBackedEncoder
-import org.gradle.internal.service.scopes.Scope
-import org.gradle.internal.service.scopes.ServiceScope
 import org.gradle.util.Path
 import java.io.Closeable
 import java.io.File
@@ -92,7 +90,6 @@ import java.io.InputStream
 import java.io.OutputStream
 
 
-@ServiceScope(Scope.Build::class)
 internal
 class DefaultConfigurationCacheIO internal constructor(
     private val startParameter: ConfigurationCacheStartParameter,

--- a/platforms/core-configuration/encryption-services/build.gradle.kts
+++ b/platforms/core-configuration/encryption-services/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     api(projects.baseServices)
     api(projects.hashing)
     api(projects.serviceProvider)
+    api(projects.stdlibJavaExtensions)
 
     api(libs.kotlinStdlib)
 
@@ -32,7 +33,6 @@ dependencies {
     implementation(projects.coreKotlinExtensions)
     implementation(projects.loggingApi)
     implementation(projects.persistentCache)
-    implementation(projects.stdlibJavaExtensions)
     implementation(projects.stdlibKotlinExtensions)
 }
 tasks.isolatedProjectsIntegTest {

--- a/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/EncryptionService.kt
+++ b/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/EncryptionService.kt
@@ -17,6 +17,8 @@
 package org.gradle.internal.encryption
 
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.service.scopes.Scope
+import org.gradle.internal.service.scopes.ServiceScope
 import org.gradle.util.internal.EncryptionAlgorithm
 import java.io.InputStream
 import java.io.OutputStream
@@ -25,6 +27,7 @@ import java.io.OutputStream
 /**
  * Provides access to configuration parameters to control encryption.
  */
+@ServiceScope(Scope.BuildTree::class)
 interface EncryptionConfiguration {
     val isEncrypting: Boolean
     val encryptionKeyHashCode: HashCode
@@ -35,6 +38,7 @@ interface EncryptionConfiguration {
 /**
  * A service for encrypting/decrypting streams.
  */
+@ServiceScope(Scope.BuildTree::class)
 interface EncryptionService : EncryptionConfiguration {
     fun outputStream(output: OutputStream): OutputStream
     fun inputStream(input: InputStream): InputStream

--- a/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/DefaultEncryptionService.kt
+++ b/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/DefaultEncryptionService.kt
@@ -25,8 +25,6 @@ import org.gradle.internal.extensions.core.getInternalFlag
 import org.gradle.internal.extensions.core.getInternalString
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.hash.Hashing
-import org.gradle.internal.service.scopes.Scope
-import org.gradle.internal.service.scopes.ServiceScope
 import org.gradle.util.internal.EncryptionAlgorithm
 import org.gradle.util.internal.SupportedEncryptionAlgorithm
 import java.io.File
@@ -36,7 +34,6 @@ import java.security.InvalidKeyException
 import javax.crypto.SecretKey
 
 
-@ServiceScope(Scope.BuildTree::class)
 internal
 class DefaultEncryptionService(
     options: InternalOptions,

--- a/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/services/EncryptionServices.kt
+++ b/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/services/EncryptionServices.kt
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.encryption.services
 
+import org.gradle.internal.encryption.EncryptionConfiguration
+import org.gradle.internal.encryption.EncryptionService
 import org.gradle.internal.encryption.impl.DefaultEncryptionService
 import org.gradle.internal.service.ServiceRegistration
 import org.gradle.internal.service.scopes.AbstractGradleModuleServices
@@ -23,6 +25,6 @@ import org.gradle.internal.service.scopes.AbstractGradleModuleServices
 
 class EncryptionServices : AbstractGradleModuleServices() {
     override fun registerBuildTreeServices(registration: ServiceRegistration) {
-        registration.add(DefaultEncryptionService::class.java)
+        registration.add(EncryptionConfiguration::class.java, EncryptionService::class.java, DefaultEncryptionService::class.java)
     }
 }

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -34,8 +34,6 @@ import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
 import org.gradle.internal.file.PathToFileResolver;
-import org.gradle.internal.service.scopes.Scope;
-import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.state.Managed;
 
 import javax.annotation.Nullable;
@@ -45,7 +43,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.gradle.api.internal.lambdas.SerializableLambdas.bifunction;
 import static org.gradle.api.internal.lambdas.SerializableLambdas.transformer;
 
-@ServiceScope({Scope.Global.class, Scope.Project.class})
 public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFactory {
     private final PropertyHost host;
     private final FileResolver fileResolver;

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileFactory.java
@@ -18,9 +18,12 @@ package org.gradle.api.internal.file;
 
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.RegularFile;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.io.File;
 
+@ServiceScope({Scope.Global.class, Scope.Project.class})
 public interface FileFactory {
     Directory dir(File dir);
 

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FilePropertyFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FilePropertyFactory.java
@@ -18,7 +18,10 @@ package org.gradle.api.internal.file;
 
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
+@ServiceScope({Scope.Global.class, Scope.Project.class})
 public interface FilePropertyFactory {
     DirectoryProperty newDirectoryProperty();
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/PropertyFactory.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/PropertyFactory.java
@@ -19,7 +19,7 @@ package org.gradle.api.internal.provider;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-@ServiceScope(Scope.Global.class)
+@ServiceScope({Scope.Global.class, Scope.Project.class})
 public interface PropertyFactory {
     <T> DefaultProperty<T> property(Class<T> type);
 

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/InputFingerprinter.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/InputFingerprinter.java
@@ -21,10 +21,13 @@ import com.google.common.collect.ImmutableSortedMap;
 import org.gradle.internal.execution.UnitOfWork.InputVisitor;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.fingerprint.FileCollectionFingerprint;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.snapshot.ValueSnapshot;
 
 import java.util.function.Consumer;
 
+@ServiceScope(Scope.BuildSession.class)
 public interface InputFingerprinter {
     Result fingerprintInputProperties(
         ImmutableSortedMap<String, ValueSnapshot> previousValueSnapshots,

--- a/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/ClassLoaderHierarchyHasher.java
+++ b/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/ClassLoaderHierarchyHasher.java
@@ -16,11 +16,15 @@
 
 package org.gradle.internal.hash;
 
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+
 import javax.annotation.Nullable;
 
 /**
  * Provides a combined hash for a hierarchy of classloaders.
  */
+@ServiceScope(Scope.UserHome.class)
 public interface ClassLoaderHierarchyHasher {
     /**
      * Returns a hash for the given classloader hierarchy, or {@code null}

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedGlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedGlobalScopeServices.java
@@ -129,7 +129,7 @@ public class WorkerSharedGlobalScopeServices extends BasicGlobalScopeServices {
         return DefaultTaskDependencyFactory.withNoAssociatedProject();
     }
 
-    @Provides
+    @Provides({FilePropertyFactory.class, FileFactory.class})
     DefaultFilePropertyFactory createFilePropertyFactory(PropertyHost propertyHost, FileResolver fileResolver, FileCollectionFactory fileCollectionFactory) {
         return new DefaultFilePropertyFactory(propertyHost, fileResolver, fileCollectionFactory);
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedProjectScopeServices.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.file.DefaultFileOperations;
 import org.gradle.api.internal.file.DefaultFilePropertyFactory;
 import org.gradle.api.internal.file.DefaultFileSystemOperations;
 import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.internal.file.FileFactory;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.file.FilePropertyFactory;
@@ -70,8 +71,8 @@ public class WorkerSharedProjectScopeServices implements ServiceRegistrationProv
     }
 
     void configure(ServiceRegistration registration) {
-        registration.add(DefaultPropertyFactory.class);
-        registration.add(DefaultFilePropertyFactory.class);
+        registration.add(PropertyFactory.class, DefaultPropertyFactory.class);
+        registration.add(FilePropertyFactory.class, FileFactory.class, DefaultFilePropertyFactory.class);
     }
 
     @Provides


### PR DESCRIPTION
Adds explicit service scopes to some service interfaces used by CC. Also ensures service _interfaces_ are exposed for consumption, rather than their implementations.