### PR TITLE
Make `addJvmArguments` TAPI method append the arguments instead of setting it

### DIFF
--- a/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
+++ b/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
@@ -182,6 +182,10 @@ public class DaemonParameters {
         return systemProperties;
     }
 
+    public void addJvmArgs(Iterable<String> jvmArgs) {
+        jvmOptions.jvmArgs(jvmArgs);
+    }
+
     public void setJvmArgs(Iterable<String> jvmArgs) {
         jvmOptions.setAllJvmArgs(jvmArgs);
     }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/connection/ProviderOperationParameters.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/connection/ProviderOperationParameters.java
@@ -51,10 +51,28 @@ public interface ProviderOperationParameters {
     File getJavaHome();
 
     /**
-     * @return When null, use the provider's default JVM arguments. When empty, use no JVM arguments.
+     * Returns the concatenated list of {@link #getBaseJvmArguments()} and {@link #getAdditionalJvmArguments()}. The method is only kept for backwards compatibility (see #31462) to support Gradle versions where {@link #getBaseJvmArguments()} and  {@link #getAdditionalJvmArguments()} is not yet available.
+     *
+     * @return null if no JVM arguments are provided, otherwise a concatenated list of JVM arguments.
      */
     @Nullable
     List<String> getJvmArguments();
+
+    /**
+     * Arguments, which will override the default JVM arguments.
+     *
+     * @return null if no JVM arguments are provided, otherwise a list of JVM arguments.
+     */
+    @Nullable
+    List<String> getBaseJvmArguments();
+
+    /**
+     * Additional arguments, which will be appended to the default/overridden JVM arguments.
+     *
+     * @return null if no additional JVM arguments are provided, otherwise a list of additional JVM arguments.
+     */
+    @Nullable
+    List<String> getAdditionalJvmArguments();
 
     /**
      * @return When null, use the provider's default environment variables. When empty, use no environment variables.

--- a/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/util/internal/CollectionUtils.java
+++ b/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/util/internal/CollectionUtils.java
@@ -265,7 +265,16 @@ public abstract class CollectionUtils {
         }
     }
 
-    public static <T> List<T> toList(Iterable<? extends T> things) {
+    /**
+     * Repacks an {@link Iterable} into a {@link List}.
+     * <p>
+     * When the input is a {@link List}, it is returned as is.
+     * Otherwise, the input is iterated and the elements are added to a new {@link List}.
+     *
+     * @param things The things to repack
+     * @return an empty list if the input is null, otherwise {@link List} containing the elements of the input otherwise
+     */
+    public static <T> List<T> toList(@Nullable Iterable<? extends T> things) {
         if (things instanceof List) {
             @SuppressWarnings("unchecked") List<T> castThings = (List<T>) things;
             return castThings;

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -52,6 +52,12 @@ The `testType` property on link:{javadocPath}/org/gradle/testing/jacoco/plugins/
 Similarly, the `testType` property was removed from link:{javadocPath}/org/gradle/api/plugins/jvm/JvmTestSuite.html[JvmTestSuite] and both the `TestSuiteTargetName` and `TestSuiteType` attributes have been removed.
 Test reports and Jacoco reports can now be aggregated between projects by specifying the name of the test suite in the target project to aggregate.
 
+==== Changed behavior when calling `BuildLauncher#addJvmArguments`
+
+Issue (link:https://github.com/gradle/gradle/issues/31462[#31426]) was fixed, that caused `BuildLauncher#addJvmArguments` to override flags coming from the `org.gradle.jvmargs` system property.
+Please ensure that you are not relying on this behavior when upgrading to Gradle 8.13.
+If system properties needs to be overridden, `BuildLauncher#setJvmArguments` should be used instead.
+
 === Deprecations
 
 ==== Recursively querying `AttributeContainer` in lazy provider

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r813/JvmArgumentPassingCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r813/JvmArgumentPassingCrossVersionTest.groovy
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r813
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.IntegTestPreconditions
+import org.gradle.tooling.ProjectConnection
+
+@ToolingApiVersion(">=8.13")
+@TargetGradleVersion(">=8.13")
+@Requires(
+    value = IntegTestPreconditions.NotEmbeddedExecutor,
+    reason = "In order to pass JVM arguments to the Gradle daemon, we need to use the external executor."
+)
+class JvmArgumentPassingCrossVersionTest extends ToolingApiSpecification {
+
+    def setup() {
+        buildFile """
+import java.lang.management.ManagementFactory
+
+List<String> jvmArgs = ManagementFactory.getRuntimeMXBean().inputArguments
+println("JVM arguments")
+println(jvmArgs)
+file("jvm-args.txt").text = jvmArgs.join("\\n")
+
+println("------")
+
+List<String> systemProperties = System.getProperties().keySet().toList()
+println("System properties")
+println(systemProperties)
+file("system-properties.txt").text = System.getProperties().keySet().join("\\n")
+        """
+    }
+
+    def "set and additional arguments work correctly when overridden from the TAPI connector with predefined values coming from the project gradle properties file"() {
+        given:
+        def gradlePropertyText = "org.gradle.jvmargs=${predefinedProperties.collect { "-D$it" }.join(" ")}"
+        propertiesFile << gradlePropertyText
+
+        when:
+        withConnection { ProjectConnection connection ->
+            def build = connection
+                .newBuild()
+                .forTasks("help")
+
+            build.setJvmArguments(setProperties.collect { "-D$it".toString() })
+            if (additionalProperties != null) {
+                build.addJvmArguments(additionalProperties.collect { "-D$it".toString() })
+            }
+
+            build.run()
+        }
+        def sysProperties = readSystemProperties()
+
+        then:
+        sysProperties == expectedSystemProperties.toSet()
+
+        where:
+        predefinedProperties | setProperties | additionalProperties || expectedSystemProperties
+        ["test-predefined"]  | null          | null                 || ["test-predefined"]
+        ["test-predefined"]  | []            | null                 || ["test-predefined"]
+        ["test-predefined"]  | ["test-set"]  | []                   || ["test-set"]
+        ["test-predefined"]  | null          | ["test-add"]         || ["test-predefined", "test-add"]
+        ["test-predefined"]  | []            | ["test-add"]         || ["test-predefined", "test-add"]
+        ["test-predefined"]  | ["test-set"]  | ["test-add"]         || ["test-set", "test-add"]
+    }
+
+    def "set and additional arguments work correctly when overridden from the TAPI connector with predefined values coming from an isolated user home"() {
+        given:
+        requireIsolatedUserHome()
+        def gradlePropertyText = "org.gradle.jvmargs=${predefinedProperties.collect { "-D$it" }.join(" ")}"
+        def isolatedPropertiesFile = file("user-home-dir").file("gradle.properties")
+        isolatedPropertiesFile << gradlePropertyText
+
+        when:
+        withConnection { ProjectConnection connection ->
+            def build = connection
+                .newBuild()
+                .forTasks("help")
+
+            build.setJvmArguments(setProperties.collect { "-D$it".toString() })
+            if (additionalProperties != null) {
+                build.addJvmArguments(additionalProperties.collect { "-D$it".toString() })
+            }
+
+            build.run()
+        }
+        def sysProperties = readSystemProperties()
+
+        then:
+        sysProperties == expectedSystemProperties.toSet()
+
+        where:
+        predefinedProperties | setProperties | additionalProperties || expectedSystemProperties
+        ["test-predefined"]  | null          | null                 || ["test-predefined"]
+        ["test-predefined"]  | []            | null                 || ["test-predefined"]
+        ["test-predefined"]  | ["test-set"]  | []                   || ["test-set"]
+        ["test-predefined"]  | null          | ["test-add"]         || ["test-predefined", "test-add"]
+        ["test-predefined"]  | []            | ["test-add"]         || ["test-predefined", "test-add"]
+        ["test-predefined"]  | ["test-set"]  | ["test-add"]         || ["test-set", "test-add"]
+    }
+
+    Set<String> readSystemProperties() {
+        return file("system-properties.txt")
+            .text
+            .split("\n")
+            .findAll {
+                it.startsWith("test-")
+            }
+    }
+
+}

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r813/JvmArgumentPassingCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r813/JvmArgumentPassingCrossVersionTest.groovy
@@ -124,6 +124,7 @@ file("system-properties.txt").text = System.getProperties().keySet().join("\\n")
             .findAll {
                 it.startsWith("test-")
             }
+            .toSet()
     }
 
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r813/ProblemProgressEventCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r813/ProblemProgressEventCrossVersionTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.integtests.tooling.r813
 
+
+import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.GroovyBuildScriptLanguage
 import org.gradle.integtests.tooling.fixture.ProblemsApiGroovyScriptUtils
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
@@ -23,6 +25,8 @@ import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
 import org.gradle.integtests.tooling.r85.CustomModel
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.IntegTestPreconditions
 import org.gradle.tooling.BuildException
 import org.gradle.tooling.Failure
 import org.gradle.tooling.events.ProgressEvent
@@ -256,6 +260,7 @@ class ProblemProgressEventCrossVersionTest extends ToolingApiSpecification {
     }
 
     @TargetGradleVersion("=8.5")
+    @Requires(IntegTestPreconditions.JavaHomeWithDifferentVersionAvailable)
     def "No problem for exceptions in 8.5"() {
         // serialization of exceptions is not working in 8.5 (Gson().toJson() fails)
         withReportProblemTask """
@@ -269,7 +274,7 @@ class ProblemProgressEventCrossVersionTest extends ToolingApiSpecification {
         withConnection {
             it.newBuild()
                 .forTasks(":reportProblem")
-                .setJavaHome(jdk17.javaHome)
+                .setJavaHome(AvailableJavaHomes.differentJdk.javaHome)
                 .addProgressListener(listener)
                 .run()
         }

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/AbstractLongRunningOperation.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/AbstractLongRunningOperation.java
@@ -120,31 +120,33 @@ public abstract class AbstractLongRunningOperation<T extends AbstractLongRunning
 
     @Override
     public T setJvmArguments(String... jvmArguments) {
-        operationParamsBuilder.setJvmArguments(rationalizeInput(jvmArguments));
+        operationParamsBuilder.setBaseJvmArguments(rationalizeInput(jvmArguments));
+        return getThis();
+    }
+
+    @Override
+    public T setJvmArguments(@Nullable Iterable<String> jvmArguments) {
+        operationParamsBuilder.setBaseJvmArguments(rationalizeInput(jvmArguments));
         return getThis();
     }
 
     @Override
     public T addJvmArguments(String... jvmArguments) {
-        operationParamsBuilder.addJvmArguments(CollectionUtils.toList(Preconditions.checkNotNull(jvmArguments)));
+        Preconditions.checkNotNull(jvmArguments);
+        operationParamsBuilder.addJvmArguments(rationalizeInput(jvmArguments));
+        return getThis();
+    }
+
+    @Override
+    public T addJvmArguments(@Nullable Iterable<String> jvmArguments) {
+        Preconditions.checkNotNull(jvmArguments);
+        operationParamsBuilder.addJvmArguments(rationalizeInput(jvmArguments));
         return getThis();
     }
 
     @Override
     public T withSystemProperties(Map<String, String> systemProperties) {
         operationParamsBuilder.setSystemProperties(systemProperties);
-        return getThis();
-    }
-
-    @Override
-    public T addJvmArguments(Iterable<String> jvmArguments) {
-        operationParamsBuilder.addJvmArguments(CollectionUtils.toList(Preconditions.checkNotNull(jvmArguments)));
-        return getThis();
-    }
-
-    @Override
-    public T setJvmArguments(Iterable<String> jvmArguments) {
-        operationParamsBuilder.setJvmArguments(rationalizeInput(jvmArguments));
         return getThis();
     }
 


### PR DESCRIPTION
Fixes #31462

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
