### PR TITLE
Polish attribute handling services

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildSessionScopeServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildSessionScopeServices.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.Desugar
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory;
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory;
 import org.gradle.api.internal.attributes.AttributeSchemaServices;
+import org.gradle.api.internal.attributes.AttributeValueIsolator;
 import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.api.internal.attributes.DefaultAttributesFactory;
 import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchemaFactory;
@@ -37,7 +38,8 @@ public class DependencyManagementBuildSessionScopeServices implements ServiceReg
 
     void configure(ServiceRegistration registration) {
         registration.add(DependenciesAccessorsWorkspaceProvider.class);
-        registration.add(DefaultAttributesFactory.class);
+        registration.add(AttributeValueIsolator.class);
+        registration.add(AttributesFactory.class, DefaultAttributesFactory.class);
         registration.add(DesugaredAttributeContainerSerializer.class);
         registration.add(MavenMutableModuleMetadataFactory.class);
         registration.add(IvyMutableModuleMetadataFactory.class);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributeValueIsolator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributeValueIsolator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.attributes;
+
+import org.gradle.api.internal.model.NamedObjectInstantiator;
+import org.gradle.internal.Cast;
+import org.gradle.internal.isolation.Isolatable;
+import org.gradle.internal.isolation.IsolatableFactory;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+import org.gradle.internal.snapshot.impl.CoercingStringValueSnapshot;
+
+import javax.annotation.Nullable;
+
+@ServiceScope(Scope.BuildSession.class)
+public class AttributeValueIsolator {
+
+    private final IsolatableFactory isolatableFactory;
+    private final NamedObjectInstantiator instantiator;
+
+    public AttributeValueIsolator(IsolatableFactory isolatableFactory, NamedObjectInstantiator instantiator) {
+        this.isolatableFactory = isolatableFactory;
+        this.instantiator = instantiator;
+    }
+
+    public <T> Isolatable<T> isolate(@Nullable T value) {
+        if (value instanceof String) {
+            return Cast.uncheckedNonnullCast(new CoercingStringValueSnapshot((String) value, instantiator));
+        } else {
+            return isolatableFactory.isolate(value);
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributesFactory.java
@@ -17,9 +17,12 @@ package org.gradle.api.internal.attributes;
 
 import org.gradle.api.attributes.Attribute;
 import org.gradle.internal.isolation.Isolatable;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.util.Map;
 
+@ServiceScope(Scope.BuildSession.class)
 public interface AttributesFactory {
     /**
      * Returns an empty mutable attribute container.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesFactory.java
@@ -22,26 +22,24 @@ import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.internal.Cast;
 import org.gradle.internal.isolation.Isolatable;
 import org.gradle.internal.isolation.IsolatableFactory;
-import org.gradle.internal.service.scopes.Scope;
-import org.gradle.internal.service.scopes.ServiceScope;
-import org.gradle.internal.snapshot.impl.CoercingStringValueSnapshot;
 
 import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
-@ServiceScope(Scope.BuildSession.class)
 public class DefaultAttributesFactory implements AttributesFactory {
     private final ImmutableAttributes root;
     private final Map<ImmutableAttributes, ImmutableList<DefaultImmutableAttributesContainer>> children;
-    private final IsolatableFactory isolatableFactory;
+    private final AttributeValueIsolator attributeValueIsolator;
     private final UsageCompatibilityHandler usageCompatibilityHandler;
-    private final NamedObjectInstantiator instantiator;
 
-    public DefaultAttributesFactory(IsolatableFactory isolatableFactory, NamedObjectInstantiator instantiator) {
-        this.isolatableFactory = isolatableFactory;
-        this.instantiator = instantiator;
+    public DefaultAttributesFactory(
+        AttributeValueIsolator attributeValueIsolator,
+        IsolatableFactory isolatableFactory,
+        NamedObjectInstantiator instantiator
+    ) {
+        this.attributeValueIsolator = attributeValueIsolator;
         this.root = ImmutableAttributes.EMPTY;
         this.children = new ConcurrentHashMap<>();
         this.usageCompatibilityHandler = new UsageCompatibilityHandler(isolatableFactory, instantiator);
@@ -53,12 +51,12 @@ public class DefaultAttributesFactory implements AttributesFactory {
 
     @Override
     public DefaultMutableAttributeContainer mutable() {
-        return new DefaultMutableAttributeContainer(this);
+        return new DefaultMutableAttributeContainer(this, attributeValueIsolator);
     }
 
     @Override
     public HierarchicalMutableAttributeContainer mutable(AttributeContainerInternal fallback) {
-        return join(fallback, new DefaultMutableAttributeContainer(this));
+        return join(fallback, new DefaultMutableAttributeContainer(this, attributeValueIsolator));
     }
 
     @Override
@@ -76,12 +74,8 @@ public class DefaultAttributesFactory implements AttributesFactory {
         return concat(node, key, isolate(value));
     }
 
-    public <T> Isolatable<T> isolate(@Nullable T value) {
-        if (value instanceof String) {
-            return Cast.uncheckedNonnullCast(new CoercingStringValueSnapshot((String) value, instantiator));
-        } else {
-            return isolatableFactory.isolate(value);
-        }
+    private <T> Isolatable<T> isolate(@Nullable T value) {
+        return attributeValueIsolator.isolate(value);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesFactory.java
@@ -71,11 +71,7 @@ public class DefaultAttributesFactory implements AttributesFactory {
 
     @Override
     public <T> ImmutableAttributes concat(ImmutableAttributes node, Attribute<T> key, @Nullable T value) {
-        return concat(node, key, isolate(value));
-    }
-
-    private <T> Isolatable<T> isolate(@Nullable T value) {
-        return attributeValueIsolator.isolate(value);
+        return concat(node, key, attributeValueIsolator.isolate(value));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultMutableAttributeContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultMutableAttributeContainer.java
@@ -41,12 +41,14 @@ final class DefaultMutableAttributeContainer extends AbstractAttributeContainer 
     private Map<Attribute<?>, Provider<?>> lazyAttributes = Cast.uncheckedCast(Collections.EMPTY_MAP);
     private boolean realizingAttributes = false;
 
-    private final DefaultAttributesFactory attributesFactory;
+    private final AttributesFactory attributesFactory;
+    private final AttributeValueIsolator attributeValueIsolator;
 
     private ImmutableAttributes immutableValue;
 
-    public DefaultMutableAttributeContainer(DefaultAttributesFactory attributesFactory) {
+    public DefaultMutableAttributeContainer(AttributesFactory attributesFactory, AttributeValueIsolator attributeValueIsolator) {
         this.attributesFactory = attributesFactory;
+        this.attributeValueIsolator = attributeValueIsolator;
     }
 
     @Override
@@ -78,7 +80,7 @@ final class DefaultMutableAttributeContainer extends AbstractAttributeContainer 
         assertAttributeValueIsNotNull(value);
         assertAttributeTypeIsValid(value.getClass(), key);
         immutableValue = null;
-        attributes.put(key, attributesFactory.isolate(value));
+        attributes.put(key, attributeValueIsolator.isolate(value));
         removeLazyAttributeIfPresent(key);
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesFactoryTest.groovy
@@ -111,7 +111,7 @@ class DefaultAttributesFactoryTest extends Specification implements TestsImmutab
 
     def "can compare attribute sets created by two different factories"() {
         given:
-        def otherFactory = new DefaultAttributesFactory(isolatableFactory, instantiator)
+        def otherFactory = new DefaultAttributesFactory(attributeValueIsolator, isolatableFactory, instantiator)
 
         when:
         def set1 = factory.concat(factory.of(FOO, "foo"), BAR, "bar")
@@ -123,7 +123,7 @@ class DefaultAttributesFactoryTest extends Specification implements TestsImmutab
 
     def "can append to a set created with a different factory"() {
         given:
-        def otherFactory = new DefaultAttributesFactory(isolatableFactory, instantiator)
+        def otherFactory = new DefaultAttributesFactory(attributeValueIsolator, isolatableFactory, instantiator)
         def attributes = otherFactory.of(FOO, 'foo')
 
         when:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
@@ -51,8 +51,12 @@ class DefaultMutableAttributeContainerTest extends Specification {
 
     def attributesFactory = AttributeTestUtil.attributesFactory()
 
+    private DefaultMutableAttributeContainer mutable() {
+        return new DefaultMutableAttributeContainer(attributesFactory, AttributeTestUtil.attributeValueIsolator())
+    }
+
     def "lazy attributes are evaluated in insertion order"() {
-        def container = new DefaultMutableAttributeContainer(attributesFactory)
+        def container = mutable()
         def actual = []
         def expected = []
         (1..100).each { idx ->
@@ -69,7 +73,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
     }
 
     def "realizing the value of lazy attributes may cause other attributes to be realized"() {
-        def container = new DefaultMutableAttributeContainer(attributesFactory)
+        def container = mutable()
         def firstAttribute = Attribute.of("first", String)
         def secondAttribute = Attribute.of("second", String)
         container.attributeProvider(firstAttribute, Providers.<String>changing {
@@ -90,7 +94,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
     }
 
     def "realizing the value of lazy attributes cannot add new attributes to the container"() {
-        def container = new DefaultMutableAttributeContainer(attributesFactory)
+        def container = mutable()
         def firstAttribute = Attribute.of("first", String)
         def secondAttribute = Attribute.of("second", String)
         container.attributeProvider(firstAttribute, Providers.<String>changing {
@@ -106,7 +110,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
     }
 
     def "realizing the value of lazy attributes cannot add new lazy attributes to the container"() {
-        def container = new DefaultMutableAttributeContainer(attributesFactory)
+        def container = mutable()
         def firstAttribute = Attribute.of("first", String)
         def secondAttribute = Attribute.of("second", String)
         container.attributeProvider(firstAttribute, Providers.<String>changing {
@@ -124,7 +128,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
     def "adding mismatched attribute types fails fast"() {
         Property<Integer> testProperty = new DefaultProperty<>(Mock(PropertyHost), Integer).convention(1)
         def testAttribute = Attribute.of("test", String)
-        def container = new DefaultMutableAttributeContainer(attributesFactory)
+        def container = mutable()
 
         when:
         //noinspection GroovyAssignabilityCheck - meant to fail
@@ -137,7 +141,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
     def "adding mismatched attribute types fails when retrieving the key when the provider does not know the type"() {
         Provider<?> testProperty = new DefaultProvider<?>( { 1 })
         def testAttribute = Attribute.of("test", String)
-        def container = new DefaultMutableAttributeContainer(attributesFactory)
+        def container = mutable()
 
         when:
         //noinspection GroovyAssignabilityCheck - meant to fail
@@ -152,8 +156,8 @@ class DefaultMutableAttributeContainerTest extends Specification {
         Property<String> testProperty1 = new DefaultProperty<>(Mock(PropertyHost), String).convention("value")
         Property<String> testProperty2 = new DefaultProperty<>(Mock(PropertyHost), String).convention("value")
         def testAttribute = Attribute.of("test", String)
-        def container1 = new DefaultMutableAttributeContainer(attributesFactory)
-        def container2 = new DefaultMutableAttributeContainer(attributesFactory)
+        def container1 = mutable()
+        def container2 = mutable()
 
         when:
         container1.attributeProvider(testAttribute, testProperty1)
@@ -168,8 +172,8 @@ class DefaultMutableAttributeContainerTest extends Specification {
         Property<String> testProperty1 = new DefaultProperty<>(Mock(PropertyHost), String).convention("value1")
         Property<String> testProperty2 = new DefaultProperty<>(Mock(PropertyHost), String).convention("value2")
         def testAttribute = Attribute.of("test", String)
-        def container1 = new DefaultMutableAttributeContainer(attributesFactory)
-        def container2 = new DefaultMutableAttributeContainer(attributesFactory)
+        def container1 = mutable()
+        def container2 = mutable()
 
         when:
         container1.attributeProvider(testAttribute, testProperty1)
@@ -184,8 +188,8 @@ class DefaultMutableAttributeContainerTest extends Specification {
         Property<String> testProperty1 = new DefaultProperty<>(Mock(PropertyHost), String).convention("value")
         Property<String> testProperty2 = new DefaultProperty<>(Mock(PropertyHost), String).convention("value")
         def testAttribute = Attribute.of("test", String)
-        def container1 = new DefaultMutableAttributeContainer(attributesFactory)
-        def container2 = new DefaultMutableAttributeContainer(attributesFactory)
+        def container1 = mutable()
+        def container2 = mutable()
 
         when:
         container1.attributeProvider(testAttribute, testProperty1)
@@ -199,8 +203,8 @@ class DefaultMutableAttributeContainerTest extends Specification {
         Property<String> testProperty1 = new DefaultProperty<>(Mock(PropertyHost), String).convention("value1")
         Property<String> testProperty2 = new DefaultProperty<>(Mock(PropertyHost), String).convention("value2")
         def testAttribute = Attribute.of("test", String)
-        def container1 = new DefaultMutableAttributeContainer(attributesFactory)
-        def container2 = new DefaultMutableAttributeContainer(attributesFactory)
+        def container1 = mutable()
+        def container2 = mutable()
 
         when:
         container1.attributeProvider(testAttribute, testProperty1)
@@ -213,7 +217,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
     def "adding attribute should override replace existing lazy attribute"() {
         given: "a container with testAttr set to a provider"
         def testAttr = Attribute.of("test", String)
-        def container = new DefaultMutableAttributeContainer(attributesFactory)
+        def container = mutable()
         Property<String> testProvider = new DefaultProperty<>(Mock(PropertyHost), String).convention("lazy value")
         container.attributeProvider(testAttr, testProvider)
 
@@ -227,7 +231,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
     def "adding lazy attribute should override replace existing attribute"() {
         given: "a container with testAttr set to a fixed value"
         def testAttr = Attribute.of("test", String)
-        def container = new DefaultMutableAttributeContainer(attributesFactory)
+        def container = mutable()
         container.attribute(testAttr, "set value")
 
         when: "adding a lazy testAttr"
@@ -240,7 +244,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
 
     def "toString should not change the internal state of the class"() {
         given: "a container and a lazy and non-lazy attribute"
-        def container = new DefaultMutableAttributeContainer(attributesFactory)
+        def container = mutable()
         def testEager = Attribute.of("eager", String)
         def testLazy = Attribute.of("lazy", String)
         Property<String> testProvider = new DefaultProperty<>(Mock(PropertyHost), String).convention("lazy value")
@@ -271,7 +275,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
         def thing2 = Attribute.of("thing2", String)
 
         when:
-        def container = new DefaultMutableAttributeContainer(attributesFactory)
+        def container = mutable()
 
         then:
         container.empty
@@ -301,7 +305,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
 
     def "A copy of an attribute container contains the same attributes and the same values as the original"() {
         given:
-        def container = new DefaultMutableAttributeContainer(attributesFactory)
+        def container = mutable()
         container.attribute(Attribute.of("a1", Integer), 1)
         container.attribute(Attribute.of("a2", String), "2")
         container.attributeProvider(Attribute.of("a3", String), Providers.of("3"))
@@ -318,7 +322,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
 
     def "changes to attribute container are not seen by immutable copy"() {
         given:
-        AttributeContainerInternal container = new DefaultMutableAttributeContainer(attributesFactory)
+        AttributeContainerInternal container = mutable()
         container.attribute(Attribute.of("a1", Integer), 1)
         container.attribute(Attribute.of("a2", String), "2")
         container.attributeProvider(Attribute.of("a3", String), Providers.of("3"))
@@ -338,7 +342,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
 
     def "An attribute container can provide the attributes through the HasAttributes interface"() {
         given:
-        def container = new DefaultMutableAttributeContainer(attributesFactory)
+        def container = mutable()
         container.attribute(Attribute.of("a1", Integer), 1)
         container.attributeProvider(Attribute.of("a2", String), Providers.of("2"))
 
@@ -357,7 +361,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
         def c = Attribute.of("c", String)
 
         when:
-        def container = new DefaultMutableAttributeContainer(attributesFactory)
+        def container = mutable()
 
         then:
         container.toString() == "{}"
@@ -374,7 +378,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
     }
 
     def "can access lazy elements while iterating over keySet"() {
-        def container = new DefaultMutableAttributeContainer(attributesFactory)
+        def container = mutable()
 
         when:
         container.attributeProvider(Attribute.of("a", String), Providers.of("foo"))

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/HierarchicalMutableAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/HierarchicalMutableAttributeContainerTest.groovy
@@ -31,7 +31,7 @@ class HierarchicalMutableAttributeContainerTest extends Specification {
     def two = Attribute.of("two", String)
 
     private DefaultMutableAttributeContainer mutable() {
-        return new DefaultMutableAttributeContainer(attributesFactory)
+        return new DefaultMutableAttributeContainer(attributesFactory, AttributeTestUtil.attributeValueIsolator())
     }
 
     def "can override attributes from fallback"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/IncubatingAttributesCheckerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/IncubatingAttributesCheckerTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 class IncubatingAttributesCheckerTest extends Specification {
+    def attributeValueIsolator = AttributeTestUtil.attributeValueIsolator()
     def attributesFactory = AttributeTestUtil.attributesFactory()
 
     // region: Single Attribute tests
@@ -55,7 +56,7 @@ class IncubatingAttributesCheckerTest extends Specification {
 
     // region: AttributeContainer tests
     def "container with attribute which doesn't use @Incubating is not reported"() {
-        def container = new DefaultMutableAttributeContainer(attributesFactory)
+        def container = new DefaultMutableAttributeContainer(attributesFactory, attributeValueIsolator)
         container.attribute(Usage.USAGE_ATTRIBUTE, TestUtil.objectFactory().named(Usage, Usage.JAVA_API))
 
         expect:
@@ -63,7 +64,7 @@ class IncubatingAttributesCheckerTest extends Specification {
     }
 
     def "container with @Incubating attribute is reported"() {
-        def container = new DefaultMutableAttributeContainer(attributesFactory)
+        def container = new DefaultMutableAttributeContainer(attributesFactory, attributeValueIsolator)
         container.attribute(TestSuiteName.TEST_SUITE_NAME_ATTRIBUTE, TestUtil.objectFactory().named(TestSuiteName, "foo"))
 
         expect:
@@ -71,7 +72,7 @@ class IncubatingAttributesCheckerTest extends Specification {
     }
 
     def "container with attribute without @Incubating annotation on class, with @Incubating on value is reported"() {
-        def container = new DefaultMutableAttributeContainer(attributesFactory)
+        def container = new DefaultMutableAttributeContainer(attributesFactory, attributeValueIsolator)
         container.attribute(Category.CATEGORY_ATTRIBUTE, TestUtil.objectFactory().named(Category, Category.VERIFICATION))
 
         expect:
@@ -79,7 +80,7 @@ class IncubatingAttributesCheckerTest extends Specification {
     }
 
     def "container with attribute without @Incubating annotation on class, with @Incubating on different value is not reported"() {
-        def container = new DefaultMutableAttributeContainer(attributesFactory)
+        def container = new DefaultMutableAttributeContainer(attributesFactory, attributeValueIsolator)
         container.attribute(Category.CATEGORY_ATTRIBUTE, TestUtil.objectFactory().named(Category, Category.LIBRARY))
 
         expect:

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/attributes/immutable/TestsImmutableAttributes.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/attributes/immutable/TestsImmutableAttributes.groovy
@@ -17,11 +17,13 @@
 package org.gradle.api.internal.attributes.immutable
 
 import org.gradle.api.attributes.Attribute
+import org.gradle.api.internal.attributes.AttributeValueIsolator
 import org.gradle.api.internal.attributes.DefaultAttributesFactory
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.attributes.AttributesFactory
 import org.gradle.api.internal.model.NamedObjectInstantiator
 import org.gradle.internal.isolation.IsolatableFactory
+import org.gradle.util.AttributeTestUtil
 import org.gradle.util.SnapshotTestUtil
 import org.gradle.util.TestUtil
 
@@ -36,6 +38,7 @@ trait TestsImmutableAttributes {
 
     IsolatableFactory isolatableFactory = SnapshotTestUtil.isolatableFactory()
     NamedObjectInstantiator instantiator = TestUtil.objectInstantiator()
+    AttributeValueIsolator attributeValueIsolator = AttributeTestUtil.attributeValueIsolator()
 
-    AttributesFactory factory = new DefaultAttributesFactory(isolatableFactory, instantiator)
+    AttributesFactory factory = new DefaultAttributesFactory(attributeValueIsolator, isolatableFactory, instantiator)
 }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/AttributeTestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/AttributeTestUtil.groovy
@@ -21,6 +21,7 @@ import groovy.transform.stc.SimpleType
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.AttributesSchema
 import org.gradle.api.internal.attributes.AttributeSchemaServices
+import org.gradle.api.internal.attributes.AttributeValueIsolator
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.DefaultAttributesFactory
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
@@ -30,8 +31,13 @@ import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchemaFac
 import org.gradle.api.internal.attributes.immutable.artifact.ImmutableArtifactTypeRegistryFactory
 
 class AttributeTestUtil {
+
+    static AttributeValueIsolator attributeValueIsolator() {
+        return new AttributeValueIsolator(SnapshotTestUtil.isolatableFactory(), TestUtil.objectInstantiator())
+    }
+
     static DefaultAttributesFactory attributesFactory() {
-        return new DefaultAttributesFactory(SnapshotTestUtil.isolatableFactory(), TestUtil.objectInstantiator())
+        return new DefaultAttributesFactory(attributeValueIsolator(), SnapshotTestUtil.isolatableFactory(), TestUtil.objectInstantiator())
     }
 
     /**

--- a/testing/architecture-test/src/changes/archunit-store/injected-services-should-have-service-scope-applied.txt
+++ b/testing/architecture-test/src/changes/archunit-store/injected-services-should-have-service-scope-applied.txt
@@ -12,7 +12,6 @@ Class <org.gradle.api.internal.ProcessOperations> is not annotated with @Service
 Class <org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator> is not annotated with @ServiceScope in (VersionComparator.java:0)
 Class <org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme> is not annotated with @ServiceScope in (VersionSelectorScheme.java:0)
 Class <org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver> is not annotated with @ServiceScope in (ProjectDependencyPublicationResolver.java:0)
-Class <org.gradle.api.internal.attributes.AttributesFactory> is not annotated with @ServiceScope in (AttributesFactory.java:0)
 Class <org.gradle.api.internal.cache.CacheConfigurationsInternal> is not annotated with @ServiceScope in (CacheConfigurationsInternal.java:0)
 Class <org.gradle.api.internal.file.DefaultProjectLayout> is not annotated with @ServiceScope in (DefaultProjectLayout.java:0)
 Class <org.gradle.api.internal.file.TaskFileVarFactory> is not annotated with @ServiceScope in (TaskFileVarFactory.java:0)


### PR DESCRIPTION
Extracts an additional service `AttributeValueIsolator` to be shared between `DefaultMutableAttributeContainer` and `DefaultAttributesFactory`, such that their implementations would not need to know about each other.

Also ensures the services are annotated with `ServiceScope`