### PR TITLE
Cache Artifact Transforms across projects

### DIFF
--- a/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/LocalFileDependencyBackedArtifactSetCodec.kt
+++ b/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/LocalFileDependencyBackedArtifactSetCodec.kt
@@ -20,11 +20,7 @@ import com.google.common.collect.ImmutableMap
 import org.gradle.api.Action
 import org.gradle.api.artifacts.FileCollectionDependency
 import org.gradle.api.artifacts.component.ComponentIdentifier
-import org.gradle.api.artifacts.transform.TransformAction
-import org.gradle.api.artifacts.transform.TransformParameters
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE
-import org.gradle.api.internal.artifacts.TransformRegistration
-import org.gradle.api.internal.artifacts.VariantTransformRegistry
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.DefaultLocalFileDependencyBackedArtifactSet
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.LocalFileDependencyBackedArtifactSet
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact
@@ -335,17 +331,5 @@ class FixedFileMetadata(
 
     override fun getSource(): FileCollectionDependency {
         throw UnsupportedOperationException("Should not be called")
-    }
-}
-
-
-private
-object EmptyVariantTransformRegistry : VariantTransformRegistry {
-    override fun <T : TransformParameters> registerTransform(actionType: Class<out TransformAction<T>>, registrationAction: Action<in org.gradle.api.artifacts.transform.TransformSpec<T>>) {
-        throw UnsupportedOperationException("Should not be called")
-    }
-
-    override fun getRegistrations(): Set<TransformRegistration> {
-        return emptySet()
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -31,7 +31,6 @@ import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
-import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationContainerInternal;
@@ -78,7 +77,6 @@ import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory;
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
-import org.gradle.api.internal.artifacts.transform.ConsumerProvidedVariantFinder;
 import org.gradle.api.internal.artifacts.transform.DefaultTransformInvocationFactory;
 import org.gradle.api.internal.artifacts.transform.DefaultTransformRegistrationFactory;
 import org.gradle.api.internal.artifacts.transform.DefaultTransformedVariantFactory;
@@ -281,7 +279,6 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             registration.add(ResolutionStrategyFactory.class);
             registration.add(LocalComponentRegistry.class, DefaultLocalComponentRegistry.class);
             registration.add(ProjectDependencyResolver.class);
-            registration.add(ConsumerProvidedVariantFinder.class);
             registration.add(DefaultConfigurationFactory.class);
             registration.add(ComponentSelectorConverter.class, DefaultComponentSelectorConverter.class);
             registration.add(ArtifactResolutionQueryFactory.class, DefaultArtifactResolutionQueryFactory.class);
@@ -293,6 +290,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             registration.add(ResolutionExecutor.class);
             registration.add(ArtifactTypeRegistry.class);
             registration.add(GlobalDependencyResolutionRules.class);
+            registration.add(VariantTransformRegistry.class, DefaultVariantTransformRegistry.class);
         }
 
         @Provides
@@ -379,18 +377,6 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 actionScheme,
                 internalServices
             );
-        }
-
-        @Provides
-        VariantTransformRegistry createVariantTransformRegistry(
-            InstantiatorFactory instantiatorFactory,
-            AttributesFactory attributesFactory,
-            ServiceRegistry services,
-            TransformRegistrationFactory transformRegistrationFactory,
-            TransformParameterScheme parameterScheme,
-            DocumentationRegistry documentationRegistry
-        ) {
-            return new DefaultVariantTransformRegistry(instantiatorFactory, attributesFactory, services, transformRegistrationFactory, parameterScheme.getInstantiationScheme(), documentationRegistry);
         }
 
         @Provides

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/VariantTransformRegistry.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/VariantTransformRegistry.java
@@ -20,16 +20,16 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.transform.TransformAction;
 import org.gradle.api.artifacts.transform.TransformParameters;
 import org.gradle.api.artifacts.transform.TransformSpec;
+import org.gradle.api.internal.artifacts.transform.RegisteredTransforms;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
-
-import java.util.Set;
 
 /**
  * A registry for artifact transforms.
  */
 @ServiceScope(Scope.Project.class)
 public interface VariantTransformRegistry {
+
     /**
      * Register an artifact transform.
      *
@@ -41,9 +41,10 @@ public interface VariantTransformRegistry {
     <T extends TransformParameters> void registerTransform(Class<? extends TransformAction<T>> actionType, Action<? super TransformSpec<T>> registrationAction);
 
     /**
-     * Returns a set of all the registered transforms.
+     * Returns all the registered transforms.
      *
-     * @return the set of registered transforms
+     * @return the registered transforms
      */
-    Set<TransformRegistration> getRegistrations();
+    RegisteredTransforms getRegistrations();
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolutionExecutor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolutionExecutor.java
@@ -80,7 +80,6 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.store.StoreSet
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
 import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
 import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal;
-import org.gradle.api.internal.artifacts.transform.ConsumerProvidedVariantFinder;
 import org.gradle.api.internal.artifacts.transform.DefaultTransformUpstreamDependenciesResolver;
 import org.gradle.api.internal.artifacts.transform.TransformUpstreamDependenciesResolver;
 import org.gradle.api.internal.artifacts.transform.TransformedVariantFactory;
@@ -159,7 +158,6 @@ public class ResolutionExecutor {
     private final AttributesFactory attributesFactory;
     private final DomainObjectContext domainObjectContext;
     private final TaskDependencyFactory taskDependencyFactory;
-    private final ConsumerProvidedVariantFinder consumerProvidedVariantFinder;
     private final AttributeSchemaServices attributeSchemaServices;
     private final ResolutionFailureHandler resolutionFailureHandler;
     private final VariantArtifactSetCache variantArtifactSetCache;
@@ -193,7 +191,6 @@ public class ResolutionExecutor {
         AttributesFactory attributesFactory,
         DomainObjectContext domainObjectContext,
         TaskDependencyFactory taskDependencyFactory,
-        ConsumerProvidedVariantFinder consumerProvidedVariantFinder,
         AttributeSchemaServices attributeSchemaServices,
         ResolutionFailureHandler resolutionFailureHandler,
         VariantArtifactSetCache variantArtifactSetCache,
@@ -225,7 +222,6 @@ public class ResolutionExecutor {
         this.attributesFactory = attributesFactory;
         this.domainObjectContext = domainObjectContext;
         this.taskDependencyFactory = taskDependencyFactory;
-        this.consumerProvidedVariantFinder = consumerProvidedVariantFinder;
         this.attributeSchemaServices = attributeSchemaServices;
         this.resolutionFailureHandler = resolutionFailureHandler;
         this.variantArtifactSetCache = variantArtifactSetCache;
@@ -428,7 +424,6 @@ public class ResolutionExecutor {
             transformedVariantFactory,
             dependenciesResolverFactory,
             consumerSchema,
-            consumerProvidedVariantFinder,
             attributesFactory,
             attributeSchemaServices,
             resolutionFailureHandler,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultVisitedArtifactSet.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultVisitedArtifactSet.java
@@ -21,8 +21,8 @@ import org.gradle.api.internal.artifacts.configurations.ResolutionHost;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults;
 import org.gradle.api.internal.artifacts.transform.ArtifactVariantSelector;
 import org.gradle.api.internal.artifacts.transform.AttributeMatchingArtifactVariantSelector;
-import org.gradle.api.internal.artifacts.transform.ConsumerProvidedVariantFinder;
 import org.gradle.api.internal.artifacts.transform.TransformUpstreamDependenciesResolver;
+import org.gradle.api.internal.artifacts.transform.TransformationChainSelector;
 import org.gradle.api.internal.artifacts.transform.TransformedVariantFactory;
 import org.gradle.api.internal.attributes.AttributeSchemaServices;
 import org.gradle.api.internal.attributes.AttributesFactory;
@@ -58,7 +58,6 @@ public class DefaultVisitedArtifactSet implements VisitedArtifactSet {
         TransformedVariantFactory transformedVariantFactory,
         TransformUpstreamDependenciesResolver.Factory transformUpstreamDependenciesResolverFactory,
         ImmutableAttributesSchema consumerSchema,
-        ConsumerProvidedVariantFinder consumerProvidedVariantFinder,
         AttributesFactory attributesFactory,
         AttributeSchemaServices attributeSchemaServices,
         ResolutionFailureHandler resolutionFailureHandler,
@@ -73,12 +72,18 @@ public class DefaultVisitedArtifactSet implements VisitedArtifactSet {
         this.artifactsResults = artifactsResults;
         this.artifactSetResolver = artifactSetResolver;
 
+        TransformationChainSelector transformationChainSelector = new TransformationChainSelector(
+            attributeSchemaServices,
+            transformRegistry,
+            resolutionFailureHandler
+        );
+
         ArtifactVariantSelector artifactVariantSelector = new AttributeMatchingArtifactVariantSelector(
             consumerSchema,
-            consumerProvidedVariantFinder,
             attributesFactory,
             attributeSchemaServices,
-            resolutionFailureHandler
+            resolutionFailureHandler,
+            transformationChainSelector
         );
 
         this.consumerServices = new ArtifactSelectionServices(

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelector.java
@@ -48,16 +48,16 @@ public class AttributeMatchingArtifactVariantSelector implements ArtifactVariant
 
     public AttributeMatchingArtifactVariantSelector(
         ImmutableAttributesSchema consumerSchema,
-        ConsumerProvidedVariantFinder transformationChainBuilder,
         AttributesFactory attributesFactory,
         AttributeSchemaServices attributeSchemaServices,
-        ResolutionFailureHandler failureHandler
+        ResolutionFailureHandler failureHandler,
+        TransformationChainSelector transformationChainSelector
     ) {
         this.consumerSchema = consumerSchema;
         this.attributesFactory = attributesFactory;
         this.attributeSchemaServices = attributeSchemaServices;
         this.failureHandler = failureHandler;
-        this.transformationChainSelector = new TransformationChainSelector(transformationChainBuilder, failureHandler);
+        this.transformationChainSelector = transformationChainSelector;
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/CacheableTransforms.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/CacheableTransforms.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.internal.artifacts.TransformRegistration;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A representation of the registered artifact transforms for a project that omits the details of the
+ * transforms themselves, other than the information required for selecting artifact transforms.
+ * <p>
+ * This class serves as an immutable, project-independent representation of the selectable transforms,
+ * which allows artifact transform selection results to be cached so that projects with equivalent registered
+ * transforms do not need to perform transform selection multiple times.
+ */
+public class CacheableTransforms {
+
+    private final List<CacheableTransform> transforms;
+
+    private final int hashCode;
+
+    public CacheableTransforms(List<CacheableTransform> transforms) {
+        this.transforms = transforms;
+        this.hashCode = transforms.hashCode();
+    }
+
+    /**
+     * Create a {@link CacheableTransforms} that contains only the project-independent details required
+     * to perform artifact transform selection.
+     */
+    public static CacheableTransforms from(ImmutableList<TransformRegistration> registrations) {
+        List<CacheableTransform> cachedTransforms = new ArrayList<>(registrations.size());
+        for (int i = 0; i < registrations.size(); i++) {
+            TransformRegistration registration = registrations.get(i);
+            cachedTransforms.add(new CacheableTransform(
+                i,
+                registration.getFrom(),
+                registration.getTo()
+            ));
+        }
+
+        return new CacheableTransforms(cachedTransforms);
+    }
+
+    /**
+     * Get all cacheable transforms in this instance.
+     */
+    public List<CacheableTransform> getTransforms() {
+        return transforms;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        CacheableTransforms that = (CacheableTransforms) o;
+        return transforms.equals(that.transforms);
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+
+    /**
+     * Represents a transform step in the transform chain detection algorithm. This class only refers to
+     * the index of the source transform in the original registered transform list in order to be cacheable
+     * while also representing a project-specific transform registration instance.
+     */
+    public static class CacheableTransform {
+
+        private final int registrationIndex;
+        private final ImmutableAttributes from;
+        private final ImmutableAttributes to;
+
+        private final int hashCode;
+
+        public CacheableTransform(int registrationIndex, ImmutableAttributes from, ImmutableAttributes to) {
+            this.registrationIndex = registrationIndex;
+            this.from = from;
+            this.to = to;
+
+            this.hashCode = computeHashCode(from, registrationIndex, to);
+        }
+
+        private static int computeHashCode(ImmutableAttributes from, int registrationIndex, ImmutableAttributes to) {
+            int result = registrationIndex;
+            result = 31 * result + from.hashCode();
+            result = 31 * result + to.hashCode();
+            return result;
+        }
+
+        /**
+         * The index in the original list of registered transforms that this cacheable transform corresponds to.
+         */
+        public int getRegistrationIndex() {
+            return registrationIndex;
+        }
+
+        /**
+         * The {@code from} attributes of the original transform registration.
+         */
+        public ImmutableAttributes getFrom() {
+            return from;
+        }
+
+        /**
+         * The {@code to} attributes of the original transform registration.
+         */
+        public ImmutableAttributes getTo() {
+            return to;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            CacheableTransform that = (CacheableTransform) o;
+            return registrationIndex == that.registrationIndex &&
+                from == that.from && // ImmutableAttributes instances are interned.
+                to == that.to;
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+
+    }
+
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinder.java
@@ -16,85 +16,122 @@
 
 package org.gradle.api.internal.artifacts.transform;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.internal.artifacts.TransformRegistration;
-import org.gradle.api.internal.artifacts.VariantTransformRegistry;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
-import org.gradle.api.internal.attributes.AttributeSchemaServices;
 import org.gradle.api.internal.attributes.AttributesFactory;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchema;
 import org.gradle.api.internal.attributes.matching.AttributeMatcher;
 import org.gradle.internal.collections.ImmutableFilteredList;
-import org.gradle.internal.lazy.Lazy;
-import org.gradle.internal.service.scopes.Scope;
-import org.gradle.internal.service.scopes.ServiceScope;
+import org.gradle.internal.model.InMemoryCacheFactory;
+import org.gradle.internal.model.InMemoryLoadingCache;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.BiFunction;
 
 /**
- * Finds all the variants that can be created from a given set of producer variants using
- * the consumer's variant transforms. Transforms can be chained. If multiple
+ * Finds all artifact sets that can be created from a given set of producer artifact sets using
+ * the consumer's artifact transforms. Transforms can be chained. If multiple
  * chains can lead to the same outcome, the shortest paths are selected.
- *
- * Caches the results, as often the same request is made for many components in a
- * dependency graph.
+ * <p>
+ * This class is scoped to a given {@link AttributeMatcher} instance. This class may be used
+ * by multiple projects and/or dependency resolution instances, each with different
+ * registered transform sets, as long as they share a common attribute matcher.
+ * <p>
+ * Results are cached, as often the same request is made for many components in a
+ * dependency graph. The cache is independent of the source artifact sets and registered
+ * transform instances by storing the index of the input parameters as the cache key
+ * and mapping input and output indices to the actual instances.
  */
-@ServiceScope(Scope.Project.class)
 public class ConsumerProvidedVariantFinder {
-    private final VariantTransformRegistry variantTransforms;
+
+    private final AttributeMatcher matcher;
     private final AttributesFactory attributesFactory;
-    private final Lazy<AttributeMatcher> matcher;
     private final TransformCache transformCache;
 
     public ConsumerProvidedVariantFinder(
-        VariantTransformRegistry variantTransforms,
-        AttributesSchemaInternal schema,
+        AttributeMatcher matcher,
         AttributesFactory attributesFactory,
-        AttributeSchemaServices attributeSchemaServices
+        InMemoryCacheFactory cacheFactory
     ) {
-        this.variantTransforms = variantTransforms;
+        this.matcher = matcher;
         this.attributesFactory = attributesFactory;
-        this.matcher = Lazy.locking().of(() -> {
-            // TODO: This is incorrect. We fail to merge the consumer schema with the producer schema
-            // and therefore we miss producer rules when matching transforms.
-            // Instead, this class should be refactored to accept a matcher as a parameter,
-            // where the matcher has already been created with the consumer and producer schema.
-            ImmutableAttributesSchema immutable = attributeSchemaServices.getSchemaFactory().create(schema);
-            return attributeSchemaServices.getMatcher(immutable, ImmutableAttributesSchema.EMPTY);
-        });
-        this.transformCache = new TransformCache(this::doFindTransformedVariants);
+        this.transformCache = new TransformCache(cacheFactory, this::doFindTransformedArtifactSets);
     }
 
     /**
-     * Executes the transform chain detection algorithm given a set of producer variants and the requested
-     * attributes. Only the transform chains of the shortest depth are returned, and all results are
-     * guaranteed to have the same depth.
+     * Executes the transform chain detection algorithm given a set of registered transforms,
+     * producer artifact sets, and the requested attributes. Only the transform chains of the shortest
+     * depth are returned, and all results are guaranteed to have the same depth.
      *
-     * @param sources The set of producer variants.
+     * @param registeredTransforms The transforms to select from.
+     * @param sources The set of producer artifact sets.
      * @param requested The requested attributes.
      *
-     * @return A collection of variant chains which, if applied to the corresponding source variant, will produce a
-     *      variant compatible with the requested attributes.
+     * @return A collection of transform chains which, if applied to the corresponding source artifact set, will produce a
+     *      artifact set compatible with the requested attributes.
      */
-    public List<TransformedVariant> findCandidateTransformationChains(List<ResolvedVariant> sources, ImmutableAttributes requested) {
-        return transformCache.query(sources, requested);
+    public List<TransformedVariant> findCandidateTransformationChains(
+        ImmutableAttributes requested,
+        RegisteredTransforms registeredTransforms,
+        List<ResolvedVariant> sources
+    ) {
+        CacheableTransforms transforms = registeredTransforms.getCacheableTransforms();
+        List<ImmutableAttributes> sourceAttributes = new ArrayList<>(sources.size());
+        for (ResolvedVariant source : sources) {
+            sourceAttributes.add(source.getAttributes());
+        }
+
+        List<CachedTransformedArtifactSet> result = transformCache.query(requested, transforms, sourceAttributes);
+
+        ImmutableList.Builder<TransformedVariant> output = ImmutableList.builderWithExpectedSize(result.size());
+        for (CachedTransformedArtifactSet cachedArtifactSet : result) {
+            output.add(getTransformedVariant(registeredTransforms, sources, cachedArtifactSet));
+        }
+
+        return output.build();
+    }
+
+    /**
+     * Converts a single cached transformed artifact set into the project-specific representation.
+     */
+    private static TransformedVariant getTransformedVariant(
+        RegisteredTransforms registeredTransforms,
+        List<ResolvedVariant> sources,
+        CachedTransformedArtifactSet cachedArtifactSet
+    ) {
+        ResolvedVariant source = sources.get(cachedArtifactSet.sourceIndex);
+        ImmutableList<TransformRegistration> transforms = registeredTransforms.getTransforms();
+
+        DefaultVariantDefinition previous = null;
+        assert !cachedArtifactSet.chain.isEmpty();
+
+        for (CachedTransformationStep step : cachedArtifactSet.chain) {
+            TransformRegistration transform = transforms.get(step.registrationIndex);
+            previous = new DefaultVariantDefinition(
+                previous,
+                step.attributes,
+                transform.getTransformStep()
+            );
+        }
+
+        return new TransformedVariant(source, previous);
     }
 
     /**
      * A node in a chain of artifact transforms.
      */
     private static class ChainNode {
+
         final ChainNode next;
-        final TransformRegistration transform;
-        public ChainNode(@Nullable ChainNode next, TransformRegistration transform) {
+        final CacheableTransforms.CacheableTransform transform;
+
+        public ChainNode(@Nullable ChainNode next, CacheableTransforms.CacheableTransform transform) {
             this.next = next;
             this.transform = transform;
         }
+
     }
 
     /**
@@ -102,68 +139,91 @@ public class ConsumerProvidedVariantFinder {
      * for different potential solutions.
      */
     private static class ChainState {
+
         final ChainNode chain;
         final ImmutableAttributes requested;
-        final ImmutableFilteredList<TransformRegistration> transforms;
+        final ImmutableFilteredList<CacheableTransforms.CacheableTransform> transforms;
 
         /**
          * @param chain The candidate transform chain.
-         * @param requested The attribute set which must be produced by any previous variant in order to achieve the
-         *      original user-requested attribute set after {@code chain} is applied to that previous variant.
+         * @param requested The attribute set which must be produced by any previous artifact set in order to achieve the
+         *      original user-requested attribute set after {@code chain} is applied to that previous artifact set.
          * @param transforms The remaining transforms which may be prepended to {@code chain} to produce a solution.
          */
-        public ChainState(@Nullable ChainNode chain, ImmutableAttributes requested, ImmutableFilteredList<TransformRegistration> transforms) {
+        public ChainState(@Nullable ChainNode chain, ImmutableAttributes requested, ImmutableFilteredList<CacheableTransforms.CacheableTransform> transforms) {
             this.chain = chain;
             this.requested = requested;
             this.transforms = transforms;
         }
+
     }
 
     /**
-     * A cached result of the transform chain detection algorithm. References an index within the source variant
-     * list instead of an actual variant itself, so that this result can be cached and used for distinct variant sets
+     * A cached result of the transform chain detection algorithm. References an index within the source artifact set
+     * list instead of an actual artifact set itself, so that this result can be cached and used for distinct solutions
      * that otherwise share the same attributes.
      */
-    private static class CachedVariant {
-        private final int sourceIndex;
-        private final VariantDefinition chain;
-        public CachedVariant(int sourceIndex, VariantDefinition chain) {
+    static class CachedTransformedArtifactSet {
+
+        final int sourceIndex;
+        final List<CachedTransformationStep> chain;
+
+        public CachedTransformedArtifactSet(int sourceIndex, List<CachedTransformationStep> chain) {
             this.sourceIndex = sourceIndex;
             this.chain = chain;
         }
+
+    }
+
+    /**
+     * A single step in an artifact transform solution, consisting of the index of the transform
+     * in the original list of transforms, and the attributes of the artifact set produced as a result
+     * of applying this step to the prior artifact set in the transformation chain.
+     */
+    static class CachedTransformationStep {
+
+        final int registrationIndex;
+        final ImmutableAttributes attributes;
+
+        public CachedTransformationStep(int registrationIndex, ImmutableAttributes attributes) {
+            this.registrationIndex = registrationIndex;
+            this.attributes = attributes;
+        }
+
     }
 
     /**
      * The algorithm itself. Performs a breadth-first search on the set of potential transform solutions in order to find
      * all solutions at a given transform chain depth. The search begins at the final node of the chain. At each depth, a candidate
-     * transform is applied to the beginning of the chain. Then, if a source variant can be used as a root of that chain,
+     * transform is applied to the beginning of the chain. Then, if a source artifact set can be used as a root of that chain,
      * we have found a solution. Otherwise, if no solutions are found at this depth, we run the search at the next depth, with all
      * candidate transforms linked to the previous level's chains.
      */
-    private List<CachedVariant> doFindTransformedVariants(List<ImmutableAttributes> sources, ImmutableAttributes requested) {
-        AttributeMatcher attributeMatcher = matcher.get();
-
+    private List<CachedTransformedArtifactSet> doFindTransformedArtifactSets(
+        ImmutableAttributes requested,
+        CacheableTransforms transforms,
+        List<ImmutableAttributes> sources
+    ) {
         List<ChainState> toProcess = new ArrayList<>();
         List<ChainState> nextDepth = new ArrayList<>();
-        toProcess.add(new ChainState(null, requested, ImmutableFilteredList.allOf(new ArrayList<>(variantTransforms.getRegistrations()))));
+        toProcess.add(new ChainState(null, requested, ImmutableFilteredList.allOf(transforms.getTransforms())));
 
-        List<CachedVariant> results = new ArrayList<>(1);
+        List<CachedTransformedArtifactSet> results = new ArrayList<>(1);
         while (results.isEmpty() && !toProcess.isEmpty()) {
             for (ChainState state : toProcess) {
-                // The set of transforms which could potentially produce a variant compatible with `requested`.
-                ImmutableFilteredList<TransformRegistration> candidates =
-                    state.transforms.matching(transform -> attributeMatcher.isMatchingCandidate(transform.getTo(), state.requested));
+                // The set of transforms which could potentially produce an artifact set compatible with `requested`.
+                ImmutableFilteredList<CacheableTransforms.CacheableTransform> candidates =
+                    state.transforms.matching(transform -> matcher.isMatchingCandidate(transform.getTo(), state.requested));
 
-                // For each candidate, attempt to find a source variant that the transform can use as its root.
-                for (TransformRegistration candidate : candidates) {
+                // For each candidate, attempt to find a source artifact set that the transform can use as its root.
+                for (CacheableTransforms.CacheableTransform candidate : candidates) {
                     for (int i = 0; i < sources.size(); i++) {
                         ImmutableAttributes sourceAttrs = sources.get(i);
-                        if (attributeMatcher.isMatchingCandidate(sourceAttrs, candidate.getFrom())) {
+                        if (matcher.isMatchingCandidate(sourceAttrs, candidate.getFrom())) {
                             ImmutableAttributes rootAttrs = attributesFactory.concat(sourceAttrs, candidate.getTo());
-                            if (attributeMatcher.isMatchingCandidate(rootAttrs, state.requested)) {
-                                DefaultVariantDefinition rootTransformedVariant = new DefaultVariantDefinition(null, rootAttrs, candidate.getTransformStep());
-                                VariantDefinition variantChain = createVariantChain(state.chain, rootTransformedVariant);
-                                results.add(new CachedVariant(i, variantChain));
+                            if (matcher.isMatchingCandidate(rootAttrs, state.requested)) {
+                                List<CachedTransformationStep> artifactSetChain = extractTransformIndices(candidate, rootAttrs, state.chain);
+                                results.add(new CachedTransformedArtifactSet(i, artifactSetChain));
                             }
                         }
                     }
@@ -176,7 +236,7 @@ public class ConsumerProvidedVariantFinder {
 
                 // Construct new states for processing at the next depth in case we can't find any solutions at this depth.
                 for (int i = 0; i < candidates.size(); i++) {
-                    TransformRegistration candidate = candidates.get(i);
+                    CacheableTransforms.CacheableTransform candidate = candidates.get(i);
                     nextDepth.add(new ChainState(
                         new ChainNode(state.chain, candidate),
                         attributesFactory.concat(state.requested, candidate.getFrom()),
@@ -195,66 +255,113 @@ public class ConsumerProvidedVariantFinder {
     }
 
     /**
-     * Constructs a complete cacheable variant chain given a root transformed variant and the chain of variants
-     * to apply to that root variant.
+     * Constructs a complete cacheable transformation chain given an initial transform and the chain of transforms
+     * to apply after it.
      *
-     * @param stateChain The transform chain from the search state to apply to the root transformed variant.
-     * @param root The root variant to apply the chain to.
+     * @param first The first transform to apply to the source artifact set.
+     * @param firstAttrs The resulting attributes produced as a result of applying the first transform to the source artifact set.
+     * @param rest The transform chain from the search state to apply to after the first transform.
      *
-     * @return A variant chain representing the final transformed variant.
+     * @return A list of transform steps, where each step corresponds to a transform registration in the original
+     *      transform list. The steps are ordered such that the first step corresponds to the first transform to
+     *      apply to the source artifact set.
      */
-    private VariantDefinition createVariantChain(final ChainNode stateChain, DefaultVariantDefinition root) {
-        ChainNode node = stateChain;
-        DefaultVariantDefinition last = root;
+    private List<CachedTransformationStep> extractTransformIndices(
+        CacheableTransforms.CacheableTransform first,
+        ImmutableAttributes firstAttrs,
+        @Nullable ChainNode rest
+    ) {
+        List<CachedTransformationStep> steps = new ArrayList<>();
+
+        CachedTransformationStep firstStep = new CachedTransformationStep(first.getRegistrationIndex(), firstAttrs);
+        steps.add(firstStep);
+
+        ChainNode node = rest;
+        CachedTransformationStep previous = firstStep;
+
         while (node != null) {
-            last = new DefaultVariantDefinition(
-                last,
-                attributesFactory.concat(last.getTargetAttributes(), node.transform.getTo()),
-                node.transform.getTransformStep()
-            );
+            ImmutableAttributes stepAttributes = attributesFactory.concat(previous.attributes, node.transform.getTo());
+            CachedTransformationStep step = new CachedTransformationStep(node.transform.getRegistrationIndex(), stepAttributes);
+            steps.add(step);
             node = node.next;
+            previous = step;
         }
-        return last;
+
+        return steps;
+    }
+
+    /**
+     * Computes the transform chains that can be applied to any of the given source artifact sets to produce an artifact set
+     * compatible with the requested attributes.
+     */
+    interface TransformCalculator {
+
+        List<CachedTransformedArtifactSet> findTransforms(
+            ImmutableAttributes requested,
+            CacheableTransforms transforms,
+            List<ImmutableAttributes> sources
+        );
+
     }
 
     /**
      * Caches calls to the transform chain selection algorithm. The cached results are stored in
-     * a variant-independent manner, such that only the attributes of the input variants are cached.
-     * This way, if multiple calls are made with different variants but those variants have the same
-     * attributes, the cached results may be used.
+     * a transform-independent and source-independent manner, such that only the indices of the
+     * registered transforms and input artifact sets are cached. This way, if multiple calls are made
+     * with different transforms or artifact sets, but they have the same attributes, the cached results
+     * may be used.
      */
     private static class TransformCache {
-        private final ConcurrentHashMap<CacheKey, List<CachedVariant>> cache = new ConcurrentHashMap<>();
-        private final BiFunction<List<ImmutableAttributes>, ImmutableAttributes, List<CachedVariant>> action;
 
-        public TransformCache(BiFunction<List<ImmutableAttributes>, ImmutableAttributes, List<CachedVariant>> action) {
+        private final TransformCalculator action;
+        private final InMemoryLoadingCache<CacheKey, List<CachedTransformedArtifactSet>> cache;
+
+        public TransformCache(InMemoryCacheFactory cacheFactory, TransformCalculator action) {
             this.action = action;
+            this.cache = cacheFactory.create(this::doQuery);
         }
 
-        private List<TransformedVariant> query(
-            List<ResolvedVariant> sources, ImmutableAttributes requested
+        public List<CachedTransformedArtifactSet> query(
+            ImmutableAttributes requested,
+            CacheableTransforms transforms,
+            List<ImmutableAttributes> sourceAttributes
         ) {
-            List<ImmutableAttributes> variantAttributes = new ArrayList<>(sources.size());
-            for (ResolvedVariant variant : sources) {
-                variantAttributes.add(variant.getAttributes().asImmutable());
-            }
-            List<CachedVariant> cached = cache.computeIfAbsent(new CacheKey(variantAttributes, requested), key -> action.apply(key.variantAttributes, key.requested));
-            List<TransformedVariant> output = new ArrayList<>(cached.size());
-            for (CachedVariant variant : cached) {
-                output.add(new TransformedVariant(sources.get(variant.sourceIndex), variant.chain));
-            }
-            return output;
+            return cache.get(new CacheKey(requested, transforms, sourceAttributes));
+        }
+
+        private List<CachedTransformedArtifactSet> doQuery(CacheKey key) {
+            return action.findTransforms(key.requested, key.transforms, key.sourceAttributes);
         }
 
         private static class CacheKey {
-            private final List<ImmutableAttributes> variantAttributes;
+
+            private final CacheableTransforms transforms;
+            private final List<ImmutableAttributes> sourceAttributes;
             private final ImmutableAttributes requested;
+
             private final int hashCode;
 
-            public CacheKey(List<ImmutableAttributes> variantAttributes, ImmutableAttributes requested) {
-                this.variantAttributes = variantAttributes;
+            public CacheKey(
+                ImmutableAttributes requested,
+                CacheableTransforms transforms,
+                List<ImmutableAttributes> sourceAttributes
+            ) {
                 this.requested = requested;
-                this.hashCode = 31 * variantAttributes.hashCode() + requested.hashCode();
+                this.transforms = transforms;
+                this.sourceAttributes = sourceAttributes;
+
+                this.hashCode = computeHashCode(requested, transforms, sourceAttributes);
+            }
+
+            private static int computeHashCode(
+                ImmutableAttributes requested,
+                CacheableTransforms transforms,
+                List<ImmutableAttributes> sourceAttributes
+            ) {
+                int result = requested.hashCode();
+                result = 31 * result + transforms.hashCode();
+                result = 31 * result + sourceAttributes.hashCode();
+                return result;
             }
 
             @Override
@@ -265,14 +372,34 @@ public class ConsumerProvidedVariantFinder {
                 if (o == null || getClass() != o.getClass()) {
                     return false;
                 }
+
                 CacheKey cacheKey = (CacheKey) o;
-                return variantAttributes.equals(cacheKey.variantAttributes) && requested.equals(cacheKey.requested);
+
+                if (requested != cacheKey.requested || // ImmutableAttributes instances are interned.
+                    transforms != cacheKey.transforms || // CacheableTransforms instances are interned.
+                    sourceAttributes.size() != cacheKey.sourceAttributes.size()
+                ) {
+                    return false;
+                }
+
+                int size = sourceAttributes.size();
+                for (int i = 0; i < size; i++) {
+                    // ImmutableAttributes instances are interned.
+                    if (sourceAttributes.get(i) != cacheKey.sourceAttributes.get(i)) {
+                        return false;
+                    }
+                }
+
+                return true;
             }
 
             @Override
             public int hashCode() {
                 return hashCode;
             }
+
         }
+
     }
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/RegisteredTransforms.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/RegisteredTransforms.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.internal.artifacts.TransformRegistration;
+
+/**
+ * The transforms registered for given project/dependency management instance.
+ * <p>
+ * Includes a secondary cacheable representation that can be used across project boundaries,
+ * containing only cacheable data required to performing transform selection.
+ */
+public class RegisteredTransforms {
+
+    private final ImmutableList<TransformRegistration> transforms;
+    private final CacheableTransforms cacheableTransforms;
+
+    public RegisteredTransforms(ImmutableList<TransformRegistration> transforms, CacheableTransforms cacheableTransforms) {
+        this.transforms = transforms;
+        this.cacheableTransforms = cacheableTransforms;
+    }
+
+    /**
+     * The registered transforms.
+     */
+    public ImmutableList<TransformRegistration> getTransforms() {
+        return transforms;
+    }
+
+    /**
+     * Cacheable representation of the registered transforms containing only cacheable
+     * data required to performing transform selection.
+     */
+    public CacheableTransforms getCacheableTransforms() {
+        return cacheableTransforms;
+    }
+
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/immutable/artifact/ImmutableArtifactTypeRegistry.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/immutable/artifact/ImmutableArtifactTypeRegistry.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.internal.artifacts.TransformRegistration;
+import org.gradle.api.internal.artifacts.transform.RegisteredTransforms;
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributesFactory;
@@ -27,7 +28,6 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 
 import java.io.File;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -71,7 +71,7 @@ public class ImmutableArtifactTypeRegistry {
         return defaultArtifactAttributes;
     }
 
-    public void visitArtifactTypeAttributes(Collection<TransformRegistration> transformRegistrations, Consumer<? super ImmutableAttributes> action) {
+    public void visitArtifactTypeAttributes(RegisteredTransforms transformRegistrations, Consumer<? super ImmutableAttributes> action) {
         // Apply default attributes before visiting
         Consumer<? super ImmutableAttributes> visitor = attributes -> {
             ImmutableAttributes attributesPlusDefaults = attributesFactory.concat(defaultArtifactAttributes.asImmutable(), attributes);
@@ -87,7 +87,7 @@ public class ImmutableArtifactTypeRegistry {
             }
         }
 
-        for (TransformRegistration registration : transformRegistrations) {
+        for (TransformRegistration registration : transformRegistrations.getTransforms()) {
             AttributeContainerInternal sourceAttributes = registration.getFrom();
             String format = sourceAttributes.getAttribute(ARTIFACT_TYPE_ATTRIBUTE);
             if (format != null && seen.add(format)) {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInvocationTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInvocationTest.groovy
@@ -113,12 +113,12 @@ class ArtifactTransformInvocationTest extends AbstractProjectBuilderSpec {
 
     private <T extends TransformParameters> TransformStep registerTransform(Class<? extends TransformAction<T>> actionType) {
         def variantTransformRegistry = project.services.get(VariantTransformRegistry)
-        int currentRegisteredTransforms = variantTransformRegistry.registrations.size()
+        int currentRegisteredTransforms = variantTransformRegistry.registrations.transforms.size()
         project.dependencies.registerTransform(actionType) {
             it.from.attribute(artifactType, 'jar')
             it.to.attribute(artifactType, 'transformed')
         }
-        return variantTransformRegistry.registrations[currentRegisteredTransforms].transformStep
+        return variantTransformRegistry.registrations.transforms[currentRegisteredTransforms].transformStep
     }
 
     private Try<ImmutableList<File>> invokeTransform(TransformStep transform, File inputArtifact) {

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/artifact/transforms/model/ArtifactTransformReportModelFactory.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/artifact/transforms/model/ArtifactTransformReportModelFactory.java
@@ -37,7 +37,7 @@ public abstract class ArtifactTransformReportModelFactory {
     }
 
     public ArtifactTransformReportModel buildForProject(Project project) {
-        List<ReportArtifactTransform> artifactTransformData = variantTransformRegistry.getRegistrations().stream()
+        List<ReportArtifactTransform> artifactTransformData = variantTransformRegistry.getRegistrations().getTransforms().stream()
             .map(this::convertArtifactTransform)
             .collect(Collectors.toList());
 

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/AttributeTestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/AttributeTestUtil.groovy
@@ -104,6 +104,7 @@ class AttributeTestUtil {
      */
     static AttributeSchemaServices services() {
         new AttributeSchemaServices(
+            attributesFactory(),
             new ImmutableAttributesSchemaFactory(TestUtil.inMemoryCacheFactory()),
             new ImmutableArtifactTypeRegistryFactory(TestUtil.inMemoryCacheFactory(), attributesFactory()),
             TestUtil.inMemoryCacheFactory()


### PR DESCRIPTION
In many cases, projects are initialized with functionally identical artifact transform registrations. While the registrations themselves may have different parameters, they are initialized in the same order and have the same from/to attributes.

Similar to caching we do with variant selection, and caching already done for source artifact sets in the transform selector, we can store the indices of input artifact transforms, effectively reusing transform selection results across projects.

This commit creates a cacheable representation of a set of transform registrations for a given project, and then uses that as an input to the artifact transform selection process. This cacheable representation is mapped back to the concrete transform registrations after results are loaded from the cache.

This results in a notable reduction of artifact selection time in projects that use artifact transforms heavily.

Fixes #13402

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
