### PR TITLE
Fix emitting progress events for problems reported from workers

### DIFF
--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientBuildEventGenerator.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientBuildEventGenerator.java
@@ -40,13 +40,13 @@ import java.util.concurrent.ConcurrentHashMap;
  * Generates progress events to send back to the client,
  */
 public class ClientBuildEventGenerator implements BuildOperationListener {
-    private final BuildOperationListener fallback;
+    private final BuildOperationListener nonMappedBuildEventGenerator;
     private final List<Mapper> mappers;
     private final List<BuildOperationTracker> trackers;
     private final Map<OperationIdentifier, Operation> running = new ConcurrentHashMap<>();
 
-    public ClientBuildEventGenerator(ProgressEventConsumer progressEventConsumer, BuildEventSubscriptions subscriptions, List<? extends BuildOperationMapper<?, ?>> mappers, BuildOperationListener fallback) {
-        this.fallback = fallback;
+    public ClientBuildEventGenerator(ProgressEventConsumer progressEventConsumer, BuildEventSubscriptions subscriptions, List<? extends BuildOperationMapper<?, ?>> mappers, BuildOperationListener nonMappedBuildEventGenerator) {
+        this.nonMappedBuildEventGenerator = nonMappedBuildEventGenerator;
         List<Mapper> mapperBuilder = new ArrayList<>(mappers.size());
         Set<BuildOperationTracker> trackers = new LinkedHashSet<>();
         for (BuildOperationMapper<?, ?> mapper : mappers) {
@@ -87,7 +87,7 @@ public class ClientBuildEventGenerator implements BuildOperationListener {
             }
         }
         // Not recognized, so generate generic events, if appropriate
-        fallback.started(buildOperation, startEvent);
+        nonMappedBuildEventGenerator.started(buildOperation, startEvent);
     }
 
     @Override
@@ -95,9 +95,10 @@ public class ClientBuildEventGenerator implements BuildOperationListener {
         Operation operation = running.get(operationIdentifier);
         if (operation != null) {
             operation.progress(progressEvent);
-            return;
         }
-        fallback.progress(operationIdentifier, progressEvent);
+        // For start and finish events we either emit a mapped or a non-mapped event. For progress events we are not doing mapping, but we emit additional progress events. Therefore, we are not
+        // returning in the if statement above.
+        nonMappedBuildEventGenerator.progress(operationIdentifier, progressEvent);
     }
 
     @Override
@@ -110,7 +111,7 @@ public class ClientBuildEventGenerator implements BuildOperationListener {
             operation.generateFinishEvent(buildOperation, finishEvent);
         } else {
             // Not recognized, so generate generic events, if appropriate
-            fallback.finished(buildOperation, finishEvent);
+            nonMappedBuildEventGenerator.finished(buildOperation, finishEvent);
         }
         for (BuildOperationTracker tracker : trackers) {
             tracker.discardState(buildOperation);

--- a/platforms/ide/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/ClientBuildEventGeneratorTest.groovy
+++ b/platforms/ide/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/ClientBuildEventGeneratorTest.groovy
@@ -75,6 +75,7 @@ class ClientBuildEventGeneratorTest extends Specification {
         then:
         1 * mapper2.createProgressEvent(clientDescriptor, progressEvent) >> mappedProgressEvent
         1 * consumer.progress(mappedProgressEvent)
+        1 * fallback.progress(_, _)
         0 * _
 
         when:
@@ -108,6 +109,7 @@ class ClientBuildEventGeneratorTest extends Specification {
         generator.progress(operationId, progressEvent)
 
         then:
+        1 * fallback.progress(_, _)
         0 * _
 
         when:

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r813/WorkerProblemCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r813/WorkerProblemCrossVersionTest.groovy
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r813
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.events.ProgressEvent
+import org.gradle.tooling.events.ProgressListener
+import org.gradle.tooling.events.problems.SingleProblemEvent
+import org.gradle.workers.fixtures.WorkerExecutorFixture
+
+@ToolingApiVersion('>=8.13')
+@TargetGradleVersion('>=8.13')
+class WorkerProblemCrossVersionTest extends ToolingApiSpecification {
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'root'
+        """
+        buildFile << """
+            plugins {
+                id 'java-library'
+            }
+        """
+    }
+
+    def "problem from worker using #isolationMode"() {
+        setup:
+        file('buildSrc/build.gradle') << """
+            plugins {
+                id 'java'
+            }
+
+            dependencies {
+                implementation(gradleApi())
+            }
+        """
+        file('buildSrc/src/main/java/org/gradle/test/ProblemsWorkerTaskParameter.java') << """
+            package org.gradle.test;
+
+            import org.gradle.workers.WorkParameters;
+
+            public interface ProblemsWorkerTaskParameter extends WorkParameters { }
+        """
+        file('buildSrc/src/main/java/org/gradle/test/ProblemWorkerTask.java') << """
+            package org.gradle.test;
+
+            import java.io.File;
+            import java.io.FileWriter;
+            import org.gradle.api.problems.Problems;
+            import org.gradle.api.problems.ProblemId;
+            import org.gradle.api.problems.ProblemGroup;
+            import org.gradle.internal.operations.CurrentBuildOperationRef;
+
+            import org.gradle.workers.WorkAction;
+
+            import javax.inject.Inject;
+
+            public abstract class ProblemWorkerTask implements WorkAction<ProblemsWorkerTaskParameter> {
+
+                @Inject
+                public abstract Problems getProblems();
+
+                @Override
+                public void execute() {
+                    ProblemId problemId = ProblemId.create("name", "Display name", ProblemGroup.create("generic", "Generic"));
+                    getProblems().getReporter().report(problemId, problem ->
+                        problem.contextualLabel("Tooling API client should receive this problem")
+                    );
+                }
+            }
+        """
+        buildFile << """
+            import javax.inject.Inject
+            import org.gradle.test.ProblemWorkerTask
+
+
+            abstract class ProblemTask extends DefaultTask {
+                @Inject
+                abstract WorkerExecutor getWorkerExecutor();
+
+                @TaskAction
+                void executeTask() {
+                    getWorkerExecutor().${isolationMode}().submit(ProblemWorkerTask.class) {}
+                }
+            }
+
+            tasks.register("reportProblem", ProblemTask)
+        """
+        def problemProgressListener = new ProblemProgressListener()
+
+        when:
+
+        withConnection { connection ->
+            connection.newBuild()
+                .forTasks('reportProblem')
+                .addProgressListener(problemProgressListener)
+                .run()
+        }
+
+        then:
+        def event = problemProgressListener.problemEvents.find {it.problem.definition.id.name == 'name' }
+        event.problem.definition.id.displayName == 'Display name'
+        event.problem.contextualLabel.contextualLabel == 'Tooling API client should receive this problem'
+
+        where:
+        isolationMode << WorkerExecutorFixture.IsolationMode.values().collect {it.method }
+    }
+
+
+    class ProblemProgressListener implements ProgressListener {
+
+        List<SingleProblemEvent> problemEvents = []
+
+        @Override
+        void statusChanged(ProgressEvent event) {
+            if (event instanceof SingleProblemEvent) {
+                problemEvents += event
+            }
+        }
+    }
+}


### PR DESCRIPTION
The build operation _progress_ events are not forwarded in case a progress event mapper is active. Progress events are different from start and finish events thought, therefore we do want to emit them, even in case of an active mapper.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->
Fixes https://github.com/gradle/gradle/issues/31954

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
