### PR TITLE
Memory optimizations

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/model/internal/core/DefaultNodeInitializerRegistry.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/model/internal/core/DefaultNodeInitializerRegistry.java
@@ -20,17 +20,23 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.gradle.internal.UncheckedException;
 import org.gradle.model.internal.manage.binding.StructBindingsStore;
 import org.gradle.model.internal.manage.schema.ModelSchema;
 import org.gradle.model.internal.manage.schema.ModelSchemaStore;
-import org.gradle.model.internal.manage.schema.extract.*;
+import org.gradle.model.internal.manage.schema.extract.ManagedImplStructNodeInitializerExtractionStrategy;
+import org.gradle.model.internal.manage.schema.extract.ModelMapNodeInitializerExtractionStrategy;
+import org.gradle.model.internal.manage.schema.extract.ModelSetNodeInitializerExtractionStrategy;
+import org.gradle.model.internal.manage.schema.extract.NodeInitializerExtractionStrategy;
+import org.gradle.model.internal.manage.schema.extract.ScalarCollectionNodeInitializerExtractionStrategy;
+import org.gradle.model.internal.manage.schema.extract.ScalarTypes;
+import org.gradle.model.internal.manage.schema.extract.SpecializedMapNodeInitializerExtractionStrategy;
 import org.gradle.model.internal.type.ModelType;
 import org.gradle.model.internal.type.ModelTypes;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -52,13 +58,13 @@ public class DefaultNodeInitializerRegistry implements NodeInitializerRegistry {
 
     public DefaultNodeInitializerRegistry(ModelSchemaStore schemaStore, StructBindingsStore structBindingsStore) {
         this.schemaStore = schemaStore;
-        this.allStrategies = Lists.newArrayList(
+        this.allStrategies = new ArrayList<>(Arrays.asList(
             new ModelSetNodeInitializerExtractionStrategy(),
             new SpecializedMapNodeInitializerExtractionStrategy(),
             new ModelMapNodeInitializerExtractionStrategy(),
             new ScalarCollectionNodeInitializerExtractionStrategy(),
             new ManagedImplStructNodeInitializerExtractionStrategy(structBindingsStore)
-        );
+        ));
         additionalStrategies = new ArrayList<>();
     }
 

--- a/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/AbstractClassLoaderWorker.java
+++ b/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/AbstractClassLoaderWorker.java
@@ -16,7 +16,6 @@
 
 package org.gradle.workers.internal;
 
-import com.google.common.collect.Lists;
 import org.gradle.api.internal.project.IsolatedAntBuilder;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
@@ -28,6 +27,7 @@ import org.gradle.workers.WorkAction;
 import org.gradle.workers.WorkParameters;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
 
 import static org.gradle.internal.classloader.ClassLoaderUtils.executeInClassloader;
 
@@ -41,7 +41,7 @@ public abstract class AbstractClassLoaderWorker implements RequestHandler<Transp
             workServices,
             instantiatorFactory,
             new IsolationScheme<>(Cast.uncheckedCast(WorkAction.class), WorkParameters.class, WorkParameters.None.class),
-            Lists.newArrayList(IsolatedAntBuilder.class));
+            Collections.singletonList(IsolatedAntBuilder.class));
     }
 
     public DefaultWorkResult executeInClassLoader(TransportableActionExecutionSpec spec, ClassLoader workerClassLoader) {

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/graph/CachingDirectedGraphWalker.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/graph/CachingDirectedGraphWalker.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.graph;
 
+import com.google.common.collect.ImmutableSet;
 import org.gradle.util.internal.GUtil;
 
 import java.util.ArrayDeque;
@@ -39,7 +40,7 @@ public class CachingDirectedGraphWalker<N, T> {
     private final DirectedGraphWithEdgeValues<N, T> graph;
     private List<N> startNodes = new ArrayList<N>();
     private Set<NodeDetails<N, T>> strongComponents = new LinkedHashSet<NodeDetails<N, T>>();
-    private final Map<N, Set<T>> cachedNodeValues = new HashMap<N, Set<T>>();
+    private final Map<N, ImmutableSet<T>> cachedNodeValues = new HashMap<N, ImmutableSet<T>>();
 
     public CachingDirectedGraphWalker(DirectedGraph<N, T> graph) {
         this.graph = new GraphWithEmptyEdges<N, T>(graph);
@@ -161,7 +162,9 @@ public class CachingDirectedGraphWalker<N, T> {
                 } else {
                     // Not part of a strongly connected component or the root of a strongly connected component
                     for (NodeDetails<N, T> componentMember : details.componentMembers) {
-                        cachedNodeValues.put(componentMember.node, details.values);
+                        // We use an immutable set for cached node values since the cache can become quite large
+                        // for very large graphs, and immutable sets are much more memory efficient than LinkedHashSets.
+                        cachedNodeValues.put(componentMember.node, ImmutableSet.copyOf(details.values));
                         componentMember.finished = true;
                         components.remove(componentMember.component);
                     }

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/graph/CachingDirectedGraphWalker.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/graph/CachingDirectedGraphWalker.java
@@ -40,6 +40,11 @@ public class CachingDirectedGraphWalker<N, T> {
     private final DirectedGraphWithEdgeValues<N, T> graph;
     private List<N> startNodes = new ArrayList<N>();
     private Set<NodeDetails<N, T>> strongComponents = new LinkedHashSet<NodeDetails<N, T>>();
+
+    /**
+     * We use an immutable set for cached node values since the cache can become quite large
+     * for very large graphs, and immutable sets are much more memory efficient than LinkedHashSets.
+     */
     private final Map<N, ImmutableSet<T>> cachedNodeValues = new HashMap<N, ImmutableSet<T>>();
 
     public CachingDirectedGraphWalker(DirectedGraph<N, T> graph) {
@@ -162,8 +167,6 @@ public class CachingDirectedGraphWalker<N, T> {
                 } else {
                     // Not part of a strongly connected component or the root of a strongly connected component
                     for (NodeDetails<N, T> componentMember : details.componentMembers) {
-                        // We use an immutable set for cached node values since the cache can become quite large
-                        // for very large graphs, and immutable sets are much more memory efficient than LinkedHashSets.
                         cachedNodeValues.put(componentMember.node, ImmutableSet.copyOf(details.values));
                         componentMember.finished = true;
                         components.remove(componentMember.component);

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/console/ProgressBar.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/console/ProgressBar.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.logging.console;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import org.gradle.internal.logging.events.StyledTextOutputEvent;
 import org.gradle.internal.logging.format.TersePrettyDurationFormatter;
 import org.gradle.internal.logging.text.StyledTextOutput;
@@ -107,7 +107,7 @@ public class ProgressBar {
                 + (timerEnabled ? " [" + elapsedTimeStr + "]" : ""));
 
             lastElapsedTimeStr = elapsedTimeStr;
-            formatted = Lists.newArrayList(
+            formatted = ImmutableList.of(
                 new StyledTextOutputEvent.Span(StyledTextOutput.Style.Header, statusPrefix),
                 new StyledTextOutputEvent.Span(failing ? StyledTextOutput.Style.FailureHeader : StyledTextOutput.Style.SuccessHeader, coloredProgress),
                 new StyledTextOutputEvent.Span(StyledTextOutput.Style.Header, statusSuffix));

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/events/BooleanQuestionPromptEvent.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/events/BooleanQuestionPromptEvent.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.logging.events;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
 
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Locale;
 
 public class BooleanQuestionPromptEvent extends PromptOutputEvent {
-    private static final List<String> LENIENT_YES_NO_CHOICES = Lists.newArrayList("yes", "no", "y", "n");
+    private static final List<String> LENIENT_YES_NO_CHOICES = ImmutableList.of("yes", "no", "y", "n");
     private final String question;
     private final boolean defaultValue;
 

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/events/YesNoQuestionPromptEvent.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/events/YesNoQuestionPromptEvent.java
@@ -16,14 +16,14 @@
 
 package org.gradle.internal.logging.events;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.List;
 
 public class YesNoQuestionPromptEvent extends PromptOutputEvent {
-    public static final List<String> YES_NO_CHOICES = Lists.newArrayList("yes", "no");
+    public static final List<String> YES_NO_CHOICES = ImmutableList.of("yes", "no");
     private final String question;
 
     public YesNoQuestionPromptEvent(long timestamp, String question) {

--- a/platforms/ide/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/AbstractCppBinaryVisualStudioTargetBinary.java
+++ b/platforms/ide/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/AbstractCppBinaryVisualStudioTargetBinary.java
@@ -16,7 +16,6 @@
 
 package org.gradle.ide.visualstudio.internal;
 
-import com.google.common.collect.Lists;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.language.cpp.CppBinary;
@@ -34,6 +33,7 @@ import org.gradle.nativeplatform.toolchain.internal.msvcpp.metadata.VisualCppMet
 import org.gradle.util.internal.VersionNumber;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -128,7 +128,7 @@ abstract public class AbstractCppBinaryVisualStudioTargetBinary implements Visua
 
     @Override
     public List<String> getVariantDimensions() {
-        return Lists.newArrayList(getBinary().getName());
+        return Collections.singletonList(getBinary().getName());
     }
 
     @Override

--- a/platforms/ide/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/NativeSpecVisualStudioTargetBinary.java
+++ b/platforms/ide/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/NativeSpecVisualStudioTargetBinary.java
@@ -16,7 +16,6 @@
 
 package org.gradle.ide.visualstudio.internal;
 
-import com.google.common.collect.Lists;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.Transformer;
@@ -43,6 +42,7 @@ import org.gradle.util.internal.VersionNumber;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -160,7 +160,7 @@ public class NativeSpecVisualStudioTargetBinary implements VisualStudioTargetBin
     public List<String> getVariantDimensions() {
         List<String> dimensions = binary.getNamingScheme().getVariantDimensions();
         if (dimensions.isEmpty()) {
-            return Lists.newArrayList(binary.getBuildType().getName());
+            return Collections.singletonList(binary.getBuildType().getName());
         } else {
             return dimensions;
         }

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
@@ -17,6 +17,7 @@ package org.gradle.plugins.ide.eclipse;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.gradle.api.Action;
@@ -368,7 +369,7 @@ public abstract class EclipsePlugin extends IdePlugin {
 
                 // exclude the dependencies already provided by SCALA_CONTAINER; prevents problems with Eclipse Scala plugin
                 project.getGradle().projectsEvaluated(gradle -> {
-                    final List<String> provided = Lists.newArrayList("scala-library", "scala-swing", "scala-dbc");
+                    Set<String> provided = ImmutableSet.of("scala-library", "scala-swing", "scala-dbc");
                     Predicate<Dependency> dependencyInProvided = dependency -> provided.contains(dependency.getName());
                     List<Dependency> dependencies = Lists.newArrayList(Iterables.filter(Iterables.concat(Iterables.transform(model.getClasspath().getPlusConfigurations(), new Function<Configuration, Iterable<Dependency>>() {
                         @Override

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.plugins.ide.eclipse;
 
-import com.google.common.collect.Lists;
 import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
@@ -46,6 +45,7 @@ import org.gradle.util.internal.WrapUtil;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -204,7 +204,9 @@ public abstract class EclipseWtpPlugin extends IdePlugin {
                         File projectDir = project.getProjectDir();
                         File webAppDir = ((War) project.getTasks().getByName("war")).getWebAppDirectory().get().getAsFile();
                         String webAppDirName = RelativePathUtil.relativePath(projectDir, webAppDir);
-                        return Lists.newArrayList(new WbResource("/", webAppDirName));
+                        List<WbResource> result = new ArrayList<>(1);
+                        result.add(new WbResource("/", webAppDirName));
+                        return result;
                     }
                 });
                 convention.map("sourceDirs", new Callable<Set<File>>() {
@@ -284,11 +286,11 @@ public abstract class EclipseWtpPlugin extends IdePlugin {
                 ((IConventionAware) eclipseModel.getWtp().getFacet()).getConventionMapping().map("facets", new Callable<List<Facet>>() {
                     @Override
                     public List<Facet> call() throws Exception {
-                        return Lists.newArrayList(
-                            new Facet(Facet.FacetType.fixed, "jst.java", null),
-                            new Facet(Facet.FacetType.installed, "jst.utility", "1.0"),
-                            new Facet(Facet.FacetType.installed, "jst.java", toJavaFacetVersion(project.getExtensions().getByType(JavaPluginExtension.class).getSourceCompatibility()))
-                        );
+                        List<Facet> result = new ArrayList<>(3);
+                        result.add(new Facet(Facet.FacetType.fixed, "jst.java", null));
+                        result.add(new Facet(Facet.FacetType.installed, "jst.utility", "1.0"));
+                        result.add(new Facet(Facet.FacetType.installed, "jst.java", toJavaFacetVersion(project.getExtensions().getByType(JavaPluginExtension.class).getSourceCompatibility())));
+                        return result;
                     }
                 });
             }
@@ -300,12 +302,12 @@ public abstract class EclipseWtpPlugin extends IdePlugin {
                 ((IConventionAware) eclipseModel.getWtp().getFacet()).getConventionMapping().map("facets", new Callable<List<Facet>>() {
                     @Override
                     public List<Facet> call() throws Exception {
-                        return Lists.newArrayList(
-                            new Facet(Facet.FacetType.fixed, "jst.java", null),
-                            new Facet(Facet.FacetType.fixed, "jst.web", null),
-                            new Facet(Facet.FacetType.installed, "jst.web", "2.4"),
-                            new Facet(Facet.FacetType.installed, "jst.java", toJavaFacetVersion(project.getExtensions().getByType(JavaPluginExtension.class).getSourceCompatibility()))
-                        );
+                        List<Facet> result = new ArrayList<>(4);
+                        result.add(new Facet(Facet.FacetType.fixed, "jst.java", null));
+                        result.add(new Facet(Facet.FacetType.fixed, "jst.web", null));
+                        result.add(new Facet(Facet.FacetType.installed, "jst.web", "2.4"));
+                        result.add(new Facet(Facet.FacetType.installed, "jst.java", toJavaFacetVersion(project.getExtensions().getByType(JavaPluginExtension.class).getSourceCompatibility())));
+                        return result;
                     }
                 });
             }
@@ -317,10 +319,10 @@ public abstract class EclipseWtpPlugin extends IdePlugin {
                 ((IConventionAware) eclipseModel.getWtp().getFacet()).getConventionMapping().map("facets", new Callable<List<Facet>>() {
                     @Override
                     public List<Facet> call() throws Exception {
-                        return Lists.newArrayList(
-                            new Facet(Facet.FacetType.fixed, "jst.ear", null),
-                            new Facet(Facet.FacetType.installed, "jst.ear", "5.0")
-                        );
+                        List<Facet> result = new ArrayList<>(2);
+                        result.add(new Facet(Facet.FacetType.fixed, "jst.ear", null));
+                        result.add(new Facet(Facet.FacetType.installed, "jst.ear", "5.0"));
+                        return result;
                     }
                 });
             }

--- a/platforms/jvm/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/WindowsInstallationSupplier.java
+++ b/platforms/jvm/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/WindowsInstallationSupplier.java
@@ -16,7 +16,6 @@
 
 package org.gradle.jvm.toolchain.internal;
 
-import com.google.common.collect.Lists;
 import net.rubygrapefruit.platform.MissingRegistryEntryException;
 import net.rubygrapefruit.platform.WindowsRegistry;
 import org.gradle.internal.nativeintegration.NativeIntegrationUnavailableException;
@@ -54,13 +53,13 @@ public class WindowsInstallationSupplier implements InstallationSupplier {
 
     private Set<InstallationLocation> findInstallationsInRegistry() {
         final Stream<String> openJdkInstallations = findOpenJDKs();
-        final Stream<String> jvms = Lists.newArrayList(
+        final Stream<String> jvms = Stream.of(
             "SOFTWARE\\JavaSoft\\JDK",
             "SOFTWARE\\JavaSoft\\Java Development Kit",
             "SOFTWARE\\JavaSoft\\Java Runtime Environment",
             "SOFTWARE\\Wow6432Node\\JavaSoft\\Java Development Kit",
             "SOFTWARE\\Wow6432Node\\JavaSoft\\Java Runtime Environment"
-        ).stream().map(this::findJvms).flatMap(List::stream);
+        ).map(this::findJvms).flatMap(List::stream);
         return Stream.concat(openJdkInstallations, jvms)
             .map(javaHome -> InstallationLocation.autoDetected(new File(javaHome), getSourceName()))
             .collect(Collectors.toSet());

--- a/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.plugins;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -28,10 +28,10 @@ import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.GeneratedSubclasses;
 import org.gradle.api.internal.IConventionAware;
-import org.gradle.api.internal.artifacts.configurations.RoleBasedConfigurationCreationRequest;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationRole;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationRoles;
 import org.gradle.api.internal.artifacts.configurations.RoleBasedConfigurationContainerInternal;
+import org.gradle.api.internal.artifacts.configurations.RoleBasedConfigurationCreationRequest;
 import org.gradle.api.internal.artifacts.configurations.UsageDescriber;
 import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.internal.plugins.DslObject;
@@ -497,9 +497,10 @@ public abstract class JavaBasePlugin implements Plugin<Project> {
 
         @Override
         public void failOnInabilityToMutateUsage() {
-            List<String> resolutions = Lists.newArrayList(
+            List<String> resolutions = ImmutableList.of(
                 RoleBasedConfigurationCreationRequest.getDefaultReservedNameAdvice(getConfigurationName()),
-                getUsageMutationAdvice());
+                getUsageMutationAdvice()
+            );
             throw new UnmodifiableUsageException(getConfigurationName(), resolutions);
         }
 

--- a/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/internal/modulemap/GenerateModuleMapFile.java
+++ b/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/internal/modulemap/GenerateModuleMapFile.java
@@ -16,13 +16,13 @@
 
 package org.gradle.nativeplatform.internal.modulemap;
 
-import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.UncheckedIOException;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.gradle.util.internal.CollectionUtils.collect;
@@ -30,9 +30,9 @@ import static org.gradle.util.internal.CollectionUtils.filter;
 
 public class GenerateModuleMapFile {
     public static void generateFile(File moduleMapFile, String moduleName, List<String> publicHeaderDirs) {
-        List<String> lines = Lists.newArrayList(
-            "module " + moduleName + " {"
-        );
+        String firstLine = "module " + moduleName + " {";
+        List<String> lines = new ArrayList<>();
+        lines.add(firstLine);
         List<String> validHeaderDirs = filter(publicHeaderDirs, path -> new File(path).exists());
         lines.addAll(collect(validHeaderDirs, path -> "\tumbrella \"" + path + "\""));
         lines.add("\texport *");

--- a/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/tasks/PrefixHeaderFileGenerateTask.java
+++ b/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/tasks/PrefixHeaderFileGenerateTask.java
@@ -16,7 +16,6 @@
 
 package org.gradle.nativeplatform.tasks;
 
-import com.google.common.collect.Lists;
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Incubating;
@@ -35,6 +34,7 @@ import org.gradle.workers.WorkerExecutor;
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import java.io.File;
+import java.util.Collections;
 
 /**
  * Generates a prefix header file from a list of headers to be precompiled.
@@ -98,7 +98,7 @@ public abstract class PrefixHeaderFileGenerateTask extends DefaultTask {
 
         @Override
         public void execute() {
-            PCHUtils.generatePrefixHeaderFile(Lists.newArrayList(getParameters().getHeader().get()), getParameters().getPrefixHeaderFile().getAsFile().get());
+            PCHUtils.generatePrefixHeaderFile(Collections.singletonList(getParameters().getHeader().get()), getParameters().getPrefixHeaderFile().getAsFile().get());
         }
     }
 }

--- a/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/SymbolExtractorOsConfig.java
+++ b/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/SymbolExtractorOsConfig.java
@@ -16,17 +16,18 @@
 
 package org.gradle.nativeplatform.toolchain.internal;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import org.gradle.internal.os.OperatingSystem;
 
+import java.util.Collections;
 import java.util.List;
 
 public enum SymbolExtractorOsConfig {
-    OBJCOPY("objcopy", Lists.newArrayList("--only-keep-debug"), ".debug"),
-    DSYMUTIL("dsymutil", Lists.<String>newArrayList("-f"), ".dwarf") {
+    OBJCOPY("objcopy", Collections.singletonList("--only-keep-debug"), ".debug"),
+    DSYMUTIL("dsymutil", Collections.singletonList("-f"), ".dwarf") {
         @Override
         public List<String> getInputOutputFileArguments(String inputFilePath, String outputFilePath) {
-            return Lists.newArrayList("-o", outputFilePath, inputFilePath);
+            return ImmutableList.of("-o", outputFilePath, inputFilePath);
         }
     };
 
@@ -59,7 +60,7 @@ public enum SymbolExtractorOsConfig {
     }
 
     public List<String> getInputOutputFileArguments(String inputFilePath, String outputFilePath) {
-        return Lists.newArrayList(inputFilePath, outputFilePath);
+        return ImmutableList.of(inputFilePath, outputFilePath);
     }
 
     public String getExtension() {

--- a/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/ArchitectureDescriptorBuilder.java
+++ b/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/ArchitectureDescriptorBuilder.java
@@ -16,12 +16,12 @@
 
 package org.gradle.nativeplatform.toolchain.internal.msvcpp;
 
-import com.google.common.collect.Lists;
 import org.gradle.nativeplatform.platform.Architecture;
 import org.gradle.nativeplatform.platform.internal.Architectures;
 import org.gradle.util.internal.VersionNumber;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -182,7 +182,9 @@ public enum ArchitectureDescriptorBuilder {
     ArchitectureSpecificVisualCpp buildDescriptor(VersionNumber compilerVersion, File basePath, File vsPath) {
         File commonTools = new File(vsPath, PATH_COMMONTOOLS);
         File commonIde = new File(vsPath, PATH_COMMONIDE);
-        List<File> paths = Lists.newArrayList(commonTools, commonIde);
+        List<File> paths = new ArrayList<>();
+        paths.add(commonTools);
+        paths.add(commonIde);
         File crossCompilePath = getCrossCompilePath(basePath);
         if (crossCompilePath!=null) {
             paths.add(crossCompilePath);

--- a/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/ArchitectureDescriptorBuilder.java
+++ b/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/ArchitectureDescriptorBuilder.java
@@ -182,7 +182,7 @@ public enum ArchitectureDescriptorBuilder {
     ArchitectureSpecificVisualCpp buildDescriptor(VersionNumber compilerVersion, File basePath, File vsPath) {
         File commonTools = new File(vsPath, PATH_COMMONTOOLS);
         File commonIde = new File(vsPath, PATH_COMMONIDE);
-        List<File> paths = new ArrayList<>();
+        List<File> paths = new ArrayList<>(3);
         paths.add(commonTools);
         paths.add(commonIde);
         File crossCompilePath = getCrossCompilePath(basePath);

--- a/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/version/CommandLineToolVersionLocator.java
+++ b/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/version/CommandLineToolVersionLocator.java
@@ -16,7 +16,7 @@
 
 package org.gradle.nativeplatform.toolchain.internal.msvcpp.version;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import com.google.gson.stream.JsonReader;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -59,7 +59,7 @@ public class CommandLineToolVersionLocator extends AbstractVisualStudioVersionLo
 
         File vswhereBinary = vswhereLocator.getVswhereInstall();
         if (vswhereBinary != null) {
-            List<String> args = Lists.newArrayList("-all", "-legacy", "-format", "json", "-utf8");
+            List<String> args = ImmutableList.of("-all", "-legacy", "-format", "json", "-utf8");
             String json = getVswhereOutput(vswhereBinary, args);
             installs.addAll(parseJson(json));
         }

--- a/platforms/native/testing-native/src/main/java/org/gradle/nativeplatform/test/internal/NativeDependentBinariesResolutionStrategyTestSupport.java
+++ b/platforms/native/testing-native/src/main/java/org/gradle/nativeplatform/test/internal/NativeDependentBinariesResolutionStrategyTestSupport.java
@@ -16,7 +16,6 @@
 
 package org.gradle.nativeplatform.test.internal;
 
-import com.google.common.collect.Lists;
 import org.gradle.nativeplatform.internal.NativeBinarySpecInternal;
 import org.gradle.nativeplatform.internal.NativeDependentBinariesResolutionStrategy;
 import org.gradle.nativeplatform.test.NativeTestSuiteBinarySpec;
@@ -36,7 +35,7 @@ public class NativeDependentBinariesResolutionStrategyTestSupport implements Nat
     public List<NativeBinarySpecInternal> getTestDependencies(NativeBinarySpecInternal nativeBinary) {
         if (nativeBinary instanceof NativeTestSuiteBinarySpec) {
             NativeBinarySpecInternal testedBinary = (NativeBinarySpecInternal) ((NativeTestSuiteBinarySpec) nativeBinary).getTestedBinary();
-            return Lists.newArrayList(testedBinary);
+            return Collections.singletonList(testedBinary);
         }
         return Collections.emptyList();
     }

--- a/platforms/native/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
+++ b/platforms/native/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
@@ -16,7 +16,6 @@
 
 package org.gradle.nativeplatform.test.xctest.plugins;
 
-import com.google.common.collect.Lists;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Dependency;
@@ -211,9 +210,13 @@ public abstract class XCTestConventionPlugin implements Plugin<Project> {
                     File frameworkDir = new File(platformSdkPath, "Developer/Library/Frameworks");
                     // Since Xcode 11/12, the XCTest framework is being replaced by a different library that's available in the sdk root
                     File extraInclude = new File(platformSdkPath, "Developer/usr/lib");
-                    return Lists.newArrayList("-F" + frameworkDir.getAbsolutePath(), "-L", extraInclude.getAbsolutePath(), "-framework", "XCTest",
-                            "-Xlinker", "-rpath", "-Xlinker", "@executable_path/../Frameworks",
-                            "-Xlinker", "-rpath", "-Xlinker", "@loader_path/../Frameworks");
+                    return Arrays.asList(
+                        "-F" + frameworkDir.getAbsolutePath(),
+                        "-L", extraInclude.getAbsolutePath(),
+                        "-framework", "XCTest",
+                        "-Xlinker", "-rpath", "-Xlinker", "@executable_path/../Frameworks",
+                        "-Xlinker", "-rpath", "-Xlinker", "@loader_path/../Frameworks"
+                    );
                 }));
 
                 task.source(binary.getObjects());

--- a/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/GitIgnoreGenerator.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/GitIgnoreGenerator.java
@@ -16,7 +16,6 @@
 
 package org.gradle.buildinit.plugins.internal;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.UncheckedIOException;
 
@@ -81,7 +80,8 @@ public class GitIgnoreGenerator implements BuildContentGenerator {
     }
 
     private static List<String> withSeparator(List<String> entry) {
-        List<String> result = Lists.newArrayList("");
+        List<String> result = new ArrayList<>(1 + entry.size());
+        result.add("");
         result.addAll(entry);
         return result;
     }

--- a/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmApplicationProjectInitDescriptor.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmApplicationProjectInitDescriptor.java
@@ -16,19 +16,18 @@
 
 package org.gradle.buildinit.plugins.internal;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.buildinit.plugins.internal.model.Description;
 import org.gradle.buildinit.plugins.internal.modifiers.ComponentType;
 import org.gradle.buildinit.plugins.internal.modifiers.Language;
 import org.gradle.buildinit.plugins.internal.modifiers.ModularizationOption;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-
-import static com.google.common.collect.Lists.newArrayList;
 
 public class JvmApplicationProjectInitDescriptor extends JvmProjectInitDescriptor {
 
@@ -81,33 +80,33 @@ public class JvmApplicationProjectInitDescriptor extends JvmProjectInitDescripto
     @Override
     protected List<String> getSourceTemplates(String subproject, InitSettings settings, TemplateFactory templateFactory) {
         if (isSingleProject(settings)) {
-            return newArrayList("App");
+            return Collections.singletonList("App");
         }
         switch (subproject) {
             case "app":
-                return newArrayList("multi/app/App", "multi/app/MessageUtils");
+                return ImmutableList.of("multi/app/App", "multi/app/MessageUtils");
             case "list":
-                return newArrayList("multi/list/LinkedList");
+                return Collections.singletonList("multi/list/LinkedList");
             case "utilities":
-                return newArrayList("multi/utilities/JoinUtils", "multi/utilities/SplitUtils", "multi/utilities/StringUtils");
+                return ImmutableList.of("multi/utilities/JoinUtils", "multi/utilities/SplitUtils", "multi/utilities/StringUtils");
             default:
-                return new ArrayList<>();
+                return Collections.emptyList();
         }
     }
 
     @Override
     protected List<String> getTestSourceTemplates(String subproject, InitSettings settings, TemplateFactory templateFactory) {
         if (isSingleProject(settings)) {
-            return newArrayList(getTestFrameWorkName(settings));
+            return Collections.singletonList(getTestFrameWorkName(settings));
         }
 
         switch (subproject) {
             case "app":
-                return newArrayList("multi/app/junit5/MessageUtilsTest");
+                return Collections.singletonList("multi/app/junit5/MessageUtilsTest");
             case "list":
-                return newArrayList("multi/list/junit5/LinkedListTest");
+                return Collections.singletonList("multi/list/junit5/LinkedListTest");
             default:
-                return new ArrayList<>();
+                return Collections.emptyList();
         }
     }
 

--- a/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmLibraryProjectInitDescriptor.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmLibraryProjectInitDescriptor.java
@@ -20,9 +20,8 @@ import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.buildinit.plugins.internal.model.Description;
 import org.gradle.buildinit.plugins.internal.modifiers.ComponentType;
 
+import java.util.Collections;
 import java.util.List;
-
-import static com.google.common.collect.Lists.newArrayList;
 
 public class JvmLibraryProjectInitDescriptor extends JvmProjectInitDescriptor {
 
@@ -53,12 +52,12 @@ public class JvmLibraryProjectInitDescriptor extends JvmProjectInitDescriptor {
 
     @Override
     protected List<String> getSourceTemplates(String subproject, InitSettings settings, TemplateFactory templateFactory) {
-        return newArrayList("Library");
+        return Collections.singletonList("Library");
     }
 
     @Override
     protected List<String> getTestSourceTemplates(String subproject, InitSettings settings, TemplateFactory templateFactory) {
-        return newArrayList(getUnitTestSourceTemplateName(settings));
+        return Collections.singletonList(getUnitTestSourceTemplateName(settings));
     }
 
     private static String getUnitTestSourceTemplateName(InitSettings settings) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyModuleDescriptorConverter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyModuleDescriptorConverter.java
@@ -17,8 +17,8 @@
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser;
 
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.ivy.core.module.descriptor.DefaultDependencyDescriptor;
 import org.apache.ivy.core.module.descriptor.DependencyArtifactDescriptor;
@@ -105,7 +105,7 @@ public class IvyModuleDescriptorConverter {
         String name = configuration.getName();
         boolean transitive = configuration.isTransitive();
         boolean visible = configuration.getVisibility() == org.apache.ivy.core.module.descriptor.Configuration.Visibility.PUBLIC;
-        List<String> extendsFrom = Lists.newArrayList(configuration.getExtends());
+        List<String> extendsFrom = ImmutableList.copyOf(configuration.getExtends());
         result.add(new Configuration(name, transitive, visible, extendsFrom));
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicy.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicy.java
@@ -45,9 +45,9 @@ public class DefaultCachePolicy implements CachePolicy {
     private boolean refresh = false;
 
     public DefaultCachePolicy() {
-        this.dependencyCacheRules = new ArrayList<>();
-        this.moduleCacheRules = new ArrayList<>();
-        this.artifactCacheRules = new ArrayList<>();
+        this.dependencyCacheRules = new ArrayList<>(1);
+        this.moduleCacheRules = new ArrayList<>(1);
+        this.artifactCacheRules = new ArrayList<>(2);
 
         cacheDynamicVersionsFor(SECONDS_IN_DAY, TimeUnit.SECONDS);
         cacheChangingModulesFor(SECONDS_IN_DAY, TimeUnit.SECONDS);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -203,7 +203,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
     @Override
     public void artifactUrls(Object... urls) {
         invalidateDescriptor();
-        additionalUrls.addAll(Lists.newArrayList(urls));
+        additionalUrls.addAll(ImmutableList.copyOf(urls));
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResult.java
@@ -17,8 +17,9 @@
 package org.gradle.api.internal.artifacts.result;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.LinkedHashMultimap;
-import com.google.common.collect.Multimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
@@ -38,20 +39,25 @@ import java.util.Optional;
 import java.util.Set;
 
 public class DefaultResolvedComponentResult implements ResolvedComponentResultInternal {
+
     private final ModuleVersionIdentifier moduleVersion;
-    private final Set<DependencyResult> dependencies = new LinkedHashSet<>();
-    private final Set<ResolvedDependencyResult> dependents = new LinkedHashSet<>();
+    private ImmutableSet<DependencyResult> dependencies = ImmutableSet.of();
+    private Set<ResolvedDependencyResult> dependents = new LinkedHashSet<>();
     private final ComponentSelectionReason selectionReason;
     private final ComponentIdentifier componentId;
-    private final List<ResolvedVariantResult> selectedVariants;
+    private final ImmutableList<ResolvedVariantResult> selectedVariants;
     private final Map<Long, ResolvedVariantResult> selectedVariantsById;
-    private final List<ResolvedVariantResult> allVariants;
+    private final ImmutableList<ResolvedVariantResult> allVariants;
     private final String repositoryName;
-    private final Multimap<ResolvedVariantResult, DependencyResult> variantDependencies = LinkedHashMultimap.create();
+    private ImmutableSetMultimap<ResolvedVariantResult, DependencyResult> variantDependencies = ImmutableSetMultimap.of();
 
     public DefaultResolvedComponentResult(
-        ModuleVersionIdentifier moduleVersion, ComponentSelectionReason selectionReason, ComponentIdentifier componentId,
-        Map<Long, ResolvedVariantResult> selectedVariants, List<ResolvedVariantResult> allVariants, @Nullable String repositoryName
+        ModuleVersionIdentifier moduleVersion,
+        ComponentSelectionReason selectionReason,
+        ComponentIdentifier componentId,
+        ImmutableMap<Long, ResolvedVariantResult> selectedVariants,
+        ImmutableList<ResolvedVariantResult> allVariants,
+        @Nullable String repositoryName
     ) {
         this.moduleVersion = moduleVersion;
         this.selectionReason = selectionReason;
@@ -81,7 +87,7 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
 
     @Override
     public Set<DependencyResult> getDependencies() {
-        return Collections.unmodifiableSet(dependencies);
+        return dependencies;
     }
 
     @Override
@@ -89,9 +95,15 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
         return Collections.unmodifiableSet(dependents);
     }
 
-    public DefaultResolvedComponentResult addDependency(DependencyResult dependency) {
-        this.dependencies.add(dependency);
-        return this;
+    public void addDependencies(ImmutableSet<DependencyResult> dependencies) {
+        if (this.dependencies.isEmpty()) {
+            this.dependencies = dependencies;
+        } else {
+            this.dependencies = ImmutableSet.<DependencyResult>builder()
+                .addAll(this.dependencies)
+                .addAll(dependencies)
+                .build();
+        }
     }
 
     public DefaultResolvedComponentResult addDependent(ResolvedDependencyResult dependent) {
@@ -149,8 +161,15 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
         return selectedVariantsById.get(id);
     }
 
-    public void associateDependencyToVariant(DependencyResult dependencyResult, ResolvedVariantResult fromVariant) {
-        variantDependencies.put(fromVariant, dependencyResult);
+    public void addVariantDependencies(ImmutableSetMultimap<ResolvedVariantResult, DependencyResult> variantDependencies) {
+        if (this.variantDependencies.isEmpty()) {
+            this.variantDependencies = variantDependencies;
+        } else {
+            this.variantDependencies =  ImmutableSetMultimap.<ResolvedVariantResult, DependencyResult>builder()
+                .putAll(this.variantDependencies)
+                .putAll(variantDependencies)
+                .build();
+        }
     }
 
     /**
@@ -178,5 +197,9 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
                 eachElement(((ResolvedDependencyResult) d).getSelected(), moduleAction, dependencyAction, visited);
             }
         }
+    }
+
+    public void complete() {
+        dependents = ImmutableSet.copyOf(dependents);
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResult.java
@@ -199,6 +199,9 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
         }
     }
 
+    /**
+     * Finalize this component, making it immutable and ensuring its contents are stored in memory-efficient data structures.
+     */
     public void complete() {
         dependents = ImmutableSet.copyOf(dependents);
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/ModuleNotationValidation.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/ModuleNotationValidation.java
@@ -15,14 +15,14 @@
  */
 package org.gradle.api.internal.notations;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import org.gradle.internal.typeconversion.UnsupportedNotationException;
 import org.gradle.util.internal.GUtil;
 
 import java.util.List;
 
 public abstract class ModuleNotationValidation {
-    private final static List<Character> INVALID_SPEC_CHARS = Lists.newArrayList('*', '[', ']', '(', ')', ',');
+    private final static List<Character> INVALID_SPEC_CHARS = ImmutableList.of('*', '[', ']', '(', ')', ',');
 
     public static String validate(String part, String notation) {
         if (!GUtil.isTrue(part)) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreator.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreator.java
@@ -19,9 +19,7 @@ package org.gradle.api.internal.runtimeshaded;
 import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import org.gradle.api.GradleException;
-import org.gradle.model.internal.asm.AsmConstants;
 import org.gradle.internal.classpath.ClasspathBuilder;
 import org.gradle.internal.classpath.ClasspathEntryVisitor;
 import org.gradle.internal.classpath.ClasspathWalker;
@@ -29,6 +27,7 @@ import org.gradle.internal.installation.GradleRuntimeShadedJarDetector;
 import org.gradle.internal.logging.progress.ProgressLogger;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.progress.PercentageProgressFormatter;
+import org.gradle.model.internal.asm.AsmConstants;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
@@ -41,6 +40,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -163,12 +163,7 @@ class RuntimeShadedJarCreator {
         String serviceType = slashesToPeriods(relocatedApiClassName)[0];
         String[] serviceProviders = slashesToPeriods(relocatedImplClassNames);
 
-        if (!services.containsKey(serviceType)) {
-            services.put(serviceType, Lists.newArrayList(serviceProviders));
-        } else {
-            List<String> providers = services.get(serviceType);
-            providers.addAll(asList(serviceProviders));
-        }
+        services.computeIfAbsent(serviceType, k -> new ArrayList<>()).addAll(asList(serviceProviders));
     }
 
     private String[] slashesToPeriods(String... slashClassNames) {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolutionResultTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolutionResultTest.groovy
@@ -16,6 +16,9 @@
 
 package org.gradle.api.internal.artifacts.result
 
+import com.google.common.collect.ImmutableList
+import com.google.common.collect.ImmutableMap
+import com.google.common.collect.ImmutableSet
 import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.artifacts.component.ComponentSelector
 import org.gradle.api.artifacts.component.ModuleComponentSelector
@@ -39,7 +42,6 @@ import spock.lang.Specification
 import static org.gradle.api.internal.artifacts.result.ResolutionResultDataBuilder.newDependency
 import static org.gradle.api.internal.artifacts.result.ResolutionResultDataBuilder.newModule
 import static org.gradle.api.internal.artifacts.result.ResolutionResultDataBuilder.newUnresolvedDependency
-import static org.gradle.api.internal.artifacts.result.ResolutionResultDataBuilder.newVariant
 
 class DefaultResolutionResultTest extends Specification {
 
@@ -48,12 +50,13 @@ class DefaultResolutionResultTest extends Specification {
         def dep1 = newDependency('dep1')
         def dep2 = newDependency('dep2')
 
-        def root = newModule('root').addDependency(dep1).addDependency(dep2)
+        def root = newModule('root')
+        root.addDependencies(ImmutableSet.of(dep1, dep2))
 
         def dep3 = newDependency('dep3')
         def dep4 = newUnresolvedDependency('dep4')
 
-        dep2.selected.addDependency(dep3).addDependency(dep4)
+        (dep2.selected as DefaultResolvedComponentResult).addDependencies(ImmutableSet.of(dep3, dep4))
 
         when:
         def deps = newResolutionResult(root).allDependencies
@@ -72,8 +75,10 @@ class DefaultResolutionResultTest extends Specification {
         //root -> dep1,dep2; dep1 -> dep3
         def dep = newDependency('dep1')
         def dep3 = newDependency('dep3')
-        def root = newModule('root').addDependency(dep).addDependency(newDependency('dep2')).addDependency(dep3)
-        dep.selected.addDependency(dep3)
+
+        def root = newModule('root')
+        root.addDependencies(ImmutableSet.of(dep, newDependency('dep2'), dep3))
+        (dep.selected as DefaultResolvedComponentResult).addDependencies(ImmutableSet.of(dep3))
 
         def result = newResolutionResult(root)
 
@@ -95,8 +100,10 @@ class DefaultResolutionResultTest extends Specification {
         // a->b->a
         def root = newModule('a', 'a', '1')
         def dep1 = newDependency('b', 'b', '1')
-        root.addDependency(dep1)
-        dep1.selected.addDependency(new DefaultResolvedDependencyResult(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId('a', 'a'), '1'), false, root, newVariant(), dep1.selected))
+        root.addDependencies(ImmutableSet.of(dep1))
+
+        def dep2 = new DefaultResolvedDependencyResult(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId('a', 'a'), '1'), false, root, ResolutionResultDataBuilder.newVariant(), dep1.selected)
+        (dep1.selected as DefaultResolvedComponentResult).addDependencies(ImmutableSet.of(dep2))
 
         when:
         def deps = newResolutionResult(root).allDependencies
@@ -112,7 +119,8 @@ class DefaultResolutionResultTest extends Specification {
         def dep1 = newDependency('dep1')
         def dep2 = newDependency('dep2')
 
-        def root = newModule('root').addDependency(dep1).addDependency(dep2)
+        def root = newModule('root')
+        root.addDependencies(ImmutableSet.of(dep1, dep2))
 
         when:
         def result = newResolutionResult(root)
@@ -142,7 +150,7 @@ class DefaultResolutionResultTest extends Specification {
         def dep = new DefaultUnresolvedDependencyResult(
             Stub(ComponentSelector), false,
             Stub(ComponentSelectionReason),
-            new DefaultResolvedComponentResult(mid, Stub(ComponentSelectionReason), projectId, [1: Stub(ResolvedVariantResult)], [Stub(ResolvedVariantResult)], null),
+            new DefaultResolvedComponentResult(mid, Stub(ComponentSelectionReason), projectId, ImmutableMap.of(1L, Stub(ResolvedVariantResult)), ImmutableList.of(Stub(ResolvedVariantResult)), null),
             new ModuleVersionNotFoundException(Stub(ModuleComponentSelector), broken, [])
         )
         def edge = new UnresolvedDependencyEdge(dep)

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResultTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResultTest.groovy
@@ -16,9 +16,13 @@
 
 package org.gradle.api.internal.artifacts.result
 
+import com.google.common.collect.ImmutableSet
+import com.google.common.collect.ImmutableSetMultimap
 import spock.lang.Specification
 
-import static org.gradle.api.internal.artifacts.result.ResolutionResultDataBuilder.*
+import static org.gradle.api.internal.artifacts.result.ResolutionResultDataBuilder.newDependency
+import static org.gradle.api.internal.artifacts.result.ResolutionResultDataBuilder.newModule
+import static org.gradle.api.internal.artifacts.result.ResolutionResultDataBuilder.newUnresolvedDependency
 
 class DefaultResolvedComponentResultTest extends Specification {
 
@@ -29,7 +33,7 @@ class DefaultResolvedComponentResultTest extends Specification {
         def dependent   = newDependency("a", "x2", "1")
 
         when:
-        module.addDependency(dependency)
+        module.addDependencies(ImmutableSet.of(dependency))
         module.addDependent(dependent)
 
         then:
@@ -54,8 +58,7 @@ class DefaultResolvedComponentResultTest extends Specification {
         def unresolved = newUnresolvedDependency()
 
         when:
-        module.addDependency(dependency)
-        module.addDependency(unresolved)
+        module.addDependencies(ImmutableSet.of(dependency, unresolved))
 
         then:
         module.dependencies == [dependency, unresolved] as Set
@@ -68,10 +71,10 @@ class DefaultResolvedComponentResultTest extends Specification {
         def variant = module.getVariant(1)
 
         when:
-        module.addDependency(dependency)
+        module.addDependencies(ImmutableSet.of(dependency))
 
-        module.associateDependencyToVariant(dependency, variant)
-        module.associateDependencyToVariant(dependency, variant)
+        module.addVariantDependencies(ImmutableSetMultimap.of(variant, dependency))
+        module.addVariantDependencies(ImmutableSetMultimap.of(variant, dependency))
 
         then:
         module.getDependenciesForVariant(variant) == [dependency]

--- a/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/result/ResolutionResultDataBuilder.groovy
+++ b/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/result/ResolutionResultDataBuilder.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.api.internal.artifacts.result
 
+import com.google.common.collect.ImmutableList
+import com.google.common.collect.ImmutableMap
 import org.gradle.api.artifacts.component.ComponentSelector
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.result.ComponentSelectionReason
@@ -46,7 +48,7 @@ class ResolutionResultDataBuilder {
     }
 
     static DefaultResolvedComponentResult newModule(String group='a', String module='a', String version='1', ComponentSelectionReason selectionReason = ComponentSelectionReasons.requested(), ResolvedVariantResult variant = newVariant(), String repoId = null) {
-        new DefaultResolvedComponentResult(newId(group, module, version), selectionReason, new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, module), version), [1L: variant], [variant], repoId)
+        new DefaultResolvedComponentResult(newId(group, module, version), selectionReason, new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, module), version), ImmutableMap.of(1L, variant), ImmutableList.of(variant), repoId)
     }
 
     static DefaultResolvedDependencyResult newDependency(ComponentSelector componentSelector, String group='a', String module='a', String selectedVersion='1') {

--- a/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpClientConfigurer.java
+++ b/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpClientConfigurer.java
@@ -182,25 +182,18 @@ public class HttpClientConfigurer {
     }
 
     private void configureProxy(HttpClientBuilder builder, CredentialsProvider credentialsProvider, HttpSettings httpSettings) {
-        HttpProxySettings.HttpProxy httpProxy = httpSettings.getProxySettings().getProxy();
-        if (httpProxy != null && httpProxy.credentials != null) {
-            AllSchemesAuthentication authentication = getAuthForProxy(httpProxy);
-            useCredentials(credentialsProvider, Collections.singleton(authentication));
-        }
-
-        HttpProxySettings.HttpProxy httpsProxy = httpSettings.getSecureProxySettings().getProxy();
-        if (httpsProxy != null && httpsProxy.credentials != null) {
-            AllSchemesAuthentication authentication = getAuthForProxy(httpsProxy);
-            useCredentials(credentialsProvider, Collections.singleton(authentication));
-        }
+        useCredentialsForProxy(credentialsProvider, httpSettings.getProxySettings().getProxy());
+        useCredentialsForProxy(credentialsProvider, httpSettings.getSecureProxySettings().getProxy());
 
         builder.setRoutePlanner(new SystemDefaultRoutePlanner(ProxySelector.getDefault()));
     }
 
-    private static AllSchemesAuthentication getAuthForProxy(HttpProxySettings.HttpProxy proxy) {
-        AllSchemesAuthentication authentication = new AllSchemesAuthentication(proxy.credentials);
-        authentication.addHost(proxy.host, proxy.port);
-        return authentication;
+    private void useCredentialsForProxy(CredentialsProvider credentialsProvider, HttpProxySettings.HttpProxy httpsProxy) {
+        if (httpsProxy != null && httpsProxy.credentials != null) {
+            AllSchemesAuthentication authentication1 = new AllSchemesAuthentication(httpsProxy.credentials);
+            authentication1.addHost(httpsProxy.host, httpsProxy.port);
+            useCredentials(credentialsProvider, Collections.singleton(authentication1));
+        }
     }
 
     private void useCredentials(CredentialsProvider credentialsProvider, Collection<? extends Authentication> authentications) {

--- a/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpClientConfigurer.java
+++ b/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpClientConfigurer.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.internal.resource.transport.http;
 
-import com.google.common.collect.Lists;
 import org.apache.http.HttpException;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
@@ -184,18 +183,24 @@ public class HttpClientConfigurer {
 
     private void configureProxy(HttpClientBuilder builder, CredentialsProvider credentialsProvider, HttpSettings httpSettings) {
         HttpProxySettings.HttpProxy httpProxy = httpSettings.getProxySettings().getProxy();
-        HttpProxySettings.HttpProxy httpsProxy = httpSettings.getSecureProxySettings().getProxy();
-
-        for (HttpProxySettings.HttpProxy proxy : Lists.newArrayList(httpProxy, httpsProxy)) {
-            if (proxy != null) {
-                if (proxy.credentials != null) {
-                    AllSchemesAuthentication authentication = new AllSchemesAuthentication(proxy.credentials);
-                    authentication.addHost(proxy.host, proxy.port);
-                    useCredentials(credentialsProvider, Collections.singleton(authentication));
-                }
-            }
+        if (httpProxy != null && httpProxy.credentials != null) {
+            AllSchemesAuthentication authentication = getAuthForProxy(httpProxy);
+            useCredentials(credentialsProvider, Collections.singleton(authentication));
         }
+
+        HttpProxySettings.HttpProxy httpsProxy = httpSettings.getSecureProxySettings().getProxy();
+        if (httpsProxy != null && httpsProxy.credentials != null) {
+            AllSchemesAuthentication authentication = getAuthForProxy(httpsProxy);
+            useCredentials(credentialsProvider, Collections.singleton(authentication));
+        }
+
         builder.setRoutePlanner(new SystemDefaultRoutePlanner(ProxySelector.getDefault()));
+    }
+
+    private static AllSchemesAuthentication getAuthForProxy(HttpProxySettings.HttpProxy proxy) {
+        AllSchemesAuthentication authentication = new AllSchemesAuthentication(proxy.credentials);
+        authentication.addHost(proxy.host, proxy.port);
+        return authentication;
     }
 
     private void useCredentials(CredentialsProvider credentialsProvider, Collection<? extends Authentication> authentications) {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ConsumerState.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ConsumerState.java
@@ -19,7 +19,7 @@ package org.gradle.execution.plan;
 import java.util.HashSet;
 import java.util.Set;
 
-public class ConsumerState {
+public final class ConsumerState {
 
     private boolean outputProduced = false;
     private final Set<Node> nodesYetToConsumeOutput = new HashSet<>();

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ConsumerState.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ConsumerState.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.execution.plan;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ConsumerState {
+
+    private boolean outputProduced = false;
+    private final Set<Node> nodesYetToConsumeOutput = new HashSet<>();
+
+    public void started() {
+        outputProduced = true;
+    }
+
+    public boolean isOutputProducedButNotYetConsumed() {
+        return outputProduced && !nodesYetToConsumeOutput.isEmpty();
+    }
+
+    public void addConsumer(Node node) {
+        nodesYetToConsumeOutput.add(node);
+    }
+
+    public void consumerCompleted(Node node) {
+        nodesYetToConsumeOutput.remove(node);
+    }
+
+    Set<Node> getNodesYetToConsumeOutput() {
+        return nodesYetToConsumeOutput;
+    }
+
+}

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultFinalizedExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultFinalizedExecutionPlan.java
@@ -279,7 +279,7 @@ public class DefaultFinalizedExecutionPlan implements WorkSource<Node>, Finalize
                 if (attemptToStart(node, resources)) {
                     readyNodes.remove();
                     waitingToStartNodes.remove(node);
-                    node.getMutationInfo().started();
+                    node.getConsumerState().started();
                     return Selection.of(node);
                 }
             }
@@ -322,7 +322,7 @@ public class DefaultFinalizedExecutionPlan implements WorkSource<Node>, Finalize
         }
 
         node.startExecution(this::recordNodeExecutionStarted);
-        if (mutations.hasValidationProblem) {
+        if (mutations.hasValidationProblem()) {
             invalidNodeRunning = true;
         }
         return true;
@@ -351,7 +351,7 @@ public class DefaultFinalizedExecutionPlan implements WorkSource<Node>, Finalize
             return true;
         } else if (mutationConflictsWithOtherNodes(node, mutations)) {
             return true;
-        } else if (destroysNotYetConsumedOutputOfAnotherNode(node, mutations.destroyablePaths)) {
+        } else if (destroysNotYetConsumedOutputOfAnotherNode(node, mutations.getDestroyablePaths())) {
             LOGGER.debug("Node {} destroys not yet consumed output of another node", node);
             return true;
         }
@@ -400,7 +400,7 @@ public class DefaultFinalizedExecutionPlan implements WorkSource<Node>, Finalize
 
     private boolean canRunWithCurrentlyExecutedNodes(MutationInfo mutations) {
         // No new work should be started when invalid work is running
-        if (mutations.hasValidationProblem) {
+        if (mutations.hasValidationProblem()) {
             // Invalid work is not allowed to run together with any other work
             return runningNodes.isEmpty();
         } else {
@@ -409,8 +409,8 @@ public class DefaultFinalizedExecutionPlan implements WorkSource<Node>, Finalize
     }
 
     private boolean mutationConflictsWithOtherNodes(Node node, MutationInfo mutations) {
-        Set<String> nodeOutputPaths = mutations.outputPaths;
-        Set<String> nodeDestroysPaths = mutations.destroyablePaths;
+        Set<String> nodeOutputPaths = mutations.getOutputPaths();
+        Set<String> nodeDestroysPaths = mutations.getDestroyablePaths();
         if (nodeOutputPaths.isEmpty() && nodeDestroysPaths.isEmpty()) {
             return false;
         }
@@ -458,11 +458,11 @@ public class DefaultFinalizedExecutionPlan implements WorkSource<Node>, Finalize
             if (current) {
                 return current;
             }
-            if (!producingNode.getMutationInfo().isOutputProducedButNotYetConsumed()) {
+            if (!producingNode.getConsumerState().isOutputProducedButNotYetConsumed()) {
                 return false;
             }
-            MutationInfo producingNodeMutations = producingNode.getMutationInfo();
-            for (Node consumer : producingNodeMutations.getNodesYetToConsumeOutput()) {
+            ConsumerState producingNodeConsumerState = producingNode.getConsumerState();
+            for (Node consumer : producingNodeConsumerState.getNodesYetToConsumeOutput()) {
                 if (doesConsumerDependOnDestroyer(consumer, destroyer)) {
                     // If there's an explicit dependency from consuming node to destroyer,
                     // then we accept that as the will of the user
@@ -521,8 +521,8 @@ public class DefaultFinalizedExecutionPlan implements WorkSource<Node>, Finalize
         }
 
         for (Node producer : node.getDependencySuccessors()) {
-            MutationInfo producerMutations = producer.getMutationInfo();
-            producerMutations.consumerCompleted(node);
+            ConsumerState producerConsumerState = producer.getConsumerState();
+            producerConsumerState.consumerCompleted(node);
         }
 
         updateAllDependenciesCompleteForPredecessors(node);

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
@@ -16,21 +16,17 @@
 
 package org.gradle.execution.plan;
 
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.properties.DefaultTaskProperties;
-import org.gradle.api.internal.tasks.properties.OutputFilePropertySpec;
 import org.gradle.api.internal.tasks.properties.TaskProperties;
-import org.gradle.api.tasks.TaskExecutionException;
 import org.gradle.internal.execution.WorkValidationContext;
 import org.gradle.internal.properties.bean.PropertyWalker;
 import org.gradle.internal.resources.ResourceLock;
 import org.gradle.internal.service.ServiceRegistry;
 
 import javax.annotation.Nullable;
-import java.io.File;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -106,6 +102,13 @@ public class LocalTaskNode extends TaskNode {
     }
 
     public TaskProperties getTaskProperties() {
+        if (taskProperties == null) {
+            ServiceRegistry serviceRegistry = taskProject.getServices();
+            final FileCollectionFactory fileCollectionFactory = serviceRegistry.get(FileCollectionFactory.class);
+            PropertyWalker propertyWalker = serviceRegistry.get(PropertyWalker.class);
+            taskProperties = DefaultTaskProperties.resolve(propertyWalker, fileCollectionFactory, task);
+        }
+
         return taskProperties;
     }
 
@@ -165,28 +168,6 @@ public class LocalTaskNode extends TaskNode {
         return task.getIdentityPath().toString();
     }
 
-    private void addOutputFilesToMutations(Set<OutputFilePropertySpec> outputFilePropertySpecs) {
-        final MutationInfo mutations = getMutationInfo();
-        outputFilePropertySpecs.forEach(spec -> {
-            File outputLocation = spec.getOutputFile();
-            mutations.outputPaths.add(outputLocation.getAbsolutePath());
-            mutations.hasOutputs = true;
-        });
-    }
-
-    private void addLocalStateFilesToMutations(FileCollection localStateFiles) {
-        final MutationInfo mutations = getMutationInfo();
-        localStateFiles.forEach(file -> {
-            mutations.outputPaths.add(file.getAbsolutePath());
-            mutations.hasLocalState = true;
-        });
-    }
-
-    private void addDestroyablesToMutations(FileCollection destroyables) {
-        destroyables
-            .forEach(file -> getMutationInfo().destroyablePaths.add(file.getAbsolutePath()));
-    }
-
     @Override
     public boolean hasPendingPreExecutionNodes() {
         return !hasVisitedMutationsNode;
@@ -217,40 +198,6 @@ public class LocalTaskNode extends TaskNode {
         super.cancelExecution(completionAction);
         if (resolveMutationsNode.isRequired()) {
             resolveMutationsNode.cancelExecution(completionAction);
-        }
-    }
-
-    public void resolveMutations() {
-        final LocalTaskNode taskNode = this;
-        final TaskInternal task = getTask();
-        final MutationInfo mutations = getMutationInfo();
-        ServiceRegistry serviceRegistry = taskProject.getServices();
-        final FileCollectionFactory fileCollectionFactory = serviceRegistry.get(FileCollectionFactory.class);
-        PropertyWalker propertyWalker = serviceRegistry.get(PropertyWalker.class);
-        try {
-            taskProperties = DefaultTaskProperties.resolve(propertyWalker, fileCollectionFactory, task);
-
-            addOutputFilesToMutations(taskProperties.getOutputFileProperties());
-            addLocalStateFilesToMutations(taskProperties.getLocalStateFiles());
-            addDestroyablesToMutations(taskProperties.getDestroyableFiles());
-
-            mutations.hasFileInputs = !taskProperties.getInputFileProperties().isEmpty();
-            // piggyback on mutation resolution to declare service references as used services
-            task.acceptServiceReferences(taskProperties.getServiceReferences());
-        } catch (Exception e) {
-            throw new TaskExecutionException(task, e);
-        }
-
-        if (!mutations.destroyablePaths.isEmpty()) {
-            if (mutations.hasOutputs) {
-                throw new IllegalStateException("Task " + taskNode + " has both outputs and destroyables defined.  A task can define either outputs or destroyables, but not both.");
-            }
-            if (mutations.hasFileInputs) {
-                throw new IllegalStateException("Task " + taskNode + " has both inputs and destroyables defined.  A task can define either inputs or destroyables, but not both.");
-            }
-            if (mutations.hasLocalState) {
-                throw new IllegalStateException("Task " + taskNode + " has both local state and destroyables defined.  A task can define either local state or destroyables, but not both.");
-            }
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/MissingTaskDependencyDetector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/MissingTaskDependencyDetector.java
@@ -52,7 +52,7 @@ public class MissingTaskDependencyDetector {
     }
 
     public void detectMissingDependencies(LocalTaskNode node, TypeValidationContext validationContext) {
-        for (String outputPath : node.getMutationInfo().outputPaths) {
+        for (String outputPath : node.getMutationInfo().getOutputPaths()) {
             inputHierarchy.getNodesAccessing(outputPath).stream()
                 .filter(consumerNode -> hasNoSpecifiedOrder(node, consumerNode))
                 .filter(MissingTaskDependencyDetector::isEnabled)

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/MutationInfo.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/MutationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,36 +16,57 @@
 
 package org.gradle.execution.plan;
 
-import java.util.HashSet;
-import java.util.Set;
+import com.google.common.collect.ImmutableSet;
 
-class MutationInfo {
-    private final Set<Node> nodesYetToConsumeOutput = new HashSet<>();
-    final Set<String> outputPaths = new HashSet<>();
-    final Set<String> destroyablePaths = new HashSet<>();
-    boolean hasFileInputs;
-    boolean hasOutputs;
-    boolean hasLocalState;
-    boolean hasValidationProblem;
-    private boolean outputProduced;
+public class MutationInfo {
 
-    void started() {
-        outputProduced = true;
+    public static final MutationInfo EMPTY = new MutationInfo(ImmutableSet.of(), ImmutableSet.of(), false, false, false, false);
+
+    private final ImmutableSet<String> outputPaths;
+    private final ImmutableSet<String> destroyablePaths;
+    private final boolean hasFileInputs;
+    private final boolean hasOutputs;
+    private final boolean hasLocalState;
+    private final boolean hasValidationProblem;
+
+    public MutationInfo(
+        ImmutableSet<String> outputPaths,
+        ImmutableSet<String> destroyablePaths,
+        boolean hasFileInputs,
+        boolean hasOutputs,
+        boolean hasLocalState,
+        boolean hasValidationProblem
+    ) {
+        this.outputPaths = outputPaths;
+        this.destroyablePaths = destroyablePaths;
+        this.hasFileInputs = hasFileInputs;
+        this.hasOutputs = hasOutputs;
+        this.hasLocalState = hasLocalState;
+        this.hasValidationProblem = hasValidationProblem;
     }
 
-    boolean isOutputProducedButNotYetConsumed() {
-        return outputProduced && !nodesYetToConsumeOutput.isEmpty();
+    public ImmutableSet<String> getOutputPaths() {
+        return outputPaths;
     }
 
-    public Set<Node> getNodesYetToConsumeOutput() {
-        return nodesYetToConsumeOutput;
+    public ImmutableSet<String> getDestroyablePaths() {
+        return destroyablePaths;
     }
 
-    public void consumerCompleted(Node node) {
-        nodesYetToConsumeOutput.remove(node);
+    public boolean hasValidationProblem() {
+        return hasValidationProblem;
     }
 
-    public void addConsumer(Node node) {
-        nodesYetToConsumeOutput.add(node);
+    public boolean hasLocalState() {
+        return hasLocalState;
     }
+
+    public boolean hasOutputs() {
+        return hasOutputs;
+    }
+
+    public boolean hasFileInputs() {
+        return hasFileInputs;
+    }
+
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
@@ -70,7 +70,8 @@ public abstract class Node {
     private int index;
     private DependencyNodesSet dependencyNodes = DependencyNodesSet.EMPTY;
     private DependentNodesSet dependentNodes = DependentNodesSet.EMPTY;
-    private final MutationInfo mutationInfo = new MutationInfo();
+    private MutationInfo mutationInfo = MutationInfo.EMPTY;
+    private final ConsumerState consumerState = new ConsumerState();
     private NodeGroup group = NodeGroup.DEFAULT_GROUP;
 
     @VisibleForTesting
@@ -387,7 +388,7 @@ public abstract class Node {
 
     void addDependencyPredecessor(Node fromNode) {
         dependentNodes = dependentNodes.addDependencyPredecessors(fromNode);
-        mutationInfo.addConsumer(fromNode);
+        consumerState.addConsumer(fromNode);
     }
 
     void addMustPredecessor(TaskNode fromNode) {
@@ -589,8 +590,16 @@ public abstract class Node {
     public void visitPostExecutionNodes(Consumer<? super Node> visitor) {
     }
 
+    public void mutationsResolved(MutationInfo mutationInfo)  {
+        this.mutationInfo = mutationInfo;
+    }
+
     public MutationInfo getMutationInfo() {
         return mutationInfo;
+    }
+
+    public ConsumerState getConsumerState() {
+        return consumerState;
     }
 
     public boolean isPublicNode() {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ResolveMutationsNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ResolveMutationsNode.java
@@ -16,10 +16,14 @@
 
 package org.gradle.execution.plan;
 
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.taskfactory.TaskIdentity;
 import org.gradle.api.internal.tasks.NodeExecutionContext;
 import org.gradle.api.internal.tasks.execution.ResolveTaskMutationsBuildOperationType;
+import org.gradle.api.internal.tasks.properties.OutputFilePropertySpec;
+import org.gradle.api.internal.tasks.properties.TaskProperties;
+import org.gradle.api.tasks.TaskExecutionException;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationRunner;
@@ -27,6 +31,7 @@ import org.gradle.internal.operations.RunnableBuildOperation;
 import org.gradle.internal.resources.ResourceLock;
 
 import javax.annotation.Nullable;
+import java.io.File;
 
 public class ResolveMutationsNode extends Node implements SelfExecutingNode {
     private final LocalTaskNode node;
@@ -84,7 +89,10 @@ public class ResolveMutationsNode extends Node implements SelfExecutingNode {
             @Override
             public void run(BuildOperationContext context) {
                 try {
-                    doResolveMutations();
+                    MutationInfo mutations = resolveAndValidateMutations();
+                    accessHierarchies.getOutputHierarchy().recordNodeAccessingLocations(node, mutations.getOutputPaths());
+                    accessHierarchies.getDestroyableHierarchy().recordNodeAccessingLocations(node, mutations.getDestroyablePaths());
+                    node.mutationsResolved(mutations);
                     context.setResult(RESOLVE_TASK_MUTATIONS_RESULT);
                 } catch (Exception e) {
                     failure = e;
@@ -99,14 +107,6 @@ public class ResolveMutationsNode extends Node implements SelfExecutingNode {
                     .details(new ResolveTaskMutationsDetails(taskIdentity));
             }
         });
-    }
-
-    private void doResolveMutations() {
-        MutationInfo mutations = node.getMutationInfo();
-        node.resolveMutations();
-        mutations.hasValidationProblem = nodeValidator.hasValidationProblems(node);
-        accessHierarchies.getOutputHierarchy().recordNodeAccessingLocations(node, mutations.outputPaths);
-        accessHierarchies.getDestroyableHierarchy().recordNodeAccessingLocations(node, mutations.destroyablePaths);
     }
 
     private static final class ResolveTaskMutationsDetails implements ResolveTaskMutationsBuildOperationType.Details {
@@ -133,4 +133,67 @@ public class ResolveMutationsNode extends Node implements SelfExecutingNode {
     }
 
     private static final ResolveTaskMutationsBuildOperationType.Result RESOLVE_TASK_MUTATIONS_RESULT = new ResolveTaskMutationsBuildOperationType.Result() {};
+
+    private MutationInfo resolveAndValidateMutations() {
+        boolean hasValidationProblem = nodeValidator.hasValidationProblems(node);
+
+        MutationInfo mutations;
+        try {
+            TaskProperties taskProperties = node.getTaskProperties();
+            mutations = resolveMutations(taskProperties, hasValidationProblem);
+
+            // piggyback on mutation resolution to declare service references as used services
+            node.getTask().acceptServiceReferences(taskProperties.getServiceReferences());
+        } catch (Exception e) {
+            throw new TaskExecutionException(node.getTask(), e);
+        }
+
+        validateMutations(mutations);
+        return mutations;
+    }
+
+    private static MutationInfo resolveMutations(TaskProperties taskProperties, boolean hasValidationProblem) {
+        boolean hasOutputs = false;
+        boolean hasLocalState = false;
+        ImmutableSet.Builder<String> outputPaths = ImmutableSet.builder();
+        ImmutableSet.Builder<String> destroyablePaths = ImmutableSet.builder();
+
+        for (OutputFilePropertySpec spec : taskProperties.getOutputFileProperties()) {
+            File outputLocation = spec.getOutputFile();
+            outputPaths.add(outputLocation.getAbsolutePath());
+            hasOutputs = true;
+        }
+        for (File file : taskProperties.getLocalStateFiles()) {
+            outputPaths.add(file.getAbsolutePath());
+            hasLocalState = true;
+        }
+        for (File file : taskProperties.getDestroyableFiles()) {
+            destroyablePaths.add(file.getAbsolutePath());
+        }
+
+        boolean hasFileInputs = !taskProperties.getInputFileProperties().isEmpty();
+
+        return new MutationInfo(
+            outputPaths.build(),
+            destroyablePaths.build(),
+            hasFileInputs,
+            hasOutputs,
+            hasLocalState,
+            hasValidationProblem
+        );
+    }
+
+    private void validateMutations(MutationInfo mutations) {
+        if (!mutations.getDestroyablePaths().isEmpty()) {
+            if (mutations.hasOutputs()) {
+                throw new IllegalStateException("Task " + node + " has both outputs and destroyables defined.  A task can define either outputs or destroyables, but not both.");
+            }
+            if (mutations.hasFileInputs()) {
+                throw new IllegalStateException("Task " + node + " has both inputs and destroyables defined.  A task can define either inputs or destroyables, but not both.");
+            }
+            if (mutations.hasLocalState()) {
+                throw new IllegalStateException("Task " + node + " has both local state and destroyables defined.  A task can define either local state or destroyables, but not both.");
+            }
+        }
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/FileCollectionFingerprinterRegistrations.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/FileCollectionFingerprinterRegistrations.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.fingerprint.impl;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.changedetection.state.CachingFileSystemLocationSnapshotHasher;
 import org.gradle.api.internal.changedetection.state.LineEndingNormalizingFileSystemLocationSnapshotHasher;
@@ -35,6 +35,7 @@ import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -102,7 +103,7 @@ public class FileCollectionFingerprinterRegistrations {
         FileCollectionSnapshotter fileCollectionSnapshotter,
         FileSystemLocationSnapshotHasher normalizedContentHasher
     ) {
-        return Lists.newArrayList(
+        return ImmutableList.of(
             new AbsolutePathFileCollectionFingerprinter(directorySensitivity, fileCollectionSnapshotter, normalizedContentHasher),
             new RelativePathFileCollectionFingerprinter(stringInterner, directorySensitivity, fileCollectionSnapshotter, normalizedContentHasher),
             new NameOnlyFileCollectionFingerprinter(directorySensitivity, fileCollectionSnapshotter, normalizedContentHasher)
@@ -122,7 +123,7 @@ public class FileCollectionFingerprinterRegistrations {
         Map<String, ResourceEntryFilter> propertiesFileFilters,
         StringInterner stringInterner
     ) {
-        return Lists.newArrayList(
+        return ImmutableList.of(
             new IgnoredPathFileCollectionFingerprinter(fileCollectionSnapshotter, normalizedContentHasher),
             new DefaultClasspathFingerprinter(
                 resourceSnapshotterCacheService,
@@ -140,7 +141,7 @@ public class FileCollectionFingerprinterRegistrations {
      * These fingerprinters do not care about line ending or directory sensitivity at all
      */
     private static List<? extends FileCollectionFingerprinter> insensitiveFingerprinters(ResourceSnapshotterCacheService resourceSnapshotterCacheService, FileCollectionSnapshotter fileCollectionSnapshotter, StringInterner stringInterner) {
-        return Lists.newArrayList(
+        return Collections.singletonList(
             new DefaultCompileClasspathFingerprinter(resourceSnapshotterCacheService, fileCollectionSnapshotter, stringInterner)
         );
     }

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporterSpec.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporterSpec.groovy
@@ -16,7 +16,8 @@
 
 package org.gradle.api.tasks.diagnostics.internal.insight
 
-
+import com.google.common.collect.ImmutableList
+import com.google.common.collect.ImmutableMap
 import org.gradle.api.artifacts.result.ComponentSelectionReason
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
@@ -193,12 +194,12 @@ class DependencyInsightReporterSpec extends Specification {
     }
 
     private static DefaultResolvedDependencyResult dep(String group, String name, String requested, String selected = requested, ComponentSelectionReason selectionReason = ComponentSelectionReasons.requested()) {
-        def selectedModule = new DefaultResolvedComponentResult(newId(group, name, selected), selectionReason, new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, name), selected), [1: defaultVariant()], [defaultVariant()], "repoId")
+        def selectedModule = new DefaultResolvedComponentResult(newId(group, name, selected), selectionReason, new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, name), selected), ImmutableMap.of(1L, defaultVariant()), ImmutableList.of(defaultVariant()), "repoId")
         new DefaultResolvedDependencyResult(newSelector(DefaultModuleIdentifier.newId(group, name), requested),
                 false,
                 selectedModule,
                 null,
-                new DefaultResolvedComponentResult(newId("a", "root", "1"), ComponentSelectionReasons.requested(), new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, name), selected), [1: defaultVariant()], [defaultVariant()], "repoId"))
+                new DefaultResolvedComponentResult(newId("a", "root", "1"), ComponentSelectionReasons.requested(), new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, name), selected), ImmutableMap.of(1L, defaultVariant()), ImmutableList.of(defaultVariant()), "repoId"))
     }
 
     private static DefaultResolvedVariantResult defaultVariant(String ownerGroup = 'com', String ownerModule = 'foo', String ownerVersion = '1.0') {
@@ -209,10 +210,10 @@ class DependencyInsightReporterSpec extends Specification {
     }
 
     private static DefaultResolvedDependencyResult path(String path) {
-        DefaultResolvedComponentResult from = new DefaultResolvedComponentResult(newId("group", "root", "1"), ComponentSelectionReasons.requested(), new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId("group", "root"), "1"), [1: defaultVariant()], [defaultVariant()], "repoId")
+        DefaultResolvedComponentResult from = new DefaultResolvedComponentResult(newId("group", "root", "1"), ComponentSelectionReasons.requested(), new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId("group", "root"), "1"), ImmutableMap.of(1L, defaultVariant()), ImmutableList.of(defaultVariant()), "repoId")
         List<DefaultResolvedDependencyResult> pathElements = (path.split(' -> ') as List).reverse().collect {
             def (name, version) = it.split(':')
-            def componentResult = new DefaultResolvedComponentResult(newId('group', name, version), ComponentSelectionReasons.requested(), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('group', name), version), [1: defaultVariant()], [defaultVariant()], "repoId")
+            def componentResult = new DefaultResolvedComponentResult(newId('group', name, version), ComponentSelectionReasons.requested(), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('group', name), version), ImmutableMap.of(1L, defaultVariant()), ImmutableList.of(defaultVariant()), "repoId")
             def result = new DefaultResolvedDependencyResult(newSelector(DefaultModuleIdentifier.newId("group", name), version), false, componentResult, null, from)
             from = componentResult
             result

--- a/testing/architecture-test/src/test/java/org/gradle/architecture/test/GuavaCollectionFactoryUsageTest.java
+++ b/testing/architecture-test/src/test/java/org/gradle/architecture/test/GuavaCollectionFactoryUsageTest.java
@@ -42,6 +42,9 @@ public class GuavaCollectionFactoryUsageTest {
             // newArrayListWithExpectedSize is especially bad, as it allocates an array with the given size + 5.
             .callMethod(com.google.common.collect.Lists.class, "newArrayListWithExpectedSize", int.class)
             .orShould()
+            // newArrayList(E...) is especially bad, as it allocates an array with the given size + 5.
+            .callMethod(com.google.common.collect.Lists.class, "newArrayList", Object[].class)
+            .orShould()
             .callMethod(com.google.common.collect.Lists.class, "newArrayListWithCapacity", int.class)
             .orShould()
             .callMethod(com.google.common.collect.Lists.class, "newCopyOnWriteArrayList")


### PR DESCRIPTION
Gradle is currently not able to execute `assemble` on the Android 6k project benchmark without running out of memory with a 55GB heap.

This PR includes changes to help reduce the amount of retained memory during task graph traversal. 

While Gradle _still_ cannot execute `assemble` with a 55GB heap after these changes, it does reduce the required memory to execute `assembleDebug` by ~3GB. Before these changes, a 26GB heap was required to complete task graph traversal. After these changes, only a 23GB heap is required. 

The majority of reduced memory usage was by using immutable collections instead of mutable collections. Immutable collections are much more memory efficient than mutable collections, as collections like (non-linked)/Linked Hash Map/Set allocate a `Node` on the heap for every entry in the collection, while Guava immutable collections store data in a contiguous array. 

This PR is separated into 5 commits:
1. Avoid `Lists.newArrayList(E...)`. This likely does not cause _much_ benefit, but this factory method allocates an oversized array for the new array list -- often wasting memory.
2. Size CachePolicy rules to initial expected size. A ResolutionStrategy is one of the largest parts of a Configuration. This marginally reduces the size of a Configuration.
3. Use ImmutableSet when caching task graph node values. When walking the task graph, we keep an in-memory cache of node dependencies. We use an immutable collection instead of mutable collection as the value to this map, reducing the memory overhead of the cache.
4. Use immutable data structures for `ResolvedComponentResult`. Migrate to immutable data structures in this type, as it is retained in memory for the entirety of graph traversal. We could look into potentially _not_ keeping this in memory in future changes. 
5. Make `MutationInfo` immutable. `MutationInfo` on a task graph `Node` stores data related to the files that a node creates, consumes, and destroys. This was functionally immutable in the past. The code has been migrated to use immutable data structures to store this data.

Future things to look at:
- Reduce the footprint of `Configuration`. In the 6k project benchmark, there are over 1.3 million `Configuration` instances. They are quite heavy-weight and the average "empty" configuration is ~5kb. 
- Reduce the footprint of `DependencyPredecessorsOnlyNodeSet`. It stores a `TreeSet` of nodes. For this large graph, the overhead of the `TreeSet` itself (only the nodes of the set, not the retained data) is ~5-7GB. 

A snapshot of the memory situation this PR worked with:
<img width="763" alt="image" src="https://github.com/user-attachments/assets/18ff5386-7324-40a5-ba0e-512e2d4ce34f" />

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
