### PR TITLE
Make Kotlin DSL extracted precompiled scripts plugins blocks compilation task a regular `KotlinCompile` task

### DIFF
--- a/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild.kotlin-dsl-dependencies-embedded.gradle.kts
+++ b/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild.kotlin-dsl-dependencies-embedded.gradle.kts
@@ -26,7 +26,7 @@ plugins {
 // --- Enable automatic generation of API extensions -------------------
 val apiExtensionsOutputDir = layout.buildDirectory.dir("generated-sources/kotlin")
 
-val publishedKotlinDslPluginVersion = "5.1.2" // TODO:kotlin-dsl
+val publishedKotlinDslPluginVersion = "5.2.0" // TODO:kotlin-dsl
 
 tasks {
     val generateKotlinDependencyExtensions by registering(GenerateKotlinDependencyExtensions::class) {

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginTasksIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginTasksIntegrationTest.kt
@@ -122,7 +122,7 @@ class PrecompiledScriptPluginTasksIntegrationTest : AbstractKotlinIntegrationTes
         val cachedTasks = listOf(
             ":extractPrecompiledScriptPluginPlugins",
             ":generateExternalPluginSpecBuilders",
-            ":compilePluginsBlocks",
+            ":compileKotlinPluginsBlocks",
             ":generateScriptPluginAdapters"
         )
         val downstreamKotlinCompileTask = ":compileKotlin"
@@ -260,7 +260,7 @@ class PrecompiledScriptPluginTasksIntegrationTest : AbstractKotlinIntegrationTes
         withKotlinDslPluginIn("consumer").appendText("""dependencies { implementation(project(":producer")) }""")
         withFile("consumer/src/main/kotlin/some.gradle.kts", "")
         build(":consumer:classes").apply {
-            assertTaskExecuted(":consumer:compilePluginsBlocks")
+            assertTaskExecuted(":consumer:compileKotlinPluginsBlocks")
             assertNotOutput("w: Classpath entry points to a non-existent location")
         }
         assertFalse(file("producer/build/classes/java/main").exists())

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginTasksIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginTasksIntegrationTest.kt
@@ -122,7 +122,7 @@ class PrecompiledScriptPluginTasksIntegrationTest : AbstractKotlinIntegrationTes
         val cachedTasks = listOf(
             ":extractPrecompiledScriptPluginPlugins",
             ":generateExternalPluginSpecBuilders",
-            ":compileKotlinPluginsBlocks",
+            ":compilePluginsBlocks",
             ":generateScriptPluginAdapters"
         )
         val downstreamKotlinCompileTask = ":compileKotlin"
@@ -260,7 +260,7 @@ class PrecompiledScriptPluginTasksIntegrationTest : AbstractKotlinIntegrationTes
         withKotlinDslPluginIn("consumer").appendText("""dependencies { implementation(project(":producer")) }""")
         withFile("consumer/src/main/kotlin/some.gradle.kts", "")
         build(":consumer:classes").apply {
-            assertTaskExecuted(":consumer:compileKotlinPluginsBlocks")
+            assertTaskExecuted(":consumer:compilePluginsBlocks")
             assertNotOutput("w: Classpath entry points to a non-existent location")
         }
         assertFalse(file("producer/build/classes/java/main").exists())

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
@@ -82,7 +82,7 @@ class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
     )
     fun `can build plugin for oldest supported Kotlin language version using last published plugin`() {
 
-        `can build plugin for oldest supported Kotlin language version`(kotlinLanguageDeprecationCount = 1)
+        `can build plugin for oldest supported Kotlin language version`()
     }
 
     @Test
@@ -94,11 +94,11 @@ class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
 
         doForceLocallyBuiltKotlinDslPlugins()
 
-        `can build plugin for oldest supported Kotlin language version`(kotlinLanguageDeprecationCount = 2)
+        `can build plugin for oldest supported Kotlin language version`()
     }
 
     private
-    fun `can build plugin for oldest supported Kotlin language version`(kotlinLanguageDeprecationCount: Int) {
+    fun `can build plugin for oldest supported Kotlin language version`() {
 
         val oldestKotlinLanguageVersion = KotlinGradlePluginVersions.getLANGUAGE_VERSIONS().first()
 
@@ -118,7 +118,7 @@ class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
         withDefaultSettings().appendText("""includeBuild("producer")""")
         withBuildScript("""plugins { id("some") }""")
 
-        repeat(kotlinLanguageDeprecationCount) {
+        repeat(2) {
             executer.expectDeprecationWarning("w: Language version $oldestKotlinLanguageVersion is deprecated and its support will be removed in a future version of Kotlin")
         }
 

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
@@ -82,7 +82,7 @@ class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
     )
     fun `can build plugin for oldest supported Kotlin language version using last published plugin`() {
 
-        `can build plugin for oldest supported Kotlin language version`()
+        `can build plugin for oldest supported Kotlin language version`(kotlinLanguageDeprecationCount = 1)
     }
 
     @Test
@@ -94,11 +94,11 @@ class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
 
         doForceLocallyBuiltKotlinDslPlugins()
 
-        `can build plugin for oldest supported Kotlin language version`()
+        `can build plugin for oldest supported Kotlin language version`(kotlinLanguageDeprecationCount = 2)
     }
 
     private
-    fun `can build plugin for oldest supported Kotlin language version`() {
+    fun `can build plugin for oldest supported Kotlin language version`(kotlinLanguageDeprecationCount: Int) {
 
         val oldestKotlinLanguageVersion = KotlinGradlePluginVersions.getLANGUAGE_VERSIONS().first()
 
@@ -118,7 +118,9 @@ class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
         withDefaultSettings().appendText("""includeBuild("producer")""")
         withBuildScript("""plugins { id("some") }""")
 
-        executer.expectDeprecationWarning("w: Language version $oldestKotlinLanguageVersion is deprecated and its support will be removed in a future version of Kotlin")
+        repeat(kotlinLanguageDeprecationCount) {
+            executer.expectDeprecationWarning("w: Language version $oldestKotlinLanguageVersion is deprecated and its support will be removed in a future version of Kotlin")
+        }
 
         build("help").apply {
             assertThat(output, containsString("some!"))

--- a/platforms/core-configuration/kotlin-dsl-plugins/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl-plugins/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 description = "Kotlin DSL Gradle Plugins deployed to the Plugin Portal"
 
 group = "org.gradle.kotlin"
-version = "5.1.3"
+version = "5.2.0"
 
 base.archivesName = "plugins"
 

--- a/platforms/core-configuration/kotlin-dsl-plugins/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl-plugins/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 description = "Kotlin DSL Gradle Plugins deployed to the Plugin Portal"
 
 group = "org.gradle.kotlin"
-version = "5.2.0"
+version = "5.2.1"
 
 base.archivesName = "plugins"
 

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
@@ -31,7 +31,6 @@ import org.gradle.api.invocation.Gradle
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.provider.ListProperty
-import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.ClasspathNormalizer
 import org.gradle.api.tasks.PathSensitivity
@@ -168,6 +167,7 @@ class DefaultPrecompiledScriptPluginsSupport : PrecompiledScriptPluginsSupport {
 }
 
 
+@Suppress("LongMethod")
 private
 fun Project.enableScriptCompilationOf(
     scriptPlugins: List<PrecompiledScriptPlugin>,

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
@@ -204,11 +204,7 @@ fun Project.enableScriptCompilationOf(
             }
 
         val compilePluginsBlocks = if (names.contains("compileKotlinPluginsBlocks")) {
-//            println("NEW SETUP")
             named("compileKotlinPluginsBlocks") { task ->
-                task.doFirst {
-                    println("DEBUG HERE")
-                }
                 task.enabled = true
                 task.dependsOn(generateExternalPluginSpecBuilders)
                 task.dependsOn(extractPrecompiledScriptPluginPlugins)
@@ -235,7 +231,6 @@ fun Project.enableScriptCompilationOf(
                 }
             }
         } else {
-//            println("OLD SETUP")
             register("compilePluginsBlocks", CompilePrecompiledScriptPluginPlugins::class.java) { task ->
                 task.javaLauncher.set(javaToolchainService.launcherFor(java.toolchain))
                 @Suppress("DEPRECATION") task.jvmTarget.set(jvmTargetProvider)

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/ConfigurePrecompiledScriptDependenciesResolver.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/ConfigurePrecompiledScriptDependenciesResolver.kt
@@ -76,14 +76,16 @@ fun resolverEnvironmentStringFor(
         listOf(
             kotlinDslImplicitImports to implicitImportsForPrecompiledScriptPlugins(implicitImports, classPathFingerprinter, classPathFiles)
         ) + precompiledScriptPluginImportsFrom(metadataDir.asFile)
-    )
+    ).also {
+        println("RESOLVER_ENVIRONMENT_STRING=$it")
+    }
 }
 
 
 private
 fun precompiledScriptPluginImportsFrom(metadataDirFile: File): List<Pair<String, List<String>>> =
     metadataDirFile.run {
-        require(isDirectory)
+        require(isDirectory) { "'$this' is not a directory!" }
         listFilesOrdered().map {
             it.name to it.readLines()
         }

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/ConfigurePrecompiledScriptDependenciesResolver.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/ConfigurePrecompiledScriptDependenciesResolver.kt
@@ -76,9 +76,7 @@ fun resolverEnvironmentStringFor(
         listOf(
             kotlinDslImplicitImports to implicitImportsForPrecompiledScriptPlugins(implicitImports, classPathFingerprinter, classPathFiles)
         ) + precompiledScriptPluginImportsFrom(metadataDir.asFile)
-    ).also {
-        println("RESOLVER_ENVIRONMENT_STRING=$it")
-    }
+    )
 }
 
 

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GenerateExternalPluginSpecBuilders.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GenerateExternalPluginSpecBuilders.kt
@@ -20,9 +20,8 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
-
 import org.gradle.kotlin.dsl.accessors.writeSourceCodeForPluginSpecBuildersFor
-
+import org.gradle.kotlin.dsl.precompile.PrecompiledScriptDependenciesResolver.EnvironmentProperties.kotlinDslPluginSpecBuildersImplicitImports
 import java.io.File
 
 
@@ -47,7 +46,7 @@ abstract class GenerateExternalPluginSpecBuilders : ClassPathSensitiveCodeGenera
             )
         }
         metadataOutputDir.withOutputDirectory { outputDir ->
-            outputDir.resolve("implicit-imports").writeText(
+            outputDir.resolve(kotlinDslPluginSpecBuildersImplicitImports).writeText(
                 "$packageName.*"
             )
         }

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
@@ -41,6 +41,7 @@ import org.gradle.kotlin.dsl.accessors.ProjectAccessorsClassPathGenerator
 import org.gradle.kotlin.dsl.accessors.Stage1BlocksAccessorClassPathGenerator
 import org.gradle.kotlin.dsl.execution.EvalOption
 import org.gradle.kotlin.dsl.precompile.PrecompiledScriptDependenciesResolver
+import org.gradle.kotlin.dsl.precompile.PrecompiledScriptDependenciesResolver.EnvironmentProperties.kotlinDslPluginSpecBuildersImplicitImports
 import org.gradle.kotlin.dsl.provider.ClassPathModeExceptionCollector
 import org.gradle.kotlin.dsl.provider.KotlinScriptClassPathProvider
 import org.gradle.kotlin.dsl.provider.KotlinScriptEvaluator
@@ -218,6 +219,10 @@ fun precompiledScriptPluginModelBuilder(
             implicitImportsFrom(
                 resolve("accessors").resolve(hashOf(scriptFile))
             ) + implicitImportsFrom(
+                resolve("plugin-spec-builders").resolve(kotlinDslPluginSpecBuildersImplicitImports)
+            ) + implicitImportsFrom(
+                // Gradle <= 8.12 was using this other name with a dash but this was incompatible with moving to kotlin-scripting-host API
+                // Keeping it for compatibility with previous Gradle versions
                 resolve("plugin-spec-builders").resolve("implicit-imports")
             )
         }

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledScriptDependenciesResolver.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledScriptDependenciesResolver.kt
@@ -66,6 +66,7 @@ class PrecompiledScriptDependenciesResolver : ScriptDependenciesResolver {
 
     object EnvironmentProperties {
         const val kotlinDslImplicitImports = "kotlinDslImplicitImports"
+        const val kotlinDslPluginSpecBuildersImplicitImports = "kotlinDslPluginSpecBuildersImplicitImports"
         const val projectRoot = "projectRoot"
     }
 

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/v1/PrecompiledScriptTemplates.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/v1/PrecompiledScriptTemplates.kt
@@ -52,11 +52,11 @@ import kotlin.script.templates.ScriptTemplateDefinition
 /**
  * Base script template for compilation of `plugins {}` blocks extracted from precompiled scripts.
  */
-@ScriptTemplateDefinition
 @KotlinScript(
     fileExtension = "gradle.kts",
     compilationConfiguration = PrecompiledPluginsBlockCompilationConfiguration::class
 )
+@ScriptTemplateDefinition
 @SamWithReceiverAnnotations("org.gradle.api.HasImplicitReceiver")
 @GradleDsl
 open class PrecompiledPluginsBlock(private val pluginDependencies: PluginDependenciesSpec) {
@@ -79,11 +79,11 @@ object PrecompiledPluginsBlockCompilationConfiguration : ScriptCompilationConfig
  *
  * @see PrecompiledProjectScript
  */
-@ScriptTemplateDefinition
 @KotlinScript(
     fileExtension = "init.gradle.kts",
     compilationConfiguration = PrecompiledInitScriptCompilationConfiguration::class
 )
+@ScriptTemplateDefinition
 @SamWithReceiverAnnotations("org.gradle.api.HasImplicitReceiver")
 @GradleDsl
 open class PrecompiledInitScript(
@@ -96,11 +96,11 @@ open class PrecompiledInitScript(
  *
  * @see PrecompiledProjectScript
  */
-@ScriptTemplateDefinition
 @KotlinScript(
     fileExtension = "settings.gradle.kts",
     compilationConfiguration = PrecompiledSettingsScriptCompilationConfiguration::class
 )
+@ScriptTemplateDefinition
 @SamWithReceiverAnnotations("org.gradle.api.HasImplicitReceiver")
 @GradleDsl
 open class PrecompiledSettingsScript(
@@ -155,11 +155,11 @@ open class PrecompiledSettingsScript(
  * `src/main/kotlin/gradlebuild/code-quality.gradle.kts` would be exposed as the `gradlebuild.code-quality`
  * plugin, again assuming it has the matching package declaration.
  */
-@ScriptTemplateDefinition
 @KotlinScript(
     fileExtension = "gradle.kts",
     compilationConfiguration = PrecompiledProjectScriptCompilationConfiguration::class
 )
+@ScriptTemplateDefinition
 @SamWithReceiverAnnotations("org.gradle.api.HasImplicitReceiver")
 @GradleDsl
 open class PrecompiledProjectScript(

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/v1/PrecompiledScriptTemplates.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/v1/PrecompiledScriptTemplates.kt
@@ -52,12 +52,26 @@ import kotlin.script.templates.ScriptTemplateDefinition
 /**
  * Base script template for compilation of `plugins {}` blocks extracted from precompiled scripts.
  */
+@ScriptTemplateDefinition
+@KotlinScript(
+    fileExtension = "gradle.kts",
+    compilationConfiguration = PrecompiledPluginsBlockCompilationConfiguration::class
+)
+@SamWithReceiverAnnotations("org.gradle.api.HasImplicitReceiver")
+@GradleDsl
 open class PrecompiledPluginsBlock(private val pluginDependencies: PluginDependenciesSpec) {
 
     fun plugins(configuration: PluginDependenciesSpecScope.() -> Unit) {
         PluginDependenciesSpecScope(pluginDependencies).configuration()
     }
 }
+
+internal
+object PrecompiledPluginsBlockCompilationConfiguration : ScriptCompilationConfiguration({
+    isStandalone(false)
+    baseClass(PrecompiledPluginsBlock::class)
+    defaultImportsForPrecompiledScript()
+})
 
 
 /**


### PR DESCRIPTION
... instead of using the old internal K1-only embedded compiler API.

This is a prerequisite for using Kotlin Language >= 2.0 in the Kotlin DSL.

* Fixes https://github.com/gradle/gradle/issues/24531
* Part of https://github.com/gradle/gradle/issues/26534

This PR includes an upgrade to the `kotlin-dsl` plugin thus mandates a wrapper update post-merge.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
