### PR TITLE
Move centralized CC-incompatible tasks marking to settings

### DIFF
--- a/build-logic-settings/configuration-cache-compatibility/build.gradle.kts
+++ b/build-logic-settings/configuration-cache-compatibility/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,16 @@
  */
 
 plugins {
-    id("gradlebuild.buildscan") // Reporting: Add more data through custom tags to build scans
-    id("gradlebuild.ide") // Local development: Tweak IDEA import
-    id("gradlebuild.dependency-analysis") // Auditing dependencies to find unused libraries
-    id("gradlebuild.warmup-ec2") // Warm up EC2 AMI
+    `kotlin-dsl`
+}
+
+description = "Provides plugins for Configuration Cache usage adjustments"
+
+group = "gradlebuild"
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+        vendor = JvmVendorSpec.ADOPTIUM
+    }
 }

--- a/build-logic-settings/settings.gradle.kts
+++ b/build-logic-settings/settings.gradle.kts
@@ -45,5 +45,6 @@ plugins {
 }
 
 include("build-environment")
+include("configuration-cache-compatibility")
 
 rootProject.name = "build-logic-settings"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,6 +28,7 @@ pluginManagement {
 
 plugins {
     id("gradlebuild.build-environment")
+    id("gradlebuild.configuration-cache-compatibility")
     id("com.gradle.develocity").version("3.19.1-rc-2") // Run `java build-logic-settings/UpdateDevelocityPluginVersion.java <new-version>` to update
     id("io.github.gradle.gradle-enterprise-conventions-plugin").version("0.10.2")
     id("org.gradle.toolchains.foojay-resolver-convention").version("0.9.0")


### PR DESCRIPTION
to make use of IP-safe `GradleLifecycle.beforeProject` callback and avoid IP violations