### PR TITLE
Trigger wrapper checks also for commits in the Merge Queue

### DIFF
--- a/.github/workflows/check-commits.yml
+++ b/.github/workflows/check-commits.yml
@@ -1,5 +1,6 @@
 name: Check commits
 on:
+  merge_group:
   workflow_dispatch:
   pull_request:
     types:


### PR DESCRIPTION
Otherwise PRs get stuck waiting for the `check_wrapper` status to appear

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
