### PR TITLE
Add public API for ConfigurationVariant description

### DIFF
--- a/platforms/jvm/platform-jvm/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServices.java
+++ b/platforms/jvm/platform-jvm/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServices.java
@@ -125,8 +125,8 @@ public class DefaultJvmPluginServices implements JvmPluginServices {
     @Override
     public ConfigurationVariant configureResourcesDirectoryVariant(Configuration configuration, SourceSet sourceSet) {
         ConfigurationPublications publications = configuration.getOutgoing();
-        ConfigurationVariantInternal variant = (ConfigurationVariantInternal) publications.getVariants().maybeCreate("resources");
-        variant.setDescription("Directories containing assembled resource files for " + sourceSet.getName() + ".");
+        ConfigurationVariant variant = publications.getVariants().maybeCreate("resources");
+        variant.getDescription().value("Directories containing assembled resource files for " + sourceSet.getName() + ".").finalizeValue();
         variant.getAttributes().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, LibraryElements.RESOURCES));
         DefaultSourceSetOutput output = Cast.uncheckedCast(sourceSet.getOutput());
         DefaultSourceSetOutput.DirectoryContribution resourcesContribution = output.getResourcesContribution();
@@ -140,7 +140,7 @@ public class DefaultJvmPluginServices implements JvmPluginServices {
     public ConfigurationVariant configureClassesDirectoryVariant(Configuration configuration, SourceSet sourceSet) {
         ConfigurationPublications publications = configuration.getOutgoing();
         ConfigurationVariantInternal variant = (ConfigurationVariantInternal) publications.getVariants().maybeCreate("classes");
-        variant.setDescription("Directories containing compiled class files for " + sourceSet.getName() + ".");
+        variant.getDescription().value("Directories containing compiled class files for " + sourceSet.getName() + ".").finalizeValue();
         variant.getAttributes().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, LibraryElements.CLASSES));
         variant.artifactsProvider(() ->  {
             FileCollection classesDirs = sourceSet.getOutput().getClassesDirs();

--- a/platforms/jvm/plugins-java-base/src/integTest/groovy/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServicesTest.groovy
+++ b/platforms/jvm/plugins-java-base/src/integTest/groovy/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServicesTest.groovy
@@ -36,6 +36,7 @@ import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.util.AttributeTestUtil
+import org.gradle.util.TestUtil
 
 import static org.gradle.api.attributes.Bundling.BUNDLING_ATTRIBUTE
 import static org.gradle.api.attributes.Bundling.EMBEDDED
@@ -185,6 +186,7 @@ class DefaultJvmPluginServicesTest extends AbstractJvmPluginServicesTest {
         def variants = Mock(NamedDomainObjectContainer)
         def variant = Mock(ConfigurationVariantInternal)
         def attrs = AttributeTestUtil.attributesFactory().mutable()
+        def description = TestUtil.objectFactory().property(String)
         def output = Mock(DefaultSourceSetOutput)
         def classes = Stub(ConfigurableFileCollection) {
             getFiles() >> [
@@ -208,7 +210,7 @@ class DefaultJvmPluginServicesTest extends AbstractJvmPluginServicesTest {
             PublishArtifact artifact = artifacts[0]
             assert artifact.name == 'toto'
         }
-        1 * variant.setDescription(_)
+        1 * variant.getDescription() >> description
         _ * sourceSet.getOutput() >> output
         1 * output.getClassesDirs() >> classes
         1 * sourceSet.getName()

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -86,6 +86,7 @@ import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
@@ -259,6 +260,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         TaskDependencyFactory taskDependencyFactory,
         ConfigurationRole roleAtCreation,
         InternalProblems problemsService,
+        ObjectFactory objectFactory,
         boolean lockUsage
     ) {
         super(taskDependencyFactory);
@@ -301,7 +303,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
         this.artifacts = new DefaultPublishArtifactSet(Describables.of(displayName, "artifacts"), ownArtifacts, fileCollectionFactory, taskDependencyFactory);
 
-        this.outgoing = instantiator.newInstance(DefaultConfigurationPublications.class, displayName, artifacts, new AllArtifactsProvider(), configurationAttributes, instantiator, artifactNotationParser, capabilityNotationParser, fileCollectionFactory, attributesFactory, domainObjectCollectionFactory, taskDependencyFactory);
+        this.outgoing = instantiator.newInstance(DefaultConfigurationPublications.class, displayName, artifacts, new AllArtifactsProvider(), configurationAttributes, instantiator, artifactNotationParser, capabilityNotationParser, fileCollectionFactory, attributesFactory, domainObjectCollectionFactory, taskDependencyFactory, objectFactory);
         this.rootComponentMetadataBuilder = rootComponentMetadataBuilder;
         this.currentResolveState = domainObjectContext.getModel().newCalculatedValue(Optional.empty());
         this.defaultConfigurationFactory = defaultConfigurationFactory;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationFactory.java
@@ -31,6 +31,7 @@ import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.internal.Factory;
 import org.gradle.internal.code.UserCodeApplicationContext;
@@ -69,6 +70,7 @@ public class DefaultConfigurationFactory {
     private final CalculatedValueFactory calculatedValueFactory;
     private final TaskDependencyFactory taskDependencyFactory;
     private final InternalProblems problemsService;
+    private final ObjectFactory objectFactory;
 
     @Inject
     public DefaultConfigurationFactory(
@@ -88,7 +90,8 @@ public class DefaultConfigurationFactory {
         DomainObjectCollectionFactory domainObjectCollectionFactory,
         CalculatedValueFactory calculatedValueFactory,
         TaskDependencyFactory taskDependencyFactory,
-        InternalProblems problemsService
+        InternalProblems problemsService,
+        ObjectFactory objectFactory
     ) {
         this.instantiator = instantiator;
         this.resolver = resolver;
@@ -97,6 +100,7 @@ public class DefaultConfigurationFactory {
         this.fileCollectionFactory = fileCollectionFactory;
         this.buildOperationRunner = buildOperationRunner;
         this.artifactNotationParser = artifactNotationParserFactory.create();
+        this.objectFactory = objectFactory;
         this.capabilityNotationParser = new CapabilityNotationParserFactory(true).create();
         this.attributesFactory = attributesFactory;
         this.exceptionContextualizer = exceptionMapper;
@@ -147,7 +151,8 @@ public class DefaultConfigurationFactory {
             this,
             taskDependencyFactory,
             role,
-            problemsService
+            problemsService,
+            objectFactory
         );
         instance.addMutationValidator(rootComponentMetadataBuilder.getValidator());
         return instance;
@@ -188,7 +193,8 @@ public class DefaultConfigurationFactory {
             calculatedValueFactory,
             this,
             taskDependencyFactory,
-            problemsService
+            problemsService,
+            objectFactory
         );
         instance.addMutationValidator(rootComponentMetadataBuilder.getValidator());
         return instance;
@@ -229,7 +235,8 @@ public class DefaultConfigurationFactory {
             calculatedValueFactory,
             this,
             taskDependencyFactory,
-            problemsService
+            problemsService,
+            objectFactory
         );
         instance.addMutationValidator(rootComponentMetadataBuilder.getValidator());
         return instance;
@@ -270,7 +277,8 @@ public class DefaultConfigurationFactory {
             calculatedValueFactory,
             this,
             taskDependencyFactory,
-            problemsService
+            problemsService,
+            objectFactory
         );
         instance.addMutationValidator(rootComponentMetadataBuilder.getValidator());
         return instance;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
@@ -35,6 +35,7 @@ import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.FinalizableValue;
@@ -59,6 +60,7 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
     private final AttributesFactory attributesFactory;
     private final DomainObjectCollectionFactory domainObjectCollectionFactory;
     private final TaskDependencyFactory taskDependencyFactory;
+    private final ObjectFactory objectFactory;
     private NamedDomainObjectContainer<ConfigurationVariant> variants;
     private ConfigurationVariantFactory variantFactory;
     private DomainObjectSet<Capability> capabilities;
@@ -75,7 +77,8 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
         FileCollectionFactory fileCollectionFactory,
         AttributesFactory attributesFactory,
         DomainObjectCollectionFactory domainObjectCollectionFactory,
-        TaskDependencyFactory taskDependencyFactory
+        TaskDependencyFactory taskDependencyFactory,
+        ObjectFactory objectFactory
     ) {
         this.displayName = displayName;
         this.artifacts = artifacts;
@@ -88,6 +91,7 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
         this.attributesFactory = attributesFactory;
         this.domainObjectCollectionFactory = domainObjectCollectionFactory;
         this.taskDependencyFactory = taskDependencyFactory;
+        this.objectFactory = objectFactory;
         this.attributes = attributesFactory.mutable(parentAttributes);
     }
 
@@ -205,7 +209,7 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
         public ConfigurationVariant create(String name) {
             if (canCreate) {
                 return instantiator.newInstance(
-                    DefaultVariant.class, displayName, name, parentAttributes, artifactNotationParser, fileCollectionFactory, attributesFactory, domainObjectCollectionFactory, taskDependencyFactory
+                    DefaultVariant.class, displayName, name, parentAttributes, artifactNotationParser, fileCollectionFactory, attributesFactory, domainObjectCollectionFactory, taskDependencyFactory, objectFactory
                 );
             } else {
                 throw new InvalidUserCodeException("Cannot create variant '" + name + "' after dependency " + displayName + " has been resolved");

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConsumableConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConsumableConfiguration.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.internal.Factory;
 import org.gradle.internal.code.UserCodeApplicationContext;
@@ -68,7 +69,8 @@ public class DefaultConsumableConfiguration extends DefaultConfiguration impleme
         CalculatedValueContainerFactory calculatedValueContainerFactory,
         DefaultConfigurationFactory defaultConfigurationFactory,
         TaskDependencyFactory taskDependencyFactory,
-        InternalProblems problemsService
+        InternalProblems problemsService,
+        ObjectFactory objectFactory
     ) {
         super(
             domainObjectContext,
@@ -95,6 +97,7 @@ public class DefaultConsumableConfiguration extends DefaultConfiguration impleme
             taskDependencyFactory,
             ConfigurationRoles.CONSUMABLE,
             problemsService,
+            objectFactory,
             true
         );
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultDependencyScopeConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultDependencyScopeConfiguration.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.internal.Factory;
 import org.gradle.internal.code.UserCodeApplicationContext;
@@ -68,7 +69,8 @@ public class DefaultDependencyScopeConfiguration extends DefaultConfiguration im
         CalculatedValueContainerFactory calculatedValueContainerFactory,
         DefaultConfigurationFactory defaultConfigurationFactory,
         TaskDependencyFactory taskDependencyFactory,
-        InternalProblems problemsService
+        InternalProblems problemsService,
+        ObjectFactory objectFactory
     ) {
         super(
             domainObjectContext,
@@ -95,6 +97,7 @@ public class DefaultDependencyScopeConfiguration extends DefaultConfiguration im
             taskDependencyFactory,
             ConfigurationRoles.DEPENDENCY_SCOPE,
             problemsService,
+            objectFactory,
             true
         );
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultResolvableConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultResolvableConfiguration.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.internal.Factory;
 import org.gradle.internal.code.UserCodeApplicationContext;
@@ -68,7 +69,8 @@ public class DefaultResolvableConfiguration extends DefaultConfiguration impleme
         CalculatedValueContainerFactory calculatedValueContainerFactory,
         DefaultConfigurationFactory defaultConfigurationFactory,
         TaskDependencyFactory taskDependencyFactory,
-        InternalProblems problemsService
+        InternalProblems problemsService,
+        ObjectFactory objectFactory
     ) {
         super(
             domainObjectContext,
@@ -95,6 +97,7 @@ public class DefaultResolvableConfiguration extends DefaultConfiguration impleme
             taskDependencyFactory,
             ConfigurationRoles.RESOLVABLE,
             problemsService,
+            objectFactory,
             true
         );
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultUnlockedConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultUnlockedConfiguration.java
@@ -29,6 +29,7 @@ import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.internal.Factory;
 import org.gradle.internal.code.UserCodeApplicationContext;
@@ -68,7 +69,8 @@ public class DefaultUnlockedConfiguration extends DefaultConfiguration {
         DefaultConfigurationFactory defaultConfigurationFactory,
         TaskDependencyFactory taskDependencyFactory,
         ConfigurationRole roleAtCreation,
-        InternalProblems problemsService
+        InternalProblems problemsService,
+        ObjectFactory objectFactory
     ) {
         super(
             domainObjectContext,
@@ -95,6 +97,7 @@ public class DefaultUnlockedConfiguration extends DefaultConfiguration {
             taskDependencyFactory,
             roleAtCreation,
             problemsService,
+            objectFactory,
             false
         );
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
@@ -31,14 +31,14 @@ import org.gradle.api.internal.attributes.FreezableAttributeContainer;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.Factory;
 import org.gradle.internal.typeconversion.NotationParser;
 
-import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Optional;
 
 public class DefaultVariant implements ConfigurationVariantInternal {
     private final Describable parentDisplayName;
@@ -46,8 +46,8 @@ public class DefaultVariant implements ConfigurationVariantInternal {
     private final FreezableAttributeContainer attributes;
     private final NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser;
     private final PublishArtifactSet artifacts;
+    private final Property<String> description;
     private Factory<List<PublishArtifact>> lazyArtifacts;
-    @Nullable private String description;
 
     public DefaultVariant(Describable parentDisplayName,
                           String name,
@@ -56,22 +56,19 @@ public class DefaultVariant implements ConfigurationVariantInternal {
                           FileCollectionFactory fileCollectionFactory,
                           AttributesFactory cache,
                           DomainObjectCollectionFactory domainObjectCollectionFactory,
-                          TaskDependencyFactory taskDependencyFactory) {
+                          TaskDependencyFactory taskDependencyFactory,
+                          ObjectFactory objectFactory) {
         this.parentDisplayName = parentDisplayName;
         this.name = name;
         this.attributes = new FreezableAttributeContainer(cache.mutable(parentAttributes), parentDisplayName);
         this.artifactNotationParser = artifactNotationParser;
+        this.description = objectFactory.property(String.class);
         artifacts = new DefaultPublishArtifactSet(getDisplayName(), domainObjectCollectionFactory.newDomainObjectSet(PublishArtifact.class), fileCollectionFactory, taskDependencyFactory);
     }
 
     @Override
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    @Override
-    public Optional<String> getDescription() {
-        return Optional.ofNullable(description);
+    public Property<String> getDescription() {
+        return description;
     }
 
     @Override
@@ -128,6 +125,8 @@ public class DefaultVariant implements ConfigurationVariantInternal {
 
     @Override
     public void preventFurtherMutation() {
+        description.finalizeValueOnRead();
+        description.disallowChanges();
         attributes.freeze();
     }
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -83,7 +83,8 @@ class DefaultConfigurationContainerSpec extends Specification {
         TestUtil.domainObjectCollectionFactory(),
         calculatedValueContainerFactory,
         TestFiles.taskDependencyFactory(),
-        TestUtil.problemsService()
+        TestUtil.problemsService(),
+        TestUtil.objectFactory()
     )
     private DefaultConfigurationContainer configurationContainer = new DefaultConfigurationContainer(
         instantiator,

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
@@ -90,7 +90,8 @@ class DefaultConfigurationContainerTest extends Specification {
         TestUtil.domainObjectCollectionFactory(),
         calculatedValueContainerFactory,
         TestFiles.taskDependencyFactory(),
-        TestUtil.problemsService()
+        TestUtil.problemsService(),
+        TestUtil.objectFactory()
     )
     private DefaultConfigurationContainer configurationContainer = instantiator.newInstance(DefaultConfigurationContainer.class,
         instantiator,

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublicationsTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublicationsTest.groovy
@@ -48,7 +48,7 @@ class DefaultConfigurationPublicationsTest extends Specification {
     def publications = new DefaultConfigurationPublications(displayName, artifacts, {
         allArtifacts
     }, parentAttributes, TestUtil.instantiatorFactory().decorateLenient(), artifactNotationParser, capabilityNotationParser, fileCollectionFactory, attributesFactory,
-        TestUtil.domainObjectCollectionFactory(), TestFiles.taskDependencyFactory()
+        TestUtil.domainObjectCollectionFactory(), TestFiles.taskDependencyFactory(), TestUtil.objectFactory()
     )
 
     def setup() {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -1784,7 +1784,8 @@ class DefaultConfigurationSpec extends Specification {
             TestUtil.domainObjectCollectionFactory(),
             calculatedValueContainerFactory,
             TestFiles.taskDependencyFactory(),
-            TestUtil.problemsService()
+            TestUtil.problemsService(),
+            TestUtil.objectFactory()
         )
     }
 

--- a/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/component/ConfigurationVariantMapping.java
+++ b/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/component/ConfigurationVariantMapping.java
@@ -29,6 +29,7 @@ import org.gradle.api.component.ConfigurationVariantDetails;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
 import org.gradle.internal.Actions;
 import org.gradle.internal.deprecation.DeprecationLogger;
 
@@ -36,7 +37,6 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.util.HashSet;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -110,10 +110,13 @@ public class ConfigurationVariantMapping {
     // Cannot be private due to reflective instantiation
     static class DefaultConfigurationVariant implements ConfigurationVariant {
         private final ConfigurationInternal outgoingConfiguration;
+        private final Property<String> description;
 
         @Inject
-        public DefaultConfigurationVariant(ConfigurationInternal outgoingConfiguration) {
+        public DefaultConfigurationVariant(ConfigurationInternal outgoingConfiguration, ObjectFactory objectFactory) {
             this.outgoingConfiguration = outgoingConfiguration;
+            this.description = objectFactory.property(String.class).value(outgoingConfiguration.getName());
+            this.description.finalizeValue();
         }
 
         @Override
@@ -137,8 +140,8 @@ public class ConfigurationVariantMapping {
         }
 
         @Override
-        public Optional<String> getDescription() {
-            return Optional.ofNullable(outgoingConfiguration.getDescription());
+        public Property<String> getDescription() {
+            return description;
         }
 
         @Override

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ConfigurationVariant.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ConfigurationVariant.java
@@ -20,9 +20,8 @@ import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 import org.gradle.api.attributes.HasConfigurableAttributes;
+import org.gradle.api.provider.Property;
 import org.gradle.internal.HasInternalProtocol;
-
-import java.util.Optional;
 
 /**
  * Represents some variant of an outgoing configuration.
@@ -34,10 +33,10 @@ public interface ConfigurationVariant extends Named, HasConfigurableAttributes<C
     /**
      * Returns an optional note describing this variant.
      *
-     * @since 7.5
+     * @since 9.0
      */
     @Incubating
-    Optional<String> getDescription();
+    Property<String> getDescription();
 
     /**
      * Returns the artifacts associated with this variant.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/ConfigurationVariantInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/ConfigurationVariantInternal.java
@@ -30,8 +30,6 @@ public interface ConfigurationVariantInternal extends ConfigurationVariant {
 
     void preventFurtherMutation();
 
-    void setDescription(String description);
-
     DisplayName getDisplayName();
 
     @Override

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/configurations/model/ConfigurationReportModelFactory.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/configurations/model/ConfigurationReportModelFactory.java
@@ -141,7 +141,7 @@ public final class ConfigurationReportModelFactory {
             .sorted(Comparator.comparing(ReportArtifact::getName))
             .collect(Collectors.toList()));
 
-        return new ReportSecondaryVariant(variant.getName(), variant.getDescription().orElse(null), attributes, artifacts);
+        return new ReportSecondaryVariant(variant.getName(), variant.getDescription().getOrElse(null), attributes, artifacts);
     }
 
     private ReportAttribute convertAttributeInContainer(Attribute<?> attribute, AttributeContainer container, AttributesSchema attributesSchema) {


### PR DESCRIPTION
Use a Gradle Property instead of a Java Optional to allow the user to set a custom description

Fixes #29241 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
