### PR TITLE
Support RC version of develocity plugin

### DIFF
--- a/build-logic-commons/settings.gradle.kts
+++ b/build-logic-commons/settings.gradle.kts
@@ -17,6 +17,17 @@
 dependencyResolutionManagement {
     repositories {
         gradlePluginPortal()
+
+        maven {
+            url = uri("https://repo.gradle.org/gradle/enterprise-libs-release-candidates")
+            content {
+                val rcAndMilestonesPattern = "\\d{1,2}?\\.\\d{1,2}?(\\.\\d{1,2}?)?-((rc-\\d{1,2}?)|(milestone-\\d{1,2}?))"
+                // GE plugin marker artifact
+                includeVersionByRegex("com.gradle.develocity", "com.gradle.develocity.gradle.plugin", rcAndMilestonesPattern)
+                // GE plugin jar
+                includeVersionByRegex("com.gradle", "develocity-gradle-plugin", rcAndMilestonesPattern)
+            }
+        }
     }
 }
 

--- a/build-logic-settings/settings.gradle.kts
+++ b/build-logic-settings/settings.gradle.kts
@@ -21,6 +21,23 @@ dependencyResolutionManagement {
     }
 }
 
+pluginManagement {
+    repositories {
+        maven {
+            url = uri("https://repo.gradle.org/gradle/enterprise-libs-release-candidates")
+            content {
+                val rcAndMilestonesPattern = "\\d{1,2}?\\.\\d{1,2}?(\\.\\d{1,2}?)?-((rc-\\d{1,2}?)|(milestone-\\d{1,2}?))"
+                // GE plugin marker artifact
+                includeVersionByRegex("com.gradle.develocity", "com.gradle.develocity.gradle.plugin", rcAndMilestonesPattern)
+                // GE plugin jar
+                includeVersionByRegex("com.gradle", "develocity-gradle-plugin", rcAndMilestonesPattern)
+            }
+        }
+
+        gradlePluginPortal()
+    }
+}
+
 plugins {
     id("com.gradle.develocity").version("3.19") // Run `java build-logic-settings/UpdateDevelocityPluginVersion.java <new-version>` to update
     id("io.github.gradle.gradle-enterprise-conventions-plugin").version("0.10.2")


### PR DESCRIPTION
Two more configuration were added:

1. `build-logic-settings` needs to access the plugin.
2. `build-logic-commons` needs to compile code against the jar.

Thread: https://gradle.slack.com/archives/CKTK0S08L/p1736517367688939
