### PR TITLE
Fix URI parsing on windows

### DIFF
--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/UriNotationConverter.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/UriNotationConverter.java
@@ -93,6 +93,6 @@ public class UriNotationConverter implements NotationConverter<Object, URI> {
     }
 
     private static boolean isWindowsRootDirectory(@Nullable String scheme) {
-        return scheme != null && scheme.length() == 2 && Character.isLetter(scheme.charAt(0)) && scheme.charAt(1) == ':' && OperatingSystem.current().isWindows();
+        return scheme != null && scheme.length() == 1 && Character.isLetter(scheme.charAt(0)) && OperatingSystem.current().isWindows();
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/UriNotationConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/UriNotationConverterTest.groovy
@@ -19,6 +19,8 @@ package org.gradle.api.internal.file
 
 import org.gradle.internal.typeconversion.UnsupportedNotationException
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.UnitTestPreconditions
 import org.junit.Rule
 import spock.lang.Issue
 import spock.lang.Specification
@@ -122,6 +124,22 @@ class UriNotationConverterTest extends Specification {
         then:
         UnsupportedNotationException e = thrown()
         showsProperMessage(e, 12)
+    }
+
+    @Requires(UnitTestPreconditions.Windows)
+    def "windows-like paths are treated as non-uris for #hint"() {
+        when:
+        parse(path)
+        then:
+        UnsupportedNotationException e = thrown()
+        showsProperMessage(e, path)
+
+        where:
+        path                        | hint
+        "C:\\some\\file"            | "path without space"
+        "C:\\some\\file with space" | "path with space"
+        "c:/some/file"              | "normalized path without space"
+        "c:/some/file with space"   | "normalized path with space"
     }
 
     def parse(def value) {


### PR DESCRIPTION
This PR adds coverage for a corner case when the path on windows does not contain special characters (e.g. space) and have normalized slashes. Other cases were working fine.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
