### PR TITLE
Synchronizer-wait build operation

### DIFF
--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/work/WaitBuildOperationFiringSynchronizer.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/work/WaitBuildOperationFiringSynchronizer.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.work;
+
+import org.gradle.internal.DisplayName;
+import org.gradle.internal.Factory;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationRunner;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class WaitBuildOperationFiringSynchronizer implements Synchronizer {
+
+    private final DisplayName targetDescription;
+    private final Synchronizer delegate;
+    private final BuildOperationRunner buildOperationRunner;
+
+    public WaitBuildOperationFiringSynchronizer(DisplayName targetDescription, Synchronizer delegate, BuildOperationRunner buildOperationRunner) {
+        this.targetDescription = targetDescription;
+        this.delegate = delegate;
+        this.buildOperationRunner = buildOperationRunner;
+    }
+
+    @Override
+    public void withLock(final Runnable action) {
+        final AtomicBoolean successfulWait = new AtomicBoolean(false);
+        final BuildOperationContext buildOperationContext = startWaitingOperation();
+
+        try {
+            delegate.withLock(new Runnable() {
+                @Override
+                public void run() {
+                    successfulWait.set(true);
+                    buildOperationContext.setResult(null);
+                    action.run();
+                }
+            });
+        } finally {
+            if (!successfulWait.get()) {
+                buildOperationContext.setResult(null);
+            }
+        }
+    }
+
+    @Override
+    public <T> T withLock(final Factory<T> action) {
+        final AtomicBoolean successfulWait = new AtomicBoolean(false);
+        final BuildOperationContext buildOperationContext = startWaitingOperation();
+
+        try {
+            return delegate.withLock(new Factory<T>() {
+                @Nullable
+                @Override
+                public T create() {
+                    successfulWait.set(true);
+                    buildOperationContext.setResult(null);
+                    return action.create();
+                }
+            });
+        } finally {
+            if (!successfulWait.get()) {
+                buildOperationContext.setResult(null);
+            }
+        }
+
+    }
+
+    private BuildOperationContext startWaitingOperation() {
+        return buildOperationRunner.start(
+            BuildOperationDescriptor
+                .displayName("Synchronizer wait: " + targetDescription.getDisplayName())
+        );
+    }
+}

--- a/platforms/core-runtime/build-state/src/main/java/org/gradle/internal/session/CrossBuildSessionState.java
+++ b/platforms/core-runtime/build-state/src/main/java/org/gradle/internal/session/CrossBuildSessionState.java
@@ -18,6 +18,8 @@ package org.gradle.internal.session;
 
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.internal.concurrent.CompositeStoppable;
+import org.gradle.internal.operations.BuildOperationsParameters;
+import org.gradle.internal.operations.DefaultBuildOperationsParameters;
 import org.gradle.internal.operations.trace.BuildOperationTrace;
 import org.gradle.internal.service.Provides;
 import org.gradle.internal.service.ServiceRegistration;
@@ -80,6 +82,7 @@ public class CrossBuildSessionState implements Closeable {
             }
             registration.add(CrossBuildSessionParameters.class, new CrossBuildSessionParameters(startParameter));
             registration.add(CrossBuildSessionState.class, CrossBuildSessionState.this);
+            registration.add(BuildOperationsParameters.class, DefaultBuildOperationsParameters.class);
         }
     }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/internal/operations/BuildOperationsParameters.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/operations/BuildOperationsParameters.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.operations;
+
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+
+@ServiceScope(Scope.CrossBuildSession.class)
+public interface BuildOperationsParameters {
+
+    /**
+     * Whether build operations should be emitted more extensively
+     * for observability purposes.
+     */
+    boolean isVerbose();
+
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/model/StateTransitionControllerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/model/StateTransitionControllerFactory.java
@@ -17,19 +17,36 @@
 package org.gradle.internal.model;
 
 import org.gradle.internal.DisplayName;
+import org.gradle.internal.operations.BuildOperationRunner;
+import org.gradle.internal.operations.BuildOperationsParameters;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
+import org.gradle.internal.work.Synchronizer;
+import org.gradle.internal.work.WaitBuildOperationFiringSynchronizer;
 import org.gradle.internal.work.WorkerLeaseService;
 
 @ServiceScope(Scope.BuildSession.class)
 public class StateTransitionControllerFactory {
-    private final WorkerLeaseService workerLeaseService;
 
-    public StateTransitionControllerFactory(WorkerLeaseService workerLeaseService) {
+    private final WorkerLeaseService workerLeaseService;
+    private final BuildOperationsParameters buildOperationsParameters;
+    private final BuildOperationRunner buildOperationRunner;
+
+    public StateTransitionControllerFactory(
+        WorkerLeaseService workerLeaseService,
+        BuildOperationsParameters buildOperationsParameters,
+        BuildOperationRunner buildOperationRunner
+    ) {
         this.workerLeaseService = workerLeaseService;
+        this.buildOperationsParameters = buildOperationsParameters;
+        this.buildOperationRunner = buildOperationRunner;
     }
 
     public <T extends StateTransitionController.State> StateTransitionController<T> newController(DisplayName displayName, T initialState) {
-        return new StateTransitionController<>(displayName, initialState, workerLeaseService.newResource());
+        Synchronizer synchronizer = workerLeaseService.newResource();
+        if (buildOperationsParameters.isVerbose()) {
+            synchronizer = new WaitBuildOperationFiringSynchronizer(displayName, synchronizer, buildOperationRunner);
+        }
+        return new StateTransitionController<>(displayName, initialState, synchronizer);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/DefaultBuildOperationsParameters.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/DefaultBuildOperationsParameters.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.operations;
+
+import org.gradle.internal.buildoption.DefaultInternalOptions;
+import org.gradle.internal.buildoption.InternalFlag;
+import org.gradle.internal.buildoption.InternalOption;
+import org.gradle.internal.buildoption.InternalOptions;
+import org.gradle.internal.service.scopes.CrossBuildSessionParameters;
+
+public class DefaultBuildOperationsParameters implements BuildOperationsParameters {
+
+    /**
+     * Whether to capture build operations more extensively for observability purposes
+     * potentially at the cost of some performance
+     */
+    public static final InternalOption<Boolean> VERBOSE_BUILD_OPERATIONS_OPTION = new InternalFlag("org.gradle.internal.operations.verbose", false);
+
+    private final boolean verbose;
+
+    public DefaultBuildOperationsParameters(CrossBuildSessionParameters crossBuildSessionParameters) {
+        InternalOptions internalOptions = new DefaultInternalOptions(crossBuildSessionParameters.getStartParameter().getSystemPropertiesArgs());
+        verbose = internalOptions.getOption(VERBOSE_BUILD_OPERATIONS_OPTION).get();
+    }
+
+    @Override
+    public boolean isVerbose() {
+        return verbose;
+    }
+}

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.FeaturePreviews
 import org.gradle.api.internal.MutationGuard
 import org.gradle.api.internal.MutationGuards
+import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.internal.collections.DefaultDomainObjectCollectionFactory
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory
 import org.gradle.api.internal.file.DefaultFilePropertyFactory
@@ -62,12 +63,15 @@ import org.gradle.internal.model.CalculatedValueContainerFactory
 import org.gradle.internal.model.InMemoryCacheFactory
 import org.gradle.internal.model.StateTransitionControllerFactory
 import org.gradle.internal.operations.CurrentBuildOperationRef
+import org.gradle.internal.operations.DefaultBuildOperationsParameters
 import org.gradle.internal.operations.OperationIdentifier
+import org.gradle.internal.operations.TestBuildOperationRunner
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.Provides
 import org.gradle.internal.service.ServiceRegistration
 import org.gradle.internal.service.ServiceRegistrationProvider
 import org.gradle.internal.service.ServiceRegistry
+import org.gradle.internal.service.scopes.CrossBuildSessionParameters
 import org.gradle.internal.state.ManagedFactoryRegistry
 import org.gradle.internal.work.DefaultWorkerLimits
 import org.gradle.test.fixtures.file.TestDirectoryProvider
@@ -163,7 +167,8 @@ class TestUtil {
     }
 
     static StateTransitionControllerFactory stateTransitionControllerFactory() {
-        return new StateTransitionControllerFactory(new TestWorkerLeaseService())
+        def buildOperationsParameters = new DefaultBuildOperationsParameters(new CrossBuildSessionParameters(new StartParameterInternal()))
+        return new StateTransitionControllerFactory(new TestWorkerLeaseService(), new TestBuildOperationRunner(), buildOperationsParameters)
     }
 
     private static ServiceRegistry createServices(FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, Action<ServiceRegistration> registrations = {}) {

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -168,7 +168,7 @@ class TestUtil {
 
     static StateTransitionControllerFactory stateTransitionControllerFactory() {
         def buildOperationsParameters = new DefaultBuildOperationsParameters(new CrossBuildSessionParameters(new StartParameterInternal()))
-        return new StateTransitionControllerFactory(new TestWorkerLeaseService(), new TestBuildOperationRunner(), buildOperationsParameters)
+        return new StateTransitionControllerFactory(new TestWorkerLeaseService(), buildOperationsParameters, new TestBuildOperationRunner())
     }
 
     private static ServiceRegistry createServices(FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, Action<ServiceRegistration> registrations = {}) {


### PR DESCRIPTION
Introduces a new (opt-in) build operation that is recorded when some `Synchronizer` instance is used to run a piece of code. This happens, for instance, when a project is requested to be configured.

Given a potential performance impact and on-demand need for this build operation, it is made opt-it. For the purposes of future build operations introduced for troubleshooting a new internal flag is introduced:
```
-Dorg.gradle.internal.operations.verbose=true
```

Having this tool is relevant for Isolated Projects where more configuration time work can happen in parallel, resulting in the need to synchronize over access to things like Project state.