### PR TITLE
Let Isolated Projects configure project tree via traversal

### DIFF
--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/operations/BuildOperationExecutor.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/operations/BuildOperationExecutor.java
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.ThreadSafe;
 public interface BuildOperationExecutor {
     /**
      * Submits an arbitrary number of runnable operations, created synchronously by the scheduling action, to be executed in the global
-     * build operation thread pool. Operations may execute concurrently. Blocks until all operations are complete.
+     * build operation thread pool constrained to {@link BuildOperationConstraint#MAX_WORKERS}. Operations may execute concurrently. Blocks until all operations are complete.
      *
      * <p>Actions are not permitted to access any mutable project state. Generally, this is preferred.</p>
      */

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
@@ -228,11 +228,6 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
         }
 
         @Override
-        public int getTotalProjectCount() {
-            return projectsByPath.size();
-        }
-
-        @Override
         public void withMutableStateOfAllProjects(Runnable runnable) {
             withMutableStateOfAllProjects(Factories.toFactory(runnable));
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.project;
 
+import com.google.common.collect.Iterables;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
@@ -330,9 +331,23 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
         public Set<ProjectState> getChildProjects() {
             Set<ProjectState> children = new TreeSet<>(Comparator.comparing(ProjectState::getIdentityPath));
             for (DefaultProjectDescriptor child : descriptor.children()) {
-                children.add(projectsByPath.get(owner.calculateIdentityPathForProject(child.path())));
+                children.add(getStateForChild(child));
             }
             return children;
+        }
+
+        @Override
+        public Iterable<ProjectState> getUnorderedChildProjects() {
+            return Iterables.transform(descriptor.children(), this::getStateForChild);
+        }
+
+        @Override
+        public boolean hasChildren() {
+            return !descriptor.children().isEmpty();
+        }
+
+        private ProjectStateImpl getStateForChild(DefaultProjectDescriptor child) {
+            return projectsByPath.get(owner.calculateIdentityPathForProject(child.path()));
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
@@ -406,6 +406,15 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
         }
 
         @Override
+        public void ensureSelfConfigured() {
+            ProjectState parent = getBuildParent();
+            if (parent != null) {
+                ((ProjectStateImpl) parent).controller.assertConfigured();
+            }
+            controller.ensureSelfConfigured();
+        }
+
+        @Override
         public void ensureTasksDiscovered() {
             controller.ensureTasksDiscovered();
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
@@ -227,6 +227,11 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
         }
 
         @Override
+        public int getTotalProjectCount() {
+            return projectsByPath.size();
+        }
+
+        @Override
         public void withMutableStateOfAllProjects(Runnable runnable) {
             withMutableStateOfAllProjects(Factories.toFactory(runnable));
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectLifecycleController.java
@@ -56,6 +56,10 @@ public class ProjectLifecycleController implements Closeable {
         return project != null;
     }
 
+    public void assertConfigured() {
+        controller.assertInStateOrLater(State.Configured);
+    }
+
     public void createMutableModel(
         DefaultProjectDescriptor descriptor,
         BuildState build,

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
@@ -128,6 +128,13 @@ public interface ProjectState extends ModelContainer<ProjectInternal> {
     void ensureConfigured();
 
     /**
+     * Configures the mutable model for this project, if not already.
+     *
+     * @throws IllegalStateException when the parent of this model is not already configured.
+     */
+    void ensureSelfConfigured();
+
+    /**
      * Configure the mutable model for this project and discovers any registered tasks, if not already done.
      */
     void ensureTasksDiscovered();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
@@ -63,6 +63,18 @@ public interface ProjectState extends ModelContainer<ProjectInternal> {
     Set<ProjectState> getChildProjects();
 
     /**
+     * Returns the direct children of this project in no particular order.
+     */
+    Iterable<ProjectState> getUnorderedChildProjects();
+
+    /**
+     * Checks whether this project has child projects.
+     *
+     * @return true when this project has child projects.
+     */
+    boolean hasChildren();
+
+    /**
      * Returns the name of this project (which may not necessarily be unique).
      */
     String getName();

--- a/subprojects/core/src/main/java/org/gradle/execution/TaskPathProjectEvaluator.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/TaskPathProjectEvaluator.java
@@ -16,25 +16,53 @@
 
 package org.gradle.execution;
 
+import org.gradle.api.Action;
 import org.gradle.api.BuildCancelledException;
 import org.gradle.api.Project;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.internal.UncheckedException;
+import org.gradle.internal.buildoption.InternalOptions;
+import org.gradle.internal.buildoption.StringInternalOption;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.operations.MultipleBuildOperationFailures;
 import org.gradle.internal.operations.RunnableBuildOperation;
+import org.gradle.internal.work.WorkerLimits;
+
+import java.util.concurrent.LinkedBlockingQueue;
 
 public class TaskPathProjectEvaluator implements ProjectConfigurer {
+
+    /**
+     * Parallel project configuration scheduling strategy, one of:
+     * <ul>
+     * <li> {@code aot}: schedule all projects ahead-of-time and let them compete for resources;
+     * <li> {@code jit}: schedule children only after their parents have been configured (just-in-time);
+     * </ul>
+     * Default is {@code jit}.
+     */
+    private static final StringInternalOption PARALLEL_CONFIGURATION_SCHEDULER =
+        new StringInternalOption("org.gradle.internal.isolated-projects.scheduler", "jit");
+
     private final BuildCancellationToken cancellationToken;
     private final BuildOperationExecutor buildOperationExecutor;
+    private final WorkerLimits workerLimits;
+    private final InternalOptions internalOptions;
 
-    public TaskPathProjectEvaluator(BuildCancellationToken cancellationToken, BuildOperationExecutor buildOperationExecutor) {
+    public TaskPathProjectEvaluator(
+        BuildCancellationToken cancellationToken,
+        BuildOperationExecutor buildOperationExecutor,
+        WorkerLimits workerLimits,
+        InternalOptions internalOptions
+    ) {
         this.cancellationToken = cancellationToken;
         this.buildOperationExecutor = buildOperationExecutor;
+        this.workerLimits = workerLimits;
+        this.internalOptions = internalOptions;
     }
 
     @Override
@@ -61,27 +89,109 @@ public class TaskPathProjectEvaluator implements ProjectConfigurer {
 
     @Override
     public void configureHierarchyInParallel(ProjectInternal project) {
-        try {
-            buildOperationExecutor.runAllWithAccessToProjectState(queue -> {
-                for (Project p : project.getAllprojects()) {
-                    queue.add(new RunnableBuildOperation() {
-                        @Override
-                        public void run(BuildOperationContext context) {
-                            configure((ProjectInternal) p);
-                        }
+        assert project.getParent() == null : "Parallel configuration must start from root!";
 
-                        @Override
-                        public BuildOperationDescriptor.Builder description() {
-                            return BuildOperationDescriptor.displayName("Configure project " + p.getName());
-                        }
-                    });
+        if (maxWorkerCount() < 2) {
+            // We need at least two workers to configure in parallel
+            configureHierarchy(project);
+            return;
+        }
+
+        final ProjectState root = project.getOwner();
+        if (!root.hasChildren()) {
+            // No hierarchy to configure
+            root.ensureConfigured();
+            return;
+        }
+
+        String strategy = schedulingStrategy();
+        if (strategy.equals("jit")) {
+            scheduleProjectsJustInTime(root);
+        } else {
+            scheduleProjectsAheadOfTime(project);
+        }
+    }
+
+    private String schedulingStrategy() {
+        return internalOptions.getOption(PARALLEL_CONFIGURATION_SCHEDULER).get();
+    }
+
+    private void scheduleProjectsAheadOfTime(ProjectInternal root) {
+        runAllWithAccessToProjectState(queue -> {
+            for (Project p : root.getAllprojects()) {
+                queue.add(configureOperationFor(p));
+            }
+        });
+    }
+
+    private void scheduleProjectsJustInTime(ProjectState root) {
+        assert maxWorkerCount() > 1 : "Parallel traversal requires more than one worker!";
+        runAllWithAccessToProjectState(queue -> {
+
+            final LinkedBlockingQueue<ProjectState> readyQueue = new LinkedBlockingQueue<>();
+            queue.add(traverseProject(root, readyQueue));
+
+            int pending = 1;
+            while (pending > 0) {
+                ProjectState next;
+                try {
+                    next = readyQueue.take();
+                    --pending;
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
                 }
-            });
+                for (final ProjectState child : next.getUnorderedChildProjects()) {
+                    queue.add(traverseProject(child, readyQueue));
+                    ++pending;
+                }
+            }
+        });
+    }
+
+    private static RunnableBuildOperation traverseProject(ProjectState project, LinkedBlockingQueue<ProjectState> readyQueue) {
+        return new RunnableBuildOperation() {
+            @Override
+            public void run(BuildOperationContext context) {
+                try {
+                    project.ensureSelfConfigured();
+                } finally {
+                    readyQueue.add(project);
+                }
+            }
+
+            @Override
+            public BuildOperationDescriptor.Builder description() {
+                return BuildOperationDescriptor.displayName("Traverse project " + project.getName());
+            }
+        };
+    }
+
+    private void runAllWithAccessToProjectState(Action<BuildOperationQueue<RunnableBuildOperation>> buildOperationQueueAction) {
+        try {
+            buildOperationExecutor.runAllWithAccessToProjectState(buildOperationQueueAction);
         } catch (MultipleBuildOperationFailures e) {
             if (e.getCauses().size() == 1) {
                 throw UncheckedException.throwAsUncheckedException(e.getCauses().get(0));
             }
             throw e;
         }
+    }
+
+    private RunnableBuildOperation configureOperationFor(Project p) {
+        return new RunnableBuildOperation() {
+            @Override
+            public void run(BuildOperationContext context) {
+                configure((ProjectInternal) p);
+            }
+
+            @Override
+            public BuildOperationDescriptor.Builder description() {
+                return BuildOperationDescriptor.displayName("Configure project " + p.getName());
+            }
+        };
+    }
+
+    private int maxWorkerCount() {
+        return workerLimits.getMaxWorkerCount();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildProjectRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildProjectRegistry.java
@@ -36,11 +36,6 @@ public interface BuildProjectRegistry {
     Set<? extends ProjectState> getAllProjects();
 
     /**
-     * Returns the number of projects in this build.
-     */
-    int getTotalProjectCount();
-
-    /**
      * Locates a project of this build, failing if the project is not present.
      *
      * @param projectPath The path relative to the root project of this build.

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildProjectRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildProjectRegistry.java
@@ -36,6 +36,11 @@ public interface BuildProjectRegistry {
     Set<? extends ProjectState> getAllProjects();
 
     /**
+     * Returns the number of projects in this build.
+     */
+    int getTotalProjectCount();
+
+    /**
      * Locates a project of this build, failing if the project is not present.
      *
      * @param projectPath The path relative to the root project of this build.


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

This PR changes the way Gradle schedules the configuration of projects when _Isolated Projects_ is enabled.

Before, Gradle would schedule all projects to be configured at once, _ahead-of-time_. While simple, this strategy causes a lot of contention and waste as workers need to wait for parent projects to be configured before they can proceed with the configuration of children.

With these changes, Gradle will now traverse the project hierarchy ensuring parents are always configured before their children are scheduled for configuration.

The old strategy is kept for benchmarking purposes and can be enabled via `-Dorg.gradle.internal.isolated-projects.scheduler=aot`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
