### PR TITLE
Fix file-events native library loading on Linux

### DIFF
--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -73,7 +73,7 @@ dependencies {
         api(libs.eclipseSisuPlexus)     { version { strictly("0.3.5"); because("transitive dependency of Maven modules to process POM metadata") }}
         api(libs.errorProneAnnotations) { version { strictly("2.29.0") }}
         api(libs.fastutil)              { version { strictly("8.5.2") }}
-        api(libs.gradleFileEvents)      { version { strictly("0.2.5") }}
+        api(libs.gradleFileEvents)      { version { strictly("0.2.6") }}
         api(libs.gradleProfiler)        { version { strictly("0.21.0-alpha-4") }}
         api(libs.develocityTestAnnotation) { version { strictly("2.0.1") }}
         api(libs.gcs)                   { version { strictly("v1-rev20220705-1.32.1") }}


### PR DESCRIPTION
Since the `gradle-fileevents` library was introduced in place of the old `native-platform` `file-events` library in Gradle 8.12, we accidentally loaded the lib twice. Once from `$GUH/native` and another time from the system temp dir. The second load on Linux caused an exception if `/tmp` was mounted with `noexec`.

This is now fixed in https://github.com/gradle/gradle-fileevents/releases/tag/0.2.6, and we only load the library from `$GUH/native` now. (See https://github.com/gradle/gradle-fileevents/pull/29)

Fixes https://github.com/gradle/gradle/issues/31946

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
