### PR TITLE
Enable custom tag in build scans in build scans with remote executor in wrong state

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -27,3 +27,5 @@ develocity.internal.testdistribution.queryResponseTimeout=PT20S
 defaultPerformanceBaselines=8.13-commit-a6bf0de82e44
 #-----------------------------------------till here^
 systemProp.dependency.analysis.test.analysis=false
+# If enabled, the build scans is tagged with TD_REMOTE_EXECUTOR_ENQUEUED_IN_WRONG_STATE if a remote executor is trying to be enqueued in a wrong state
+systemProp.develocity.internal.testacceleration.enableCustomValues=true


### PR DESCRIPTION
This PR configure a system property which - when enabled - add a custom tag `TD_REMOTE_EXECUTOR_ENQUEUED_IN_WRONG_STATE` to build scans, if a remote executor is trying to be enqueued in a wrong state (example [here](https://ge.gradle.org/s/t4akw7t3umcqa/failure))

This PR should be merged after [this one](https://github.com/gradle/gradle/pull/32033) which updates the Develocity plugin.
