### PR TITLE
Split service build platform from task input

### DIFF
--- a/platforms/core-runtime/native/build.gradle.kts
+++ b/platforms/core-runtime/native/build.gradle.kts
@@ -22,12 +22,12 @@ dependencies {
     api(projects.serviceProvider)
     api(projects.stdlibJavaExtensions)
 
-    api(libs.inject)
     api(libs.jsr305)
     api(libs.nativePlatform)
 
     implementation(projects.serviceRegistryBuilder)
 
+    implementation(libs.inject)
     implementation(libs.gradleFileEvents)
     implementation(libs.slf4jApi)
     implementation(libs.guava)

--- a/platforms/core-runtime/native/src/main/java/org/gradle/platform/internal/DefaultBuildPlatform.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/platform/internal/DefaultBuildPlatform.java
@@ -16,66 +16,31 @@
 
 package org.gradle.platform.internal;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
-import net.rubygrapefruit.platform.SystemInfo;
-import org.gradle.api.GradleException;
 import org.gradle.platform.Architecture;
 import org.gradle.platform.BuildPlatform;
 import org.gradle.platform.OperatingSystem;
 
-import javax.inject.Inject;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.Objects;
 
 public class DefaultBuildPlatform implements BuildPlatform, Serializable {
 
-    private Supplier<Architecture> architecture;
-
-    private Supplier<OperatingSystem> operatingSystem;
-
-    @Inject
-    public DefaultBuildPlatform(final SystemInfo systemInfo, final org.gradle.internal.os.OperatingSystem operatingSystem) {
-        this.architecture = Suppliers.memoize(new Supplier<Architecture>() {
-            @Override
-            public Architecture get() {
-                return getArchitecture(systemInfo);
-            }
-        });
-        this.operatingSystem = Suppliers.memoize(new Supplier<OperatingSystem>() {
-            @Override
-            public OperatingSystem get() {
-                return getOperatingSystem(operatingSystem);
-            }
-        });
-    }
+    private final Architecture architecture;
+    private final OperatingSystem operatingSystem;
 
     public DefaultBuildPlatform(final Architecture architecture, final OperatingSystem operatingSystem) {
-        this.architecture = Suppliers.memoize(new Supplier<Architecture>() {
-            @Override
-            public Architecture get() {
-                return architecture;
-            }
-        });
-        this.operatingSystem = Suppliers.memoize(new Supplier<OperatingSystem>() {
-            @Override
-            public OperatingSystem get() {
-                return operatingSystem;
-            }
-        });
+        this.architecture = architecture;
+        this.operatingSystem = operatingSystem;
     }
 
     @Override
     public Architecture getArchitecture() {
-        return architecture.get();
+        return architecture;
     }
 
     @Override
     public OperatingSystem getOperatingSystem() {
-        return operatingSystem.get();
+        return operatingSystem;
     }
 
     @Override
@@ -93,58 +58,5 @@ public class DefaultBuildPlatform implements BuildPlatform, Serializable {
     @Override
     public int hashCode() {
         return Objects.hash(getArchitecture(), getOperatingSystem());
-    }
-
-    private static Architecture getArchitecture(SystemInfo systemInfo) {
-        SystemInfo.Architecture architecture = systemInfo.getArchitecture();
-        switch (architecture) {
-            case i386:
-                return Architecture.X86;
-            case amd64:
-                return Architecture.X86_64;
-            case aarch64:
-                return Architecture.AARCH64;
-        }
-        throw new GradleException("Unhandled system architecture: " + architecture);
-    }
-
-    public static OperatingSystem getOperatingSystem(org.gradle.internal.os.OperatingSystem operatingSystem) {
-        if (org.gradle.internal.os.OperatingSystem.LINUX == operatingSystem) {
-            return OperatingSystem.LINUX;
-        } else if (org.gradle.internal.os.OperatingSystem.UNIX == operatingSystem) {
-            return OperatingSystem.UNIX;
-        } else if (org.gradle.internal.os.OperatingSystem.WINDOWS == operatingSystem) {
-            return OperatingSystem.WINDOWS;
-        } else if (org.gradle.internal.os.OperatingSystem.MAC_OS == operatingSystem) {
-            return OperatingSystem.MAC_OS;
-        } else if (org.gradle.internal.os.OperatingSystem.SOLARIS == operatingSystem) {
-            return OperatingSystem.SOLARIS;
-        } else if (org.gradle.internal.os.OperatingSystem.FREE_BSD == operatingSystem) {
-            return OperatingSystem.FREE_BSD;
-        } else {
-            throw new GradleException("Unhandled operating system: " + operatingSystem.getName());
-        }
-    }
-
-    private void writeObject(ObjectOutputStream out) throws IOException {
-        out.writeObject(architecture.get());
-        out.writeObject(operatingSystem.get());
-    }
-
-    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
-        final Architecture architecture = (Architecture) in.readObject();
-        final OperatingSystem operatingSystem = (OperatingSystem) in.readObject();
-        this.architecture = Suppliers.memoize(new Supplier<Architecture>() {
-            @Override
-            public Architecture get() {
-                return architecture;
-            }
-        });
-        this.operatingSystem = Suppliers.memoize(new Supplier<OperatingSystem>() {
-            @Override
-            public OperatingSystem get() {
-                return operatingSystem;
-            }
-        });
     }
 }

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
@@ -49,13 +49,7 @@ class ServiceScopeValidatorWorkarounds {
 
         "org.gradle.nativeplatform.platform.internal.NativePlatforms",
         "org.gradle.nativeplatform.internal.NativePlatformResolver",
-        "org.gradle.nativeplatform.internal.DefaultTargetMachineFactory",
-
-        // Problematic with UpdateDaemonJvm task and CC, because marked as a service
-        // This is a data class, but declared as a service for ease of injection
-        // It also is becoming a task input for daemon toolchain
-        // Tried using Factory<BuildPlatform> and it would work but would require all consumers to declare they need the factory
-        "org.gradle.platform.BuildPlatform"
+        "org.gradle.nativeplatform.internal.DefaultTargetMachineFactory"
     ));
 
     public static boolean shouldSuppressValidation(Class<?> serviceType) {

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadIntegrationTest.groovy
@@ -20,7 +20,7 @@ import net.rubygrapefruit.platform.internal.DefaultSystemInfo
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.DocumentationUtils
 import org.gradle.internal.os.OperatingSystem
-import org.gradle.platform.internal.DefaultBuildPlatform
+import org.gradle.jvm.toolchain.internal.CurrentBuildPlatform
 
 import static org.gradle.integtests.fixtures.SuggestionsMessages.GET_HELP
 import static org.gradle.integtests.fixtures.SuggestionsMessages.INFO_DEBUG
@@ -154,7 +154,7 @@ class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec {
     }
 
     private def getFailureMessageBuildPlatform() {
-        def buildPlatform = new DefaultBuildPlatform(new DefaultSystemInfo(), OperatingSystem.current())
+        def buildPlatform = new CurrentBuildPlatform(new DefaultSystemInfo(), OperatingSystem.current())
         return "for ${buildPlatform.operatingSystem} on ${buildPlatform.architecture.toString().toLowerCase()}"
     }
 

--- a/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/internal/services/ToolchainsJvmServices.java
+++ b/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/internal/services/ToolchainsJvmServices.java
@@ -16,7 +16,6 @@
 
 package org.gradle.jvm.internal.services;
 
-import net.rubygrapefruit.platform.SystemInfo;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.temp.GradleUserHomeTemporaryFileProvider;
@@ -42,6 +41,7 @@ import org.gradle.internal.service.scopes.AbstractGradleModuleServices;
 import org.gradle.jvm.toolchain.JavaToolchainResolverRegistry;
 import org.gradle.jvm.toolchain.JvmToolchainManagement;
 import org.gradle.jvm.toolchain.internal.AsdfInstallationSupplier;
+import org.gradle.jvm.toolchain.internal.CurrentBuildPlatform;
 import org.gradle.jvm.toolchain.internal.DefaultJavaToolchainResolverRegistry;
 import org.gradle.jvm.toolchain.internal.DefaultJavaToolchainResolverService;
 import org.gradle.jvm.toolchain.internal.DefaultJavaToolchainService;
@@ -63,19 +63,12 @@ import org.gradle.jvm.toolchain.internal.WindowsInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.install.DefaultJavaToolchainProvisioningService;
 import org.gradle.jvm.toolchain.internal.install.DefaultJdkCacheDirectory;
 import org.gradle.jvm.toolchain.internal.install.SecureFileDownloader;
-import org.gradle.platform.BuildPlatform;
-import org.gradle.platform.internal.DefaultBuildPlatform;
 import org.gradle.process.internal.ClientExecHandleBuilderFactory;
 
 import java.util.List;
 
 public class ToolchainsJvmServices extends AbstractGradleModuleServices {
     protected static class BuildServices implements ServiceRegistrationProvider {
-
-        @Provides
-        protected BuildPlatform createBuildPlatform(ObjectFactory objectFactory, SystemInfo systemInfo, OperatingSystem operatingSystem) {
-            return objectFactory.newInstance(DefaultBuildPlatform.class, systemInfo, operatingSystem);
-        }
 
         @Provides
         protected JavaToolchainResolverRegistryInternal createJavaToolchainResolverRegistry(
@@ -117,6 +110,11 @@ public class ToolchainsJvmServices extends AbstractGradleModuleServices {
             registration.add(InstallationSupplier.class, OsXInstallationSupplier.class);
             registration.add(InstallationSupplier.class, WindowsInstallationSupplier.class);
         }
+    }
+
+    @Override
+    public void registerGlobalServices(ServiceRegistration registration) {
+        registration.add(CurrentBuildPlatform.class);
     }
 
     @Override

--- a/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/toolchain/internal/CurrentBuildPlatform.java
+++ b/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/toolchain/internal/CurrentBuildPlatform.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import net.rubygrapefruit.platform.SystemInfo;
+import org.gradle.api.GradleException;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+import org.gradle.platform.Architecture;
+import org.gradle.platform.BuildPlatform;
+import org.gradle.platform.BuildPlatformFactory;
+import org.gradle.platform.OperatingSystem;
+
+import javax.inject.Inject;
+
+/**
+ * Information about the machine host Gradle is running on.
+ */
+@ServiceScope(Scope.Global.class)
+public class CurrentBuildPlatform {
+
+    private final Supplier<Architecture> architecture;
+
+    private final OperatingSystem operatingSystem;
+
+    @Inject
+    public CurrentBuildPlatform(final SystemInfo systemInfo, final org.gradle.internal.os.OperatingSystem operatingSystem) {
+        this.architecture = Suppliers.memoize(() -> getArchitecture(systemInfo));
+        this.operatingSystem = getOperatingSystem(operatingSystem);
+    }
+
+    public OperatingSystem getOperatingSystem() {
+        return operatingSystem;
+    }
+
+    public Architecture getArchitecture() {
+        return architecture.get();
+    }
+
+    private static Architecture getArchitecture(SystemInfo systemInfo) {
+        SystemInfo.Architecture architecture = systemInfo.getArchitecture();
+        switch (architecture) {
+            case i386:
+                return Architecture.X86;
+            case amd64:
+                return Architecture.X86_64;
+            case aarch64:
+                return Architecture.AARCH64;
+        }
+        throw new GradleException("Unhandled system architecture: " + architecture);
+    }
+
+    public static OperatingSystem getOperatingSystem(org.gradle.internal.os.OperatingSystem operatingSystem) {
+        if (org.gradle.internal.os.OperatingSystem.LINUX == operatingSystem) {
+            return OperatingSystem.LINUX;
+        } else if (org.gradle.internal.os.OperatingSystem.UNIX == operatingSystem) {
+            return OperatingSystem.UNIX;
+        } else if (org.gradle.internal.os.OperatingSystem.WINDOWS == operatingSystem) {
+            return OperatingSystem.WINDOWS;
+        } else if (org.gradle.internal.os.OperatingSystem.MAC_OS == operatingSystem) {
+            return OperatingSystem.MAC_OS;
+        } else if (org.gradle.internal.os.OperatingSystem.SOLARIS == operatingSystem) {
+            return OperatingSystem.SOLARIS;
+        } else if (org.gradle.internal.os.OperatingSystem.FREE_BSD == operatingSystem) {
+            return OperatingSystem.FREE_BSD;
+        } else {
+            throw new GradleException("Unhandled operating system: " + operatingSystem.getName());
+        }
+    }
+
+    public BuildPlatform toBuildPlatform() {
+        return BuildPlatformFactory.of(getArchitecture(), getOperatingSystem());
+    }
+}

--- a/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
+++ b/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
@@ -36,7 +36,6 @@ import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
 import org.gradle.jvm.toolchain.internal.install.JavaToolchainProvisioningService;
-import org.gradle.platform.BuildPlatform;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -103,7 +102,7 @@ public class JavaToolchainQueryService {
     private final ConcurrentMap<ToolchainLookupKey, Object> matchingToolchains;
     private final CurrentJvmToolchainSpec fallbackToolchainSpec;
     private final File currentJavaHome;
-    private final BuildPlatform buildPlatform;
+    private final CurrentBuildPlatform currentBuildPlatform;
 
     @Inject
     public JavaToolchainQueryService(
@@ -112,9 +111,9 @@ public class JavaToolchainQueryService {
         FileFactory fileFactory,
         JavaToolchainProvisioningService provisioningService,
         ObjectFactory objectFactory,
-        BuildPlatform buildPlatform
+        CurrentBuildPlatform currentBuildPlatform
     ) {
-        this(registry, detector, fileFactory, provisioningService, objectFactory, Jvm.current().getJavaHome(), buildPlatform);
+        this(registry, detector, fileFactory, provisioningService, objectFactory, Jvm.current().getJavaHome(), currentBuildPlatform);
     }
 
     @VisibleForTesting
@@ -125,7 +124,7 @@ public class JavaToolchainQueryService {
         JavaToolchainProvisioningService provisioningService,
         ObjectFactory objectFactory,
         File currentJavaHome,
-        BuildPlatform buildPlatform
+        CurrentBuildPlatform currentBuildPlatform
     ) {
         this.registry = registry;
         this.detector = detector;
@@ -134,7 +133,7 @@ public class JavaToolchainQueryService {
         this.matchingToolchains = new ConcurrentHashMap<>();
         this.fallbackToolchainSpec = objectFactory.newInstance(CurrentJvmToolchainSpec.class);
         this.currentJavaHome = currentJavaHome;
-        this.buildPlatform = buildPlatform;
+        this.currentBuildPlatform = currentBuildPlatform;
     }
 
     public ProviderInternal<JavaToolchain> findMatchingToolchain(JavaToolchainSpec filter) {
@@ -224,7 +223,7 @@ public class JavaToolchainQueryService {
             // TODO: inform installation process of required capabilities, needs public API change
             installation = installService.tryInstall(spec);
         } catch (ToolchainDownloadFailedException e) {
-            throw new NoToolchainAvailableException(spec, buildPlatform, e);
+            throw new NoToolchainAvailableException(spec, currentBuildPlatform.toBuildPlatform(), e);
         }
 
         InstallationLocation downloadedInstallation = InstallationLocation.autoProvisioned(installation, "provisioned toolchain");

--- a/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/toolchain/internal/install/DefaultJavaToolchainProvisioningService.java
+++ b/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/toolchain/internal/install/DefaultJavaToolchainProvisioningService.java
@@ -33,12 +33,12 @@ import org.gradle.jvm.toolchain.JavaToolchainDownload;
 import org.gradle.jvm.toolchain.JavaToolchainResolver;
 import org.gradle.jvm.toolchain.JavaToolchainResolverRegistry;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
+import org.gradle.jvm.toolchain.internal.CurrentBuildPlatform;
 import org.gradle.jvm.toolchain.internal.DefaultJavaToolchainRequest;
 import org.gradle.jvm.toolchain.internal.JavaToolchainResolverRegistryInternal;
 import org.gradle.jvm.toolchain.internal.JdkCacheDirectory;
 import org.gradle.jvm.toolchain.internal.RealizedJavaToolchainRepository;
 import org.gradle.jvm.toolchain.internal.ToolchainDownloadFailedException;
-import org.gradle.platform.BuildPlatform;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,7 +75,7 @@ public class DefaultJavaToolchainProvisioningService implements JavaToolchainPro
     private final DefaultJdkCacheDirectory cacheDirProvider;
     private final Provider<Boolean> downloadEnabled;
     private final BuildOperationRunner buildOperationRunner;
-    private final BuildPlatform buildPlatform;
+    private final CurrentBuildPlatform currentBuildPlatform;
 
     @Inject
     public DefaultJavaToolchainProvisioningService(
@@ -84,14 +84,14 @@ public class DefaultJavaToolchainProvisioningService implements JavaToolchainPro
         JdkCacheDirectory cacheDirProvider,
         ProviderFactory factory,
         BuildOperationRunner executor,
-        BuildPlatform buildPlatform
+        CurrentBuildPlatform currentBuildPlatform
     ) {
         this.toolchainResolverRegistry = (JavaToolchainResolverRegistryInternal) toolchainResolverRegistry;
         this.downloader = downloader;
         this.cacheDirProvider = (DefaultJdkCacheDirectory)cacheDirProvider;
         this.downloadEnabled = factory.gradleProperty(AUTO_DOWNLOAD).map(Boolean::parseBoolean);
         this.buildOperationRunner = executor;
-        this.buildPlatform = buildPlatform;
+        this.currentBuildPlatform = currentBuildPlatform;
     }
 
     @Override
@@ -126,7 +126,7 @@ public class DefaultJavaToolchainProvisioningService implements JavaToolchainPro
             JavaToolchainResolver resolver = repository.getResolver();
             Optional<JavaToolchainDownload> download;
             try {
-                download = resolver.resolve(new DefaultJavaToolchainRequest(spec, buildPlatform));
+                download = resolver.resolve(new DefaultJavaToolchainRequest(spec, currentBuildPlatform.toBuildPlatform()));
             } catch (Exception e) {
                 downloadFailureTracker.addResolveFailure(repository.getRepositoryName(), e);
                 continue;

--- a/platforms/jvm/toolchains-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/DefaultJavaToolchainProvisioningServiceTest.groovy
+++ b/platforms/jvm/toolchains-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/DefaultJavaToolchainProvisioningServiceTest.groovy
@@ -29,13 +29,13 @@ import org.gradle.jvm.toolchain.JavaToolchainDownload
 import org.gradle.jvm.toolchain.JavaToolchainRequest
 import org.gradle.jvm.toolchain.JavaToolchainResolver
 import org.gradle.jvm.toolchain.JavaToolchainSpec
+import org.gradle.jvm.toolchain.internal.CurrentBuildPlatform
 import org.gradle.jvm.toolchain.internal.JavaToolchainResolverRegistryInternal
 import org.gradle.jvm.toolchain.internal.RealizedJavaToolchainRepository
 import org.gradle.jvm.toolchain.internal.ToolchainDownloadFailedException
 import org.gradle.jvm.toolchain.internal.install.DefaultJavaToolchainProvisioningService
 import org.gradle.jvm.toolchain.internal.install.DefaultJdkCacheDirectory
 import org.gradle.jvm.toolchain.internal.install.SecureFileDownloader
-import org.gradle.platform.BuildPlatform
 import spock.lang.Specification
 import spock.lang.TempDir
 
@@ -55,7 +55,7 @@ class DefaultJavaToolchainProvisioningServiceTest extends Specification {
     def downloader = Mock(SecureFileDownloader)
     def cache = Mock(DefaultJdkCacheDirectory)
     def archiveFileLock = Mock(FileLock)
-    def buildPlatform = Mock(BuildPlatform)
+    def buildPlatform = Mock(CurrentBuildPlatform)
     def buildOperationRunner = new TestBuildOperationRunner()
 
     def setup() {

--- a/platforms/jvm/toolchains-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
+++ b/platforms/jvm/toolchains-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.jvm.toolchain.internal
 
+import net.rubygrapefruit.platform.SystemInfo
 import org.gradle.api.GradleException
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.internal.jvm.Jvm
@@ -25,13 +26,12 @@ import org.gradle.internal.jvm.inspection.JvmInstallationMetadata
 import org.gradle.internal.jvm.inspection.JvmMetadataDetector
 import org.gradle.internal.jvm.inspection.JvmToolchainMetadata
 import org.gradle.internal.jvm.inspection.JvmVendor
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JavaToolchainSpec
 import org.gradle.jvm.toolchain.JvmImplementation
 import org.gradle.jvm.toolchain.JvmVendorSpec
 import org.gradle.jvm.toolchain.internal.install.JavaToolchainProvisioningService
-import org.gradle.platform.Architecture
-import org.gradle.platform.BuildPlatform
 import org.gradle.util.TestUtil
 import spock.lang.Issue
 import spock.lang.Specification
@@ -549,17 +549,9 @@ class JavaToolchainQueryServiceTest extends Specification {
         JavaToolchainProvisioningService provisioningService,
         File currentJavaHome = Jvm.current().getJavaHome()
     ) {
-        def buildPlatform = new BuildPlatform() {
-            @Override
-            org.gradle.platform.OperatingSystem getOperatingSystem() {
-                return org.gradle.platform.OperatingSystem.LINUX
-            }
-
-            @Override
-            Architecture getArchitecture() {
-                return Architecture.X86_64
-            }
-        }
+        def systemInfo = Mock(SystemInfo)
+        systemInfo.getArchitecture() >> SystemInfo.Architecture.amd64
+        def buildPlatform = new CurrentBuildPlatform(systemInfo, OperatingSystem.LINUX)
         new JavaToolchainQueryService(registry, detector, TestFiles.fileFactory(), provisioningService, TestUtil.objectFactory(), currentJavaHome, buildPlatform)
     }
 }

--- a/testing/internal-integ-testing/build.gradle.kts
+++ b/testing/internal-integ-testing/build.gradle.kts
@@ -94,6 +94,7 @@ dependencies {
     implementation(projects.fileTemp)
     implementation(projects.instrumentationAgentServices)
     implementation(projects.io)
+    implementation(projects.toolchainsJvm)
     implementation(projects.messaging)
     implementation(projects.modelCore)
     implementation(projects.serialization)

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/PlatformInOutputNormalizer.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/PlatformInOutputNormalizer.groovy
@@ -18,14 +18,14 @@ package org.gradle.integtests.fixtures.logging
 import org.gradle.exemplar.executor.ExecutionMetadata
 import org.gradle.exemplar.test.normalizer.OutputNormalizer
 import org.gradle.internal.os.OperatingSystem
-import org.gradle.platform.internal.DefaultBuildPlatform
+import org.gradle.jvm.toolchain.internal.CurrentBuildPlatform;
 
 /**
  * This normalizer converts toolchain error message so it doesn't contain platform-specific information.
  */
 class PlatformInOutputNormalizer implements OutputNormalizer {
     def static internalOs = OperatingSystem.current()
-    def static os = DefaultBuildPlatform.getOperatingSystem(internalOs)
+    def static os = CurrentBuildPlatform.getOperatingSystem(internalOs)
     def static arch = getArchitectureString()
 
     private static getArchitectureString() {


### PR DESCRIPTION
This also simplifies the two implementations. We keep using the task input type for the whole chain of toolchains related calls.