### PR TITLE
Deprecate Configuration.getTaskDependencyFromProjectDependency

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -107,6 +107,12 @@ container.attributeProvider(firstAttribute, project.getProviders().provider(() -
 }));
 ----
 
+==== Deprecate Configuration#getTaskDependencyFromProjectDependency(boolean, String)
+
+The Configuration#getTaskDependencyFromProjectDependency(boolean, String) method has been deprecated and will be removed in Gradle 10.0.
+This method has been deprecated without replacement.
+This method is inherently Isolated Projects incompatible.
+
 [[changes_8.12]]
 == Upgrading from 8.11 and earlier
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationBuildDependenciesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationBuildDependenciesIntegrationTest.groovy
@@ -399,6 +399,20 @@ class ConfigurationBuildDependenciesIntegrationTest extends AbstractHttpDependen
         executed ":child:jar", ":useCompileConfiguration"
     }
 
+    def "getTaskDependencyFromProjectDependency is deprecated"() {
+        given:
+        buildFile << """
+            configurations.compile.getTaskDependencyFromProjectDependency($useDependsOn, "build")
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("The Configuration.getTaskDependencyFromProjectDependency(boolean, String) method has been deprecated. This is scheduled to be removed in Gradle 10.0. This method has been removed without replacement. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_10.html#deprecate_getTaskDependencyFromProjectDependency")
+        succeeds("help")
+
+        where:
+        useDependsOn << [true, false]
+    }
+
     void makeFluid(boolean fluid) {
         if (fluid) {
             buildFile << """

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -943,6 +943,12 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
      */
     @Override
     public TaskDependency getTaskDependencyFromProjectDependency(final boolean useDependedOn, final String taskName) {
+        DeprecationLogger.deprecateMethod(Configuration.class, "getTaskDependencyFromProjectDependency(boolean, String)")
+            .withContext("This method has been removed without replacement.")
+            .willBeRemovedInGradle10()
+            .withUpgradeGuideSection(10, "deprecate_getTaskDependencyFromProjectDependency")
+            .nagUser();
+
         if (useDependedOn) {
             return new TasksFromProjectDependencies(taskName, () -> {
                 return getAllDependencies().withType(ProjectDependency.class);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/TasksFromDependentProjects.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/TasksFromDependentProjects.java
@@ -30,7 +30,7 @@ import org.gradle.util.Path;
 import javax.annotation.Nullable;
 import java.util.Set;
 
-class TasksFromDependentProjects implements TaskDependencyContainerInternal {
+public class TasksFromDependentProjects implements TaskDependencyContainerInternal {
 
     private final String taskName;
     private final String configurationName;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/TasksFromProjectDependencies.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/TasksFromProjectDependencies.java
@@ -30,7 +30,7 @@ import javax.annotation.Nullable;
 import java.util.Set;
 import java.util.function.Supplier;
 
-class TasksFromProjectDependencies implements TaskDependencyContainerInternal {
+public class TasksFromProjectDependencies implements TaskDependencyContainerInternal {
     private final TaskDependencyContainerInternal taskDependencyDelegate;
 
     public TasksFromProjectDependencies(

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinMultiplatformPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinMultiplatformPluginSmokeTest.groovy
@@ -39,7 +39,9 @@ class KotlinMultiplatformPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
         replaceCssSupportBlocksInBuildFile(kotlinVersionNumber)
 
         when:
-        def result = kgpRunner(false, kotlinVersionNumber, ':tasks').build()
+        def result = kgpRunner(false, kotlinVersionNumber, ':tasks')
+            .expectLegacyDeprecationWarning("The Configuration.getTaskDependencyFromProjectDependency(boolean, String) method has been deprecated. This is scheduled to be removed in Gradle 10.0. This method has been removed without replacement. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_10.html#deprecate_getTaskDependencyFromProjectDependency")
+            .build()
 
         then:
         result.task(':tasks').outcome == SUCCESS
@@ -109,7 +111,9 @@ class KotlinMultiplatformPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
         def kotlinVersionNumber = VersionNumber.parse(kotlinVersion)
 
         when:
-        def result = kgpRunner(false, kotlinVersionNumber, ':tasks').build()
+        def result = kgpRunner(false, kotlinVersionNumber, ':tasks')
+            .expectLegacyDeprecationWarning("The Configuration.getTaskDependencyFromProjectDependency(boolean, String) method has been deprecated. This is scheduled to be removed in Gradle 10.0. This method has been removed without replacement. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_10.html#deprecate_getTaskDependencyFromProjectDependency")
+            .build()
 
         then:
         result.task(':tasks').outcome == SUCCESS


### PR DESCRIPTION
This method is by nature IP incompatible. We should not expose methods like this in the API

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
