### PR TITLE
Remove ProjectDependencyInternal.getIdentityPath

### DIFF
--- a/platforms/jvm/language-jvm/src/test/groovy/org/gradle/api/plugins/jvm/internal/TestFixturesDependencyModifiersTest.groovy
+++ b/platforms/jvm/language-jvm/src/test/groovy/org/gradle/api/plugins/jvm/internal/TestFixturesDependencyModifiersTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDepen
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependency
 import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory
 import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.internal.tasks.DefaultTaskDependencyFactory
 import org.gradle.api.plugins.jvm.TestFixturesDependencyModifiers
 import org.gradle.util.TestUtil
 import spock.lang.Specification
@@ -49,7 +50,7 @@ class TestFixturesDependencyModifiersTest extends Specification {
             name >> "name"
             version >> "1.0"
         }
-        def dependency = new DefaultProjectDependency(projectInternal, false)
+        def dependency = new DefaultProjectDependency(projectInternal, false, DefaultTaskDependencyFactory.withNoAssociatedProject())
         dependency.setCapabilityNotationParser(new CapabilityNotationParserFactory(true).create())
         dependency.setObjectFactory(TestUtil.objectFactory())
 
@@ -84,7 +85,7 @@ class TestFixturesDependencyModifiersTest extends Specification {
             name >> "name"
             version >> "1.0"
         }
-        def dependency = new DefaultProjectDependency(projectInternal, false)
+        def dependency = new DefaultProjectDependency(projectInternal, false, DefaultTaskDependencyFactory.withNoAssociatedProject())
         dependency.setCapabilityNotationParser(new CapabilityNotationParserFactory(true).create())
         dependency.setObjectFactory(TestUtil.objectFactory())
 

--- a/platforms/native/language-native/src/main/java/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPlugin.java
+++ b/platforms/native/language-native/src/main/java/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPlugin.java
@@ -204,7 +204,7 @@ public abstract class SwiftPackageManagerExportPlugin implements Plugin<Project>
             for (org.gradle.api.artifacts.Dependency dependency : configuration.getAllDependencies()) {
                 if (dependency instanceof ProjectDependency) {
                     ProjectDependency projectDependency = (ProjectDependency) dependency;
-                    Path identityPath = ((ProjectDependencyInternal) projectDependency).getIdentityPath();
+                    Path identityPath = ((ProjectDependencyInternal) projectDependency).getTargetProjectIdentity().getBuildTreePath();
                     SwiftPmTarget identifier = publicationResolver.resolveComponent(SwiftPmTarget.class, identityPath);
                     target.getRequiredTargets().add(identifier.getTargetName());
                 } else if (dependency instanceof ExternalModuleDependency) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectDependencyFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectDependencyFactory.java
@@ -21,7 +21,6 @@ import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependency;
 import org.gradle.api.internal.attributes.AttributesFactory;
-import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
@@ -57,12 +56,6 @@ public class DefaultProjectDependencyFactory {
         this.attributesFactory = attributesFactory;
         this.taskDependencyFactory = taskDependencyFactory;
         this.projectStateRegistry = projectStateRegistry;
-    }
-
-    public ProjectDependency create(ProjectInternal project, String configuration) {
-        DefaultProjectDependency projectDependency = instantiator.newInstance(DefaultProjectDependency.class, project, configuration, buildProjectDependencies, taskDependencyFactory);
-        injectServices(projectDependency);
-        return projectDependency;
     }
 
     public ProjectDependency create(Project project) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/TasksFromDependentProjects.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/TasksFromDependentProjects.java
@@ -87,7 +87,7 @@ class TasksFromDependentProjects implements TaskDependencyContainerInternal {
         private static boolean doesConfigurationDependOnProject(Configuration configuration, Path identityPath) {
             Set<ProjectDependency> projectDependencies = configuration.getAllDependencies().withType(ProjectDependency.class);
             for (ProjectDependency projectDependency : projectDependencies) {
-                Path dependencyIdentityPath = ((ProjectDependencyInternal) projectDependency).getIdentityPath();
+                Path dependencyIdentityPath = ((ProjectDependencyInternal) projectDependency).getTargetProjectIdentity().getBuildTreePath();
                 if (dependencyIdentityPath.equals(identityPath)) {
                     return true;
                 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/TasksFromProjectDependencies.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/TasksFromProjectDependencies.java
@@ -56,7 +56,7 @@ class TasksFromProjectDependencies implements TaskDependencyContainerInternal {
         String taskName
     ) {
         for (ProjectDependency projectDependency : projectDependencies) {
-            Path identityPath = ((ProjectDependencyInternal) projectDependency).getIdentityPath();
+            Path identityPath = ((ProjectDependencyInternal) projectDependency).getTargetProjectIdentity().getBuildTreePath();
             ProjectState projectState = projectStateRegistry.stateFor(identityPath);
             projectState.ensureTasksDiscovered();
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractExternalModuleDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractExternalModuleDependency.java
@@ -42,21 +42,25 @@ public abstract class AbstractExternalModuleDependency extends AbstractModuleDep
     private final DefaultMutableVersionConstraint versionConstraint;
 
     public AbstractExternalModuleDependency(ModuleIdentifier module, String version, @Nullable String configuration) {
-        super(configuration);
         if (module == null) {
             throw new InvalidUserDataException("Module must not be null!");
         }
         this.moduleIdentifier = module;
         this.versionConstraint = new DefaultMutableVersionConstraint(version);
+        if (configuration != null) {
+            setTargetConfiguration(configuration);
+        }
     }
 
     public AbstractExternalModuleDependency(ModuleIdentifier module, MutableVersionConstraint version, @Nullable String configuration) {
-        super(configuration);
         if (module == null) {
             throw new InvalidUserDataException("Module must not be null!");
         }
         this.moduleIdentifier = module;
         this.versionConstraint = (DefaultMutableVersionConstraint) version;
+        if (configuration != null) {
+            setTargetConfiguration(configuration);
+        }
     }
 
     protected void copyTo(AbstractExternalModuleDependency target) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -38,7 +38,6 @@ import org.gradle.internal.component.resolution.failure.exception.VariantSelecti
 import org.gradle.internal.component.resolution.failure.type.ConfigurationNotConsumableFailure;
 import org.gradle.internal.deprecation.DeprecatableConfiguration;
 import org.gradle.internal.deprecation.DeprecationLogger;
-import org.gradle.util.Path;
 import org.gradle.util.internal.GUtil;
 
 import javax.annotation.Nullable;
@@ -100,11 +99,6 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
     }
 
     @Override
-    public Path getIdentityPath() {
-        return dependencyProject.getIdentityPath();
-    }
-
-    @Override
     public ProjectIdentity getTargetProjectIdentity() {
         return dependencyProject.getOwner().getIdentity();
     }
@@ -159,7 +153,7 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
     @Deprecated
     public Set<File> resolve(boolean transitive) {
 
-        DeprecationLogger.deprecate("Directly resolving the files of project dependency '" + getIdentityPath() + "'")
+        DeprecationLogger.deprecate("Directly resolving the files of project dependency '" + getTargetProjectIdentity().getBuildTreePath() + "'")
             .withAdvice("Add the dependency to a resolvable configuration and resolve the configuration.")
             .willBecomeAnErrorInGradle9()
             .withUpgradeGuideSection(8, "deprecate_self_resolving_dependency")
@@ -191,7 +185,7 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
     @Deprecated
     public TaskDependencyInternal getBuildDependencies() {
 
-        DeprecationLogger.deprecate("Accessing the build dependencies of project dependency '" + getIdentityPath() + "'")
+        DeprecationLogger.deprecate("Accessing the build dependencies of project dependency '" + getTargetProjectIdentity().getBuildTreePath() + "'")
             .withAdvice("Add the dependency to a resolvable configuration and use the configuration to track task dependencies.")
             .willBecomeAnErrorInGradle9()
             .withUpgradeGuideSection(8, "deprecate_self_resolving_dependency")
@@ -246,7 +240,7 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
             return false;
         }
 
-        return getIdentityPath().equals(that.getIdentityPath());
+        return getTargetProjectIdentity().equals(that.getTargetProjectIdentity());
     }
 
     @Override
@@ -259,7 +253,7 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
         }
 
         DefaultProjectDependency that = (DefaultProjectDependency) o;
-        if (!this.getIdentityPath().equals(that.getIdentityPath())) {
+        if (!this.getTargetProjectIdentity().equals(that.getTargetProjectIdentity())) {
             return false;
         }
         if (getTargetConfiguration() != null ? !this.getTargetConfiguration().equals(that.getTargetConfiguration())
@@ -280,7 +274,7 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
 
     @Override
     public int hashCode() {
-        int hashCode = getIdentityPath().hashCode();
+        int hashCode = getTargetProjectIdentity().hashCode();
         if (getTargetConfiguration() != null) {
             hashCode = 31 * hashCode + getTargetConfiguration().hashCode();
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -30,7 +30,6 @@ import org.gradle.api.internal.artifacts.capability.FeatureCapabilitySelector;
 import org.gradle.api.internal.artifacts.capability.SpecificCapabilitySelector;
 import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.internal.tasks.DefaultTaskDependencyFactory;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.internal.tasks.TaskDependencyInternal;
 import org.gradle.internal.component.external.model.ProjectDerivedCapability;
@@ -40,7 +39,6 @@ import org.gradle.internal.deprecation.DeprecatableConfiguration;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.util.internal.GUtil;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
@@ -51,17 +49,7 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
     private final boolean buildProjectDependencies;
     private final TaskDependencyFactory taskDependencyFactory;
 
-    @SuppressWarnings("unused") // Called reflectively by instantiator
     public DefaultProjectDependency(ProjectInternal dependencyProject, boolean buildProjectDependencies, TaskDependencyFactory taskDependencyFactory) {
-        this(dependencyProject, null, buildProjectDependencies, taskDependencyFactory);
-    }
-
-    public DefaultProjectDependency(ProjectInternal dependencyProject, boolean buildProjectDependencies) {
-        this(dependencyProject, null, buildProjectDependencies, DefaultTaskDependencyFactory.withNoAssociatedProject());
-    }
-
-    public DefaultProjectDependency(ProjectInternal dependencyProject, @Nullable String configuration, boolean buildProjectDependencies, TaskDependencyFactory taskDependencyFactory) {
-        super(configuration);
         this.dependencyProject = dependencyProject;
         this.buildProjectDependencies = buildProjectDependencies;
         this.taskDependencyFactory = taskDependencyFactory;
@@ -138,7 +126,7 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
 
     @Override
     public ProjectDependency copy() {
-        DefaultProjectDependency copiedProjectDependency = new DefaultProjectDependency(dependencyProject, getTargetConfiguration(), buildProjectDependencies, taskDependencyFactory);
+        DefaultProjectDependency copiedProjectDependency = new DefaultProjectDependency(dependencyProject, buildProjectDependencies, taskDependencyFactory);
         copyTo(copiedProjectDependency);
         return copiedProjectDependency;
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DelegatingProjectDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DelegatingProjectDependency.java
@@ -30,7 +30,6 @@ import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.dependencies.ProjectDependencyInternal;
 import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.api.tasks.TaskDependency;
-import org.gradle.util.Path;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -54,11 +53,6 @@ public class DelegatingProjectDependency implements ProjectDependencyInternal {
 
     protected TypeSafeProjectDependencyFactory getFactory() {
         return factory;
-    }
-
-    @Override
-    public Path getIdentityPath() {
-        return delegate.getIdentityPath();
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/ProjectDependencyFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/ProjectDependencyFactory.java
@@ -52,7 +52,11 @@ public class ProjectDependencyFactory {
             @MapKey("path") String path,
             @MapKey("configuration") @Nullable String configuration
         ) {
-            return factory.create(projectFinder.getProject(path), configuration);
+            ProjectDependency defaultProjectDependency = factory.create(projectFinder.getProject(path));
+            if (configuration != null) {
+                defaultProjectDependency.setTargetConfiguration(configuration);
+            }
+            return defaultProjectDependency;
         }
 
         @Override

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/TasksFromProjectDependenciesTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/TasksFromProjectDependenciesTest.groovy
@@ -17,9 +17,11 @@
 
 package org.gradle.api.internal.artifacts.configurations
 
+import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.artifacts.dependencies.ProjectDependencyInternal
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectState
 import org.gradle.api.internal.project.ProjectStateRegistry
@@ -38,10 +40,12 @@ class TasksFromProjectDependenciesTest extends AbstractProjectBuilderSpec {
     def project2State = Mock(ProjectState)
     def project1 = Mock(ProjectInternal)
     def project2 = Mock(ProjectInternal)
-    def projectId1 = Path.path("project1")
-    def projectId2 = Path.path("project2")
-    def projectDep1 = Mock(ProjectDependencyInternal) { getIdentityPath() >> projectId1 }
-    def projectDep2 = Mock(ProjectDependencyInternal) { getIdentityPath() >> projectId2 }
+    def projectPath1 = Path.path("project1")
+    def projectPath2 = Path.path("project2")
+    def projectId1 = new ProjectIdentity(Mock(BuildIdentifier), projectPath1, projectPath1, "project1")
+    def projectId2 = new ProjectIdentity(Mock(BuildIdentifier), projectPath2, projectPath2, "project2")
+    def projectDep1 = Mock(ProjectDependencyInternal) { getTargetProjectIdentity() >> projectId1 }
+    def projectDep2 = Mock(ProjectDependencyInternal) { getTargetProjectIdentity() >> projectId2 }
     def tasks1 = Mock(TaskContainerInternal)
     def tasks2 = Mock(TaskContainerInternal)
     ProjectStateRegistry projectStateRegistry
@@ -52,8 +56,8 @@ class TasksFromProjectDependenciesTest extends AbstractProjectBuilderSpec {
         _ * project1State.getMutableModel() >> project1
         _ * project2State.getMutableModel() >> project2
         projectStateRegistry = Mock(ProjectStateRegistry) {
-            stateFor(projectId1) >> project1State
-            stateFor(projectId2) >> project2State
+            stateFor(projectPath1) >> project1State
+            stateFor(projectPath2) >> project2State
         }
     }
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
@@ -363,9 +363,9 @@ class DefaultDependencyHandlerTest extends Specification {
     }
 
     void "local platform dependencies are endorsing"() {
-        ModuleDependency dep1 = new DefaultProjectDependency(null, null, false, TestFiles.taskDependencyFactory())
+        ModuleDependency dep1 = new DefaultProjectDependency(null, false, TestFiles.taskDependencyFactory())
         dep1.attributesFactory = AttributeTestUtil.attributesFactory()
-        ModuleDependency dep2 = new DefaultProjectDependency(null, null, false, TestFiles.taskDependencyFactory())
+        ModuleDependency dep2 = new DefaultProjectDependency(null, false, TestFiles.taskDependencyFactory())
         dep2.attributesFactory = AttributeTestUtil.attributesFactory()
 
         when:
@@ -399,7 +399,7 @@ class DefaultDependencyHandlerTest extends Specification {
     }
 
     void "local platform dependency can be made non-endorsing"() {
-        ModuleDependency dep1 = new DefaultProjectDependency(null, null, false, TestFiles.taskDependencyFactory())
+        ModuleDependency dep1 = new DefaultProjectDependency(null, false, TestFiles.taskDependencyFactory())
         dep1.attributesFactory = AttributeTestUtil.attributesFactory()
 
         when:

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyMetadataConverterTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyMetadataConverterTest.groovy
@@ -69,6 +69,9 @@ class ProjectDependencyMetadataConverterTest extends AbstractDependencyDescripto
         if (dependencyConfiguration != null) {
             dependencyProject.configurations.create(dependencyConfiguration)
         }
-        return new DefaultProjectDependency(dependencyProject, dependencyConfiguration, true, DefaultTaskDependencyFactory.withNoAssociatedProject())
+
+        def dependency = new DefaultProjectDependency(dependencyProject, true, DefaultTaskDependencyFactory.withNoAssociatedProject())
+        dependency.setTargetConfiguration(dependencyConfiguration)
+        return dependency
     }
 }

--- a/platforms/software/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/platforms/software/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.ivy.internal.publication
 
 import org.gradle.api.InvalidUserDataException
-import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.DependencyArtifact
 import org.gradle.api.artifacts.ExcludeRule
@@ -25,6 +24,7 @@ import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.PublishArtifact
+import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.component.ComponentWithVariants
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
@@ -35,11 +35,12 @@ import org.gradle.api.internal.artifacts.dependencies.ProjectDependencyInternal
 import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver
 import org.gradle.api.internal.attributes.AttributeDesugaring
+import org.gradle.api.internal.attributes.AttributesFactory
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.ImmutableAttributes
-import org.gradle.api.internal.attributes.AttributesFactory
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.component.UsageContext
+import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.publish.internal.mapping.DefaultDependencyCoordinateResolverFactory
 import org.gradle.api.publish.internal.versionmapping.VariantVersionMappingStrategyInternal
@@ -171,14 +172,15 @@ class DefaultIvyPublicationTest extends Specification {
     def "maps project dependency to ivy dependency"() {
         given:
         def publication = createPublication()
+        def buildTreePath = Mock(Path)
+        def projectIdentity = new ProjectIdentity(Mock(BuildIdentifier), buildTreePath, buildTreePath, "foo")
         def projectDependency = Mock(ProjectDependencyInternal) {
-            getDependencyProject() >> Mock(Project)
-            getIdentityPath() >> Stub(Path)
+            getTargetProjectIdentity() >> projectIdentity
         }
         def exclude = Mock(ExcludeRule)
 
         and:
-        projectDependencyResolver.resolveComponent(ModuleVersionIdentifier, projectDependency.identityPath) >> DefaultModuleVersionIdentifier.newId("pub-org", "pub-module", "pub-revision")
+        projectDependencyResolver.resolveComponent(ModuleVersionIdentifier, buildTreePath) >> DefaultModuleVersionIdentifier.newId("pub-org", "pub-module", "pub-revision")
         projectDependency.targetConfiguration >> "dep-configuration"
         projectDependency.artifacts >> []
         projectDependency.excludeRules >> [exclude]

--- a/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/mapping/DefaultDependencyCoordinateResolverFactory.java
+++ b/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/mapping/DefaultDependencyCoordinateResolverFactory.java
@@ -192,7 +192,7 @@ public class DefaultDependencyCoordinateResolverFactory implements DependencyCoo
 
         @Override
         public ResolvedCoordinates resolveComponentCoordinates(ProjectDependency dependency) {
-            Path identityPath = ((ProjectDependencyInternal) dependency).getIdentityPath();
+            Path identityPath = ((ProjectDependencyInternal) dependency).getTargetProjectIdentity().getBuildTreePath();
             return ResolvedCoordinates.create(projectDependencyResolver.resolveComponent(ModuleVersionIdentifier.class, identityPath));
         }
 

--- a/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/mapping/ResolutionBackedPublicationDependencyResolver.java
+++ b/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/mapping/ResolutionBackedPublicationDependencyResolver.java
@@ -284,7 +284,7 @@ public class ResolutionBackedPublicationDependencyResolver implements VariantDep
 
     @Override
     public ResolvedCoordinates resolveVariantCoordinates(ProjectDependency dependency, VariantWarningCollector warnings) {
-        Path identityPath = ((ProjectDependencyInternal) dependency).getIdentityPath();
+        Path identityPath = ((ProjectDependencyInternal) dependency).getTargetProjectIdentity().getBuildTreePath();
         ProjectDependencyKey key = new ProjectDependencyKey(identityPath, ModuleDependencyDetails.from(dependency, attributeDesugaring));
 
         ModuleVersionIdentifier resolved = mappings.resolvedProjectVariants.get(key);
@@ -321,7 +321,7 @@ public class ResolutionBackedPublicationDependencyResolver implements VariantDep
 
     @Override
     public ResolvedCoordinates resolveComponentCoordinates(ProjectDependency dependency) {
-        Path identityPath = ((ProjectDependencyInternal) dependency).getIdentityPath();
+        Path identityPath = ((ProjectDependencyInternal) dependency).getTargetProjectIdentity().getBuildTreePath();
         ModuleVersionIdentifier resolved = mappings.resolvedProjectComponents.get(identityPath);
         if (resolved != null) {
             return ResolvedCoordinates.create(resolved);

--- a/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/mapping/VersionMappingComponentDependencyResolver.java
+++ b/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/mapping/VersionMappingComponentDependencyResolver.java
@@ -68,7 +68,7 @@ public class VersionMappingComponentDependencyResolver implements ComponentDepen
 
     @Override
     public ResolvedCoordinates resolveComponentCoordinates(ProjectDependency dependency) {
-        Path identityPath = ((ProjectDependencyInternal) dependency).getIdentityPath();
+        Path identityPath = ((ProjectDependencyInternal) dependency).getTargetProjectIdentity().getBuildTreePath();
         ModuleVersionIdentifier coordinates = projectDependencyResolver.resolveComponent(ModuleVersionIdentifier.class, identityPath);
         ModuleVersionIdentifier resolved = maybeResolveVersion(coordinates.getGroup(), coordinates.getName(), identityPath);
         return ResolvedCoordinates.create(resolved != null ? resolved : coordinates);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
@@ -62,10 +62,6 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
     private boolean transitive = true;
     private boolean endorsing;
 
-    protected AbstractModuleDependency(@Nullable String configuration) {
-        this.configuration = configuration;
-    }
-
     @Override
     public boolean isTransitive() {
         return transitive;
@@ -168,6 +164,9 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
             target.moduleDependencyCapabilities = moduleDependencyCapabilities.copy();
         }
         target.endorsing = endorsing;
+        if (target.getTargetConfiguration() != null) {
+            target.setTargetConfiguration(getTargetConfiguration());
+        }
     }
 
     protected boolean isKeyEquals(ModuleDependency dependencyRhs) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/ProjectDependencyInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/ProjectDependencyInternal.java
@@ -18,14 +18,8 @@ package org.gradle.api.internal.artifacts.dependencies;
 
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.internal.project.ProjectIdentity;
-import org.gradle.util.Path;
 
 public interface ProjectDependencyInternal extends ProjectDependency {
-
-    /**
-     * Returns a unique path for the target project within the current build tree.
-     */
-    Path getIdentityPath();
 
     /**
      * Get the identity of the target project.

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraintTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraintTest.groovy
@@ -79,7 +79,8 @@ class DefaultProjectDependencyConstraintTest extends Specification {
             TestFiles.taskDependencyFactory(),
             Mock(ProjectStateRegistry)
         )
-        def projectDependency = dependencyFactory.create(project, "mockConfiguration")
+        def projectDependency = dependencyFactory.create(project)
+        projectDependency.setTargetConfiguration("mockConfiguration")
         new DefaultProjectDependencyConstraint(projectDependency)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
@@ -18,12 +18,16 @@ package org.gradle.api.internal.artifacts.dependencies
 
 import org.gradle.api.artifacts.ExternalDependency
 import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.artifacts.dsl.DependencyFactory
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.internal.project.ProjectState
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.internal.component.resolution.failure.exception.VariantSelectionByNameException
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
+import org.gradle.util.Path
 
 import static org.gradle.api.internal.artifacts.dependencies.AbstractModuleDependencySpec.assertDeepCopy
 import static org.gradle.util.Matchers.strictlyEqual
@@ -217,7 +221,13 @@ class DefaultProjectDependencyTest extends AbstractProjectBuilderSpec {
         def base = new DefaultProjectDependency(project, "conf1", true, TestFiles.taskDependencyFactory())
         def differentConf = new DefaultProjectDependency(project, "conf2", true, TestFiles.taskDependencyFactory())
         def differentBuildDeps = new DefaultProjectDependency(project, "conf1", false, TestFiles.taskDependencyFactory())
-        def differentProject = new DefaultProjectDependency(Mock(ProjectInternal), "conf1", true, TestFiles.taskDependencyFactory())
+
+        def otherProject = Mock(ProjectInternal) {
+            getOwner() >> Mock(ProjectState) {
+                getIdentity() >> new ProjectIdentity(Mock(BuildIdentifier), Path.path(":foo"), Path.path(":foo"), "foo")
+            }
+        }
+        def differentProject = new DefaultProjectDependency(otherProject, "conf1", true, TestFiles.taskDependencyFactory())
 
         then:
         base != differentConf


### PR DESCRIPTION
ProjectDependencyInternal.getTargetProjectIdentity covers this use case and more. Replace by using getTargetProjectIdentity

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
