### PR TITLE
Replace locked map by `ConcurrentHashMap` in `AbstractCrossBuildInMemoryCache`

### DIFF
--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/lazy/ConstantLazy.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/lazy/ConstantLazy.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.lazy;
+
+/**
+ * A {@link Lazy} value that always returns the given {@link #value}.
+ */
+public class ConstantLazy<V> implements Lazy<V> {
+    private final V value;
+
+    public ConstantLazy(V value) {this.value = value;}
+
+    @Override
+    public V get() {
+        return value;
+    }
+}

--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/lazy/ConstantLazy.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/lazy/ConstantLazy.java
@@ -22,7 +22,9 @@ package org.gradle.internal.lazy;
 public class ConstantLazy<V> implements Lazy<V> {
     private final V value;
 
-    public ConstantLazy(V value) {this.value = value;}
+    public ConstantLazy(V value) {
+        this.value = value;
+    }
 
     @Override
     public V get() {

--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/lazy/FixedLazy.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/lazy/FixedLazy.java
@@ -19,10 +19,10 @@ package org.gradle.internal.lazy;
 /**
  * A {@link Lazy} value that always returns the given {@link #value}.
  */
-public class ConstantLazy<V> implements Lazy<V> {
+public class FixedLazy<V> implements Lazy<V> {
     private final V value;
 
-    public ConstantLazy(V value) {
+    public FixedLazy(V value) {
         this.value = value;
     }
 

--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/lazy/Lazy.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/lazy/Lazy.java
@@ -65,10 +65,11 @@ public interface Lazy<T> extends Supplier<T> {
 
     /**
      * Constructs a lazy value that always returns the given value.
+     *
      * @param <V> the type of the lazy value
      */
-    static <V> Lazy<V> constant(V value) {
-        return new ConstantLazy<>(value);
+    static <V> Lazy<V> fixed(V value) {
+        return new FixedLazy<>(value);
     }
 
     static Factory unsafe() {

--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/lazy/Lazy.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/lazy/Lazy.java
@@ -63,6 +63,14 @@ public interface Lazy<T> extends Supplier<T> {
         return unsafe().of(() -> mapper.apply(get()));
     }
 
+    /**
+     * Constructs a lazy value that always returns the given value.
+     * @param <V> the type of the lazy value
+     */
+    static <V> Lazy<V> constant(V value) {
+        return new ConstantLazy<>(value);
+    }
+
     static Factory unsafe() {
         return UnsafeLazy::new;
     }

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
@@ -90,8 +90,8 @@ public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemory
 
     @Override
     public <V> CrossBuildInMemoryCache<Class<?>, V> newClassCache() {
-        // Should use some variation of DefaultClassMap below to associate values with classes, as currently we retain a strong reference to each value for one session after the ClassLoader
-        // for the entry's key is discarded, which is unnecessary because we won't attempt to locate the entry again once the ClassLoader has been discarded
+        // TODO: Should use some variation of DefaultClassMap below to associate values with classes, as currently we retain a strong reference to each value for one session after the ClassLoader
+        //       for the entry's key is discarded, which is unnecessary because we won't attempt to locate the entry again once the ClassLoader has been discarded
         DefaultCrossBuildInMemoryCache<Class<?>, V> cache = new DefaultCrossBuildInMemoryCache<>(synchronizedMap(new WeakHashMap<>()));
         listenerManager.addListener(cache);
         return cache;
@@ -199,10 +199,10 @@ public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemory
         private final Map<K, SoftReference<V>> allValues;
 
         /**
-         * @param allValues thread-safe map used for retaining values in the current session.
+         * @param retainedValues thread-safe map used for retaining values in the current session.
          */
-        public DefaultCrossBuildInMemoryCache(Map<K, SoftReference<V>> allValues) {
-            this.allValues = allValues;
+        public DefaultCrossBuildInMemoryCache(Map<K, SoftReference<V>> retainedValues) {
+            this.allValues = retainedValues;
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
@@ -207,13 +207,17 @@ public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemory
         @Override
         protected void retainValuesFromCurrentSession(Stream<V> values) {
             // Retain strong references to the values created for this session
-            valuesForPreviousSession.clear();
-            values.forEach(valuesForPreviousSession::add);
+            synchronized (valuesForPreviousSession) {
+                valuesForPreviousSession.clear();
+                values.forEach(valuesForPreviousSession::add);
+            }
         }
 
         @Override
         protected void discardRetainedValues() {
-            valuesForPreviousSession.clear();
+            synchronized (valuesForPreviousSession) {
+                valuesForPreviousSession.clear();
+            }
             allValues.clear();
         }
 

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
@@ -152,7 +152,7 @@ public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemory
             return valuesForThisSession.computeIfAbsent(key, k -> {
                 V retained = maybeGetRetainedValue(k);
                 return retained != null
-                    ? Lazy.unsafe().of(() -> retained)
+                    ? Lazy.constant(retained)
                     : Lazy.locking().of(() -> produceAndRetain(factory, k));
             }).get();
         }

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
@@ -165,10 +165,9 @@ public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemory
 
         @Override
         public void put(K key, V value) {
-            valuesForThisSession.put(key, Lazy.unsafe().of(() -> {
-                retainValue(key, value);
-                return value;
-            }));
+            // Update doesn't need to be atomic since all retained values are equivalent
+            retainValue(key, value);
+            valuesForThisSession.put(key, Lazy.constant(value));
         }
 
         private V produceAndRetain(Function<? super K, ? extends V> factory, K k) {

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
@@ -141,7 +141,7 @@ public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemory
                 .computeIfAbsent(key, k -> {
                     V retained = maybeGetRetainedValue(k);
                     return retained != null
-                        ? Lazy.constant(retained)
+                        ? Lazy.fixed(retained)
                         : null;
                 });
             return present != null
@@ -158,7 +158,7 @@ public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemory
             return valuesForThisSession.computeIfAbsent(key, k -> {
                 V retained = maybeGetRetainedValue(k);
                 return retained != null
-                    ? Lazy.constant(retained)
+                    ? Lazy.fixed(retained)
                     : Lazy.locking().of(() -> produceAndRetain(factory, k));
             }).get();
         }
@@ -167,7 +167,7 @@ public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemory
         public void put(K key, V value) {
             // Update doesn't need to be atomic since all retained values are equivalent
             retainValue(key, value);
-            valuesForThisSession.put(key, Lazy.constant(value));
+            valuesForThisSession.put(key, Lazy.fixed(value));
         }
 
         private V produceAndRetain(Function<? super K, ? extends V> factory, K k) {

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
@@ -104,10 +104,15 @@ public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemory
     }
 
     private abstract static class AbstractCrossBuildInMemoryCache<K, V> implements CrossBuildInMemoryCache<K, V>, BuildSessionLifecycleListener {
-        private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
-        private final Lock readLock = readWriteLock.readLock();
-        private final Lock writeLock = readWriteLock.writeLock();
         private final Map<K, V> valuesForThisSession = new HashMap<>();
+        private final Lock readLock;
+        private final Lock writeLock;
+
+        protected AbstractCrossBuildInMemoryCache() {
+            ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
+            readLock = readWriteLock.readLock();
+            writeLock = readWriteLock.writeLock();
+        }
 
         @Override
         public void beforeComplete() {

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
@@ -138,9 +138,16 @@ public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemory
         @Nullable
         @Override
         public V getIfPresent(K key) {
-            return valuesForThisSession
-                .computeIfAbsent(key, k -> Lazy.unsafe().of(() -> maybeGetRetainedValue(k)))
-                .get();
+            Lazy<V> present = valuesForThisSession
+                .computeIfAbsent(key, k -> {
+                    V retained = maybeGetRetainedValue(k);
+                    return retained != null
+                        ? Lazy.constant(retained)
+                        : null;
+                });
+            return present != null
+                ? present.get()
+                : null;
         }
 
         /**


### PR DESCRIPTION
In order to reduce contention with _Isolated Projects_ parallel project configuration.

This improves performance by around 10% in the `perf-isolated-projects/java-extra-large` benchmark (on top of #32023) without any noticeable drop in performance when running without IP (except for a 0.2% increase in memory consumption).

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
