### PR TITLE
Fix typo in introduction to Gradle Daemon

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle_daemon.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle_daemon.adoc
@@ -34,8 +34,7 @@ The Gradle Daemon reduces build times by:
 == Understanding the Daemon
 
 The Gradle JVM client sends the Daemon build information such as command line arguments, project directories, and environment variables so that it can run the build.
-[[understanding_wrapper]]
-The Wrapper is responsible for resolving dependencies, executing build scripts, creating and running tasks; when it is done, it sends the client the output.
+The Daemon is responsible for resolving dependencies, executing build scripts, creating and running tasks; when it is done, it sends the client the output.
 Communication between the client and the Daemon happens via a local socket connection.
 
 Daemons use the JVM's default minimum heap size.


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
[Slack Discussion ](https://gradle-community.slack.com/archives/CAB4AE8TA/p1736869424370729)

> Shouldn't "The Wrapper" be "The Daemon"? It seems like the paragraph as a whole would make more sense if in the second sentence the Daemon is related back to the client:
> "The Gradle JVM client sends the Daemon build information such as command line arguments, project directories, and environment variables so that it can run the build. The Wrapper is responsible for resolving dependencies, executing build scripts, creating and running tasks; when it is done, it sends the client the output."
> This definition of the Wrapper conflicts with earlier notion from the Gradle Wrapper Reference (https://docs.gradle.org/current/userguide/gradle_wrapper.html), "The Wrapper is a script that invokes a declared version of Gradle, downloading it beforehand if necessary."

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
