### PR TITLE
Add an extra build operation around build logic build queue

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOperationsIntegrationTest.groovy
@@ -242,7 +242,7 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         def treeTaskGraphOps = operations.all(CalculateTreeTaskGraphBuildOperationType)
         treeTaskGraphOps.size() == 2
         treeTaskGraphOps[0].displayName == "Calculate build tree task graph"
-        treeTaskGraphOps[0].parentId == applyRootProjectBuildScript.id
+        applyRootProjectBuildScript in operations.parentsOf(treeTaskGraphOps[0])
         treeTaskGraphOps[1].displayName == "Calculate build tree task graph"
         treeTaskGraphOps[1].parentId == root.id
 
@@ -321,7 +321,7 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         def treeTaskGraphOps = operations.all(CalculateTreeTaskGraphBuildOperationType)
         treeTaskGraphOps.size() == 2
         treeTaskGraphOps[0].displayName == "Calculate build tree task graph"
-        treeTaskGraphOps[0].parentId == applyRootProjectBuildScript.id
+        applyRootProjectBuildScript in operations.parentsOf(treeTaskGraphOps[0])
         treeTaskGraphOps[1].displayName == "Calculate build tree task graph"
         treeTaskGraphOps[1].parentId == root.id
 
@@ -345,7 +345,7 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         def runTasksOps = operations.all(Pattern.compile("Run tasks.*"))
         runTasksOps.size() == 3
         runTasksOps[0].displayName == "Run tasks (:buildB)"
-        runTasksOps[0].parentId == applyRootProjectBuildScript.id
+        applyRootProjectBuildScript in operations.parentsOf(runTasksOps[0])
         // Build operations are run in parallel, so can appear in either order
         [runTasksOps[1].displayName, runTasksOps[2].displayName].sort() == ["Run tasks", "Run tasks (:buildB)"]
         runTasksOps[1].parentId == runMainTasks.id

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultBuildLogicBuildQueue.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultBuildLogicBuildQueue.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.initialization;
 
-import com.google.common.collect.ImmutableList;
 import org.gradle.cache.FileLock;
 import org.gradle.cache.FileLockManager;
 import org.gradle.composite.internal.BuildTreeWorkGraphController;
@@ -63,22 +62,6 @@ public class DefaultBuildLogicBuildQueue implements BuildLogicBuildQueue {
         this.resource = workerLeaseService.newResource();
     }
 
-    private static class OperationDetails {
-        private final List<String> requestedTasks;
-
-        public List<String> getRequestedTasks() {
-            return requestedTasks;
-        }
-
-        OperationDetails(List<TaskIdentifier.TaskBasedTaskIdentifier> tasks) {
-            ImmutableList.Builder<String> builder = ImmutableList.builderWithExpectedSize(tasks.size());
-            tasks.forEach(ti -> {
-                builder.add(ti.getBuildIdentifier().getBuildPath() + ":" + ti.getTaskPath());
-            });
-            requestedTasks = builder.build();
-        }
-    }
-
     @Override
     public <T> T build(BuildState requester, List<TaskIdentifier.TaskBasedTaskIdentifier> tasks, Supplier<T> continuationUnderLock) {
         if (tasks.isEmpty()) {
@@ -98,8 +81,7 @@ public class DefaultBuildLogicBuildQueue implements BuildLogicBuildQueue {
 
             @Override
             public BuildOperationDescriptor.Builder description() {
-                return BuildOperationDescriptor.displayName("Build build logic for " + requester.getDisplayName().getDisplayName())
-                    .details(new OperationDetails(tasks));
+                return BuildOperationDescriptor.displayName("Build build logic for " + requester.getDisplayName().getDisplayName());
             }
         });
     }


### PR DESCRIPTION
The lock in the queue is highly contentious and may block project configuration for a prolonged period of time. In gradle/gradle build, the time spent locked goes up to 500ms per project, because their configuration is effectively serialized.

This commit doesn't address the root cause, but highlights the time-consuming operation in the build traces.

![image](https://github.com/user-attachments/assets/70c0b127-4a3a-4029-8f8f-585fbfcfbc24)


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
