### PR TITLE
Partially disable KGP statistics collection in :build-logic

### DIFF
--- a/build-logic/gradle.properties
+++ b/build-logic/gradle.properties
@@ -1,3 +1,6 @@
 org.gradle.jvmargs=-Xmx2500m -XX:MaxMetaspaceSize=768m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 kotlin.stdlib.default.dependency=false
+
+# Temporarily disable statistics collection, because it causes concurrency problems when running with Isolated Projects
+kotlin.internal.collectFUSMetrics=false


### PR DESCRIPTION
because it causes concurrency problems with Isolated Projects

Property:
https://github.com/JetBrains/kotlin/blob/5dd9cea66ee526f0251c9b1d2543229202622f6b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/PropertiesProvider.kt#L703

Related problems:
- https://github.com/gradle/gradle/issues/31947

---

A slight downside of disabling this property is that a warning gets unconditionally printed out:
```
> Configure project :build-logic:binary-compatibility
w: ATTENTION! This build uses the following Kotlin Gradle Plugin properties:

kotlin.internal.collectFUSMetrics

Internal properties are not recommended for production use. 
Stability and future compatibility of the build is not guaranteed.
```