### PR TITLE
Enable IP test coverage for :antlr

### DIFF
--- a/platforms/software/antlr/build.gradle.kts
+++ b/platforms/software/antlr/build.gradle.kts
@@ -51,6 +51,3 @@ dependencies {
 packageCycles {
     excludePatterns.add("org/gradle/api/plugins/antlr/internal/*")
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/software/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/AbstractAntlrIntegrationTest.groovy
+++ b/platforms/software/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/AbstractAntlrIntegrationTest.groovy
@@ -23,33 +23,44 @@ abstract class AbstractAntlrIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         // So we can assert on which version of ANTLR is used at runtime
         executer.withArgument("-i")
-        buildFile << """
-            allprojects {
-                apply plugin: 'java'
-                ${mavenCentralRepository()}
-                tasks.withType(JavaCompile) {
-                    options.compilerArgs << "-proc:none"
-                }
-            }
-            project(":grammar-builder") {
-                apply plugin: "antlr"
 
-                dependencies {
-                    antlr '$antlrDependency'
-                }
-            }
-            project(":grammar-user") {
-
-                dependencies {
-                    implementation project(":grammar-builder")
-                }
-            }
-"""
-        createDirs("grammar-builder", "grammar-user")
-        settingsFile << """
+        settingsFile """
             include 'grammar-builder'
             include 'grammar-user'
-"""
+        """
+
+        buildFile "grammar-builder/build.gradle", """
+            plugins {
+                id("java")
+                id("antlr")
+            }
+
+            ${mavenCentralRepository()}
+
+            dependencies {
+                antlr '$antlrDependency'
+            }
+
+            tasks.withType(JavaCompile).configureEach {
+                options.compilerArgs << "-proc:none"
+            }
+        """
+
+        buildFile "grammar-user/build.gradle", """
+            plugins {
+                id("java")
+            }
+
+            ${mavenCentralRepository()}
+
+            dependencies {
+                implementation project(":grammar-builder")
+            }
+
+            tasks.withType(JavaCompile).configureEach {
+                options.compilerArgs << "-proc:none"
+            }
+        """
     }
 
     abstract String getAntlrDependency()

--- a/platforms/software/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/Antlr2PluginIntegrationTest.groovy
+++ b/platforms/software/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/Antlr2PluginIntegrationTest.groovy
@@ -48,7 +48,8 @@ class Antlr2PluginIntegrationTest extends AbstractAntlrIntegrationTest {
     }
 
     def "uses antlr v2 if no explicit dependency is set"() {
-        buildFile.text = buildFile.text.replace("antlr '$antlrDependency'", "")
+        def grammarBuilder = file("grammar-builder/build.gradle")
+        grammarBuilder.text = grammarBuilder.text.replace("antlr '$antlrDependency'", "")
 
         goodGrammar()
         goodProgram()

--- a/platforms/software/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/Antlr4PluginIntegrationTest.groovy
+++ b/platforms/software/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/Antlr4PluginIntegrationTest.groovy
@@ -56,12 +56,10 @@ class Antlr4PluginIntegrationTest extends AbstractAntlrIntegrationTest {
             WS : [ \\t\\r\\n]+ -> skip ;
         """
         when:
-        buildFile << """
-        project(":grammar-builder") {
+        buildFile "grammar-builder/build.gradle", """
             generateGrammarSource {
                 arguments << "-lib" << "src/main/antlr/org/acme"
             }
-        }
         """
         then:
         succeeds("generateGrammarSource")

--- a/platforms/software/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/IncrementalAntlrTaskIntegrationTest.groovy
+++ b/platforms/software/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/IncrementalAntlrTaskIntegrationTest.groovy
@@ -101,11 +101,9 @@ class IncrementalAntlrTaskIntegrationTest extends AbstractAntlrIntegrationTest {
         def test1LexerFileSnapshot = test1LexerFile.snapshot()
         def test1ParserFileSnapshot = test1ParserFile.snapshot()
 
-        buildFile << """
-            project(":grammar-builder") {
-                generateGrammarSource {
-                    arguments << '-dfa'
-                }
+        buildFile "grammar-builder/build.gradle", """
+            generateGrammarSource {
+                arguments << '-dfa'
             }
         """
 

--- a/platforms/software/build-init/build.gradle.kts
+++ b/platforms/software/build-init/build.gradle.kts
@@ -115,7 +115,3 @@ packageCycles {
 }
 
 integTest.testJvmXmx = "1g"
-
-tasks.isolatedProjectsIntegTest {
-    enabled = true
-}


### PR DESCRIPTION
- Polish the integration test for `:antlr` so that they work with Isolated Projects runner.
- Enable the IP runner on the project